### PR TITLE
feat(platform): implement GKE operator agent dynamic provisioning

### DIFF
--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -111,5 +111,8 @@ COPY --chmod=644 agents/platform/config.yaml /tmp/platform-config.yaml
 # Copy devteam deployment template
 COPY --chmod=644 agents/devteam/deployment.yaml /opt/defaults/templates/devteam/deployment.yaml
 
+# Copy operator deployment template
+COPY --chmod=644 agents/operator/deployment.yaml /opt/defaults/templates/operator/deployment.yaml
+
 # Dynamically merge config.yamls using virtualenv python
 RUN /opt/hermes/.venv/bin/python3 -c "import pathlib, yaml; p1=pathlib.Path('/opt/defaults/config.yaml'); p2=pathlib.Path('/tmp/platform-config.yaml'); s=yaml.safe_load(p1.read_text()) if p1.exists() else {}; p=yaml.safe_load(p2.read_text()) if p2.exists() else {}; s.update(p); p1.write_text(yaml.safe_dump(s))" && rm -f /tmp/platform-config.yaml

--- a/agents/operator/deployment.yaml
+++ b/agents/operator/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
 type: Opaque
 stringData:
   api-server-key: "<API_SERVER_KEY>"
-  github-token: "<GITHUB_TOKEN>"
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -84,11 +83,6 @@ spec:
                 secretKeyRef:
                   name: operator-agent-secrets
                   key: api-server-key
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: operator-agent-secrets
-                  key: github-token
             - name: MODEL_NAME
               value: "gemini-model"
             - name: MODEL_BASE_URL

--- a/agents/operator/deployment.yaml
+++ b/agents/operator/deployment.yaml
@@ -1,3 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: operator-agent-sa
+  namespace: agent-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-agent-secrets
+  namespace: agent-system
+type: Opaque
+stringData:
+  api-server-key: "<API_SERVER_KEY>"
+  github-token: "<GITHUB_TOKEN>"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: operator-agent-config
+  namespace: agent-system
+data:
+  SETTINGS.md: |
+    # GKE Scope Configuration
+    - **Cluster Name:** <CLUSTER_NAME>
+    - **Cluster Location:** <CLUSTER_LOCATION>
+    - **Git Repo:** <GIT_REPO>
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: operator-agent-pvc
+  namespace: agent-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,6 +56,7 @@ spec:
         app: operator-agent
     spec:
       runtimeClassName: gvisor
+      serviceAccountName: operator-agent-sa
       containers:
         - name: operator-agent
           image: <REPO>/operator-agent:latest
@@ -43,6 +84,11 @@ spec:
                 secretKeyRef:
                   name: operator-agent-secrets
                   key: api-server-key
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: operator-agent-secrets
+                  key: github-token
             - name: MODEL_NAME
               value: "gemini-model"
             - name: MODEL_BASE_URL
@@ -52,19 +98,54 @@ spec:
           volumeMounts:
             - name: data-volume
               mountPath: /opt/data
+            - name: config-volume
+              mountPath: /opt/data/SETTINGS.md
+              subPath: SETTINGS.md
       volumes:
         - name: data-volume
           persistentVolumeClaim:
             claimName: operator-agent-pvc
+        - name: config-volume
+          configMap:
+            name: operator-agent-config
 ---
-apiVersion: v1
-kind: PersistentVolumeClaim
+# --- Strict Read-Only Cluster Permissions ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: operator-agent-pvc
-  namespace: agent-system
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi
+  name: operator-agent-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      [
+        "nodes",
+        "namespaces",
+        "pods",
+        "services",
+        "events",
+        "persistentvolumes",
+        "serviceaccounts",
+      ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "daemonsets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-agent-cluster-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: operator-agent-sa
+    namespace: agent-system
+roleRef:
+  kind: ClusterRole
+  name: operator-agent-cluster-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Pull Request

## Why This Change

To enable the Platform Agent to dynamically and securely provision GKE Operator Agents. The Operator Agent requires a structured, templated deployment manifest that includes secure token setups and least-privilege RBAC boundaries to run safely on target GKE clusters.

## What Changed

We packaged the Operator Agent's deployment template and defined its security/access perimeter.

**Files:**

- `agents/Dockerfile`
- `agents/operator/deployment.yaml`

**Added/Changed/Fixed:**

- **Dockerfile Update**: Configured `agents/Dockerfile` to copy the operator `deployment.yaml` template into `/opt/defaults/templates/operator/` so the Platform Agent's provisioning skill can read and parameterize it at runtime.
- **Operator Manifest Enrichment**:
  - Added a dedicated `ServiceAccount` (`operator-agent-sa`) and `Secret` placeholder (`operator-agent-secrets`) to secure the API Server Key and GitHub Token.
  - Added a `ConfigMap` block (`operator-agent-config`) to dynamically mount GKE scope parameters (`CLUSTER_NAME`, `CLUSTER_LOCATION`, `GIT_REPO`) to `/opt/data/SETTINGS.md`.
  - Defined a **Strict Read-Only `ClusterRole`** and binding, limiting the Operator Agent to only get, list, and watch core resources (nodes, namespaces, pods, services, deployments, networkpolicies) to ensure zero unauthorized mutations inside the cluster.
  - Retained the upstream `runtimeClassName: gvisor` configuration for sandbox isolation.

## Why This Matters

This change enforces the secure boundary of the multi-agent system. By locking the GKE Operator Agent to a strict read-only RBAC configuration, we guarantee it operates as an observer. Any remediations or optimizations it identifies will be proposed via Git/PR workflows rather than direct cluster mutations.

## Context

This is the foundational manifest change required for the Platform Agent's dynamic Operator provisioning flow.

## Testing

- Rebuilt the unified container image locally to verify the template copy hook triggers successfully on startup.
- Manually verified the YAML syntax and indentation structure of the new RBAC resources.

---
TAG=agy
CONV=5215139b-367f-427f-b0cf-f8d969466b27
