### PR TITLE
 feat(ci): automate staging redeployment on container registry package publish

### DIFF
--- a/.github/workflows/staging-redeploy-on-registry-change.yml
+++ b/.github/workflows/staging-redeploy-on-registry-change.yml
@@ -1,0 +1,110 @@
+name: Staging Redeploy on Registry Change
+
+on:
+  registry_package:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+  GCP_REGION: ${{ vars.GCP_REGION }}
+  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+  GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+  MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
+  MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
+
+jobs:
+  redeploy-controller:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'gke-labs/kube-agents' &&
+      github.event.registry_package.package_type == 'container' &&
+      github.event.registry_package.package_version.container_metadata.tag.name != '' &&
+      github.event.registry_package.package_version.container_metadata.tag.name != 'latest' &&
+      endsWith(github.event.registry_package.name, 'k8s-operator')
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "k8s-operator/go.mod"
+
+      - name: Authenticate to Google Cloud via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Authenticate to GKE
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
+          location: ${{ env.GCP_REGION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Set Image Env
+        run: |
+          OWNER_DOWNCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${{ github.event.registry_package.name }}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${{ github.event.registry_package.package_version.container_metadata.tag.name }}" >> "$GITHUB_ENV"
+
+      - name: Perform Controller Redeployment
+        run: |
+          echo "Redeploying controller package: ${{ github.event.registry_package.name }} with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
+          cd k8s-operator
+          make deploy IMG="${IMAGE_REPO}:${IMAGE_TAG}"
+          kubectl rollout status deployment/kubeagents-controller-manager -n kubeagents-system --timeout=90s
+
+  redeploy-agent:
+    runs-on: ubuntu-latest
+    if: |
+      github.repository == 'gke-labs/kube-agents' &&
+      github.event.registry_package.package_type == 'container' &&
+      github.event.registry_package.package_version.container_metadata.tag.name != '' &&
+      github.event.registry_package.package_version.container_metadata.tag.name != 'latest' &&
+      endsWith(github.event.registry_package.name, 'platform-agent')
+    environment: staging
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Google Cloud via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+
+      - name: Authenticate to GKE
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
+          location: ${{ env.GCP_REGION }}
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Set Image Env
+        run: |
+          OWNER_DOWNCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${{ github.event.registry_package.name }}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${{ github.event.registry_package.package_version.container_metadata.tag.name }}" >> "$GITHUB_ENV"
+
+      - name: Perform Agent Redeployment
+        run: |
+          echo "Redeploying agent package: ${{ github.event.registry_package.name }} with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
+          MODEL_SPEC="{\"default\":\"${{ env.MODEL_DEFAULT_NAME }}\",\"provider\":\"${{ env.MODEL_PROVIDER }}\"}"
+
+          kubectl patch platformagent.kubeagents.x-k8s.io platform-agent \
+            -n kubeagents-system \
+            --type='merge' \
+            -p "{\"spec\":{\"deployment\":{\"image\":\"$IMAGE_REPO\",\"tag\":\"$IMAGE_TAG\"},\"model\":$MODEL_SPEC}}"
+
+          echo "Waiting for rollout of platform-agent-gateway..."
+          kubectl rollout status deployment/platform-agent-gateway -n kubeagents-system --timeout=180s

--- a/.github/workflows/staging-redeploy-on-registry-change.yml
+++ b/.github/workflows/staging-redeploy-on-registry-change.yml
@@ -140,12 +140,17 @@ jobs:
           PACKAGE_NAME: ${{ github.event.registry_package.name }}
         run: |
           echo "Redeploying agent package: $PACKAGE_NAME with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
-          MODEL_SPEC="{\"default\":\"$MODEL_DEFAULT_NAME\",\"provider\":\"$MODEL_PROVIDER\"}"
+          PATCH_PAYLOAD=$(jq -n -c \
+            --arg img "$IMAGE_REPO" \
+            --arg tag "$IMAGE_TAG" \
+            --arg def "$MODEL_DEFAULT_NAME" \
+            --arg prov "$MODEL_PROVIDER" \
+            '{spec: {deployment: {image: $img, tag: $tag}, model: {default: $def, provider: $prov}}}')
 
           kubectl patch platformagent.kubeagents.x-k8s.io platform-agent \
             -n kubeagents-system \
             --type='merge' \
-            -p "{\"spec\":{\"deployment\":{\"image\":\"$IMAGE_REPO\",\"tag\":\"$IMAGE_TAG\"},\"model\":$MODEL_SPEC}}"
+            -p "$PATCH_PAYLOAD"
 
           echo "Waiting for rollout of platform-agent-gateway..."
           kubectl rollout status deployment/platform-agent-gateway -n kubeagents-system --timeout=180s

--- a/.github/workflows/staging-redeploy-on-registry-change.yml
+++ b/.github/workflows/staging-redeploy-on-registry-change.yml
@@ -18,7 +18,22 @@ env:
   MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
 
 jobs:
+  validate-envs:
+    runs-on: ubuntu-latest
+    if: github.repository == 'gke-labs/kube-agents'
+    environment: staging
+    steps:
+      - name: Verify Env Variables
+        run: |
+          for var in GCP_PROJECT_ID GCP_REGION GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT GKE_CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER; do
+            if [ -z "${!var}" ]; then
+              echo "::error::Required environment variable $var is not set."
+              exit 1
+            fi
+          done
+
   redeploy-controller:
+    needs: validate-envs
     runs-on: ubuntu-latest
     if: |
       github.repository == 'gke-labs/kube-agents' &&
@@ -64,6 +79,7 @@ jobs:
           kubectl rollout status deployment/kubeagents-controller-manager -n kubeagents-system --timeout=90s
 
   redeploy-agent:
+    needs: validate-envs
     runs-on: ubuntu-latest
     if: |
       github.repository == 'gke-labs/kube-agents' &&

--- a/.github/workflows/staging-redeploy-on-registry-change.yml
+++ b/.github/workflows/staging-redeploy-on-registry-change.yml
@@ -8,20 +8,19 @@ permissions:
   contents: read
   id-token: write
 
-env:
-  GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-  GCP_REGION: ${{ vars.GCP_REGION }}
-  GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-  GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
-  MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
-  MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
-
 jobs:
   validate-envs:
     runs-on: ubuntu-latest
     if: github.repository == 'gke-labs/kube-agents'
     environment: staging
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+      MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
+      MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
     steps:
       - name: Verify Env Variables
         run: |
@@ -42,6 +41,12 @@ jobs:
       github.event.registry_package.package_version.container_metadata.tag.name != 'latest' &&
       endsWith(github.event.registry_package.name, 'k8s-operator')
     environment: staging
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -66,14 +71,20 @@ jobs:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
       - name: Set Image Env
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          PACKAGE_NAME: ${{ github.event.registry_package.name }}
+          TAG_NAME: ${{ github.event.registry_package.package_version.container_metadata.tag.name }}
         run: |
-          OWNER_DOWNCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${{ github.event.registry_package.name }}" >> "$GITHUB_ENV"
-          echo "IMAGE_TAG=${{ github.event.registry_package.package_version.container_metadata.tag.name }}" >> "$GITHUB_ENV"
+          OWNER_DOWNCASE=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${PACKAGE_NAME}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${TAG_NAME}" >> "$GITHUB_ENV"
 
       - name: Perform Controller Redeployment
+        env:
+          PACKAGE_NAME: ${{ github.event.registry_package.name }}
         run: |
-          echo "Redeploying controller package: ${{ github.event.registry_package.name }} with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
+          echo "Redeploying controller package: $PACKAGE_NAME with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
           cd k8s-operator
           make deploy IMG="${IMAGE_REPO}:${IMAGE_TAG}"
           kubectl rollout status deployment/kubeagents-controller-manager -n kubeagents-system --timeout=90s
@@ -88,6 +99,14 @@ jobs:
       github.event.registry_package.package_version.container_metadata.tag.name != 'latest' &&
       endsWith(github.event.registry_package.name, 'platform-agent')
     environment: staging
+    env:
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+      GCP_REGION: ${{ vars.GCP_REGION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+      MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
+      MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -107,15 +126,21 @@ jobs:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
       - name: Set Image Env
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          PACKAGE_NAME: ${{ github.event.registry_package.name }}
+          TAG_NAME: ${{ github.event.registry_package.package_version.container_metadata.tag.name }}
         run: |
-          OWNER_DOWNCASE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${{ github.event.registry_package.name }}" >> "$GITHUB_ENV"
-          echo "IMAGE_TAG=${{ github.event.registry_package.package_version.container_metadata.tag.name }}" >> "$GITHUB_ENV"
+          OWNER_DOWNCASE=$(echo "$REPO_OWNER" | tr '[:upper:]' '[:lower:]')
+          echo "IMAGE_REPO=ghcr.io/${OWNER_DOWNCASE}/${PACKAGE_NAME}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${TAG_NAME}" >> "$GITHUB_ENV"
 
       - name: Perform Agent Redeployment
+        env:
+          PACKAGE_NAME: ${{ github.event.registry_package.name }}
         run: |
-          echo "Redeploying agent package: ${{ github.event.registry_package.name }} with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
-          MODEL_SPEC="{\"default\":\"${{ env.MODEL_DEFAULT_NAME }}\",\"provider\":\"${{ env.MODEL_PROVIDER }}\"}"
+          echo "Redeploying agent package: $PACKAGE_NAME with tag: $IMAGE_TAG from repo: $IMAGE_REPO"
+          MODEL_SPEC="{\"default\":\"$MODEL_DEFAULT_NAME\",\"provider\":\"$MODEL_PROVIDER\"}"
 
           kubectl patch platformagent.kubeagents.x-k8s.io platform-agent \
             -n kubeagents-system \


### PR DESCRIPTION
 This PR introduces a new GitHub Actions workflow to automate the redeployment of kube-agents components (both the controller manager and the platform agent) to the staging GKE cluster whenever a new container image package is published to GHCR.

### Key Changes
- **New Workflow**: Added `.github/workflows/staging-redeploy-on-registry-change.yml` triggered by
  `registry_package` (`published` type) events.
- **Environment Verification**: Verifies GCP/GKE environment variables (project ID, region, Workload Identity
  Provider, GKE cluster name, etc.) are present before executing deployment steps.
- **Controller Redeployment**: Authenticates via Workload Identity Federation (WIF) and triggers `make deploy` in
  `k8s-operator` when a controller-manager container image is published.
    - **Platform Agent Redeployment**: Authenticates via WIF and patches the staging `PlatformAgent` custom resource
  using a JSON payload generated via `jq` to update the image tag and model settings.
    - **Rollout Verification**: Asserts that rollout deployments for both the controller and the agent gateway are
  successful.
