### PR TITLE
ci: split docker build and publish workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,6 @@
 name: Docker Build
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,70 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Load tags
+        run: cat tags.env >> "$GITHUB_ENV"
+
+      - name: Downcase repository name
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          echo "IMAGE_REPOSITORY=$(echo $GITHUB_REPO | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push DevTeam Agent
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: agents/devteam/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build and Push Operator Agent
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: agents/operator/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build and Push Platform Agent
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: agents/platform/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
         run: |
-          echo "IMAGE_REPOSITORY=$(echo $GITHUB_REPO | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "IMAGE_REPOSITORY=$(echo "$GITHUB_REPO" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
# Pull Request

## Why This Change

Currently, the Docker build workflow runs on both push and pull request events. This causes redundant builds when pushing directly to main (which triggers the publish workflow anyway) and runs the publish step when it's only necessary to test whether the docker build succeeds for pull requests. 

By splitting this into two workflows:
1. `docker-build.yml` (which only runs `pull_request` on `main` to check if it builds successfully).
2. `docker-publish.yml` (which runs `push` on `main` to build and publish the updated images to GHCR).

We optimize CI build times and cleanly separate the validation phase from the release/publishing phase.

## What Changed

- Modified `.github/workflows/docker-build.yml` to trigger only on `pull_request` to `main`.
- Created `.github/workflows/docker-publish.yml` to trigger only on `push` to `main`, building and publishing DevTeam, Operator, and Platform agents to GHCR.

**Files:**

- `.github/workflows/docker-build.yml`
- `.github/workflows/docker-publish.yml`

**Added/Changed/Fixed:**

- Removed push triggers from `docker-build.yml`.
- Added `docker-publish.yml` with push triggers to `main` and steps to push built Docker images to GHCR.

## Why This Matters

- Reduces redundant CI runs on main.
- Speeds up pull request validation.
- Ensures docker images are only published to the registry upon successful merge into the main branch.

## Context

This separates testing from publishing.

## Testing

Tested by verifying the YAML configuration formats.
