### PR TITLE
feat(deploy): add Fluent Bit sidecar to all Agent Pods

### DIFF
--- a/deploy/kustomize/devteam/deployment.yaml
+++ b/deploy/kustomize/devteam/deployment.yaml
@@ -55,7 +55,7 @@ data:
         Name              tail
         Tag               agent.logs
         Path              /opt/data/logs/*.log
-        DB                /fluent-bit/state/hermes.db
+        DB                /fluent-bit/state/fluent-bit.db
         Refresh_Interval  5
         Rotate_Wait       30
         Mem_Buf_Limit     20MB

--- a/deploy/kustomize/devteam/deployment.yaml
+++ b/deploy/kustomize/devteam/deployment.yaml
@@ -41,7 +41,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agent-fluent-bit-config
+  name: devteam-agent-fluent-bit-config
   namespace: agent-system
 data:
   fluent-bit.conf: |
@@ -156,22 +156,25 @@ spec:
             - /fluent-bit/etc/fluent-bit.conf
           resources:
             requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+            limits:
               cpu: 500m
               ephemeral-storage: 1Gi
-              memory: 2Gi
-            limits:
-              ephemeral-storage: 1Gi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
           volumeMounts:
             - mountPath: /opt/data
               name: data-volume
               readOnly: true
-            - mountPath: /fluent-bit/etc
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
               name: fluent-bit-config
+              subPath: fluent-bit.conf
               readOnly: true
             - mountPath: /fluent-bit/state
               name: fluent-bit-state
@@ -185,7 +188,7 @@ spec:
         - name: fluent-bit-config
           configMap:
             defaultMode: 420
-            name: agent-fluent-bit-config
+            name: devteam-agent-fluent-bit-config
         - name: fluent-bit-state
           emptyDir: {}
 ---

--- a/deploy/kustomize/devteam/deployment.yaml
+++ b/deploy/kustomize/devteam/deployment.yaml
@@ -38,6 +38,42 @@ spec:
     requests:
       storage: 10Gi
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-fluent-bit-config
+  namespace: agent-system
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/hermes.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -113,6 +149,32 @@ spec:
             - name: config-volume
               mountPath: /opt/data/SETTINGS.md
               subPath: SETTINGS.md
+        - name: fluent-bit
+          image: fluent/fluent-bit:5.0.7
+          args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          resources:
+            requests:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 2Gi
+            limits:
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - NET_RAW
+          volumeMounts:
+            - mountPath: /opt/data
+              name: data-volume
+              readOnly: true
+            - mountPath: /fluent-bit/etc
+              name: fluent-bit-config
+              readOnly: true
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
       volumes:
         - name: data-volume
           persistentVolumeClaim:
@@ -120,6 +182,12 @@ spec:
         - name: config-volume
           configMap:
             name: devteam-agent-config
+        - name: fluent-bit-config
+          configMap:
+            defaultMode: 420
+            name: agent-fluent-bit-config
+        - name: fluent-bit-state
+          emptyDir: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/kustomize/operator/deployment.yaml
+++ b/deploy/kustomize/operator/deployment.yaml
@@ -45,7 +45,7 @@ data:
         Name              tail
         Tag               agent.logs
         Path              /opt/data/logs/*.log
-        DB                /fluent-bit/state/hermes.db
+        DB                /fluent-bit/state/fluent-bit.db
         Refresh_Interval  5
         Rotate_Wait       30
         Mem_Buf_Limit     20MB

--- a/deploy/kustomize/operator/deployment.yaml
+++ b/deploy/kustomize/operator/deployment.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: agent-fluent-bit-config
+  name: <OPERATOR_AGENT_NAME>-fluent-bit-config
   namespace: agent-system
 data:
   fluent-bit.conf: |
@@ -131,22 +131,25 @@ spec:
             - /fluent-bit/etc/fluent-bit.conf
           resources:
             requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+            limits:
               cpu: 500m
               ephemeral-storage: 1Gi
-              memory: 2Gi
-            limits:
-              ephemeral-storage: 1Gi
+              memory: 256Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
               drop:
-                - NET_RAW
+                - ALL
           volumeMounts:
             - mountPath: /opt/data
               name: data-volume
               readOnly: true
-            - mountPath: /fluent-bit/etc
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
               name: fluent-bit-config
+              subPath: fluent-bit.conf
               readOnly: true
             - mountPath: /fluent-bit/state
               name: fluent-bit-state
@@ -160,7 +163,7 @@ spec:
         - name: fluent-bit-config
           configMap:
             defaultMode: 420
-            name: agent-fluent-bit-config
+            name: <OPERATOR_AGENT_NAME>-fluent-bit-config
         - name: fluent-bit-state
           emptyDir: {}
 ---

--- a/deploy/kustomize/operator/deployment.yaml
+++ b/deploy/kustomize/operator/deployment.yaml
@@ -28,6 +28,42 @@ spec:
     requests:
       storage: 10Gi
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-fluent-bit-config
+  namespace: agent-system
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/hermes.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -88,6 +124,32 @@ spec:
             - name: config-volume
               mountPath: /opt/data/SETTINGS.md
               subPath: SETTINGS.md
+        - name: fluent-bit
+          image: fluent/fluent-bit:5.0.7
+          args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          resources:
+            requests:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 2Gi
+            limits:
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - NET_RAW
+          volumeMounts:
+            - mountPath: /opt/data
+              name: data-volume
+              readOnly: true
+            - mountPath: /fluent-bit/etc
+              name: fluent-bit-config
+              readOnly: true
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
       volumes:
         - name: data-volume
           persistentVolumeClaim:
@@ -95,6 +157,12 @@ spec:
         - name: config-volume
           configMap:
             name: <OPERATOR_AGENT_NAME>-config
+        - name: fluent-bit-config
+          configMap:
+            defaultMode: 420
+            name: agent-fluent-bit-config
+        - name: fluent-bit-state
+          emptyDir: {}
 ---
 # --- Strict Read-Only Cluster Permissions ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -100,12 +100,13 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	// Reconcile Fluent Bit ConfigMap
-	if err := r.reconcileFluentBitConfigMap(ctx, instance); err != nil {
+	fluentBitHash, err := r.reconcileFluentBitConfigMap(ctx, instance)
+	if err != nil {
 		return ctrl.Result{}, err
 	}
 
 	// 7. Reconcile Deployment (with pod template hash annotation)
-	if err := r.reconcileDeployment(ctx, instance, configMapHash); err != nil {
+	if err := r.reconcileDeployment(ctx, instance, configMapHash, fluentBitHash); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -189,16 +190,26 @@ func (r *PlatformAgentReconciler) reconcileConfigMap(ctx context.Context, agent 
 	return hash, nil
 }
 
-func (r *PlatformAgentReconciler) reconcileFluentBitConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+func (r *PlatformAgentReconciler) reconcileFluentBitConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) (string, error) {
 	cm := buildFluentBitConfigMap(agent)
 	if err := ctrl.SetControllerReference(agent, cm, r.Scheme); err != nil {
-		return err
+		return "", err
 	}
-	return r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+
+	err := r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := getConfigMapHash(cm)
+	if err != nil {
+		return "", err
+	}
+	return hash, nil
 }
 
-func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash string) error {
-	dep := buildDeployment(agent, configHash)
+func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash string) error {
+	dep := buildDeployment(agent, configHash, fluentBitHash)
 	if err := ctrl.SetControllerReference(agent, dep, r.Scheme); err != nil {
 		return err
 	}

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -99,6 +99,11 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	// Reconcile Fluent Bit ConfigMap
+	if err := r.reconcileFluentBitConfigMap(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// 7. Reconcile Deployment (with pod template hash annotation)
 	if err := r.reconcileDeployment(ctx, instance, configMapHash); err != nil {
 		return ctrl.Result{}, err
@@ -182,6 +187,14 @@ func (r *PlatformAgentReconciler) reconcileConfigMap(ctx context.Context, agent 
 		return "", err
 	}
 	return hash, nil
+}
+
+func (r *PlatformAgentReconciler) reconcileFluentBitConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	cm := buildFluentBitConfigMap(agent)
+	if err := ctrl.SetControllerReference(agent, cm, r.Scheme); err != nil {
+		return err
+	}
+	return r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
 }
 
 func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash string) error {

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -53,8 +53,8 @@ func buildConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
 // renderConfigYAML generates the YAML payload for the agent config
 func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	cwd := "/opt/data"
-	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PlatformAgentHome != "" {
-		cwd = agent.Spec.Harness.Hermes.PlatformAgentHome
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.AgentHome != "" {
+		cwd = agent.Spec.Harness.Hermes.AgentHome
 	}
 
 	cfg := struct {
@@ -171,8 +171,8 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 	}
 
 	homeDir := "/opt/data"
-	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PlatformAgentHome != "" {
-		homeDir = agent.Spec.Harness.Hermes.PlatformAgentHome
+	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.AgentHome != "" {
+		homeDir = agent.Spec.Harness.Hermes.AgentHome
 	}
 
 	dashboardVal := "0"
@@ -348,6 +348,46 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 								},
 							},
 						},
+						{
+							Name:  "fluent-bit",
+							Image: "fluent/fluent-bit:5.0.7",
+							Args: []string{
+								"-c",
+								"/fluent-bit/etc/fluent-bit.conf",
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("500m"),
+									corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+									corev1.ResourceMemory:           resource.MustParse("2Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "platform-agent-data-vol",
+									MountPath: "/opt/data",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "fluent-bit-config",
+									MountPath: "/fluent-bit/etc",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "fluent-bit-state",
+									MountPath: "/fluent-bit/state",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"NET_RAW"},
+								},
+							},
+						},
 					},
 					Volumes: []corev1.Volume{
 						{
@@ -367,6 +407,23 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 									},
 									DefaultMode: ptr.To(int32(0755)),
 								},
+							},
+						},
+						{
+							Name: "fluent-bit-config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "agent-fluent-bit-config",
+									},
+									DefaultMode: ptr.To(int32(420)),
+								},
+							},
+						},
+						{
+							Name: "fluent-bit-state",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -437,4 +494,49 @@ func getConfigMapHash(configMap *corev1.ConfigMap) (string, error) {
 	}
 	hash := sha256.Sum256(dataBytes)
 	return fmt.Sprintf("%x", hash), nil
+}
+
+// buildFluentBitConfigMap generates the ConfigMap manifest containing fluent-bit.conf
+func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-fluent-bit-config",
+			Namespace: agent.Namespace,
+		},
+		Data: map[string]string{
+			"fluent-bit.conf": `[SERVICE]
+    Flush         1
+    Daemon        Off
+    Log_Level     info
+    Parsers_File  parsers.conf
+
+[INPUT]
+    Name              tail
+    Tag               agent.logs
+    Path              /opt/data/logs/*.log
+    DB                /fluent-bit/state/hermes.db
+    Refresh_Interval  5
+    Rotate_Wait       30
+    Mem_Buf_Limit     20MB
+    Skip_Long_Lines   On
+    Read_from_Head    On
+    Path_Key          file_path
+
+[FILTER]
+    Name              record_modifier
+    Match             agent.logs
+    Record            app agent
+    Record            log_source agent-file
+
+[OUTPUT]
+    Name              stdout
+    Match             agent.logs
+    Format            json_lines
+`,
+		},
+	}
 }

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -146,7 +146,7 @@ func buildPVC(agent *agentv1alpha1.PlatformAgent) *corev1.PersistentVolumeClaim 
 }
 
 // buildDeployment generates the Deployment manifest for the agent payload
-func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *appsv1.Deployment {
+func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash string) *appsv1.Deployment {
 	replicas := int32(1)
 	fsGroup := int64(10000)
 
@@ -291,7 +291,8 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 						"app": agent.Name + "-gateway",
 					},
 					Annotations: map[string]string{
-						"kubeagents.x-k8s.io/config-hash": configHash,
+						"kubeagents.x-k8s.io/config-hash":            configHash,
+						"kubeagents.x-k8s.io/fluent-bit-config-hash": fluentBitHash,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -357,12 +358,14 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:              resource.MustParse("500m"),
+									corev1.ResourceCPU:              resource.MustParse("100m"),
 									corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-									corev1.ResourceMemory:           resource.MustParse("2Gi"),
+									corev1.ResourceMemory:           resource.MustParse("128Mi"),
 								},
 								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:              resource.MustParse("500m"),
 									corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+									corev1.ResourceMemory:           resource.MustParse("256Mi"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{
@@ -373,7 +376,8 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 								},
 								{
 									Name:      "fluent-bit-config",
-									MountPath: "/fluent-bit/etc",
+									MountPath: "/fluent-bit/etc/fluent-bit.conf",
+									SubPath:   "fluent-bit.conf",
 									ReadOnly:  true,
 								},
 								{
@@ -384,7 +388,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{"NET_RAW"},
+									Drop: []corev1.Capability{"ALL"},
 								},
 							},
 						},
@@ -414,7 +418,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash string) *app
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "agent-fluent-bit-config",
+										Name: agent.Name + "-fluent-bit-config",
 									},
 									DefaultMode: ptr.To(int32(420)),
 								},
@@ -504,7 +508,7 @@ func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigM
 			Kind:       "ConfigMap",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "agent-fluent-bit-config",
+			Name:      agent.Name + "-fluent-bit-config",
 			Namespace: agent.Namespace,
 		},
 		Data: map[string]string{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -518,7 +518,7 @@ func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigM
     Name              tail
     Tag               agent.logs
     Path              /opt/data/logs/*.log
-    DB                /fluent-bit/state/hermes.db
+    DB                /fluent-bit/state/fluent-bit.db
     Refresh_Interval  5
     Rotate_Wait       30
     Mem_Buf_Limit     20MB

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -205,7 +205,7 @@ func TestBuildDeployment(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678")
 
 	if dep.Name != "my-agent-gateway" {
 		t.Errorf("expected deployment name my-agent-gateway, got %s", dep.Name)
@@ -213,6 +213,10 @@ func TestBuildDeployment(t *testing.T) {
 
 	if dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"] != "abcd1234" {
 		t.Errorf("expected config-hash annotation to be abcd1234, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"])
+	}
+
+	if dep.Spec.Template.Annotations["kubeagents.x-k8s.io/fluent-bit-config-hash"] != "efgh5678" {
+		t.Errorf("expected fluent-bit-config-hash annotation to be efgh5678, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/fluent-bit-config-hash"])
 	}
 
 	if len(dep.Spec.Template.Spec.Containers) != 2 {
@@ -291,8 +295,8 @@ func TestBuildFluentBitConfigMap(t *testing.T) {
 		},
 	}
 	cm := buildFluentBitConfigMap(agent)
-	if cm.Name != "agent-fluent-bit-config" {
-		t.Errorf("expected configmap name agent-fluent-bit-config, got %s", cm.Name)
+	if cm.Name != "test-agent-fluent-bit-config" {
+		t.Errorf("expected configmap name test-agent-fluent-bit-config, got %s", cm.Name)
 	}
 	if cm.Namespace != "test-ns" {
 		t.Errorf("expected configmap namespace test-ns, got %s", cm.Namespace)

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -38,9 +38,9 @@ func TestBuildConfigMap(t *testing.T) {
 				Provider: "gemini",
 				Default:  "gemini-2.5-flash",
 			},
-			Harness: &agentv1alpha1.HarnessSpec{
+			Harness: &agentv1alpha1.PlatformAgentHarnessSpec{
 				Hermes: &agentv1alpha1.HermesSpec{
-					PlatformAgentHome: "/custom/home",
+					AgentHome: "/custom/home",
 				},
 			},
 			Integration: &agentv1alpha1.IntegrationSpec{
@@ -172,13 +172,13 @@ func TestBuildDeployment(t *testing.T) {
 			Security: &agentv1alpha1.SecuritySpec{
 				ServiceAccountName: "custom-sa",
 			},
-			Harness: &agentv1alpha1.HarnessSpec{
+			Harness: &agentv1alpha1.PlatformAgentHarnessSpec{
 				ClusterName: "gke-cluster",
 				Location:    "us-east1",
 				Hermes: &agentv1alpha1.HermesSpec{
-					DashboardEnabled:  ptr.To(true),
-					PluginsDebug:      ptr.To(false),
-					PlatformAgentHome: "/var/agent",
+					DashboardEnabled: ptr.To(true),
+					PluginsDebug:     ptr.To(false),
+					AgentHome:        "/var/agent",
 					ApiServerSecretRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{Name: "secrets"},
 						Key:                  "api-key",
@@ -213,6 +213,10 @@ func TestBuildDeployment(t *testing.T) {
 
 	if dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"] != "abcd1234" {
 		t.Errorf("expected config-hash annotation to be abcd1234, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/config-hash"])
+	}
+
+	if len(dep.Spec.Template.Spec.Containers) != 2 {
+		t.Errorf("expected 2 containers, got %d", len(dep.Spec.Template.Spec.Containers))
 	}
 
 	container := dep.Spec.Template.Spec.Containers[0]
@@ -255,5 +259,49 @@ func TestBuildDeployment(t *testing.T) {
 	}
 	if envMap["GOOGLE_CHAT_ALLOWED_USERS"].Value != "alice,bob" {
 		t.Errorf("expected GOOGLE_CHAT_ALLOWED_USERS alice,bob, got %s", envMap["GOOGLE_CHAT_ALLOWED_USERS"].Value)
+	}
+
+	// Verify Fluent Bit container
+	fbContainer := dep.Spec.Template.Spec.Containers[1]
+	if fbContainer.Name != "fluent-bit" {
+		t.Errorf("expected container name fluent-bit, got %s", fbContainer.Name)
+	}
+	if fbContainer.Image != "fluent/fluent-bit:5.0.7" {
+		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.0.7, got %s", fbContainer.Image)
+	}
+
+	// Verify volumes
+	volumesMap := make(map[string]corev1.Volume)
+	for _, vol := range dep.Spec.Template.Spec.Volumes {
+		volumesMap[vol.Name] = vol
+	}
+	if _, ok := volumesMap["fluent-bit-config"]; !ok {
+		t.Errorf("expected fluent-bit-config volume, not found")
+	}
+	if _, ok := volumesMap["fluent-bit-state"]; !ok {
+		t.Errorf("expected fluent-bit-state volume, not found")
+	}
+}
+
+func TestBuildFluentBitConfigMap(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+	}
+	cm := buildFluentBitConfigMap(agent)
+	if cm.Name != "agent-fluent-bit-config" {
+		t.Errorf("expected configmap name agent-fluent-bit-config, got %s", cm.Name)
+	}
+	if cm.Namespace != "test-ns" {
+		t.Errorf("expected configmap namespace test-ns, got %s", cm.Namespace)
+	}
+	fbConf, ok := cm.Data["fluent-bit.conf"]
+	if !ok {
+		t.Fatalf("expected fluent-bit.conf key, not found")
+	}
+	if !strings.Contains(fbConf, "Name              tail") {
+		t.Errorf("expected fluent-bit.conf to contain Input Name tail")
 	}
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

Adds logging pipeline collection capability via Fluent Bit to all AI agent workloads, enabling consolidated log parsing, filtering, and shipping in subsequent steps.

## What Changed

Injected `fluent-bit` sidecar container to all agent pods and reconciled it appropriately.

**Files:**

- `deploy/kustomize/devteam/deployment.yaml`
- `deploy/kustomize/operator/deployment.yaml`
- `k8s-operator/internal/controller/platformagent_controller.go`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`

**Added/Changed/Fixed:**

- Added `agent-fluent-bit-config` ConfigMap containing `fluent-bit.conf` to Operator and DevTeam agent manifests.
- Injected `fluent-bit` sidecar container, volume mounts (for data-volume, config, and state), and volumes to Operator and DevTeam agent deployments.
- Updated `PlatformAgentReconciler` to build and reconcile `agent-fluent-bit-config` ConfigMap in the agent's namespace.
- Added `fluent-bit` container, config, and state volumes/mounts to dynamic `PlatformAgent` deployment generation.
- Fixed preexisting compilation errors in `platformagent` controller and unit tests.
- Added test coverage in `platformagent_manifests_test.go` to assert correct generation of Fluent Bit configmap, container, and volumes.

## Why This Matters

Fluent Bit allows us to stream agent execution logs securely to stdout/log collectors in JSON format, facilitating monitoring, debugging, and audit logging of agent workflows.

## Context

Requested in task for Fluent Bit sidecar logging.

## Testing

- Verified compile/build of operator code via `make build`.
- Ran unit tests in `k8s-operator/internal/controller` via `go test`, confirming 100% success.
- Checked formatting constraints using Prettier.
