### PR TITLE
feat(ci): add keyless image signing with Sigstore Cosign

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,3 +108,6 @@ jobs:
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Build and Push DevTeam Agent
         uses: docker/build-push-action@v7
+        id: build-devteam
         with:
           context: .
           file: agents/Dockerfile
@@ -69,6 +70,7 @@ jobs:
 
       - name: Build and Push Operator Agent
         uses: docker/build-push-action@v7
+        id: build-operator
         with:
           context: .
           file: agents/Dockerfile
@@ -84,6 +86,7 @@ jobs:
 
       - name: Build and Push Platform Agent
         uses: docker/build-push-action@v7
+        id: build-platform
         with:
           context: .
           file: agents/Dockerfile
@@ -96,3 +99,12 @@ jobs:
             ${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign the images
+        run: |
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,7 +101,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@v4
 
       - name: Sign the images
         run: |


### PR DESCRIPTION
# Pull Request

## Why This Change

Adds secure container image signing to the Docker publish release pipeline to establish software supply chain trust and meet security standards (e.g. SLSA / GKE security guidelines).

## What Changed

**Files:**

- [.github/workflows/docker-publish.yml](file:///usr/local/google/home/bhoekstra/kube-agents/.github/workflows/docker-publish.yml)

**Added/Changed/Fixed:**

- Added `id-token: write` permission to the `publish` job to support OIDC / keyless signing.
- Assigned unique step IDs to the `docker/build-push-action` steps for DevTeam, Operator, and Platform agents to capture their image digests.
- Added step to install Sigstore Cosign (`sigstore/cosign-installer@v3`).
- Added step to sign each pushed container image using their digest.

## Why This Matters

Using image digests prevents race conditions where mutable tags might be updated or tampered with before signing. Keyless OIDC signing removes the need to store or rotate static private signing keys.

## Context

Supports GKE workload supply chain security.

## Testing

Verified with `npx prettier` formatting. The workflow relies on standard Sigstore Cosign actions for keyless OIDC signing.
