### PR TITLE
fix(platform): prevent clear-text logging of sensitive data

### DIFF
--- a/agents/platform/defaults/scripts/platform_mcp_server.py
+++ b/agents/platform/defaults/scripts/platform_mcp_server.py
@@ -78,7 +78,7 @@ def call_agent_api(endpoint: str, api_key: str, query: str, agent_id: str) -> st
         "messages": [{"role": "user", "content": query}]
     }
 
-    log(f"Sending secure synchronous call to '{agent_id}' at: {url}")
+    log(f"Sending secure synchronous call to '{agent_id}'")
     req = urllib.request.Request(
         url, 
         data=json.dumps(payload).encode("utf-8"), 


### PR DESCRIPTION
# Pull Request

## Why This Change

Prevent clear-text logging of sensitive data. CodeQL flagged a security alert because the platform agent logs the full URL which contains tainted info (the endpoint is in the same file as the API key).

## What Changed

**Files:**

- `agents/platform/defaults/scripts/platform_mcp_server.py`

**Added/Changed/Fixed:**

- Removed the URL from the log statement in `call_agent_api`, logging only the `agent_id`.

## Why This Matters

Fixes a security vulnerability (CWE-532: Insertion of Sensitive Information into Log File) and resolves Code Scanning Alert #3.

## Context

Fixes security alert #3.

## Testing

Verified syntax by compiling the python script.

---

TAG=agy
CONV=26a09df3-fb35-4998-bbc1-b451fcccf4d3
