### PR TITLE
Add litellm GitHub to makefile

### DIFF
--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -100,6 +100,15 @@ deploy-litellm: kustomize ## Deploy LiteLLM integration.
 undeploy-litellm: kustomize ## Undeploy LiteLLM integration.
 	$(KUSTOMIZE) build config/integrations/litellm | envsubst '$$NAMESPACE $$MODEL_PROVIDER $$MODEL_DEFAULT_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-agent-system} -f -
 
+.PHONY: deploy-github
+deploy-github: kustomize ## Deploy GitHub integration.
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER $$KEYRING $$KEY $$KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
+
+.PHONY: undeploy-github
+undeploy-github: kustomize ## Undeploy GitHub integration.
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER $$KEYRING $$KEY $$KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
+
+
 
 ##@ Dependencies
 

--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -92,6 +92,15 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: deploy-litellm
+deploy-litellm: kustomize ## Deploy LiteLLM integration.
+	$(KUSTOMIZE) build config/integrations/litellm | envsubst '$$NAMESPACE $$MODEL_PROVIDER $$MODEL_DEFAULT_NAME' | kubectl apply -n $${NAMESPACE:-agent-system} -f -
+
+.PHONY: undeploy-litellm
+undeploy-litellm: kustomize ## Undeploy LiteLLM integration.
+	$(KUSTOMIZE) build config/integrations/litellm | envsubst '$$NAMESPACE $$MODEL_PROVIDER $$MODEL_DEFAULT_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-agent-system} -f -
+
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -149,25 +149,59 @@ kubectl get pods -n kubeagents-system
 
 ---
 
+## Deploying LiteLLM Integration
+
+LiteLLM gateway can be deployed to the Kubernetes cluster using the `kustomize` targets in the Makefile.
+
+### Prerequisites
+
+To successfully deploy LiteLLM, you must have:
+
+1. The `platform-agent-secrets` Secret created in your destination namespace (containing `GEMINI_API_KEY`).
+
+### Step-by-Step Deployment
+
+Run the `make deploy-litellm` target, passing the required environment variables:
+
+```bash
+# 1. Define the destination namespace, model provider, and default model name:
+export NAMESPACE=kubeagents-system
+export MODEL_PROVIDER=gemini
+export MODEL_DEFAULT_NAME=gemini-3.1-flash
+
+# 2. Deploy LiteLLM:
+make deploy-litellm
+```
+
+To uninstall/remove the LiteLLM integration:
+
+```bash
+make undeploy-litellm
+```
+
+---
+
 ## Makefile Reference
 
 The [Makefile](file:///usr/local/google/home/fatoshoti/playground/kube-agents/k8s-operator/Makefile) provides several targets to automate development workflows:
 
-| Target              | Description                                             |
-| :------------------ | :------------------------------------------------------ |
-| `make manifests`    | Generates WebhookConfiguration, ClusterRole, and CRDs.  |
-| `make generate`     | Generates code containing DeepCopy implementations.     |
-| `make fmt`          | Formats Go source code using `go fmt`.                  |
-| `make vet`          | Examines Go source code and reports suspect constructs. |
-| `make test`         | Runs unit/integration tests with `setup-envtest`.       |
-| `make build`        | Compiles the manager binary to `bin/manager`.           |
-| `make run`          | Runs the controller locally from your host.             |
-| `make docker-build` | Builds the Docker image.                                |
-| `make docker-push`  | Pushes the Docker image to the registry.                |
-| `make install`      | Installs the generated CRDs into the cluster.           |
-| `make uninstall`    | Removes the CRDs from the cluster.                      |
-| `make deploy`       | Deploys the controller to the cluster.                  |
-| `make undeploy`     | Removes the controller deployment from the cluster.     |
+| Target                  | Description                                             |
+| :---------------------- | :------------------------------------------------------ |
+| `make manifests`        | Generates WebhookConfiguration, ClusterRole, and CRDs.  |
+| `make generate`         | Generates code containing DeepCopy implementations.     |
+| `make fmt`              | Formats Go source code using `go fmt`.                  |
+| `make vet`              | Examines Go source code and reports suspect constructs. |
+| `make test`             | Runs unit/integration tests with `setup-envtest`.       |
+| `make build`            | Compiles the manager binary to `bin/manager`.           |
+| `make run`              | Runs the controller locally from your host.             |
+| `make docker-build`     | Builds the Docker image.                                |
+| `make docker-push`      | Pushes the Docker image to the registry.                |
+| `make install`          | Installs the generated CRDs into the cluster.           |
+| `make uninstall`        | Removes the CRDs from the cluster.                      |
+| `make deploy`           | Deploys the controller to the cluster.                  |
+| `make undeploy`         | Removes the controller deployment from the cluster.     |
+| `make deploy-litellm`   | Deploys the LiteLLM integration.                        |
+| `make undeploy-litellm` | Removes the LiteLLM integration.                        |
 
 ---
 

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -181,6 +181,45 @@ make undeploy-litellm
 
 ---
 
+## Deploying GitHub Integration
+
+The GitHub Token Broker (Minty) can be deployed to the Kubernetes cluster using the `kustomize` targets in the Makefile.
+
+### Prerequisites
+
+Before deploying the GitHub integration, ensure you have:
+
+1. Created the `github-app-credentials` Secret containing your GitHub App ID in the destination namespace.
+2. Completed the Workload Identity and GCP Cloud KMS setup (see [integrations/github/README.md](integrations/github/README.md) for details).
+
+### Step-by-Step Deployment
+
+Run the `make deploy-github` target, passing the required environment variables:
+
+```bash
+# 1. Define the destination namespace and GCP/GitHub parameter variables:
+export NAMESPACE=kubeagents-system
+export PROJECT_ID=your-gcp-project-id
+export REGION=your-gcp-region
+export CLUSTER=your-gke-cluster-name
+export KEYRING=your-kms-keyring
+export KEY=your-kms-key
+export KEY_VERSION=your-kms-key-version
+export GITHUB_ORG=your-github-org
+export GITHUB_REPO=your-github-repo
+
+# 2. Deploy GitHub:
+make deploy-github
+```
+
+To uninstall/remove the GitHub integration:
+
+```bash
+make undeploy-github
+```
+
+---
+
 ## Makefile Reference
 
 The [Makefile](file:///usr/local/google/home/fatoshoti/playground/kube-agents/k8s-operator/Makefile) provides several targets to automate development workflows:
@@ -202,6 +241,8 @@ The [Makefile](file:///usr/local/google/home/fatoshoti/playground/kube-agents/k8
 | `make undeploy`         | Removes the controller deployment from the cluster.     |
 | `make deploy-litellm`   | Deploys the LiteLLM integration.                        |
 | `make undeploy-litellm` | Removes the LiteLLM integration.                        |
+| `make deploy-github`    | Deploys the GitHub integration.                         |
+| `make undeploy-github`  | Removes the GitHub integration.                         |
 
 ---
 

--- a/k8s-operator/config/integrations/github/configmap.yaml
+++ b/k8s-operator/config/integrations/github/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: github-token-minter-config
+data:
+  ${GITHUB_ORG}-${GITHUB_REPO}.yaml: |
+    version: 'minty.abcxyz.dev/v2'
+    rule:
+      if: "assertion.iss == 'https://container.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/clusters/${CLUSTER}'"
+    scope:
+      platform-agent-scope:
+        rule:
+          if: "assertion.sub == 'system:serviceaccount:agent-system:platform-agent'"
+        repositories:
+          - '${GITHUB_REPO}'
+        permissions:
+          contents: 'write'
+          pull_requests: 'write'

--- a/k8s-operator/config/integrations/github/deployment.yaml
+++ b/k8s-operator/config/integrations/github/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-token-minter
+  labels:
+    app: github-token-minter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: github-token-minter
+  template:
+    metadata:
+      labels:
+        app: github-token-minter
+    spec:
+      serviceAccountName: github-token-minter-ksa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: token-minter
+          image: us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server:v2.7.1-amd64
+          imagePullPolicy: IfNotPresent
+          command: ["/minty"]
+          args: ["server", "run"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: PORT
+              value: "8080"
+            - name: CONFIGS_DIR
+              value: "/etc/minty"
+            - name: ISSUER_ALLOWLIST
+              value: "https://container.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/clusters/${CLUSTER}"
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-app-credentials
+                  key: app-id
+            - name: KMS_KEY_NAME
+              value: "projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KEYRING}/cryptoKeys/${KEY}/cryptoKeyVersions/${KEY_VERSION}"
+            - name: SOURCE_SYSTEM_AUTH
+              value: "gha://$(GITHUB_APP_ID)?kms_id=$(KMS_KEY_NAME)"
+          livenessProbe:
+            httpGet:
+              path: /version
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /version
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/minty/${GITHUB_ORG}/${GITHUB_REPO}.yaml
+              subPath: ${GITHUB_ORG}-${GITHUB_REPO}.yaml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: github-token-minter-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: github-token-minter
+spec:
+  selector:
+    app: github-token-minter
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: github-token-minter-policy
+spec:
+  podSelector:
+    matchLabels:
+      app: github-token-minter
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: platform-agent
+        - podSelector:
+            matchLabels:
+              app: devteam-agent
+        - podSelector:
+            matchLabels:
+              app: operator-agent
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow HTTPS outbound connection to GitHub and KMS APIs
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/k8s-operator/config/integrations/github/kustomization.yaml
+++ b/k8s-operator/config/integrations/github/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - serviceaccount.yaml
+  - configmap.yaml
+  - deployment.yaml

--- a/k8s-operator/config/integrations/github/serviceaccount.yaml
+++ b/k8s-operator/config/integrations/github/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-token-minter-ksa
+  annotations:
+    iam.gke.io/gcp-service-account: github-token-minter-sa@${PROJECT_ID}.iam.gserviceaccount.com
+automountServiceAccountToken: false

--- a/k8s-operator/config/integrations/kustomization.yaml
+++ b/k8s-operator/config/integrations/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - litellm/

--- a/k8s-operator/config/integrations/kustomization.yaml
+++ b/k8s-operator/config/integrations/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - litellm/
+  - github/

--- a/k8s-operator/config/integrations/litellm/configmap.yaml
+++ b/k8s-operator/config/integrations/litellm/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-config
+data:
+  config.yaml: |
+    model_list:
+      - model_name: model-default
+        litellm_params:
+          model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
+          api_key: os.environ/GEMINI_API_KEY

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    metadata:
+      labels:
+        app: litellm
+    spec:
+      containers:
+        - name: litellm-container
+          image: ghcr.io/berriai/litellm:v1.86.0
+          args: ["--config", "/app/config.yaml"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+            limits:
+              cpu: "500m"
+              memory: "2Gi"
+          env:
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: platform-agent-secrets
+                  key: GEMINI_API_KEY
+          ports:
+            - containerPort: 4000
+          volumeMounts:
+            - name: config-volume
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: litellm-config

--- a/k8s-operator/config/integrations/litellm/kustomization.yaml
+++ b/k8s-operator/config/integrations/litellm/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml

--- a/k8s-operator/config/integrations/litellm/service.yaml
+++ b/k8s-operator/config/integrations/litellm/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+spec:
+  selector:
+    app: litellm
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 4000
+  type: ClusterIP

--- a/k8s-operator/config/manager/kustomization.yaml
+++ b/k8s-operator/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
   - name: controller
-    newName: us-central1-docker.pkg.dev/ai-platform-1-464114/k8s-harness-poc/kube-agents-operator
-    newTag: v1.0.0
+    newName: controller
+    newTag: latest


### PR DESCRIPTION
# Pull Request

## Why This Change

Unify all installation actions on k8s cluster.

## What Changed

Migrated installation scripts for github and litellm deployment.

**Files:**

- `k8s-operator/Makefile`
- `k8s-operator/config/integrations/*`
- `k8s-operator/readme`

**Added/Changed/Fixed:**

- `k8s-operator/Makefile`
- `k8s-operator/config/integrations/*`
- `k8s-operator/readme`

## Why This Matters

- Moves the installation script from the old folder to the new one
- Unifies all installation guides
