### PR TITLE
feat: platform agent operator migration

### DIFF
--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -32,19 +32,6 @@ rules:
       - update
       - watch
   - apiGroups:
-      - iam.cnrm.cloud.google.com
-    resources:
-      - iampolicymembers
-      - iamserviceaccounts
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - kubeagents.x-k8s.io
     resources:
       - devteamagents
@@ -77,19 +64,6 @@ rules:
       - patch
       - update
   - apiGroups:
-      - pubsub.cnrm.cloud.google.com
-    resources:
-      - pubsubsubscriptions
-      - pubsubtopics
-    verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
@@ -98,7 +72,6 @@ rules:
       - bind
       - create
       - delete
-      - escalate
       - get
       - list
       - patch

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -18,12 +18,22 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
 )
@@ -41,32 +51,220 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups=kubeagents.x-k8s.io,resources=platformagents/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;persistentvolumeclaims;configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=iam.cnrm.cloud.google.com,resources=iamserviceaccounts;iampolicymembers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=pubsub.cnrm.cloud.google.com,resources=pubsubtopics;pubsubsubscriptions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind;escalate
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
 
 func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	// 1. Fetch the PlatformAgent instance
 	instance := &agentv1alpha1.PlatformAgent{}
-	err := r.Get(ctx, req.NamespacedName, instance)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return ctrl.Result{}, nil
+	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	log.Info("Reconciling PlatformAgent", "name", instance.Name, "namespace", instance.Namespace)
+
+	// 1. Intercept Deletion
+	if !instance.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, instance)
+	}
+
+	// 2. Add Finalizer if not present
+	if !controllerutil.ContainsFinalizer(instance, platformAgentFinalizer) {
+		controllerutil.AddFinalizer(instance, platformAgentFinalizer)
+		if err := r.Update(ctx, instance); err != nil {
+			return ctrl.Result{}, err
 		}
+		// Return immediately after update to fetch the fresh ResourceVersion, preventing OptimisticLockErrors
+		return ctrl.Result{}, nil
+	}
+
+	// 3. Reconcile K8s Service Account (with Workload Identity annotation)
+	if err := r.reconcileServiceAccount(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	log.Info("Reconciling PlatformAgent", "name", instance.Name)
+	// 4. Reconcile RBAC (ClusterRole and ClusterRoleBindings)
+	if err := r.reconcileRBAC(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
+	// 5. Reconcile PVC for agent persistent data
+	if err := r.reconcilePVC(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 6. Reconcile ConfigMap (config.yaml content)
+	configMapHash, err := r.reconcileConfigMap(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 7. Reconcile Deployment (with pod template hash annotation)
+	if err := r.reconcileDeployment(ctx, instance, configMapHash); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// 8. Update status phase to Ready
+	return ctrl.Result{}, r.updateStatusReady(ctx, instance)
+}
+
+func (r *PlatformAgentReconciler) handleDeletion(ctx context.Context, agent *agentv1alpha1.PlatformAgent) (ctrl.Result, error) {
+	if controllerutil.ContainsFinalizer(agent, platformAgentFinalizer) {
+		viewerBindingName := fmt.Sprintf("kubeagents:viewer:%s:%s", agent.Namespace, agent.Name)
+		explorerBindingName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
+		explorerRoleName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
+
+		// Delete Viewer ClusterRoleBinding
+		crbViewer := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: viewerBindingName}}
+		if err := client.IgnoreNotFound(r.Delete(ctx, crbViewer)); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Delete Explorer ClusterRoleBinding
+		crbExplorer := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: explorerBindingName}}
+		if err := client.IgnoreNotFound(r.Delete(ctx, crbExplorer)); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Delete Explorer ClusterRole
+		crExplorer := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: explorerRoleName}}
+		if err := client.IgnoreNotFound(r.Delete(ctx, crExplorer)); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		// Resource is deleted. Safe to remove finalizer and update.
+		controllerutil.RemoveFinalizer(agent, platformAgentFinalizer)
+		if err := r.Update(ctx, agent); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{}, nil
+}
+
+func (r *PlatformAgentReconciler) reconcileServiceAccount(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	sa := buildServiceAccount(agent)
+	if err := ctrl.SetControllerReference(agent, sa, r.Scheme); err != nil {
+		return err
+	}
+	return r.Patch(ctx, sa, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+}
+
+func (r *PlatformAgentReconciler) reconcilePVC(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	pvc := buildPVC(agent)
+	if err := ctrl.SetControllerReference(agent, pvc, r.Scheme); err != nil {
+		return err
+	}
+
+	found := &corev1.PersistentVolumeClaim{}
+	err := r.Get(ctx, client.ObjectKey{Name: pvc.Name, Namespace: pvc.Namespace}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return r.Create(ctx, pvc)
+		}
+		return err
+	}
+	return nil
+}
+
+func (r *PlatformAgentReconciler) reconcileConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) (string, error) {
+	cm := buildConfigMap(agent)
+	if err := ctrl.SetControllerReference(agent, cm, r.Scheme); err != nil {
+		return "", err
+	}
+
+	err := r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := getConfigMapHash(cm)
+	if err != nil {
+		return "", err
+	}
+	return hash, nil
+}
+
+func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash string) error {
+	dep := buildDeployment(agent, configHash)
+	if err := ctrl.SetControllerReference(agent, dep, r.Scheme); err != nil {
+		return err
+	}
+	return r.Patch(ctx, dep, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+}
+
+func (r *PlatformAgentReconciler) reconcileRBAC(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	viewerBindingName := fmt.Sprintf("kubeagents:viewer:%s:%s", agent.Namespace, agent.Name)
+	crbViewer := buildClusterRoleBinding(agent, viewerBindingName, "view")
+	err := r.Patch(ctx, crbViewer, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+	if err != nil {
+		return fmt.Errorf("failed to reconcile viewer ClusterRoleBinding: %w", err)
+	}
+
+	explorerRole := buildPlatformExplorerRole(agent)
+	err = r.Patch(ctx, explorerRole, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+	if err != nil {
+		return fmt.Errorf("failed to reconcile explorer ClusterRole: %w", err)
+	}
+
+	explorerBindingName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
+	crbExplorer := buildClusterRoleBinding(agent, explorerBindingName, explorerRole.Name)
+	err = r.Patch(ctx, crbExplorer, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+	if err != nil {
+		return fmt.Errorf("failed to reconcile explorer ClusterRoleBinding: %w", err)
+	}
+
+	return nil
+}
+
+func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	dep := &appsv1.Deployment{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: agent.Namespace, Name: agent.Name + "-gateway"}, dep)
+	if err == nil {
+		agent.Status.DeploymentStatus.Name = dep.Name
+		agent.Status.DeploymentStatus.ReadyReplicas = dep.Status.ReadyReplicas
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	err = r.Get(ctx, types.NamespacedName{Namespace: agent.Namespace, Name: agent.Name + "-data"}, pvc)
+	if err == nil {
+		agent.Status.StorageStatus.Bound = (pvc.Status.Phase == corev1.ClaimBound)
+	}
+
+	agent.Status.Phase = "Ready"
+	now := metav1.Now()
+	agent.Status.LastReconcileTime = &now
+
+	return r.Status().Update(ctx, agent)
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *PlatformAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&agentv1alpha1.PlatformAgent{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&corev1.ConfigMap{}).
+		Watches(
+			&rbacv1.ClusterRoleBinding{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				parts := strings.Split(obj.GetName(), ":") // format: kubeagents:<role>:<namespace>:<name>
+				if len(parts) == 4 && parts[0] == "kubeagents" {
+					return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: parts[2], Name: parts[3]}}}
+				}
+				return nil
+			}),
+		).
+		Watches(
+			&rbacv1.ClusterRole{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				parts := strings.Split(obj.GetName(), ":") // format: kubeagents:<role>:<namespace>:<name>
+				if len(parts) == 4 && parts[0] == "kubeagents" {
+					return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: parts[2], Name: parts[3]}}}
+				}
+				return nil
+			}),
+		).
 		Named("platformagent").
 		Complete(r)
 }

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -230,7 +230,11 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 		agent.Status.StorageStatus.Bound = (pvc.Status.Phase == corev1.ClaimBound)
 	}
 
-	agent.Status.Phase = "Ready"
+	if err == nil && dep.Status.ReadyReplicas > 0 {
+		agent.Status.Phase = "Ready"
+	} else {
+		agent.Status.Phase = "Provisioning"
+	}
 	now := metav1.Now()
 	agent.Status.LastReconcileTime = &now
 

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -1,0 +1,438 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+// buildConfigMap generates the ConfigMap manifest containing config.yaml
+func buildConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name + "-config",
+			Namespace: agent.Namespace,
+		},
+		Data: map[string]string{
+			"config.yaml": renderConfigYAML(agent),
+		},
+	}
+}
+
+// renderConfigYAML generates the YAML payload for the agent config
+func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
+	cwd := "/opt/data"
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PlatformAgentHome != "" {
+		cwd = agent.Spec.Harness.Hermes.PlatformAgentHome
+	}
+
+	cfg := struct {
+		Model struct {
+			Default  string `json:"default"`
+			Provider string `json:"provider"`
+		} `json:"model"`
+		Terminal struct {
+			Backend string `json:"backend"`
+			Cwd     string `json:"cwd"`
+		} `json:"terminal"`
+		Platforms struct {
+			GoogleChat struct {
+				Enabled bool `json:"enabled"`
+			} `json:"google_chat"`
+		} `json:"platforms"`
+	}{}
+
+	cfg.Model.Default = agent.Spec.Model.Default
+	cfg.Model.Provider = agent.Spec.Model.Provider
+	cfg.Terminal.Backend = "local"
+	cfg.Terminal.Cwd = cwd
+
+	if agent.Spec.Integration != nil && agent.Spec.Integration.GoogleChat != nil {
+		gchat := agent.Spec.Integration.GoogleChat
+		if gchat.Enabled != nil {
+			cfg.Platforms.GoogleChat.Enabled = *gchat.Enabled
+		}
+	}
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+// buildServiceAccount generates the ServiceAccount manifest (with Workload Identity annotation)
+func buildServiceAccount(agent *agentv1alpha1.PlatformAgent) *corev1.ServiceAccount {
+	saName := agent.Name
+	if agent.Spec.Security != nil && agent.Spec.Security.ServiceAccountName != "" {
+		saName = agent.Spec.Security.ServiceAccountName
+	}
+
+	sa := &corev1.ServiceAccount{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ServiceAccount",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        saName,
+			Namespace:   agent.Namespace,
+			Annotations: make(map[string]string),
+		},
+	}
+
+	if agent.Spec.Security != nil && agent.Spec.Security.WorkloadIdentity != nil {
+		if gcp := agent.Spec.Security.WorkloadIdentity.Gcp; gcp != nil && gcp.GSAName != "" && gcp.ProjectID != "" {
+			gsaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", gcp.GSAName, gcp.ProjectID)
+			sa.Annotations["iam.gke.io/gcp-service-account"] = gsaEmail
+		}
+	}
+
+	return sa
+}
+
+// buildPVC generates the PVC manifest for agent data persistence
+func buildPVC(agent *agentv1alpha1.PlatformAgent) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name + "-data",
+			Namespace: agent.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("10Gi"),
+				},
+			},
+		},
+	}
+}
+
+// buildDeployment generates the Deployment manifest for the agent payload
+func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *appsv1.Deployment {
+	replicas := int32(1)
+	fsGroup := int64(10000)
+
+	saName := agent.Name
+	if agent.Spec.Security != nil && agent.Spec.Security.ServiceAccountName != "" {
+		saName = agent.Spec.Security.ServiceAccountName
+	}
+
+	image := ""
+	if agent.Spec.Deployment != nil {
+		image = agent.Spec.Deployment.Image
+		tag := "latest"
+		if agent.Spec.Deployment.Tag != nil && *agent.Spec.Deployment.Tag != "" {
+			tag = *agent.Spec.Deployment.Tag
+		}
+		image = fmt.Sprintf("%s:%s", image, tag)
+	}
+
+	pullPolicy := corev1.PullAlways
+	if agent.Spec.Deployment != nil && agent.Spec.Deployment.ImagePullPolicy != nil {
+		pullPolicy = *agent.Spec.Deployment.ImagePullPolicy
+	}
+
+	homeDir := "/opt/data"
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PlatformAgentHome != "" {
+		homeDir = agent.Spec.Harness.Hermes.PlatformAgentHome
+	}
+
+	dashboardVal := "0"
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.DashboardEnabled != nil {
+		if *agent.Spec.Harness.Hermes.DashboardEnabled {
+			dashboardVal = "1"
+		}
+	}
+
+	pluginsDebugVal := "0"
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PluginsDebug != nil {
+		if *agent.Spec.Harness.Hermes.PluginsDebug {
+			pluginsDebugVal = "1"
+		}
+	}
+
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "PLATFORM_AGENT_HOME",
+			Value: homeDir,
+		},
+		{
+			Name:  "PLATFORM_AGENT_DASHBOARD",
+			Value: dashboardVal,
+		},
+		{
+			Name:  "PLATFORM_AGENT_PLUGINS_DEBUG",
+			Value: pluginsDebugVal,
+		},
+		{
+			Name:  "OTEL_SERVICE_NAME",
+			Value: agent.Name + "-gateway",
+		},
+	}
+
+	if agent.Spec.Harness != nil {
+		if agent.Spec.Harness.ClusterName != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "GKE_CLUSTER_NAME",
+				Value: agent.Spec.Harness.ClusterName,
+			})
+		}
+		if agent.Spec.Harness.Location != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "GKE_LOCATION",
+				Value: agent.Spec.Harness.Location,
+			})
+		}
+		if agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.ApiServerSecretRef != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name: "API_SERVER_KEY",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: agent.Spec.Harness.Hermes.ApiServerSecretRef,
+				},
+			})
+		}
+	}
+
+	if agent.Spec.Model != nil && agent.Spec.Model.Gemini != nil && agent.Spec.Model.Gemini.ApiKeySecretRef != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name: "GEMINI_API_KEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: agent.Spec.Model.Gemini.ApiKeySecretRef,
+			},
+		})
+	}
+
+	if integration := agent.Spec.Integration; integration != nil {
+		if gchat := integration.GoogleChat; gchat != nil && gchat.Enabled != nil && *gchat.Enabled {
+			envVars = append(envVars, []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_CHAT_PROJECT_ID",
+					Value: gchat.ProjectID,
+				},
+				{
+					Name:  "GOOGLE_CHAT_SUBSCRIPTION_NAME",
+					Value: fmt.Sprintf("projects/%s/subscriptions/%s", gchat.ProjectID, gchat.SubscriptionName),
+				},
+				{
+					Name:  "GOOGLE_CHAT_ALLOWED_USERS",
+					Value: strings.Join(gchat.AllowedUsers, ","),
+				},
+				{
+					Name:  "GOOGLE_CHAT_HOME_CHANNEL",
+					Value: gchat.HomeChannel,
+				},
+			}...)
+		}
+	}
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name + "-gateway",
+			Namespace: agent.Namespace,
+			Labels: map[string]string{
+				"app": agent.Name + "-gateway",
+			},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RecreateDeploymentStrategyType,
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": agent.Name + "-gateway",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": agent.Name + "-gateway",
+					},
+					Annotations: map[string]string{
+						"kubeagents.x-k8s.io/config-hash": configHash,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: saName,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:        &fsGroup,
+						RunAsUser:      ptr.To(int64(1000)),
+						RunAsNonRoot:   ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:            "platform-agent",
+							Image:           image,
+							ImagePullPolicy: pullPolicy,
+							Command:         []string{"hermes"},
+							Args:            []string{"gateway", "run"},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "dashboard",
+									ContainerPort: 9119,
+								},
+								{
+									Name:          "api",
+									ContainerPort: 8642,
+								},
+							},
+							Env: envVars,
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "platform-agent-data-vol",
+									MountPath: homeDir,
+								},
+								{
+									Name:      "platform-agent-config-vol",
+									MountPath: fmt.Sprintf("%s/config.yaml", homeDir),
+									SubPath:   "config.yaml",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "platform-agent-data-vol",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: agent.Name + "-data",
+								},
+							},
+						},
+						{
+							Name: "platform-agent-config-vol",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: agent.Name + "-config",
+									},
+									DefaultMode: ptr.To(int32(0755)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildPlatformExplorerRole generates the custom ClusterRole manifest
+func buildPlatformExplorerRole(agent *agentv1alpha1.PlatformAgent) *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRole",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name),
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"nodes", "pods", "namespaces"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+}
+
+// buildClusterRoleBinding generates a ClusterRoleBinding manifest
+func buildClusterRoleBinding(agent *agentv1alpha1.PlatformAgent, bindingName, roleName string) *rbacv1.ClusterRoleBinding {
+	saName := agent.Name
+	if agent.Spec.Security != nil && agent.Spec.Security.ServiceAccountName != "" {
+		saName = agent.Spec.Security.ServiceAccountName
+	}
+
+	return &rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "ClusterRoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: bindingName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      saName,
+				Namespace: agent.Namespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     roleName,
+		},
+	}
+}
+
+// Helper to calculate the SHA256 hash of ConfigMap Data for rolling restarts.
+func getConfigMapHash(configMap *corev1.ConfigMap) (string, error) {
+	if configMap == nil {
+		return "", nil
+	}
+	dataBytes, err := json.Marshal(configMap.Data)
+	if err != nil {
+		return "", err
+	}
+	hash := sha256.Sum256(dataBytes)
+	return fmt.Sprintf("%x", hash), nil
+}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -73,8 +73,10 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 		} `json:"platforms"`
 	}{}
 
-	cfg.Model.Default = agent.Spec.Model.Default
-	cfg.Model.Provider = agent.Spec.Model.Provider
+	if agent.Spec.Model != nil {
+		cfg.Model.Default = agent.Spec.Model.Default
+		cfg.Model.Provider = agent.Spec.Model.Provider
+	}
 	cfg.Terminal.Backend = "local"
 	cfg.Terminal.Cwd = cwd
 

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+func TestBuildConfigMap(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Model: &agentv1alpha1.ModelSpec{
+				Provider: "gemini",
+				Default:  "gemini-2.5-flash",
+			},
+			Harness: &agentv1alpha1.HarnessSpec{
+				Hermes: &agentv1alpha1.HermesSpec{
+					PlatformAgentHome: "/custom/home",
+				},
+			},
+			Integration: &agentv1alpha1.IntegrationSpec{
+				GoogleChat: &agentv1alpha1.GoogleChatSpec{
+					Enabled: ptr.To(true),
+				},
+			},
+		},
+	}
+
+	cm := buildConfigMap(agent)
+	if cm.Name != "test-agent-config" {
+		t.Errorf("expected configmap name test-agent-config, got %s", cm.Name)
+	}
+
+	yamlContent := cm.Data["config.yaml"]
+	if !strings.Contains(yamlContent, "provider: gemini") {
+		t.Errorf("expected config to contain provider: gemini, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "default: gemini-2.5-flash") {
+		t.Errorf("expected config to contain default model, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "cwd: /custom/home") {
+		t.Errorf("expected config to contain custom home path, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "enabled: true") {
+		t.Errorf("expected config to enable google_chat platform, got:\n%s", yamlContent)
+	}
+}
+
+func TestBuildServiceAccount(t *testing.T) {
+	tests := []struct {
+		name   string
+		agent  *agentv1alpha1.PlatformAgent
+		verify func(*testing.T, *corev1.ServiceAccount)
+	}{
+		{
+			name: "uses default name if ServiceAccountName is empty",
+			agent: &agentv1alpha1.PlatformAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-agent",
+					Namespace: "my-ns",
+				},
+				Spec: agentv1alpha1.PlatformAgentSpec{
+					Security: &agentv1alpha1.SecuritySpec{
+						ServiceAccountName: "",
+					},
+				},
+			},
+			verify: func(t *testing.T, sa *corev1.ServiceAccount) {
+				if sa.Name != "my-agent" {
+					t.Errorf("expected SA name to be my-agent, got %q", sa.Name)
+				}
+				if len(sa.Annotations) != 0 {
+					t.Errorf("expected no annotations, got %v", sa.Annotations)
+				}
+			},
+		},
+		{
+			name: "uses custom name and injects GKE Workload Identity annotation",
+			agent: &agentv1alpha1.PlatformAgent{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-agent",
+					Namespace: "my-ns",
+				},
+				Spec: agentv1alpha1.PlatformAgentSpec{
+					Security: &agentv1alpha1.SecuritySpec{
+						ServiceAccountName: "custom-sa",
+						WorkloadIdentity: &agentv1alpha1.WorkloadIdentitySpec{
+							Gcp: &agentv1alpha1.GcpWorkloadIdentitySpec{
+								GSAName:   "my-gsa",
+								ProjectID: "my-gcp-project",
+							},
+						},
+					},
+				},
+			},
+			verify: func(t *testing.T, sa *corev1.ServiceAccount) {
+				if sa.Name != "custom-sa" {
+					t.Errorf("expected SA name to be custom-sa, got %q", sa.Name)
+				}
+				expectedAnnotation := "my-gsa@my-gcp-project.iam.gserviceaccount.com"
+				actual := sa.Annotations["iam.gke.io/gcp-service-account"]
+				if actual != expectedAnnotation {
+					t.Errorf("expected annotation %q, got %q", expectedAnnotation, actual)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sa := buildServiceAccount(tc.agent)
+			tc.verify(t, sa)
+		})
+	}
+}
+
+func TestBuildPVC(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+	}
+
+	pvc := buildPVC(agent)
+	if pvc.Name != "test-agent-data" {
+		t.Errorf("expected PVC name test-agent-data, got %s", pvc.Name)
+	}
+	storageReq := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if storageReq.String() != "10Gi" {
+		t.Errorf("expected storage request 10Gi, got %s", storageReq.String())
+	}
+}
+
+func TestBuildDeployment(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-agent",
+			Namespace: "my-ns",
+		},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Deployment: &agentv1alpha1.DeploymentSpec{
+				Image:           "gcr.io/my-proj/agent",
+				Tag:             ptr.To("v1.0.0"),
+				ImagePullPolicy: ptr.To(corev1.PullAlways),
+			},
+			Security: &agentv1alpha1.SecuritySpec{
+				ServiceAccountName: "custom-sa",
+			},
+			Harness: &agentv1alpha1.HarnessSpec{
+				ClusterName: "gke-cluster",
+				Location:    "us-east1",
+				Hermes: &agentv1alpha1.HermesSpec{
+					DashboardEnabled:  ptr.To(true),
+					PluginsDebug:      ptr.To(false),
+					PlatformAgentHome: "/var/agent",
+					ApiServerSecretRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "secrets"},
+						Key:                  "api-key",
+					},
+				},
+			},
+			Model: &agentv1alpha1.ModelSpec{
+				Gemini: &agentv1alpha1.GeminiSpec{
+					ApiKeySecretRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "gemini-secrets"},
+						Key:                  "api-key",
+					},
+				},
+			},
+			Integration: &agentv1alpha1.IntegrationSpec{
+				GoogleChat: &agentv1alpha1.GoogleChatSpec{
+					Enabled:          ptr.To(true),
+					ProjectID:        "my-gcp-project",
+					SubscriptionName: "chat-sub",
+					AllowedUsers:     []string{"alice", "bob"},
+					HomeChannel:      "spaces/123",
+				},
+			},
+		},
+	}
+
+	dep := buildDeployment(agent, "abcd1234")
+
+	if dep.Name != "my-agent-gateway" {
+		t.Errorf("expected deployment name my-agent-gateway, got %s", dep.Name)
+	}
+
+	if dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"] != "abcd1234" {
+		t.Errorf("expected config-hash annotation to be abcd1234, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"])
+	}
+
+	container := dep.Spec.Template.Spec.Containers[0]
+	if container.Image != "gcr.io/my-proj/agent:v1.0.0" {
+		t.Errorf("expected container image gcr.io/my-proj/agent:v1.0.0, got %s", container.Image)
+	}
+
+	// Verify env vars
+	envMap := make(map[string]corev1.EnvVar)
+	for _, env := range container.Env {
+		envMap[env.Name] = env
+	}
+
+	if envMap["PLATFORM_AGENT_HOME"].Value != "/var/agent" {
+		t.Errorf("expected PLATFORM_AGENT_HOME /var/agent, got %s", envMap["PLATFORM_AGENT_HOME"].Value)
+	}
+	if envMap["PLATFORM_AGENT_DASHBOARD"].Value != "1" {
+		t.Errorf("expected PLATFORM_AGENT_DASHBOARD 1, got %s", envMap["PLATFORM_AGENT_DASHBOARD"].Value)
+	}
+	if envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value != "0" {
+		t.Errorf("expected PLATFORM_AGENT_PLUGINS_DEBUG 0, got %s", envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value)
+	}
+	if envMap["GKE_CLUSTER_NAME"].Value != "gke-cluster" {
+		t.Errorf("expected GKE_CLUSTER_NAME gke-cluster, got %s", envMap["GKE_CLUSTER_NAME"].Value)
+	}
+	if envMap["GKE_LOCATION"].Value != "us-east1" {
+		t.Errorf("expected GKE_LOCATION us-east1, got %s", envMap["GKE_LOCATION"].Value)
+	}
+	if envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name != "secrets" {
+		t.Errorf("expected API_SERVER_KEY SecretRef secrets, got %s", envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name)
+	}
+	if envMap["GEMINI_API_KEY"].ValueFrom.SecretKeyRef.Name != "gemini-secrets" {
+		t.Errorf("expected GEMINI_API_KEY SecretRef gemini-secrets, got %s", envMap["GEMINI_API_KEY"].ValueFrom.SecretKeyRef.Name)
+	}
+	if envMap["GOOGLE_CHAT_PROJECT_ID"].Value != "my-gcp-project" {
+		t.Errorf("expected GOOGLE_CHAT_PROJECT_ID my-gcp-project, got %s", envMap["GOOGLE_CHAT_PROJECT_ID"].Value)
+	}
+	if envMap["GOOGLE_CHAT_SUBSCRIPTION_NAME"].Value != "projects/my-gcp-project/subscriptions/chat-sub" {
+		t.Errorf("expected GOOGLE_CHAT_SUBSCRIPTION_NAME project sub, got %s", envMap["GOOGLE_CHAT_SUBSCRIPTION_NAME"].Value)
+	}
+	if envMap["GOOGLE_CHAT_ALLOWED_USERS"].Value != "alice,bob" {
+		t.Errorf("expected GOOGLE_CHAT_ALLOWED_USERS alice,bob, got %s", envMap["GOOGLE_CHAT_ALLOWED_USERS"].Value)
+	}
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

Previously, the `PlatformAgent` CRD controller in `k8s-operator` was a stub reconciler that didn't provision any workload resources. This change implements the full lifecycle reconciliation logic for the `PlatformAgent` inside the main operator. 

Specifically, this migration consolidates and refactors the logic from the standalone GChat CRD operator located at:
- `integrations/gchat/crd/platform-agent-operator/internal/controller/platformagent_controller.go`

This migration transitions the operator to be **fully cloud-agnostic**:
- It removes all direct Google Cloud SDK API logic from the reconciliation code.
- It removes all Google Config Connector (KCC) dependencies and resources (like Pub/Sub and Cloud IAM CRDs), making the controller execution environment-portable.
- Cloud-specific authentication is now cleanly delegated to standard Kubernetes ServiceAccount annotations (e.g. GKE Workload Identity) and pre-provisioned secret mounts.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_controller.go`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/config/rbac/role.yaml`

**Added/Changed/Fixed:**

- **Reconciliation Engine**: Migrated the reconciliation logic from the standalone operator into `k8s-operator/internal/controller/platformagent_controller.go`. It now provisions a `ServiceAccount`, `ClusterRole`/`ClusterRoleBindings` (for viewer/explorer permissions), `PersistentVolumeClaim` (for data persistence), `ConfigMap` (rendering the `config.yaml` payload), and a `Deployment` (running the `hermes gateway run` container payload).
- **KCC & GCP SDK Removal**: Removed direct calls to the Google Cloud APIs (Pub/Sub, IAM, Resource Manager) and stripped out Config Connector RBAC rules from the operator's ClusterRole.
- **Resource Ownership & Watches**: Setup the controller to own child resources (`Deployment`, `ServiceAccount`, `PersistentVolumeClaim`, `ConfigMap`) and watch external RBAC resources (`ClusterRole`, `ClusterRoleBinding`), mapping changes back to the corresponding agent instance using a namespace/name lookup key format (`kubeagents:<role>:<namespace>:<name>`).
- **Rollout Triggers**: Added a `kubeagents.x-k8s.io/config-hash` annotation on the Pod template to trigger rolling updates automatically whenever the ConfigMap configuration changes.
- **Manifest Builders**: Created `platformagent_manifests.go` containing helper functions to construct Kubernetes resources for the `PlatformAgent`. Includes support for GKE Workload Identity annotations and Google Chat integration specs.
- **Unit Testing**: Added unit tests in `platformagent_manifests_test.go` verifying that the ConfigMap, ServiceAccount (with annotation check), PVC, and Deployment (with env vars, secret references, and pod annotations) are constructed correctly.
- **Operator RBAC Cleanup**: Cleaned up the operator's ClusterRole rules in `role.yaml` to remove KCC resource permissions (`iamserviceaccounts`, `iampolicymembers`, `pubsubtopics`, `pubsubsubscriptions`) and the `escalate` RBAC verb.

## Why This Matters

- **Cloud-Agnostic Controller**: The operator itself now operates entirely on Kubernetes-native primitives, allowing it to run in any standard Kubernetes environment without requiring cloud provider SDK credentials or Config Connector configurations.
- **Full Lifecycle Management**: The operator can now deploy, manage, and tear down `PlatformAgent` instances dynamically based on CRD manifests.
- **Security Best Practices**: Workloads are deployed with secure container settings (non-root run, dropped capabilities, runtime-default seccomp profiles, and Workload Identity annotation mappings instead of raw credentials).
- **Reduced Operational Overhead**: Eliminating the dependency on KCC resources simplifies cluster provisioning and removes cloud resources from the operator's reconciliation state machine.

## Context

This migration consolidates the platform agent operator logic into the main Kubernetes operator (`kube-agents`).

## Testing

- Unit tests added in `platformagent_manifests_test.go` covering resource rendering under various spec combinations.
- Ran tests successfully with `go test ./...` in the `k8s-operator` folder:

```
ok github.com/gke-labs/kube-agents/k8s-operator/internal/controller 0.064s
```

---
*This migration introduces complete cloud-agnostic reconcile-loop features for the PlatformAgent, aligning local configurations and deploying securely onto the GKE cluster.*