### PR TITLE
fix: resolve docker-publish paths and restrict to upstream repository

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: github.repository == 'gke-labs/kube-agents'
     permissions:
       contents: read
       packages: write
@@ -37,7 +38,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: agents/devteam/Dockerfile
+          file: agents/Dockerfile
+          target: devteam
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
@@ -49,7 +51,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: agents/operator/Dockerfile
+          file: agents/Dockerfile
+          target: operator
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
@@ -61,7 +64,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: agents/platform/Dockerfile
+          file: agents/Dockerfile
+          target: platform
           push: true
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest


### PR DESCRIPTION
# Pull Request

## Why This Change

The Docker publish workflow in GitHub Actions was failing due to path mismatches (seeking nonexistent individual Dockerfiles in the agent directories) and we want to restrict it to run only on the main repository to avoid failures/unwanted behavior on forks.

## What Changed

**Files:**

- `.github/workflows/docker-publish.yml`

**Added/Changed/Fixed:**

- Fixed build steps to use the unified `agents/Dockerfile` and specified the correct build targets (`devteam`, `operator`, `platform`).
- Added a condition `if: github.repository == 'gke-labs/kube-agents'` to the publish job.

## Why This Matters

- Fixes CI/CD publication pipeline issues so new versions of the agents can be pushed to GHCR successfully.
- Prevents the publish pipeline from running or failing in forks of `kube-agents`.

## Context

- Relates to: https://github.com/gke-labs/kube-agents/actions/runs/26841387250/job/79149119348

## Testing

- Verified using `actionlint` locally on `.github/workflows/docker-publish.yml` to ensure schema validity.
- Successfully verified local Docker builds of all three agent targets using `make docker-build`.
- **Verified locally with `act` (GitHub Actions local runner):**
  - Simulated running on the fork (`--remote-name origin` -> `bradhoekstra/kube-agents`), and confirmed that the job **correctly skipped** execution.
  - Simulated running on the upstream repository (`--remote-name upstream` -> `gke-labs/kube-agents`), and confirmed that the job successfully resolved the new Dockerfile paths and target stages (`devteam`, `operator`, `platform`) and completed dry-run execution successfully.

---

Minimal risk since this only fixes build paths in GitHub Actions workflows and applies upstream constraints.
