### PR TITLE
feat: enable DuckDuckGo web search for all agents

### DIFF
--- a/deploy/shared/defaults/config.yaml
+++ b/deploy/shared/defaults/config.yaml
@@ -28,3 +28,7 @@ platform_toolsets:
 # Approval settings. Allow dangerous commands to execute autonomously in cron watchdogs.
 approvals:
   cron_mode: approve
+
+# Enable DuckDuckGo web search
+web:
+  backend: "ddgs"


### PR DESCRIPTION
# Pull Request

## Why This Change

Enable web searching capability via DuckDuckGo (ddgs) for all agents within the Kubernetes Agentic Harness (`kube-agents`).

## What Changed

**Files:**

- `deploy/shared/defaults/config.yaml`

**Added/Changed/Fixed:**

- Configured `web.backend` to `"ddgs"` under the shared defaults configuration.

## Why This Matters

This allows all deployed agents (`platform`, `devteam`, and `operator`) to use free, keyless DuckDuckGo search out of the box when they need to search the web for information.

## Context

Requested by the user to enable DuckDuckGo websearch based on the Hermes Agent documentation.

## Testing

Validated that the YAML configuration is well-formed using `make validate` and formatted via Prettier.

TAG=agy
CONV=5f2c64d2-4606-45f6-9744-cde74b4741e1
