### PR TITLE
fix(ci): log in to Artifact Registry to authenticate cosign

### DIFF
--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -28,6 +28,13 @@ jobs:
           workload_identity_provider: projects/125393897113/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
           service_account: github-actions@kube-agents-prow.iam.gserviceaccount.com
 
+      - name: Log in to Google Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: us-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The GCP publish workflow failed during the `Sign the images` step because the runner was not logged in/authenticated to Google Artifact Registry when running `cosign`.

## What Changed

Added a `docker/login-action` step after authenticating to Google Cloud, using the access token from the workload identity federation auth step.

**Files:**

- `.github/workflows/docker-publish-gcp.yml`

**Added/Changed/Fixed:**

- Fixed authentication for `cosign` when signing images on Google Artifact Registry (`us-docker.pkg.dev`).

## Why This Matters

This allows the images to be signed successfully by cosign.

## Context

Fixes the failure on workflow run: https://github.com/gke-labs/kube-agents/actions/runs/27277408045

## Testing

Verified by analyzing workflow configuration. Functional execution will be validated upon run.
