### PR TITLE
feat: add RBAC configuration for platform agent service account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ prettier-check:
 	npx prettier --check "**/*.md" "**/*.yaml" "**/*.yml"
 
 prettier-write:
-	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
+	npx prettier --write "k8s-operator/**/*.yaml" "k8s-operator/**/*.yaml" "k8s-operator/**/*.md"
 
 validate:
 	@if [ -n "$(BAD_SKILLS)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ prettier-check:
 	npx prettier --check "**/*.md" "**/*.yaml" "**/*.yml"
 
 prettier-write:
-	npx prettier --write "k8s-operator/**/*.yaml" "k8s-operator/**/*.yaml" "k8s-operator/**/*.md"
+	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
 
 validate:
 	@if [ -n "$(BAD_SKILLS)" ]; then \

--- a/k8s-operator/config/agent_rbac/kustomization.yaml
+++ b/k8s-operator/config/agent_rbac/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- platformagent.yaml
+  - platformagent.yaml

--- a/k8s-operator/config/agent_rbac/kustomization.yaml
+++ b/k8s-operator/config/agent_rbac/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- platformagent.yaml

--- a/k8s-operator/config/agent_rbac/platformagent.yaml
+++ b/k8s-operator/config/agent_rbac/platformagent.yaml
@@ -52,4 +52,3 @@ roleRef:
   kind: Role
   name: platform-agent-role
   apiGroup: rbac.authorization.k8s.io
-  

--- a/k8s-operator/config/agent_rbac/platformagent.yaml
+++ b/k8s-operator/config/agent_rbac/platformagent.yaml
@@ -51,5 +51,5 @@ subjects:
 roleRef:
   kind: Role
   name: platform-agent-role
-  apiGroup: rbac.authorization.k8s.i
+  apiGroup: rbac.authorization.k8s.io
   

--- a/k8s-operator/config/agent_rbac/platformagent.yaml
+++ b/k8s-operator/config/agent_rbac/platformagent.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: platform-agent
+  namespace: kubeagents-system
+---
+# ── Least-Privilege K8s RBAC Roles for Platform Agent ──────────────────────────
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: platform-agent-role
+  namespace: kubeagents-system
+rules:
+  # Allow managing GKE Cluster Custom Resources (for KCC-native GKE provisioning)
+  - apiGroups: ["container.cnrm.cloud.google.com"]
+    resources: ["containerclusters"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - persistentvolumeclaims
+      - events
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kubeagents.x-k8s.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: platform-agent-rolebinding
+  namespace: kubeagents-system
+subjects:
+  - kind: ServiceAccount
+    name: platform-agent
+    namespace: kubeagents-system
+roleRef:
+  kind: Role
+  name: platform-agent-role
+  apiGroup: rbac.authorization.k8s.i
+  

--- a/k8s-operator/config/default/kustomization.yaml
+++ b/k8s-operator/config/default/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ../crd
   - ../rbac
   - ../manager
+  - ../agent_rbac


### PR DESCRIPTION
# Pull Request

## Why This Change

Adding the service account, role and role binding for the platform agent

## What Changed

Added definitions for platform agent service account, role and role binding

**Files:**

- `k8s-operator/config/agent_rbac/kustomization.yaml`
- `k8s-operator/config/agent_rbac/platformagent.yaml`
- `k8s-operator/config/default/kustomization.yaml`

**Added/Changed/Fixed:**

- `k8s-operator/config/agent_rbac/kustomization.yaml`
- `k8s-operator/config/agent_rbac/platformagent.yaml`
- `k8s-operator/config/default/kustomization.yaml`


## Why This Matters

Using this service account will allow the platform agent to run with a proper set of permissions

## Testing

N/A