### PR TITLE
fix(ci): add explicit permissions to github workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses GitHub Code Scanning Alert #2 (and #1) which flagged missing GITHUB_TOKEN permissions in the CI workflows. By default, if no permissions are explicitly specified, workflows inherit the default permissions of the repository (which can sometimes be read-write). This violates the principle of least privilege.

## What Changed

Explicitly set `permissions: contents: read` for the Prettier and Docker Build workflows to restrict the GITHUB_TOKEN to read-only repository access.

**Files:**

- `.github/workflows/prettier.yml`
- `.github/workflows/docker-build.yml`

**Added/Changed/Fixed:**

- Added `permissions: contents: read` block to `.github/workflows/prettier.yml`
- Added `permissions: contents: read` block to `.github/workflows/docker-build.yml`

## Why This Matters

Restricting workflow permissions mitigates the risk of token theft or compromise. If a dependency or action in the workflow is compromised, the attacker will only have read access to public/accessible contents rather than write access to the repository.

## Context

- Closes Code Scanning Alert #2: https://github.com/gke-labs/kube-agents/security/code-scanning/2
- Closes Code Scanning Alert #1: https://github.com/gke-labs/kube-agents/security/code-scanning/1

## Testing

- Validated both workflows locally using a YAML parser to ensure syntactical correctness.

---

Low risk change with no functional impact on the agents or the build output. Safe to merge.
