### PR TITLE
feat(agents): add permissions to list clusters to platform agent

### DIFF
--- a/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
+++ b/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
@@ -169,6 +169,18 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	// Reconcile Platform custom ClusterRole
+	if err := r.reconcilePlatformExplorerRole(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile Platform ClusterRole")
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile Platform custom ClusterRoleBinding
+	if err := r.reconcilePlatformExplorerRoleBinding(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile Platform ClusterRoleBinding")
+		return ctrl.Result{}, err
+	}
+
 	// 7. Reconcile PVC
 	if err := r.reconcilePVC(ctx, instance); err != nil {
 		log.Error(err, "Failed to reconcile PVC")
@@ -508,6 +520,18 @@ func (r *PlatformAgentReconciler) reconcileIAMBindings(ctx context.Context, inst
 		return true, nil
 	}
 
+	// 3.5. GSA Cluster Viewer on Project
+	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-cluster-viewer", map[string]any{
+		"kind":     "Project",
+		"external": instance.Spec.ProjectID,
+	}, "roles/container.clusterViewer", "serviceAccount:"+gsaEmail)
+	if err != nil {
+		return false, err
+	}
+	if requeue {
+		return true, nil
+	}
+
 	// 4. GChat System SA Publisher on Topic
 	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-chat-publisher", map[string]any{
 		"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
@@ -721,9 +745,9 @@ func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, insta
 							Name:            "platform-agent",
 							Image:           instance.Spec.ImageURI,
 							ImagePullPolicy: corev1.PullAlways,
-							Command:         []string{"hermes"}, 
-        			Args:            []string{"gateway", "run"},
-        			Ports: []corev1.ContainerPort{
+							Command:         []string{"hermes"},
+							Args:            []string{"gateway", "run"},
+							Ports: []corev1.ContainerPort{
 								{
 									Name:          "dashboard",
 									ContainerPort: 9119,
@@ -920,6 +944,82 @@ func (r *PlatformAgentReconciler) reconcileClusterRoleBinding(ctx context.Contex
 	return nil
 }
 
+func (r *PlatformAgentReconciler) reconcilePlatformExplorerRole(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: instance.Namespace + "-" + instance.Name + "-platform-explorer",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "pods", "namespaces"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+
+	found := &rbacv1.ClusterRole{}
+	err := r.Get(ctx, client.ObjectKey{Name: cr.Name}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.Create(ctx, cr)
+		}
+		return err
+	}
+
+	if !reflect.DeepEqual(found.Rules, cr.Rules) {
+		found.Rules = cr.Rules
+		return r.Update(ctx, found)
+	}
+	return nil
+}
+
+func (r *PlatformAgentReconciler) reconcilePlatformExplorerRoleBinding(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	crbName := instance.Namespace + "-" + instance.Name + "-platform-explorer-binding"
+	roleName := instance.Namespace + "-" + instance.Name + "-platform-explorer"
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: crbName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      instance.Spec.KSAName,
+				Namespace: instance.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+	}
+
+	found := &rbacv1.ClusterRoleBinding{}
+	err := r.Get(ctx, client.ObjectKey{Name: crb.Name}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.Create(ctx, crb)
+		}
+		return err
+	}
+
+	if !reflect.DeepEqual(found.RoleRef, crb.RoleRef) {
+		log := logf.FromContext(ctx)
+		log.Info("RoleRef of ClusterRoleBinding changed. Deleting and recreating...", "name", crb.Name)
+		if err := r.Delete(ctx, found); err != nil {
+			return err
+		}
+		return r.Create(ctx, crb)
+	}
+
+	if !reflect.DeepEqual(found.Subjects, crb.Subjects) {
+		found.Subjects = crb.Subjects
+		return r.Update(ctx, found)
+	}
+	return nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *PlatformAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -947,6 +1047,31 @@ func (r *PlatformAgentReconciler) deleteExternalResources(ctx context.Context, i
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
+
+	platformExplorerCrbName := instance.Namespace + "-" + instance.Name + "-platform-explorer-binding"
+	platformExplorerCrb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: platformExplorerCrbName,
+		},
+	}
+	log.Info("Deleting associated Platform ClusterRoleBinding during finalizer cleanup", "name", platformExplorerCrbName)
+	err = r.Delete(ctx, platformExplorerCrb)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	platformExplorerCrName := instance.Namespace + "-" + instance.Name + "-platform-explorer"
+	platformExplorerCr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: platformExplorerCrName,
+		},
+	}
+	log.Info("Deleting associated Platform ClusterRole during finalizer cleanup", "name", platformExplorerCrName)
+	err = r.Delete(ctx, platformExplorerCr)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
 	return nil
 }
 

--- a/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller_test.go
+++ b/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -89,12 +90,45 @@ var _ = Describe("PlatformAgent Controller", func() {
 				Scheme: k8sClient.Scheme(),
 			}
 
+			// First reconcile: registers finalizer
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+
+			// Second reconcile: updates status to Provisioning
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Third reconcile: actually creates resources
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Verify ClusterRole is created
+			cr := &rbacv1.ClusterRole{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: "default-test-resource-platform-explorer"}, cr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cr.Rules).To(ConsistOf(rbacv1.PolicyRule{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "pods", "namespaces"},
+				Verbs:     []string{"get", "list"},
+			}))
+
+			// Verify ClusterRoleBinding is created
+			crb := &rbacv1.ClusterRoleBinding{}
+			crbName := "default-test-resource-platform-explorer-binding"
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: crbName}, crb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(crb.RoleRef.Name).To(Equal("default-test-resource-platform-explorer"))
+			Expect(crb.Subjects).To(ConsistOf(rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				Name:      "test-ksa",
+				Namespace: "default",
+			}))
 		})
 	})
 })


### PR DESCRIPTION
# Pull Request

Update platform agent operator to grant permissions to list clusters, nodes, pods and namespaces to the platform agent.

## Why This Change

This change automates the provisioning of cluster-level read permissions (specifically to list nodes, pods, and namespaces) and GCP-level GKE cluster viewer permissions, making the deployment process fully declarative and self-healing.

## What Changed

Added automatic reconciliation of Kubernetes RBAC (ClusterRole and ClusterRoleBinding) and GCP IAM roles (via Config Connector `IAMPolicyMember`) directly into the `PlatformAgent` controller.

**Files:**

- `integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go`
- `integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller_test.go`

**Added/Changed/Fixed:**

- **Added** `reconcileHermesClusterRole` to create/maintain a `hermes-cluster-explorer` ClusterRole allowing `get` and `list` on `nodes`, `pods`, and `namespaces`.
- **Added** `reconcileHermesClusterRoleBinding` to bind the above role to the agent's ServiceAccount (`spec.ksaName`).
- **Added** cleanup logic in `deleteExternalResources` to remove the ClusterRoleBinding when the `PlatformAgent` CR is deleted.
- **Added** GCP `roles/container.clusterViewer` IAM binding to the GSA reconciliation loop (`reconcileIAMBindings`) using Config Connector.
- **Updated** unit tests to verify the automatic creation of the new ClusterRole and ClusterRoleBinding resources.

## Why This Matters

- **Out-of-the-box functionality**: The agent has the correct permissions immediately upon deploying the Custom Resource, without requiring extra manual script executions.
- **Self-Healing**: If the ClusterRoleBinding or ClusterRole is deleted manually, the operator will automatically recreate them on the next reconcile loop.
- **Consistency**: Aligns GCP IAM permission management with the existing pattern used for `roles/aiplatform.user`.

## Context

Follow-up to GKE standard setup integration where the agent requires visibility into the cluster resources it is running on.

## Testing

- Ran tests locally using `go test ./internal/controller/...` with envtest, confirming all tests pass.