### PR TITLE
docs: forbid --fill with gh pr create in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,6 @@ To use these agents:
 - Use Conventional Commits for commit messages.
 - Push PR branches to a fork, not to the upstream repository.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
-  detail.
+  detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
 - When updating Markdown files, run `npx prettier --write <files>` on the
   changed Markdown files before committing.


### PR DESCRIPTION
# Pull Request

## Why This Change

To prevent AI agents (and humans) from bypassing the Pull Request template by using the `gh pr create --fill` command, ensuring that all PRs have the required structure and level of detail.

## What Changed

Updated `AGENTS.md` in the "Pull Request Hygiene" section to explicitly forbid the use of `--fill` with `gh pr create` because it bypasses the template.

**Files:**

- `AGENTS.md`

**Added/Changed/Fixed:**

- Added rule against using `--fill` with `gh pr create`.

## Why This Matters

Maintains quality and consistency of PR descriptions in the repository.

## Context

Prompted by a mistake I made in this conversation where I used `--fill` and missed the template.

## Testing

N/A (Documentation change).

---

Low risk documentation update.
