### PR TITLE
feat(gateway): add inference replay mechanism

### DIFF
--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -1,27 +1,36 @@
 # Inference Replay Proxy
-This directory contains an example of deploying a Inference Replay proxy. It intercepts traffic destined for your primary LLM gateway (`litellm`), serves instant repeated responses from a local Persistent Disk (PVC), and forwards cache misses to the real LLM gateway automatically.
----
+
+## This directory contains an example of deploying a Inference Replay proxy. It intercepts traffic destined for your primary LLM gateway (`litellm`), serves instant repeated responses from a local Persistent Disk (PVC), and forwards cache misses to the real LLM gateway automatically.
+
 ## Architecture Overview
+
 ```mermaid
 graph TD
     Agent[Agent Harness] -->|Calls http://litellm| ProxySvc[Service: litellm]
     ProxySvc -->|Port 8080| ProxyPod[Replay Pod]
-    
+
     subgraph Persistent Cache
         ProxyPod <-->|Read / Write KV Store| PVC[(1Gi ReadWriteOnce Disk)]
     end
-    
+
     ProxyPod -->|Cache Miss| RealSvc[Service: litellm-gateway]
     RealSvc -->|Port 4000| RealPod[Original LiteLLM Pod]
 ```
-* **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.
-* **Context-Aware Hashing**: Calculates a SHA-256 hash combining the exact **Prompt + Available Kubernetes Skills + Target Model**.
-* **Permanent Lazy-Caching**: Trajectories are permanently captured directly onto a Google Cloud Persistent Disk (`/data/replay_cache.json`).
+
+- **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.
+- **Context-Aware Hashing**: Calculates a SHA-256 hash combining the exact **Prompt + Available Kubernetes Skills + Target Model**.
+- **Permanent Lazy-Caching**: Trajectories are permanently captured directly onto a Google Cloud Persistent Disk (`/data/replay_cache.json`).
+
 ---
+
 ## Deployment Instructions
+
 Follow these steps to build, deploy, and verify the standalone replay proxy in your cluster.
+
 ### Step 1: Build and Push the Proxy Image
+
 Run these commands from your local workstation (replace `<YOUR-REGISTRY>` with your container registry path, e.g., `us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay` for GCP Artifact Registry):
+
 ```bash
 # 1. Authenticate Docker to your registry (e.g., for GCP Artifact Registry):
 gcloud auth configure-docker us-central1-docker.pkg.dev
@@ -30,19 +39,27 @@ docker build -t <YOUR-REGISTRY>/replay-proxy:latest replay-proxy
 # 3. Push the image to your registry
 docker push <YOUR-REGISTRY>/replay-proxy:latest
 ```
+
 ---
+
 ### Step 2: Update the Image Tag in `deployment.yaml`
+
 Open `deployment.yaml` and update the `image` field under `replay-proxy-container` to match your newly pushed image path:
+
 ```yaml
-    containers:
-      - name: replay-proxy-container
-        # Change this line to point to your registry:
-        image: <YOUR-REGISTRY>/replay-proxy:latest
-        imagePullPolicy: Always
+containers:
+  - name: replay-proxy-container
+    # Change this line to point to your registry:
+    image: <YOUR-REGISTRY>/replay-proxy:latest
+    imagePullPolicy: Always
 ```
+
 ---
+
 ### Step 3: Apply the Manifests to the Cluster
+
 Deploy the persistent volume, gateway routing, and standalone proxy in the `agent-system` namespace:
+
 ```bash
 cd examples/inference-replay
 # 1. Provision the 1Gi Persistent Disk (PVC)
@@ -54,22 +71,32 @@ kubectl apply -f deployment.yaml
 # 4. Intercept primary 'litellm' traffic to route to the Proxy
 kubectl apply -f service.yaml
 ```
+
 Verify that the standalone proxy transitions successfully to **`Running`**:
+
 ```bash
 kubectl get pods -n agent-system -l app=standalone-replay
 ```
+
 ---
+
 ## Verification & Testing
+
 ### 1. Start an Explicit Port-Forward
+
 Forward local port `8080` directly to the running standalone replay deployment:
+
 ```bash
 # Kill any broken background forwarding jobs
 pkill -f "port-forward"
 # Forward explicitly to the Standalone Replay deployment
 kubectl port-forward deployment/standalone-replay 8080:8080 -n agent-system &
 ```
+
 ### 2. Execute a Test Call (Recording Miss)
+
 Run this `curl` command. The first run forwards to Gemini and captures the golden response to disk:
+
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
@@ -78,11 +105,16 @@ curl -X POST http://localhost:8080/v1/chat/completions \
     "messages": [{"role": "user", "content": "Explain quantum computing in one sentence."}]
   }'
 ```
+
 ### 3. Verify the Cache Contents
+
 Inspect the formatted JSON Key/Value store saved directly on your persistent disk:
+
 ```bash
 POD_NAME=$(kubectl get pods -n agent-system -l app=standalone-replay -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -n agent-system $POD_NAME -- cat /data/replay_cache.json | jq .
 ```
+
 ### 4. Observe the Instant Replay Hit
+
 Execute the exact same `curl` command a second time. It will complete near-instantaneously (<10ms) with **zero Gemini API calls**, serving entirely from your persistent volume!

--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -1,0 +1,88 @@
+# Inference Replay Proxy
+This directory contains an example of deploying a Inference Replay proxy. It intercepts traffic destined for your primary LLM gateway (`litellm`), serves instant repeated responses from a local Persistent Disk (PVC), and forwards cache misses to the real LLM gateway automatically.
+---
+## Architecture Overview
+```mermaid
+graph TD
+    Agent[Agent Harness] -->|Calls http://litellm| ProxySvc[Service: litellm]
+    ProxySvc -->|Port 8080| ProxyPod[Replay Pod]
+    
+    subgraph Persistent Cache
+        ProxyPod <-->|Read / Write KV Store| PVC[(1Gi ReadWriteOnce Disk)]
+    end
+    
+    ProxyPod -->|Cache Miss| RealSvc[Service: litellm-gateway]
+    RealSvc -->|Port 4000| RealPod[Original LiteLLM Pod]
+```
+* **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.
+* **Context-Aware Hashing**: Calculates a SHA-256 hash combining the exact **Prompt + Available Kubernetes Skills + Target Model**.
+* **Permanent Lazy-Caching**: Trajectories are permanently captured directly onto a Google Cloud Persistent Disk (`/data/replay_cache.json`).
+---
+## Deployment Instructions
+Follow these steps to build, deploy, and verify the standalone replay proxy in your cluster.
+### Step 1: Build and Push the Proxy Image
+Run these commands from your local Cloud Shell or Cloudtop workstation (ensure you replace `<YOUR-DEV-PROJECT>` with your actual Google Cloud Project ID):
+```bash
+# 1. Configure Docker authentication
+gcloud auth configure-docker us-central1-docker.pkg.dev
+# 2. Build the proxy container image
+docker build -t us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest replay-proxy
+# 3. Push the image to Artifact Registry
+docker push us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
+```
+---
+### Step 2: Update the Image Tag in `deployment.yaml`
+Open `deployment.yaml` and update the `image` field under `replay-proxy-container` to match your newly pushed Artifact Registry image path:
+```yaml
+    containers:
+      - name: replay-proxy-container
+        # Change this line to point to your Artifact Registry:
+        image: us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
+        imagePullPolicy: Always
+```
+---
+### Step 3: Apply the Manifests to the Cluster
+Deploy the persistent volume, gateway routing, and standalone proxy in the `agent-system` namespace:
+```bash
+cd examples/inference-replay
+# 1. Provision the 1Gi Persistent Disk (PVC)
+kubectl apply -f pvc.yaml
+# 2. Expose the original LiteLLM pods under the new name 'litellm-gateway'
+kubectl apply -f service-gateway.yaml
+# 3. Deploy the Standalone Replay Proxy pod
+kubectl apply -f deployment.yaml
+# 4. Intercept primary 'litellm' traffic to route to the Proxy
+kubectl apply -f service.yaml
+```
+Verify that the standalone proxy transitions successfully to **`Running`**:
+```bash
+kubectl get pods -n agent-system -l app=standalone-replay
+```
+---
+## Verification & Testing
+### 1. Start an Explicit Port-Forward
+Forward local port `8080` directly to the running standalone replay deployment:
+```bash
+# Kill any broken background forwarding jobs
+pkill -f "port-forward"
+# Forward explicitly to the Standalone Replay deployment
+kubectl port-forward deployment/standalone-replay 8080:8080 -n agent-system &
+```
+### 2. Execute a Test Call (Recording Miss)
+Run this `curl` command. The first run forwards to Gemini and captures the golden response to disk:
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemini-model",
+    "messages": [{"role": "user", "content": "Explain quantum computing in one sentence."}]
+  }'
+```
+### 3. Verify the Cache Contents
+Inspect the formatted JSON Key/Value store saved directly on your persistent disk:
+```bash
+POD_NAME=$(kubectl get pods -n agent-system -l app=standalone-replay -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n agent-system $POD_NAME -- cat /data/replay_cache.json | jq .
+```
+### 4. Observe the Instant Replay Hit
+Execute the exact same `curl` command a second time. It will complete near-instantaneously (<10ms) with **zero Gemini API calls**, serving entirely from your persistent volume!

--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -21,23 +21,23 @@ graph TD
 ## Deployment Instructions
 Follow these steps to build, deploy, and verify the standalone replay proxy in your cluster.
 ### Step 1: Build and Push the Proxy Image
-Run these commands from your local Cloud Shell or Cloudtop workstation (ensure you replace `<YOUR-DEV-PROJECT>` with your actual Google Cloud Project ID):
+Run these commands from your local workstation (replace `<YOUR-REGISTRY>` with your container registry path, e.g., `us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay` for GCP Artifact Registry):
 ```bash
-# 1. Configure Docker authentication
+# 1. Authenticate Docker to your registry (e.g., for GCP Artifact Registry):
 gcloud auth configure-docker us-central1-docker.pkg.dev
 # 2. Build the proxy container image
-docker build -t us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest replay-proxy
-# 3. Push the image to Artifact Registry
-docker push us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
+docker build -t <YOUR-REGISTRY>/replay-proxy:latest replay-proxy
+# 3. Push the image to your registry
+docker push <YOUR-REGISTRY>/replay-proxy:latest
 ```
 ---
 ### Step 2: Update the Image Tag in `deployment.yaml`
-Open `deployment.yaml` and update the `image` field under `replay-proxy-container` to match your newly pushed Artifact Registry image path:
+Open `deployment.yaml` and update the `image` field under `replay-proxy-container` to match your newly pushed image path:
 ```yaml
     containers:
       - name: replay-proxy-container
-        # Change this line to point to your Artifact Registry:
-        image: us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
+        # Change this line to point to your registry:
+        image: <YOUR-REGISTRY>/replay-proxy:latest
         imagePullPolicy: Always
 ```
 ---

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: replay-proxy-container
-        image: us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
+        image: <YOUR-REGISTRY>/replay-proxy:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -14,30 +14,29 @@ spec:
         app: standalone-replay
     spec:
       containers:
-      - name: replay-proxy-container
-        image: <YOUR-REGISTRY>/replay-proxy:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 8080
-        env:
-        - name: INFERENCE_URL
-          value: "http://litellm-gateway.agent-system.svc.cluster.local"
-        - name: PROXY_MODE
-          value: "lazy-cache" # Permanently locked in dynamic lazy-caching
-        - name: CACHE_FILE
-          value: "/data/replay_cache.json"
-        resources:
-          requests:
-            cpu: "100m"      # Lightweight request to schedule instantly
-            memory: "256Mi"
-          limits:
-            cpu: "500m"
-            memory: "1Gi"
-        volumeMounts:
-        - name: cache-volume
-          mountPath: /data
+        - name: replay-proxy-container
+          image: <YOUR-REGISTRY>/replay-proxy:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: INFERENCE_URL
+              value: "http://litellm-gateway.agent-system.svc.cluster.local"
+            - name: PROXY_MODE
+              value: "lazy-cache" # Permanently locked in dynamic lazy-caching
+            - name: CACHE_FILE
+              value: "/data/replay_cache.json"
+          resources:
+            requests:
+              cpu: "100m" # Lightweight request to schedule instantly
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          volumeMounts:
+            - name: cache-volume
+              mountPath: /data
       volumes:
-      - name: cache-volume
-        persistentVolumeClaim:
-          claimName: standalone-replay-pvc
-
+        - name: cache-volume
+          persistentVolumeClaim:
+            claimName: standalone-replay-pvc

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: standalone-replay
+  namespace: agent-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: standalone-replay
+  template:
+    metadata:
+      labels:
+        app: standalone-replay
+    spec:
+      containers:
+      - name: replay-proxy-container
+        image: us-central1-docker.pkg.dev/stalhaali-gke-dev/inference-replay/replay-proxy:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8080
+        env:
+        - name: LITELLM_URL
+          value: "http://litellm-gateway.agent-system.svc.cluster.local"
+        - name: PROXY_MODE
+          value: "lazy-cache" # Permanently locked in dynamic lazy-caching
+        - name: CACHE_FILE
+          value: "/data/replay_cache.json"
+        resources:
+          requests:
+            cpu: "100m"      # Lightweight request to schedule instantly
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
+        volumeMounts:
+        - name: cache-volume
+          mountPath: /data
+      volumes:
+      - name: cache-volume
+        persistentVolumeClaim:
+          claimName: standalone-replay-pvc
+

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: replay-proxy-container
-        image: us-central1-docker.pkg.dev/stalhaali-gke-dev/inference-replay/replay-proxy:latest
+        image: us-central1-docker.pkg.dev/<YOUR-DEV-PROJECT>/inference-replay/replay-proxy:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 8080
         env:
-        - name: LITELLM_URL
+        - name: INFERENCE_URL
           value: "http://litellm-gateway.agent-system.svc.cluster.local"
         - name: PROXY_MODE
           value: "lazy-cache" # Permanently locked in dynamic lazy-caching

--- a/examples/inference-replay/pvc.yaml
+++ b/examples/inference-replay/pvc.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
- name: standalone-replay-pvc
- namespace: agent-system
+  name: standalone-replay-pvc
+  namespace: agent-system
 spec:
- accessModes:
-  - ReadWriteOnce
- resources:
-  requests:
-   storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/inference-replay/pvc.yaml
+++ b/examples/inference-replay/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+ name: standalone-replay-pvc
+ namespace: agent-system
+spec:
+ accessModes:
+  - ReadWriteOnce
+ resources:
+  requests:
+   storage: 1Gi

--- a/examples/inference-replay/replay-proxy/Dockerfile
+++ b/examples/inference-replay/replay-proxy/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install fastapi uvicorn httpx
+COPY replay_proxy.py .
+EXPOSE 8080
+CMD ["uvicorn", "replay_proxy:app", "--host", "0.0.0.0", "--port", "8080"]
+

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -92,7 +92,7 @@ async def chat_completions(request: Request):
         else:
             return cache_entry["data"]
             
-    # Cache miss -> Forward to LiteLLM and record
+    # Cache miss -> Forward to inference backend and record
     logger.info(f"Forwarding inference request to: {INFERENCE_URL}")
     
     headers = _forward_headers(request)

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -74,6 +74,8 @@ async def replay_stream(lines):
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):
     body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
     req_hash = get_request_hash(body)
     is_stream = body.get("stream", False)
     

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -59,14 +59,10 @@ def get_request_hash(body: dict) -> str:
     canonical_json = json.dumps(body, sort_keys=True)
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
-async def replay_stream(chunks):
-    for chunk in chunks:
-        if isinstance(chunk, dict):
-            yield f"data: {json.dumps(chunk)}\n\n"
-        else:
-            yield chunk
+async def replay_stream(lines):
+    for line in lines:
+        yield line + "\n"
         await asyncio.sleep(0.01)
-    yield "data: [DONE]\n\n"
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: Request):
@@ -121,7 +117,7 @@ async def chat_completions(request: Request):
             raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
 
 async def forward_and_record_stream(client, body, headers, req_hash):
-    recorded_chunks = []
+    recorded_lines = []
     async with client.stream(
         "POST",
         f"{LITELLM_URL}/v1/chat/completions",
@@ -134,25 +130,14 @@ async def forward_and_record_stream(client, body, headers, req_hash):
             yield content
             return
         async for line in response.aiter_lines():
-            if line.startswith("data: "):
-                data_str = line[6:]
-                if data_str.strip() == "[DONE]":
-                    yield line + "\n\n"
-                    continue
-                try:
-                    data_json = json.loads(data_str)
-                    recorded_chunks.append(data_json)
-                except json.JSONDecodeError:
-                    recorded_chunks.append(line + "\n\n")
-            else:
-                recorded_chunks.append(line + "\n\n")
-            yield line + "\n\n"
-                
-    if recorded_chunks:
+            recorded_lines.append(line)
+            yield line + "\n"
+
+    if recorded_lines:
         logger.info(f"Recording stream response for hash: {req_hash}")
         cache[req_hash] = {
             "type": "stream",
-            "data": recorded_chunks
+            "data": recorded_lines
         }
         await save_cache()
 

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -121,7 +121,7 @@ async def chat_completions(request: Request):
             await save_cache()
             return resp_body
         except httpx.RequestError as exc:
-            raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
+            raise HTTPException(status_code=502, detail=f"Failed to contact LiteLLM: {exc}")
 
 async def forward_and_record_stream(client, body, headers, req_hash):
     recorded_lines = []
@@ -157,13 +157,16 @@ async def fallback(request: Request, path: str):
     method = request.method
     content = await request.body()
 
-    response = await client.request(
-        method,
-        url,
-        headers=headers,
-        content=content,
-        params=request.query_params,
-        timeout=60.0
-    )
+    try:
+        response = await client.request(
+            method,
+            url,
+            headers=headers,
+            content=content,
+            params=request.query_params,
+            timeout=60.0
+        )
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to contact LiteLLM: {exc}")
     return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
 

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -23,7 +23,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
-LITELLM_URL = os.environ.get("LITELLM_URL", "http://localhost:4000")
+INFERENCE_URL = os.environ.get("INFERENCE_URL", "http://localhost:4000")
 CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
 
 _HOP_BY_HOP = {"host", "content-length", "transfer-encoding", "connection", "accept-encoding"}
@@ -93,7 +93,7 @@ async def chat_completions(request: Request):
             return cache_entry["data"]
             
     # Cache miss -> Forward to LiteLLM and record
-    logger.info(f"Forwarding request to LiteLLM: {LITELLM_URL}")
+    logger.info(f"Forwarding inference request to: {INFERENCE_URL}")
     
     headers = _forward_headers(request)
     
@@ -107,7 +107,7 @@ async def chat_completions(request: Request):
     else:
         try:
             response = await client.post(
-                f"{LITELLM_URL}/v1/chat/completions",
+                f"{INFERENCE_URL}/v1/chat/completions",
                 json=body,
                 headers=headers,
                 timeout=60.0
@@ -129,7 +129,7 @@ async def forward_and_record_stream(client, body, headers, req_hash):
     recorded_lines = []
     async with client.stream(
         "POST",
-        f"{LITELLM_URL}/v1/chat/completions",
+        f"{INFERENCE_URL}/v1/chat/completions",
         json=body,
         headers=headers,
         timeout=60.0
@@ -154,7 +154,7 @@ async def forward_and_record_stream(client, body, headers, req_hash):
 async def fallback(request: Request, path: str):
     logger.info(f"Fallback forwarding for path: {path}")
     client = request.app.state.http_client
-    url = f"{LITELLM_URL}/{path}"
+    url = f"{INFERENCE_URL}/{path}"
     headers = _forward_headers(request)
     method = request.method
     content = await request.body()

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -3,6 +3,7 @@ import json
 import hashlib
 import logging
 import asyncio
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, Response, HTTPException
 from fastapi.responses import StreamingResponse
 import httpx
@@ -10,7 +11,17 @@ import httpx
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("replay-proxy-v1")
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    app.state.http_client = httpx.AsyncClient(timeout=60.0)
+    try:
+        yield
+    finally:
+        await app.state.http_client.aclose()
+
+
+app = FastAPI(lifespan=lifespan)
 
 LITELLM_URL = os.environ.get("LITELLM_URL", "http://localhost:4000")
 CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
@@ -81,61 +92,61 @@ async def chat_completions(request: Request):
     
     headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
     
+    client = request.app.state.http_client
+
     if is_stream:
         return StreamingResponse(
-            forward_and_record_stream(body, headers, req_hash),
+            forward_and_record_stream(client, body, headers, req_hash),
             media_type="text/event-stream"
         )
     else:
-        async with httpx.AsyncClient() as client:
-            try:
-                response = await client.post(
-                    f"{LITELLM_URL}/v1/chat/completions",
-                    json=body,
-                    headers=headers,
-                    timeout=60.0
-                )
-                if response.status_code != 200:
-                    return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
-                
-                resp_body = response.json()
-                cache[req_hash] = {
-                    "type": "completion",
-                    "data": resp_body
-                }
-                await save_cache()
-                return resp_body
-            except httpx.RequestError as exc:
-                raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
-
-async def forward_and_record_stream(body, headers, req_hash):
-    recorded_chunks = []
-    async with httpx.AsyncClient() as client:
-        async with client.stream(
-            "POST",
-            f"{LITELLM_URL}/v1/chat/completions",
-            json=body,
-            headers=headers,
-            timeout=60.0
-        ) as response:
+        try:
+            response = await client.post(
+                f"{LITELLM_URL}/v1/chat/completions",
+                json=body,
+                headers=headers,
+                timeout=60.0
+            )
             if response.status_code != 200:
-                content = await response.aread()
-                yield content
-                return
-            async for line in response.aiter_lines():
-                if line.startswith("data: "):
-                    data_str = line[6:]
-                    if data_str.strip() == "[DONE]":
-                        yield line + "\n\n"
-                        continue
-                    try:
-                        data_json = json.loads(data_str)
-                        recorded_chunks.append(data_json)
-                    except json.JSONDecodeError:
-                        recorded_chunks.append(line + "\n\n")
-                else:
+                return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+
+            resp_body = response.json()
+            cache[req_hash] = {
+                "type": "completion",
+                "data": resp_body
+            }
+            await save_cache()
+            return resp_body
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
+
+async def forward_and_record_stream(client, body, headers, req_hash):
+    recorded_chunks = []
+    async with client.stream(
+        "POST",
+        f"{LITELLM_URL}/v1/chat/completions",
+        json=body,
+        headers=headers,
+        timeout=60.0
+    ) as response:
+        if response.status_code != 200:
+            content = await response.aread()
+            yield content
+            return
+        async for line in response.aiter_lines():
+            if line.startswith("data: "):
+                data_str = line[6:]
+                if data_str.strip() == "[DONE]":
+                    yield line + "\n\n"
+                    continue
+                try:
+                    data_json = json.loads(data_str)
+                    recorded_chunks.append(data_json)
+                except json.JSONDecodeError:
                     recorded_chunks.append(line + "\n\n")
-                yield line + "\n\n"
+            else:
+                recorded_chunks.append(line + "\n\n")
+            yield line + "\n\n"
                 
     if recorded_chunks:
         logger.info(f"Recording stream response for hash: {req_hash}")
@@ -148,19 +159,19 @@ async def forward_and_record_stream(body, headers, req_hash):
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def fallback(request: Request, path: str):
     logger.info(f"Fallback forwarding for path: {path}")
-    async with httpx.AsyncClient() as client:
-        url = f"{LITELLM_URL}/{path}"
-        headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
-        method = request.method
-        content = await request.body()
-        
-        response = await client.request(
-            method,
-            url,
-            headers=headers,
-            content=content,
-            params=request.query_params,
-            timeout=60.0
-        )
-        return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+    client = request.app.state.http_client
+    url = f"{LITELLM_URL}/{path}"
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    method = request.method
+    content = await request.body()
+
+    response = await client.request(
+        method,
+        url,
+        headers=headers,
+        content=content,
+        params=request.query_params,
+        timeout=60.0
+    )
+    return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
 

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -36,16 +36,7 @@ def save_cache():
         logger.error(f"Failed to save cache: {e}")
 
 def get_request_hash(body: dict) -> str:
-    relevant_data = {
-        "model": body.get("model"),
-        "messages": body.get("messages"),
-        "tools": body.get("tools"),
-        "functions": body.get("functions"),
-        "response_format": body.get("response_format"),
-        "stream": body.get("stream", False)
-    }
-    relevant_data = {k: v for k, v in relevant_data.items() if v is not None}
-    canonical_json = json.dumps(relevant_data, sort_keys=True)
+    canonical_json = json.dumps(body, sort_keys=True)
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
 async def replay_stream(chunks):

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -1,0 +1,166 @@
+import os
+import json
+import hashlib
+import logging
+import asyncio
+from fastapi import FastAPI, Request, Response, HTTPException
+from fastapi.responses import StreamingResponse
+import httpx
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("replay-proxy-v1")
+
+app = FastAPI()
+
+LITELLM_URL = os.environ.get("LITELLM_URL", "http://localhost:4000")
+CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
+
+cache = {}
+if os.path.exists(CACHE_FILE):
+    try:
+        with open(CACHE_FILE, "r") as f:
+            cache = json.load(f)
+        logger.info(f"Loaded {len(cache)} entries from cache file {CACHE_FILE}")
+    except Exception as e:
+        logger.error(f"Failed to load cache file: {e}")
+else:
+    logger.info(f"Cache file {CACHE_FILE} not found, starting with empty cache.")
+
+def save_cache():
+    try:
+        os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
+        with open(CACHE_FILE, "w") as f:
+            json.dump(cache, f, indent=2)
+        logger.info(f"Saved cache to {CACHE_FILE}")
+    except Exception as e:
+        logger.error(f"Failed to save cache: {e}")
+
+def get_request_hash(body: dict) -> str:
+    relevant_data = {
+        "model": body.get("model"),
+        "messages": body.get("messages"),
+        "tools": body.get("tools"),
+        "functions": body.get("functions"),
+        "response_format": body.get("response_format"),
+        "stream": body.get("stream", False)
+    }
+    relevant_data = {k: v for k, v in relevant_data.items() if v is not None}
+    canonical_json = json.dumps(relevant_data, sort_keys=True)
+    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
+
+async def replay_stream(chunks):
+    for chunk in chunks:
+        if isinstance(chunk, dict):
+            yield f"data: {json.dumps(chunk)}\n\n"
+        else:
+            yield chunk
+        await asyncio.sleep(0.01)
+    yield "data: [DONE]\n\n"
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    body = await request.json()
+    req_hash = get_request_hash(body)
+    is_stream = body.get("stream", False)
+    
+    logger.info(f"Received chat completion request. Hash: {req_hash}, Stream: {is_stream}")
+    
+    if req_hash in cache:
+        logger.info(f"Cache hit for hash: {req_hash}. Replaying response.")
+        cache_entry = cache[req_hash]
+        if cache_entry.get("type") == "stream":
+            return StreamingResponse(
+                replay_stream(cache_entry["data"]),
+                media_type="text/event-stream"
+            )
+        else:
+            return cache_entry["data"]
+            
+    # Cache miss -> Forward to LiteLLM and record
+    logger.info(f"Forwarding request to LiteLLM: {LITELLM_URL}")
+    
+    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    
+    if is_stream:
+        return StreamingResponse(
+            forward_and_record_stream(body, headers, req_hash),
+            media_type="text/event-stream"
+        )
+    else:
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(
+                    f"{LITELLM_URL}/v1/chat/completions",
+                    json=body,
+                    headers=headers,
+                    timeout=60.0
+                )
+                if response.status_code != 200:
+                    return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+                
+                resp_body = response.json()
+                cache[req_hash] = {
+                    "type": "completion",
+                    "data": resp_body
+                }
+                save_cache()
+                return resp_body
+            except httpx.RequestError as exc:
+                raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
+
+async def forward_and_record_stream(body, headers, req_hash):
+    recorded_chunks = []
+    async with httpx.AsyncClient() as client:
+        async with client.stream(
+            "POST",
+            f"{LITELLM_URL}/v1/chat/completions",
+            json=body,
+            headers=headers,
+            timeout=60.0
+        ) as response:
+            if response.status_code != 200:
+                content = await response.aread()
+                yield content
+                return
+            async for line in response.aiter_lines():
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    if data_str.strip() == "[DONE]":
+                        yield line + "\n\n"
+                        continue
+                    try:
+                        data_json = json.loads(data_str)
+                        recorded_chunks.append(data_json)
+                    except json.JSONDecodeError:
+                        recorded_chunks.append(line + "\n\n")
+                else:
+                    recorded_chunks.append(line + "\n\n")
+                yield line + "\n\n"
+                
+    if recorded_chunks:
+        logger.info(f"Recording stream response for hash: {req_hash}")
+        cache[req_hash] = {
+            "type": "stream",
+            "data": recorded_chunks
+        }
+        save_cache()
+
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
+async def fallback(request: Request, path: str):
+    logger.info(f"Fallback forwarding for path: {path}")
+    async with httpx.AsyncClient() as client:
+        url = f"{LITELLM_URL}/{path}"
+        headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+        method = request.method
+        content = await request.body()
+        
+        response = await client.request(
+            method,
+            url,
+            headers=headers,
+            content=content,
+            params=request.query_params,
+            timeout=60.0
+        )
+        return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -26,14 +26,23 @@ if os.path.exists(CACHE_FILE):
 else:
     logger.info(f"Cache file {CACHE_FILE} not found, starting with empty cache.")
 
-def save_cache():
-    try:
-        os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
-        with open(CACHE_FILE, "w") as f:
-            json.dump(cache, f, indent=2)
-        logger.info(f"Saved cache to {CACHE_FILE}")
-    except Exception as e:
-        logger.error(f"Failed to save cache: {e}")
+_cache_lock = asyncio.Lock()
+
+def _write_cache_atomic(snapshot: dict) -> None:
+    os.makedirs(os.path.dirname(CACHE_FILE), exist_ok=True)
+    tmp_path = f"{CACHE_FILE}.tmp"
+    with open(tmp_path, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    os.replace(tmp_path, CACHE_FILE)
+
+async def save_cache():
+    async with _cache_lock:
+        snapshot = dict(cache)
+        try:
+            await asyncio.to_thread(_write_cache_atomic, snapshot)
+            logger.info(f"Saved cache to {CACHE_FILE}")
+        except Exception as e:
+            logger.error(f"Failed to save cache: {e}")
 
 def get_request_hash(body: dict) -> str:
     canonical_json = json.dumps(body, sort_keys=True)
@@ -94,7 +103,7 @@ async def chat_completions(request: Request):
                     "type": "completion",
                     "data": resp_body
                 }
-                save_cache()
+                await save_cache()
                 return resp_body
             except httpx.RequestError as exc:
                 raise HTTPException(status_code=500, detail=f"Failed to contact LiteLLM: {exc}")
@@ -134,7 +143,7 @@ async def forward_and_record_stream(body, headers, req_hash):
             "type": "stream",
             "data": recorded_chunks
         }
-        save_cache()
+        await save_cache()
 
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def fallback(request: Request, path: str):

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -26,6 +26,13 @@ app = FastAPI(lifespan=lifespan)
 LITELLM_URL = os.environ.get("LITELLM_URL", "http://localhost:4000")
 CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
 
+_HOP_BY_HOP = {"host", "content-length", "transfer-encoding", "connection", "accept-encoding"}
+
+
+def _forward_headers(request: Request) -> dict:
+    return {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
 cache = {}
 if os.path.exists(CACHE_FILE):
     try:
@@ -86,7 +93,7 @@ async def chat_completions(request: Request):
     # Cache miss -> Forward to LiteLLM and record
     logger.info(f"Forwarding request to LiteLLM: {LITELLM_URL}")
     
-    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    headers = _forward_headers(request)
     
     client = request.app.state.http_client
 
@@ -146,7 +153,7 @@ async def fallback(request: Request, path: str):
     logger.info(f"Fallback forwarding for path: {path}")
     client = request.app.state.http_client
     url = f"{LITELLM_URL}/{path}"
-    headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
+    headers = _forward_headers(request)
     method = request.method
     content = await request.body()
 

--- a/examples/inference-replay/service-gateway.yaml
+++ b/examples/inference-replay/service-gateway.yaml
@@ -7,8 +7,7 @@ spec:
   selector:
     app: litellm # Routes to the original LiteLLM deployment
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 4000
+    - protocol: TCP
+      port: 80
+      targetPort: 4000
   type: ClusterIP
-

--- a/examples/inference-replay/service-gateway.yaml
+++ b/examples/inference-replay/service-gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-gateway # New service name for the original LiteLLM gateway
+  namespace: agent-system
+spec:
+  selector:
+    app: litellm # Routes to the original LiteLLM deployment
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 4000
+  type: ClusterIP
+

--- a/examples/inference-replay/service.yaml
+++ b/examples/inference-replay/service.yaml
@@ -7,8 +7,7 @@ spec:
   selector:
     app: standalone-replay
   ports:
-  - protocol: TCP
-    port: 80
-    targetPort: 8080 # Routes to the proxy
+    - protocol: TCP
+      port: 80
+      targetPort: 8080 # Routes to the proxy
   type: ClusterIP
-  

--- a/examples/inference-replay/service.yaml
+++ b/examples/inference-replay/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm # Intercepts the original name so agents don't need configuration changes
+  namespace: agent-system
+spec:
+  selector:
+    app: standalone-replay
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080 # Routes to the proxy
+  type: ClusterIP
+  


### PR DESCRIPTION
# Pull Request

## Why This Change

Caches LLM responses at the gateway level to eliminate redundant API calls and save token consumption across repeated runs.

## What Changed

Introduced a standalone **Inference Replay & Lazy-Caching Proxy** (`examples/inference-replay`) that seamlessly intercepts model gateway requests (`litellm`), records golden agent trajectories permanently to a Google Cloud Persistent Disk (PVC), and replays them locally on subsequent evaluation runs.

**Files:**

* `examples/inference-replay/replay-proxy/replay_proxy.py`
  * **Added**: FastAPI proxy application featuring context-aware SHA-256 hashing (Prompt + Tools + Model).
* `examples/inference-replay/replay-proxy/Dockerfile`
  * **Added**: Minimal Python runtime container specification.
* `examples/inference-replay/pvc.yaml`
  * **Added**: 1Gi PersistentVolumeClaim for permanent read-write lazy-caching.
* `examples/inference-replay/deployment.yaml`
  * **Added**: Standalone replay proxy pod deployment.
* `examples/inference-replay/service-gateway.yaml`
  * **Added**: Exposes running upstream gateways as `litellm-gateway`.
* `examples/inference-replay/service.yaml`
  * **Added**: Intercepts primary `litellm` traffic into the proxy pod with zero agent configuration changes.
* `examples/inference-replay/README.md`
  * **Added**: Step-by-step deployment and verification guide.

## Why This Matters

Achieves near-instantaneous (<10ms) responses with **zero external Gemini API calls** during repeat evaluation runs—keeping outer-loop token costs near zero, safeguarding quota limits, and ensuring 100% deterministic regression pipelines.

## Testing

https://screencast.googleplex.com/cast/NDYyOTE1NzgxOTQ0OTM0NHxiYzQ2MDBhYy1kZg
---

<!-- Close with a short note on functional impact, risk, or rollout. -->
