### PR TITLE
ci: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/agents/platform"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/agents/operator"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/agents/devteam"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
# Pull Request

## Why This Change

Dependabot should keep CI Actions and Docker base image references current without requiring manual update checks.

## What Changed

**Files:**

- `.github/dependabot.yml`

**Added/Changed/Fixed:**

- Added weekly Dependabot updates for GitHub Actions workflows.
- Added weekly Dependabot updates for Dockerfiles in `agents/platform`, `agents/operator`, and `agents/devteam`.
- Applied dependency labels and `ci` commit-message prefixes to generated PRs.

## Why This Matters

- Keeps workflow Actions current with upstream security and compatibility fixes.
- Surfaces Docker base image updates for each agent image.
- Reduces maintenance toil for routine dependency updates.

## Context

This is an initial low-noise Dependabot setup scoped to the dependency types currently present in the repository.

## Testing

- Parsed `.github/dependabot.yml` with Python/PyYAML.
- Ran `npx --yes prettier@latest --write .github/dependabot.yml` and confirmed it was unchanged.

---

No runtime behavior changes; this only enables dependency update PR automation.
