### PR TITLE
Copied actual skills instead of symlinks

### DIFF
--- a/workspace/agents/platform/skills/gke-cluster-creator
+++ b/workspace/agents/platform/skills/gke-cluster-creator
@@ -1,1 +1,0 @@
-/usr/local/google/home/dmitryshnayder/git/gke-mcp/skills/gke-cluster-creator

--- a/workspace/agents/platform/skills/gke-cluster-creator/SKILL.md
+++ b/workspace/agents/platform/skills/gke-cluster-creator/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: gke-cluster-creator
+description: Guides the user through creating GKE clusters using pre-defined templates (Standard, Autopilot, GPU/AI).
+---
+
+# GKE Cluster Creation Skill
+
+This skill helps users create Google Kubernetes Engine (GKE) clusters by providing a set of best-practice templates and guiding them through the customization process.
+
+## core_behavior
+
+1. **Template Selection**:
+   - Present the available templates to the user if they haven't specified one.
+   - Explain the trade-offs (e.g., Cost vs. Availability, Autopilot vs. Standard).
+2. **Customization**:
+   - Once a template is selected, present the default configuration (JSON/YAML).
+   - Ask the user for essential missing information: `project_id`, `location`, `cluster_name`.
+   - Ask if they want to modify optional fields (e.g., `machineType`, `nodeCount`, `network`).
+3. **Validation**:
+   - Ensure `project_id`, `location`, and `cluster_name` are set.
+   - Ensure the configuration matches the `create_cluster` MCP tool schema.
+4. **Execution**:
+   - Call the `create_cluster` MCP tool with the final configuration.
+
+## best_practices
+
+When guiding the user or generating configurations, adhere to the following GKE cluster creation best practices:
+
+### Security
+
+1. **Private Clusters**: Default to private clusters with a private control plane and restricted public endpoints to minimize attack surface.
+2. **VPC-Native Networking**: Use VPC-native clusters to enable alias IP ranges, which allows pod-level firewall rules and better network security.
+3. **Workload Identity**: Prefer Workload Identity for securely granting GKE workloads access to Google Cloud services instead of using static service account keys.
+4. **Shielded GKE Nodes**: Enable Shielded GKE Nodes to protect against rootkits and bootkits.
+5. **Least Privilege (RBAC)**: Institute strict Role-Based Access Control limits granting minimal privilege to users and workloads.
+
+### Cost Optimization
+
+1. **Autoscaling**: Enable Cluster Autoscaler and Horizontal Pod Autoscaler to adjust resources based on demand.
+2. **Right-Sizing**: Choose the appropriate machine types and node counts. Consider Spot VMs for fault-tolerant, non-critical workloads.
+
+### High Availability & Reliability
+
+1. **Regional Clusters**: Use Regional Clusters for production environments to ensure control plane replication across multiple zones. (Note: standard regional creates nodes across 3 zones by default).
+2. **Pod Disruption Budgets**: Recommend setting Pod Disruption Budgets for application stability during node maintenance.
+3. **Release Channels**: Subscribe to a release channel (e.g., Regular or Stable) for automated and safer cluster upgrades.
+
+## templates
+
+### 1. Standard Zonal (Cost-Effective Dev/Test)
+
+Best for: Development, testing, non-critical workloads.
+
+```json
+{
+  "name": "projects/{PROJECT_ID}/locations/{ZONE}/clusters/{CLUSTER_NAME}",
+  "initialNodeCount": 1,
+  "nodeConfig": {
+    "machineType": "e2-medium",
+    "diskSizeGb": 50,
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append"
+    ]
+  }
+}
+```
+
+### 2. Standard Regional (High Availability)
+
+Best for: Production workloads requiring high availability.
+_Note: Creates 3 nodes (one per zone in the region) by default._
+
+```json
+{
+  "name": "projects/{PROJECT_ID}/locations/{REGION}/clusters/{CLUSTER_NAME}",
+  "initialNodeCount": 1,
+  "nodeConfig": {
+    "machineType": "e2-standard-4",
+    "diskSizeGb": 100,
+    "oauthScopes": ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+```
+
+### 3. Autopilot (Operations-Free)
+
+Best for: Most workloads where you don't want to manage nodes.
+
+```json
+{
+  "name": "projects/{PROJECT_ID}/locations/{REGION}/clusters/{CLUSTER_NAME}",
+  "autopilot": {
+    "enabled": true
+  }
+}
+```
+
+### 4. GPU Inference (L4)
+
+Best for: AI/ML Inference, small model serving.
+_Note: Requires `g2-standard-4` quota._
+
+```json
+{
+  "name": "projects/{PROJECT_ID}/locations/{REGION}/clusters/{CLUSTER_NAME}",
+  "initialNodeCount": 1,
+  "nodeConfig": {
+    "machineType": "g2-standard-4",
+    "accelerators": [
+      {
+        "acceleratorCount": "1",
+        "acceleratorType": "nvidia-l4"
+      }
+    ],
+    "diskSizeGb": 100,
+    "oauthScopes": ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+```
+
+### 5. AI Hypercompute (A3 HighGPU)
+
+Best for: Large Model Training/Inference.
+_Note: High cost and strict quota requirements._
+
+```json
+{
+  "name": "projects/{PROJECT_ID}/locations/{REGION}/clusters/{CLUSTER_NAME}",
+  "initialNodeCount": 1,
+  "nodeConfig": {
+    "machineType": "a3-highgpu-8g",
+    "accelerators": [
+      {
+        "acceleratorCount": "8",
+        "acceleratorType": "nvidia-h100-80gb-hbm3"
+      }
+    ],
+    "diskSizeGb": 200,
+    "oauthScopes": ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+```
+
+## instructions
+
+- **ALWAYS** ask for the `project_id` if it is not in the context.
+- **ALWAYS** ask for the `location` (Region or Zone).
+- **ALWAYS** ask for a unique `cluster_name`.
+- **CHECK** if the user wants `Access to Google Cloud APIs` (default `cloud-platform` scope is usually best for modern GKE).
+- **WARN** the user about cost if they select GPU or Reginal clusters.
+- **USE** `create_cluster` MCP tool to create the cluster. The `parent` argument is `projects/{PROJECT_ID}/locations/{LOCATION}` and the `cluster` argument is the JSON object. The `cluster.name` is just the short name (e.g. "my-cluster").
+- **IMPORTANT**: When calling `create_cluster`, the `cluster.name` should be the **short name** (e.g., `my-cluster`), NOT the full resource path, because the `parent` argument defines the scope.
+
+## example_usage
+
+**User**: "I want to create a GKE cluster."
+**Model**: "I can help with that. What kind of cluster do you need?
+
+1. **Standard Zonal**: Good for dev/test.
+2. **Standard Regional**: High availability.
+3. **Autopilot**: Fully managed.
+4. **GPU Enabled**: For AI/ML workloads."
+
+**User**: "Standard Zonal, please."
+**Model**: "Great. I'll need a few details:
+
+- Project ID
+- Zone (e.g., us-central1-a)
+- Cluster Name"
+
+**User**: "Project `my-proj`, zone `us-west1-b`, name `dev-cluster`."
+**Model**: "Here is the configuration I will use:
+[JSON view]
+Do you want to proceed?"

--- a/workspace/agents/platform/skills/gke-compute-class-creator
+++ b/workspace/agents/platform/skills/gke-compute-class-creator
@@ -1,1 +1,0 @@
-/usr/local/google/home/dmitryshnayder/git/gke-mcp/skills/gke-compute-class-creator

--- a/workspace/agents/platform/skills/gke-compute-class-creator/SKILL.md
+++ b/workspace/agents/platform/skills/gke-compute-class-creator/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gke-compute-class-creator
+description: Guide for creating GKE ComputeClass resources. Use this skill when users want to define custom node configurations, autoscaling priorities, or hardware requirements (e.g., Spot VMs, GPUs, specific machine families) for their GKE workloads.
+---
+
+# Creating GKE ComputeClasses
+
+This skill helps you construct `ComputeClass` resources for Google Kubernetes Engine (GKE). ComputeClasses allow for declarative node configuration and sophisticated autoscaling behaviors like fallback priorities and active migration.
+
+## Workflow
+
+1. **Analyze Requirements**: Determine the user's goals (Cost optimization? Specific hardware? High availability?).
+2. **Select Strategy**:
+   - **Cost Optimization**: Use `spot: true` as a high priority, with `spot: false` as a fallback.
+   - **Performance**: Select specific `machineFamily` (e.g., `c3`, `c4`) or `machineType`.
+   - **AI/ML**: Configure `gpu` or `tpu` fields.
+3. **Construct YAML**: Use the references below to build the `ComputeClass` manifest.
+4. **Validate**: Ensure all fields comply with the specification.
+5. **Apply**: Provide the user with the `kubectl apply -f <filename>.yaml` command.
+
+## References
+
+- **[Specification](references/compute-class-spec.md)**: Detailed breakdown of the `ComputeClass` CRD fields (`priorities`, `machineFamily`, `gpu`, etc.).
+- **[Examples](references/compute-class-examples.md)**: Copy-pasteable YAML patterns for common scenarios (Spot fallback, GPU, Zonal).
+
+## Usage Tips
+
+- **Active Migration**: If the user wants to automatically move back to Spot VMs when they become available, ensure `spec.activeMigration.optimizeRulePriority` is set to `true`.
+- **Node Selection**: Remind the user that to use the class, their Pods must specify:
+  ```yaml
+  nodeSelector:
+    cloud.google.com/compute-class: "<class-name>"
+  ```
+- **Conflict Warning**: Advise against mixing `ComputeClass` selection with other hard node selectors (like `cloud.google.com/gke-spot`) as this can lead to scheduling conflicts.

--- a/workspace/agents/platform/skills/gke-compute-class-creator/references/compute-class-examples.md
+++ b/workspace/agents/platform/skills/gke-compute-class-creator/references/compute-class-examples.md
@@ -1,0 +1,100 @@
+# ComputeClass Examples
+
+This file contains common patterns for defining GKE ComputeClasses.
+
+## Scenario 1: Spot VMs with Fallback to On-Demand
+
+This configuration prioritizes Spot VMs for cost savings but falls back to standard On-Demand VMs if Spot capacity is unavailable.
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: spot-with-fallback
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  priorities:
+    # Priority 1: Try to get Spot VMs in the N4 family
+    - machineFamily: n4
+      spot: true
+    # Priority 2: Fallback to On-Demand VMs in the N4 family
+    - machineFamily: n4
+      spot: false
+```
+
+## Scenario 2: GPU Workload (L4)
+
+This configuration targets NVIDIA L4 GPUs for AI inference workloads.
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: l4-gpu-class
+spec:
+  priorities:
+    - machineFamily: g2
+      gpu:
+        type: nvidia-l4
+        count: 1
+      minCores: 4
+      minMemoryGb: 16
+      storage:
+        bootDisk:
+          type: pd-balanced
+          sizeGb: 100
+```
+
+## Scenario 3: High Performance Compute (C3)
+
+Prioritizes the C3 machine family for compute-intensive workloads.
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: high-perf-compute
+spec:
+  priorities:
+    - machineFamily: c3
+      minCores: 8
+      minMemoryGb: 16
+```
+
+## Scenario 4: Specific Zone Targeting
+
+Ensures workloads only run in specific zones (e.g., to colocatee with other zonal resources).
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: zonal-targeting
+spec:
+  priorities:
+    - machineFamily: e2
+      location:
+        zones:
+          - us-central1-a
+          - us-central1-b
+```
+
+## Scenario 5: Active Migration
+
+Enables active migration to move workloads back to higher-priority resources (e.g., Spot VMs) when they become available.
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: active-migration-enabled
+spec:
+  activeMigration:
+    optimizeRulePriority: true
+  priorities:
+    - machineFamily: n2
+      spot: true
+    - machineFamily: n2
+      spot: false
+```

--- a/workspace/agents/platform/skills/gke-compute-class-creator/references/compute-class-spec.md
+++ b/workspace/agents/platform/skills/gke-compute-class-creator/references/compute-class-spec.md
@@ -1,0 +1,120 @@
+# ComputeClass CRD Specification
+
+The `ComputeClass` resource (API group: `cloud.google.com/v1`) allows you to define custom node configurations and autoscaling priorities.
+
+## Object Structure
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: <string> # Required. The name of the ComputeClass.
+spec:
+  # Required. Ordered list of rules. GKE attempts to satisfy them in order.
+  priorities:
+    - <PriorityRule>
+
+  # Optional. Defaults to "DoNotScaleUp".
+  # Options: "DoNotScaleUp", "ScaleUpAnyway"
+  whenUnsatisfiable: <string>
+
+  # Optional. Configuration for automatic node pool management.
+  nodePoolAutoCreation:
+    enabled: <boolean> # Default: true
+
+  # Optional. Configuration for active migration of workloads.
+  activeMigration:
+    optimizeRulePriority: <boolean> # Default: false
+
+  # Optional. Fine-tuning for autoscaling behavior.
+  autoscalingPolicy:
+    consolidationDelay: <duration> # e.g., "10m"
+
+  # Optional. Default values for fields omitted in 'priorities'.
+  priorityDefaults: <PriorityRule>
+```
+
+## PriorityRule Fields
+
+Each item in `spec.priorities` (and `spec.priorityDefaults`) can contain the following fields:
+
+| Field | Type | Description | Example |
+|Ref|---|---|---|
+| `machineFamily` | string | The Compute Engine machine family. | `n4`, `c3`, `t2a` |
+| `machineType` | string | Specific machine type. | `n4-standard-32` |
+| `spot` | boolean | Whether to use Spot VMs. | `true` |
+| `minCores` | int | Minimum number of vCPUs. | `4` |
+| `minMemoryGb` | int | Minimum memory in GB. | `16` |
+| `gpu` | object | GPU configuration. | See below |
+| `tpu` | object | TPU configuration. | See below |
+| `storage` | object | Boot disk configuration. | See below |
+| `location` | object | Zone/Region targeting. | See below |
+| `reservations` | object | Consumption of specific reservations. | See below |
+
+### GPU Configuration (`gpu`)
+
+```yaml
+gpu:
+  type: <string> # e.g., "nvidia-l4", "nvidia-h100-80gb"
+  count: <int> # Number of GPUs per node.
+  driverVersion: <string> # Optional. e.g., "latest", "default"
+```
+
+### TPU Configuration (`tpu`)
+
+```yaml
+tpu:
+  type: <string> # e.g., "v5p-slice"
+  count: <int> # Number of TPU chips.
+  topology: <string> # e.g., "2x2x1"
+```
+
+### Storage Configuration (`storage`)
+
+```yaml
+storage:
+  bootDisk:
+    type: <string> # e.g., "pd-balanced", "hyperdisk-balanced"
+    sizeGb: <int> # Size of the boot disk.
+    kmsKey: <string> # Optional. Cloud KMS key URI.
+  localSsd:
+    count: <int> # Number of local SSDs to attach.
+    interface: <string> # Optional. "NVME" or "SCSI".
+```
+
+### Location Configuration (`location`)
+
+```yaml
+location:
+  # List of specific zones to target.
+  zones:
+    - "us-central1-a"
+    - "us-central1-b"
+
+  # OR set type to "Any" to allow GKE to pick from cluster zones.
+  type: "Any"
+```
+
+### Reservations (`reservations`)
+
+```yaml
+reservations:
+  consumeReservationType: <string>
+  # Options:
+  # "NO_RESERVATION": Do not use reservations.
+  # "ANY_RESERVATION": Use any applicable reservation.
+  # "SPECIFIC_RESERVATION": Use a named reservation.
+
+  key: <string> # "projects/.../reservations/name" (Required if SPECIFIC_RESERVATION)
+  values: <list> # (Required if SPECIFIC_RESERVATION)
+```
+
+## Workload Usage
+
+To use a `ComputeClass`, add a node selector to your Pod specification:
+
+```yaml
+nodeSelector:
+  cloud.google.com/compute-class: "<compute-class-name>"
+  cloud.google.com/gke-nodepool: "" # Optional but recommended to allow dynamic selection
+```

--- a/workspace/agents/platform/skills/gke-multi-tenancy
+++ b/workspace/agents/platform/skills/gke-multi-tenancy
@@ -1,1 +1,0 @@
-/usr/local/google/home/dmitryshnayder/git/gke-mcp/skills/gke-multi-tenancy

--- a/workspace/agents/platform/skills/gke-multi-tenancy/SKILL.md
+++ b/workspace/agents/platform/skills/gke-multi-tenancy/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: gke-multi-tenancy
+description: Guidance on implementing multi-tenancy and governance in Google Kubernetes Engine (GKE) clusters.
+---
+
+# GKE Multi-tenancy and Governance
+
+This skill provides guidance on implementing multi-tenancy and governance in Google Kubernetes Engine (GKE) clusters.
+
+## Overview
+
+Multi-tenancy allows you to share a single GKE cluster among multiple teams or applications securely. Governance ensures that policies and resource limits are enforced.
+
+## Workflows
+
+### 1. Create Namespaces for Isolation
+
+Namespaces provide a scope for names and are the primary unit of isolation in Kubernetes.
+
+**Steps:**
+
+1. Create a namespace for each tenant.
+
+**Example Namespace Manifest:**
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-a
+  labels:
+    team: alpha
+```
+
+### 2. Configure RBAC for Least Privilege
+
+Role-Based Access Control (RBAC) allows you to control who has access to what resources within a namespace.
+
+**Steps:**
+
+1. Define a `Role` with specific permissions.
+2. Bind the `Role` to a user or group using a `RoleBinding`.
+
+**Example Role and RoleBinding Manifest:**
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: tenant-a
+  name: pod-reader
+rules:
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-pods
+  namespace: tenant-a
+subjects:
+  - kind: User
+    name: user@example.com # Name is case sensitive
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io
+```
+
+### 3. Enforce Resource Quotas
+
+Resource quotas prevent a single tenant from consuming all resources in the cluster.
+
+**Example ResourceQuota Manifest:**
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: tenant-a-quota
+  namespace: tenant-a
+spec:
+  hard:
+    requests.cpu: "2"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 8Gi
+```
+
+## Best Practices
+
+1. **Namespace Per Tenant**: Always use separate namespaces for different teams or applications.
+2. **Least Privilege RBAC**: Grant only the permissions necessary for users and service accounts to do their jobs.
+3. **Enforce Quotas**: Use Resource Quotas to ensure fair sharing of cluster resources.
+4. **Network Policies**: Combine namespaces with Network Policies (see [gke-workload-security](../gke-workload-security/SKILL.md)) to restrict cross-tenant traffic.

--- a/workspace/agents/platform/skills/gke-storage
+++ b/workspace/agents/platform/skills/gke-storage
@@ -1,1 +1,0 @@
-/usr/local/google/home/dmitryshnayder/git/gke-mcp/skills/gke-storage

--- a/workspace/agents/platform/skills/gke-storage/SKILL.md
+++ b/workspace/agents/platform/skills/gke-storage/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gke-storage
+description: Guidance on managing storage in Google Kubernetes Engine (GKE) clusters.
+---
+
+# GKE Storage Best Practices
+
+This skill provides guidance on managing storage in Google Kubernetes Engine (GKE) clusters.
+
+## Overview
+
+GKE supports various storage options, from Persistent Disks to Cloud Storage. Choosing the right storage type and configuring it correctly is essential for performance and reliability.
+
+## Workflows
+
+### 1. Configure Storage Classes
+
+StorageClasses allow you to describe the "classes" of storage you offer. Different classes might map to quality-of-service levels, or to backup policies.
+
+**Example StorageClass Manifest:**
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: premium-rwo
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-ssd
+  replication-type: regional-pd
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+```
+
+Setting `allowVolumeExpansion: true` is highly recommended for production.
+
+### 2. Use CSI Drivers
+
+GKE includes container storage interface (CSI) drivers for dynamic provisioning of storage.
+
+- **Compute Engine Persistent Disk CSI Driver**: Default for block storage.
+- **Google Cloud Filestore CSI Driver**: For managed NFS (ReadWriteMany).
+- **Cloud Storage FUSE CSI Driver**: For mounting GCS buckets as volumes.
+
+**Example using Filestore CSI Driver:**
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: filestore-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: standard-rwm # Pre-defined for Filestore
+  resources:
+    requests:
+      storage: 1Ti
+```
+
+### 3. Implement Volume Expansion
+
+If `allowVolumeExpansion` is true in the StorageClass, you can resize a volume by updating the PVC manifest.
+
+**Steps:**
+
+1. Edit the PVC manifest and increase the storage request.
+2. Apply the changes.
+
+Kubernetes will automatically resize the file system on the volume.
+
+## Best Practices
+
+1. **Use CSI Drivers**: Always use the official Google Cloud CSI drivers for best integration and performance.
+2. **Enable Volume Expansion**: Always set `allowVolumeExpansion: true` in your StorageClasses to allow for growth.
+3. **Choose the Right Disk Type**: Use `pd-ssd` or `pd-extreme` for I/O intensive workloads, and `pd-standard` or `pd-balanced` for others.
+4. **Use ReadWriteMany Carefully**: Filestore (NFS) is great for sharing data among multiple Pods, but be aware of file locking and consistency semantics.


### PR DESCRIPTION
Initial commit for `platform` agent contained symlinks instead of actual skill files. Adding the skills.