### PR TITLE
feat(agents): add Google Chat integration libraries

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -29,6 +29,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 
+RUN /usr/local/bin/uv pip install \
+    google-api-python-client \
+    google-auth \
+    google-cloud-pubsub
+
 # 4. Apply the common stage2-hook patch
 COPY agents/shared/stage2-hook.patch /tmp/stage2-hook.patch
 RUN patch /opt/hermes/docker/stage2-hook.sh < /tmp/stage2-hook.patch && rm /tmp/stage2-hook.patch


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform Agent needs to integrate with Google Chat, which requires specific Google API client libraries and Pub/Sub support.

## What Changed

Added installation of Google Chat integration libraries to the base agent Docker image.

**Files:**

- `agents/Dockerfile`

**Added/Changed/Fixed:**

- Installed `google-api-python-client`, `google-auth`, and `google-cloud-pubsub` in the `agent-base` stage using `uv pip`.

## Why This Matters

Enables agents to use Google Chat APIs and interact with Google Cloud Pub/Sub for messaging and event handling.

## Context

Related to Google Chat integration feature.

## Testing

Validated by successfully building the Docker image target `platform` locally.
