### PR TITLE
fix: install wget, nano, and vim in agent runner

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -8,16 +8,16 @@ USER root
 RUN apt-get update && apt-get install -y \
     apt-transport-https \
     ca-certificates \
-    gnupg \
     curl \
-    wget \
-    nano \
-    vim \
-    patch \
-    git \
-    jq \
     dnsutils \
+    git \
+    gnupg \
     iputils-ping \
+    jq \
+    nano \
+    patch \
+    vim \
+    wget \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     gnupg \
     curl \
+    wget \
+    nano \
+    vim \
     patch \
     git \
     jq \


### PR DESCRIPTION
# Pull Request

## Why This Change

The user requested installing `wget`, `nano`, and `vim` for the agents so that these tools are available to agents when interacting within their workspace environments.

## What Changed

Added the packages `wget`, `nano`, and `vim` to the main package installation block in the Dockerfile and sorted all packages alphabetically.

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Installed `wget`, `nano`, and `vim` via `apt-get` in the base runner.
- Sorted the list of apt packages alphabetically.

## Why This Matters

Ensures agents have standard debugging and file editing tools available in their local runtime context.

## Context

Requested by the user.

## Testing

Ran a local Docker build for the `platform` target:
`docker build --build-arg HERMES_AGENT_TAG=v2026.5.29.2@sha256:2bba4ab37729ebdd864d4caf277b24fec4cd8bfc2855185fd9f4c90f9bf7bfa3 --target platform -t local-test-platform -f deploy/docker/Dockerfile .`
The build was successful.

---

TAG=agy
CONV=384b10a8-befa-4135-ba78-ce3469268d9e
