### PR TITLE
fix(networkpolicy): allow egress to node-local-dns and metadata server DNS

### DIFF
--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -23,8 +23,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
         - ipBlock:
             cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
     - ports:
         - port: 443
           protocol: TCP

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -23,8 +23,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
         - ipBlock:
             cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
     - ports:
         - port: 443
           protocol: TCP

--- a/examples/vllm-gemma/networkpolicy.yaml
+++ b/examples/vllm-gemma/networkpolicy.yaml
@@ -23,8 +23,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
         - ipBlock:
             cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
     - ports:
         - port: 443
           protocol: TCP

--- a/integrations/github/deployment.yaml
+++ b/integrations/github/deployment.yaml
@@ -130,6 +130,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+        - ipBlock:
+            cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
       ports:
         - protocol: UDP
           port: 53

--- a/k8s-operator/config/integrations/github/deployment.yaml
+++ b/k8s-operator/config/integrations/github/deployment.yaml
@@ -127,6 +127,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+        - ipBlock:
+            cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
       ports:
         - protocol: UDP
           port: 53

--- a/k8s-operator/config/integrations/litellm/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/networkpolicy.yaml
@@ -16,8 +16,16 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: kube-dns
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
         - ipBlock:
             cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
     - ports:
         - port: 443
           protocol: TCP


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses Gari's review feedback in PR #160 requesting to account for node-local DNS configurations when applying NetworkPolicies.

## What Changed

Added explicit egress rules in all telemetry and integration NetworkPolicies to allow DNS queries (port 53 UDP/TCP) to:
- `k8s-app: node-local-dns` pods in the `kube-system` namespace.
- GKE metadata server's DNS service (`169.254.169.254/32`).

**Files:**

- `examples/litellm-chatgpt-subscription/networkpolicy.yaml`
- `examples/litellm-gemini/networkpolicy.yaml`
- `examples/vllm-gemma/networkpolicy.yaml`
- `k8s-operator/config/integrations/litellm/networkpolicy.yaml`
- `integrations/github/deployment.yaml`
- `k8s-operator/config/integrations/github/deployment.yaml`

**Added/Changed/Fixed:**

- Allows egress to local DNS caches and GCP metadata DNS server.

## Why This Matters

Ensures robust DNS resolution for GKE workloads under all DNS provider and caching setups, preventing timeouts on container starts or agent execution.

## Context

Follow-up to https://github.com/gke-labs/kube-agents/pull/160.

## Testing

Ran `make` verification in `k8s-operator/` and verified structure matches standard Kubernetes NetworkPolicy schemas.

TAG=agy
CONV=f94fd965-2f23-42ce-937f-c4b05311a23b
