### PR TITLE
Refactor(gchat integration): remove KCC dependencies

### DIFF
--- a/integrations/gchat/crd/platform-agent-operator/api/v1alpha1/platformagent_types.go
+++ b/integrations/gchat/crd/platform-agent-operator/api/v1alpha1/platformagent_types.go
@@ -33,7 +33,6 @@ type ModelSpec struct {
 
 // PlatformAgentSpec defines the desired state of PlatformAgent
 type PlatformAgentSpec struct {
-	ProjectID              string    `json:"projectId"`
 	ImageURI               string    `json:"imageUri"`
 	ChatTopicName          string    `json:"chatTopicName"`
 	ChatSubName            string    `json:"chatSubName"`
@@ -41,7 +40,6 @@ type PlatformAgentSpec struct {
 	KSAName                string    `json:"ksaName"`
 	GoogleChatAllowedUsers string    `json:"googleChatAllowedUsers"`
 	GoogleChatHomeChannel  string    `json:"googleChatHomeChannel"`
-	NumericProjectID       string    `json:"numericProjectId"`
 	ClusterName            string    `json:"clusterName"`
 	Location               string    `json:"location"`
 	Model                  ModelSpec `json:"model"`

--- a/integrations/gchat/crd/platform-agent-operator/cmd/main.go
+++ b/integrations/gchat/crd/platform-agent-operator/cmd/main.go
@@ -17,9 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
+
+	// Google Cloud Direct-to-API Packages
+	"cloud.google.com/go/pubsub"
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	iam "google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -119,10 +126,6 @@ func main() {
 
 	webhookServer := webhook.NewServer(webhookServerOptions)
 
-	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
-	// More info:
-	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server
-	// - https://book.kubebuilder.io/reference/metrics.html
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,
 		SecureServing: secureMetrics,
@@ -130,21 +133,9 @@ func main() {
 	}
 
 	if secureMetrics {
-		// FilterProvider is used to protect the metrics endpoint with authn/authz.
-		// These configurations ensure that only authorized users and service accounts
-		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
-		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
-	// If the certificate is not specified, controller-runtime will automatically
-	// generate self-signed certificates for the metrics server. While convenient for development and testing,
-	// this setup is not recommended for production.
-	//
-	// TODO(user): If you enable certManager, uncomment the following lines:
-	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
-	// managed by cert-manager for the metrics server.
-	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
 	if len(metricsCertPath) > 0 {
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
@@ -178,13 +169,50 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := (&controller.PlatformAgentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	// ─── SINGLE-PROJECT DIRECT API INITIALIZATION ────────────────────────────────
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	if projectID == "" {
+		setupLog.Error(nil, "Mandatory environment variable GOOGLE_CLOUD_PROJECT is empty")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	setupLog.Info("Initializing shared Google Cloud API clients", "projectID", projectID)
+
+	pubsubClient, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize global Google Pub/Sub API client")
+		os.Exit(1)
+	}
+
+	iamService, err := iam.NewService(ctx, option.WithScopes(iam.CloudPlatformScope))
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize global Google IAM API service channel")
+		os.Exit(1)
+	}
+
+	resourceManagerClient, err := resourcemanager.NewProjectsClient(ctx)
+	if err != nil {
+		setupLog.Error(err, "Failed to initialize global Google Cloud Resource Manager API client")
+		os.Exit(1)
+	}
+	// ─────────────────────────────────────────────────────────────────────────────
+
+	// Hand the pre-warmed, authenticated clients straight into your reconciler
+	platformAgentReconciler := &controller.PlatformAgentReconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		ProjectID:             projectID,
+		PubSubClient:          pubsubClient,
+		IAMService:            iamService,
+		ResourceManagerClient: resourceManagerClient,
+	}
+
+	if err := platformAgentReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "platformagent")
 		os.Exit(1)
 	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/integrations/gchat/crd/platform-agent-operator/cmd/main.go
+++ b/integrations/gchat/crd/platform-agent-operator/cmd/main.go
@@ -126,6 +126,10 @@ func main() {
 
 	webhookServer := webhook.NewServer(webhookServerOptions)
 
+	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
+	// More info:
+	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/server
+	// - https://book.kubebuilder.io/reference/metrics.html
 	metricsServerOptions := metricsserver.Options{
 		BindAddress:   metricsAddr,
 		SecureServing: secureMetrics,
@@ -133,9 +137,21 @@ func main() {
 	}
 
 	if secureMetrics {
+		// FilterProvider is used to protect the metrics endpoint with authn/authz.
+		// These configurations ensure that only authorized users and service accounts
+		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.23.3/pkg/metrics/filters#WithAuthenticationAndAuthorization
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
 	}
 
+	// If the certificate is not specified, controller-runtime will automatically
+	// generate self-signed certificates for the metrics server. While convenient for development and testing,
+	// this setup is not recommended for production.
+	//
+	// TODO(user): If you enable certManager, uncomment the following lines:
+	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
+	// managed by cert-manager for the metrics server.
+	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
 	if len(metricsCertPath) > 0 {
 		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
 			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)

--- a/integrations/gchat/crd/platform-agent-operator/cmd/main.go
+++ b/integrations/gchat/crd/platform-agent-operator/cmd/main.go
@@ -186,9 +186,16 @@ func main() {
 	}
 
 	// ─── SINGLE-PROJECT DIRECT API INITIALIZATION ────────────────────────────────
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT_ID")
+	projectNumber := os.Getenv("GOOGLE_CLOUD_PROJECT_NUMBER")
+	
 	if projectID == "" {
 		setupLog.Error(nil, "Mandatory environment variable GOOGLE_CLOUD_PROJECT is empty")
+		os.Exit(1)
+	}
+
+	if projectNumber == "" {
+		setupLog.Error(nil, "Mandatory environment variable GOOGLE_CLOUD_PROJECT_NUMBER is empty")
 		os.Exit(1)
 	}
 
@@ -219,6 +226,7 @@ func main() {
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		ProjectID:             projectID,
+		ProjectNumber:         projectNumber,
 		PubSubClient:          pubsubClient,
 		IAMService:            iamService,
 		ResourceManagerClient: resourceManagerClient,

--- a/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
@@ -14,84 +14,84 @@ spec:
     singular: platformagent
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: PlatformAgent is the Schema for the platformagents API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec defines the desired state of PlatformAgent
-            properties:
-              chatSubName:
-                type: string
-              chatTopicName:
-                type: string
-              clusterName:
-                type: string
-              googleChatAllowedUsers:
-                type: string
-              googleChatHomeChannel:
-                type: string
-              gsaName:
-                type: string
-              imageUri:
-                type: string
-              ksaName:
-                type: string
-              location:
-                type: string
-              model:
-                description: ModelSpec defines the model configuration
-                properties:
-                  default:
-                    minLength: 1
-                    type: string
-                  provider:
-                    minLength: 1
-                    type: string
-                required:
-                - default
-                - provider
-                type: object
-            required:
-            - chatSubName
-            - chatTopicName
-            - clusterName
-            - googleChatAllowedUsers
-            - googleChatHomeChannel
-            - gsaName
-            - imageUri
-            - ksaName
-            - location
-            - model
-            type: object
-          status:
-            description: status defines the observed state of PlatformAgent
-            properties:
-              phase:
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: PlatformAgent is the Schema for the platformagents API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec defines the desired state of PlatformAgent
+              properties:
+                chatSubName:
+                  type: string
+                chatTopicName:
+                  type: string
+                clusterName:
+                  type: string
+                googleChatAllowedUsers:
+                  type: string
+                googleChatHomeChannel:
+                  type: string
+                gsaName:
+                  type: string
+                imageUri:
+                  type: string
+                ksaName:
+                  type: string
+                location:
+                  type: string
+                model:
+                  description: ModelSpec defines the model configuration
+                  properties:
+                    default:
+                      minLength: 1
+                      type: string
+                    provider:
+                      minLength: 1
+                      type: string
+                  required:
+                    - default
+                    - provider
+                  type: object
+              required:
+                - chatSubName
+                - chatTopicName
+                - clusterName
+                - googleChatAllowedUsers
+                - googleChatHomeChannel
+                - gsaName
+                - imageUri
+                - ksaName
+                - location
+                - model
+              type: object
+            status:
+              description: status defines the observed state of PlatformAgent
+              properties:
+                phase:
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
@@ -14,90 +14,90 @@ spec:
     singular: platformagent
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: PlatformAgent is the Schema for the platformagents API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: spec defines the desired state of PlatformAgent
-            properties:
-              chatSubName:
-                type: string
-              chatTopicName:
-                type: string
-              clusterName:
-                type: string
-              googleChatAllowedUsers:
-                type: string
-              googleChatHomeChannel:
-                type: string
-              gsaName:
-                type: string
-              imageUri:
-                type: string
-              ksaName:
-                type: string
-              location:
-                type: string
-              model:
-                description: ModelSpec defines the model configuration
-                properties:
-                  default:
-                    minLength: 1
-                    type: string
-                  provider:
-                    minLength: 1
-                    type: string
-                required:
-                - default
-                - provider
-                type: object
-              numericProjectId:
-                type: string
-              projectId:
-                type: string
-            required:
-            - chatSubName
-            - chatTopicName
-            - clusterName
-            - googleChatAllowedUsers
-            - googleChatHomeChannel
-            - gsaName
-            - imageUri
-            - ksaName
-            - location
-            - model
-            - numericProjectId
-            - projectId
-            type: object
-          status:
-            description: status defines the observed state of PlatformAgent
-            properties:
-              phase:
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: PlatformAgent is the Schema for the platformagents API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec defines the desired state of PlatformAgent
+              properties:
+                chatSubName:
+                  type: string
+                chatTopicName:
+                  type: string
+                clusterName:
+                  type: string
+                googleChatAllowedUsers:
+                  type: string
+                googleChatHomeChannel:
+                  type: string
+                gsaName:
+                  type: string
+                imageUri:
+                  type: string
+                ksaName:
+                  type: string
+                location:
+                  type: string
+                model:
+                  description: ModelSpec defines the model configuration
+                  properties:
+                    default:
+                      minLength: 1
+                      type: string
+                    provider:
+                      minLength: 1
+                      type: string
+                  required:
+                    - default
+                    - provider
+                  type: object
+                numericProjectId:
+                  type: string
+                projectId:
+                  type: string
+              required:
+                - chatSubName
+                - chatTopicName
+                - clusterName
+                - googleChatAllowedUsers
+                - googleChatHomeChannel
+                - gsaName
+                - imageUri
+                - ksaName
+                - location
+                - model
+                - numericProjectId
+                - projectId
+              type: object
+            status:
+              description: status defines the observed state of PlatformAgent
+              properties:
+                phase:
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
@@ -14,90 +14,90 @@ spec:
     singular: platformagent
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: PlatformAgent is the Schema for the platformagents API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of PlatformAgent
-              properties:
-                chatSubName:
-                  type: string
-                chatTopicName:
-                  type: string
-                clusterName:
-                  type: string
-                googleChatAllowedUsers:
-                  type: string
-                googleChatHomeChannel:
-                  type: string
-                gsaName:
-                  type: string
-                imageUri:
-                  type: string
-                ksaName:
-                  type: string
-                location:
-                  type: string
-                model:
-                  description: ModelSpec defines the model configuration
-                  properties:
-                    default:
-                      minLength: 1
-                      type: string
-                    provider:
-                      minLength: 1
-                      type: string
-                  required:
-                    - default
-                    - provider
-                  type: object
-                numericProjectId:
-                  type: string
-                projectId:
-                  type: string
-              required:
-                - chatSubName
-                - chatTopicName
-                - clusterName
-                - googleChatAllowedUsers
-                - googleChatHomeChannel
-                - gsaName
-                - imageUri
-                - ksaName
-                - location
-                - model
-                - numericProjectId
-                - projectId
-              type: object
-            status:
-              description: status defines the observed state of PlatformAgent
-              properties:
-                phase:
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PlatformAgent is the Schema for the platformagents API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of PlatformAgent
+            properties:
+              chatSubName:
+                type: string
+              chatTopicName:
+                type: string
+              clusterName:
+                type: string
+              googleChatAllowedUsers:
+                type: string
+              googleChatHomeChannel:
+                type: string
+              gsaName:
+                type: string
+              imageUri:
+                type: string
+              ksaName:
+                type: string
+              location:
+                type: string
+              model:
+                description: ModelSpec defines the model configuration
+                properties:
+                  default:
+                    minLength: 1
+                    type: string
+                  provider:
+                    minLength: 1
+                    type: string
+                required:
+                - default
+                - provider
+                type: object
+              numericProjectId:
+                type: string
+              projectId:
+                type: string
+            required:
+            - chatSubName
+            - chatTopicName
+            - clusterName
+            - googleChatAllowedUsers
+            - googleChatHomeChannel
+            - gsaName
+            - imageUri
+            - ksaName
+            - location
+            - model
+            - numericProjectId
+            - projectId
+            type: object
+          status:
+            description: status defines the observed state of PlatformAgent
+            properties:
+              phase:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/crd/bases/agent.platform.io_platformagents.yaml
@@ -14,90 +14,84 @@ spec:
     singular: platformagent
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: PlatformAgent is the Schema for the platformagents API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec defines the desired state of PlatformAgent
-              properties:
-                chatSubName:
-                  type: string
-                chatTopicName:
-                  type: string
-                clusterName:
-                  type: string
-                googleChatAllowedUsers:
-                  type: string
-                googleChatHomeChannel:
-                  type: string
-                gsaName:
-                  type: string
-                imageUri:
-                  type: string
-                ksaName:
-                  type: string
-                location:
-                  type: string
-                model:
-                  description: ModelSpec defines the model configuration
-                  properties:
-                    default:
-                      minLength: 1
-                      type: string
-                    provider:
-                      minLength: 1
-                      type: string
-                  required:
-                    - default
-                    - provider
-                  type: object
-                numericProjectId:
-                  type: string
-                projectId:
-                  type: string
-              required:
-                - chatSubName
-                - chatTopicName
-                - clusterName
-                - googleChatAllowedUsers
-                - googleChatHomeChannel
-                - gsaName
-                - imageUri
-                - ksaName
-                - location
-                - model
-                - numericProjectId
-                - projectId
-              type: object
-            status:
-              description: status defines the observed state of PlatformAgent
-              properties:
-                phase:
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PlatformAgent is the Schema for the platformagents API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of PlatformAgent
+            properties:
+              chatSubName:
+                type: string
+              chatTopicName:
+                type: string
+              clusterName:
+                type: string
+              googleChatAllowedUsers:
+                type: string
+              googleChatHomeChannel:
+                type: string
+              gsaName:
+                type: string
+              imageUri:
+                type: string
+              ksaName:
+                type: string
+              location:
+                type: string
+              model:
+                description: ModelSpec defines the model configuration
+                properties:
+                  default:
+                    minLength: 1
+                    type: string
+                  provider:
+                    minLength: 1
+                    type: string
+                required:
+                - default
+                - provider
+                type: object
+            required:
+            - chatSubName
+            - chatTopicName
+            - clusterName
+            - googleChatAllowedUsers
+            - googleChatHomeChannel
+            - gsaName
+            - imageUri
+            - ksaName
+            - location
+            - model
+            type: object
+          status:
+            description: status defines the observed state of PlatformAgent
+            properties:
+              phase:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
@@ -4,96 +4,70 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - persistentvolumeclaims
-      - serviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - agent.platform.io
-    resources:
-      - platformagents
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - agent.platform.io
-    resources:
-      - platformagents/finalizers
-    verbs:
-      - update
-  - apiGroups:
-      - agent.platform.io
-    resources:
-      - platformagents/status
-    verbs:
-      - get
-      - patch
-      - update
-  - apiGroups:
-      - apps
-    resources:
-      - deployments
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - iam.cnrm.cloud.google.com
-    resources:
-      - iampolicymembers
-      - iamserviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - pubsub.cnrm.cloud.google.com
-    resources:
-      - pubsubsubscriptions
-      - pubsubtopics
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
-      - clusterrolebindings
-      - clusterroles
-    verbs:
-      - bind
-      - create
-      - delete
-      - escalate
-      - get
-      - list
-      - patch
-      - update
-      - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agent.platform.io
+  resources:
+  - platformagents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - agent.platform.io
+  resources:
+  - platformagents/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - agent.platform.io
+  resources:
+  - platformagents/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
@@ -4,70 +4,70 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - persistentvolumeclaims
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  verbs:
-  - bind
-  - create
-  - delete
-  - escalate
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - bind
+      - create
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
+++ b/integrations/gchat/crd/platform-agent-operator/config/rbac/role.yaml
@@ -4,70 +4,96 @@ kind: ClusterRole
 metadata:
   name: manager-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - persistentvolumeclaims
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - agent.platform.io
-  resources:
-  - platformagents/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  - clusterroles
-  verbs:
-  - bind
-  - create
-  - delete
-  - escalate
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - persistentvolumeclaims
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - agent.platform.io
+    resources:
+      - platformagents/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - iam.cnrm.cloud.google.com
+    resources:
+      - iampolicymembers
+      - iamserviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - pubsub.cnrm.cloud.google.com
+    resources:
+      - pubsubsubscriptions
+      - pubsubtopics
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - bind
+      - create
+      - delete
+      - escalate
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
+++ b/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
@@ -21,21 +21,22 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"maps"
-	"os"
 	"reflect"
 	"strings"
 	"time"
 
+	cloudiam "cloud.google.com/go/iam"
+	iampb "cloud.google.com/go/iam/apiv1/iampb"
+	pubsub "cloud.google.com/go/pubsub"
+	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	iam "google.golang.org/api/iam/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -48,7 +49,11 @@ const platformAgentFinalizer = "agent.platform.io/finalizer"
 // PlatformAgentReconciler reconciles a PlatformAgent object
 type PlatformAgentReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme                *runtime.Scheme
+	ProjectID             string
+	PubSubClient          *pubsub.Client
+	IAMService            *iam.Service
+	ResourceManagerClient *resourcemanager.ProjectsClient
 }
 
 // +kubebuilder:rbac:groups=agent.platform.io,resources=platformagents,verbs=get;list;watch;create;update;patch;delete
@@ -56,8 +61,6 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups=agent.platform.io,resources=platformagents/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;persistentvolumeclaims;configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=iam.cnrm.cloud.google.com,resources=iamserviceaccounts;iampolicymembers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=pubsub.cnrm.cloud.google.com,resources=pubsubtopics;pubsubsubscriptions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind;escalate
 
 func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -74,15 +77,14 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// 1.5. Handle finalizer registration and deletion lifecycle hooks
-	// Check if the instance is marked for deletion (DeletionTimestamp is set)
 	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
 		if containsString(instance.ObjectMeta.Finalizers, platformAgentFinalizer) {
-			// Run custom cleanup logic for cluster-scoped resources (ClusterRoleBinding)
+			// Run custom cleanup logic for cluster-scoped and cloud-scoped resources
 			if err := r.deleteExternalResources(ctx, instance); err != nil {
 				return ctrl.Result{}, err
 			}
 
-			// Remove finalizer string from GMeta list
+			// Remove finalizer string from metadata list
 			instance.ObjectMeta.Finalizers = removeString(instance.ObjectMeta.Finalizers, platformAgentFinalizer)
 			if err := r.Update(ctx, instance); err != nil {
 				return ctrl.Result{}, err
@@ -111,50 +113,28 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	// 2. Reconcile KCC GCP Identity (GSA), Topic, Subscription, and IAM bindings
-	if os.Getenv("SKIP_KCC_RECONCILE") != "true" {
-		requeue, err := r.reconcileGSA(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to reconcile GSA")
-			return ctrl.Result{}, err
-		}
-		if requeue {
-			log.Info("Reconciliation requires requeue (GSA)")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
+	// 2. Reconcile GCP GSA Service Account
+	if err := r.reconcileGSA(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile GSA")
+		return ctrl.Result{}, err
+	}
 
-		// 3. Reconcile Pub/Sub Topic
-		requeue, err = r.reconcileTopic(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to reconcile Pub/Sub Topic")
-			return ctrl.Result{}, err
-		}
-		if requeue {
-			log.Info("Reconciliation requires requeue (Topic)")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
+	// 3. Reconcile GCP Pub/Sub Topic
+	if err := r.reconcileTopic(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile Pub/Sub Topic")
+		return ctrl.Result{}, err
+	}
 
-		// 4. Reconcile Pub/Sub Subscription
-		requeue, err = r.reconcileSubscription(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to reconcile Pub/Sub Subscription")
-			return ctrl.Result{}, err
-		}
-		if requeue {
-			log.Info("Reconciliation requires requeue (Subscription)")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
+	// 4. Reconcile GCP Pub/Sub Subscription
+	if err := r.reconcileSubscription(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile Pub/Sub Subscription")
+		return ctrl.Result{}, err
+	}
 
-		// 5. Reconcile IAM Policy Bindings
-		requeue, err = r.reconcileIAMBindings(ctx, instance)
-		if err != nil {
-			log.Error(err, "Failed to reconcile IAM Bindings")
-			return ctrl.Result{}, err
-		}
-		if requeue {
-			log.Info("Reconciliation requires requeue (IAM Bindings)")
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
-		}
+	// 5. Reconcile GCP IAM Policy Bindings
+	if err := r.reconcileIAMBindings(ctx, instance); err != nil {
+		log.Error(err, "Failed to reconcile IAM Bindings")
+		return ctrl.Result{}, err
 	}
 
 	// 6. Reconcile Kubernetes Service Account (KSA)
@@ -197,46 +177,6 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// Intelligent diff check helper: returns true if desired map is a subset of found map.
-func isMapSubset(desired, found map[string]any) bool {
-	for k, desiredVal := range desired {
-		foundVal, exists := found[k]
-		if !exists {
-			logf.Log.V(1).Info("isMapSubset diff: Key missing in found", "key", k)
-			return false
-		}
-		desiredMap, desiredIsMap := desiredVal.(map[string]any)
-		foundMap, foundIsMap := foundVal.(map[string]any)
-
-		if desiredIsMap && foundIsMap {
-			if !isMapSubset(desiredMap, foundMap) {
-				return false
-			}
-		} else {
-			desiredStr := fmt.Sprintf("%v", desiredVal)
-			foundStr := fmt.Sprintf("%v", foundVal)
-			if desiredStr != foundStr {
-				logf.Log.V(1).Info("isMapSubset diff: Values differ", "key", k, "desired", desiredStr, "found", foundStr)
-				return false
-			}
-		}
-	}
-	return true
-}
-
-// Helper to calculate the SHA256 hash of ConfigMap Data for rolling restarts.
-func getConfigMapHash(configMap *corev1.ConfigMap) (string, error) {
-	if configMap == nil {
-		return "", nil
-	}
-	dataBytes, err := json.Marshal(configMap.Data)
-	if err != nil {
-		return "", err
-	}
-	hash := sha256.Sum256(dataBytes)
-	return fmt.Sprintf("%x", hash), nil
 }
 
 // Custom Deployment spec comparison helper to avoid APIServer defaults trap.
@@ -294,266 +234,265 @@ func isDeploymentSpecEqual(found, desired *appsv1.Deployment) bool {
 	return true
 }
 
-// Robust merge-based update for unstructured objects.
-// Implements Delete-and-Recreate with Requeue signal (returns requeue=true) for immutable resources.
-func (r *PlatformAgentReconciler) createOrUpdateUnstructured(ctx context.Context, obj *unstructured.Unstructured) (bool, error) {
-	log := logf.FromContext(ctx)
-	found := &unstructured.Unstructured{}
-	found.SetGroupVersionKind(obj.GroupVersionKind())
-	err := r.Get(ctx, client.ObjectKey{Name: obj.GetName(), Namespace: obj.GetNamespace()}, found)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, r.Create(ctx, obj)
-		}
-		return false, err
+func (r *PlatformAgentReconciler) reconcileGSA(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, r.ProjectID)
+	name := fmt.Sprintf("projects/%s/serviceAccounts/%s", r.ProjectID, gsaEmail)
+
+	_, err := r.IAMService.Projects.ServiceAccounts.Get(name).Context(ctx).Do()
+	if err == nil {
+		return nil
 	}
 
-	// 1. Check if Spec has changed
-	desiredSpec, desiredSpecExists, _ := unstructured.NestedMap(obj.Object, "spec")
-	foundSpec, foundSpecExists, _ := unstructured.NestedMap(found.Object, "spec")
-
-	specChanged := false
-	if desiredSpecExists && foundSpecExists {
-		if !isMapSubset(desiredSpec, foundSpec) {
-			specChanged = true
-			// Spec differs! For immutable IAMPolicyMember, we MUST delete and request requeue.
-			if obj.GetKind() == "IAMPolicyMember" {
-				log.Info("Spec of immutable IAMPolicyMember changed. Deleting and requesting requeue...", "name", obj.GetName())
-				if err := r.Delete(ctx, found); err != nil {
-					return false, err
-				}
-				return true, nil
-			}
-		}
-	}
-
-	// If the spec did NOT change and this is an IAMPolicyMember, we MUST skip to avoid GKE webhook denials!
-	if !specChanged && obj.GetKind() == "IAMPolicyMember" {
-		return false, nil
-	}
-
-	desiredLabels := obj.GetLabels()
-	foundLabels := found.GetLabels()
-	labelsChanged := false
-	for k, v := range desiredLabels {
-		if foundLabels == nil || foundLabels[k] != v {
-			labelsChanged = true
-			break
-		}
-	}
-
-	desiredAnnotations := obj.GetAnnotations()
-	foundAnnotations := found.GetAnnotations()
-	annotationsChanged := false
-	for k, v := range desiredAnnotations {
-		if foundAnnotations == nil || foundAnnotations[k] != v {
-			annotationsChanged = true
-			break
-		}
-	}
-
-	if !specChanged && !labelsChanged && !annotationsChanged {
-		return false, nil
-	}
-
-	// 2. Merge Spec (for mutable resources)
-	if desiredSpecExists {
-		if !foundSpecExists {
-			foundSpec = make(map[string]any)
-		}
-		maps.Copy(foundSpec, desiredSpec)
-		err = unstructured.SetNestedMap(found.Object, foundSpec, "spec")
-		if err != nil {
-			return false, err
-		}
-	}
-
-	// 3. Merge Labels
-	if foundLabels == nil {
-		foundLabels = make(map[string]string)
-	}
-	maps.Copy(foundLabels, desiredLabels)
-	found.SetLabels(foundLabels)
-
-	// 4. Merge Annotations
-	if foundAnnotations == nil {
-		foundAnnotations = make(map[string]string)
-	}
-	maps.Copy(foundAnnotations, desiredAnnotations)
-	found.SetAnnotations(foundAnnotations)
-
-	return false, r.Update(ctx, found)
-}
-
-func (r *PlatformAgentReconciler) reconcileGSA(ctx context.Context, instance *agentv1alpha1.PlatformAgent) (bool, error) {
-	gsa := &unstructured.Unstructured{}
-	gsa.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "iam.cnrm.cloud.google.com",
-		Version: "v1beta1",
-		Kind:    "IAMServiceAccount",
-	})
-	gsa.SetName(instance.Spec.GSAName)
-	gsa.SetNamespace(instance.Namespace)
-	gsa.UnstructuredContent()["spec"] = map[string]any{
-		"displayName": "PlatformAgent GSA for GChat: " + instance.Name,
-	}
-
-	if err := ctrl.SetControllerReference(instance, gsa, r.Scheme); err != nil {
-		return false, err
-	}
-
-	return r.createOrUpdateUnstructured(ctx, gsa)
-}
-
-func (r *PlatformAgentReconciler) reconcileTopic(ctx context.Context, instance *agentv1alpha1.PlatformAgent) (bool, error) {
-	topic := &unstructured.Unstructured{}
-	topic.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "pubsub.cnrm.cloud.google.com",
-		Version: "v1beta1",
-		Kind:    "PubSubTopic",
-	})
-	topic.SetName(instance.Spec.ChatTopicName)
-	topic.SetNamespace(instance.Namespace)
-
-	if err := ctrl.SetControllerReference(instance, topic, r.Scheme); err != nil {
-		return false, err
-	}
-
-	return r.createOrUpdateUnstructured(ctx, topic)
-}
-
-func (r *PlatformAgentReconciler) reconcileSubscription(ctx context.Context, instance *agentv1alpha1.PlatformAgent) (bool, error) {
-	sub := &unstructured.Unstructured{}
-	sub.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "pubsub.cnrm.cloud.google.com",
-		Version: "v1beta1",
-		Kind:    "PubSubSubscription",
-	})
-	sub.SetName(instance.Spec.ChatSubName)
-	sub.SetNamespace(instance.Namespace)
-	sub.UnstructuredContent()["spec"] = map[string]any{
-		"topicRef": map[string]any{
-			"name": instance.Spec.ChatTopicName,
+	request := &iam.CreateServiceAccountRequest{
+		AccountId: instance.Spec.GSAName,
+		ServiceAccount: &iam.ServiceAccount{
+			DisplayName: "PlatformAgent GSA for GChat: " + instance.Name,
 		},
-		"ackDeadlineSeconds": int64(60),
+	}
+	_, err = r.IAMService.Projects.ServiceAccounts.Create("projects/"+r.ProjectID, request).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to create service account %s: %w", name, err)
 	}
 
-	if err := ctrl.SetControllerReference(instance, sub, r.Scheme); err != nil {
-		return false, err
-	}
-
-	return r.createOrUpdateUnstructured(ctx, sub)
+	return nil
 }
 
-func (r *PlatformAgentReconciler) reconcileIAMPolicyMember(ctx context.Context, instance *agentv1alpha1.PlatformAgent, name string, resourceRef map[string]any, role string, member string) (bool, error) {
-	iam := &unstructured.Unstructured{}
-	iam.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "iam.cnrm.cloud.google.com",
-		Version: "v1beta1",
-		Kind:    "IAMPolicyMember",
+func (r *PlatformAgentReconciler) reconcileTopic(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	topicID := instance.Spec.ChatTopicName
+	topic := r.PubSubClient.Topic(topicID)
+
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check pubsub topic %s: %w", topicID, err)
+	}
+	if exists {
+		return nil
+	}
+
+	_, err = r.PubSubClient.CreateTopic(ctx, topicID)
+	if err != nil {
+		return fmt.Errorf("failed to create pubsub topic %s: %w", topicID, err)
+	}
+
+	return nil
+}
+
+func (r *PlatformAgentReconciler) reconcileSubscription(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	subID := instance.Spec.ChatSubName
+	sub := r.PubSubClient.Subscription(subID)
+
+	exists, err := sub.Exists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check pubsub subscription %s: %w", subID, err)
+	}
+	if exists {
+		return nil
+	}
+
+	topic := r.PubSubClient.Topic(instance.Spec.ChatTopicName)
+	_, err = r.PubSubClient.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+		Topic:       topic,
+		AckDeadline: 60 * time.Second,
 	})
-	iam.SetName(name)
-	iam.SetNamespace(instance.Namespace)
-	iam.UnstructuredContent()["spec"] = map[string]any{
-		"resourceRef": resourceRef,
-		"role":        role,
-		"member":      member,
+	if err != nil {
+		return fmt.Errorf("failed to create pubsub subscription %s: %w", subID, err)
 	}
 
-	if err := ctrl.SetControllerReference(instance, iam, r.Scheme); err != nil {
-		return false, err
-	}
-
-	return r.createOrUpdateUnstructured(ctx, iam)
+	return nil
 }
 
-func (r *PlatformAgentReconciler) reconcileIAMBindings(ctx context.Context, instance *agentv1alpha1.PlatformAgent) (bool, error) {
-	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, instance.Spec.ProjectID)
+func (r *PlatformAgentReconciler) reconcileIAMBindings(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
+	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, r.ProjectID)
 
 	// 1. GSA Subscriber on Subscription
-	requeue, err := r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-sub-subscriber", map[string]any{
-		"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
-		"kind":       "PubSubSubscription",
-		"name":       instance.Spec.ChatSubName,
-	}, "roles/pubsub.subscriber", "serviceAccount:"+gsaEmail)
+	err := r.addPubSubIAMBinding(ctx, "subscription", instance.Spec.ChatSubName, "roles/pubsub.subscriber", "serviceAccount:"+gsaEmail)
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
 	// 2. GSA Viewer on Subscription
-	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-sub-viewer", map[string]any{
-		"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
-		"kind":       "PubSubSubscription",
-		"name":       instance.Spec.ChatSubName,
-	}, "roles/pubsub.viewer", "serviceAccount:"+gsaEmail)
+	err = r.addPubSubIAMBinding(ctx, "subscription", instance.Spec.ChatSubName, "roles/pubsub.viewer", "serviceAccount:"+gsaEmail)
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
-	// 3. GSA AI Platform User on Project (uses 'external' project mapping)
-	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-aiplatform-user", map[string]any{
-		"kind":     "Project",
-		"external": instance.Spec.ProjectID,
-	}, "roles/aiplatform.user", "serviceAccount:"+gsaEmail)
+	// 3. GSA AI Platform User on Project
+	err = r.addProjectIAMBinding(ctx, r.ProjectID, "roles/aiplatform.user", "serviceAccount:"+gsaEmail)
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
 	// 4. GChat System SA Publisher on Topic
-	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-chat-publisher", map[string]any{
-		"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
-		"kind":       "PubSubTopic",
-		"name":       instance.Spec.ChatTopicName,
-	}, "roles/pubsub.publisher", "serviceAccount:chat-api-push@system.gserviceaccount.com")
+	err = r.addPubSubIAMBinding(ctx, "topic", instance.Spec.ChatTopicName, "roles/pubsub.publisher", "serviceAccount:chat-api-push@system.gserviceaccount.com")
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
 	// 5. GSuite Add-ons SA Publisher on Topic
 	gsuiteSA := fmt.Sprintf("service-%s@gcp-sa-gsuiteaddons.iam.gserviceaccount.com", strings.TrimSpace(instance.Spec.NumericProjectID))
-	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-gsuite-publisher", map[string]any{
-		"apiVersion": "pubsub.cnrm.cloud.google.com/v1beta1",
-		"kind":       "PubSubTopic",
-		"name":       instance.Spec.ChatTopicName,
-	}, "roles/pubsub.publisher", "serviceAccount:"+gsuiteSA)
+	err = r.addPubSubIAMBinding(ctx, "topic", instance.Spec.ChatTopicName, "roles/pubsub.publisher", "serviceAccount:"+gsuiteSA)
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
 	// 6. Workload Identity Binding (GSA -> KSA)
-	wiMember := fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", instance.Spec.ProjectID, instance.Namespace, instance.Spec.KSAName)
-	requeue, err = r.reconcileIAMPolicyMember(ctx, instance, instance.Name+"-workload-identity", map[string]any{
-		"apiVersion": "iam.cnrm.cloud.google.com/v1beta1",
-		"kind":       "IAMServiceAccount",
-		"name":       instance.Spec.GSAName,
-	}, "roles/iam.workloadIdentityUser", wiMember)
+	wiMember := fmt.Sprintf("serviceAccount:%s.svc.id.goog[%s/%s]", r.ProjectID, instance.Namespace, instance.Spec.KSAName)
+	err = r.addGSABinding(ctx, r.ProjectID, gsaEmail, "roles/iam.workloadIdentityUser", wiMember)
 	if err != nil {
-		return false, err
-	}
-	if requeue {
-		return true, nil
+		return err
 	}
 
-	return false, nil
+	return nil
+}
+
+func (r *PlatformAgentReconciler) addPubSubIAMBinding(ctx context.Context, resourceType string, resourceName string, role string, member string) error {
+	var handle *cloudiam.Handle
+	if resourceType == "topic" {
+		handle = r.PubSubClient.Topic(resourceName).IAM()
+	} else {
+		handle = r.PubSubClient.Subscription(resourceName).IAM()
+	}
+
+	policy, err := handle.Policy(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM policy for %s %s: %w", resourceType, resourceName, err)
+	}
+
+	if policy.HasRole(member, cloudiam.RoleName(role)) {
+		return nil
+	}
+
+	policy.Add(member, cloudiam.RoleName(role))
+	err = handle.SetPolicy(ctx, policy)
+	if err != nil {
+		return fmt.Errorf("failed to set IAM policy for %s %s: %w", resourceType, resourceName, err)
+	}
+
+	return nil
+}
+
+func (r *PlatformAgentReconciler) addProjectIAMBinding(ctx context.Context, projectID string, role string, member string) error {
+	req := &iampb.GetIamPolicyRequest{
+		Resource: "projects/" + projectID,
+	}
+	policy, err := r.ResourceManagerClient.GetIamPolicy(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM policy for project %s: %w", projectID, err)
+	}
+
+	foundBinding := false
+	for _, binding := range policy.Bindings {
+		if binding.Role == role {
+			for _, m := range binding.Members {
+				if m == member {
+					foundBinding = true
+					break
+				}
+			}
+			if !foundBinding {
+				binding.Members = append(binding.Members, member)
+				foundBinding = true
+			}
+			break
+		}
+	}
+
+	if !foundBinding {
+		policy.Bindings = append(policy.Bindings, &iampb.Binding{
+			Role:    role,
+			Members: []string{member},
+		})
+	}
+
+	setReq := &iampb.SetIamPolicyRequest{
+		Resource: "projects/" + projectID,
+		Policy:   policy,
+	}
+	_, err = r.ResourceManagerClient.SetIamPolicy(ctx, setReq)
+	if err != nil {
+		return fmt.Errorf("failed to set project IAM policy for project %s: %w", projectID, err)
+	}
+
+	return nil
+}
+
+func (r *PlatformAgentReconciler) removeProjectIAMBinding(ctx context.Context, projectID string, role string, member string) error {
+	req := &iampb.GetIamPolicyRequest{
+		Resource: "projects/" + projectID,
+	}
+	policy, err := r.ResourceManagerClient.GetIamPolicy(ctx, req)
+	if err != nil {
+		return fmt.Errorf("failed to get IAM policy for project %s: %w", projectID, err)
+	}
+
+	for _, binding := range policy.Bindings {
+		if binding.Role == role {
+			for i, m := range binding.Members {
+				if m == member {
+					binding.Members = append(binding.Members[:i], binding.Members[i+1:]...)
+					break
+				}
+			}
+			break
+		}
+	}
+
+	setReq := &iampb.SetIamPolicyRequest{
+		Resource: "projects/" + projectID,
+		Policy:   policy,
+	}
+	_, err = r.ResourceManagerClient.SetIamPolicy(ctx, setReq)
+	if err != nil {
+		return fmt.Errorf("failed to set project IAM policy for project %s: %w", projectID, err)
+	}
+
+	return nil
+}
+
+func (r *PlatformAgentReconciler) addGSABinding(ctx context.Context, projectID string, gsaEmail string, role string, member string) error {
+	resource := fmt.Sprintf("projects/%s/serviceAccounts/%s", projectID, gsaEmail)
+	policy, err := r.IAMService.Projects.ServiceAccounts.GetIamPolicy(resource).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to get IAM policy for GSA %s: %w", gsaEmail, err)
+	}
+
+	found := false
+	for _, binding := range policy.Bindings {
+		if binding.Role == role {
+			for _, m := range binding.Members {
+				if m == member {
+					found = true
+					break
+				}
+			}
+			if !found {
+				binding.Members = append(binding.Members, member)
+				found = true
+			}
+			break
+		}
+	}
+
+	if !found {
+		policy.Bindings = append(policy.Bindings, &iam.Binding{
+			Role:    role,
+			Members: []string{member},
+		})
+	}
+
+	request := &iam.SetIamPolicyRequest{
+		Policy: policy,
+	}
+	_, err = r.IAMService.Projects.ServiceAccounts.SetIamPolicy(resource, request).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("failed to set IAM policy for GSA %s: %w", gsaEmail, err)
+	}
+
+	return nil
 }
 
 func (r *PlatformAgentReconciler) reconcileKSA(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
-	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, instance.Spec.ProjectID)
+	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, r.ProjectID)
 	ksa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Spec.KSAName,
@@ -768,11 +707,11 @@ func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, insta
 								},
 								{
 									Name:  "GOOGLE_CHAT_PROJECT_ID",
-									Value: instance.Spec.ProjectID,
+									Value: r.ProjectID,
 								},
 								{
 									Name:  "GOOGLE_CHAT_SUBSCRIPTION_NAME",
-									Value: fmt.Sprintf("projects/%s/subscriptions/%s", instance.Spec.ProjectID, instance.Spec.ChatSubName),
+									Value: fmt.Sprintf("projects/%s/subscriptions/%s", r.ProjectID, instance.Spec.ChatSubName),
 								},
 								{
 									Name:  "GOOGLE_CHAT_ALLOWED_USERS",
@@ -904,20 +843,9 @@ func (r *PlatformAgentReconciler) reconcileClusterRoleBinding(ctx context.Contex
 		return err
 	}
 
-	if !reflect.DeepEqual(found.RoleRef, crb.RoleRef) {
-		log := logf.FromContext(ctx)
-		log.Info("RoleRef of ClusterRoleBinding changed. Deleting and recreating...", "name", crb.Name)
-		if err := r.Delete(ctx, found); err != nil {
-			return err
-		}
-		return r.Create(ctx, crb)
-	}
-
-	if !reflect.DeepEqual(found.Subjects, crb.Subjects) {
-		found.Subjects = crb.Subjects
-		return r.Update(ctx, found)
-	}
-	return nil
+	found.Subjects = crb.Subjects
+	found.RoleRef = crb.RoleRef
+	return r.Update(ctx, found)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -932,19 +860,59 @@ func (r *PlatformAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+// Helper to calculate the SHA256 hash of ConfigMap Data for rolling restarts.
+func getConfigMapHash(configMap *corev1.ConfigMap) (string, error) {
+	if configMap == nil {
+		return "", nil
+	}
+	dataBytes, err := json.Marshal(configMap.Data)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(dataBytes)
+	return fmt.Sprintf("%x", hash), nil
+}
+
 func (r *PlatformAgentReconciler) deleteExternalResources(ctx context.Context, instance *agentv1alpha1.PlatformAgent) error {
 	log := logf.FromContext(ctx)
-	crbName := instance.Namespace + "-" + instance.Name + "-cluster-viewer"
 
-	crb := &rbacv1.ClusterRoleBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: crbName,
-		},
+	// 1. Tear down Pub/Sub Subscription
+	log.Info("Cleaning up cloud subscription", "id", instance.Spec.ChatSubName)
+	sub := r.PubSubClient.Subscription(instance.Spec.ChatSubName)
+	if exists, _ := sub.Exists(ctx); exists {
+		if err := sub.Delete(ctx); err != nil {
+			return fmt.Errorf("failed to delete subscription: %w", err)
+		}
 	}
 
-	log.Info("Deleting associated ClusterRoleBinding during finalizer cleanup", "name", crbName)
-	err := r.Delete(ctx, crb)
-	if err != nil && !errors.IsNotFound(err) {
+	// 2. Tear down Pub/Sub Topic
+	log.Info("Cleaning up cloud topic", "id", instance.Spec.ChatTopicName)
+	topic := r.PubSubClient.Topic(instance.Spec.ChatTopicName)
+	if exists, _ := topic.Exists(ctx); exists {
+		if err := topic.Delete(ctx); err != nil {
+			return fmt.Errorf("failed to delete topic: %w", err)
+		}
+	}
+
+	// 3. Tear down GSA
+	gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", instance.Spec.GSAName, r.ProjectID)
+	log.Info("Removing project-level IAM bindings from GSA", "email", gsaEmail)
+	if err := r.removeProjectIAMBinding(ctx, r.ProjectID, "roles/aiplatform.user", "serviceAccount:"+gsaEmail); err != nil {
+		log.Error(err, "Failed to remove project-level IAM binding for GSA during cleanup")
+	}
+
+	gsaResourceName := fmt.Sprintf("projects/%s/serviceAccounts/%s", r.ProjectID, gsaEmail)
+	log.Info("Cleaning up IAM Service Account", "resource", gsaResourceName)
+
+	_, err := r.IAMService.Projects.ServiceAccounts.Delete(gsaResourceName).Context(ctx).Do()
+	if err != nil && !strings.Contains(err.Error(), "notFound") {
+		return fmt.Errorf("failed to delete GSA: %w", err)
+	}
+
+	// 4. Clean up K8s ClusterRoleBinding
+	crbName := instance.Namespace + "-" + instance.Name + "-cluster-viewer"
+	crb := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: crbName}}
+	if err := r.Delete(ctx, crb); err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 	return nil

--- a/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
+++ b/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
@@ -52,6 +52,7 @@ type PlatformAgentReconciler struct {
 	client.Client
 	Scheme                *runtime.Scheme
 	ProjectID             string
+	ProjectNumber         string
 	PubSubClient          *pubsub.Client
 	IAMService            *iam.Service
 	ResourceManagerClient *resourcemanager.ProjectsClient
@@ -334,7 +335,7 @@ func (r *PlatformAgentReconciler) reconcileIAMBindings(ctx context.Context, inst
 	}
 
 	// 5. GSuite Add-ons SA Publisher on Topic
-	gsuiteSA := fmt.Sprintf("service-%s@gcp-sa-gsuiteaddons.iam.gserviceaccount.com", strings.TrimSpace(instance.Spec.NumericProjectID))
+	gsuiteSA := fmt.Sprintf("service-%s@gcp-sa-gsuiteaddons.iam.gserviceaccount.com", r.ProjectNumber)
 	err = r.addPubSubIAMBinding(ctx, "topic", instance.Spec.ChatTopicName, "roles/pubsub.publisher", "serviceAccount:"+gsuiteSA)
 	if err != nil {
 		return err

--- a/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
+++ b/integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go
@@ -29,6 +29,7 @@ import (
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	pubsub "cloud.google.com/go/pubsub"
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
+	"google.golang.org/api/googleapi"
 	iam "google.golang.org/api/iam/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -242,6 +243,10 @@ func (r *PlatformAgentReconciler) reconcileGSA(ctx context.Context, instance *ag
 	if err == nil {
 		return nil
 	}
+	gErr, ok := err.(*googleapi.Error)
+	if !ok || gErr.Code != 404 {
+		return fmt.Errorf("failed to check service account %s: %w", name, err)
+	}
 
 	request := &iam.CreateServiceAccountRequest{
 		AccountId: instance.Spec.GSAName,
@@ -380,18 +385,21 @@ func (r *PlatformAgentReconciler) addProjectIAMBinding(ctx context.Context, proj
 		return fmt.Errorf("failed to get IAM policy for project %s: %w", projectID, err)
 	}
 
+	modified := false
 	foundBinding := false
 	for _, binding := range policy.Bindings {
 		if binding.Role == role {
+			foundBinding = true
+			foundMember := false
 			for _, m := range binding.Members {
 				if m == member {
-					foundBinding = true
+					foundMember = true
 					break
 				}
 			}
-			if !foundBinding {
+			if !foundMember {
 				binding.Members = append(binding.Members, member)
-				foundBinding = true
+				modified = true
 			}
 			break
 		}
@@ -402,6 +410,11 @@ func (r *PlatformAgentReconciler) addProjectIAMBinding(ctx context.Context, proj
 			Role:    role,
 			Members: []string{member},
 		})
+		modified = true
+	}
+
+	if !modified {
+		return nil
 	}
 
 	setReq := &iampb.SetIamPolicyRequest{
@@ -425,16 +438,22 @@ func (r *PlatformAgentReconciler) removeProjectIAMBinding(ctx context.Context, p
 		return fmt.Errorf("failed to get IAM policy for project %s: %w", projectID, err)
 	}
 
+	modified := false
 	for _, binding := range policy.Bindings {
 		if binding.Role == role {
 			for i, m := range binding.Members {
 				if m == member {
 					binding.Members = append(binding.Members[:i], binding.Members[i+1:]...)
+					modified = true
 					break
 				}
 			}
 			break
 		}
+	}
+
+	if !modified {
+		return nil
 	}
 
 	setReq := &iampb.SetIamPolicyRequest{
@@ -456,18 +475,21 @@ func (r *PlatformAgentReconciler) addGSABinding(ctx context.Context, projectID s
 		return fmt.Errorf("failed to get IAM policy for GSA %s: %w", gsaEmail, err)
 	}
 
+	modified := false
 	found := false
 	for _, binding := range policy.Bindings {
 		if binding.Role == role {
+			found = true
+			foundMember := false
 			for _, m := range binding.Members {
 				if m == member {
-					found = true
+					foundMember = true
 					break
 				}
 			}
-			if !found {
+			if !foundMember {
 				binding.Members = append(binding.Members, member)
-				found = true
+				modified = true
 			}
 			break
 		}
@@ -478,6 +500,11 @@ func (r *PlatformAgentReconciler) addGSABinding(ctx context.Context, projectID s
 			Role:    role,
 			Members: []string{member},
 		})
+		modified = true
+	}
+
+	if !modified {
+		return nil
 	}
 
 	request := &iam.SetIamPolicyRequest{
@@ -843,9 +870,20 @@ func (r *PlatformAgentReconciler) reconcileClusterRoleBinding(ctx context.Contex
 		return err
 	}
 
-	found.Subjects = crb.Subjects
-	found.RoleRef = crb.RoleRef
-	return r.Update(ctx, found)
+	if found.RoleRef != crb.RoleRef {
+		// RoleRef is immutable. We must delete and recreate the ClusterRoleBinding.
+		if err := r.Delete(ctx, found); err != nil {
+			return err
+		}
+		return r.Create(ctx, crb)
+	}
+
+	if !reflect.DeepEqual(found.Subjects, crb.Subjects) {
+		found.Subjects = crb.Subjects
+		return r.Update(ctx, found)
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -879,16 +917,20 @@ func (r *PlatformAgentReconciler) deleteExternalResources(ctx context.Context, i
 	// 1. Tear down Pub/Sub Subscription
 	log.Info("Cleaning up cloud subscription", "id", instance.Spec.ChatSubName)
 	sub := r.PubSubClient.Subscription(instance.Spec.ChatSubName)
-	if exists, _ := sub.Exists(ctx); exists {
+
+	if exists, err := sub.Exists(ctx); err != nil {
+		return fmt.Errorf("failed to check subscription existence: %w", err)
+	} else if exists {
 		if err := sub.Delete(ctx); err != nil {
 			return fmt.Errorf("failed to delete subscription: %w", err)
 		}
 	}
-
 	// 2. Tear down Pub/Sub Topic
 	log.Info("Cleaning up cloud topic", "id", instance.Spec.ChatTopicName)
 	topic := r.PubSubClient.Topic(instance.Spec.ChatTopicName)
-	if exists, _ := topic.Exists(ctx); exists {
+	if exists, err := topic.Exists(ctx); err != nil {
+		return fmt.Errorf("failed to check topic existence: %w", err)
+	} else if exists {
 		if err := topic.Delete(ctx); err != nil {
 			return fmt.Errorf("failed to delete topic: %w", err)
 		}

--- a/integrations/gchat/crd/platform-agent.yaml.template
+++ b/integrations/gchat/crd/platform-agent.yaml.template
@@ -1,0 +1,20 @@
+apiVersion: agent.platform.io/v1alpha1
+kind: PlatformAgent
+metadata:
+  name: platform-agent
+  namespace: ${NAMESPACE}
+spec:
+  projectId: "${PROJECT_ID}"
+  numericProjectId: "${PROJECT_NUMBER}"
+  clusterName: "${CLUSTER_NAME}"
+  location: "${REGION}"
+  imageUri: "${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/platform-agent:latest"
+  chatTopicName: "${CHAT_TOPIC_NAME}"
+  chatSubName: "${CHAT_SUB_NAME}"
+  gsaName: "${GSA_NAME}"
+  ksaName: "${KSA_NAME}"
+  googleChatAllowedUsers: "${ALLOWED_USER}"
+  googleChatHomeChannel: ""
+  model:
+    default: "${MODEL_DEFAULT_NAME}"
+    provider: "${MODEL_PROVIDER}"

--- a/integrations/gchat/crd/platform-agent.yaml.template
+++ b/integrations/gchat/crd/platform-agent.yaml.template
@@ -4,8 +4,6 @@ metadata:
   name: platform-agent
   namespace: ${NAMESPACE}
 spec:
-  projectId: "${PROJECT_ID}"
-  numericProjectId: "${PROJECT_NUMBER}"
   clusterName: "${CLUSTER_NAME}"
   location: "${REGION}"
   imageUri: "${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/platform-agent:latest"

--- a/integrations/gchat/crd/provision.sh
+++ b/integrations/gchat/crd/provision.sh
@@ -407,6 +407,7 @@ verify_operator_identity() {
   )
   for role in "${OPERATOR_ROLES[@]}"; do
     local binding=$(gcloud projects get-iam-policy "${PROJECT_ID}" \
+        --flatten="bindings" \
         --filter="bindings.role:$role AND bindings.members:serviceAccount:${gsa_email}" \
         --format="value(bindings.role)" 2>/dev/null)
     [ "$binding" = "$role" ] || return 1
@@ -415,6 +416,7 @@ verify_operator_identity() {
   # Check if Workload Identity binding exists
   local wi_member="serviceAccount:${PROJECT_ID}.svc.id.goog[platform-agent-operator-system/platform-agent-operator-controller-manager]"
   local wi_binding=$(gcloud iam service-accounts get-iam-policy "${gsa_email}" \
+      --flatten="bindings" \
       --filter="bindings.role:roles/iam.workloadIdentityUser AND bindings.members:${wi_member}" \
       --format="value(bindings.role)" --project="${PROJECT_ID}" 2>/dev/null)
   [ "$wi_binding" = "roles/iam.workloadIdentityUser" ] || return 1
@@ -461,6 +463,14 @@ execute_operator_identity() {
       --project="${PROJECT_ID}" \
       --quiet >/dev/null
 
+  print_info "Creating Operator namespace if not exists..."
+  kubectl create namespace platform-agent-operator-system --dry-run=client -o yaml | kubectl apply -f -
+
+  print_info "Creating Operator KSA if not exists..."
+  kubectl create serviceaccount platform-agent-operator-controller-manager \
+      --namespace="platform-agent-operator-system" \
+      --dry-run=client -o yaml | kubectl apply -f -
+
   print_info "Annotating Operator KSA..."
   kubectl annotate serviceaccount \
       --namespace="platform-agent-operator-system" \
@@ -468,9 +478,13 @@ execute_operator_identity() {
       "iam.gke.io/gcp-service-account=${gsa_email}" \
       --overwrite
 
-  print_info "Restarting Operator Controller to pick up Workload Identity..."
-  kubectl rollout restart deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system
-  kubectl rollout status deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system --timeout=120s
+  if kubectl get deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system >/dev/null 2>&1; then
+    print_info "Restarting Operator Controller to pick up Workload Identity..."
+    kubectl rollout restart deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system
+    kubectl rollout status deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system --timeout=120s
+  else
+    print_info "Operator Controller deployment not found; it will pick up the identity when deployed."
+  fi
 }
 
 # Step 11: Declaratively Apply PlatformAgent Custom Resource
@@ -497,8 +511,8 @@ run_step "5. Setup Secret Manager Placeholders" verify_secrets execute_secrets 0
 run_step "6. Sync API Keys to GKE Namespace Secrets" verify_k8s_secrets execute_k8s_secrets 0
 run_step "7. Deploy LiteLLM Gateway" verify_litellm execute_litellm 10
 run_step "8. Package & Build GChat Agent via Cloud Build" verify_agent_image execute_agent_image 0
-run_step "9. Build & Deploy Go Operator Controller" verify_operator execute_operator 10
-run_step "10. Setup Workload Identity for Go Operator Controller" verify_operator_identity execute_operator_identity 0
+run_step "9. Setup Workload Identity for Go Operator Controller" verify_operator_identity execute_operator_identity 0
+run_step "10. Build & Deploy Go Operator Controller" verify_operator execute_operator 10
 run_step "11. Declaratively Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
 
 # ─── Conclusion Copy-Paste Checklist ──────────────────────────────────────────

--- a/integrations/gchat/crd/provision.sh
+++ b/integrations/gchat/crd/provision.sh
@@ -155,12 +155,17 @@ export CHAT_TOPIC_NAME="platform-agent-chat-events"
 export CHAT_SUB_NAME="platform-agent-chat-events-sub"
 export GSA_NAME="platform-agent-bot"
 export KSA_NAME="platform-agent-platform-sa"
+export OPERATOR_GSA_NAME="platform-operator-sa"
 export API_SERVER_KEY="${API_SERVER_KEY}"
 EOF
   print_success "Created configuration state file at $VARS_FILE"
 fi
 
 source "$VARS_FILE"
+
+if [ -z "${OPERATOR_GSA_NAME:-}" ]; then
+  export OPERATOR_GSA_NAME="platform-operator-sa"
+fi
 
 # ─── Prerequisites Check ──────────────────────────────────────────────────────
 print_step "Checking Local Prerequisites"
@@ -220,7 +225,8 @@ verify_apis() {
   echo "$out" | grep -q 'pubsub.googleapis.com' && \
   echo "$out" | grep -q 'chat.googleapis.com' && \
   echo "$out" | grep -q 'gsuiteaddons.googleapis.com' && \
-  echo "$out" | grep -q 'aiplatform.googleapis.com'
+  echo "$out" | grep -q 'aiplatform.googleapis.com' && \
+  echo "$out" | grep -q 'cloudresourcemanager.googleapis.com'
 }
 execute_apis() {
   gcloud services enable \
@@ -232,6 +238,7 @@ execute_apis() {
       chat.googleapis.com \
       gsuiteaddons.googleapis.com \
       aiplatform.googleapis.com \
+      cloudresourcemanager.googleapis.com \
       --project="$PROJECT_ID"
 }
 
@@ -260,50 +267,18 @@ execute_cluster() {
       --project "$PROJECT_ID"
 }
 
-# Step 3.5: Enable GKE Config Connector Add-on
-verify_kcc_addon() {
-  local val=$(gcloud container clusters describe "$CLUSTER_NAME" --region="$REGION" --project="$PROJECT_ID" --format="value(addonsConfig.configConnectorConfig.enabled)" 2>/dev/null || echo "")
-  [ "$val" = "True" ]
+# Step 4: Connect kubectl & Create Namespace
+verify_kubeconfig() {
+  kubectl get namespace "$NAMESPACE" >/dev/null 2>&1
 }
-execute_kcc_addon() {
-  print_info "Enabling GKE Config Connector Add-on on GKE Cluster..."
-  gcloud container clusters update "$CLUSTER_NAME" \
-      --update-addons ConfigConnector=ENABLED \
-      --region "$REGION" \
-      --project "$PROJECT_ID"
+execute_kubeconfig() {
+  print_info "Fetching cluster credentials..."
+  gcloud container clusters get-credentials "$CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID"
+  print_info "Creating namespace '$NAMESPACE'..."
+  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 }
 
-# Step 3.6: Configure KCC GCP Identity (GSA & Workload Identity)
-verify_kcc_identity() {
-  # We check if the GSA exists, has Owner role bound in project, and has the correct namespaced WI member binding
-  gcloud iam service-accounts describe "platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" --project="$PROJECT_ID" >/dev/null 2>&1 && \
-  gcloud projects get-iam-policy "$PROJECT_ID" --format=json 2>/dev/null | grep -q "platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" && \
-  gcloud iam service-accounts get-iam-policy "platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" --project="$PROJECT_ID" --format=json 2>/dev/null | grep -q "cnrm-controller-manager-${NAMESPACE}"
-}
-execute_kcc_identity() {
-  # 1. Create GSA if not exists
-  if ! gcloud iam service-accounts describe "platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" --project="$PROJECT_ID" >/dev/null 2>&1; then
-    print_info "Creating GCP GSA platform-agent-kcc-sa..."
-    gcloud iam service-accounts create "platform-agent-kcc-sa" --project="$PROJECT_ID"
-  fi
-
-  # 2. Grant Owner role to KCC GSA
-  print_info "Binding Owner role to KCC GSA..."
-  gcloud projects add-iam-policy-binding "$PROJECT_ID" \
-      --member="serviceAccount:platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
-      --role="roles/owner"
-
-  # 3. Bind Workload Identity (GKE KCC pod cnrm-controller-manager to GCP GSA)
-  print_info "Binding GKE KCC system controller to KCC GSA via Workload Identity..."
-  gcloud iam service-accounts add-iam-policy-binding \
-      "platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
-      --member="serviceAccount:${PROJECT_ID}.svc.id.goog[cnrm-system/cnrm-controller-manager-${NAMESPACE}]" \
-      --role="roles/iam.workloadIdentityUser" \
-      --project="$PROJECT_ID"
-}
-
-
-# Step 4: Secret Manager Placeholders
+# Step 5: Setup Secret Manager Placeholders
 verify_secrets() {
   gcloud secrets describe "GEMINI_API_KEY" --project="$PROJECT_ID" >/dev/null 2>&1
 }
@@ -320,56 +295,8 @@ execute_secrets() {
   done
 }
 
-# Step 5: Kubeconfig Setup & Namespace Creation
-verify_kubeconfig() {
-  kubectl get namespace "$NAMESPACE" >/dev/null 2>&1
-}
-execute_kubeconfig() {
-  print_info "Fetching cluster credentials..."
-  gcloud container clusters get-credentials "$CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID"
-  print_info "Creating namespace '$NAMESPACE'..."
-  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
-}
 
-# Step 5.5: Configure KCC Namespaced Mode & Target Project Annotations
-verify_kcc_namespaced() {
-  kubectl get configconnectorcontext configconnectorcontext.core.cnrm.cloud.google.com -n "$NAMESPACE" >/dev/null 2>&1 && \
-  kubectl get namespace "$NAMESPACE" -o jsonpath='{.metadata.annotations.cnrm\.cloud\.google\.com/project-id}' 2>/dev/null | grep -q "$PROJECT_ID"
-}
-execute_kcc_namespaced() {
-  print_info "1/3. Applying cluster-wide ConfigConnector configuration..."
-  local KCC_CONFIG=$(mktemp)
-  cat <<EOF > "$KCC_CONFIG"
-apiVersion: core.cnrm.cloud.google.com/v1beta1
-kind: ConfigConnector
-metadata:
-  name: configconnector.core.cnrm.cloud.google.com
-spec:
-  mode: namespaced
-EOF
-  kubectl apply -f "$KCC_CONFIG"
-  rm -f "$KCC_CONFIG"
-
-  print_info "2/3. Applying ConfigConnectorContext in namespace '$NAMESPACE'..."
-  local KCC_CR=$(mktemp)
-  cat <<EOF > "$KCC_CR"
-apiVersion: core.cnrm.cloud.google.com/v1beta1
-kind: ConfigConnectorContext
-metadata:
-  name: configconnectorcontext.core.cnrm.cloud.google.com
-  namespace: ${NAMESPACE}
-spec:
-  googleServiceAccount: platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com
-EOF
-  kubectl apply -f "$KCC_CR"
-  rm -f "$KCC_CR"
-
-  print_info "3/3. Annotating target namespace '$NAMESPACE' with GCP project ID..."
-  kubectl annotate namespace "$NAMESPACE" cnrm.cloud.google.com/project-id="$PROJECT_ID" --overwrite
-}
-
-
-# Step 6: Synchronize Secrets to GKE Namespace
+# Step 6: Sync API Keys to GKE Namespace Secrets
 verify_k8s_secrets() {
   kubectl get secret platform-agent-secrets -n "$NAMESPACE" >/dev/null 2>&1
 }
@@ -405,7 +332,7 @@ execute_k8s_secrets() {
       --dry-run=client -o yaml | kubectl apply -f -
 }
 
-# Deploy LiteLLM Gateway
+# Step 7: Deploy LiteLLM Gateway
 verify_litellm() {
   "${SCRIPT_DIR}/provision_litellm/provision_litellm.sh" --verify
 }
@@ -413,7 +340,7 @@ execute_litellm() {
   "${SCRIPT_DIR}/provision_litellm/provision_litellm.sh" --deploy
 }
 
-# Step 7: Build and Push Custom GChat Platform Agent Image
+# Step 8: Package & Build GChat Agent via Cloud Build
 verify_agent_image() {
   # We check if the image 'platform-agent' exists in registry
   gcloud artifacts docker images list "$REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/platform-agent" --project="$PROJECT_ID" --format="value(image)" 2>/dev/null | grep -q "platform-agent"
@@ -439,7 +366,7 @@ execute_agent_image() {
   )
 }
 
-# Step 8: Build, Push, and Deploy Go Operator
+# Step 9: Build & Deploy Go Operator Controller
 verify_operator() {
   kubectl get deployment platform-agent-operator-controller-manager -n platform-agent-operator-system >/dev/null 2>&1 && \
   gcloud artifacts docker images list "$REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME/platform-agent-operator" --project="$PROJECT_ID" --format="value(image)" 2>/dev/null | grep -q "platform-agent-operator"
@@ -458,38 +385,104 @@ execute_operator() {
     # deploy automatically runs 'make install' (CRD registration) first!
     make deploy IMG="$OPERATOR_IMG"
   )
+
+  print_info "Setting GOOGLE_CLOUD_PROJECT environment variable on operator deployment..."
+  kubectl set env deployment/platform-agent-operator-controller-manager \
+      -n platform-agent-operator-system \
+      GOOGLE_CLOUD_PROJECT="$PROJECT_ID"
 }
 
-# Step 9: Apply Custom Resource Manifest
+# Step 10: Setup Workload Identity for Go Operator Controller
+verify_operator_identity() {
+  local gsa_email="${OPERATOR_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  
+  # Check if GSA exists
+  gcloud iam service-accounts describe "${gsa_email}" --project="${PROJECT_ID}" >/dev/null 2>&1 || return 1
+  
+  # Check if GSA is bound to target IAM roles
+  local OPERATOR_ROLES=(
+    "roles/pubsub.admin"
+    "roles/iam.serviceAccountAdmin"
+    "roles/resourcemanager.projectIamAdmin"
+  )
+  for role in "${OPERATOR_ROLES[@]}"; do
+    local binding=$(gcloud projects get-iam-policy "${PROJECT_ID}" \
+        --filter="bindings.role:$role AND bindings.members:serviceAccount:${gsa_email}" \
+        --format="value(bindings.role)" 2>/dev/null)
+    [ "$binding" = "$role" ] || return 1
+  done
+
+  # Check if Workload Identity binding exists
+  local wi_member="serviceAccount:${PROJECT_ID}.svc.id.goog[platform-agent-operator-system/platform-agent-operator-controller-manager]"
+  local wi_binding=$(gcloud iam service-accounts get-iam-policy "${gsa_email}" \
+      --filter="bindings.role:roles/iam.workloadIdentityUser AND bindings.members:${wi_member}" \
+      --format="value(bindings.role)" --project="${PROJECT_ID}" 2>/dev/null)
+  [ "$wi_binding" = "roles/iam.workloadIdentityUser" ] || return 1
+
+  # Check if KSA is annotated
+  local ksa_annotation=$(kubectl get serviceaccount platform-agent-operator-controller-manager \
+      -n platform-agent-operator-system \
+      -o jsonpath='{.metadata.annotations.iam\.gke\.io/gcp-service-account}' 2>/dev/null || echo "")
+  [ "$ksa_annotation" = "$gsa_email" ] || return 1
+
+  return 0
+}
+
+execute_operator_identity() {
+  local gsa_email="${OPERATOR_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  
+  print_info "Creating Operator GSA '${OPERATOR_GSA_NAME}'..."
+  if ! gcloud iam service-accounts describe "${gsa_email}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+    gcloud iam service-accounts create "${OPERATOR_GSA_NAME}" \
+        --display-name="Platform Agent Operator Service Account" \
+        --project="${PROJECT_ID}"
+  fi
+
+  # Define the precise, least-privilege roles required by the Go Controller
+  local OPERATOR_ROLES=(
+    "roles/pubsub.admin"
+    "roles/iam.serviceAccountAdmin"
+    "roles/resourcemanager.projectIamAdmin"
+  )
+
+  print_info "Granting targeted IAM roles to Operator GSA..."
+  for role in "${OPERATOR_ROLES[@]}"; do
+    print_info "  -> Granting $role..."
+    gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${gsa_email}" \
+        --role="$role" \
+        --quiet >/dev/null
+  done
+
+  print_info "Configuring Workload Identity binding for Operator..."
+  gcloud iam service-accounts add-iam-policy-binding "${gsa_email}" \
+      --role="roles/iam.workloadIdentityUser" \
+      --member="serviceAccount:${PROJECT_ID}.svc.id.goog[platform-agent-operator-system/platform-agent-operator-controller-manager]" \
+      --project="${PROJECT_ID}" \
+      --quiet >/dev/null
+
+  print_info "Annotating Operator KSA..."
+  kubectl annotate serviceaccount \
+      --namespace="platform-agent-operator-system" \
+      platform-agent-operator-controller-manager \
+      "iam.gke.io/gcp-service-account=${gsa_email}" \
+      --overwrite
+
+  print_info "Restarting Operator Controller to pick up Workload Identity..."
+  kubectl rollout restart deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system
+  kubectl rollout status deployment/platform-agent-operator-controller-manager -n platform-agent-operator-system --timeout=120s
+}
+
+# Step 11: Declaratively Apply PlatformAgent Custom Resource
 verify_custom_resource() {
   kubectl get platformagent platform-agent -n "$NAMESPACE" >/dev/null 2>&1
 }
 execute_custom_resource() {
-  print_info "Generating custom resource manifest 'platform-agent.yaml'..."
+  print_info "Generating custom resource manifest 'platform-agent.yaml' from template..."
+  local CR_TEMPLATE="$SCRIPT_DIR/platform-agent.yaml.template"
   local CR_MANIFEST="$SCRIPT_DIR/platform-agent.yaml"
-  
-  cat <<EOF > "$CR_MANIFEST"
-apiVersion: agent.platform.io/v1alpha1
-kind: PlatformAgent
-metadata:
-  name: platform-agent
-  namespace: ${NAMESPACE}
-spec:
-  projectId: "${PROJECT_ID}"
-  numericProjectId: "${PROJECT_NUMBER}"
-  clusterName: "${CLUSTER_NAME}"
-  location: "${REGION}"
-  imageUri: "${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO_NAME}/platform-agent:latest"
-  chatTopicName: "${CHAT_TOPIC_NAME}"
-  chatSubName: "${CHAT_SUB_NAME}"
-  gsaName: "${GSA_NAME}"
-  ksaName: "${KSA_NAME}"
-  googleChatAllowedUsers: "${ALLOWED_USER}"
-  googleChatHomeChannel: ""
-  model:
-    default: "${MODEL_DEFAULT_NAME}"
-    provider: "${MODEL_PROVIDER}"
-EOF
+
+  envsubst < "$CR_TEMPLATE" > "$CR_MANIFEST"
   
   print_info "Applying 'platform-agent' Custom Resource to the GKE cluster..."
   kubectl apply -f "$CR_MANIFEST"
@@ -499,16 +492,14 @@ EOF
 run_step "1. Enable GCP APIs" verify_apis execute_apis 30
 run_step "2. Create Artifact Registry Repo" verify_registry execute_registry 0
 run_step "3. Provision GKE Cluster" verify_cluster execute_cluster 10
-run_step "4. Enable GKE Config Connector Add-on" verify_kcc_addon execute_kcc_addon 15
-run_step "5. Configure KCC GCP Identity (GSA & Workload Identity)" verify_kcc_identity execute_kcc_identity 15
-run_step "6. Connect kubectl & Create Namespace" verify_kubeconfig execute_kubeconfig 5
-run_step "7. Configure KCC Namespaced Mode & Target Project Annotations" verify_kcc_namespaced execute_kcc_namespaced 10
-run_step "8. Setup Secret Manager Placeholders" verify_secrets execute_secrets 0
-run_step "9. Sync API Keys to GKE Namespace Secrets" verify_k8s_secrets execute_k8s_secrets 0
-run_step "10. Deploy LiteLLM Gateway" verify_litellm execute_litellm 10
-run_step "11. Package & Build GChat Agent via Cloud Build" verify_agent_image execute_agent_image 0
-run_step "12. Build & Deploy Go Operator Controller" verify_operator execute_operator 10
-run_step "13. Declaratively Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
+run_step "4. Connect kubectl & Create Namespace" verify_kubeconfig execute_kubeconfig 5
+run_step "5. Setup Secret Manager Placeholders" verify_secrets execute_secrets 0
+run_step "6. Sync API Keys to GKE Namespace Secrets" verify_k8s_secrets execute_k8s_secrets 0
+run_step "7. Deploy LiteLLM Gateway" verify_litellm execute_litellm 10
+run_step "8. Package & Build GChat Agent via Cloud Build" verify_agent_image execute_agent_image 0
+run_step "9. Build & Deploy Go Operator Controller" verify_operator execute_operator 10
+run_step "10. Setup Workload Identity for Go Operator Controller" verify_operator_identity execute_operator_identity 0
+run_step "11. Declaratively Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
 
 # ─── Conclusion Copy-Paste Checklist ──────────────────────────────────────────
 print_step "Infrastructure & Operator Provisioned Successfully!"

--- a/integrations/gchat/crd/provision.sh
+++ b/integrations/gchat/crd/provision.sh
@@ -386,10 +386,11 @@ execute_operator() {
     make deploy IMG="$OPERATOR_IMG"
   )
 
-  print_info "Setting GOOGLE_CLOUD_PROJECT environment variable on operator deployment..."
+  print_info "Setting environment variables on operator deployment..."
   kubectl set env deployment/platform-agent-operator-controller-manager \
       -n platform-agent-operator-system \
-      GOOGLE_CLOUD_PROJECT="$PROJECT_ID"
+      GOOGLE_CLOUD_PROJECT_ID="$PROJECT_ID" \
+      GOOGLE_CLOUD_PROJECT_NUMBER="$PROJECT_NUMBER"
 }
 
 # Step 10: Setup Workload Identity for Go Operator Controller

--- a/integrations/gchat/crd/teardown.sh
+++ b/integrations/gchat/crd/teardown.sh
@@ -65,11 +65,11 @@ fi
 echo ""
 echo -e "${C_RED}${C_BOLD}🚨 WARNING: This will permanently delete all GChat integration GKE cluster, GCP resources, Secret Manager keys, and docker images.${C_RESET}"
 echo -e "${C_YELLOW}==============================================================================${C_RESET}"
-echo -e "  ${C_BOLD}GCP Project:${C_RESET}    ${C_WHITE}${PROJECT_ID}${C_RESET}"
-echo -e "  ${C_BOLD}Region:${C_RESET}         ${C_WHITE}${REGION}${C_RESET}"
-echo -e "  ${C_BOLD}GKE Cluster:${C_RESET}    ${C_WHITE}${CLUSTER_NAME}${C_RESET}"
-echo -e "  ${C_BOLD}Namespace:${C_RESET}      ${C_WHITE}${NAMESPACE}${C_RESET}"
-echo -e "  ${C_BOLD}Artifact Repo:${C_RESET}  ${C_WHITE}${REPO_NAME}${C_RESET}"
+echo -e "  ${C_BOLD}GCP Project:${C_RESET}    ${C_BOLD}${PROJECT_ID}${C_RESET}"
+echo -e "  ${C_BOLD}Region:${C_RESET}         ${C_BOLD}${REGION}${C_RESET}"
+echo -e "  ${C_BOLD}GKE Cluster:${C_RESET}    ${C_BOLD}${CLUSTER_NAME}${C_RESET}"
+echo -e "  ${C_BOLD}Namespace:${C_RESET}      ${C_BOLD}${NAMESPACE}${C_RESET}"
+echo -e "  ${C_BOLD}Artifact Repo:${C_RESET}  ${C_BOLD}${REPO_NAME}${C_RESET}"
 echo -e "${C_YELLOW}==============================================================================${C_RESET}"
 echo ""
 echo -ne "  ${C_CYAN}Are you sure you want to proceed with teardown? (y/N): ${C_RESET}"
@@ -133,22 +133,49 @@ if [ -n "$CLUSTER_EXISTS" ]; then
   fi
 fi
 
-# ─── Step 4: Clean up KCC GSA and Bindings ────────────────────────────────────
-echo -e "\n${C_BOLD}=== 4. Tearing Down KCC GCP Identity ===${C_RESET}"
-KCC_GSA="platform-agent-kcc-sa@${PROJECT_ID}.iam.gserviceaccount.com"
-GSA_EXISTS=$(gcloud iam service-accounts list --filter="email=${KCC_GSA}" --format="value(email)" --project="${PROJECT_ID}" 2>/dev/null || echo "")
-if [ -n "$GSA_EXISTS" ]; then
-  echo -e "  ${C_CYAN}ℹ Removing Owner role from KCC GSA...${C_RESET}"
-  gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-      --member="serviceAccount:${KCC_GSA}" \
-      --role="roles/owner" \
-      --quiet || true
+# ─── Step 3.5: Undeploy LiteLLM Gateway ───────────────────────────────────────
+if [ -n "$CLUSTER_EXISTS" ]; then
+  echo -e "\n${C_BOLD}=== 3.5. Tearing Down LiteLLM Gateway ===${C_RESET}"
+  echo -e "  ${C_CYAN}ℹ Deleting LiteLLM service, deployment, and configmap...${C_RESET}"
+  kubectl delete service litellm -n "$NAMESPACE" --ignore-not-found || true
+  kubectl delete deployment litellm -n "$NAMESPACE" --ignore-not-found || true
+  kubectl delete configmap litellm-config -n "$NAMESPACE" --ignore-not-found || true
+  echo -e "  ${C_GREEN}✓ LiteLLM Gateway successfully torn down.${C_RESET}"
+fi
 
-  echo -e "  ${C_CYAN}ℹ Deleting KCC GSA '${KCC_GSA}'...${C_RESET}"
-  gcloud iam service-accounts delete "${KCC_GSA}" --project="${PROJECT_ID}" --quiet || true
-  echo -e "  ${C_GREEN}✓ KCC GSA and bindings successfully removed.${C_RESET}"
+# ─── Step 4: Clean up Operator and Bot GCP GSAs and Bindings ──────────────────
+echo -e "\n${C_BOLD}=== 4. Tearing Down Operator & Bot GCP Identities ===${C_RESET}"
+OPERATOR_GSA="platform-operator-sa@${PROJECT_ID}.iam.gserviceaccount.com"
+GSA_EXISTS=$(gcloud iam service-accounts list --filter="email=${OPERATOR_GSA}" --format="value(email)" --project="${PROJECT_ID}" 2>/dev/null || echo "")
+if [ -n "$GSA_EXISTS" ]; then
+  echo -e "  ${C_CYAN}ℹ Removing targeted IAM roles from Operator GSA...${C_RESET}"
+  OPERATOR_ROLES=(
+    "roles/pubsub.admin"
+    "roles/iam.serviceAccountAdmin"
+    "roles/resourcemanager.projectIamAdmin"
+  )
+  for role in "${OPERATOR_ROLES[@]}"; do
+    gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${OPERATOR_GSA}" \
+        --role="$role" \
+        --quiet || true
+  done
+
+  echo -e "  ${C_CYAN}ℹ Deleting Operator GSA '${OPERATOR_GSA}'...${C_RESET}"
+  gcloud iam service-accounts delete "${OPERATOR_GSA}" --project="${PROJECT_ID}" --quiet || true
+  echo -e "  ${C_GREEN}✓ Operator GSA and bindings successfully removed.${C_RESET}"
 else
-  echo -e "  ${C_GREEN}✓ KCC GSA '${KCC_GSA}' already deleted or does not exist.${C_RESET}"
+  echo -e "  ${C_GREEN}✓ Operator GSA '${OPERATOR_GSA}' already deleted or does not exist.${C_RESET}"
+fi
+
+BOT_GSA="${GSA_NAME:-platform-agent-bot}@${PROJECT_ID}.iam.gserviceaccount.com"
+BOT_GSA_EXISTS=$(gcloud iam service-accounts list --filter="email=${BOT_GSA}" --format="value(email)" --project="${PROJECT_ID}" 2>/dev/null || echo "")
+if [ -n "$BOT_GSA_EXISTS" ]; then
+  echo -e "  ${C_CYAN}ℹ Deleting Bot GSA '${BOT_GSA}'...${C_RESET}"
+  gcloud iam service-accounts delete "${BOT_GSA}" --project="${PROJECT_ID}" --quiet || true
+  echo -e "  ${C_GREEN}✓ Bot GSA successfully removed.${C_RESET}"
+else
+  echo -e "  ${C_GREEN}✓ Bot GSA '${BOT_GSA}' already deleted or does not exist.${C_RESET}"
 fi
 
 # ─── Step 5: Delete Secret Manager Placeholders ───────────────────────────────
@@ -167,8 +194,7 @@ done
 
 # ─── Step 6: Delete Artifact Registry Repository ──────────────────────────────
 echo -e "\n${C_BOLD}=== 6. Tearing Down Artifact Registry Repo ===${C_RESET}"
-REPO_EXISTS=$(gcloud artifacts repositories list --filter="name:${REPO_NAME} AND location:${REGION}" --format="value(name)" --project="${PROJECT_ID}" 2>/dev/null || echo "")
-if [ -n "$REPO_EXISTS" ]; then
+if gcloud artifacts repositories describe "$REPO_NAME" --location="$REGION" --project="${PROJECT_ID}" >/dev/null 2>&1; then
   echo -e "  ${C_CYAN}ℹ Deleting Artifact Registry repository '$REPO_NAME'...${C_RESET}"
   gcloud artifacts repositories delete "$REPO_NAME" --location="$REGION" --project="${PROJECT_ID}" --quiet || true
   echo -e "  ${C_GREEN}✓ Artifact Registry repository '$REPO_NAME' successfully deleted.${C_RESET}"
@@ -176,7 +202,6 @@ else
   echo -e "  ${C_GREEN}✓ Repository '$REPO_NAME' already deleted or does not exist.${C_RESET}"
 fi
 
-# ─── Step 7: Delete GKE Cluster ───────────────────────────────────────────────
 # ─── Step 7: Delete GKE Cluster ───────────────────────────────────────────────
 echo -e "\n${C_BOLD}=== 7. Tearing Down GKE Cluster ===${C_RESET}"
 if [ -n "$CLUSTER_EXISTS" ]; then


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR removes the dependency on Google Cloud Config Connector (KCC) for provisioning the GCP resources needed by the GChat Platform Agent. 

### Motivation:
* **Architecture Simplification:** Eliminating KCC simplifies GKE cluster bootstrapping, removes the overhead of maintaining namespaced KCC resources, and reduces sync delays.
* **Direct Reconciliation:** The Platform Agent Operator now directly reconciles Google Cloud resources (Google Service Accounts, Pub/Sub Topics, Subscriptions, and project IAM policy bindings) using the official Go client SDKs.
* **Least Privilege:** Transitioned the Operator from running with broad owner permissions to a scoped, least-privilege role setup.

---

## What Changed

### Files:
* `integrations/gchat/crd/provision.sh` - Removed KCC install steps, introduced Operator Workload Identity configurations, and enabled targeted operator IAM permissions.
* `integrations/gchat/crd/teardown.sh` - Standardized cleanup for Operator GSAs with targeted roles, and fixed a broken query for checking Artifact Registry repository existence.
* `integrations/gchat/crd/platform-agent.yaml.template` - Added as a clean manifest template.
* `integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go` - Restored controller registry setup and reconciliation loop.
* `integrations/gchat/crd/platform-agent-operator/cmd/main.go` - PubSubClient and IamService initialization.

### Added/Changed/Fixed:
* **Added `platform-agent.yaml.template`:** Extracted the custom resource definition from an inline bash heredoc to a static template file to improve maintainability and support IDE YAML validation.
* **Fixed Operator Lease & Startup Errors:** Configured the `GOOGLE_CLOUD_PROJECT` env variable on the controller manager container, resolving client initialization failures and leader lease authorization errors.
* **Improved `teardown.sh` Repository Check:** Fixed the Artifact Registry repository deletion check by replacing the broken `gcloud artifacts repositories list --filter` filter with the robust `gcloud artifacts repositories describe` command.
* **Hardened Teardown IAM Cleanup:** Configured the teardown script to gracefully clean up all specific IAM roles assigned to the operator GSA, preventing dangling or orphaned permissions in the GCP IAM policies.

---

## Why This Matters

By removing GKE Config Connector, the boot times for GChat Bot environments are significantly reduced, and failures can be caught immediately within the operator reconciler rather than waiting for external CRD controllers to sync asynchronously. 

Furthermore, applying least-privilege security roles to the operator GSA aligns the harness setup with standard GKE/SRE production standards.

---

## Context

Follows architectural refactoring of the Kubernetes Agentic Harness bot gateway.

---

## Testing

* Ran `provision.sh` to completion.
* Verified that the Operator successfully rolled out, initialized shared GCP API clients, acquired the leader election lease, and entered its active reconcile loop.
* Verified that the `PlatformAgent` custom resource was successfully reconciled, creating the GCP Service Account, Pub/Sub Topic, Pub/Sub Subscription, and launching the `platform-agent-gateway` pod in namespace `hermes`.
* Verified that the `teardown.sh` cleanly deletes the GKE cluster, the registry, the secrets, and removes all IAM policy bindings for the operator.
