### PR TITLE
feat(deploy): deep merge platform config using Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ docker-build-agents: $(foreach agent,$(AGENTS),docker-build-$(agent))
 
 .PHONY: $(foreach agent,$(AGENTS),docker-build-$(agent))
 $(foreach agent,$(AGENTS),docker-build-$(agent)): docker-build-%:
-	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target $* -t $(REPO)/$*-agent:latest -f agents/Dockerfile .
+	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target $* -t $(REPO)/$*-agent:latest -f deploy/docker/Dockerfile .
 
 # Docker pushes
 docker-push: docker-push-agents

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     patch \
     git \
+    yq \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository
@@ -139,15 +140,14 @@ COPY agents/platform/skills/ /opt/hermes/skills/
 # Copy platform defaults configuration as temp file
 COPY agents/platform/config.yaml /tmp/platform-config.yaml
 
-
 # Copy devteam deployment template
 COPY deploy/kustomize/devteam/deployment.yaml /opt/defaults/templates/devteam/deployment.yaml
 
 # Copy operator deployment template
 COPY deploy/kustomize/operator/deployment.yaml /opt/defaults/templates/operator/deployment.yaml
 
-# Dynamically merge config.yamls using virtualenv python
-RUN /opt/hermes/.venv/bin/python3 -c "import pathlib, yaml; p1=pathlib.Path('/opt/defaults/config.yaml'); p2=pathlib.Path('/tmp/platform-config.yaml'); s=(yaml.safe_load(p1.read_text()) or {}) if p1.exists() else {}; p=(yaml.safe_load(p2.read_text()) or {}) if p2.exists() else {}; s.update(p); p1.write_text(yaml.safe_dump(s))" && rm -f /tmp/platform-config.yaml
+# Dynamically merge config.yamls using yq
+RUN yq -y -s 'def merge(a; b): (a | type) as $a_type | (b | type) as $b_type | if $a_type == "object" and $b_type == "object" then a as $a | b as $b | reduce ($b | keys_unsorted[]) as $k ($a; .[$k] = merge(.[$k]; $b[$k])) elif $a_type == "array" and $b_type == "array" then (a + b) | unique else b end; merge(.[0]; .[1])' /opt/defaults/config.yaml /tmp/platform-config.yaml > /opt/defaults/config.yaml.new && mv /opt/defaults/config.yaml.new /opt/defaults/config.yaml && rm -f /tmp/platform-config.yaml
 
 # Normalize ownership and permissions at the end of build
 RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills && \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     patch \
     git \
-    yq \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository
@@ -146,8 +145,25 @@ COPY deploy/kustomize/devteam/deployment.yaml /opt/defaults/templates/devteam/de
 # Copy operator deployment template
 COPY deploy/kustomize/operator/deployment.yaml /opt/defaults/templates/operator/deployment.yaml
 
-# Dynamically merge config.yamls using yq
-RUN yq -y -s 'def merge(a; b): (a | type) as $a_type | (b | type) as $b_type | if $a_type == "object" and $b_type == "object" then a as $a | b as $b | reduce ($b | keys_unsorted[]) as $k ($a; .[$k] = merge(.[$k]; $b[$k])) elif $a_type == "array" and $b_type == "array" then (a + b) | unique else b end; merge(.[0]; .[1])' /opt/defaults/config.yaml /tmp/platform-config.yaml > /opt/defaults/config.yaml.new && mv /opt/defaults/config.yaml.new /opt/defaults/config.yaml && rm -f /tmp/platform-config.yaml
+# Dynamically merge config.yamls using virtualenv python
+RUN /opt/hermes/.venv/bin/python3 <<'EOF'
+import pathlib, yaml
+def merge(a, b):
+    if isinstance(a, dict) and isinstance(b, dict):
+        for k, v in b.items():
+            a[k] = merge(a[k], v) if k in a else v
+        return a
+    elif isinstance(a, list) and isinstance(b, list):
+        return list(dict.fromkeys(a + b))
+    return b
+
+p1 = pathlib.Path('/opt/defaults/config.yaml')
+p2 = pathlib.Path('/tmp/platform-config.yaml')
+s = yaml.safe_load(p1.read_text()) if p1.exists() else {}
+p = yaml.safe_load(p2.read_text()) if p2.exists() else {}
+p1.write_text(yaml.safe_dump(merge(s or {}, p or {})))
+EOF
+RUN rm -f /tmp/platform-config.yaml
 
 # Normalize ownership and permissions at the end of build
 RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills && \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -145,25 +145,12 @@ COPY deploy/kustomize/devteam/deployment.yaml /opt/defaults/templates/devteam/de
 # Copy operator deployment template
 COPY deploy/kustomize/operator/deployment.yaml /opt/defaults/templates/operator/deployment.yaml
 
-# Dynamically merge config.yamls using virtualenv python
-RUN /opt/hermes/.venv/bin/python3 <<'EOF'
-import pathlib, yaml
-def merge(a, b):
-    if isinstance(a, dict) and isinstance(b, dict):
-        for k, v in b.items():
-            a[k] = merge(a[k], v) if k in a else v
-        return a
-    elif isinstance(a, list) and isinstance(b, list):
-        return list(dict.fromkeys(a + b))
-    return b
+# Copy config merge helper script
+COPY deploy/docker/merge_configs.py /tmp/merge_configs.py
 
-p1 = pathlib.Path('/opt/defaults/config.yaml')
-p2 = pathlib.Path('/tmp/platform-config.yaml')
-s = yaml.safe_load(p1.read_text()) if p1.exists() else {}
-p = yaml.safe_load(p2.read_text()) if p2.exists() else {}
-p1.write_text(yaml.safe_dump(merge(s or {}, p or {})))
-EOF
-RUN rm -f /tmp/platform-config.yaml
+# Dynamically merge config.yamls using helper script
+RUN /opt/hermes/.venv/bin/python3 /tmp/merge_configs.py /opt/defaults/config.yaml /tmp/platform-config.yaml && \
+    rm -f /tmp/merge_configs.py /tmp/platform-config.yaml
 
 # Normalize ownership and permissions at the end of build
 RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills && \

--- a/deploy/docker/merge_configs.py
+++ b/deploy/docker/merge_configs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper script to deep merge YAML configurations during Docker image build."""
+
+import argparse
+import pathlib
+import yaml
+
+
+def merge(a, b):
+  """Recursively deep merge two dictionaries/lists."""
+  if isinstance(a, dict) and isinstance(b, dict):
+    for k, v in b.items():
+      a[k] = merge(a[k], v) if k in a else v
+    return a
+  elif isinstance(a, list) and isinstance(b, list):
+    return list(dict.fromkeys(a + b))
+  return b
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Deep merge YAML configuration files."
+  )
+  parser.add_argument(
+      "base",
+      type=pathlib.Path,
+      help="Base YAML configuration file to modify in place.",
+  )
+  parser.add_argument("overlay", type=pathlib.Path, help="Overlay YAML file.")
+  args = parser.parse_args()
+
+  s = yaml.safe_load(args.base.read_text()) if args.base.exists() else {}
+  p = yaml.safe_load(args.overlay.read_text()) if args.overlay.exists() else {}
+
+  merged = merge(s or {}, p or {})
+  args.base.write_text(yaml.safe_dump(merged))
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
## Why This Change

The platform agent's configuration was dropping the base-configured GCP Developer Knowledge MCP server because the previous configuration merge in the Dockerfile used a top-level `s.update(p)` update, which completely overwrote the `mcp_servers` dictionary.

## What Changed

Updated the platform config merge step in the Dockerfile to use a Python-based recursive function to deep-merge dictionaries and union arrays. Corrected the root `Makefile` to use the correct Dockerfile path.

Files:

• deploy/docker/Dockerfile
• Makefile

Added/Changed/Fixed:

• Changed platform merge RUN instruction in `deploy/docker/Dockerfile` to use a recursive Python-based deep-merge.
• Fixed root Makefile Dockerfile path reference (`deploy/docker/Dockerfile` instead of `agents/Dockerfile`).

## Why This Matters

This ensures that the platform agent has access to all base MCP servers, including the GCP Developer Knowledge server, without duplicating the config block in the platform config YAML.

## Context

Follow-up request to add the GCP Developer Knowledge MCP server to all 3 agents.

## Testing

Ran local `make docker-build` to build all three agent targets. Verified `/opt/defaults/config.yaml` in the built platform-agent container contains both `platform_control` and `developer_knowledge` servers under `mcp_servers` and `mcp-developer_knowledge` under `platform_toolsets`.

--------

TAG=agy
CONV=71fcb0ef-a2ca-41b3-81e0-89d0b426b2ea
