### PR TITLE
fix: install hermes-agent in correct venv in Dockerfile

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -29,10 +29,11 @@ RUN ARCH=$(dpkg --print-architecture) && \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb
 
-RUN /usr/local/bin/uv pip install \
+RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     google-api-python-client \
     google-auth \
-    google-cloud-pubsub
+    google-cloud-pubsub \
+    "hermes-agent[google_chat]"
 
 # 4. Apply the common stage2-hook patch
 COPY agents/shared/stage2-hook.patch /tmp/stage2-hook.patch


### PR DESCRIPTION
## Summary
- Use correct python path for uv pip install in Dockerfile to target the hermes venv.
- Add `hermes-agent[google_chat]` to the installed packages.

## Test Plan
- N/A
