### PR TITLE
feat(litellm): scale replicas to 2 and configure OTel metrics/v2 integration

### DIFF
--- a/k8s-operator/config/integrations/litellm/configmap.yaml
+++ b/k8s-operator/config/integrations/litellm/configmap.yaml
@@ -9,3 +9,5 @@ data:
         litellm_params:
           model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
           api_key: os.environ/GEMINI_API_KEY
+    litellm_settings:
+      callbacks: ["otel"]

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -3,7 +3,12 @@ kind: Deployment
 metadata:
   name: litellm
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: litellm
@@ -14,7 +19,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.86.0
+          image: ghcr.io/berriai/litellm:v1.88.2
           args: ["--config", "/app/config.yaml"]
           resources:
             requests:
@@ -29,6 +34,14 @@ spec:
                 secretKeyRef:
                   name: platform-agent-secrets
                   key: GEMINI_API_KEY
+            - name: LITELLM_OTEL_V2
+              value: "true"
+            - name: OTEL_EXPORTER
+              value: "otlp_http"
+            - name: OTEL_ENDPOINT
+              value: "http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318"
+            - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
+              value: "true"
           ports:
             - containerPort: 4000
           volumeMounts:

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -36,10 +36,12 @@ spec:
                   key: GEMINI_API_KEY
             - name: LITELLM_OTEL_V2
               value: "true"
-            - name: OTEL_EXPORTER
-              value: "otlp_http"
-            - name: OTEL_ENDPOINT
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
+            - name: OTEL_SERVICE_NAME
+              value: "litellm"
             - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
               value: "true"
           ports:


### PR DESCRIPTION
## Summary
- Scale replicas of litellm to 2 for high availability during rollouts
- Configure RollingUpdate strategy with maxSurge: 1 and maxUnavailable: 0
- Enable OpenTelemetry v2 integration and OTel metrics

TAG=agy
CONV=83791482-b1a6-4127-a2b9-4514152a4cf4