### PR TITLE
feat(operator): add details to weekly cost report heartbeat

### DIFF
--- a/workspace/agents/platform/templates/operator/HEARTBEAT.md
+++ b/workspace/agents/platform/templates/operator/HEARTBEAT.md
@@ -65,7 +65,12 @@ Each time you receive a heartbeat poll (triggered periodically by the agent harn
 ### 8. Weekly Cost Report
 
 - **Schedule**: Weekly (Every 7 days)
-- **Function**: Generate a detailed weekly cost report by integrating Google Cloud Billing data with Kubecost metrics to optimize resource spending.
+- **Function**: Generate a detailed weekly cost report by leveraging GKE Cost Allocation and integrating Google Cloud Billing data via BigQuery to optimize resource spending.
+- **Procedure**:
+  1. Check if GKE Cost Allocation is enabled (see `skills/gke-cost-analysis/SKILL.md` for details).
+  2. Use the `gke-cost-analysis` skill to query BigQuery for costs over the last 7 days, breaking it down by project, cluster, and namespace.
+  3. Compile a report summarizing total cost and top spenders.
+  4. Write the detailed report to `memory/reports/cost-report-$(date +%Y%m%d).md`.
 
 ### 9. Certificate Expiry Scan
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The weekly cost report task in the operator's heartbeat was underspecified and incorrectly mentioned Kubecost. We need to guide the agent to use the appropriate tool (BigQuery billing export) and skill (`gke-cost-analysis`).

## What Changed

Modified `workspace/agents/platform/templates/operator/HEARTBEAT.md` to reference the `gke-cost-analysis` skill and provide a high-level procedure for the weekly cost report.

**Files:**

- `workspace/agents/platform/templates/operator/HEARTBEAT.md`

**Added/Changed/Fixed:**

- Changed the `Function` description to mention GKE Cost Allocation.
- Added a `Procedure` section that references the `gke-cost-analysis` skill and outlines report generation steps.

## Why This Matters

Ensures the agent has clear instructions to generate cost reports effectively using the correct infrastructure (BigQuery).

## Context

Requested by user to add details to the operator heartbeat for the weekly cost report.

## Testing

Manual verification of documentation changes.

---

Low risk documentation update.

TAG=agy
CONV=5443f7c1-2864-4788-8fb1-94bdbab5e44b
