### PR TITLE
fix(shared): add default key to model config for hermes compatibility

### DIFF
--- a/agents/shared/defaults/config.yaml
+++ b/agents/shared/defaults/config.yaml
@@ -1,6 +1,7 @@
 model:
   provider: custom
   model: gemini-model
+  default: gemini-model
   base_url: http://litellm.agent-system.svc.cluster.local/v1
   api_key: none
 


### PR DESCRIPTION
## Why This Change

    The Platform Agent was failing to initialize its model, starting up with `Model: (not set)` and subsequently failing with a `ProxyModelNotFoundError` (400) when trying to communicate with the LiteLLM proxy.

    Upon inspecting the Hermes OSS source code inside the running pod, we discovered a parser inconsistency in the framework:
    *   The main model resolution code ([`auxiliary_client.py:_read_main_model`](https://github.com/NousResearch/hermes-agent/blob/main/agent/auxiliary_client.py)) strictly expects a key named **`default`** when the `model` configuration is a dictionary.
    *   However, the Platform Agent's `config.yaml` was using the key **`model`** inside the dictionary.
    *   Other parts of the framework (like `curator.py`) accept either `default` or `model`, which led to this mismatch going unnoticed.

    This PR fixes the configuration to ensure the Platform Agent can successfully resolve and bind to its model on startup.

    ## What Changed

    **Files:**

    *   `agents/shared/defaults/config.yaml`

    **Added/Changed/Fixed:**

    *   Added `default: gemini-model` under the `model` block in the shared defaults configuration.
    *   Retained `model: gemini-model` to ensure backward compatibility with parts of the framework (like `curator.py`) that fallback to the `model` key.

    ## Why This Matters

    This is a critical bootstrap fix. Without it, the Platform Agent cannot resolve its model and is completely unable to process completions requests, rendering the harness non-functional in environments using custom/peered LLM gateways.

    ## Context

    Discovered while debugging the Platform Agent in the `agentic-harness-demo` cluster.

    The root cause is a parser limitation in the upstream **NousResearch/hermes-agent** repository. Specifically, in [agent/auxiliary_client.py](https://github.com/NousResearch/hermes-agent/blob/main/agent/auxiliary_client.py#L1628-L1631) (around line 1628), the model resolution logic is implemented as follows:

    ```python
            model_cfg = cfg.get("model", {})
            if isinstance(model_cfg, str) and model_cfg.strip():
                return model_cfg.strip()
            if isinstance(model_cfg, dict):
                default = model_cfg.get("default", "")  # <--- Strictly expects 'default'
                if isinstance(default, str) and default.strip():
                    return default.strip()

  Because the Platform Agent's  config.yaml  was configured with  model: gemini-model  inside the  model  dictionary (instead of  default: gemini-model ), the parser failed to resolve the model name, resulting in  Model: (not set)  on startup and subsequent  ProxyModelNotFoundError  (400) errors during API calls.

  ## Testing

  • Code Analysis: Verified the parser behavior directly by reading the installed  hermes-agent  package source code inside the running  platform-agent  pod.
  • Local Verification: Applied the change locally and verified it matches the expected schema.