### PR TITLE
docs: add PR hygiene guidelines and template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Pull Request
+
+## Why This Change
+
+<!-- Explain the problem, motivation, or user need this PR addresses. -->
+
+## What Changed
+
+<!-- Summarize the important files, behavior, or workflow changes. -->
+
+**Files:**
+
+- `path/to/file`
+
+**Added/Changed/Fixed:**
+
+-
+
+## Why This Matters
+
+-
+
+## Context
+
+<!-- Include related issues, PRs, follow-up work, or other background. -->
+
+## Testing
+
+---
+
+<!-- Close with a short note on functional impact, risk, or rollout. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
 This repository is primarily a configuration and documentation repository for AI agents. It does not contain code that requires compilation or traditional building.
 
 To use these agents:
+
 1. Follow the instructions in [INSTALL.md](INSTALL.md) to set up and register the Platform Agent in your agent harness.
 2. Refer to [workspace/README.md](workspace/README.md) for details on how to interact with the cooperative agent layout, use routing shortcuts, and run demo scenarios.
 
@@ -33,3 +34,9 @@ To use these agents:
 - Keep changes scoped to the request.
 - Do not commit unrelated formatting changes.
 - Maintain the structure and intent of the agent configuration files.
+- Use Conventional Commits for commit messages.
+- Push PR branches to a fork, not to the upstream repository.
+- Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
+  detail.
+- When updating Markdown files, run `npx prettier --write <files>` on the
+  changed Markdown files before committing.


### PR DESCRIPTION
# Pull Request

## Why This Change

This change adds PR hygiene guidelines to `AGENTS.md` and introduces a standard Pull Request template to improve repository maintainability and contributor alignment.

## What Changed

**Files:**

- `AGENTS.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

**Added/Changed/Fixed:**

- Added rules for PR hygiene to `AGENTS.md`, including Conventional Commits, fork workflow, and running Prettier.
- Created `.github/PULL_REQUEST_TEMPLATE.md` to guide future PR descriptions.

## Why This Matters

Enforcing these rules ensures consistent commit history and better code review experiences.

## Context

These rules were present in the user instructions and are now being formalized in the repository.

## Testing

N/A (Documentation only)
