### PR TITLE
chore: add OWNERS file to enable Prow approvals

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- bradhoekstra
+- dshnayder
+- haoxuw
+- jayantid
+- toshiowang
+

--- a/k8s-operator/OWNERS
+++ b/k8s-operator/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- fatoshoti
+- mateuszklinowski
+- mplakhtiy
+


### PR DESCRIPTION
## Why This Change

Enables Prow and Tide to automate PR approvals, reviews, and merging on this repository. Prow plugins (specifically `approve` and `lgtm`) look at the `OWNERS` file at the root and component directories of the repository to identify valid approvers.

## What Changed

Added the `OWNERS` file at the root repository directory and the `k8s-operator` directory listing default approvers.

Files:

• OWNERS [OWNERS](file:///usr/local/google/home/bhoekstra/kube-agents/OWNERS)
• k8s-operator/OWNERS [k8s-operator/OWNERS](file:///usr/local/google/home/bhoekstra/kube-agents/k8s-operator/OWNERS)

Added/Changed/Fixed:

• Added root `OWNERS` file with default approvers (bradhoekstra, dshnayder, haoxuw, jayantid, toshiowang).
• Added `k8s-operator/OWNERS` file with default approvers (fatoshoti, mateuszklinowski, mplakhtiy).

## Why This Matters

Reduces manual overhead by letting the team use Prow chat commands (`/approve`, `/lgtm`) to approve changes, allowing Tide to automatically merge PRs when all conditions are met.

## Context

• None

## Testing

N/A - Configuration file only.

--------

TAG=agy
CONV=0eaaa7d7-370e-4949-b068-ee4adbec15be
