### PR TITLE
chore: pin hermes-agent image to specific digest

### DIFF
--- a/agents/devteam/Dockerfile
+++ b/agents/devteam/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent
+FROM nousresearch/hermes-agent:sha-bec2250d2c8349fc85201bcd1aa39bcaa766a555
 
 USER root
 

--- a/agents/operator/Dockerfile
+++ b/agents/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent
+FROM nousresearch/hermes-agent:sha-bec2250d2c8349fc85201bcd1aa39bcaa766a555
 
 USER root
 

--- a/agents/platform/Dockerfile
+++ b/agents/platform/Dockerfile
@@ -1,4 +1,4 @@
-FROM nousresearch/hermes-agent
+FROM nousresearch/hermes-agent:sha-bec2250d2c8349fc85201bcd1aa39bcaa766a555
 
 USER root
 


### PR DESCRIPTION
## Summary
Pins the `nousresearch/hermes-agent` base image to a specific digest (`sha-bec2250d2c8349fc85201bcd1aa39bcaa766a555`) in all Dockerfiles for reproducibility and security.

## Test Plan
- N/A (image update only)