### PR TITLE
fix(platform): add SETUID and SETGID capabilities

### DIFF
--- a/agents/platform/deployment.yaml
+++ b/agents/platform/deployment.yaml
@@ -69,6 +69,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+              # Required by s6-overlay to drop privileges to the non-root user
               add:
                 - SETUID
                 - SETGID

--- a/agents/platform/deployment.yaml
+++ b/agents/platform/deployment.yaml
@@ -69,6 +69,9 @@ spec:
             capabilities:
               drop:
                 - ALL
+              add:
+                - SETUID
+                - SETGID
           ports:
             - containerPort: 8642
               name: api


### PR DESCRIPTION
# Pull Request

## Why This Change

The `platform-agent` pod fails to start with a `CrashLoopBackOff` error, showing the following logs:
```
s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted
cont-init: info: /etc/cont-init.d/01-hermes-setup exited 111
```

This occurs because a recent security hardening change dropped all Linux capabilities (`capabilities.drop: [ALL]`). The container uses `s6-overlay` which starts as root and attempts to drop privileges to the `hermes` user. Dropping `ALL` capabilities removes `CAP_SETGID` and `CAP_SETUID`, which are required by `s6-applyuidgid` to switch users and set supplementary groups, causing the startup wrapper to fail.

## What Changed

Added the `SETUID` and `SETGID` capabilities back to the allowed list for the `platform-agent` container.

**Files:**

- `agents/platform/deployment.yaml`

**Added/Changed/Fixed:**

- Updated `securityContext.capabilities.add` in the container spec to include `SETUID` and `SETGID`.

## Why This Matters

This resolves the startup crash of the Platform Agent while maintaining a hardened security profile (all other capabilities are still dropped, and privilege escalation is still disabled).

## Context

Fixes the startup failure introduced in the GitHub token broker integration PR (#80).

Other deployments in the repo were audited:
- `github-token-minter` runs directly as non-root (`runAsNonRoot: true`, `runAsUser: 10001`) and does not use `s6-overlay`, so it does not require `SETUID`/`SETGID` and runs fine with `drop: [ALL]`.
- Other agents do not drop all capabilities and are unaffected.

## Testing

Manually patched the deployment on the `agentic-harness-management` GKE cluster. Verified that the pod started successfully and reached `Running` (1/1) status with 0 restarts.

---
TAG=agy
CONV=53a7d6e4-fa77-4f6e-a794-905c88fb36f9
