### PR TITLE
feat(platform): add platform-agent-read-all permissions to platform-agent-role

### DIFF
--- a/agents/platform/deployment.yaml
+++ b/agents/platform/deployment.yaml
@@ -20,6 +20,29 @@ rules:
   - apiGroups: ["container.cnrm.cloud.google.com"]
     resources: ["containerclusters"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumeclaims
+      - events
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["platform.harness.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Why This Change

Enables comprehensive cluster-wide observability for the GKE Platform Agent across non-secret Core resources, applications, batch jobs, and gateway resources, as defined in `platform-agent-read-all.yaml`.

## What Changed

**Files:**

- `agents/platform/deployment.yaml`

**Added/Changed/Fixed:**

- Added read and watch permissions (`get`, `list`, `watch`) for Core resources (`pods`, `pods/log`, `services`, `endpoints`, `configmaps`, `persistentvolumeclaims`, `events`, `serviceaccounts`) under `platform-agent-role`.
- Added read and watch permissions for `apps`, `batch`, `networking.k8s.io`, and `platform.harness.io` API groups (`*`).

## Why This Matters

- Equips the Platform Agent to monitor fleet health and route status accurately without granting elevated secret-reading or cluster mutation privileges.

## Context

- Incorporates least-privilege observability rules from `platform-agent-read-all.yaml`.

## Testing

- Verified manifest applies cleanly and role syntax matches GKE RBAC validation standards.

---

Rollout is safe and backwards-compatible for existing agent pods.
