### PR TITLE
docs: create agentic glossary and ground core terms

### DIFF
--- a/agents/devteam/AGENTS.md
+++ b/agents/devteam/AGENTS.md
@@ -13,6 +13,7 @@ Use runtime-provided startup context first.
 That context may already include:
 
 - `AGENTS.md`, `SOUL.md`, and `USER.md`
+- `/opt/defaults/docs/glossary.md` (or `docs/glossary.md` in the workspace) — Glossary of Agentic Terms (e.g. Agent Substrate)
 - recent daily memory such as `memory/YYYY-MM-DD.md`
 - `MEMORY.md` when this is the main session
 

--- a/agents/operator/AGENTS.md
+++ b/agents/operator/AGENTS.md
@@ -13,6 +13,7 @@ Use runtime-provided startup context first.
 That context may already include:
 
 - `AGENTS.md`, `SOUL.md`, and `USER.md`
+- `/opt/defaults/docs/glossary.md` (or `docs/glossary.md` in the workspace) — Glossary of Agentic Terms (e.g. Agent Substrate)
 - recent daily memory such as `memory/YYYY-MM-DD.md`
 - `MEMORY.md` when this is the main session
 

--- a/agents/platform/AGENTS.md
+++ b/agents/platform/AGENTS.md
@@ -6,6 +6,7 @@ This folder is home. Treat it that way.
 
 Use runtime-provided startup context first, including `AGENTS.md`, `SOUL.md`, and `USER.md`.
 Do not manually reread startup files unless the user explicitly asks or the context is missing vital information.
+Always refer to the glossary of agentic terms at `/opt/defaults/docs/glossary.md` (or `docs/glossary.md` in the workspace) to ground concepts like **Agent Substrate** and other harness terminology.
 
 ## Memory
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -71,6 +71,8 @@ RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && 
 # 6. Create base defaults directory and copy shared defaults
 RUN mkdir -p /opt/defaults && chown hermes:hermes /opt/defaults
 COPY --chown=hermes:hermes deploy/shared/defaults/ /opt/defaults/
+COPY --chown=hermes:hermes docs/ /opt/defaults/docs/
+
 
 # 6.5. Install and enable hermes-otel plugin in /opt/defaults
 RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel && \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && 
 # 6. Create base defaults directory and copy shared defaults
 RUN mkdir -p /opt/defaults && chown hermes:hermes /opt/defaults
 COPY --chown=hermes:hermes deploy/shared/defaults/ /opt/defaults/
-COPY --chown=hermes:hermes docs/ /opt/defaults/docs/
+COPY --chown=hermes:hermes docs/glossary.md /opt/defaults/docs/
 
 
 # 6.5. Install and enable hermes-otel plugin in /opt/defaults

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,49 @@
+# Glossary of Agentic Terms
+
+This glossary defines key terms and concepts related to the Kubernetes Agentic Harness (`kube-agents`) and the broader agentic ecosystem.
+
+---
+
+## Agent Platforms for Kubernetes
+
+### Agent Substrate
+
+- **Source:** [agent-substrate/substrate](https://github.com/agent-substrate/substrate)
+- **Definition:** An open-source, Kubernetes-native platform specifically engineered to orchestrate, scale, and manage AI agent workloads. It introduces abstractions like Workers (managed compute pools in Kubernetes Pods) and Actors (individual agent instances running inside Pods) to facilitate high-efficiency multiplexing and stateful execution sandboxes.
+
+### Agent Sandbox
+
+- **Source:** [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+- **Definition:** An open-source Kubernetes SIG Apps project designed to manage isolated, stateful, singleton workloads. It provides low-latency warm pod pools, stable identity, persistence, and secure sandboxed execution environments (e.g., via gVisor or Kata Containers) suitable for running untrusted LLM-generated code.
+
+---
+
+## Agent Runtimes & Frameworks
+
+### Agent Executor (AX)
+
+- **Source:** [google/ax](https://github.com/google/ax)
+- **Definition:** An open-source distributed agent runtime designed to manage the execution lifecycle of AI agents. It provides durable execution capabilities (including pausing, resuming, snapshotting, and replaying agent states) to ensure agent workloads remain operational and recover automatically from transient infrastructure failures.
+
+### Kubernetes Agentic Harness (`kube-agents`)
+
+- **Definition:** A cooperative multi-agent system designed to replace traditional Kubernetes/GKE interfaces (e.g., `kubectl`, `gcloud`, Google Cloud Console) with intelligent, intent-driven autonomous agents.
+
+---
+
+## Agents in `kube-agents`
+
+### Platform Agent (`platform`)
+
+- **Role:** Architectural custodian and agent orchestrator.
+- **Scope:** Configured with an architectural persona (`SOUL.md`). It manages multi-tenancy boundaries, fleet-wide governance, and RBAC isolation. It is responsible for dynamically provisioning and configuring specialized subagents (`operator` and `devteam`) at runtime based on the required operational scopes.
+
+### Kubernetes Operator Agent (`operator`)
+
+- **Role:** Infrastructure custodian and operations manager.
+- **Scope:** Configured with a calm, analytical persona (`SOUL.md`). It handles global concerns like multi-cluster balancing, node capacity, cluster upgrades, and platform security policy enforcement. It also executes scheduled background tasks (e.g., health patrols, CVE scans, and log management).
+
+### Development Team Agent (`devteam`)
+
+- **Role:** Developer coach and workload custodian.
+- **Scope:** Configured with a performance-driven persona (`SOUL.md`). It represents the interests of application developers, enforcing manifest validation, resource allocation templates, and automatic NetworkPolicy generation. It manages development-specific loops like rollout monitoring and SLO checks.


### PR DESCRIPTION
# Pull Request

## Why This Change

Create a shared glossary to ground agentic and ecosystem terminology, ensuring Platform, Operator, and DevTeam agents share consistent terminology when operating on Kubernetes.

## What Changed

**Files:**

- `docs/glossary.md`
- `agents/devteam/AGENTS.md`
- `agents/operator/AGENTS.md`
- `agents/platform/AGENTS.md`
- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Created a consolidated glossary defining Agent Substrate, Agent Executor (AX), Agent Sandbox, and core harness agents.
- Category-grouped terms under Agent Platforms, Agent Runtimes, and kube-agents.
- Copied `docs/` to the agent base image defaults directory.
- Wired glossary reference into Platform, Operator, and DevTeam startup instructions context.

## Why This Matters

Ensures cooperative agents share alignment on vocabulary (e.g. Agent Sandbox vs Agent Substrate) and makes it natively accessible in their ambient contexts.

## Context

Requested by the human operator.

## Testing

Ran local Docker image build `make docker-build-platform` to verify the Dockerfile compiled correctly with the new copying step.

---

TAG=agy
CONV=8344da24-9718-4ce2-9894-e7a11bddf1be
