### PR TITLE
feat(operator): restrict cluster-heartbeat to single-cluster scope

### DIFF
--- a/agents/operator/defaults/cron/jobs.json
+++ b/agents/operator/defaults/cron/jobs.json
@@ -8,7 +8,7 @@
         "expr": "*/15 * * * *",
         "display": "*/15 * * * *"
       },
-      "prompt": "Perform a comprehensive 15-minute diagnostic scan across all clusters (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Maintain constant system awareness.",
+      "prompt": "Perform a comprehensive 15-minute diagnostic scan of the specific cluster you are responsible for (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Do not attempt to scan other clusters. Maintain constant system awareness.",
       "skills": ["gke-observability", "gke-reliability"],
       "enabled": true
     },

--- a/agents/operator/defaults/cron/jobs.json
+++ b/agents/operator/defaults/cron/jobs.json
@@ -8,7 +8,7 @@
         "expr": "*/15 * * * *",
         "display": "*/15 * * * *"
       },
-      "prompt": "Perform a comprehensive 15-minute diagnostic scan of the specific cluster you are responsible for (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Do not attempt to scan other clusters. Maintain constant system awareness.",
+      "prompt": "Perform a comprehensive 15-minute diagnostic scan of the specific GKE cluster you are responsible for (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Do not attempt to scan other clusters. Maintain constant system awareness.",
       "skills": ["gke-observability", "gke-reliability"],
       "enabled": true
     },

--- a/workspace/agents/platform/templates/operator/HEARTBEAT.md
+++ b/workspace/agents/platform/templates/operator/HEARTBEAT.md
@@ -11,7 +11,7 @@ Each time you receive a heartbeat poll (triggered periodically by the agent harn
 ### 1. Cluster Heartbeat
 
 - **Schedule**: Every 15 minutes
-- **Function**: Perform a comprehensive 15-minute diagnostic scan across all clusters (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Maintain constant system awareness.
+- **Function**: Perform a comprehensive 15-minute diagnostic scan of the specific GKE cluster you are responsible for (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Do not attempt to scan other clusters. Maintain constant system awareness.
 
 ### 2. Utilization Optimizer
 


### PR DESCRIPTION
This PR restricts the Operator's cluster-heartbeat diagnostic scan to its own assigned target GKE cluster, enforcing least-privilege scoping and preventing multi-cluster cross-talk. It updates both the active jobs.json prompt and the master HEARTBEAT.md manual template to maintain absolute context consistency.