### PR TITLE
ci: authorize and upload Docker images to GCP Artifact Registry via WIF

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -26,6 +27,21 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/125393897113/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
+          service_account: github-actions@kube-agents-prow.iam.gserviceaccount.com
+
+      - name: Log in to GCP Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -44,6 +60,8 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/devteam-agent:latest
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/devteam-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
@@ -57,6 +75,8 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/operator-agent:latest
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/operator-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
@@ -70,5 +90,7 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest
+            us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
       packages: write
       id-token: write
+    env:
+      GCP_REGISTRY: us-docker.pkg.dev/kube-agents-prow/kube-agents
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -60,8 +62,8 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/devteam-agent:latest
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/devteam-agent:${{ github.sha }}
+            ${{ env.GCP_REGISTRY }}/devteam-agent:latest
+            ${{ env.GCP_REGISTRY }}/devteam-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
@@ -75,8 +77,8 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/operator-agent:latest
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/operator-agent:${{ github.sha }}
+            ${{ env.GCP_REGISTRY }}/operator-agent:latest
+            ${{ env.GCP_REGISTRY }}/operator-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
@@ -90,7 +92,7 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest
-            us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:${{ github.sha }}
+            ${{ env.GCP_REGISTRY }}/platform-agent:latest
+            ${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}


### PR DESCRIPTION
## Summary
This PR enables uploading the built Docker images to the GCP Artifact Registry in the `kube-agents-prow` project using Workload Identity Federation (WIF).

* Adds `id-token: write` permission to authorization.
* Integrates `google-github-actions/auth` to request credentials.
* Logs in to the Artifact Registry at `us-docker.pkg.dev` via OIDC.
* Pushes built images to the registry.

Co-authored-by: Antigravity AI Agent