### PR TITLE
ci: update sigstore/cosign-installer to v4.1.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,7 +101,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.0
 
       - name: Sign the images
         run: |


### PR DESCRIPTION
# Pull Request

## Why This Change

Fixes the CI run failure where `sigstore/cosign-installer@v4` was failing to install. This fixes the failure seen in: https://github.com/gke-labs/kube-agents/actions/runs/27159466602/job/80170788727

## What Changed

Updated the `sigstore/cosign-installer` version to `v4.1.0` in the `docker-publish.yml` workflow.

**Files:**

- `.github/workflows/docker-publish.yml`

**Added/Changed/Fixed:**

- Changed `uses: sigstore/cosign-installer@v4` to `uses: sigstore/cosign-installer@v4.1.0`

## Why This Matters

Ensures keyless image signing with Cosign doesn't fail during Docker publish workflow.

## Context

Addresses CI failure: https://github.com/gke-labs/kube-agents/actions/runs/27159466602/job/80170788727

## Testing

Validated workflow YAML syntax with Python.
