### PR TITLE
feat(platform): support X-Hermes-Session-Id in call_agent for continu…

### DIFF
--- a/agents/platform/defaults/scripts/platform_mcp_server.py
+++ b/agents/platform/defaults/scripts/platform_mcp_server.py
@@ -73,8 +73,9 @@ def call_agent_api(endpoint: str, api_key: str, query: str, agent_id: str, sessi
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}"
     }
-    if session_id:
-        headers["X-Hermes-Session-Id"] = session_id
+    clean_session_id = "".join(c for c in str(session_id) if c.isalnum() or c in "-_.").strip() if session_id else ""
+    if clean_session_id:
+        headers["X-Hermes-Session-Id"] = clean_session_id
     payload = {
         "model": "hermes-agent",
         "messages": [{"role": "user", "content": query}]

--- a/agents/platform/defaults/scripts/platform_mcp_server.py
+++ b/agents/platform/defaults/scripts/platform_mcp_server.py
@@ -62,7 +62,7 @@ def resolve_agent_credentials(agent_id: str) -> tuple[str, str]:
 
     return endpoint, api_key
 
-def call_agent_api(endpoint: str, api_key: str, query: str, agent_id: str) -> str:
+def call_agent_api(endpoint: str, api_key: str, query: str, agent_id: str, session_id: str = "") -> str:
     """Perform the synchronous HTTP POST call to the target agent's completions API using Bearer Token auth."""
     protocol = "https" if endpoint.startswith("https://") else "http"
     clean_endpoint = endpoint.replace("http://", "").replace("https://", "")
@@ -73,6 +73,8 @@ def call_agent_api(endpoint: str, api_key: str, query: str, agent_id: str) -> st
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}"
     }
+    if session_id:
+        headers["X-Hermes-Session-Id"] = session_id
     payload = {
         "model": "hermes-agent",
         "messages": [{"role": "user", "content": query}]
@@ -334,7 +336,7 @@ def list_operators() -> str:
 
 
 @mcp.tool()
-def call_agent(target_agent_id: str, query: str) -> str:
+def call_agent(target_agent_id: str, query: str, session_id: str = "") -> str:
     """
     Directly and securely execute a synchronous, token-authorized completions API call
     to a GKE Operator or DevTeam agent across clusters in your GKE fleet.
@@ -347,12 +349,17 @@ def call_agent(target_agent_id: str, query: str) -> str:
     Args:
         target_agent_id: The unique ID of the target agent (e.g., 'operator-mercury-03-us-central1').
         query: The natural language query or operational instruction to send to the target agent.
+        session_id: Optional. An arbitrary stable string (like a UUID) to maintain conversation 
+            continuity. If you wish to have a continuous, multi-turn conversation with the 
+            target agent, generate a session ID and pass the same value in subsequent calls 
+            to this agent. If omitted, the call is treated as stateless.
     """
     try:
         endpoint, api_key = resolve_agent_credentials(target_agent_id)
     except ValueError as e:
         return str(e)
-    return call_agent_api(endpoint, api_key, query, target_agent_id)
+    
+    return call_agent_api(endpoint, api_key, query, target_agent_id, session_id)
 
 
 @mcp.tool()


### PR DESCRIPTION
# Pull Request

## Why This Change

To support continuous, stateful, multi-turn conversations between GKE Platform Agents and subagents (Operator or DevTeam agents) across the fleet. Previously, cross-agent calls via the `call_agent` MCP tool were stateless, preventing subagents from maintaining conversation context.

## What Changed

Added a `session_id` parameter to the `call_agent` tool and the underlying `call_agent_api` HTTP client helper to forward the `X-Hermes-Session-Id` header to the target agent.

**Files:**

- `agents/platform/defaults/scripts/platform_mcp_server.py`

**Added/Changed/Fixed:**

- Updated `call_agent_api()` signature to accept `session_id` and conditionally add `X-Hermes-Session-Id` to outbound HTTP headers.
- Updated `call_agent()` MCP tool definition to accept an optional `session_id` argument.
- Documented `session_id` usage in the `call_agent` tool docstring, explaining how the calling agent can pass a stable string (e.g., UUID) to maintain stateful multi-turn contexts.

## Why This Matters

This allows cooperative multi-agent operations to execute complex, multi-step tasks that require iterative back-and-forth communication while preserving conversational context (e.g. debugging loops, progressive configurations).

## Context

Follow-up to allow the Hermes gateway to run stateful orchestrations.

## Testing

Manually deployed the updated script to a running `platform-agent` pod in the `agentic-harness-management` GKE cluster. Verified that the `platform-agent` MCP server loaded the tool with the updated signature and successfully forwarded the session header.

---
TAG=agy
CONV=53a7d6e4-fa77-4f6e-a794-905c88fb36f9
