### PR TITLE
feat(telemetry): configure prometheus and opentelemetry for litellm and vllm

### DIFF
--- a/agents/platform/SOUL.md
+++ b/agents/platform/SOUL.md
@@ -96,7 +96,7 @@ The `kube-agents` harness supports comprehensive cluster telemetry via OpenTelem
 ### Assisting the User with GCP Console Links:
 
 Whenever you are discussing telemetry, tracing, logs, or debugging with the user, you must construct and provide direct links to the Google Cloud Console for their active project.
-Use the active GCP project ID (defaulting to `bhoekstra-gke-dev` unless otherwise specified).
+Use the active GCP project ID.
 
 #### Standard GCP Console URL Templates:
 

--- a/agents/platform/SOUL.md
+++ b/agents/platform/SOUL.md
@@ -82,3 +82,33 @@ If a newly provisioned or existing worker (subagent, provisioning task, or remot
 When you need to coordinate, delegate, or communicate with a GKE Operator or DevTeam agent across clusters, you **must** use your native inter-agent communication tool to execute secure, synchronous completions API queries. Do not use manual shell scripts or external HTTP helpers.
 
 ---
+
+## 7. Observability and Telemetry (GCP Integration)
+
+The `kube-agents` harness supports comprehensive cluster telemetry via OpenTelemetry (OTel) and Prometheus metrics.
+
+### Key Capabilities:
+
+- **Prometheus Metrics**: LiteLLM and vLLM components expose Prometheus metrics scraped automatically by GKE Managed Prometheus.
+- **OpenTelemetry Tracing**: LiteLLM and vLLM are configured to export trace telemetry directly to the GKE OTel collector (`gke-managed-otel` namespace), which routes them to Google Cloud Trace.
+- **Unified Log Ingestion**: All logs from container workloads are ingested by Google Cloud Logging.
+
+### Assisting the User with GCP Console Links:
+
+Whenever you are discussing telemetry, tracing, logs, or debugging with the user, you must construct and provide direct links to the Google Cloud Console for their active project.
+Use the active GCP project ID (defaulting to `bhoekstra-gke-dev` unless otherwise specified).
+
+#### Standard GCP Console URL Templates:
+
+- **Cloud Logging (Logs Explorer)**:
+  `https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22{project_id}%22?project={project_id}`
+- **Cloud Trace (Trace Explorer)**:
+  `https://console.cloud.google.com/traces/list?project={project_id}`
+- **Cloud Monitoring (Metrics Explorer)**:
+  `https://console.cloud.google.com/monitoring/metrics-explorer?project={project_id}`
+- **GKE Workloads Console**:
+  `https://console.cloud.google.com/kubernetes/workload/overview?project={project_id}`
+
+Ensure all generated links are formatted as clickable Markdown links.
+
+---

--- a/examples/litellm-chatgpt-subscription/README.md
+++ b/examples/litellm-chatgpt-subscription/README.md
@@ -19,13 +19,16 @@ kubectl apply -f deployment.yaml
 kubectl apply -f service.yaml
 ```
 
-4.  Apply NetworkPolicy and configure Prometheus monitoring:
-    ```bash
-    kubectl apply -f networkpolicy.yaml
-    kubectl apply -f podmonitoring.yaml
-    ```
+### 2. Configure Monitoring and Security
 
-### 2. Retrieve the Authentication Link
+Apply the NetworkPolicy and PodMonitoring configurations to the namespace:
+
+```bash
+kubectl apply -f networkpolicy.yaml
+kubectl apply -f podmonitoring.yaml
+```
+
+### 3. Retrieve the Authentication Link
 
 LiteLLM uses the OAuth Device Code flow. You must retrieve the unique authorization link and code from the pod's logs:
 
@@ -33,7 +36,7 @@ LiteLLM uses the OAuth Device Code flow. You must retrieve the unique authorizat
 kubectl logs -n agent-system -l app=litellm -f
 ```
 
-### 3. Complete the Browser Login
+### 4. Complete the Browser Login
 
 Once the logs start streaming, look for a message that looks like this:
 
@@ -48,7 +51,7 @@ Sign in with ChatGPT using device code:
 3.  **Submit Code:** Enter the unique 8-character code displayed in your terminal logs.
 4.  **Confirm:** Check `kubectl logs` in previous log to confirm login was successful.
 
-### 4. Confirm Configuration
+### 5. Confirm Configuration
 
 Verify that the ConfigMap is correctly applied and pointing to the `chatgpt/` model:
 

--- a/examples/litellm-chatgpt-subscription/README.md
+++ b/examples/litellm-chatgpt-subscription/README.md
@@ -19,8 +19,9 @@ kubectl apply -f deployment.yaml
 kubectl apply -f service.yaml
 ```
 
-4.  Configure Prometheus monitoring:
+4.  Apply NetworkPolicy and configure Prometheus monitoring:
     ```bash
+    kubectl apply -f networkpolicy.yaml
     kubectl apply -f podmonitoring.yaml
     ```
 

--- a/examples/litellm-chatgpt-subscription/README.md
+++ b/examples/litellm-chatgpt-subscription/README.md
@@ -19,6 +19,11 @@ kubectl apply -f deployment.yaml
 kubectl apply -f service.yaml
 ```
 
+4.  Configure Prometheus monitoring:
+    ```bash
+    kubectl apply -f podmonitoring.yaml
+    ```
+
 ### 2. Retrieve the Authentication Link
 
 LiteLLM uses the OAuth Device Code flow. You must retrieve the unique authorization link and code from the pod's logs:
@@ -53,3 +58,10 @@ kubectl get configmap litellm-config -n agent-system -o yaml
 ---
 
 **Note:** This example includes a `PersistentVolumeClaim` (PVC) mounted to `/data/litellm/chatgpt`. This ensures that your OAuth login tokens are preserved even if the pod is evicted or restarted, so you don't have to re-authenticate every time.
+
+## Verification
+
+You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
+
+- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-chatgpt-subscription/configmap.yaml
+++ b/examples/litellm-chatgpt-subscription/configmap.yaml
@@ -9,3 +9,5 @@ data:
       - model_name: model-default
         litellm_params:
           model: chatgpt/gpt-5.4
+    litellm_settings:
+      callbacks: ["prometheus"]

--- a/examples/litellm-chatgpt-subscription/configmap.yaml
+++ b/examples/litellm-chatgpt-subscription/configmap.yaml
@@ -10,4 +10,4 @@ data:
         litellm_params:
           model: chatgpt/gpt-5.4
     litellm_settings:
-      callbacks: ["prometheus"]
+      callbacks: ["otel", "prometheus"]

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.87.0
+          image: ghcr.io/berriai/litellm:v1.88.2
           args: ["--config", "/app/config.yaml"]
           env:
             - name: CHATGPT_TOKEN_DIR

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -34,6 +34,16 @@ spec:
           env:
             - name: CHATGPT_TOKEN_DIR
               value: "/data/litellm/chatgpt"
+            - name: LITELLM_OTEL_V2
+              value: "true"
+            - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_SERVICE_NAME
+              value: litellm
           ports:
             - containerPort: 4000
           volumeMounts:

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -21,6 +21,10 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
+            cidr: 169.254.20.10/32
     - ports:
         - port: 443
           protocol: TCP

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -17,16 +17,17 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
     - ports:
         - port: 443
-          protocol: TCP
-        - port: 80
           protocol: TCP
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+
   ingress:
     - from:
         - podSelector:

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -17,7 +17,9 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -31,6 +33,10 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
     - ports:
         - port: 4317
           protocol: TCP

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -35,6 +35,9 @@ spec:
               app: platform-agent
         - podSelector:
             matchLabels:
+              app: platform-agent-gateway
+        - podSelector:
+            matchLabels:
               group: operator-agent
         - podSelector:
             matchLabels:

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litellm-policy
+  namespace: agent-system
+spec:
+  podSelector:
+    matchLabels:
+      app: litellm
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: platform-agent
+        - podSelector:
+            matchLabels:
+              group: operator-agent
+        - podSelector:
+            matchLabels:
+              group: devteam-agent
+      ports:
+        - port: 4000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-gmp-system
+      ports:
+        - port: 4000
+          protocol: TCP

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -27,6 +27,18 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-managed-otel
+          podSelector:
+            matchLabels:
+              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -30,18 +30,7 @@ spec:
 
   ingress:
     - from:
-        - podSelector:
-            matchLabels:
-              app: platform-agent
-        - podSelector:
-            matchLabels:
-              app: platform-agent-gateway
-        - podSelector:
-            matchLabels:
-              group: operator-agent
-        - podSelector:
-            matchLabels:
-              group: devteam-agent
+        - podSelector: {}
       ports:
         - port: 4000
           protocol: TCP

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -38,6 +38,12 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
     - ports:
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+    - ports:
         - port: 4317
           protocol: TCP
         - port: 4318

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -50,9 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
-          podSelector:
-            matchLabels:
-              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -24,8 +24,6 @@ spec:
             matchLabels:
               k8s-app: kube-dns
         - ipBlock:
-            cidr: 169.254.169.254/32
-        - ipBlock:
             cidr: 169.254.20.10/32
     - ports:
         - port: 443

--- a/examples/litellm-chatgpt-subscription/podmonitoring.yaml
+++ b/examples/litellm-chatgpt-subscription/podmonitoring.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: litellm-monitoring
+  namespace: agent-system
+spec:
+  selector:
+    matchLabels:
+      app: litellm
+  endpoints:
+    - port: 4000
+      path: /metrics
+      interval: 30s

--- a/examples/litellm-gemini/README.md
+++ b/examples/litellm-gemini/README.md
@@ -20,8 +20,9 @@ This directory contains an example of deploying a LiteLLM proxy configured to us
     kubectl apply -f service.yaml
     ```
 
-4.  Configure Prometheus monitoring:
+4.  Apply NetworkPolicy and configure Prometheus monitoring:
     ```bash
+    kubectl apply -f networkpolicy.yaml
     kubectl apply -f podmonitoring.yaml
     ```
 

--- a/examples/litellm-gemini/README.md
+++ b/examples/litellm-gemini/README.md
@@ -12,9 +12,22 @@ This directory contains an example of deploying a LiteLLM proxy configured to us
 1.  Open `secret.yaml`.
 2.  Replace `PLACEHOLDER_FOR_GEMINI_API_KEY` with your actual Gemini API key.
 3.  Apply the manifests:
+
     ```bash
     kubectl apply -f secret.yaml
     kubectl apply -f configmap.yaml
     kubectl apply -f deployment.yaml
     kubectl apply -f service.yaml
     ```
+
+4.  Configure Prometheus monitoring:
+    ```bash
+    kubectl apply -f podmonitoring.yaml
+    ```
+
+## Verification
+
+You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
+
+- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-gemini/configmap.yaml
+++ b/examples/litellm-gemini/configmap.yaml
@@ -10,3 +10,5 @@ data:
         litellm_params:
           model: gemini/gemini-3.1-flash-lite
           api_key: os.environ/GEMINI_API_KEY
+    litellm_settings:
+      callbacks: ["prometheus"]

--- a/examples/litellm-gemini/configmap.yaml
+++ b/examples/litellm-gemini/configmap.yaml
@@ -11,4 +11,4 @@ data:
           model: gemini/gemini-3.1-flash-lite
           api_key: os.environ/GEMINI_API_KEY
     litellm_settings:
-      callbacks: ["prometheus"]
+      callbacks: ["otel", "prometheus"]

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -23,6 +23,16 @@ spec:
                 secretKeyRef:
                   name: gemini-secret
                   key: GEMINI_API_KEY
+            - name: LITELLM_OTEL_V2
+              value: "true"
+            - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_SERVICE_NAME
+              value: litellm
           ports:
             - containerPort: 4000
           volumeMounts:

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -4,7 +4,12 @@ metadata:
   name: litellm
   namespace: agent-system
 spec:
-  replicas: 1
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: litellm

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.87.0
+          image: ghcr.io/berriai/litellm:v1.88.2
           args: ["--config", "/app/config.yaml"]
           env:
             - name: GEMINI_API_KEY

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -21,6 +21,10 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
+            cidr: 169.254.20.10/32
     - ports:
         - port: 443
           protocol: TCP

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -17,16 +17,17 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
     - ports:
         - port: 443
-          protocol: TCP
-        - port: 80
           protocol: TCP
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+
   ingress:
     - from:
         - podSelector:

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -17,7 +17,9 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -31,6 +33,10 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
     - ports:
         - port: 4317
           protocol: TCP

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -35,6 +35,9 @@ spec:
               app: platform-agent
         - podSelector:
             matchLabels:
+              app: platform-agent-gateway
+        - podSelector:
+            matchLabels:
               group: operator-agent
         - podSelector:
             matchLabels:

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litellm-policy
+  namespace: agent-system
+spec:
+  podSelector:
+    matchLabels:
+      app: litellm
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: platform-agent
+        - podSelector:
+            matchLabels:
+              group: operator-agent
+        - podSelector:
+            matchLabels:
+              group: devteam-agent
+      ports:
+        - port: 4000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-gmp-system
+      ports:
+        - port: 4000
+          protocol: TCP

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -27,6 +27,18 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-managed-otel
+          podSelector:
+            matchLabels:
+              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -30,18 +30,7 @@ spec:
 
   ingress:
     - from:
-        - podSelector:
-            matchLabels:
-              app: platform-agent
-        - podSelector:
-            matchLabels:
-              app: platform-agent-gateway
-        - podSelector:
-            matchLabels:
-              group: operator-agent
-        - podSelector:
-            matchLabels:
-              group: devteam-agent
+        - podSelector: {}
       ports:
         - port: 4000
           protocol: TCP

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -38,6 +38,12 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
     - ports:
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+    - ports:
         - port: 4317
           protocol: TCP
         - port: 4318

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -50,9 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
-          podSelector:
-            matchLabels:
-              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -24,8 +24,6 @@ spec:
             matchLabels:
               k8s-app: kube-dns
         - ipBlock:
-            cidr: 169.254.169.254/32
-        - ipBlock:
             cidr: 169.254.20.10/32
     - ports:
         - port: 443

--- a/examples/litellm-gemini/podmonitoring.yaml
+++ b/examples/litellm-gemini/podmonitoring.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: litellm-monitoring
+  namespace: agent-system
+spec:
+  selector:
+    matchLabels:
+      app: litellm
+  endpoints:
+    - port: 4000
+      path: /metrics
+      interval: 30s

--- a/examples/vllm-gemma/README.md
+++ b/examples/vllm-gemma/README.md
@@ -9,11 +9,25 @@ This directory contains an example of deploying vLLM configured to serve Google'
 ## Setup
 
 1.  Apply the manifests:
+
     ```bash
     kubectl apply -f deployment.yaml
     kubectl apply -f service.yaml
     ```
 
+2.  Apply NetworkPolicy and configure Prometheus monitoring:
+    ```bash
+    kubectl apply -f networkpolicy.yaml
+    kubectl apply -f podmonitoring.yaml
+    ```
+
 ## Configuration
 
 The `deployment.yaml` is configured to use the `gemma-4-e2b-it` model and the specialized Vertex AI vLLM image as described in the GKE tutorial.
+
+## Verification
+
+You can verify that metrics are being successfully exported and collected:
+
+- Directly: Query the `/metrics` endpoint on port 8000 of the vLLM container.
+- Cloud Monitoring: Search for vLLM metrics prefixed with `prometheus.googleapis.com/vllm_` (e.g. `prometheus.googleapis.com/vllm_num_requests_waiting/gauge` or `prometheus.googleapis.com/vllm_gpu_cache_usage_factor/gauge`).

--- a/examples/vllm-gemma/deployment.yaml
+++ b/examples/vllm-gemma/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - --gpu-memory-utilization=0.95
             - --reasoning-parser=gemma4
             - --trust-remote-code
-            - --otlp-traces-endpoint=http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
+            - --otlp-traces-endpoint=opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
           env:
             - name: LD_LIBRARY_PATH
               value: ${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64

--- a/examples/vllm-gemma/deployment.yaml
+++ b/examples/vllm-gemma/deployment.yaml
@@ -48,11 +48,14 @@ spec:
             - --gpu-memory-utilization=0.95
             - --reasoning-parser=gemma4
             - --trust-remote-code
+            - --otlp-traces-endpoint=http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4317
           env:
             - name: LD_LIBRARY_PATH
               value: ${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64
             - name: MODEL_ID
               value: google/gemma-4-E2B-it
+            - name: OTEL_SERVICE_NAME
+              value: vllm-gemma
 
           volumeMounts:
             - mountPath: /dev/shm

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -21,6 +21,10 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
+            cidr: 169.254.20.10/32
     - ports:
         - port: 443
           protocol: TCP

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -17,7 +17,9 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -31,6 +33,10 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
     - ports:
         - port: 4317
           protocol: TCP

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -35,6 +35,9 @@ spec:
               app: platform-agent
         - podSelector:
             matchLabels:
+              app: platform-agent-gateway
+        - podSelector:
+            matchLabels:
               group: operator-agent
         - podSelector:
             matchLabels:

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -27,6 +27,18 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-managed-otel
+          podSelector:
+            matchLabels:
+              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -38,6 +38,12 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
     - ports:
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+    - ports:
         - port: 4317
           protocol: TCP
         - port: 4318

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -30,21 +30,11 @@ spec:
 
   ingress:
     - from:
-        - podSelector:
-            matchLabels:
-              app: platform-agent
-        - podSelector:
-            matchLabels:
-              app: platform-agent-gateway
-        - podSelector:
-            matchLabels:
-              group: operator-agent
-        - podSelector:
-            matchLabels:
-              group: devteam-agent
+        - podSelector: {}
       ports:
         - port: 8000
           protocol: TCP
+
     - from:
         - namespaceSelector:
             matchLabels:

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -9,6 +9,25 @@ spec:
       app: gemma-server
   policyTypes:
     - Ingress
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+
   ingress:
     - from:
         - podSelector:

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vllm-policy
+  namespace: agent-system
+spec:
+  podSelector:
+    matchLabels:
+      app: gemma-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: platform-agent
+        - podSelector:
+            matchLabels:
+              group: operator-agent
+        - podSelector:
+            matchLabels:
+              group: devteam-agent
+      ports:
+        - port: 8000
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-gmp-system
+      ports:
+        - port: 8000
+          protocol: TCP

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -50,9 +50,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
-          podSelector:
-            matchLabels:
-              app: opentelemetry-collector
 
   ingress:
     - from:

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -24,8 +24,6 @@ spec:
             matchLabels:
               k8s-app: kube-dns
         - ipBlock:
-            cidr: 169.254.169.254/32
-        - ipBlock:
             cidr: 169.254.20.10/32
     - ports:
         - port: 443

--- a/examples/vllm-gemma/podmonitoring.yaml
+++ b/examples/vllm-gemma/podmonitoring.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: vllm-monitoring
+  namespace: agent-system
+spec:
+  selector:
+    matchLabels:
+      app: gemma-server
+  endpoints:
+    - port: 8000
+      path: /metrics
+      interval: 30s

--- a/k8s-operator/config/integrations/litellm/configmap.yaml
+++ b/k8s-operator/config/integrations/litellm/configmap.yaml
@@ -9,3 +9,5 @@ data:
         litellm_params:
           model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
           api_key: os.environ/GEMINI_API_KEY
+    litellm_settings:
+      callbacks: ["otel", "prometheus"]

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: litellm
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: litellm
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.86.0
+          image: ghcr.io/berriai/litellm:v1.88.2
           args: ["--config", "/app/config.yaml"]
           resources:
             requests:
@@ -29,6 +29,16 @@ spec:
                 secretKeyRef:
                   name: platform-agent-secrets
                   key: GEMINI_API_KEY
+            - name: LITELLM_OTEL_V2
+              value: "true"
+            - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_SERVICE_NAME
+              value: litellm
           ports:
             - containerPort: 4000
           volumeMounts:

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: litellm
 spec:
   replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: litellm

--- a/k8s-operator/config/integrations/litellm/kustomization.yaml
+++ b/k8s-operator/config/integrations/litellm/kustomization.yaml
@@ -2,3 +2,5 @@ resources:
   - configmap.yaml
   - deployment.yaml
   - service.yaml
+  - podmonitoring.yaml
+  - networkpolicy.yaml

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -14,6 +14,10 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
+            cidr: 169.254.20.10/32
     - ports:
         - port: 443
           protocol: TCP

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -43,9 +43,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
-          podSelector:
-            matchLabels:
-              app: opentelemetry-collector
   ingress:
     - from:
         - podSelector: {}

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -39,6 +39,9 @@ spec:
               app: platform-agent
         - podSelector:
             matchLabels:
+              app: platform-agent-gateway
+        - podSelector:
+            matchLabels:
               group: operator-agent
         - podSelector:
             matchLabels:

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -10,7 +10,9 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
           podSelector:
             matchLabels:
               k8s-app: kube-dns
@@ -24,6 +26,10 @@ spec:
       to:
         - ipBlock:
             cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
     - ports:
         - port: 4317
           protocol: TCP

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -17,8 +17,6 @@ spec:
             matchLabels:
               k8s-app: kube-dns
         - ipBlock:
-            cidr: 169.254.169.254/32
-        - ipBlock:
             cidr: 169.254.20.10/32
     - ports:
         - port: 443

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -1,0 +1,63 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litellm-policy
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 4317
+          protocol: TCP
+        - port: 4318
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-managed-otel
+          podSelector:
+            matchLabels:
+              app: opentelemetry-collector
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: platform-agent
+        - podSelector:
+            matchLabels:
+              group: operator-agent
+        - podSelector:
+            matchLabels:
+              group: devteam-agent
+      ports:
+        - port: 4000
+          protocol: TCP
+        - port: 80
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gke-gmp-system
+      ports:
+        - port: 4000
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app: litellm
+  policyTypes:
+    - Ingress
+    - Egress

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -31,6 +31,12 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
     - ports:
+        - port: 80
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 169.254.169.254/32
+    - ports:
         - port: 4317
           protocol: TCP
         - port: 4318

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -34,18 +34,7 @@ spec:
               app: opentelemetry-collector
   ingress:
     - from:
-        - podSelector:
-            matchLabels:
-              app: platform-agent
-        - podSelector:
-            matchLabels:
-              app: platform-agent-gateway
-        - podSelector:
-            matchLabels:
-              group: operator-agent
-        - podSelector:
-            matchLabels:
-              group: devteam-agent
+        - podSelector: {}
       ports:
         - port: 4000
           protocol: TCP

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -10,12 +10,12 @@ spec:
         - port: 53
           protocol: TCP
       to:
-        - ipBlock:
-            cidr: 0.0.0.0/0
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
     - ports:
         - port: 443
-          protocol: TCP
-        - port: 80
           protocol: TCP
       to:
         - ipBlock:
@@ -45,8 +45,6 @@ spec:
               group: devteam-agent
       ports:
         - port: 4000
-          protocol: TCP
-        - port: 80
           protocol: TCP
     - from:
         - namespaceSelector:

--- a/k8s-operator/config/integrations/litellm/podmonitoring.yaml
+++ b/k8s-operator/config/integrations/litellm/podmonitoring.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: litellm-monitoring
+spec:
+  selector:
+    matchLabels:
+      app: litellm
+  endpoints:
+    - port: 4000
+      path: /metrics
+      interval: 30s


### PR DESCRIPTION
# Pull Request

## Why This Change

Configure comprehensive telemetry (Prometheus metrics and OpenTelemetry tracing) for both LiteLLM and vLLM servers across integration configurations and example setups, ensuring GKE observability and security controls.

## What Changed

Added Prometheus and OpenTelemetry setups to LiteLLM and vLLM deployments, configured GKE PodMonitoring targets, and established secure NetworkPolicies that limit ingress and egress traffic according to least-privilege standards.

**Files:**

- `k8s-operator/config/integrations/litellm/configmap.yaml`
- `k8s-operator/config/integrations/litellm/deployment.yaml`
- `k8s-operator/config/integrations/litellm/kustomization.yaml`
- `k8s-operator/config/integrations/litellm/podmonitoring.yaml`
- `k8s-operator/config/integrations/litellm/networkpolicy.yaml`
- `examples/litellm-gemini/configmap.yaml`
- `examples/litellm-gemini/deployment.yaml`
- `examples/litellm-gemini/podmonitoring.yaml`
- `examples/litellm-gemini/networkpolicy.yaml`
- `examples/litellm-gemini/README.md`
- `examples/litellm-chatgpt-subscription/configmap.yaml`
- `examples/litellm-chatgpt-subscription/deployment.yaml`
- `examples/litellm-chatgpt-subscription/podmonitoring.yaml`
- `examples/litellm-chatgpt-subscription/networkpolicy.yaml`
- `examples/litellm-chatgpt-subscription/README.md`
- `examples/vllm-gemma/deployment.yaml`
- `examples/vllm-gemma/podmonitoring.yaml`
- `examples/vllm-gemma/networkpolicy.yaml`
- `examples/vllm-gemma/README.md`
- `agents/platform/SOUL.md`

**Added/Changed/Fixed:**

- **Prometheus Metrics**: Enabled `"prometheus"` callback on LiteLLM configmaps and created `podmonitoring.yaml` manifests for LiteLLM (port 4000) and vLLM (port 8000) target endpoints.
- **OpenTelemetry Tracing**: Configured OTel endpoint/protocol variables on LiteLLM containers, enabled `--otlp-traces-endpoint` flag on vLLM (pointing directly to OTel collector on port 4317 without scheme prefix), and configured `OTEL_SERVICE_NAME` for proper tracing.
- **Secure NetworkPolicies**: Restrained DNS egress to `kube-dns` pods exclusively inside the `kube-system` namespace and NodeLocal DNSCache (`169.254.20.10/32`). Allowed HTTP port 80 egress to the GKE metadata server (`169.254.169.254/32`) for Workload Identity. Restricted outbound HTTPS (port 443) to external public IP addresses only (excluding RFC1918 private ranges). Allowed ingress from same-namespace pods and GKE Managed Prometheus namespace (`gke-gmp-system`), and allowed egress to any pod inside the `gke-managed-otel` collector namespace on ports 4317/4318.
- **High Availability & Deployments**: Scaled LiteLLM operator and Gemini example deployments to 2 replicas, configured zero-downtime `RollingUpdate` strategy (`maxSurge: 1`, `maxUnavailable: 0`), and upgraded LiteLLM example container image tags to match the operator deployment (`v1.88.2`).
- **Examples & Documentation**: Added `networkpolicy.yaml` and `podmonitoring.yaml` to all three serving examples, updated step chronology in the ChatGPT subscription example README, and updated README files to guide users on secure deployment and Cloud Monitoring verification.
- **Platform Agent Telemetry Knowledge**: Documented OTel/Prometheus capabilities in the Platform Agent's `SOUL.md` blueprint and defined instructions for providing direct, clickable links to Google Cloud Console (Logs, Traces, Metrics) using the user's active project ID.

## Why This Matters

Standardizes cluster observability, tracing, cost/spend tracking, and GKE hardening rules across all LLM inference endpoints.

## Context

Supports GKE Managed Prometheus and OpenTelemetry integrations.

## Testing

- Deployed successfully via operator and applied all examples.
- Confirmed metrics scrape target and ingestion to Cloud Monitoring.

TAG=agy
CONV=aeda3970-5b17-4f5d-90c0-e7fafddedfb7
