### PR TITLE
feat: add auto PR review assignment workflow

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -9,7 +9,7 @@ reviewers:
       - bradhoekstra
       - jayantid
       - toshiowang
-      - dmitry
+      - dshnayder
 
 files:
   # Keys are glob expressions.

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,0 +1,34 @@
+reviewers:
+  # The default reviewers
+  defaults:
+    - repository-owners # group
+
+  # Reviewer groups each of which has a list of GitHub usernames
+  groups:
+    repository-owners:
+      - bradhoekstra
+      - GinnyJI
+      - haoxuw
+      - jayantid
+      - stalhaali
+      - toshiowang
+
+files:
+  # Keys are glob expressions.
+  # You can assign groups defined above as well as GitHub usernames.
+  "**":
+    - repository-owners # group
+
+options:
+  ignore_draft: true
+  ignored_keywords:
+    - DO NOT REVIEW
+  enable_group_assignment: false
+
+  # Randomly pick reviewers up to this number.
+  # Do not set this option if you'd like to assign all matching reviewers.
+  number_of_reviewers: 1
+
+  # If it's true, the last matching files-change pattern takes the most precedence (CODEOWNERS-compatible)
+  # See https://github.com/necojackarc/auto-request-review/pull/80 for more details.
+  last_files_match_only: false

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -7,11 +7,9 @@ reviewers:
   groups:
     repository-owners:
       - bradhoekstra
-      - GinnyJI
-      - haoxuw
       - jayantid
-      - stalhaali
       - toshiowang
+      - dmitry
 
 files:
   # Keys are glob expressions.

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,19 @@
+name: Auto Request Review
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.13.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Adds the auto PR review assignment workflow and configuration.
Default reviewers are set to `bradhoekstra`, `jayantid`, `toshiowang`, and `dshnayder`.

## Test Plan
- N/A (workflow configuration)