### PR TITLE
fix(cron): replace legacy value field with expr in jobs.json

### DIFF
--- a/agents/operator/defaults/cron/jobs.json
+++ b/agents/operator/defaults/cron/jobs.json
@@ -5,7 +5,7 @@
       "name": "Cluster Heartbeat",
       "schedule": {
         "kind": "cron",
-        "value": "*/15 * * * *",
+        "expr": "*/15 * * * *",
         "display": "*/15 * * * *"
       },
       "prompt": "Perform a comprehensive 15-minute diagnostic scan across all clusters (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Maintain constant system awareness.",
@@ -17,7 +17,7 @@
       "name": "Utilization Optimizer",
       "schedule": {
         "kind": "cron",
-        "value": "*/15 * * * *",
+        "expr": "*/15 * * * *",
         "display": "*/15 * * * *"
       },
       "prompt": "Proactively evaluate cluster-wide resource utilization. Propose resource right-sizing or node pool adjustments to optimize capacity based on real-time pressure signals.",
@@ -29,7 +29,7 @@
       "name": "CVE Scan",
       "schedule": {
         "kind": "cron",
-        "value": "0 * * * *",
+        "expr": "0 * * * *",
         "display": "0 * * * *"
       },
       "prompt": "Conduct hourly container image vulnerability scan. Read '/opt/defaults/procedures/cve_scan_sop.md' and audit running container images against registries, alerting only on new findings.",
@@ -41,7 +41,7 @@
       "name": "Daily Cluster Report",
       "schedule": {
         "kind": "cron",
-        "value": "0 0 * * *",
+        "expr": "0 0 * * *",
         "display": "0 0 * * *"
       },
       "prompt": "Compile a comprehensive daily health summary. Analyze the heartbeats from the previous 24 hours, GKE operational states, active incidents, and cost usage deltas.",
@@ -53,7 +53,7 @@
       "name": "Log Cleanup",
       "schedule": {
         "kind": "cron",
-        "value": "0 1 * * *",
+        "expr": "0 1 * * *",
         "display": "0 1 * * *"
       },
       "prompt": "Automatically rotate and purge old system logs to ensure sufficient disk space on control plane and worker nodes.",
@@ -65,7 +65,7 @@
       "name": "Stale Object Cleanup",
       "schedule": {
         "kind": "cron",
-        "value": "0 2 * * *",
+        "expr": "0 2 * * *",
         "display": "0 2 * * *"
       },
       "prompt": "Automatically prune orphaned ReplicaSets, completed Jobs, and other ephemeral Kubernetes objects to reduce database bloat.",
@@ -77,7 +77,7 @@
       "name": "Backup Validation",
       "schedule": {
         "kind": "cron",
-        "value": "0 3 * * *",
+        "expr": "0 3 * * *",
         "display": "0 3 * * *"
       },
       "prompt": "Verify the integrity of recent volume snapshots and backups to ensure disaster recovery readiness.",
@@ -89,7 +89,7 @@
       "name": "Weekly Cost Report",
       "schedule": {
         "kind": "cron",
-        "value": "0 4 * * 0",
+        "expr": "0 4 * * 0",
         "display": "0 4 * * 0"
       },
       "prompt": "Generate a detailed weekly cost report. Read '/opt/defaults/procedures/weekly_cost_report_sop.md' to leverage GKE Cost Allocation and integrate Google Cloud Billing data.",
@@ -101,7 +101,7 @@
       "name": "Certificate Expiry Scan",
       "schedule": {
         "kind": "cron",
-        "value": "0 5 * * 0",
+        "expr": "0 5 * * 0",
         "display": "0 5 * * 0"
       },
       "prompt": "Check expiration dates for all TLS certificates and secrets in the clusters to preemptively alert on potential outages.",

--- a/agents/platform/defaults/cron/jobs.json
+++ b/agents/platform/defaults/cron/jobs.json
@@ -5,7 +5,7 @@
       "name": "Blueprint Sync",
       "schedule": {
         "kind": "cron",
-        "value": "0 9 * * *",
+        "expr": "0 9 * * *",
         "display": "0 9 * * *"
       },
       "prompt": "Execute GKE blueprint alignment audit. Read '/opt/defaults/governance/blueprint_sync_sop.md' and perform the daily GKE cluster compliance checks against the master blueprints.",
@@ -17,7 +17,7 @@
       "name": "Compliance Audit",
       "schedule": {
         "kind": "cron",
-        "value": "0 9 * * 0",
+        "expr": "0 9 * * 0",
         "display": "0 9 * * 0"
       },
       "prompt": "Execute fleet-wide security compliance audit. Read '/opt/defaults/governance/compliance_audit_sop.md' and scan all clusters for deviations from corporate GKE security and network policies.",
@@ -29,7 +29,7 @@
       "name": "Policy Propagation",
       "schedule": {
         "kind": "cron",
-        "value": "0 * * * *",
+        "expr": "0 * * * *",
         "display": "0 * * * *"
       },
       "prompt": "Propagate updated operational policies. Read '/opt/defaults/governance/policy_propagation_sop.md' and sync the latest security policies and resource configs to active operators.",
@@ -41,7 +41,7 @@
       "name": "Global Capacity Orchestrator",
       "schedule": {
         "kind": "cron",
-        "value": "0 * * * *",
+        "expr": "0 * * * *",
         "display": "0 * * * *"
       },
       "prompt": "Execute cross-cluster capacity optimization. Read '/opt/defaults/governance/global_capacity_orchestrator_sop.md' to analyze fleet-wide regional demand and direct operators to balance capacity pools.",
@@ -53,7 +53,7 @@
       "name": "Fleet-wide Cost Analysis",
       "schedule": {
         "kind": "cron",
-        "value": "0 10 * * *",
+        "expr": "0 10 * * *",
         "display": "0 10 * * *"
       },
       "prompt": "Execute daily cost delta audit. Read '/opt/defaults/governance/fleet_wide_cost_analysis_sop.md' to aggregate cost usage stats across all clusters and identify saving opportunities.",
@@ -65,7 +65,7 @@
       "name": "Security Patch Orchestrator",
       "schedule": {
         "kind": "cron",
-        "value": "0 11 * * *",
+        "expr": "0 11 * * *",
         "display": "0 11 * * *"
       },
       "prompt": "Run vulnerability and patch compliance scan. Read '/opt/defaults/governance/security_patch_orchestrator_sop.md' to identify GKE vulnerabilities and coordinate staggered emergency rolling updates.",
@@ -77,7 +77,7 @@
       "name": "Lifecycle / Deprecation Manager",
       "schedule": {
         "kind": "cron",
-        "value": "0 9 1 * *",
+        "expr": "0 9 1 * *",
         "display": "0 9 1 * *"
       },
       "prompt": "Execute monthly toolchain lifecycle audit. Read '/opt/defaults/governance/lifecycle_deprecation_manager_sop.md' to track K8s version deprecations and proactively notify development teams.",
@@ -89,7 +89,7 @@
       "name": "Standardization Validator",
       "schedule": {
         "kind": "cron",
-        "value": "0 10 * * 0",
+        "expr": "0 10 * * 0",
         "display": "0 10 * * 0"
       },
       "prompt": "Run weekly structural GKE alignment audit. Read '/opt/defaults/governance/standardization_validator_sop.md' to perform deep-diff analysis between GKE live states and global standards.",
@@ -101,7 +101,7 @@
       "name": "Obtainability Audit",
       "schedule": {
         "kind": "cron",
-        "value": "0 12 * * *",
+        "expr": "0 12 * * *",
         "display": "0 12 * * *"
       },
       "prompt": "Execute dynamic capacity pool alignment audit. Read '/opt/defaults/governance/obtainability_audit_sop.md' to identify rigid cluster allocations and generate YAML patches to align with flexible capacity.",


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform and Operator agents were configured with cron jobs using the legacy `value` key in their `schedule` block. The underlying Hermes agent runner expects the `expr` key for cron schedules. Using `value` caused the scheduler to fail to parse the cron expression, preventing the scheduled jobs (like heartbeats, CVE scans, etc.) from running.

## What Changed

Renamed the `value` key to `expr` in the `schedule` configuration for all cron jobs in both agent default configurations.

**Files:**

- `agents/operator/defaults/cron/jobs.json`
- `agents/platform/defaults/cron/jobs.json`

**Added/Changed/Fixed:**

- Changed `"value": "..."` to `"expr": "..."` for 9 jobs in Operator's `jobs.json`.
- Changed `"value": "..."` to `"expr": "..."` for 9 jobs in Platform's `jobs.json`.

## Why This Matters

This fix enables the scheduled heartbeats and operational tasks (SOPs) to run as intended, ensuring system awareness and proactive remediation capabilities are functional.

## Context

This is a follow-up fix for the native cron heartbeat implementation.

## Testing

Validated both `jobs.json` files using a custom python validation script (`validate_jobs.py`) which verified:
- JSON syntax is correct.
- `expr` field is present for all `cron` jobs.
- No legacy `value` fields remain.

---
TAG=agy
CONV=5e711abd-5d0e-4f09-9471-49bf86778e98
