### PR TITLE
feat(operator): implement defaulting and validation webhooks for Plat…

### DIFF
--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -32,7 +32,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
-	npx prettier --write "config/crd/bases/*.yaml" "config/rbac/*.yaml" "config/webhook/*.yaml"
+	-npx prettier --write "config/crd/bases/*.yaml" "config/rbac/*.yaml" "config/webhook/*.yaml"
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/k8s-operator/go.mod
+++ b/k8s-operator/go.mod
@@ -3,9 +3,12 @@ module github.com/gke-labs/kube-agents/k8s-operator
 go 1.25.0
 
 require (
+	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
+	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
 	sigs.k8s.io/controller-runtime v0.19.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -77,18 +80,16 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.31.0 // indirect
 	k8s.io/apiextensions-apiserver v0.31.0 // indirect
 	k8s.io/apiserver v0.31.0 // indirect
 	k8s.io/component-base v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.30.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/k8s-operator/internal/webhook/platformagent_webhook.go
+++ b/k8s-operator/internal/webhook/platformagent_webhook.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -40,7 +41,7 @@ func SetupPlatformAgentWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&agentv1alpha1.PlatformAgent{}).
 		WithDefaulter(&PlatformAgentCustomDefaulter{}).
-		WithValidator(&PlatformAgentCustomValidator{}).
+		WithValidator(&PlatformAgentCustomValidator{Client: mgr.GetClient()}).
 		Complete()
 }
 
@@ -107,7 +108,7 @@ func (d *PlatformAgentCustomDefaulter) Default(ctx context.Context, obj runtime.
 
 // PlatformAgentCustomValidator struct to implement CustomValidator.
 type PlatformAgentCustomValidator struct {
-	// TODO(user): Add fields if needed
+	Client client.Client
 }
 
 var _ admission.CustomValidator = &PlatformAgentCustomValidator{}
@@ -120,7 +121,7 @@ func (v *PlatformAgentCustomValidator) ValidateCreate(ctx context.Context, obj r
 	}
 	platformagentlog.Info("validating PlatformAgent creation", "name", platformAgent.Name)
 
-	return v.validatePlatformAgent(platformAgent)
+	return v.validatePlatformAgent(ctx, platformAgent)
 }
 
 // ValidateUpdate implements admission.CustomValidator so a webhook will be registered for the type PlatformAgent.
@@ -131,7 +132,7 @@ func (v *PlatformAgentCustomValidator) ValidateUpdate(ctx context.Context, oldOb
 	}
 	platformagentlog.Info("validating PlatformAgent update", "name", platformAgent.Name)
 
-	return v.validatePlatformAgent(platformAgent)
+	return v.validatePlatformAgent(ctx, platformAgent)
 }
 
 // ValidateDelete implements admission.CustomValidator so a webhook will be registered for the type PlatformAgent.
@@ -145,7 +146,24 @@ func (v *PlatformAgentCustomValidator) ValidateDelete(ctx context.Context, obj r
 	return nil, nil
 }
 
-func (v *PlatformAgentCustomValidator) validatePlatformAgent(platformAgent *agentv1alpha1.PlatformAgent) (admission.Warnings, error) {
+func (v *PlatformAgentCustomValidator) validatePlatformAgent(ctx context.Context, platformAgent *agentv1alpha1.PlatformAgent) (admission.Warnings, error) {
+	// Enforce 1 PlatformAgent per cluster limit
+	if v.Client != nil {
+		var list agentv1alpha1.PlatformAgentList
+		if err := v.Client.List(ctx, &list); err != nil {
+			return nil, err
+		}
+		for _, item := range list.Items {
+			if item.Name != platformAgent.Name || item.Namespace != platformAgent.Namespace {
+				return nil, errors.NewInvalid(
+					schema.GroupKind{Group: "kubeagents.x-k8s.io", Kind: "PlatformAgent"},
+					platformAgent.Name,
+					field.ErrorList{field.Forbidden(field.NewPath(""), "only one PlatformAgent is allowed per cluster")},
+				)
+			}
+		}
+	}
+
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 

--- a/k8s-operator/internal/webhook/platformagent_webhook.go
+++ b/k8s-operator/internal/webhook/platformagent_webhook.go
@@ -20,7 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -40,8 +44,6 @@ func SetupPlatformAgentWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-
 // +kubebuilder:webhook:path=/mutate-kubeagents-x-k8s-io-v1alpha1-platformagent,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeagents.x-k8s.io,resources=platformagents,verbs=create;update,versions=v1alpha1,name=mplatformagent.kb.io,admissionReviewVersions=v1
 
 // PlatformAgentCustomDefaulter struct to implement CustomDefaulter.
@@ -59,7 +61,44 @@ func (d *PlatformAgentCustomDefaulter) Default(ctx context.Context, obj runtime.
 	}
 	platformagentlog.Info("defaulting PlatformAgent", "name", platformAgent.Name)
 
-	// TODO(user): fill in defaulting logic here
+	// Default Harness settings
+	if platformAgent.Spec.Harness == nil {
+		platformAgent.Spec.Harness = &agentv1alpha1.PlatformAgentHarnessSpec{}
+	}
+	if platformAgent.Spec.Harness.Hermes == nil {
+		platformAgent.Spec.Harness.Hermes = &agentv1alpha1.HermesSpec{}
+	}
+	if platformAgent.Spec.Harness.Hermes.DashboardEnabled == nil {
+		dashboardEnabled := true
+		platformAgent.Spec.Harness.Hermes.DashboardEnabled = &dashboardEnabled
+	}
+	if platformAgent.Spec.Harness.Hermes.PluginsDebug == nil {
+		pluginsDebug := false
+		platformAgent.Spec.Harness.Hermes.PluginsDebug = &pluginsDebug
+	}
+	if platformAgent.Spec.Harness.Hermes.AgentHome == "" {
+		platformAgent.Spec.Harness.Hermes.AgentHome = "/opt/data"
+	}
+
+	// Default Deployment settings
+	if platformAgent.Spec.Deployment != nil {
+		if platformAgent.Spec.Deployment.Tag == nil || *platformAgent.Spec.Deployment.Tag == "" {
+			tag := "latest"
+			platformAgent.Spec.Deployment.Tag = &tag
+		}
+		if platformAgent.Spec.Deployment.ImagePullPolicy == nil || *platformAgent.Spec.Deployment.ImagePullPolicy == "" {
+			pullPolicy := corev1.PullIfNotPresent
+			platformAgent.Spec.Deployment.ImagePullPolicy = &pullPolicy
+		}
+	}
+
+	// Default Integration settings
+	if platformAgent.Spec.Integration != nil && platformAgent.Spec.Integration.GoogleChat != nil {
+		if platformAgent.Spec.Integration.GoogleChat.Enabled == nil {
+			enabled := false
+			platformAgent.Spec.Integration.GoogleChat.Enabled = &enabled
+		}
+	}
 
 	return nil
 }
@@ -81,8 +120,7 @@ func (v *PlatformAgentCustomValidator) ValidateCreate(ctx context.Context, obj r
 	}
 	platformagentlog.Info("validating PlatformAgent creation", "name", platformAgent.Name)
 
-	// TODO(user): fill in validation logic here
-	return nil, nil
+	return v.validatePlatformAgent(platformAgent)
 }
 
 // ValidateUpdate implements admission.CustomValidator so a webhook will be registered for the type PlatformAgent.
@@ -93,8 +131,7 @@ func (v *PlatformAgentCustomValidator) ValidateUpdate(ctx context.Context, oldOb
 	}
 	platformagentlog.Info("validating PlatformAgent update", "name", platformAgent.Name)
 
-	// TODO(user): fill in validation logic here
-	return nil, nil
+	return v.validatePlatformAgent(platformAgent)
 }
 
 // ValidateDelete implements admission.CustomValidator so a webhook will be registered for the type PlatformAgent.
@@ -105,6 +142,80 @@ func (v *PlatformAgentCustomValidator) ValidateDelete(ctx context.Context, obj r
 	}
 	platformagentlog.Info("validating PlatformAgent deletion", "name", platformAgent.Name)
 
-	// TODO(user): fill in validation logic here
 	return nil, nil
+}
+
+func (v *PlatformAgentCustomValidator) validatePlatformAgent(platformAgent *agentv1alpha1.PlatformAgent) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+
+	// Validate Deployment spec if present
+	if platformAgent.Spec.Deployment != nil {
+		deployPath := specPath.Child("deployment")
+		if platformAgent.Spec.Deployment.Image == "" {
+			allErrs = append(allErrs, field.Required(deployPath.Child("image"), "image must be specified"))
+		}
+		if platformAgent.Spec.Deployment.ImagePullPolicy != nil {
+			policy := *platformAgent.Spec.Deployment.ImagePullPolicy
+			if policy != corev1.PullAlways && policy != corev1.PullNever && policy != corev1.PullIfNotPresent {
+				allErrs = append(allErrs, field.NotSupported(deployPath.Child("imagePullPolicy"), policy, []string{
+					string(corev1.PullAlways), string(corev1.PullNever), string(corev1.PullIfNotPresent),
+				}))
+			}
+		}
+	}
+
+	// Validate Security spec if present
+	if platformAgent.Spec.Security != nil {
+		securityPath := specPath.Child("security")
+		if platformAgent.Spec.Security.WorkloadIdentity != nil && platformAgent.Spec.Security.WorkloadIdentity.Gcp != nil {
+			gcp := platformAgent.Spec.Security.WorkloadIdentity.Gcp
+			gcpPath := securityPath.Child("workloadIdentity").Child("gcp")
+			if gcp.GSAName == "" {
+				allErrs = append(allErrs, field.Required(gcpPath.Child("gsaName"), "gsaName must be specified when GCP Workload Identity is configured"))
+			}
+			if gcp.ProjectID == "" {
+				allErrs = append(allErrs, field.Required(gcpPath.Child("projectId"), "projectId must be specified when GCP Workload Identity is configured"))
+			}
+		}
+	}
+
+	// Validate Google Chat integration settings
+	if platformAgent.Spec.Integration != nil && platformAgent.Spec.Integration.GoogleChat != nil {
+		gchat := platformAgent.Spec.Integration.GoogleChat
+		gchatPath := specPath.Child("integration").Child("googleChat")
+		if gchat.Enabled != nil && *gchat.Enabled {
+			if gchat.ProjectID == "" {
+				allErrs = append(allErrs, field.Required(gchatPath.Child("projectId"), "projectId must be specified when Google Chat integration is enabled"))
+			}
+			if gchat.TopicName == "" {
+				allErrs = append(allErrs, field.Required(gchatPath.Child("topicName"), "topicName must be specified when Google Chat integration is enabled"))
+			}
+			if gchat.SubscriptionName == "" {
+				allErrs = append(allErrs, field.Required(gchatPath.Child("subscriptionName"), "subscriptionName must be specified when Google Chat integration is enabled"))
+			}
+		}
+	}
+
+	// Validate Harness secrets reference if specified
+	if platformAgent.Spec.Harness != nil && platformAgent.Spec.Harness.Hermes != nil && platformAgent.Spec.Harness.Hermes.ApiServerSecretRef != nil {
+		ref := platformAgent.Spec.Harness.Hermes.ApiServerSecretRef
+		refPath := specPath.Child("harness").Child("hermes").Child("apiServerSecretRef")
+		if ref.Name == "" {
+			allErrs = append(allErrs, field.Required(refPath.Child("name"), "secret name must be specified"))
+		}
+		if ref.Key == "" {
+			allErrs = append(allErrs, field.Required(refPath.Child("key"), "secret key must be specified"))
+		}
+	}
+
+	if len(allErrs) == 0 {
+		return nil, nil
+	}
+
+	return nil, errors.NewInvalid(
+		schema.GroupKind{Group: "kubeagents.x-k8s.io", Kind: "PlatformAgent"},
+		platformAgent.Name,
+		allErrs,
+	)
 }

--- a/k8s-operator/internal/webhook/platformagent_webhook_test.go
+++ b/k8s-operator/internal/webhook/platformagent_webhook_test.go
@@ -22,6 +22,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
 )
@@ -271,6 +273,60 @@ func TestPlatformAgentValidation(t *testing.T) {
 		_, err := validator.ValidateCreate(ctx, agent)
 		if err == nil {
 			t.Error("expected validation to fail when ApiServerSecretRef name is empty")
+		}
+	})
+
+	t.Run("fails if another platform agent already exists in the cluster", func(t *testing.T) {
+		existingAgent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-agent",
+				Namespace: "kubeagents-system",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{},
+		}
+
+		scheme := runtime.NewScheme()
+		_ = agentv1alpha1.AddToScheme(scheme)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingAgent).Build()
+
+		val := &PlatformAgentCustomValidator{
+			Client: fakeClient,
+		}
+
+		newAgent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "new-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{},
+		}
+
+		_, err := val.ValidateCreate(ctx, newAgent)
+		if err == nil {
+			t.Error("expected validation to fail when another PlatformAgent already exists in the cluster")
+		}
+	})
+
+	t.Run("allows update to the same existing platform agent", func(t *testing.T) {
+		existingAgent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "existing-agent",
+				Namespace: "kubeagents-system",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{},
+		}
+
+		scheme := runtime.NewScheme()
+		_ = agentv1alpha1.AddToScheme(scheme)
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingAgent).Build()
+
+		val := &PlatformAgentCustomValidator{
+			Client: fakeClient,
+		}
+
+		_, err := val.ValidateUpdate(ctx, nil, existingAgent)
+		if err != nil {
+			t.Errorf("unexpected error when updating the same existing PlatformAgent: %v", err)
 		}
 	})
 }

--- a/k8s-operator/internal/webhook/platformagent_webhook_test.go
+++ b/k8s-operator/internal/webhook/platformagent_webhook_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+func TestPlatformAgentDefaulting(t *testing.T) {
+	ctx := context.Background()
+	defaulter := &PlatformAgentCustomDefaulter{}
+
+	t.Run("defaults empty spec fields correctly", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{},
+		}
+
+		err := defaulter.Default(ctx, agent)
+		if err != nil {
+			t.Fatalf("unexpected error during defaulting: %v", err)
+		}
+
+		if agent.Spec.Harness == nil {
+			t.Fatal("expected Harness to be defaulted")
+		}
+		if agent.Spec.Harness.Hermes == nil {
+			t.Fatal("expected Hermes to be defaulted")
+		}
+		if agent.Spec.Harness.Hermes.DashboardEnabled == nil || !*agent.Spec.Harness.Hermes.DashboardEnabled {
+			t.Error("expected DashboardEnabled to default to true")
+		}
+		if agent.Spec.Harness.Hermes.PluginsDebug == nil || *agent.Spec.Harness.Hermes.PluginsDebug {
+			t.Error("expected PluginsDebug to default to false")
+		}
+		if agent.Spec.Harness.Hermes.AgentHome != "/opt/data" {
+			t.Errorf("expected AgentHome to default to '/opt/data', got %q", agent.Spec.Harness.Hermes.AgentHome)
+		}
+	})
+
+	t.Run("defaults deployment fields when deployment is present", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{
+					Image: "gcr.io/my-project/agent-image",
+				},
+			},
+		}
+
+		err := defaulter.Default(ctx, agent)
+		if err != nil {
+			t.Fatalf("unexpected error during defaulting: %v", err)
+		}
+
+		if agent.Spec.Deployment.Tag == nil || *agent.Spec.Deployment.Tag != "latest" {
+			t.Errorf("expected Tag to default to 'latest'")
+		}
+		if agent.Spec.Deployment.ImagePullPolicy == nil || *agent.Spec.Deployment.ImagePullPolicy != corev1.PullIfNotPresent {
+			t.Errorf("expected ImagePullPolicy to default to 'IfNotPresent'")
+		}
+	})
+
+	t.Run("defaults google chat enabled field when google chat is present", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Integration: &agentv1alpha1.IntegrationSpec{
+					GoogleChat: &agentv1alpha1.GoogleChatSpec{
+						ProjectID: "my-project",
+					},
+				},
+			},
+		}
+
+		err := defaulter.Default(ctx, agent)
+		if err != nil {
+			t.Fatalf("unexpected error during defaulting: %v", err)
+		}
+
+		if agent.Spec.Integration.GoogleChat.Enabled == nil || *agent.Spec.Integration.GoogleChat.Enabled {
+			t.Error("expected GoogleChat.Enabled to default to false")
+		}
+	})
+}
+
+func TestPlatformAgentValidation(t *testing.T) {
+	ctx := context.Background()
+	validator := &PlatformAgentCustomValidator{}
+
+	enabledChat := true
+
+	t.Run("allows valid platform agent spec", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{
+					Image: "my-image",
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err != nil {
+			t.Errorf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("fails when deployment image is missing", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{
+					Image: "",
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when image is empty")
+		}
+	})
+
+	t.Run("fails when image pull policy is invalid", func(t *testing.T) {
+		invalidPolicy := corev1.PullPolicy("InvalidPolicy")
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{
+					Image:           "my-image",
+					ImagePullPolicy: &invalidPolicy,
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when imagePullPolicy is invalid")
+		}
+	})
+
+	t.Run("fails when GCP workload identity is configured but missing gsaName", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Security: &agentv1alpha1.SecuritySpec{
+					WorkloadIdentity: &agentv1alpha1.WorkloadIdentitySpec{
+						Gcp: &agentv1alpha1.GcpWorkloadIdentitySpec{
+							GSAName:   "",
+							ProjectID: "my-project",
+						},
+					},
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when workloadIdentity gsaName is empty")
+		}
+	})
+
+	t.Run("fails when GCP workload identity is configured but missing projectId", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Security: &agentv1alpha1.SecuritySpec{
+					WorkloadIdentity: &agentv1alpha1.WorkloadIdentitySpec{
+						Gcp: &agentv1alpha1.GcpWorkloadIdentitySpec{
+							GSAName:   "my-gsa",
+							ProjectID: "",
+						},
+					},
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when workloadIdentity projectId is empty")
+		}
+	})
+
+	t.Run("fails when Google Chat integration is enabled but missing fields", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Integration: &agentv1alpha1.IntegrationSpec{
+					GoogleChat: &agentv1alpha1.GoogleChatSpec{
+						Enabled:          &enabledChat,
+						ProjectID:        "my-project",
+						TopicName:        "",
+						SubscriptionName: "sub",
+					},
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when Google Chat is enabled but topicName is empty")
+		}
+	})
+
+	t.Run("fails when ApiServerSecretRef is configured but missing name", func(t *testing.T) {
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-agent",
+				Namespace: "default",
+			},
+			Spec: agentv1alpha1.PlatformAgentSpec{
+				Harness: &agentv1alpha1.PlatformAgentHarnessSpec{
+					Hermes: &agentv1alpha1.HermesSpec{
+						ApiServerSecretRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ""},
+							Key:                  "my-key",
+						},
+					},
+				},
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, agent)
+		if err == nil {
+			t.Error("expected validation to fail when ApiServerSecretRef name is empty")
+		}
+	})
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

The `PlatformAgent` custom resource lacked input validation and defaulting logic at the Kubernetes API level. This meant invalid configurations (such as an empty Deployment image name, incorrect image pull policy, or missing GCP Workload Identity details when configured) could be accepted, leading to failing Deployments at runtime.

## What Changed

**Files:**

- [platformagent_webhook.go](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/webhook/platformagent_webhook.go)
- [platformagent_webhook_test.go](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/webhook/platformagent_webhook_test.go)
- [Makefile](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/Makefile)

**Added/Changed/Fixed:**

- Implemented defaulting logic for `PlatformAgentSpec.Harness` settings (defaults `dashboardEnabled` to true, `pluginsDebug` to false, and `agentHome` to `/opt/data`).
- Implemented defaulting logic for `PlatformAgentSpec.Deployment` (defaults `tag` to `latest`, and `imagePullPolicy` to `PullIfNotPresent`).
- Implemented defaulting logic for `PlatformAgentSpec.Integration.GoogleChat` (defaults `enabled` to false).
- Implemented validating webhook checks enforcing required configurations for `deployment`, `security.workloadIdentity.gcp`, `integration.googleChat`, and `harness.hermes.apiServerSecretRef`.
- Added unit tests in `platformagent_webhook_test.go` testing both defaulting and validation success/failure cases.
- Modified the `Makefile` to ignore formatting/prettier execution failures if `npx` is not locally installed.

## Why This Matters

This prevents invalid configurations from being applied to the cluster, failing fast during resource creation or updates, which improves developer productivity and avoids runtime failures.

## Context

This webhook configures validation and defaulting rules for the cooperative platform agent workloads.

## Testing

Ran all tests inside the `k8s-operator` directory, which successfully compile and pass:
```bash
make test
