### PR TITLE
feat(examples): add LiteLLM Gemini example

### DIFF
--- a/examples/litellm-gemini/README.md
+++ b/examples/litellm-gemini/README.md
@@ -1,0 +1,20 @@
+# LiteLLM Gemini Example
+
+This directory contains an example of deploying LiteLLM proxy configured to use Google's Gemini models on Kubernetes.
+
+## Prerequisites
+
+- A Kubernetes cluster.
+- A Gemini API key.
+
+## Setup
+
+1.  Open `secret.yaml`.
+2.  Replace `PLACEHOLDER_FOR_GEMINI_API_KEY` with your actual Gemini API key.
+3.  Apply the manifests:
+    ```bash
+    kubectl apply -f secret.yaml
+    kubectl apply -f configmap.yaml
+    kubectl apply -f deployment.yaml
+    kubectl apply -f service.yaml
+    ```

--- a/examples/litellm-gemini/configmap.yaml
+++ b/examples/litellm-gemini/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: litellm-config
-  namespace: default
+  namespace: agent-system
 data:
   config.yaml: |
     model_list:

--- a/examples/litellm-gemini/configmap.yaml
+++ b/examples/litellm-gemini/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+  namespace: default
+data:
+  config.yaml: |
+    model_list:
+      - model_name: gemini-model
+        litellm_params:
+          model: gemini/gemini-3.1-flash-lite
+          api_key: os.environ/GEMINI_API_KEY

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      containers:
+      - name: litellm-container
+        image: ghcr.io/berriai/litellm:main-latest
+        args: ["--config", "/app/config.yaml"]
+        env:
+        - name: GEMINI_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: gemini-secret
+              key: GEMINI_API_KEY
+        ports:
+        - containerPort: 4000
+        volumeMounts:
+        - name: config-volume
+          mountPath: /app/config.yaml
+          subPath: config.yaml
+      volumes:
+      - name: config-volume
+        configMap:
+          name: litellm-config

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: litellm
-  namespace: default
+  namespace: agent-system
 spec:
   replicas: 1
   selector:
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: litellm-container
-        image: ghcr.io/berriai/litellm:main-latest
+        image: ghcr.io/berriai/litellm:v1.86.0
         args: ["--config", "/app/config.yaml"]
         env:
         - name: GEMINI_API_KEY

--- a/examples/litellm-gemini/secret.yaml
+++ b/examples/litellm-gemini/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gemini-secret
+  namespace: default
+type: Opaque
+stringData:
+  GEMINI_API_KEY: PLACEHOLDER_FOR_GEMINI_API_KEY

--- a/examples/litellm-gemini/secret.yaml
+++ b/examples/litellm-gemini/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gemini-secret
-  namespace: default
+  namespace: agent-system
 type: Opaque
 stringData:
   GEMINI_API_KEY: PLACEHOLDER_FOR_GEMINI_API_KEY

--- a/examples/litellm-gemini/service.yaml
+++ b/examples/litellm-gemini/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+  namespace: default
+spec:
+  selector:
+    app: litellm
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 4000
+  type: ClusterIP

--- a/examples/litellm-gemini/service.yaml
+++ b/examples/litellm-gemini/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: litellm
-  namespace: default
+  namespace: agent-system
 spec:
   selector:
     app: litellm


### PR DESCRIPTION
# Pull Request

## Why This Change
Adds a sample deployment for LiteLLM configured to use Google's Gemini models on Kubernetes.

## What Changed
Added files in `examples/litellm-gemini/`.

**Files:**
- `examples/litellm-gemini/configmap.yaml`
- `examples/litellm-gemini/deployment.yaml`
- `examples/litellm-gemini/secret.yaml`
- `examples/litellm-gemini/service.yaml`

**Added/Changed/Fixed:**
- Added LiteLLM configuration for `gemini-3.1-flash-lite`.
- Added K8s Deployment, Service, and Secret manifests.

## Why This Matters
Provides a starting point for users to run LiteLLM with Gemini on GKE.

## Context
None.

## Testing
Manifests are static examples. Not tested in a live cluster.
