### PR TITLE
feat: add YAML support to prettier checks

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -3,34 +3,32 @@ name: Prettier Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - '**/*.md'
 
 jobs:
   prettier:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
-    - name: Install Prettier
-      run: npm install prettier
+      - name: Install Prettier
+        run: npm install prettier
 
-    - name: Run Prettier Check on changed files
-      run: |
-        git fetch origin ${{ github.base_ref }}
-        CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep '\.md$' || true)
-        if [ -n "$CHANGED_FILES" ]; then
-          echo "Checking files: $CHANGED_FILES"
-          npx prettier --check $CHANGED_FILES
-        else
-          echo "No markdown files changed."
-        fi
+      - name: Run Prettier Check on changed files
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '\.md$|\.yaml$|\.yml$' || true)
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "Checking files: $CHANGED_FILES"
+            npx prettier --check $CHANGED_FILES
+          else
+            echo "No markdown or YAML files changed."
+          fi

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ status:
 	git status
 
 prettier-check:
-	npx prettier --check "**/*.md"
+	npx prettier --check "**/*.md" "**/*.yaml" "**/*.yml"
 
 prettier-write:
-	npx prettier --write "**/*.md"
+	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"


### PR DESCRIPTION
# Pull Request

## Why This Change

Prettier supports YAML files, but the check was only configured for Markdown files. This PR adds support for checking YAML files to ensure consistent formatting across the repository.

## What Changed

- Updated `Makefile` to include `**/*.yaml` and `**/*.yml` in `prettier-check` and `prettier-write` targets.
- Updated `.github/workflows/prettier.yml` to remove the `paths` filter (so it always runs) and updated the script to check for changed `.md`, `.yaml`, and `.yml` files.

**Files:**

- `Makefile`
- `.github/workflows/prettier.yml`

## Why This Matters

Ensures YAML files are also checked for formatting, maintaining repository code quality.

## Context

Follow-up to the change to make the prettier check always run.

## Testing

Ran `make prettier-check` and verified it checks YAML files. Note that 9 YAML files currently fail formatting, but the workflow only checks changed files in PRs, so it won't fail on existing files unless modified.
