### PR TITLE
feat: add utility script to sync GKE MCP skills from upstream

### DIFF
--- a/scripts/sync-upstream-skills.py
+++ b/scripts/sync-upstream-skills.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Syncs matching agent skills from the upstream gke-mcp repository."""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+UPSTREAM_REPO = "https://github.com/GoogleCloudPlatform/gke-mcp.git"
+
+# Maps upstream skill name to one or more local destination agents ("platform", "operator", "devteam")
+SKILL_MAPPINGS = {
+    "gke-app-onboarding": ["devteam"],
+    "gke-backup-dr": ["operator"],
+    "gke-cluster-creator": ["platform"],
+    "gke-cluster-lifecycle": ["operator"],
+    "gke-compute-class-creator": ["platform"],
+    "gke-cost-analysis": ["operator"],
+    "gke-inference-quickstart": ["devteam"],
+    "gke-multi-tenancy": ["platform"],
+    "gke-networking-edge": ["operator"],
+    "gke-observability": ["operator"],
+    "gke-productionize": ["devteam", "operator"],
+    "gke-reliability": ["devteam", "operator"],
+    "gke-storage": ["platform"],
+    "gke-workload-scaling": ["devteam", "operator"],
+    "gke-workload-security": ["devteam", "operator"]
+}
+
+def run_cmd(cmd, cwd=None):
+    """Runs a shell command and returns the result, raising an exception on failure."""
+    res = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if res.returncode != 0:
+        print(f"Error running command: {' '.join(cmd)}", file=sys.stderr)
+        print(f"Stdout:\n{res.stdout}", file=sys.stderr)
+        print(f"Stderr:\n{res.stderr}", file=sys.stderr)
+        res.check_returncode()
+    return res
+
+def main():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    
+    try:
+        print("Creating temporary directory for sparse checkout...")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            print(f"Cloning upstream repository (sparse, depth 1): {UPSTREAM_REPO}...")
+            run_cmd([
+                "git", "clone", "--depth", "1", "--filter=blob:none", "--sparse",
+                UPSTREAM_REPO, tmpdir
+            ])
+            
+            print("Configuring sparse-checkout to retrieve only skills directory...")
+            run_cmd(["git", "sparse-checkout", "set", "skills"], cwd=tmpdir)
+            
+            upstream_skills_dir = os.path.join(tmpdir, "skills")
+            if not os.path.isdir(upstream_skills_dir):
+                print(f"Error: upstream skills directory not found in clone: {upstream_skills_dir}", file=sys.stderr)
+                sys.exit(1)
+                
+            print("\nSyncing skills...")
+            for skill_name, agents in SKILL_MAPPINGS.items():
+                src_skill_path = os.path.join(upstream_skills_dir, skill_name)
+                if not os.path.isdir(src_skill_path):
+                    print(f"Warning: Upstream skill '{skill_name}' not found at {src_skill_path}. Skipping.")
+                    continue
+                    
+                for agent in agents:
+                    dest_path = os.path.join(repo_root, "agents", agent, "skills", skill_name)
+                    print(f"Syncing '{skill_name}' to agents/{agent}/skills/{skill_name}...")
+                    
+                    # Delete existing destination directory to remove stale files
+                    if os.path.exists(dest_path):
+                        shutil.rmtree(dest_path)
+                        
+                    # Re-create destination parent directories if needed
+                    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+                    
+                    # Copy from sparse-checkout src to dest
+                    shutil.copytree(src_skill_path, dest_path)
+                    
+            print("\nSynchronization complete!")
+    except subprocess.CalledProcessError:
+        print("\nError: Synchronization failed due to command error. Details above.", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"\nError: An unexpected error occurred: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses the need to easily sync agent skills that are shared with the upstream `GoogleCloudPlatform/gke-mcp` repository, treating the upstream repository as the Source of Truth for these skills.

## What Changed

Added a Python utility script to automate sparse-checkout of only the skills from `GoogleCloudPlatform/gke-mcp` and safely overwrite local agent skill folders.

**Files:**

- `scripts/sync-upstream-skills.py`

**Added/Changed/Fixed:**

- Added `scripts/sync-upstream-skills.py` script.
- Configured mappings of matching skills to their respective agent directories.
- Implemented clean execution outputs and error handling in case of command failures.

## Why This Matters

This makes maintaining shared skills between repositories seamless and reduces manual copy-pasting or errors when upstream skills undergo improvements.

## Context

Requested in conversation `9b1b7f56-d8dd-4011-b0d1-543f82e8632d` to sync the 15 matching skills between the two repositories.

## Testing

Ran the script locally under the workspace root. Verified successful clones, checkouts, copying, and final checks.

---

No risk of regressions to custom local-only skills (`dev-team-provisioner`, `gke-manifest-generation`, etc.) as they are not mapped and skipped.

TAG=agy
CONV=9b1b7f56-d8dd-4011-b0d1-543f82e8632d
