### PR TITLE
ci: prevent skills under defaults/skills

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,21 @@
+name: Validate Repo Structure
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Validate Structure
+        run: make validate

--- a/Makefile
+++ b/Makefile
@@ -39,13 +39,15 @@ prettier-write:
 	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
 
 validate:
-ifneq ($(BAD_SKILLS),)
-	@echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"
-	@for file in $(BAD_SKILLS); do echo "  $$file"; done
-	@exit 1
-else
-	@echo "Validation passed: No skills found in invalid paths."
-endif
+	@if [ -n "$(BAD_SKILLS)" ]; then \
+		echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"; \
+		set -- $(BAD_SKILLS); \
+		for file; do echo "  $$file"; done; \
+		exit 1; \
+	else \
+		echo "Validation passed: No skills found in invalid paths."; \
+	fi
+
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ include tags.env
 LOCATION ?= us-central1
 REPO ?= $(eval REPO := $(LOCATION)-docker.pkg.dev/$(shell gcloud config get core/project)/kube-agents)$(REPO)
 
-.PHONY: default docker-build docker-build-agents docker-push docker-push-agents status prettier-check prettier-write
+BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
+
+.PHONY: default docker-build docker-build-agents docker-push docker-push-agents status prettier-check prettier-write validate
 
 # Only match directories under agents/
 AGENTS := $(filter-out shared,$(notdir $(patsubst %/,%,$(wildcard agents/*/))))
@@ -35,3 +37,11 @@ prettier-check:
 
 prettier-write:
 	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
+
+validate:
+	@if [ -n "$(BAD_SKILLS)" ]; then \
+		echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"; \
+		for file in $(BAD_SKILLS); do echo "  $$file"; done; \
+		exit 1; \
+	fi
+

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ ifneq ($(BAD_SKILLS),)
 	@echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"
 	@for file in $(BAD_SKILLS); do echo "  $$file"; done
 	@exit 1
+else
+	@echo "Validation passed: No skills found in invalid paths."
 endif
+
 
 

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,10 @@ prettier-write:
 	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
 
 validate:
-	@if [ -n "$(BAD_SKILLS)" ]; then \
-		echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"; \
-		for file in $(BAD_SKILLS); do echo "  $$file"; done; \
-		exit 1; \
-	fi
+ifneq ($(BAD_SKILLS),)
+	@echo "Error: Skills should not be placed under agents/*/defaults/skills. Move them to agents/*/skills/"
+	@for file in $(BAD_SKILLS); do echo "  $$file"; done
+	@exit 1
+endif
+
 


### PR DESCRIPTION
## Summary
Adds a validation check to prevent skills from being incorrectly placed under `agents/*/defaults/skills/`.
This prevents regressions like the one fixed in PR #101.

The solution includes:
1. A `validate` target in the `Makefile` using GNU Make wildcards.
2. A new GitHub Actions workflow `validate.yml` that runs `make validate` on PRs.

## Test Plan
Verified locally that `make validate` fails when a skill exists in `agents/devteam/defaults/skills/...` and passes when it is removed/moved.