### PR TITLE
chore(k8s-operator): format generated manifests in Makefile

### DIFF
--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -32,6 +32,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	npx prettier --write "config/crd/bases/*.yaml" "config/rbac/*.yaml" "config/webhook/*.yaml"
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.


### PR DESCRIPTION
# Pull Request

## Why This Change

The generated Kubernetes manifests (WebhookConfiguration, ClusterRole, and CustomResourceDefinition) produced by `controller-gen` inside `k8s-operator/` should automatically be formatted to ensure codebase style consistency and passing CI formatting checks.

## What Changed

Added a `prettier` command execution step to the `manifests` target in `k8s-operator/Makefile`.

**Files:**

- `k8s-operator/Makefile`

**Added/Changed/Fixed:**

- The `manifests` target now runs `npx prettier --write "config/crd/bases/*.yaml" "config/rbac/*.yaml" "config/webhook/*.yaml"` to format all generated YAML manifests.

## Why This Matters

Reduces manual work of formatting manifests and prevents CI failures caused by unformatted generated files.

## Context

None.

## Testing

Ran `make manifests` successfully inside `k8s-operator` and verified that prettier formatted all the generated files.

TAG=agy
CONV=0e311c8b-8acc-44a9-988d-0e7d4caa12fd
