### PR TITLE
feat: install jq, yq, k9s, helm, dnsutils, and iputils-ping

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -12,6 +12,9 @@ RUN apt-get update && apt-get install -y \
     curl \
     patch \
     git \
+    jq \
+    dnsutils \
+    iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository
@@ -23,11 +26,20 @@ RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dear
     kubectl \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Install GitHub CLI (gh)
+# 3. Install GitHub CLI (gh), yq, k9s, and helm
 RUN ARCH=$(dpkg --print-architecture) && \
     curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" \
     && dpkg -i /tmp/gh.deb \
-    && rm /tmp/gh.deb
+    && rm /tmp/gh.deb && \
+    curl -sSLf -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH}" && \
+    chmod +x /usr/local/bin/yq && \
+    curl -sSLf -o /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/latest/download/k9s_Linux_${ARCH}.tar.gz" && \
+    tar -xzf /tmp/k9s.tar.gz -C /usr/local/bin k9s && \
+    rm /tmp/k9s.tar.gz && \
+    curl -sSLf -o /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.15.2-linux-${ARCH}.tar.gz" && \
+    tar -xzf /tmp/helm.tar.gz -C /tmp && \
+    mv /tmp/linux-${ARCH}/helm /usr/local/bin/helm && \
+    rm -rf /tmp/helm.tar.gz /tmp/linux-${ARCH}
 
 RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     google-api-python-client \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -31,9 +31,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" \
     && dpkg -i /tmp/gh.deb \
     && rm /tmp/gh.deb && \
-    curl -sSLf -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH}" && \
+    curl -sSLf -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_${ARCH}" && \
     chmod +x /usr/local/bin/yq && \
-    curl -sSLf -o /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/latest/download/k9s_Linux_${ARCH}.tar.gz" && \
+    curl -sSLf -o /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/download/v0.51.0/k9s_Linux_${ARCH}.tar.gz" && \
     tar -xzf /tmp/k9s.tar.gz -C /usr/local/bin k9s && \
     rm /tmp/k9s.tar.gz && \
     curl -sSLf -o /tmp/helm.tar.gz "https://get.helm.sh/helm-v3.15.2-linux-${ARCH}.tar.gz" && \


### PR DESCRIPTION
# Pull Request

## Why This Change

The agents require key tools to inspect, modify, and troubleshoot Kubernetes resources, networking, and deployment charts:
- `jq` and `yq` for JSON and YAML manipulation.
- `k9s` for terminal-based Kubernetes dashboard capabilities.
- `helm` for package and chart management.
- `dnsutils` (`dig`, `nslookup`) and `iputils-ping` (`ping`) for troubleshooting internal cluster network issues.

## What Changed

Added the installation steps of these tools in the Dockerfile base image:
- System diagnostics tools (`jq`, `dnsutils`, `iputils-ping`) are installed via `apt-get` in step 1.
- Dev tools (`yq`, `k9s`, `helm`) are fetched directly as binary releases from their official repositories in step 3.

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Installed `jq`, `dnsutils`, `iputils-ping`, `yq`, `k9s`, and `helm` in `agent-base` stage.

## Why This Matters

This makes standard utilities native to the agents, reducing the need for runtime/adhoc installations or errors when trying to run tasks that rely on parsing manifests, networking, or deploying Helm charts.

## Context

Requested by the user.

TAG=agy
CONV=8a11f673-544c-4ed2-ae7d-88e0c6a52892

## Testing

Validated that the Docker image builds successfully across all agent targets (`devteam`, `operator`, `platform`) using `make docker-build`.
