### PR TITLE
feat: add vLLM Gemma example

### DIFF
--- a/examples/vllm-gemma/README.md
+++ b/examples/vllm-gemma/README.md
@@ -1,0 +1,19 @@
+# vLLM Gemma Example
+
+This directory contains an example of deploying vLLM configured to serve Google's Gemma models on Kubernetes, based on the [official GKE tutorial](https://docs.cloud.google.com/kubernetes-engine/docs/tutorials/serve-gemma-gpu-vllm).
+
+## Prerequisites
+
+- A Kubernetes cluster with GPU nodes (e.g., NVIDIA L4 or RTX Pro 6000).
+
+## Setup
+
+1.  Apply the manifests:
+    ```bash
+    kubectl apply -f deployment.yaml
+    kubectl apply -f service.yaml
+    ```
+
+## Configuration
+
+The `deployment.yaml` is configured to use the `gemma-4-e2b-it` model and the specialized Vertex AI vLLM image as described in the GKE tutorial.

--- a/examples/vllm-gemma/deployment.yaml
+++ b/examples/vllm-gemma/deployment.yaml
@@ -17,49 +17,49 @@ spec:
         examples.ai.gke.io/source: user-guide
     spec:
       containers:
-      - name: inference-server
-        image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve:gemma4
-        resources:
-          requests:
-            cpu: "2"
-            memory: "10Gi"
-            ephemeral-storage: "10Gi"
-            nvidia.com/gpu: "1"
-          limits:
-            cpu: "2"
-            memory: "10Gi"
-            ephemeral-storage: "10Gi"
-            nvidia.com/gpu: "1"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
-        args:
-          - --model=$(MODEL_ID)
-          - --host=0.0.0.0
-          - --port=8000
-          - --tensor-parallel-size=1
-          - --enable-log-requests
-          - --enable-chunked-prefill
-          - --enable-prefix-caching
-          - --enable-auto-tool-choice
-          - --generation-config=auto
-          - --tool-call-parser=gemma4
-          - --dtype=bfloat16
-          - --max-num-seqs=16
-          - --max-model-len=32768
-          - --gpu-memory-utilization=0.95
-          - --reasoning-parser=gemma4
-          - --trust-remote-code
-        env:
-        - name: LD_LIBRARY_PATH
-          value: ${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64
-        - name: MODEL_ID
-          value: google/gemma-4-E2B-it
+        - name: inference-server
+          image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve:gemma4
+          resources:
+            requests:
+              cpu: "2"
+              memory: "10Gi"
+              ephemeral-storage: "10Gi"
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "2"
+              memory: "10Gi"
+              ephemeral-storage: "10Gi"
+              nvidia.com/gpu: "1"
+          command: ["python3", "-m", "vllm.entrypoints.api_server"]
+          args:
+            - --model=$(MODEL_ID)
+            - --host=0.0.0.0
+            - --port=8000
+            - --tensor-parallel-size=1
+            - --enable-log-requests
+            - --enable-chunked-prefill
+            - --enable-prefix-caching
+            - --enable-auto-tool-choice
+            - --generation-config=auto
+            - --tool-call-parser=gemma4
+            - --dtype=bfloat16
+            - --max-num-seqs=16
+            - --max-model-len=32768
+            - --gpu-memory-utilization=0.95
+            - --reasoning-parser=gemma4
+            - --trust-remote-code
+          env:
+            - name: LD_LIBRARY_PATH
+              value: ${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64
+            - name: MODEL_ID
+              value: google/gemma-4-E2B-it
 
-        volumeMounts:
-        - mountPath: /dev/shm
-          name: dshm
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
       volumes:
-      - name: dshm
-        emptyDir:
+        - name: dshm
+          emptyDir:
             medium: Memory
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000

--- a/examples/vllm-gemma/deployment.yaml
+++ b/examples/vllm-gemma/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm-gemma-deployment
+  namespace: agent-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gemma-server
+  template:
+    metadata:
+      labels:
+        app: gemma-server
+        ai.gke.io/model: gemma-4-e2b-it
+        ai.gke.io/inference-server: vllm
+        examples.ai.gke.io/source: user-guide
+    spec:
+      containers:
+      - name: inference-server
+        image: us-docker.pkg.dev/vertex-ai/vertex-vision-model-garden-dockers/pytorch-vllm-serve:gemma4
+        resources:
+          requests:
+            cpu: "2"
+            memory: "10Gi"
+            ephemeral-storage: "10Gi"
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: "2"
+            memory: "10Gi"
+            ephemeral-storage: "10Gi"
+            nvidia.com/gpu: "1"
+        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        args:
+          - --model=$(MODEL_ID)
+          - --host=0.0.0.0
+          - --port=8000
+          - --tensor-parallel-size=1
+          - --enable-log-requests
+          - --enable-chunked-prefill
+          - --enable-prefix-caching
+          - --enable-auto-tool-choice
+          - --generation-config=auto
+          - --tool-call-parser=gemma4
+          - --dtype=bfloat16
+          - --max-num-seqs=16
+          - --max-model-len=32768
+          - --gpu-memory-utilization=0.95
+          - --reasoning-parser=gemma4
+          - --trust-remote-code
+        env:
+        - name: LD_LIBRARY_PATH
+          value: ${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64
+        - name: MODEL_ID
+          value: google/gemma-4-E2B-it
+
+        volumeMounts:
+        - mountPath: /dev/shm
+          name: dshm
+      volumes:
+      - name: dshm
+        emptyDir:
+            medium: Memory
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-rtx-pro-6000
+        cloud.google.com/gke-gpu-driver-version: latest

--- a/examples/vllm-gemma/service.yaml
+++ b/examples/vllm-gemma/service.yaml
@@ -8,6 +8,6 @@ spec:
     app: gemma-server
   type: ClusterIP
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 8000
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/examples/vllm-gemma/service.yaml
+++ b/examples/vllm-gemma/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-service
+  namespace: agent-system
+spec:
+  selector:
+    app: gemma-server
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000


### PR DESCRIPTION
# Pull Request

## Why This Change

The user requested an example for installing vLLM and Gemma in the `kube-agents` repository, similar to the existing LiteLLM example. This helps users understand how to deploy and serve open models like Gemma on GKE using vLLM.

## What Changed

Added a new example directory `examples/vllm-gemma/` containing:
- `README.md`: Instructions for setup based on the official GKE tutorial.
- `deployment.yaml`: Deployment spec for vLLM serving `gemma-4-e2b-it` on GPUs.
- `service.yaml`: Service mapping port 80 to vLLM's port 8000.

**Files:**

- `examples/vllm-gemma/README.md`
- `examples/vllm-gemma/deployment.yaml`
- `examples/vllm-gemma/service.yaml`

**Added/Changed/Fixed:**

- Added vLLM Gemma example.

## Why This Matters

Provides a concrete example for users to follow when deploying GKE agents that need to interact with locally served open models.

## Context

Requested by user in conversation `85968d40-05ce-4f5f-8c25-28c49c477d2c`.

## Testing

Manifests were validated with `dryRun: true` against the cluster, failing only on missing namespace which is expected for a clean setup.

---

Low risk, adds new example documentation and manifests.
