### PR TITLE
feat(operator): disable scheduled background cron watchdogs

### DIFF
--- a/agents/operator/cron/jobs.json
+++ b/agents/operator/cron/jobs.json
@@ -10,7 +10,7 @@
       },
       "prompt": "Perform a comprehensive 15-minute diagnostic scan of the specific GKE cluster you are responsible for (checking node status Ready/NotReady, resource pressure CPU/Memory/Disk, and identifying pending/unschedulable pods). Do not attempt to scan other clusters. Maintain constant system awareness.",
       "skills": ["gke-observability", "gke-reliability"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "utilization-optimizer",
@@ -22,7 +22,7 @@
       },
       "prompt": "Proactively evaluate cluster-wide resource utilization. Propose resource right-sizing or node pool adjustments to optimize capacity based on real-time pressure signals.",
       "skills": ["gke-workload-scaling"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "cve-scan",
@@ -34,7 +34,7 @@
       },
       "prompt": "Conduct hourly container image vulnerability scan. Read '/opt/defaults/procedures/cve_scan_sop.md' and audit running container images against registries, alerting only on new findings.",
       "skills": ["gke-workload-security"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "daily-cluster-report",
@@ -46,7 +46,7 @@
       },
       "prompt": "Compile a comprehensive daily health summary. Analyze the heartbeats from the previous 24 hours, GKE operational states, active incidents, and cost usage deltas.",
       "skills": ["gke-observability"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "log-cleanup",
@@ -58,7 +58,7 @@
       },
       "prompt": "Automatically rotate and purge old system logs to ensure sufficient disk space on control plane and worker nodes.",
       "skills": ["gke-observability"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "stale-object-cleanup",
@@ -70,7 +70,7 @@
       },
       "prompt": "Automatically prune orphaned ReplicaSets, completed Jobs, and other ephemeral Kubernetes objects to reduce database bloat.",
       "skills": ["gke-reliability"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "backup-validation",
@@ -82,7 +82,7 @@
       },
       "prompt": "Verify the integrity of recent volume snapshots and backups to ensure disaster recovery readiness.",
       "skills": ["gke-backup-dr"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "weekly-cost-report",
@@ -94,7 +94,7 @@
       },
       "prompt": "Generate a detailed weekly cost report. Read '/opt/defaults/procedures/weekly_cost_report_sop.md' to leverage GKE Cost Allocation and integrate Google Cloud Billing data.",
       "skills": ["gke-cost-analysis"],
-      "enabled": true
+      "enabled": false
     },
     {
       "id": "cert-expiry-scan",
@@ -106,7 +106,7 @@
       },
       "prompt": "Check expiration dates for all TLS certificates and secrets in the clusters to preemptively alert on potential outages.",
       "skills": ["gke-networking-edge", "gke-workload-security"],
-      "enabled": true
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

In multi-agent GKE test environments running parallel agent gateways, background scheduled cron watchdogs query upstream inference APIs periodically. On developer preview tiers (such as `gemini-3.5-flash` or `gemini-flash-latest`), these continuous background polls saturate project rate limits (`HTTP 429 RESOURCE_EXHAUSTED`), starving live interactive SRE delegation turns.

## What Changed

**Files:**

- `agents/operator/cron/jobs.json`

**Added/Changed/Fixed:**

- Set `"enabled": false` across all 10 scheduled background cron watchdogs in the Operator Agent blueprint (`cluster-heartbeat`, `utilization-optimizer`, `cve-scan`, `daily-cluster-report`, `log-cleanup`, `stale-object-cleanup`, `backup-validation`, `weekly-cost-report`, `cert-expiry-scan`).

## Why This Matters

- Preserves 100% of upstream Gemini API requests-per-minute quota strictly for explicit, real-time SRE interactive negotiations.
- Eliminates background inference noise during multi-agent test execution.

## Context

Separated cleanly from inter-agent delegation negotiation SOP feature work (`feat/operator-negotiation`) to maintain strict atomic PR scoping.

## Testing

- Validated JSON formatting with `npx prettier --check` (pass).
- Verified live in GKE cluster that disabling cron silences background inference requests while preserving interactive `hermes -z` responsiveness.

---

Functional impact: Zero disruption to core inter-agent messaging or direct prompt handling. Rollout is declarative via blueprint sync.

TAG=agy
CONV=a41a6e54-b0ba-4f51-b8b4-c97afdd0be96
