### PR TITLE
feat: deploy LiteLLM in installation scripts

### DIFF
--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -67,16 +67,17 @@ graph TD
 3. **[provision_03_gcp_iam.sh](scripts/provision_03_gcp_iam.sh)**:
    - Pre-provisions GCP Service Accounts (GSAs) and Workload Identity bindings for the Controller and all Agent types.
    - Configures the Controller's GSA with cluster management permissions and annotates the Controller KSA.
-   - Configures the Agent GSAs (Platform Agent, Operator Agent, DevTeam Agent) with Vertex AI and container viewer/admin permissions.
+   - Configures the Agent GSAs (Platform Agent, Operator Agent, DevTeam Agent) with container viewer/admin permissions.
 
 4. **[provision_04_gcp_k8s_secrets.sh](scripts/provision_04_gcp_k8s_secrets.sh)**:
-   - Prompts for or reads the `GEMINI_API_KEY`, `HERMES_API_KEY`, and `GITHUB_KEY`.
+   - Prompts for or reads the `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HERMES_API_KEY`, and `GITHUB_KEY`.
    - Creates the Kubernetes Secret (`platform-agent-secrets`) directly in the GKE Namespace.
 
 5. **[provision_05_gcp_gchat.sh](scripts/provision_05_gcp_gchat.sh)**:
    - Creates the Pub/Sub Chat Event Topic and Subscriber Subscription for Google Chat events.
 
 6. **[provision_06_deploy_platform_agent.sh](scripts/provision_06_deploy_platform_agent.sh)**:
+   - Deploys the LiteLLM Gateway to the cluster.
    - Generates [scripts/platform-agent.yaml](scripts/platform-agent.yaml) from its template and applies the Custom Resource (CR) to deploy the Platform Agent.
 
 ---
@@ -108,6 +109,7 @@ graph TD
 ```
 
 1. **[teardown_06_deploy_platform_agent.sh](scripts/teardown_06_deploy_platform_agent.sh)**:
+   - Undeploys the LiteLLM Gateway from the cluster.
    - Deletes the applied `PlatformAgent` Custom Resource (safely handling finalizer blocks if they timeout).
    - Deletes the local generated `platform-agent.yaml` manifest.
 
@@ -338,13 +340,16 @@ kubectl get pods -n kubeagents-system
 
 ## Deploying LiteLLM Integration
 
+> [!NOTE]
+> LiteLLM is now automatically deployed during the `make gcp-provision` flow by `provision_06_deploy_platform_agent.sh`. The following instructions are for manual standalone deployment.
+
 LiteLLM gateway can be deployed to the Kubernetes cluster using the `kustomize` targets in the Makefile.
 
 ### Prerequisites
 
 To successfully deploy LiteLLM, you must have:
 
-1. The `platform-agent-secrets` Secret created in your destination namespace (containing `GEMINI_API_KEY`).
+1. The `platform-agent-secrets` Secret created in your destination namespace (containing `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`).
 
 ### Step-by-Step Deployment
 

--- a/k8s-operator/config/integrations/litellm/configmap.yaml
+++ b/k8s-operator/config/integrations/litellm/configmap.yaml
@@ -8,6 +8,5 @@ data:
       - model_name: model-default
         litellm_params:
           model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
-          api_key: os.environ/GEMINI_API_KEY
     litellm_settings:
       callbacks: ["otel", "prometheus"]

--- a/k8s-operator/config/integrations/litellm/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/deployment.yaml
@@ -34,6 +34,19 @@ spec:
                 secretKeyRef:
                   name: platform-agent-secrets
                   key: GEMINI_API_KEY
+                  optional: true
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: platform-agent-secrets
+                  key: ANTHROPIC_API_KEY
+                  optional: true
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: platform-agent-secrets
+                  key: OPENAI_API_KEY
+                  optional: true
             - name: LITELLM_OTEL_V2
               value: "true"
             - name: LITELLM_OTEL_INTEGRATION_ENABLE_METRICS

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -61,6 +61,9 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 		Model struct {
 			Default  string `json:"default"`
 			Provider string `json:"provider"`
+			Model    string `json:"model,omitempty"`
+			BaseURL  string `json:"base_url,omitempty"`
+			APIKey   string `json:"api_key,omitempty"`
 		} `json:"model"`
 		Terminal struct {
 			Backend string `json:"backend"`
@@ -76,6 +79,12 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	if agent.Spec.Model != nil {
 		cfg.Model.Default = agent.Spec.Model.Default
 		cfg.Model.Provider = agent.Spec.Model.Provider
+		if agent.Spec.Model.Provider == "litellm" || agent.Spec.Model.Provider == "custom" {
+			cfg.Model.Provider = "custom"
+			cfg.Model.Model = agent.Spec.Model.Default
+			cfg.Model.BaseURL = fmt.Sprintf("http://litellm.%s.svc.cluster.local/v1", agent.Namespace)
+			cfg.Model.APIKey = "none"
+		}
 	}
 	cfg.Terminal.Backend = "local"
 	cfg.Terminal.Cwd = cwd

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -313,3 +313,63 @@ func TestBuildFluentBitConfigMap(t *testing.T) {
 		t.Errorf("expected fluent-bit.conf to contain Input Name tail")
 	}
 }
+
+func TestBuildConfigMapCustomProvider(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Model: &agentv1alpha1.ModelSpec{
+				Provider: "custom",
+				Default:  "model-default",
+			},
+		},
+	}
+
+	cm := buildConfigMap(agent)
+	yamlContent := cm.Data["config.yaml"]
+	if !strings.Contains(yamlContent, "provider: custom") {
+		t.Errorf("expected config to contain provider: custom, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "model: model-default") {
+		t.Errorf("expected config to contain model: model-default, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "base_url: http://litellm.test-ns.svc.cluster.local/v1") {
+		t.Errorf("expected config to contain correct base_url, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "api_key: none") {
+		t.Errorf("expected config to contain api_key: none, got:\n%s", yamlContent)
+	}
+}
+
+func TestBuildConfigMapLiteLLMProvider(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Model: &agentv1alpha1.ModelSpec{
+				Provider: "litellm",
+				Default:  "model-default",
+			},
+		},
+	}
+
+	cm := buildConfigMap(agent)
+	yamlContent := cm.Data["config.yaml"]
+	if !strings.Contains(yamlContent, "provider: custom") {
+		t.Errorf("expected config to map to provider: custom, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "model: model-default") {
+		t.Errorf("expected config to contain model: model-default, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "base_url: http://litellm.test-ns.svc.cluster.local/v1") {
+		t.Errorf("expected config to contain correct base_url, got:\n%s", yamlContent)
+	}
+	if !strings.Contains(yamlContent, "api_key: none") {
+		t.Errorf("expected config to contain api_key: none, got:\n%s", yamlContent)
+	}
+}

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -34,20 +34,21 @@ When any script is run:
 3. **[provision_03_gcp_iam.sh](provision_03_gcp_iam.sh)**
    - Pre-provisions GCP Service Accounts (GSAs) for the Controller, Platform Agent, Operator Agent, and DevTeam Agent.
    - Configures Workload Identity policy bindings mapping the Kubernetes SAs to the GCP GSAs.
-   - Grants GKE admin permissions to the Controller GSA, and Vertex AI and GKE permissions to the Agent GSAs.
+   - Grants GKE admin permissions to the Controller GSA, and GKE permissions to the Agent GSAs.
    - Annotates the Controller KSA in GKE and restarts the controller manager deployment to apply Workload Identity instantly.
 4. **[provision_04_gcp_k8s_secrets.sh](provision_04_gcp_k8s_secrets.sh)**
-   - Prompts for/reads the `GEMINI_API_KEY`, `HERMES_API_KEY`, and `GITHUB_KEY`.
+   - Prompts for/reads the `GEMINI_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `HERMES_API_KEY`, and `GITHUB_KEY`.
    - Creates the Kubernetes Secret (`platform-agent-secrets`) directly in the target GKE namespace.
 5. **[provision_05_gcp_gchat.sh](provision_05_gcp_gchat.sh)**
    - Sets up the Pub/Sub Topic and Subscription for Google Chat events.
 6. **[provision_06_deploy_platform_agent.sh](provision_06_deploy_platform_agent.sh)**
+   - Deploys the LiteLLM Gateway to the GKE cluster.
    - Uses `envsubst` to render `platform-agent.yaml` from its template.
    - Applies the resulting `PlatformAgent` Custom Resource (CR) to deploy the platform agent instance.
 
 ### Teardown Steps
 
-- **[teardown_06_deploy_platform_agent.sh](teardown_06_deploy_platform_agent.sh)**: Safely deletes the `PlatformAgent` Custom Resource and cleans up local manifests.
+- **[teardown_06_deploy_platform_agent.sh](teardown_06_deploy_platform_agent.sh)**: Undeploys the LiteLLM Gateway, safely deletes the `PlatformAgent` Custom Resource, and cleans up local manifests.
 - **[teardown_05_gcp_gchat.sh](teardown_05_gcp_gchat.sh)**: Deletes the Google Chat Pub/Sub topic and subscription.
 - **[teardown_04_gcp_k8s_secrets.sh](teardown_04_gcp_k8s_secrets.sh)**: Deletes the Kubernetes secrets in GKE.
 - **[teardown_03_gcp_iam.sh](teardown_03_gcp_iam.sh)**: Removes all GCP IAM policy bindings, Workload Identity mappings, and deletes the GSAs for the Controller and Agents.

--- a/k8s-operator/scripts/platform-agent.yaml.template
+++ b/k8s-operator/scripts/platform-agent.yaml.template
@@ -27,10 +27,10 @@ spec:
   model:
     provider: "${MODEL_PROVIDER}"
     default: "${MODEL_DEFAULT_NAME}"
-    gemini:
+    ${MODEL_PROVIDER}:
       apiKeySecretRef:
         name: platform-agent-secrets
-        key: GEMINI_API_KEY
+        key: ${MODEL_PROVIDER_UPPER}_API_KEY
   integration:
     googleChat:
       enabled: true

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -85,13 +85,11 @@ execute_agent_iam() {
 verify_apis() {
   local out=$(gcloud services list --enabled --project="$PROJECT_ID" --format="value(config.name)" 2>/dev/null || echo "")
   echo "$out" | grep -q 'container.googleapis.com' && \
-  echo "$out" | grep -q 'aiplatform.googleapis.com' && \
   echo "$out" | grep -q 'cloudresourcemanager.googleapis.com'
 }
 execute_apis() {
   gcloud services enable \
       container.googleapis.com \
-      aiplatform.googleapis.com \
       cloudresourcemanager.googleapis.com \
       --project="$PROJECT_ID" || return 1
 }
@@ -111,7 +109,6 @@ execute_controller() {
 # Step 3: Configure Platform Agent IAM
 verify_platform_agent() {
   verify_agent_iam "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
       "roles/container.clusterAdmin" \
       "roles/container.admin" \
       "roles/monitoring.admin" \
@@ -119,8 +116,7 @@ verify_platform_agent() {
 }
 execute_platform_agent() {
   execute_agent_iam "Platform Agent" "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
-      "roles/container.clusterAdmin"\
+      "roles/container.clusterAdmin" \
       "roles/container.admin" \
       "roles/monitoring.admin" \
       "roles/logging.admin"
@@ -129,14 +125,12 @@ execute_platform_agent() {
 # Step 4: Configure Operator Agent IAM
 verify_operator_agent() {
   verify_agent_iam "${OPERATOR_AGENT_KSA_NAME}" "${OPERATOR_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
       "roles/container.clusterViewer" \
       "roles/monitoring.viewer" \
       "roles/logging.viewer"
 }
 execute_operator_agent() {
   execute_agent_iam "Operator Agent" "${OPERATOR_AGENT_KSA_NAME}" "${OPERATOR_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
       "roles/container.clusterViewer" \
       "roles/monitoring.viewer" \
       "roles/logging.viewer"
@@ -145,14 +139,12 @@ execute_operator_agent() {
 # Step 5: Configure DevTeam Agent IAM
 verify_devteam_agent() {
   verify_agent_iam "${DEVTEAM_AGENT_KSA_NAME}" "${DEVTEAM_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
       "roles/container.clusterViewer" \
       "roles/monitoring.viewer" \
       "roles/logging.viewer"
 }
 execute_devteam_agent() {
   execute_agent_iam "DevTeam Agent" "${DEVTEAM_AGENT_KSA_NAME}" "${DEVTEAM_AGENT_GSA_NAME}" \
-      "roles/aiplatform.user" \
       "roles/container.clusterViewer" \
       "roles/monitoring.viewer" \
       "roles/logging.viewer"

--- a/k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh
+++ b/k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh
@@ -45,6 +45,32 @@ if [ -z "${GEMINI_API_KEY:-}" ]; then
   fi
 fi
 
+# Securely prompt for OpenAI API Key if not present in environment or state
+if [ -z "${OPENAI_API_KEY:-}" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    export OPENAI_API_KEY="placeholder"
+  else
+    echo -ne "  ${C_CYAN}Enter your OPENAI_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
+    read -s -r INPUT_KEY
+    echo ""
+    export OPENAI_API_KEY="${INPUT_KEY:-placeholder}"
+    printf "export OPENAI_API_KEY=%q\n" "${OPENAI_API_KEY}" >> "$VARS_FILE"
+  fi
+fi
+
+# Securely prompt for Anthropic API Key if not present in environment or state
+if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    export ANTHROPIC_API_KEY="placeholder"
+  else
+    echo -ne "  ${C_CYAN}Enter your ANTHROPIC_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
+    read -s -r INPUT_KEY
+    echo ""
+    export ANTHROPIC_API_KEY="${INPUT_KEY:-placeholder}"
+    printf "export ANTHROPIC_API_KEY=%q\n" "${ANTHROPIC_API_KEY}" >> "$VARS_FILE"
+  fi
+fi
+
 if [ -z "${API_SERVER_KEY:-}" ]; then
   print_info "Generating a secure random API_SERVER_KEY..."
   export API_SERVER_KEY=$(openssl rand -hex 16)
@@ -79,8 +105,11 @@ execute_k8s_secrets() {
       --namespace="$NAMESPACE" \
       --from-literal=GEMINI_API_KEY="$GEMINI_API_KEY" \
       --from-literal=API_SERVER_KEY="$API_SERVER_KEY" \
+      --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
+      --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
       --dry-run=client -o yaml | kubectl apply -f -
 }
+
 
 # ─── Execution Pipeline ───────────────────────────────────────────────────────
 run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0

--- a/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
@@ -9,6 +9,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
 VARS_FILE="${SCRIPT_DIR}/vars.sh"
 
 # ─── ANSI Colors ──────────────────────────────────────────────────────────────
@@ -54,7 +59,19 @@ execute_kubeconfig() {
   connect_cluster
 }
 
-# Step 2: Apply PlatformAgent Custom Resource
+# Step 2: Deploy LiteLLM Gateway
+verify_litellm() {
+  kubectl get configmap litellm-config -n "${NAMESPACE}" >/dev/null 2>&1 && \
+  kubectl get deployment litellm -n "${NAMESPACE}" >/dev/null 2>&1 && \
+  kubectl get service litellm -n "${NAMESPACE}" >/dev/null 2>&1
+}
+execute_litellm() {
+  print_info "Deploying LiteLLM Gateway into GKE..."
+  export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
+  make -C "${OPERATOR_DIR}" deploy-litellm || return 1
+}
+
+# Step 3: Apply PlatformAgent Custom Resource
 verify_custom_resource() {
   # Always return false to ensure configuration updates are applied to the Custom Resource
   return 1
@@ -69,6 +86,8 @@ execute_custom_resource() {
     exit 1
   fi
 
+  export MODEL_PROVIDER_UPPER=$(echo "$MODEL_PROVIDER" | tr '[:lower:]' '[:upper:]')
+
   # Ensure variables are explicitly exported so envsubst can access them
   export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME
 
@@ -80,7 +99,8 @@ execute_custom_resource() {
 
 # ─── Execution Pipeline ───────────────────────────────────────────────────────
 run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0
-run_step "2. Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
+run_step "2. Deploy LiteLLM Gateway" verify_litellm execute_litellm 0
+run_step "3. Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
 
 # ─── Conclusion Checklist ─────────────────────────────────────────────────────
 echo -e "\n${C_GREEN}${C_BOLD}✓ PlatformAgent Custom Resource applied successfully to GKE!${C_RESET}"

--- a/k8s-operator/scripts/teardown_06_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/teardown_06_deploy_platform_agent.sh
@@ -9,6 +9,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
 VARS_FILE="${SCRIPT_DIR}/vars.sh"
 
 # ─── ANSI Colors ──────────────────────────────────────────────────────────────
@@ -53,7 +58,13 @@ else
   echo -e "  ${C_GREEN}✓ CRD 'platformagents.kubeagents.x-k8s.io' is not registered. Skipping.${C_RESET}"
 fi
 
-# ─── Step 3: Clean up Local Manifest File ─────────────────────────────────────
+# ─── Step 3: Undeploy LiteLLM Gateway ─────────────────────────────────────────
+echo -e "  ${C_CYAN}ℹ Undeploying LiteLLM Gateway...${C_RESET}"
+export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
+make -C "${OPERATOR_DIR}" undeploy-litellm || true
+echo -e "  ${C_GREEN}✓ LiteLLM Gateway undeploy command completed.${C_RESET}"
+
+# ─── Step 4: Clean up Local Manifest File ─────────────────────────────────────
 local_yaml="${SCRIPT_DIR}/platform-agent.yaml"
 if [ -f "$local_yaml" ]; then
   rm -f "$local_yaml"


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR introduces LiteLLM as an LLM gateway for the Kubernetes Agentic Harness, transitioning from direct Vertex/Gemini API integrations to a flexible, multi-provider setup. It abstracts model interactions, allowing users to seamlessly switch between model providers like Gemini, OpenAI, and Anthropic.

## What Changed

**Files:**

- `k8s-operator/config/integrations/litellm/*`
- `k8s-operator/internal/controller/platformagent_manifests*`
- `k8s-operator/scripts/platform-agent.yaml.template`
- `k8s-operator/scripts/provision_03_gcp_iam.sh`
- `k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh`
- `k8s-operator/scripts/provision_06_deploy_platform_agent.sh`

**Added/Changed/Fixed:**

- **Added:** LiteLLM Kubernetes manifests (Deployment, ConfigMap) and integrated them into the operator controller.
- **Added:** Secure prompts for `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` during secret provisioning (`provision_04`).
- **Added:** A `deploy-litellm` step in the platform agent deployment script (`provision_06`) to launch the gateway on GKE.
- **Changed:** Updated `platform-agent.yaml.template` to use a dynamic `${MODEL_PROVIDER_UPPER}_API_KEY` instead of a hardcoded Gemini key.
- **Changed:** Removed `aiplatform.googleapis.com` API requirement and `roles/aiplatform.user` IAM roles from the Platform, Operator, and DevTeam service accounts (`provision_03`), as model requests are now routed through LiteLLM.

## Why This Matters

- **Provider Flexibility:** Enables seamless integration with various LLMs (OpenAI, Anthropic, Gemini) without refactoring agent logic.
- **Security & Least Privilege:** Eliminates the need to grant direct Vertex AI IAM roles (`aiplatform.user`) to individual agent service accounts.

## Context

This is part of the `feature/instalation-scripts-followup` work to refine the local developer experience, unify model integrations, and streamline the platform provisioning logic.

## Testing

<!-- Outline how you validated these changes, e.g.: -->
- Verified LiteLLM gateway deploys successfully via `provision_06_deploy_platform_agent.sh`.
- Confirmed `platform-agent-secrets` populate correctly for chosen providers.
- Verified agent workloads no longer require `aiplatform.user` bindings.
- Successfully ran operator locally (`make run`).

---

By routing model requests through a centralized LiteLLM gateway, we simplify individual agent configurations and standardize the model connection interface across the cluster.
