### PR TITLE
ci: split docker publish workflow into GHCR and GCP AR workflows

### DIFF
--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -1,16 +1,15 @@
-name: Docker Publish
+name: Publish to GCP Artifact Registry
 
 on:
   push:
     branches: [main]
 
 jobs:
-  publish:
+  publish-gcp:
     runs-on: ubuntu-latest
     if: github.repository == 'gke-labs/kube-agents'
     permissions:
       contents: read
-      packages: write
       id-token: write
     env:
       GCP_REGISTRY: us-docker.pkg.dev/kube-agents-prow/kube-agents
@@ -20,15 +19,6 @@ jobs:
 
       - name: Load tags
         run: cat tags.env >> "$GITHUB_ENV"
-
-      - name: Downcase repository name
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-        run: |
-          echo "IMAGE_REPOSITORY=$(echo "$GITHUB_REPO" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -41,34 +31,6 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
-      - name: Log in to GCP Artifact Registry
-        uses: docker/login-action@v4
-        with:
-          registry: us-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and Push DevTeam Agent (GHCR)
-        uses: docker/build-push-action@v7
-        id: build-devteam
-        with:
-          context: .
-          file: agents/Dockerfile
-          target: devteam
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
-          build-args: |
-            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
-
       - name: Build and Push DevTeam Agent (GCP Cloud Build)
         id: gcp-devteam
         run: |
@@ -79,20 +41,6 @@ jobs:
           DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/devteam-agent:${{ github.sha }}" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
-      - name: Build and Push Operator Agent (GHCR)
-        uses: docker/build-push-action@v7
-        id: build-operator
-        with:
-          context: .
-          file: agents/Dockerfile
-          target: operator
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
-          build-args: |
-            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
-
       - name: Build and Push Operator Agent (GCP Cloud Build)
         id: gcp-operator
         run: |
@@ -102,20 +50,6 @@ jobs:
             .
           DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/operator-agent:${{ github.sha }}" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-
-      - name: Build and Push Platform Agent (GHCR)
-        uses: docker/build-push-action@v7
-        id: build-platform
-        with:
-          context: .
-          file: agents/Dockerfile
-          target: platform
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
-            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
-          build-args: |
-            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Build and Push Platform Agent (GCP Cloud Build)
         id: gcp-platform
@@ -132,9 +66,6 @@ jobs:
 
       - name: Sign the images
         run: |
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
           cosign sign --yes "${{ env.GCP_REGISTRY }}/devteam-agent@${{ steps.gcp-devteam.outputs.digest }}"
           cosign sign --yes "${{ env.GCP_REGISTRY }}/operator-agent@${{ steps.gcp-operator.outputs.digest }}"
           cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -1,0 +1,87 @@
+name: Publish to GHCR
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish-ghcr:
+    runs-on: ubuntu-latest
+    if: github.repository == 'gke-labs/kube-agents'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Load tags
+        run: cat tags.env >> "$GITHUB_ENV"
+
+      - name: Downcase repository name
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          echo "IMAGE_REPOSITORY=$(echo "$GITHUB_REPO" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push DevTeam Agent (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-devteam
+        with:
+          context: .
+          file: agents/Dockerfile
+          target: devteam
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build and Push Operator Agent (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-operator
+        with:
+          context: .
+          file: agents/Dockerfile
+          target: operator
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build and Push Platform Agent (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-platform
+        with:
+          context: .
+          file: agents/Dockerfile
+          target: platform
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.0
+
+      - name: Sign the images
+        run: |
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/devteam-agent@${{ steps.build-devteam.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/operator-agent@${{ steps.build-operator.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"


### PR DESCRIPTION
# Pull Request

## Why This Change

Split the monolithic Docker publish workflow into two separate workflows: one dedicated to GHCR, and one dedicated to GCP Artifact Registry. This prevents GCP/Cloud Build issues from blocking GHCR publishing and simplifies troubleshooting/isolation.

## What Changed

**Files:**

- `.github/workflows/docker-publish.yml`
- `.github/workflows/docker-publish-ghcr.yml`
- `.github/workflows/docker-publish-gcp.yml`

**Added/Changed/Fixed:**

- Created `.github/workflows/docker-publish-ghcr.yml` to handle build, push, and cosign signing for GHCR.
- Created `.github/workflows/docker-publish-gcp.yml` to handle GCP Cloud Build and cosign signing for GCP Artifact Registry.
- Removed the old unified `.github/workflows/docker-publish.yml` workflow.

## Why This Matters

- Provides better isolation of failure domains in CI/CD.
- Simplifies execution logic per target registry.

## Context

- Requested by user to split the publish action.

## Testing

--------
TAG=agy
CONV=1fd0f601-c32c-4c80-8829-31548302d5cb
