### PR TITLE
feat: always run prettier check on pull requests

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -3,34 +3,32 @@ name: Prettier Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '**/*.md'
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
-    - name: Install Prettier
-      run: npm install prettier
+      - name: Install Prettier
+        run: npm install prettier
 
-    - name: Run Prettier Check on changed files
-      run: |
-        git fetch origin ${{ github.base_ref }}
-        CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.md$' || true)
-        if [ -n "$CHANGED_FILES" ]; then
-          echo "Checking files: $CHANGED_FILES"
-          npx prettier --check $CHANGED_FILES
-        else
-          echo "No markdown files changed."
-        fi
+      - name: Run Prettier Check on changed files
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.md$' || true)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Checking files: $CHANGED_FILES"
+            npx prettier --check $CHANGED_FILES
+          else
+            echo "No markdown files changed."
+          fi


### PR DESCRIPTION
# Pull Request

## Why This Change

The prettier check currently only runs when markdown files are modified in a PR. This prevents us from making it a required check in GitHub, as GitHub expects required checks to report a status for all PRs.

## What Changed

Removed the `paths` filter from the `pull_request` trigger in the Prettier check workflow.

**Files:**

- `.github/workflows/prettier.yml`

**Added/Changed/Fixed:**

- Removed `paths` filter from the `pull_request` trigger.

## Why This Matters

Enables setting the Prettier check as a required status check in GitHub.

## Context

Requested by user to enable required checks.

## Testing

Workflow still only runs the check on changed files in the script to avoid failing on existing unformatted files.
