### PR TITLE
chore: install ddgs Python package

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     && rm /tmp/gh.deb
 
 RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
+    ddgs \
     google-api-python-client \
     google-auth \
     google-cloud-pubsub \


### PR DESCRIPTION
# Pull Request

## Why This Change

Support DuckDuckGo search by installing the successor library `ddgs`.

## What Changed

Added `ddgs` to the pip dependencies in the base docker image.

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Added `ddgs` to the pip install layer in Dockerfile.

## Why This Matters

Ensures Python agents can access search features without dependency resolution issues.

## Context

Follow-up to previous DuckDuckGo PR.

## Testing

Successfully built the `platform` target locally:
`docker build -f deploy/docker/Dockerfile --target platform .`
