### PR TITLE
ci: use GCP Cloud Build for Artifact Registry push in publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,9 @@ jobs:
           workload_identity_provider: projects/125393897113/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
           service_account: github-actions@kube-agents-prow.iam.gserviceaccount.com
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
       - name: Log in to GCP Artifact Registry
         uses: docker/login-action@v4
         with:
@@ -52,7 +55,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push DevTeam Agent
+      - name: Build and Push DevTeam Agent (GHCR)
         uses: docker/build-push-action@v7
         id: build-devteam
         with:
@@ -63,12 +66,20 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
-            ${{ env.GCP_REGISTRY }}/devteam-agent:latest
-            ${{ env.GCP_REGISTRY }}/devteam-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
-      - name: Build and Push Operator Agent
+      - name: Build and Push DevTeam Agent (GCP Cloud Build)
+        id: gcp-devteam
+        run: |
+          gcloud builds submit \
+            --config=agents/cloudbuild.yaml \
+            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/devteam-agent:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/devteam-agent:latest,_TARGET=devteam,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            .
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/devteam-agent:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Build and Push Operator Agent (GHCR)
         uses: docker/build-push-action@v7
         id: build-operator
         with:
@@ -79,12 +90,20 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
-            ${{ env.GCP_REGISTRY }}/operator-agent:latest
-            ${{ env.GCP_REGISTRY }}/operator-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
-      - name: Build and Push Platform Agent
+      - name: Build and Push Operator Agent (GCP Cloud Build)
+        id: gcp-operator
+        run: |
+          gcloud builds submit \
+            --config=agents/cloudbuild.yaml \
+            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/operator-agent:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/operator-agent:latest,_TARGET=operator,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            .
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/operator-agent:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Build and Push Platform Agent (GHCR)
         uses: docker/build-push-action@v7
         id: build-platform
         with:
@@ -95,10 +114,18 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
-            ${{ env.GCP_REGISTRY }}/platform-agent:latest
-            ${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build and Push Platform Agent (GCP Cloud Build)
+        id: gcp-platform
+        run: |
+          gcloud builds submit \
+            --config=agents/cloudbuild.yaml \
+            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            .
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.0
@@ -108,6 +135,6 @@ jobs:
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/devteam-agent@${{ steps.gcp-devteam.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/operator-agent@${{ steps.gcp-operator.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,7 @@ jobs:
           service_account: github-actions@kube-agents-prow.iam.gserviceaccount.com
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Log in to GCP Artifact Registry
         uses: docker/login-action@v4

--- a/agents/cloudbuild.yaml
+++ b/agents/cloudbuild.yaml
@@ -3,20 +3,23 @@ steps:
     env:
       - "DOCKER_BUILDKIT=1"
     args:
-      [
-        "build",
-        "-t",
-        "$_IMAGE_URI",
-        "-t",
-        "$_IMAGE_URI_LATEST",
-        "-f",
-        "agents/Dockerfile",
-        "--target",
-        "$_TARGET",
-        "--build-arg",
-        "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG",
-        ".",
-      ]
+      - "build"
+      - "-t"
+      - "$_IMAGE_URI"
+      - "-t"
+      - "$_IMAGE_URI_LATEST"
+      - "-f"
+      - "agents/Dockerfile"
+      - "--target"
+      - "$_TARGET"
+      - "--build-arg"
+      - "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG"
+      - "."
 images:
   - "$_IMAGE_URI"
   - "$_IMAGE_URI_LATEST"
+substitutions:
+  _IMAGE_URI: ""
+  _IMAGE_URI_LATEST: ""
+  _TARGET: "platform"
+  _HERMES_AGENT_TAG: "latest"

--- a/agents/cloudbuild.yaml
+++ b/agents/cloudbuild.yaml
@@ -21,5 +21,5 @@ images:
 substitutions:
   _IMAGE_URI: ""
   _IMAGE_URI_LATEST: ""
-  _TARGET: "platform"
-  _HERMES_AGENT_TAG: "latest"
+  _TARGET: ""
+  _HERMES_AGENT_TAG: ""

--- a/agents/cloudbuild.yaml
+++ b/agents/cloudbuild.yaml
@@ -1,0 +1,22 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    env:
+      - "DOCKER_BUILDKIT=1"
+    args:
+      [
+        "build",
+        "-t",
+        "$_IMAGE_URI",
+        "-t",
+        "$_IMAGE_URI_LATEST",
+        "-f",
+        "agents/Dockerfile",
+        "--target",
+        "$_TARGET",
+        "--build-arg",
+        "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG",
+        ".",
+      ]
+images:
+  - "$_IMAGE_URI"
+  - "$_IMAGE_URI_LATEST"


### PR DESCRIPTION
# Pull Request

## Why This Change

The push step to GCP Artifact Registry was previously run locally in the Makefile. For cleaner CI/CD execution and security, this has been shifted to run via GCP Cloud Build, but only as part of the release/publish workflow.

## What Changed

**Files:**

- [agents/cloudbuild.yaml](file:///usr/local/google/home/bhoekstra/kube-agents/agents/cloudbuild.yaml)
- [.github/workflows/docker-publish.yml](file:///usr/local/google/home/bhoekstra/kube-agents/.github/workflows/docker-publish.yml)

**Added/Changed/Fixed:**

- Created a generic `agents/cloudbuild.yaml` to handle Cloud Build docker image building and pushing with dual tag support.
- Modified `.github/workflows/docker-publish.yml` to trigger the GCP build steps using `gcloud builds submit` instead of building locally inside the GitHub Action runner.
- Added GCP image digest resolution and updated `Sign the images` step to sign the correct digests from Cloud Build.

## Why This Matters

- Improves security by building GCP-bound images in the cloud using GCP Cloud Build.
- Separates local developer builds from publishing automation.

## Context

- Requested by user to shift AR push to Cloud Build inside the publish workflow.

## Testing

- Validated syntax and execution by running `gcloud builds submit` using `agents/cloudbuild.yaml` against a test project (`kube-agents-prow`), successfully building and pushing the images.

---

TAG=agy
CONV=fdcc7d66-0222-4924-a879-69539b840d93
