### PR TITLE
feat(operator): wire Platform Agent to Managed OpenTelemetry for user attribution

### DIFF
--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -1,92 +1,140 @@
-# User Attribution: contract & queries
+# User Attribution: Contract and Queries
 
-How an agent action is linked back to the human who requested it. Design rationale is in
-[designs/audit-logging-user-attribution.md](designs/audit-logging-user-attribution.md); this
-page is the operational contract and the query runbook.
+This page describes how to connect an agent action to the authenticated human who requested
+it. The design rationale is in
+[designs/audit-logging-user-attribution.md](designs/audit-logging-user-attribution.md).
 
-The gateway authenticates the requesting user (Google Chat, via the allow-list) and stamps
-that identity onto the records we already collect. There are three planes, joined by the
-requester's email and the OpenTelemetry trace ID.
+Attribution uses records that kube-agents already produces. The requester identity and the
+OpenTelemetry trace or session ID are the join keys.
 
-## The contract
+## Contract
 
-| Plane                       | Carrier                                                                                                                   | Set by            | Status              |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------- |
-| **LLM calls**               | OpenAI `user` field + `metadata.requested_by` on each request to LiteLLM                                                  | gateway / runtime | runtime (follow-up) |
-| **Traces**                  | a per-request OTel trace with `enduser.id=<email>` and a `hermes.session_id` attribute; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
-| **Cluster / Cloud changes** | `kubeagents.x-k8s.io/requested-by: <email>` label on objects the agent creates                                            | gateway / runtime | runtime (follow-up) |
+| Plane                       | Carrier                                                                                               | Status            |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------- |
+| **Agent traces**            | `hermes.sender.id=<email>`, `user.id=<platform>:<user>`, and `session.id=<Hermes session>` span attrs | Implemented       |
+| **Kubernetes actions**      | API audit entry naming the agent ServiceAccount                                                       | Implemented       |
+| **LLM calls**               | OpenAI `user` plus `metadata.requested_by` on each request to LiteLLM                                 | Runtime follow-up |
+| **Created cluster objects** | `kubeagents.x-k8s.io/requested-by: <identity>` annotation; optional `request-id` trace annotation     | Runtime follow-up |
 
-What the operator provides today (this repo):
+The current repository provides:
 
-- Agent containers are wired to the GKE Managed OpenTelemetry collector
-  (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`) and carry identifying
-  resource attributes (`OTEL_RESOURCE_ATTRIBUTES`: `kubeagents.agent_type`,
-  `kubeagents.agent_name`, namespace). Defaults are overridable via `spec.deployment.env`.
-- A reference API-server audit policy: [`k8s-operator/config/audit/audit-policy.yaml`](../k8s-operator/config/audit/audit-policy.yaml).
+- OpenTelemetry environment defaults on the Platform Agent Deployment: the managed collector
+  endpoint, OTLP protocol, service name, namespace, and agent identity. All defaults can be
+  overridden through `spec.deployment.env`.
+- Session-to-user span enrichment through the `session_store` and `session_otel_bridge`
+  plugins. See [Google Chat session metadata data flow](gchat-session-metadata-data-flow.md).
+- Structured chat and tool audit records on standard output. GKE's logging agent collects
+  container standard output without giving the workload direct write access to Cloud Logging.
+- A reference API-server audit policy for self-managed clusters:
+  [`k8s-operator/config/audit/audit-policy.yaml`](../k8s-operator/config/audit/audit-policy.yaml).
 
-## Enabling
+## Enable Managed OpenTelemetry
 
-Agent traces/logs export to the in-cluster GKE Managed OpenTelemetry collector, which
-forwards to Cloud Trace/Logging. Enable it on the cluster:
+The provisioning script enables Managed OpenTelemetry on new GKE clusters. For an existing
+supported cluster, run:
 
 ```bash
 gcloud beta container clusters update "$CLUSTER_NAME" \
-    --location "$LOCATION" \
-    --managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS
+  --project "$PROJECT_ID" \
+  --location "$LOCATION" \
+  --managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS
 ```
 
-The operator wires each agent to the collector automatically; override per-agent via
-`spec.deployment.env` if needed. On GKE, API audit logs flow to Cloud Logging automatically;
-use [`audit-policy.yaml`](../k8s-operator/config/audit/audit-policy.yaml) as the reference
-policy for self-managed clusters.
+Check the current GKE version and release-channel prerequisites in the
+[Managed OpenTelemetry setup guide](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-otel-gke).
+The in-cluster collector endpoint is
+`http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318`.
 
-> **Label/annotation key:** `kubeagents.x-k8s.io/requested-by`. Value is the requester's
-> email. Optional companion `kubeagents.x-k8s.io/request-id` carries the trace ID for a direct
-> jump to Cloud Trace.
+GKE applies a managed Kubernetes audit policy and writes Kubernetes API audit entries to Cloud
+Logging. Admin Activity audit logs are always enabled; enable Data Access audit logs explicitly
+if your investigation or retention policy requires them. See
+[GKE audit logging](https://cloud.google.com/kubernetes-engine/docs/how-to/audit-logging).
 
-## Trust boundary
+For a self-managed cluster, adapt the reference policy to the deployment namespace and configure
+an API-server audit backend. The checked-in policy assumes `kubeagents-system`.
 
-- The **agent actor** (its ServiceAccount / GCP SA) is recorded tamper-proof, server-side, by
-  the Kubernetes API audit log and Cloud Audit Logs — independent of any label.
-- The **requester** is _asserted by the gateway_. A single trusted, audited choke point — far
-  better than chat history, but not cryptographically tamper-proof. If a stronger guarantee is
-  needed later, see the design doc's "stronger guarantees" section.
+## Attribution Annotations
 
-## Query runbook
+The runtime follow-up should use these annotations on objects that it creates:
 
-Replace `alice@example.com` and the project/cluster as needed.
+- `kubeagents.x-k8s.io/requested-by`: authenticated requester identity; currently the Google
+  Chat sender email.
+- `kubeagents.x-k8s.io/request-id`: OpenTelemetry trace ID, when available.
 
-**Every LLM call a person made (Cloud Logging):**
+These are annotations, not labels. Email addresses contain characters that Kubernetes label
+values reject, while annotation values permit arbitrary strings. Annotations also avoid placing
+personally identifiable information in selector indexes.
 
+## Trust Boundary
+
+- The Kubernetes API server records the **agent actor** server-side as its ServiceAccount. This
+  record does not depend on a workload-supplied annotation.
+- The Google Chat adapter and session plugins assert the **requester** on spans from authenticated
+  ingress metadata. The planned LLM fields and object annotations must be set by the trusted
+  runtime, not generated by the model.
+- An object annotation is supporting correlation data, not durable proof. It can be changed, is
+  unavailable after some deletions, and does not identify the requester for unannotated updates.
+- Server-generated logs are tamper-resistant only when retention and IAM prevent the agent from
+  modifying or deleting the log sink. The default provisioning grants the agent read-only log
+  access; stronger environments should route an immutable copy to a separate security project.
+- Prompts, model outputs, chat messages, and tool arguments can contain secrets or personal data.
+  Restrict access and retention, and redact sensitive values before exporting them.
+
+## Query Runbook
+
+Replace the example identities, project, cluster, and ServiceAccount as needed.
+
+### Find traces for a requester
+
+In Cloud Trace Explorer, add an attribute filter:
+
+```text
+hermes.sender.id: "alice@example.com"
 ```
-resource.type="k8s_container"
-labels."k8s-pod/app"="litellm"
-jsonPayload.metadata.requested_by="alice@example.com"
+
+To narrow the result to a Hermes session, add:
+
+```text
+session.id: "20260702_153830_50074bf0"
 ```
 
-**Every trace for a person (Cloud Trace filter):**
+### Find agent Kubernetes mutations on GKE
 
-```
-enduser.id:"alice@example.com"
-```
+Use this Cloud Logging filter:
 
-**Every cluster object created for a person:**
-
-```
-kubectl get all,configmap,rolebinding -A \
-  -l kubeagents.x-k8s.io/requested-by=alice@example.com
+```text
+resource.type="k8s_cluster"
+protoPayload.serviceName="k8s.io"
+protoPayload.authenticationInfo.principalEmail="system:serviceaccount:kubeagents-system:AGENT_SERVICE_ACCOUNT"
 ```
 
-**Who caused a specific change (from a K8s audit entry):** read the object's
-`kubeagents.x-k8s.io/requested-by` label; the audit entry's `user.username` is the agent
-ServiceAccount that performed it.
+The audit entry contains the verb, resource, namespace, name, timestamp, and agent identity. On a
+self-managed cluster, the equivalent audit event field is `user.username`.
 
-**From an LLM call to the cluster change it caused:** take the `trace_id` on the LLM span and
-filter Cloud Trace / the `request-id` label by it.
+### Find objects annotated for a requester
 
-**From a trace to the Hermes session logs (Cloud Logging):** take the `hermes.session_id`
-attribute on the trace and match it against the Hermes logs shipped via Fluent Bit:
+After the cluster-object runtime follow-up lands:
 
+```bash
+kubectl get all,configmap,rolebinding -A -o json | \
+  jq --arg requester "alice@example.com" '
+    .items[]
+    | select(.metadata.annotations["kubeagents.x-k8s.io/requested-by"] == $requester)
+    | [.apiVersion, .kind, .metadata.namespace, .metadata.name]
+    | @tsv
+  '
 ```
-jsonPayload.session_id="<hermes.session_id>"
+
+### Find LiteLLM calls for a requester
+
+After the LLM runtime follow-up lands, filter the LiteLLM records on
+`metadata.requested_by="alice@example.com"`. Use the record's trace ID to open the related Cloud
+Trace trace.
+
+### Join traces to chat logs
+
+Take `session.id` from a span and filter structured container logs by the same value:
+
+```text
+jsonPayload.session_id="20260702_153830_50074bf0"
 ```

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -13,7 +13,7 @@ requester's email and the OpenTelemetry trace ID.
 | Plane | Carrier | Set by | Status |
 |------|---------|--------|--------|
 | **LLM calls** | OpenAI `user` field + `metadata.requested_by` on each request to LiteLLM | gateway / runtime | runtime (follow-up) |
-| **Traces** | a per-request OTel trace with `enduser.id=<email>`; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
+| **Traces** | a per-request OTel trace with `enduser.id=<email>` and a `hermes.session_id` attribute; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
 | **Cluster / Cloud changes** | `kubeagents.x-k8s.io/requested-by: <email>` label on objects the agent creates | gateway / runtime | runtime (follow-up) |
 
 What the operator provides today (this repo):
@@ -80,3 +80,9 @@ ServiceAccount that performed it.
 
 **From an LLM call to the cluster change it caused:** take the `trace_id` on the LLM span and
 filter Cloud Trace / the `request-id` label by it.
+
+**From a trace to the Hermes session logs (Cloud Logging):** take the `hermes.session_id`
+attribute on the trace and match it against the Hermes logs shipped via Fluent Bit:
+```
+jsonPayload.session_id="<hermes.session_id>"
+```

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -1,0 +1,82 @@
+# User Attribution: contract & queries
+
+How an agent action is linked back to the human who requested it. Design rationale is in
+[designs/audit-logging-user-attribution.md](designs/audit-logging-user-attribution.md); this
+page is the operational contract and the query runbook.
+
+The gateway authenticates the requesting user (Google Chat, via the allow-list) and stamps
+that identity onto the records we already collect. There are three planes, joined by the
+requester's email and the OpenTelemetry trace ID.
+
+## The contract
+
+| Plane | Carrier | Set by | Status |
+|------|---------|--------|--------|
+| **LLM calls** | OpenAI `user` field + `metadata.requested_by` on each request to LiteLLM | gateway / runtime | runtime (follow-up) |
+| **Traces** | a per-request OTel trace with `enduser.id=<email>`; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
+| **Cluster / Cloud changes** | `kubeagents.x-k8s.io/requested-by: <email>` label on objects the agent creates | gateway / runtime | runtime (follow-up) |
+
+What the operator provides today (this repo):
+
+- Agent containers are wired to the GKE Managed OpenTelemetry collector
+  (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`) and carry identifying
+  resource attributes (`OTEL_RESOURCE_ATTRIBUTES`: `kubeagents.agent_type`,
+  `kubeagents.agent_name`, namespace). Defaults are overridable via `spec.deployment.env`.
+- A reference API-server audit policy: [`k8s-operator/config/audit/audit-policy.yaml`](../k8s-operator/config/audit/audit-policy.yaml).
+
+## Enabling
+
+Agent traces/logs export to the in-cluster GKE Managed OpenTelemetry collector, which
+forwards to Cloud Trace/Logging. Enable it on the cluster:
+
+```bash
+gcloud beta container clusters update "$CLUSTER_NAME" \
+    --location "$LOCATION" \
+    --managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS
+```
+
+The operator wires each agent to the collector automatically; override per-agent via
+`spec.deployment.env` if needed. On GKE, API audit logs flow to Cloud Logging automatically;
+use [`audit-policy.yaml`](../k8s-operator/config/audit/audit-policy.yaml) as the reference
+policy for self-managed clusters.
+
+> **Label/annotation key:** `kubeagents.x-k8s.io/requested-by`. Value is the requester's
+> email. Optional companion `kubeagents.x-k8s.io/request-id` carries the trace ID for a direct
+> jump to Cloud Trace.
+
+## Trust boundary
+
+- The **agent actor** (its ServiceAccount / GCP SA) is recorded tamper-proof, server-side, by
+  the Kubernetes API audit log and Cloud Audit Logs — independent of any label.
+- The **requester** is *asserted by the gateway*. A single trusted, audited choke point — far
+  better than chat history, but not cryptographically tamper-proof. If a stronger guarantee is
+  needed later, see the design doc's "stronger guarantees" section.
+
+## Query runbook
+
+Replace `alice@example.com` and the project/cluster as needed.
+
+**Every LLM call a person made (Cloud Logging):**
+```
+resource.type="k8s_container"
+labels."k8s-pod/app"="litellm"
+jsonPayload.metadata.requested_by="alice@example.com"
+```
+
+**Every trace for a person (Cloud Trace filter):**
+```
+enduser.id:"alice@example.com"
+```
+
+**Every cluster object created for a person:**
+```
+kubectl get all,configmap,rolebinding -A \
+  -l kubeagents.x-k8s.io/requested-by=alice@example.com
+```
+
+**Who caused a specific change (from a K8s audit entry):** read the object's
+`kubeagents.x-k8s.io/requested-by` label; the audit entry's `user.username` is the agent
+ServiceAccount that performed it.
+
+**From an LLM call to the cluster change it caused:** take the `trace_id` on the LLM span and
+filter Cloud Trace / the `request-id` label by it.

--- a/docs/attribution.md
+++ b/docs/attribution.md
@@ -10,11 +10,11 @@ requester's email and the OpenTelemetry trace ID.
 
 ## The contract
 
-| Plane | Carrier | Set by | Status |
-|------|---------|--------|--------|
-| **LLM calls** | OpenAI `user` field + `metadata.requested_by` on each request to LiteLLM | gateway / runtime | runtime (follow-up) |
-| **Traces** | a per-request OTel trace with `enduser.id=<email>` and a `hermes.session_id` attribute; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
-| **Cluster / Cloud changes** | `kubeagents.x-k8s.io/requested-by: <email>` label on objects the agent creates | gateway / runtime | runtime (follow-up) |
+| Plane                       | Carrier                                                                                                                   | Set by            | Status              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------------------- |
+| **LLM calls**               | OpenAI `user` field + `metadata.requested_by` on each request to LiteLLM                                                  | gateway / runtime | runtime (follow-up) |
+| **Traces**                  | a per-request OTel trace with `enduser.id=<email>` and a `hermes.session_id` attribute; W3C context propagated downstream | gateway / runtime | runtime (follow-up) |
+| **Cluster / Cloud changes** | `kubeagents.x-k8s.io/requested-by: <email>` label on objects the agent creates                                            | gateway / runtime | runtime (follow-up) |
 
 What the operator provides today (this repo):
 
@@ -48,7 +48,7 @@ policy for self-managed clusters.
 
 - The **agent actor** (its ServiceAccount / GCP SA) is recorded tamper-proof, server-side, by
   the Kubernetes API audit log and Cloud Audit Logs — independent of any label.
-- The **requester** is *asserted by the gateway*. A single trusted, audited choke point — far
+- The **requester** is _asserted by the gateway_. A single trusted, audited choke point — far
   better than chat history, but not cryptographically tamper-proof. If a stronger guarantee is
   needed later, see the design doc's "stronger guarantees" section.
 
@@ -57,6 +57,7 @@ policy for self-managed clusters.
 Replace `alice@example.com` and the project/cluster as needed.
 
 **Every LLM call a person made (Cloud Logging):**
+
 ```
 resource.type="k8s_container"
 labels."k8s-pod/app"="litellm"
@@ -64,11 +65,13 @@ jsonPayload.metadata.requested_by="alice@example.com"
 ```
 
 **Every trace for a person (Cloud Trace filter):**
+
 ```
 enduser.id:"alice@example.com"
 ```
 
 **Every cluster object created for a person:**
+
 ```
 kubectl get all,configmap,rolebinding -A \
   -l kubeagents.x-k8s.io/requested-by=alice@example.com
@@ -83,6 +86,7 @@ filter Cloud Trace / the `request-id` label by it.
 
 **From a trace to the Hermes session logs (Cloud Logging):** take the `hermes.session_id`
 attribute on the trace and match it against the Hermes logs shipped via Fluent Bit:
+
 ```
 jsonPayload.session_id="<hermes.session_id>"
 ```

--- a/docs/designs/audit-logging-user-attribution.md
+++ b/docs/designs/audit-logging-user-attribution.md
@@ -1,0 +1,129 @@
+# Design: Audit Logging & User Attribution for kube-agents
+
+**Status:** Draft for review
+**Priority:** P0 — addresses external concern (Waze #2) and the internal "Audit log all agents" objective
+
+---
+
+## TL;DR
+
+Today we can see *that an agent acted*, but not *which human asked for it* — that link lives
+only in chat history, which is not durable, queryable, or joinable to what the agent did.
+
+We don't need to build a new system. The telemetry already exists: LiteLLM and GKE Managed
+OpenTelemetry already capture LLM calls, traces, and audit logs. The only thing missing is the
+**requester's identity** in those records.
+
+The fix: **stamp the requester onto records we already produce.** The gateway already knows
+who the user is, so it tags each request, and that tag rides into the existing logs and audit.
+We use only things the stack already understands — the LLM `user` field, OpenTelemetry trace
+context, and Kubernetes labels. No new resource, nothing new for the agent to learn.
+
+---
+
+## 1. Problem
+
+We need an audit trail that links **every agent action back to the human who requested it**,
+and that is **durable** and **queryable** — independent of chat history.
+
+Chat history can't be that trail:
+- **Not durable** — messages age out; spaces get deleted; history is editable.
+- **Not joinable** — nothing connects a chat message to the cluster changes, PRs, or LLM
+  calls the agent then makes.
+- **Not queryable** — you can't ask "what did Alice cause last week?" or "who triggered this
+  deletion?"
+
+**Root cause.** A request crosses two identity domains, and nothing links them:
+
+| | Human → Agent | Agent → LLM / Kubernetes / Cloud |
+|---|---|---|
+| **Who** | Google Chat email | the agent's service account |
+| **Recorded in** | chat history | LiteLLM logs, K8s audit, Cloud audit |
+
+Every action record names the *agent*, never the *human*. The fix is a single tag, set where
+the human is known and carried into the records where actions are logged.
+
+### Goals
+- Attribute every agent action (LLM call, cluster change, tool run) to the requesting human.
+- Keep the trail durable and queryable, independent of chat history.
+- Reuse existing infrastructure; use concepts the agent already understands.
+
+### Non-goals (this version)
+- Tamper-proof, non-repudiable proof of the *human* claim — see §5. v1 trusts the gateway,
+  which already authenticates the user.
+- Per-action authorization / policy enforcement.
+- Changing the agent runtime's internals.
+
+---
+
+## 2. What we already have
+
+The expensive part — a pipeline that durably ships telemetry to a queryable store — is already
+running. That's why this fix is small.
+
+| Asset | What it does today | Why it matters |
+|------|--------------------|----------------|
+| **GKE Managed OpenTelemetry** | In-cluster collector exporting traces/metrics/logs to Cloud Observability | A managed telemetry pipeline we don't run or secure |
+| **LiteLLM proxy** | Every agent's LLM calls route through it; it logs prompt/output/cost and exports to the collector | LLM activity is already captured — it just lacks the human's identity |
+| **Per-agent service account** | The operator gives each agent its own SA | The *agent* actor is already recorded tamper-proof by K8s/Cloud audit |
+| **Agent OTEL wiring** | `OTEL_SERVICE_NAME` already set on the agent Deployment | Agent traces are one config step from the collector |
+
+The agent's own identity is already captured server-side. We only need to add the **human**
+half, as a tag.
+
+---
+
+## 3. Solution: stamp the requester
+
+The gateway authenticates the chat user (it already does, via the allow-list). It tags each
+request with that identity, and the tag flows into the three places actions are recorded.
+
+| Plane | Already records | We add | Using |
+|------|-----------------|--------|-------|
+| **LLM calls** | LiteLLM logs every call | `user` and `requested_by` on each call | the standard LLM `user` field |
+| **Traces** | OTel collector, deployed | a per-request trace tagged with the requester | standard OpenTelemetry trace context |
+| **Cluster / Cloud changes** | K8s + Cloud audit record the SA actor | a `requested-by` label on objects the agent creates | standard Kubernetes labels |
+
+**How you use it.** Filter any of these by the requester's email to see everything a person
+caused; or start from one action and read its tag to find who asked. The trace ID ties an LLM
+call to the cluster change that followed from the same request.
+
+### Trust model (the honest limit)
+- The **agent actor** is always recorded tamper-proof by K8s/Cloud audit, server-side.
+- The **human tag** is *asserted by the gateway*. The gateway is a single, trusted, audited
+  choke point — far better than editable chat history, but not cryptographically tamper-proof.
+  A compromised agent could mislabel an object it creates; even then the real actor and
+  timestamp remain in the audit log, so the action is never *unattributable* — only its human
+  tag is suspect.
+- If stronger proof is ever needed, §5 is the upgrade. v1 stops here on purpose: most of the
+  value for a small fraction of the effort.
+
+---
+
+## 4. Plan
+
+Each step is independently shippable and useful. Ordered by return on effort.
+
+| Step | Delivers | Work | Effort |
+|------|----------|------|--------|
+| **1. LLM attribution** | Every prompt/output/cost tied to a human in LiteLLM logs | Gateway sets `user` + `requested_by` on each LLM call; document the contract | **Small** (mostly config) |
+| **2. Trace identity** | One trace per request, tagged with the human, across agent + LiteLLM | Operator adds the OTLP endpoint + agent identity env; gateway starts a tagged trace and propagates context; enable Managed OTel | **Small–Medium** |
+| **3. Cluster tag + queries** | `requested-by` on cluster objects; a reference audit policy; a query runbook | Helper to stamp the label on created objects; reference `AuditPolicy`; document the queries | **Medium** |
+
+Step 1 alone already attributes the most sensitive data — LLM prompts and outputs — to the
+requesting human, almost entirely through configuration. Steps 2–3 extend the same tag to the
+trace and cluster planes.
+
+---
+
+## 5. If we need stronger guarantees later
+
+Only if gateway-asserted attribution proves insufficient (e.g. for compliance or to gate
+policy). None of this is needed for v1:
+
+- **A request record stamped at admission.** A small resource the *gateway code* creates per
+  request (not the agent), stamped with the authenticated submitter's identity and made
+  immutable — making the "who asked" claim tamper-evident. Creation stays in deterministic
+  code, so the agent never has to understand a new concept.
+- **Signed requests** — the gateway signs the requester, verified before action.
+- **Long-term export** — a BigQuery / Log Analytics sink for retention and reporting.

--- a/docs/designs/audit-logging-user-attribution.md
+++ b/docs/designs/audit-logging-user-attribution.md
@@ -1,134 +1,153 @@
-# Design: Audit Logging & User Attribution for kube-agents
+# Design: Audit Logging and User Attribution for kube-agents
 
 **Status:** Draft for review
-**Priority:** P0 — addresses external concern (Waze #2) and the internal "Audit log all agents" objective
+
+**Priority:** P0 — addresses external concern (Waze #2) and the internal "Audit log all agents"
+objective
 
 ---
 
 ## TL;DR
 
-Today we can see _that an agent acted_, but not _which human asked for it_ — that link lives
-only in chat history, which is not durable, queryable, or joinable to what the agent did.
+Kubernetes and Cloud audit logs identify the agent ServiceAccount, but that identity alone does
+not identify the human who requested an action. kube-agents can close most of that gap by adding
+the authenticated requester and trace or session ID to telemetry records it already produces.
 
-We don't need to build a new system. The telemetry already exists: LiteLLM and GKE Managed
-OpenTelemetry already capture LLM calls, traces, and audit logs. The only thing missing is the
-**requester's identity** in those records.
-
-The fix: **stamp the requester onto records we already produce.** The gateway already knows
-who the user is, so it tags each request, and that tag rides into the existing logs and audit.
-We use only things the stack already understands — the LLM `user` field, OpenTelemetry trace
-context, and Kubernetes labels. No new resource, nothing new for the agent to learn.
+The current runtime enriches Hermes spans with the Google Chat sender and session. This change
+wires the Platform Agent Deployment to the GKE Managed OpenTelemetry endpoint, adds stable agent
+resource attributes, documents the correlation contract, and provides a reference Kubernetes
+audit policy. LLM-request attribution and cluster-object annotations remain runtime follow-ups.
 
 ---
 
 ## 1. Problem
 
-We need an audit trail that links **every agent action back to the human who requested it**,
-and that is **durable** and **queryable** — independent of chat history.
+An investigation should be able to connect these identities:
 
-Chat history can't be that trail:
+| Boundary                     | Identity available at that boundary       |
+| ---------------------------- | ----------------------------------------- |
+| Human to Platform Agent      | Authenticated chat sender                 |
+| Platform Agent to Kubernetes | Kubernetes ServiceAccount                 |
+| Platform Agent to Cloud APIs | Google service account                    |
+| Platform Agent to LiteLLM    | Agent or workload identity, but not human |
 
-- **Not durable** — messages age out; spaces get deleted; history is editable.
-- **Not joinable** — nothing connects a chat message to the cluster changes, PRs, or LLM
-  calls the agent then makes.
-- **Not queryable** — you can't ask "what did Alice cause last week?" or "who triggered this
-  deletion?"
+Chat history cannot be the only join:
 
-**Root cause.** A request crosses two identity domains, and nothing links them:
-
-|                 | Human → Agent     | Agent → LLM / Kubernetes / Cloud     |
-| --------------- | ----------------- | ------------------------------------ |
-| **Who**         | Google Chat email | the agent's service account          |
-| **Recorded in** | chat history      | LiteLLM logs, K8s audit, Cloud audit |
-
-Every action record names the _agent_, never the _human_. The fix is a single tag, set where
-the human is known and carried into the records where actions are logged.
+- Messages can age out, spaces can be deleted, and retention differs by platform.
+- A chat message does not inherently carry the trace ID of the work it initiated.
+- Kubernetes and Cloud audit entries name the workload identity, not the chat sender.
 
 ### Goals
 
-- Attribute every agent action (LLM call, cluster change, tool run) to the requesting human.
-- Keep the trail durable and queryable, independent of chat history.
-- Reuse existing infrastructure; use concepts the agent already understands.
+- Provide durable, queryable records for agent traces and Kubernetes API mutations.
+- Carry an authenticated requester identifier through the records where the runtime can do so
+  reliably.
+- Correlate records using trace and Hermes session IDs.
+- Reuse Managed OpenTelemetry, Cloud Logging, LiteLLM, and Kubernetes audit infrastructure.
 
-### Non-goals (this version)
+### Non-goals
 
-- Tamper-proof, non-repudiable proof of the _human_ claim — see §5. v1 trusts the gateway,
-  which already authenticates the user.
-- Per-action authorization / policy enforcement.
-- Changing the agent runtime's internals.
-
----
-
-## 2. What we already have
-
-The expensive part — a pipeline that durably ships telemetry to a queryable store — is already
-running. That's why this fix is small.
-
-| Asset                         | What it does today                                                                                | Why it matters                                                        |
-| ----------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| **GKE Managed OpenTelemetry** | In-cluster collector exporting traces/metrics/logs to Cloud Observability                         | A managed telemetry pipeline we don't run or secure                   |
-| **LiteLLM proxy**             | Every agent's LLM calls route through it; it logs prompt/output/cost and exports to the collector | LLM activity is already captured — it just lacks the human's identity |
-| **Per-agent service account** | The operator gives each agent its own SA                                                          | The _agent_ actor is already recorded tamper-proof by K8s/Cloud audit |
-| **Agent OTEL wiring**         | `OTEL_SERVICE_NAME` already set on the agent Deployment                                           | Agent traces are one config step from the collector                   |
-
-The agent's own identity is already captured server-side. We only need to add the **human**
-half, as a tag.
+- Cryptographic non-repudiation of the human identity.
+- Per-action authorization or policy enforcement.
+- Treating a model-generated field as trusted identity.
+- Claiming that an object annotation alone attributes every update or deletion.
 
 ---
 
-## 3. Solution: stamp the requester
+## 2. Existing Components
 
-The gateway authenticates the chat user (it already does, via the allow-list). It tags each
-request with that identity, and the tag flows into the three places actions are recorded.
+| Component                            | Current behavior                                                                                              |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| **Managed OpenTelemetry for GKE**    | Provides an in-cluster OTLP endpoint and exports accepted signals to Google Cloud Observability               |
+| **Hermes OTel and session plugins**  | Add `hermes.sender.id`, `user.id`, and `session.id` to spans using authenticated gateway session metadata     |
+| **LiteLLM proxy**                    | Receives agent LLM calls and exports telemetry, but requester fields are a follow-up                          |
+| **Dedicated agent ServiceAccount**   | Gives Kubernetes audit entries a stable workload actor                                                        |
+| **Chat and tool audit records**      | Write structured records to standard output for collection by the platform logging agent                      |
+| **Kubernetes API-server audit logs** | Record the requesting ServiceAccount, verb, target resource, and timestamp independently of workload metadata |
 
-| Plane                       | Already records                       | We add                                                                                      | Using                                |
-| --------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------ |
-| **LLM calls**               | LiteLLM logs every call               | `user` and `requested_by` on each call                                                      | the standard LLM `user` field        |
-| **Traces**                  | OTel collector, deployed              | a per-request trace tagged with the requester, plus the Hermes `session_id` as an attribute | standard OpenTelemetry trace context |
-| **Cluster / Cloud changes** | K8s + Cloud audit record the SA actor | a `requested-by` label on objects the agent creates                                         | standard Kubernetes labels           |
-
-**How you use it.** Filter any of these by the requester's email to see everything a person
-caused; or start from one action and read its tag to find who asked. The trace ID ties an LLM
-call to the cluster change that followed from the same request, and the Hermes `session_id`
-attribute correlates a trace with the Hermes session logs already shipped via Fluent Bit.
-
-### Trust model (the honest limit)
-
-- The **agent actor** is always recorded tamper-proof by K8s/Cloud audit, server-side.
-- The **human tag** is _asserted by the gateway_. The gateway is a single, trusted, audited
-  choke point — far better than editable chat history, but not cryptographically tamper-proof.
-  A compromised agent could mislabel an object it creates; even then the real actor and
-  timestamp remain in the audit log, so the action is never _unattributable_ — only its human
-  tag is suspect.
-- If stronger proof is ever needed, §5 is the upgrade. v1 stops here on purpose: most of the
-  value for a small fraction of the effort.
+The expensive storage and query pipelines already exist. The remaining work is to use consistent
+identity and correlation fields at each boundary.
 
 ---
 
-## 4. Plan
+## 3. Attribution Contract
 
-Each step is independently shippable and useful. Ordered by return on effort.
+| Plane                       | Carrier                                                                                               | Status            |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------- |
+| **Agent traces**            | `hermes.sender.id=<email>`, `user.id=<platform>:<user>`, and `session.id=<Hermes session>` span attrs | Implemented       |
+| **Kubernetes actions**      | API audit record naming the agent ServiceAccount                                                      | Implemented       |
+| **LLM calls**               | OpenAI `user` and `metadata.requested_by`                                                             | Runtime follow-up |
+| **Created cluster objects** | `kubeagents.x-k8s.io/requested-by` and optional `request-id` annotations                              | Runtime follow-up |
 
-| Step                         | Delivers                                                                     | Work                                                                                                                            | Effort                    |
-| ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| **1. LLM attribution**       | Every prompt/output/cost tied to a human in LiteLLM logs                     | Gateway sets `user` + `requested_by` on each LLM call; document the contract                                                    | **Small** (mostly config) |
-| **2. Trace identity**        | One trace per request, tagged with the human, across agent + LiteLLM         | Operator adds the OTLP endpoint + agent identity env; gateway starts a tagged trace and propagates context; enable Managed OTel | **Small–Medium**          |
-| **3. Cluster tag + queries** | `requested-by` on cluster objects; a reference audit policy; a query runbook | Helper to stamp the label on created objects; reference `AuditPolicy`; document the queries                                     | **Medium**                |
+The operator also adds process-level resource identity:
 
-Step 1 alone already attributes the most sensitive data — LLM prompts and outputs — to the
-requesting human, almost entirely through configuration. Steps 2–3 extend the same tag to the
-trace and cluster planes.
+```text
+service.name=<agent-name>-gateway
+service.namespace=<namespace>
+k8s.namespace.name=<namespace>
+kubeagents.agent_type=platform
+kubeagents.agent_name=<agent-name>
+```
+
+Object identity must use an annotation rather than a label. The current requester identifier is
+an email address, and `@` is not valid in a Kubernetes label value. An annotation accepts the
+identity without lossy encoding and makes clear that this is correlation metadata, not a selector
+or authorization input.
+
+### Correlation
+
+- Start from a person: filter spans by `hermes.sender.id`, then follow the trace and session IDs.
+- Start from a Kubernetes mutation: inspect the audit entry for the agent ServiceAccount, then
+  correlate by time and target object. When present, the object's requester and request-ID
+  annotations narrow the join.
+- Start from a chat log: use its `session_id` to find spans with the same `session.id`.
+- Start from an LLM call after the follow-up lands: use `requested_by` or its trace ID.
+
+The [operational runbook](../attribution.md) contains concrete queries.
 
 ---
 
-## 5. If we need stronger guarantees later
+## 4. Trust and Security Model
 
-Only if gateway-asserted attribution proves insufficient (e.g. for compliance or to gate
-policy). None of this is needed for v1:
+- **Workload actor:** The Kubernetes API server generates the audit entry. A workload-supplied
+  annotation cannot change the ServiceAccount recorded by the API server.
+- **Human requester:** The gateway/runtime asserts the requester from authenticated ingress
+  metadata. The model must not supply or rewrite this value.
+- **Object annotation:** This is supporting evidence only. It can be changed, might not exist on
+  updates, and can disappear with the object. It must not be used for authorization.
+- **Audit-log isolation:** Server-generated records are tamper-resistant only if the agent cannot
+  modify their sink or retention. The standard provisioning grants read-only log access. Higher
+  assurance deployments should export an immutable copy to a separate security project.
+- **Data minimization:** Emails, prompts, outputs, chat messages, and tool inputs can be sensitive.
+  Apply least-privilege access and retention, and scrub secrets before export. The reference audit
+  policy records only metadata for arbitrary mutations so Secret bodies are not captured.
+- **Dedicated identity:** Each Platform Agent uses a dedicated ServiceAccount rather than the
+  namespace's `default` ServiceAccount.
 
-- **A request record stamped at admission.** A small resource the _gateway code_ creates per
-  request (not the agent), stamped with the authenticated submitter's identity and made
-  immutable — making the "who asked" claim tamper-evident. Creation stays in deterministic
-  code, so the agent never has to understand a new concept.
-- **Signed requests** — the gateway signs the requester, verified before action.
-- **Long-term export** — a BigQuery / Log Analytics sink for retention and reporting.
+---
+
+## 5. Delivery Plan
+
+| Step                             | Work                                                                                              | State             |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------- |
+| **Session and trace identity**   | Persist authenticated session metadata and attach the fixed identity allowlist to Hermes spans    | Implemented       |
+| **Agent telemetry export**       | Set OTLP endpoint, protocol, service name, namespace, and agent resource attributes               | This change       |
+| **Server-side action ledger**    | Document GKE behavior and provide a reference audit policy for self-managed clusters              | This change       |
+| **LLM requester fields**         | Set `user` and `metadata.requested_by` deterministically on LiteLLM requests                      | Runtime follow-up |
+| **Cluster object annotations**   | Stamp `requested-by` and `request-id` on objects created through trusted runtime paths            | Runtime follow-up |
+| **End-to-end correlation tests** | Verify a chat request, trace, LLM record, and Kubernetes mutation can be joined in a test cluster | Follow-up         |
+
+---
+
+## 6. Stronger Guarantees
+
+If gateway-asserted attribution is insufficient for compliance or policy decisions, add one or
+more of these controls:
+
+- An admission component that stamps immutable request metadata from authenticated context.
+- Signed requester assertions verified before a tool or API call executes.
+- A request record written by deterministic gateway code and protected from agent mutation.
+- A cross-project log sink with retention lock and access controlled by the security team.
+
+These controls are intentionally outside the first version, but the trace and session join keys
+remain useful if they are added later.

--- a/docs/designs/audit-logging-user-attribution.md
+++ b/docs/designs/audit-logging-user-attribution.md
@@ -7,7 +7,7 @@
 
 ## TL;DR
 
-Today we can see *that an agent acted*, but not *which human asked for it* — that link lives
+Today we can see _that an agent acted_, but not _which human asked for it_ — that link lives
 only in chat history, which is not durable, queryable, or joinable to what the agent did.
 
 We don't need to build a new system. The telemetry already exists: LiteLLM and GKE Managed
@@ -27,6 +27,7 @@ We need an audit trail that links **every agent action back to the human who req
 and that is **durable** and **queryable** — independent of chat history.
 
 Chat history can't be that trail:
+
 - **Not durable** — messages age out; spaces get deleted; history is editable.
 - **Not joinable** — nothing connects a chat message to the cluster changes, PRs, or LLM
   calls the agent then makes.
@@ -35,21 +36,23 @@ Chat history can't be that trail:
 
 **Root cause.** A request crosses two identity domains, and nothing links them:
 
-| | Human → Agent | Agent → LLM / Kubernetes / Cloud |
-|---|---|---|
-| **Who** | Google Chat email | the agent's service account |
-| **Recorded in** | chat history | LiteLLM logs, K8s audit, Cloud audit |
+|                 | Human → Agent     | Agent → LLM / Kubernetes / Cloud     |
+| --------------- | ----------------- | ------------------------------------ |
+| **Who**         | Google Chat email | the agent's service account          |
+| **Recorded in** | chat history      | LiteLLM logs, K8s audit, Cloud audit |
 
-Every action record names the *agent*, never the *human*. The fix is a single tag, set where
+Every action record names the _agent_, never the _human_. The fix is a single tag, set where
 the human is known and carried into the records where actions are logged.
 
 ### Goals
+
 - Attribute every agent action (LLM call, cluster change, tool run) to the requesting human.
 - Keep the trail durable and queryable, independent of chat history.
 - Reuse existing infrastructure; use concepts the agent already understands.
 
 ### Non-goals (this version)
-- Tamper-proof, non-repudiable proof of the *human* claim — see §5. v1 trusts the gateway,
+
+- Tamper-proof, non-repudiable proof of the _human_ claim — see §5. v1 trusts the gateway,
   which already authenticates the user.
 - Per-action authorization / policy enforcement.
 - Changing the agent runtime's internals.
@@ -61,12 +64,12 @@ the human is known and carried into the records where actions are logged.
 The expensive part — a pipeline that durably ships telemetry to a queryable store — is already
 running. That's why this fix is small.
 
-| Asset | What it does today | Why it matters |
-|------|--------------------|----------------|
-| **GKE Managed OpenTelemetry** | In-cluster collector exporting traces/metrics/logs to Cloud Observability | A managed telemetry pipeline we don't run or secure |
-| **LiteLLM proxy** | Every agent's LLM calls route through it; it logs prompt/output/cost and exports to the collector | LLM activity is already captured — it just lacks the human's identity |
-| **Per-agent service account** | The operator gives each agent its own SA | The *agent* actor is already recorded tamper-proof by K8s/Cloud audit |
-| **Agent OTEL wiring** | `OTEL_SERVICE_NAME` already set on the agent Deployment | Agent traces are one config step from the collector |
+| Asset                         | What it does today                                                                                | Why it matters                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| **GKE Managed OpenTelemetry** | In-cluster collector exporting traces/metrics/logs to Cloud Observability                         | A managed telemetry pipeline we don't run or secure                   |
+| **LiteLLM proxy**             | Every agent's LLM calls route through it; it logs prompt/output/cost and exports to the collector | LLM activity is already captured — it just lacks the human's identity |
+| **Per-agent service account** | The operator gives each agent its own SA                                                          | The _agent_ actor is already recorded tamper-proof by K8s/Cloud audit |
+| **Agent OTEL wiring**         | `OTEL_SERVICE_NAME` already set on the agent Deployment                                           | Agent traces are one config step from the collector                   |
 
 The agent's own identity is already captured server-side. We only need to add the **human**
 half, as a tag.
@@ -78,11 +81,11 @@ half, as a tag.
 The gateway authenticates the chat user (it already does, via the allow-list). It tags each
 request with that identity, and the tag flows into the three places actions are recorded.
 
-| Plane | Already records | We add | Using |
-|------|-----------------|--------|-------|
-| **LLM calls** | LiteLLM logs every call | `user` and `requested_by` on each call | the standard LLM `user` field |
-| **Traces** | OTel collector, deployed | a per-request trace tagged with the requester, plus the Hermes `session_id` as an attribute | standard OpenTelemetry trace context |
-| **Cluster / Cloud changes** | K8s + Cloud audit record the SA actor | a `requested-by` label on objects the agent creates | standard Kubernetes labels |
+| Plane                       | Already records                       | We add                                                                                      | Using                                |
+| --------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **LLM calls**               | LiteLLM logs every call               | `user` and `requested_by` on each call                                                      | the standard LLM `user` field        |
+| **Traces**                  | OTel collector, deployed              | a per-request trace tagged with the requester, plus the Hermes `session_id` as an attribute | standard OpenTelemetry trace context |
+| **Cluster / Cloud changes** | K8s + Cloud audit record the SA actor | a `requested-by` label on objects the agent creates                                         | standard Kubernetes labels           |
 
 **How you use it.** Filter any of these by the requester's email to see everything a person
 caused; or start from one action and read its tag to find who asked. The trace ID ties an LLM
@@ -90,11 +93,12 @@ call to the cluster change that followed from the same request, and the Hermes `
 attribute correlates a trace with the Hermes session logs already shipped via Fluent Bit.
 
 ### Trust model (the honest limit)
+
 - The **agent actor** is always recorded tamper-proof by K8s/Cloud audit, server-side.
-- The **human tag** is *asserted by the gateway*. The gateway is a single, trusted, audited
+- The **human tag** is _asserted by the gateway_. The gateway is a single, trusted, audited
   choke point — far better than editable chat history, but not cryptographically tamper-proof.
   A compromised agent could mislabel an object it creates; even then the real actor and
-  timestamp remain in the audit log, so the action is never *unattributable* — only its human
+  timestamp remain in the audit log, so the action is never _unattributable_ — only its human
   tag is suspect.
 - If stronger proof is ever needed, §5 is the upgrade. v1 stops here on purpose: most of the
   value for a small fraction of the effort.
@@ -105,11 +109,11 @@ attribute correlates a trace with the Hermes session logs already shipped via Fl
 
 Each step is independently shippable and useful. Ordered by return on effort.
 
-| Step | Delivers | Work | Effort |
-|------|----------|------|--------|
-| **1. LLM attribution** | Every prompt/output/cost tied to a human in LiteLLM logs | Gateway sets `user` + `requested_by` on each LLM call; document the contract | **Small** (mostly config) |
-| **2. Trace identity** | One trace per request, tagged with the human, across agent + LiteLLM | Operator adds the OTLP endpoint + agent identity env; gateway starts a tagged trace and propagates context; enable Managed OTel | **Small–Medium** |
-| **3. Cluster tag + queries** | `requested-by` on cluster objects; a reference audit policy; a query runbook | Helper to stamp the label on created objects; reference `AuditPolicy`; document the queries | **Medium** |
+| Step                         | Delivers                                                                     | Work                                                                                                                            | Effort                    |
+| ---------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **1. LLM attribution**       | Every prompt/output/cost tied to a human in LiteLLM logs                     | Gateway sets `user` + `requested_by` on each LLM call; document the contract                                                    | **Small** (mostly config) |
+| **2. Trace identity**        | One trace per request, tagged with the human, across agent + LiteLLM         | Operator adds the OTLP endpoint + agent identity env; gateway starts a tagged trace and propagates context; enable Managed OTel | **Small–Medium**          |
+| **3. Cluster tag + queries** | `requested-by` on cluster objects; a reference audit policy; a query runbook | Helper to stamp the label on created objects; reference `AuditPolicy`; document the queries                                     | **Medium**                |
 
 Step 1 alone already attributes the most sensitive data — LLM prompts and outputs — to the
 requesting human, almost entirely through configuration. Steps 2–3 extend the same tag to the
@@ -122,7 +126,7 @@ trace and cluster planes.
 Only if gateway-asserted attribution proves insufficient (e.g. for compliance or to gate
 policy). None of this is needed for v1:
 
-- **A request record stamped at admission.** A small resource the *gateway code* creates per
+- **A request record stamped at admission.** A small resource the _gateway code_ creates per
   request (not the agent), stamped with the authenticated submitter's identity and made
   immutable — making the "who asked" claim tamper-evident. Creation stays in deterministic
   code, so the agent never has to understand a new concept.

--- a/docs/designs/audit-logging-user-attribution.md
+++ b/docs/designs/audit-logging-user-attribution.md
@@ -81,12 +81,13 @@ request with that identity, and the tag flows into the three places actions are 
 | Plane | Already records | We add | Using |
 |------|-----------------|--------|-------|
 | **LLM calls** | LiteLLM logs every call | `user` and `requested_by` on each call | the standard LLM `user` field |
-| **Traces** | OTel collector, deployed | a per-request trace tagged with the requester | standard OpenTelemetry trace context |
+| **Traces** | OTel collector, deployed | a per-request trace tagged with the requester, plus the Hermes `session_id` as an attribute | standard OpenTelemetry trace context |
 | **Cluster / Cloud changes** | K8s + Cloud audit record the SA actor | a `requested-by` label on objects the agent creates | standard Kubernetes labels |
 
 **How you use it.** Filter any of these by the requester's email to see everything a person
 caused; or start from one action and read its tag to find who asked. The trace ID ties an LLM
-call to the cluster change that followed from the same request.
+call to the cluster change that followed from the same request, and the Hermes `session_id`
+attribute correlates a trace with the Hermes session logs already shipped via Fluent Bit.
 
 ### Trust model (the honest limit)
 - The **agent actor** is always recorded tamper-proof by K8s/Cloud audit, server-side.

--- a/k8s-operator/config/audit/audit-policy.yaml
+++ b/k8s-operator/config/audit/audit-policy.yaml
@@ -1,0 +1,40 @@
+# Reference Kubernetes API audit policy for kube-agents.
+#
+# Purpose: produce an authoritative, server-side record of what each agent service account
+# does against the Kubernetes API. This is the tamper-proof "action ledger" half of user
+# attribution — it always records the *agent* actor (its ServiceAccount) and the affected
+# object. The *human* who requested the action is carried separately as the
+# `kubeagents.x-k8s.io/requested-by` label on objects the agent creates (see
+# docs/attribution.md), letting you join an audit entry back to a person.
+#
+# This file is a reference. On GKE the API server audit configuration is managed by the
+# platform (audit logs flow to Cloud Logging automatically); use this policy as the basis for
+# a self-managed cluster, or as documentation of the coverage we rely on. See docs/attribution.md.
+apiVersion: audit.k8s.io/v1
+kind: Policy
+# Do not log routine, high-volume, low-signal requests.
+omitStages:
+  - RequestReceived
+rules:
+  # Never log read-only traffic from the agents — it is noise for an attribution trail.
+  - level: None
+    verbs: ["get", "list", "watch"]
+
+  # Capture full request + response for mutations to the kube-agents custom resources
+  # (agents and any future attribution resources).
+  - level: RequestResponse
+    apiGroups: ["kubeagents.x-k8s.io"]
+
+  # Capture mutations to RBAC — agents provisioning access is security-sensitive.
+  - level: RequestResponse
+    apiGroups: ["rbac.authorization.k8s.io"]
+    verbs: ["create", "update", "patch", "delete"]
+
+  # Capture metadata for all other mutations made by agent service accounts. The object's
+  # `kubeagents.x-k8s.io/requested-by` label ties the change to the requesting human.
+  - level: Metadata
+    verbs: ["create", "update", "patch", "delete"]
+    userGroups: ["system:serviceaccounts:agent-system"]
+
+  # Everything else: metadata only.
+  - level: Metadata

--- a/k8s-operator/config/audit/audit-policy.yaml
+++ b/k8s-operator/config/audit/audit-policy.yaml
@@ -32,9 +32,10 @@ rules:
 
   # Capture metadata for all other mutations made by agent service accounts. The object's
   # `kubeagents.x-k8s.io/requested-by` label ties the change to the requesting human.
+  # kubeagents-system is the operator/agent namespace (see config/default/kustomization.yaml).
   - level: Metadata
     verbs: ["create", "update", "patch", "delete"]
-    userGroups: ["system:serviceaccounts:agent-system"]
+    userGroups: ["system:serviceaccounts:kubeagents-system"]
 
   # Everything else: metadata only.
   - level: Metadata

--- a/k8s-operator/config/audit/audit-policy.yaml
+++ b/k8s-operator/config/audit/audit-policy.yaml
@@ -1,40 +1,49 @@
 # Reference Kubernetes API audit policy for kube-agents.
 #
 # Purpose: produce an authoritative, server-side record of what each agent service account
-# does against the Kubernetes API. This is the tamper-proof "action ledger" half of user
+# does against the Kubernetes API. This is the server-generated "action ledger" half of user
 # attribution — it always records the *agent* actor (its ServiceAccount) and the affected
-# object. The *human* who requested the action is carried separately as the
-# `kubeagents.x-k8s.io/requested-by` label on objects the agent creates (see
-# docs/attribution.md), letting you join an audit entry back to a person.
+# object. A planned runtime follow-up carries the *human* who requested the action as the
+# `kubeagents.x-k8s.io/requested-by` annotation on objects the agent creates (see
+# docs/attribution.md), providing supporting correlation data.
 #
 # This file is a reference. On GKE the API server audit configuration is managed by the
 # platform (audit logs flow to Cloud Logging automatically); use this policy as the basis for
 # a self-managed cluster, or as documentation of the coverage we rely on. See docs/attribution.md.
 apiVersion: audit.k8s.io/v1
 kind: Policy
-# Do not log routine, high-volume, low-signal requests.
+# Emit completed request records, not the initial RequestReceived stage.
 omitStages:
   - RequestReceived
 rules:
-  # Never log read-only traffic from the agents — it is noise for an attribution trail.
+  # Record agent reads at Metadata so data access remains attributable without logging response
+  # bodies. Move or duplicate this rule when agents run in another namespace.
+  - level: Metadata
+    verbs: ["get", "list", "watch"]
+    userGroups: ["system:serviceaccounts:kubeagents-system"]
+
+  # Drop routine read-only traffic from other actors to keep the reference policy focused.
   - level: None
     verbs: ["get", "list", "watch"]
 
   # Capture full request + response for mutations to the kube-agents custom resources
   # (agents and any future attribution resources).
   - level: RequestResponse
-    apiGroups: ["kubeagents.x-k8s.io"]
+    resources:
+      - group: kubeagents.x-k8s.io
 
   # Capture mutations to RBAC — agents provisioning access is security-sensitive.
   - level: RequestResponse
-    apiGroups: ["rbac.authorization.k8s.io"]
-    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: rbac.authorization.k8s.io
+    verbs: ["create", "update", "patch", "delete", "deletecollection"]
 
-  # Capture metadata for all other mutations made by agent service accounts. The object's
-  # `kubeagents.x-k8s.io/requested-by` label ties the change to the requesting human.
-  # kubeagents-system is the operator/agent namespace (see config/default/kustomization.yaml).
+  # Capture metadata for all other mutations made by agent service accounts. When present, the
+  # object's `kubeagents.x-k8s.io/requested-by` annotation supports correlation to the requester.
+  # kubeagents-system is the default operator/agent namespace (see
+  # config/default/kustomization.yaml). Replace it when agents run in another namespace.
   - level: Metadata
-    verbs: ["create", "update", "patch", "delete"]
+    verbs: ["create", "update", "patch", "delete", "deletecollection"]
     userGroups: ["system:serviceaccounts:kubeagents-system"]
 
   # Everything else: metadata only.

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -34,7 +34,36 @@ import (
 
 const (
 	defaultPlatformAgentImage = "ghcr.io/gke-labs/kube-agents/platform-agent:latest"
+
+	// managedOTelEndpoint is the OTLP/HTTP endpoint of the GKE Managed OpenTelemetry
+	// collector. The same endpoint is already used by the LiteLLM integration, so agent
+	// traces and LLM-call telemetry land in the same place (Cloud Trace/Logging).
+	managedOTelEndpoint = "http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318"
 )
+
+// otelTelemetryEnvVars returns the OpenTelemetry exporter configuration that points an agent
+// container at the GKE Managed OpenTelemetry collector, plus resource attributes carrying the
+// agent's identity. Callers set OTEL_SERVICE_NAME separately. These defaults can be overridden
+// per-agent via Deployment.Env (see mergeEnvVars).
+func otelTelemetryEnvVars(agentType, name, namespace string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
+			Value: managedOTelEndpoint,
+		},
+		{
+			Name:  "OTEL_EXPORTER_OTLP_PROTOCOL",
+			Value: "http/protobuf",
+		},
+		{
+			Name: "OTEL_RESOURCE_ATTRIBUTES",
+			Value: fmt.Sprintf(
+				"service.namespace=%s,k8s.namespace.name=%s,kubeagents.agent_type=%s,kubeagents.agent_name=%s",
+				namespace, namespace, agentType, name,
+			),
+		},
+	}
+}
 
 // resolveAgentImage determines the full image reference using the optional deployment spec and a fallback default.
 func resolveAgentImage(deployment *agentv1alpha1.DeploymentSpec, defaultImage string) string {

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -41,12 +41,16 @@ const (
 	managedOTelEndpoint = "http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318"
 )
 
-// otelTelemetryEnvVars returns the OpenTelemetry exporter configuration that points an agent
-// container at the GKE Managed OpenTelemetry collector, plus resource attributes carrying the
-// agent's identity. Callers set OTEL_SERVICE_NAME separately. These defaults can be overridden
-// per-agent via Deployment.Env (see mergeEnvVars).
+// otelTelemetryEnvVars returns the OpenTelemetry configuration for an agent container: the
+// service name, the GKE Managed OpenTelemetry collector endpoint, and resource attributes
+// carrying the agent's identity. These defaults can be overridden per-agent via Deployment.Env
+// (see mergeEnvVars).
 func otelTelemetryEnvVars(agentType, name, namespace string) []corev1.EnvVar {
 	return []corev1.EnvVar{
+		{
+			Name:  "OTEL_SERVICE_NAME",
+			Value: name + "-gateway",
+		},
 		{
 			Name:  "OTEL_EXPORTER_OTLP_ENDPOINT",
 			Value: managedOTelEndpoint,

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -350,10 +350,6 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			Value: pluginsDebugVal,
 		},
 		{
-			Name:  "OTEL_SERVICE_NAME",
-			Value: agent.Name + "-gateway",
-		},
-		{
 			Name:  "API_SERVER_ENABLED",
 			Value: "true",
 		},

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -367,6 +367,8 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		},
 	}
 
+	envVars = append(envVars, otelTelemetryEnvVars("platform", agent.Name, agent.Namespace)...)
+
 	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.BrowserArgs) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "AGENT_BROWSER_ARGS",

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -971,4 +971,3 @@ func TestGetConfigMapHash(t *testing.T) {
 		t.Errorf("expected different hashes for different configmap data")
 	}
 }
-

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -37,6 +37,9 @@ func TestOTelTelemetryEnvVars(t *testing.T) {
 	envs := otelTelemetryEnvVars("platform", "my-agent", "my-ns")
 	m := envMapOf(envs)
 
+	if m["OTEL_SERVICE_NAME"].Value != "my-agent-gateway" {
+		t.Errorf("expected OTEL_SERVICE_NAME my-agent-gateway, got %s", m["OTEL_SERVICE_NAME"].Value)
+	}
 	if m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value != managedOTelEndpoint {
 		t.Errorf("expected OTLP endpoint %s, got %s", managedOTelEndpoint, m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value)
 	}

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -81,3 +81,29 @@ func TestBuildDeploymentHasOTelEnv(t *testing.T) {
 		t.Errorf("expected OTEL_RESOURCE_ATTRIBUTES to be set")
 	}
 }
+
+func TestBuildDeploymentAllowsOTelEnvOverrides(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			AgentSpec: agentv1alpha1.AgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{
+					Env: []corev1.EnvVar{
+						{Name: "OTEL_EXPORTER_OTLP_ENDPOINT", Value: "http://custom-collector:4318"},
+						{Name: "OTEL_RESOURCE_ATTRIBUTES", Value: "deployment.environment=testing"},
+					},
+				},
+			},
+		},
+	}
+
+	dep := buildDeployment(agent, "h1", "h2", "h3")
+	m := envMapOf(dep.Spec.Template.Spec.Containers[0].Env)
+
+	if got := m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value; got != "http://custom-collector:4318" {
+		t.Errorf("expected custom OTLP endpoint, got %q", got)
+	}
+	if got := m["OTEL_RESOURCE_ATTRIBUTES"].Value; got != "deployment.environment=testing" {
+		t.Errorf("expected custom resource attributes, got %q", got)
+	}
+}

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+func envMapOf(envs []corev1.EnvVar) map[string]corev1.EnvVar {
+	m := make(map[string]corev1.EnvVar, len(envs))
+	for _, e := range envs {
+		m[e.Name] = e
+	}
+	return m
+}
+
+func TestOTelTelemetryEnvVars(t *testing.T) {
+	envs := otelTelemetryEnvVars("platform", "my-agent", "my-ns")
+	m := envMapOf(envs)
+
+	if m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value != managedOTelEndpoint {
+		t.Errorf("expected OTLP endpoint %s, got %s", managedOTelEndpoint, m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value)
+	}
+	if m["OTEL_EXPORTER_OTLP_PROTOCOL"].Value != "http/protobuf" {
+		t.Errorf("expected protocol http/protobuf, got %s", m["OTEL_EXPORTER_OTLP_PROTOCOL"].Value)
+	}
+	want := "service.namespace=my-ns,k8s.namespace.name=my-ns,kubeagents.agent_type=platform,kubeagents.agent_name=my-agent"
+	if m["OTEL_RESOURCE_ATTRIBUTES"].Value != want {
+		t.Errorf("expected resource attributes %q, got %q", want, m["OTEL_RESOURCE_ATTRIBUTES"].Value)
+	}
+}
+
+// TestBuildDeploymentHasOTelEnv verifies the agent container is wired to the managed
+// collector and still carries its service name, without duplicate env entries.
+func TestBuildDeploymentHasOTelEnv(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
+	}
+
+	dep := buildDeployment(agent, "h1", "h2")
+	container := dep.Spec.Template.Spec.Containers[0]
+
+	seen := make(map[string]bool)
+	for _, e := range container.Env {
+		if seen[e.Name] {
+			t.Errorf("duplicate env var: %s", e.Name)
+		}
+		seen[e.Name] = true
+	}
+	m := envMapOf(container.Env)
+
+	if m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value != managedOTelEndpoint {
+		t.Errorf("expected agent wired to managed collector, got %q", m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value)
+	}
+	if m["OTEL_SERVICE_NAME"].Value != "my-agent-gateway" {
+		t.Errorf("expected OTEL_SERVICE_NAME my-agent-gateway, got %q", m["OTEL_SERVICE_NAME"].Value)
+	}
+	if m["OTEL_RESOURCE_ATTRIBUTES"].Value == "" {
+		t.Errorf("expected OTEL_RESOURCE_ATTRIBUTES to be set")
+	}
+}

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -59,7 +59,7 @@ func TestBuildDeploymentHasOTelEnv(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2")
+	dep := buildDeployment(agent, "h1", "h2", "h3")
 	container := dep.Spec.Template.Spec.Containers[0]
 
 	seen := make(map[string]bool)

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -317,14 +317,20 @@ spec:
               value: "1"
             - name: PLATFORM_AGENT_PLUGINS_DEBUG
               value: "0"
-            - name: OTEL_SERVICE_NAME
-              value: platformagent-gateway
             - name: API_SERVER_ENABLED
               value: "true"
             - name: API_SERVER_HOST
               value: 0.0.0.0
             - name: SESSION_KV_DB_PATH
               value: /var/lib/kube-agents/session/session_kv.db
+            - name: OTEL_SERVICE_NAME
+              value: platformagent-gateway
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
             - name: GKE_CLUSTER_NAME
               value: cluster-a
             - name: GKE_LOCATION

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -65,6 +65,12 @@ verify_agent_iam() {
   for role in "${roles[@]}"; do
     echo "$project_roles" | grep -q "${role}" || return 1
   done
+
+  # Reconcile the legacy broad logging grant unless a custom role set still requests it.
+  if [[ ! " ${roles[*]} " =~ " roles/logging.admin " ]] && \
+     echo "$project_roles" | grep -Fxq "roles/logging.admin"; then
+    return 1
+  fi
   
   return 0
 }
@@ -93,6 +99,14 @@ execute_agent_iam() {
         --role="${role}" \
         --quiet >/dev/null || return 1
   done
+
+  if [[ ! " ${roles[*]} " =~ " roles/logging.admin " ]]; then
+    gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+        --member="serviceAccount:${gsa_email}" \
+        --role="roles/logging.admin" \
+        --condition=None \
+        --quiet >/dev/null 2>&1 || true
+  fi
   
   print_info "Binding Workload Identity for ${gsa_name} to ${ksa_name}..."
   local wi_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${ksa_name}]"
@@ -154,7 +168,8 @@ get_platform_agent_roles() {
     "roles/container.clusterAdmin"
     "roles/container.admin"
     "roles/monitoring.admin"
-    "roles/logging.admin"
+    # The agent can query logs for diagnostics but must not administer the audit-log sink.
+    "roles/logging.viewer"
     "roles/iam.serviceAccountUser"
     "roles/iam.securityReviewer"
     "roles/mcp.toolUser"


### PR DESCRIPTION
# Pull Request

## Why This Change

Kubernetes and Cloud audit records identify the agent ServiceAccount, but they do not identify the human who requested an action. The Platform Agent also needs stable process-level identity on its exported telemetry so traces can be queried and correlated with the session attribution already implemented on `main`.

## What Changed

The operator now configures the Platform Agent with the GKE Managed OpenTelemetry endpoint, OTLP protocol, service name, namespace, and agent resource attributes. The change also adds a valid reference API-server audit policy, a current attribution contract and query runbook, and isolates the audit sink from agent administration.

**Files:**

- `k8s-operator/internal/controller/manifest_helpers.go`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/config/audit/audit-policy.yaml`
- `k8s-operator/scripts/provision_03_gcp_iam.sh`
- `docs/attribution.md`
- `docs/designs/audit-logging-user-attribution.md`

**Added/Changed/Fixed:**

- Adds `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, and `OTEL_RESOURCE_ATTRIBUTES`; consolidates `OTEL_SERVICE_NAME` in the same helper.
- Keeps all OTel defaults overridable through `spec.deployment.env`, with unit and golden coverage.
- Rebases the implementation onto the current single-Platform-Agent architecture.
- Updates the contract to the implemented span attributes: `hermes.sender.id`, `user.id`, and `session.id`.
- Uses annotations for requester emails because email addresses are invalid Kubernetes label values.
- Corrects the audit policy to the Kubernetes audit API schema, records agent reads at Metadata level, and avoids arbitrary request/response bodies.
- Replaces `roles/logging.admin` with `roles/logging.viewer` and removes the legacy broad binding on reprovisioning unless a custom permission set explicitly requests it.

## Why This Matters

- Agent traces and LiteLLM telemetry reach the same managed collector with queryable workload identity.
- Kubernetes API activity has a server-generated agent actor record, while the docs clearly distinguish implemented requester attribution from runtime follow-ups.
- The reference policy is accepted by kube-apiserver and no longer relies on invalid RBAC-style fields.
- The Platform Agent can query logs for diagnostics but cannot administer the sink used to audit it.

## Context

Session-to-user trace attribution is already present on `main`. Deterministically adding `user` / `metadata.requested_by` to LiteLLM requests and requester annotations to created objects remains runtime follow-up work. Object annotations are documented as correlation metadata, not authorization input or durable proof for every update and deletion.

## Testing

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `bash -n k8s-operator/scripts/provision_03_gcp_iam.sh`
- `npx prettier --check` on changed Markdown and YAML
- `git diff --check origin/main...HEAD`
- Kubernetes v1.31 `kube-apiserver` loaded the reference audit policy during local schema validation

---

This is the operator-side telemetry and audit foundation; no new resource type is introduced.