### PR TITLE
feat(inference-replay): add togglable on/off mode to proxy

### DIFF
--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -20,6 +20,20 @@ graph TD
 - **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.
 - **Context-Aware Hashing**: Calculates a SHA-256 hash combining the exact **Prompt + Available Kubernetes Skills + Target Model**.
 - **Permanent Lazy-Caching**: Trajectories are permanently captured directly onto a Google Cloud Persistent Disk (`/data/replay_cache.json`).
+- **Runtime Togglable**: A `ConfigMap`-backed mode flag flips caching on/off without a pod restart.
+
+---
+
+## Modes
+
+The proxy reads its current mode from a file mounted from the `inference-replay-config` ConfigMap. Changes are hot-reloaded within ~1 second; no pod restart required.
+
+| Mode  | Behavior                                                                       |
+| ----- | ------------------------------------------------------------------------------ |
+| `off` | Pure pass-through. No cache reads, no cache writes. Proxy is invisible. (default) |
+| `on`  | Serve cached responses on hit; on miss, forward to upstream and record the response. |
+
+The cache file on the PVC is untouched when you flip modes — switching `on → off → on` resumes from the same cache.
 
 ---
 
@@ -64,11 +78,13 @@ Deploy the persistent volume, gateway routing, and standalone proxy in the `agen
 cd examples/inference-replay
 # 1. Provision the 1Gi Persistent Disk (PVC)
 kubectl apply -f pvc.yaml
-# 2. Expose the original LiteLLM pods under the new name 'litellm-gateway'
+# 2. Create the mode ConfigMap (defaults to 'off' — pure pass-through)
+kubectl apply -f configmap.yaml
+# 3. Expose the original LiteLLM pods under the new name 'litellm-gateway'
 kubectl apply -f service-gateway.yaml
-# 3. Deploy the Standalone Replay Proxy pod
+# 4. Deploy the Standalone Replay Proxy pod
 kubectl apply -f deployment.yaml
-# 4. Intercept primary 'litellm' traffic to route to the Proxy
+# 5. Intercept primary 'litellm' traffic to route to the Proxy
 kubectl apply -f service.yaml
 ```
 
@@ -118,3 +134,51 @@ kubectl exec -n agent-system $POD_NAME -- cat /data/replay_cache.json | jq .
 ### 4. Observe the Instant Replay Hit
 
 Execute the exact same `curl` command a second time. It will complete near-instantaneously (<10ms) with **zero Gemini API calls**, serving entirely from your persistent volume!
+
+---
+
+## Toggling Replay
+
+The proxy is always in the traffic path once deployed. To enable caching or return to pure pass-through, patch the ConfigMap — the proxy hot-reloads within ~1s, no pod restart.
+
+### Turn caching on
+
+```bash
+kubectl patch configmap inference-replay-config -n agent-system \
+  --type merge -p '{"data":{"mode":"on"}}'
+```
+
+### Turn caching off (pure pass-through)
+
+```bash
+kubectl patch configmap inference-replay-config -n agent-system \
+  --type merge -p '{"data":{"mode":"off"}}'
+```
+
+### Check current mode
+
+```bash
+# From inside the cluster (or via port-forward):
+curl http://localhost:8080/admin/mode
+# → {"mode":"on","cache_size":42,"valid_modes":["off","on"]}
+```
+
+Or read the ConfigMap directly:
+
+```bash
+kubectl get configmap inference-replay-config -n agent-system -o jsonpath='{.data.mode}'
+```
+
+### Typical workflow
+
+```bash
+# Start a recording session
+kubectl patch configmap inference-replay-config -n agent-system \
+  --type merge -p '{"data":{"mode":"on"}}'
+
+# ...exercise your agents; cache fills up...
+
+# Return to live traffic (cache stays on disk, untouched)
+kubectl patch configmap inference-replay-config -n agent-system \
+  --type merge -p '{"data":{"mode":"off"}}'
+```

--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -28,9 +28,9 @@ graph TD
 
 The proxy reads its current mode from a file mounted from the `inference-replay-config` ConfigMap. Changes are hot-reloaded within ~1 second; no pod restart required.
 
-| Mode  | Behavior                                                                       |
-| ----- | ------------------------------------------------------------------------------ |
-| `off` | Pure pass-through. No cache reads, no cache writes. Proxy is invisible. (default) |
+| Mode  | Behavior                                                                             |
+| ----- | ------------------------------------------------------------------------------------ |
+| `off` | Pure pass-through. No cache reads, no cache writes. Proxy is invisible. (default)    |
 | `on`  | Serve cached responses on hit; on miss, forward to upstream and record the response. |
 
 The cache file on the PVC is untouched when you flip modes — switching `on → off → on` resumes from the same cache.

--- a/examples/inference-replay/configmap.yaml
+++ b/examples/inference-replay/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inference-replay-config
+  namespace: agent-system
+data:
+  mode: "off"

--- a/examples/inference-replay/deployment.yaml
+++ b/examples/inference-replay/deployment.yaml
@@ -22,10 +22,10 @@ spec:
           env:
             - name: INFERENCE_URL
               value: "http://litellm-gateway.agent-system.svc.cluster.local"
-            - name: PROXY_MODE
-              value: "lazy-cache" # Permanently locked in dynamic lazy-caching
             - name: CACHE_FILE
               value: "/data/replay_cache.json"
+            - name: MODE_FILE
+              value: "/etc/replay/mode"
           resources:
             requests:
               cpu: "100m" # Lightweight request to schedule instantly
@@ -36,7 +36,13 @@ spec:
           volumeMounts:
             - name: cache-volume
               mountPath: /data
+            - name: mode-config
+              mountPath: /etc/replay
+              readOnly: true
       volumes:
         - name: cache-volume
           persistentVolumeClaim:
             claimName: standalone-replay-pvc
+        - name: mode-config
+          configMap:
+            name: inference-replay-config

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -139,27 +139,40 @@ async def _forward_completion(client, body, headers, req_hash, record):
 
 
 async def _forward_stream(client, body, headers, req_hash, record):
-    recorded_lines = []
-    async with client.stream(
+    req = client.build_request(
         "POST",
         f"{INFERENCE_URL}/v1/chat/completions",
         json=body,
         headers=headers,
-        timeout=60.0
-    ) as response:
-        if response.status_code != 200:
-            content = await response.aread()
-            yield content
-            return
-        async for line in response.aiter_lines():
-            if record:
-                recorded_lines.append(line)
-            yield line + "\n"
+        timeout=60.0,
+    )
+    try:
+        response = await client.send(req, stream=True)
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to contact inference backend: {exc}")
 
-    if record and recorded_lines:
-        logger.info(f"Recording stream response for hash: {req_hash}")
-        cache[req_hash] = {"type": "stream", "data": recorded_lines}
-        await save_cache()
+    if response.status_code != 200:
+        try:
+            content = await response.aread()
+        finally:
+            await response.aclose()
+        return Response(content=content, status_code=response.status_code, headers=dict(response.headers))
+
+    async def stream_body():
+        recorded_lines = []
+        try:
+            async for line in response.aiter_lines():
+                if record:
+                    recorded_lines.append(line)
+                yield line + "\n"
+        finally:
+            await response.aclose()
+            if record and recorded_lines:
+                logger.info(f"Recording stream response for hash: {req_hash}")
+                cache[req_hash] = {"type": "stream", "data": recorded_lines}
+                await save_cache()
+
+    return StreamingResponse(stream_body(), media_type="text/event-stream")
 
 
 @app.post("/v1/chat/completions")
@@ -177,10 +190,7 @@ async def chat_completions(request: Request):
 
     if mode == "off":
         if is_stream:
-            return StreamingResponse(
-                _forward_stream(client, body, headers, req_hash, record=False),
-                media_type="text/event-stream",
-            )
+            return await _forward_stream(client, body, headers, req_hash, record=False)
         return await _forward_completion(client, body, headers, req_hash, record=False)
 
     if req_hash in cache:
@@ -195,10 +205,7 @@ async def chat_completions(request: Request):
 
     logger.info(f"Cache miss for hash: {req_hash}. Forwarding to {INFERENCE_URL}")
     if is_stream:
-        return StreamingResponse(
-            _forward_stream(client, body, headers, req_hash, record=True),
-            media_type="text/event-stream",
-        )
+        return await _forward_stream(client, body, headers, req_hash, record=True)
     return await _forward_completion(client, body, headers, req_hash, record=True)
 
 

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -11,20 +11,67 @@ import httpx
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("replay-proxy-v1")
 
+INFERENCE_URL = os.environ.get("INFERENCE_URL", "http://localhost:4000")
+CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
+MODE_FILE = os.environ.get("MODE_FILE", "/etc/replay/mode")
+
+VALID_MODES = {"on", "off"}
+DEFAULT_MODE = "off"
+
+current_mode = DEFAULT_MODE
+_mode_mtime = 0.0
+
+
+def _load_mode() -> None:
+    global current_mode, _mode_mtime
+    try:
+        st = os.stat(MODE_FILE)
+    except FileNotFoundError:
+        return
+    if st.st_mtime == _mode_mtime:
+        return
+    try:
+        with open(MODE_FILE, "r") as f:
+            new_mode = f.read().strip().lower()
+    except OSError as e:
+        logger.warning(f"Failed to read mode file {MODE_FILE}: {e}; keeping mode={current_mode}")
+        return
+    if new_mode not in VALID_MODES:
+        logger.warning(f"Invalid mode {new_mode!r} in {MODE_FILE}; keeping mode={current_mode}")
+        return
+    _mode_mtime = st.st_mtime
+    if new_mode != current_mode:
+        logger.info(f"mode changed: {current_mode} -> {new_mode}")
+        current_mode = new_mode
+
+
+async def _mode_watcher() -> None:
+    while True:
+        await asyncio.sleep(1.0)
+        try:
+            _load_mode()
+        except Exception as e:
+            logger.error(f"mode watcher error: {e}")
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _load_mode()
+    logger.info(f"Starting in mode={current_mode}")
     app.state.http_client = httpx.AsyncClient(timeout=60.0)
+    watcher_task = asyncio.create_task(_mode_watcher())
     try:
         yield
     finally:
+        watcher_task.cancel()
+        try:
+            await watcher_task
+        except asyncio.CancelledError:
+            pass
         await app.state.http_client.aclose()
 
 
 app = FastAPI(lifespan=lifespan)
-
-INFERENCE_URL = os.environ.get("INFERENCE_URL", "http://localhost:4000")
-CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
 
 _HOP_BY_HOP = {"host", "content-length", "transfer-encoding", "connection", "accept-encoding"}
 
@@ -71,61 +118,27 @@ async def replay_stream(lines):
         yield line + "\n"
         await asyncio.sleep(0.01)
 
-@app.post("/v1/chat/completions")
-async def chat_completions(request: Request):
-    body = await request.json()
-    if not isinstance(body, dict):
-        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
-    req_hash = get_request_hash(body)
-    is_stream = body.get("stream", False)
-    
-    logger.info(f"Received chat completion request. Hash: {req_hash}, Stream: {is_stream}")
-    
-    if req_hash in cache:
-        logger.info(f"Cache hit for hash: {req_hash}. Replaying response.")
-        cache_entry = cache[req_hash]
-        if cache_entry.get("type") == "stream":
-            return StreamingResponse(
-                replay_stream(cache_entry["data"]),
-                media_type="text/event-stream"
-            )
-        else:
-            return cache_entry["data"]
-            
-    # Cache miss -> Forward to inference backend and record
-    logger.info(f"Forwarding inference request to: {INFERENCE_URL}")
-    
-    headers = _forward_headers(request)
-    
-    client = request.app.state.http_client
 
-    if is_stream:
-        return StreamingResponse(
-            forward_and_record_stream(client, body, headers, req_hash),
-            media_type="text/event-stream"
+async def _forward_completion(client, body, headers, req_hash, record):
+    try:
+        response = await client.post(
+            f"{INFERENCE_URL}/v1/chat/completions",
+            json=body,
+            headers=headers,
+            timeout=60.0
         )
-    else:
-        try:
-            response = await client.post(
-                f"{INFERENCE_URL}/v1/chat/completions",
-                json=body,
-                headers=headers,
-                timeout=60.0
-            )
-            if response.status_code != 200:
-                return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Failed to contact inference backend: {exc}")
+    if response.status_code != 200:
+        return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+    resp_body = response.json()
+    if record:
+        cache[req_hash] = {"type": "completion", "data": resp_body}
+        await save_cache()
+    return resp_body
 
-            resp_body = response.json()
-            cache[req_hash] = {
-                "type": "completion",
-                "data": resp_body
-            }
-            await save_cache()
-            return resp_body
-        except httpx.RequestError as exc:
-            raise HTTPException(status_code=502, detail=f"Failed to contact LiteLLM: {exc}")
 
-async def forward_and_record_stream(client, body, headers, req_hash):
+async def _forward_stream(client, body, headers, req_hash, record):
     recorded_lines = []
     async with client.stream(
         "POST",
@@ -139,16 +152,64 @@ async def forward_and_record_stream(client, body, headers, req_hash):
             yield content
             return
         async for line in response.aiter_lines():
-            recorded_lines.append(line)
+            if record:
+                recorded_lines.append(line)
             yield line + "\n"
 
-    if recorded_lines:
+    if record and recorded_lines:
         logger.info(f"Recording stream response for hash: {req_hash}")
-        cache[req_hash] = {
-            "type": "stream",
-            "data": recorded_lines
-        }
+        cache[req_hash] = {"type": "stream", "data": recorded_lines}
         await save_cache()
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    mode = current_mode  # snapshot for this request — mid-request reload cannot tear
+    body = await request.json()
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+    req_hash = get_request_hash(body)
+    is_stream = body.get("stream", False)
+    headers = _forward_headers(request)
+    client = request.app.state.http_client
+
+    logger.info(f"chat completion request. mode={mode}, hash={req_hash}, stream={is_stream}")
+
+    if mode == "off":
+        if is_stream:
+            return StreamingResponse(
+                _forward_stream(client, body, headers, req_hash, record=False),
+                media_type="text/event-stream",
+            )
+        return await _forward_completion(client, body, headers, req_hash, record=False)
+
+    if req_hash in cache:
+        logger.info(f"Cache hit for hash: {req_hash}. Replaying response.")
+        cache_entry = cache[req_hash]
+        if cache_entry.get("type") == "stream":
+            return StreamingResponse(
+                replay_stream(cache_entry["data"]),
+                media_type="text/event-stream"
+            )
+        return cache_entry["data"]
+
+    logger.info(f"Cache miss for hash: {req_hash}. Forwarding to {INFERENCE_URL}")
+    if is_stream:
+        return StreamingResponse(
+            _forward_stream(client, body, headers, req_hash, record=True),
+            media_type="text/event-stream",
+        )
+    return await _forward_completion(client, body, headers, req_hash, record=True)
+
+
+@app.get("/admin/mode")
+async def admin_mode():
+    return {
+        "mode": current_mode,
+        "cache_size": len(cache),
+        "valid_modes": sorted(VALID_MODES),
+    }
+
 
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])
 async def fallback(request: Request, path: str):
@@ -169,6 +230,5 @@ async def fallback(request: Request, path: str):
             timeout=60.0
         )
     except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=f"Failed to contact LiteLLM: {exc}")
+        raise HTTPException(status_code=502, detail=f"Failed to contact inference backend: {exc}")
     return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
-


### PR DESCRIPTION
Proxy now reads its mode from a ConfigMap-backed file at /etc/replay/mode and hot-reloads within ~1s of a change. Two modes:
  - off (default): pure pass-through, no cache reads or writes
  - on: serve cached responses, record misses to the PVC

Adds GET /admin/mode for runtime introspection. Cache file on the PVC is untouched on mode flips, so on -> off -> on resumes from the same data.

# Pull Request

## Why This Change

The inference replay proxy was always-on with no runtime control — caching
  behavior could only be changed by redeploying the pod. Dev workflows (record a
  session, then switch back to live traffic, or compare cached vs fresh
  behavior) need a fast, declarative toggle that doesn't require image rebuilds
  or rollouts.

  This PR makes the proxy mode runtime-togglable via a ConfigMap-backed source
  of truth, hot-reloaded within ~1 second of a change.

## What Changed

- Mode-aware proxy behavior: The proxy reads its current mode from
  /etc/replay/mode (sourced from a mounted ConfigMap) and branches on it per
  request. Two modes:
      - off (default): pure pass-through, no cache reads or writes — proxy is
    invisible.
      - on: serve cached responses on hit; on miss, forward to upstream and
    record.
 - File-watch hot-reload: A background asyncio task polls the mode file's mtime
  once per second and reloads on change. No pod restart required when flipping
  modes.
 - Admin introspection endpoint: GET /admin/mode returns the current mode,
  cache size, and valid mode set.
 - ConfigMap-backed source of truth: New inference-replay-config ConfigMap with
  data.mode: "off" default. Deployment mounts it read-only at /etc/replay.
 - Documentation: README adds a Modes section, a Toggling Replay section with
  kubectl patch workflow examples, and updated install steps.

**Files:**

- examples/inference-replay/replay-proxy/replay_proxy.py
  - examples/inference-replay/configmap.yaml
  - examples/inference-replay/deployment.yaml
  - examples/inference-replay/README.md

**Added/Changed/Fixed:**

  - Added: inference-replay-config ConfigMap as the runtime source of truth for
  proxy mode.
  - Added: _load_mode() and _mode_watcher() in replay_proxy.py — file-mtime
  polling, validation, atomic in-memory updates.
  - Added: GET /admin/mode endpoint for runtime mode/cache introspection.
  - Added: ConfigMap volume mount at /etc/replay (read-only) in deployment.yaml.
  - Changed: chat_completions handler now snapshots current_mode per request and
  branches between pass-through and cache-and-record behavior.
  - Changed: README documents modes, toggle commands, and updated apply order.
  - Removed: Unused PROXY_MODE: lazy-cache env var (was hardcoded and never
  read).


## Why This Matters

  - Enables interactive record/replay workflows during agent development without
  redeploying.
  - off is the default, so installing the proxy has zero behavioral cost when
  not in use — agents pass through transparently.
  - Mode persists across pod restarts because the ConfigMap is the source of
  truth.
  - Cache file on the PVC is untouched on mode flips, so on → off → on resumes
  from the same captured data.

## Testing
tested manually on local cluster
---

<!-- Close with a short note on functional impact, risk, or rollout. -->
