### PR TITLE
feat(operator): add custom env vars support in dev and operator agents

### DIFF
--- a/k8s-operator/internal/controller/devteamagent_manifests.go
+++ b/k8s-operator/internal/controller/devteamagent_manifests.go
@@ -216,6 +216,10 @@ func buildDevTeamDeployment(agent *agentv1alpha1.DevTeamAgent, configHash, fluen
 		}
 	}
 
+	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.Env) > 0 {
+		envVars = mergeEnvVars(envVars, agent.Spec.Deployment.Env)
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
 )
 
@@ -53,4 +55,39 @@ func resolveAgentImage(deployment *agentv1alpha1.DeploymentSpec, defaultImage st
 		}
 	}
 	return image
+}
+
+// mergeEnvVars merges custom env vars into defaults. Custom env vars override defaults with the same name.
+func mergeEnvVars(defaults []corev1.EnvVar, custom []corev1.EnvVar) []corev1.EnvVar {
+	if len(custom) == 0 {
+		return defaults
+	}
+	if len(defaults) == 0 {
+		return custom
+	}
+
+	customMap := make(map[string]corev1.EnvVar, len(custom))
+	for _, env := range custom {
+		customMap[env.Name] = env
+	}
+
+	merged := make([]corev1.EnvVar, 0, len(defaults)+len(custom))
+	for _, env := range defaults {
+		if customEnv, exists := customMap[env.Name]; exists {
+			merged = append(merged, customEnv)
+			delete(customMap, env.Name)
+		} else {
+			merged = append(merged, env)
+		}
+	}
+
+	// Append remaining custom env vars in their original order
+	for _, env := range custom {
+		if customEnv, exists := customMap[env.Name]; exists {
+			merged = append(merged, customEnv)
+			delete(customMap, env.Name)
+		}
+	}
+
+	return merged
 }

--- a/k8s-operator/internal/controller/manifest_helpers_test.go
+++ b/k8s-operator/internal/controller/manifest_helpers_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
@@ -94,6 +96,61 @@ func TestResolveAgentImage(t *testing.T) {
 			result := resolveAgentImage(tt.deployment, tt.defaultImage)
 			if result != tt.expected {
 				t.Errorf("resolveAgentImage() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMergeEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		defaults []corev1.EnvVar
+		custom   []corev1.EnvVar
+		expected []corev1.EnvVar
+	}{
+		{
+			name:     "empty custom returns defaults",
+			defaults: []corev1.EnvVar{{Name: "A", Value: "1"}},
+			custom:   nil,
+			expected: []corev1.EnvVar{{Name: "A", Value: "1"}},
+		},
+		{
+			name:     "empty defaults returns custom",
+			defaults: nil,
+			custom:   []corev1.EnvVar{{Name: "B", Value: "2"}},
+			expected: []corev1.EnvVar{{Name: "B", Value: "2"}},
+		},
+		{
+			name:     "no overlap, appends custom",
+			defaults: []corev1.EnvVar{{Name: "A", Value: "1"}},
+			custom:   []corev1.EnvVar{{Name: "B", Value: "2"}},
+			expected: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "2"}},
+		},
+		{
+			name:     "overlap, custom overrides default",
+			defaults: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "2"}},
+			custom:   []corev1.EnvVar{{Name: "B", Value: "3"}},
+			expected: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "3"}},
+		},
+		{
+			name:     "duplicate custom, last one wins",
+			defaults: []corev1.EnvVar{{Name: "A", Value: "1"}},
+			custom:   []corev1.EnvVar{{Name: "B", Value: "2"}, {Name: "B", Value: "3"}},
+			expected: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "3"}},
+		},
+		{
+			name:     "duplicate custom overrides default, last one wins",
+			defaults: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "2"}},
+			custom:   []corev1.EnvVar{{Name: "B", Value: "3"}, {Name: "B", Value: "4"}},
+			expected: []corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "4"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeEnvVars(tt.defaults, tt.custom)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("mergeEnvVars() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}

--- a/k8s-operator/internal/controller/operatoragent_manifests.go
+++ b/k8s-operator/internal/controller/operatoragent_manifests.go
@@ -192,6 +192,10 @@ func buildOperatorDeployment(agent *agentv1alpha1.OperatorAgent, configHash, flu
 		}
 	}
 
+	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.Env) > 0 {
+		envVars = mergeEnvVars(envVars, agent.Spec.Deployment.Env)
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -556,30 +556,3 @@ func buildPlatformService(agent *agentv1alpha1.PlatformAgent) *corev1.Service {
 	}
 }
 
-// mergeEnvVars merges custom env vars into defaults. Custom env vars override defaults with the same name.
-func mergeEnvVars(defaults []corev1.EnvVar, custom []corev1.EnvVar) []corev1.EnvVar {
-	customMap := make(map[string]corev1.EnvVar)
-	for _, env := range custom {
-		customMap[env.Name] = env
-	}
-
-	var merged []corev1.EnvVar
-	for _, env := range defaults {
-		if customEnv, exists := customMap[env.Name]; exists {
-			merged = append(merged, customEnv)
-			delete(customMap, env.Name)
-		} else {
-			merged = append(merged, env)
-		}
-	}
-
-	// Append remaining custom env vars in their original order
-	for _, env := range custom {
-		if customEnv, exists := customMap[env.Name]; exists {
-			merged = append(merged, customEnv)
-			delete(customMap, env.Name)
-		}
-	}
-
-	return merged
-}


### PR DESCRIPTION
# Pull Request

## Why This Change

The previous PR added support for custom environment variables (`env` field) to the common `DeploymentSpec` and implemented the merging logic for `PlatformAgent`. 

This PR extends that support to `OperatorAgent` and `DevTeamAgent` by integrating the same environment variable merging logic into their respective deployment manifests. It also refactors the merging logic into a shared helper file to avoid code duplication.

## What Changed

**Files:**

- `k8s-operator/internal/controller/manifest_helpers.go` (Added)
- `k8s-operator/internal/controller/manifest_helpers_test.go` (Added)
- `k8s-operator/internal/controller/platformagent_manifests.go` (Modified)
- `k8s-operator/internal/controller/operatoragent_manifests.go` (Modified)
- `k8s-operator/internal/controller/devteamagent_manifests.go` (Modified)
- `k8s-operator/internal/controller/image_helper.go` (Removed)
- `k8s-operator/internal/controller/image_helper_test.go` (Removed)

**Added/Changed/Fixed:**

- **Refactoring**: Extracted the `mergeEnvVars` helper function from `platformagent_manifests.go` into a new shared file `manifest_helpers.go`.
- **OperatorAgent**: Updated `buildOperatorDeployment` in `operatoragent_manifests.go` to merge user-defined env vars with defaults.
- **DevTeamAgent**: Updated `buildDevTeamDeployment` in `devteamagent_manifests.go` to merge user-defined env vars with defaults.

## Why This Matters

- **Consistency**: Ensures all agent types (Platform, Operator, DevTeam) support custom environment variables in their deployments.
- **Maintainability**: Consolidates the merging logic into a single shared helper, reducing code duplication.

## Context

Follow-up to the initial PR that introduced the `Env` field in the API.

## Testing

Ran local unit tests to ensure compilation and existing manifest tests pass:

```bash
go test ./internal/controller/...
```
