### PR TITLE
feat(gitops): add minty deployment to provision script

### DIFF
--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -111,11 +111,11 @@ undeploy-litellm: kustomize ## Undeploy LiteLLM integration.
 
 .PHONY: deploy-github
 deploy-github: kustomize ## Deploy GitHub integration.
-	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER $$KEYRING $$KEY $$KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME $$OPERATOR_AGENT_GSA_NAME $$DEVTEAM_AGENT_GSA_NAME' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
 
 .PHONY: undeploy-github
 undeploy-github: kustomize ## Undeploy GitHub integration.
-	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER $$KEYRING $$KEY $$KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME $$OPERATOR_AGENT_GSA_NAME $$DEVTEAM_AGENT_GSA_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
 
 
 

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -52,6 +52,8 @@ graph TD
     A --> E[provision_04_gcp_k8s_secrets.sh]
     A --> F[provision_05_gcp_gchat.sh]
     A --> G[provision_06_deploy_platform_agent.sh]
+    A --> I[provision_08_deploy_litellm.sh]
+    A --> J[provision_09_deploy_github_minter.sh]
 ```
 
 1. **[provision_01_gcp_cluster.sh](scripts/provision_01_gcp_cluster.sh)**:
@@ -77,8 +79,15 @@ graph TD
    - Creates the Pub/Sub Chat Event Topic and Subscriber Subscription for Google Chat events.
 
 6. **[provision_06_deploy_platform_agent.sh](scripts/provision_06_deploy_platform_agent.sh)**:
-   - Deploys the LiteLLM Gateway to the cluster.
    - Generates [scripts/platform-agent.yaml](scripts/platform-agent.yaml) from its template and applies the Custom Resource (CR) to deploy the Platform Agent.
+
+7. **[provision_08_deploy_litellm.sh](scripts/provision_08_deploy_litellm.sh)**:
+   - Deploys the LiteLLM Gateway to the cluster.
+
+8. **[provision_09_deploy_github_minter.sh](scripts/provision_09_deploy_github_minter.sh)**:
+   - Sets up Google Cloud KMS keyrings and keys for token signing.
+   - Deploys the GitHub Token Minter into the cluster with its authorization configs.
+   - For detailed configuration instructions, see the [GitHub Token Minter README](config/integrations/github/README.md).
 
 ---
 
@@ -391,12 +400,17 @@ Run the `make deploy-github` target, passing the required environment variables:
 # 1. Define the GCP and GitHub parameter variables:
 export PROJECT_ID=your-gcp-project-id
 export REGION=your-gcp-region
-export CLUSTER=your-gke-cluster-name
-export KEYRING=your-kms-keyring
-export KEY=your-kms-key
-export KEY_VERSION=your-kms-key-version
+export CLUSTER_NAME=your-gke-cluster-name
+export KMS_KEYRING=your-kms-keyring
+export KMS_KEY=your-kms-key
+export KMS_KEY_VERSION=your-kms-key-version
 export GITHUB_ORG=your-github-org
 export GITHUB_REPO=your-github-repo
+export GITHUB_MINTER_KSA_NAME=kubeagents-github-minter
+export GITHUB_MINTER_GSA_NAME=kubeagents-github-minter-gsa
+export PLATFORM_AGENT_GSA_NAME=kubeagents-platform-agent-gsa
+export OPERATOR_AGENT_GSA_NAME=kubeagents-operator-agent-gsa
+export DEVTEAM_AGENT_GSA_NAME=kubeagents-devteam-agent-gsa
 
 # 2. Deploy GitHub:
 make deploy-github

--- a/k8s-operator/config/integrations/github/README.md
+++ b/k8s-operator/config/integrations/github/README.md
@@ -1,0 +1,91 @@
+# GitHub Token Minter (Minty) Integration
+
+This directory contains the configuration and deployment manifests for integrating the **GitHub Token Minter (Minty)** broker into the cluster. This integration allows agents to securely request short-lived GitHub access tokens without storing long-lived, static credentials.
+
+## How It All Works
+
+Minty acts as a secure broker between Google Cloud IAM (Workload Identity) and GitHub. When an agent requires access to a GitHub repository, the following flow occurs:
+
+1. **The Request:** The agent initiates an HTTP request to the Minty service, specifying the target organization and repository. The request is authenticated using the agent's Google Service Account (GSA) OIDC token to cryptographically prove its identity.
+2. **The Verification:** Minty evaluates the request against its local rules (provided by `configmap.yaml`). It extracts the `"email"` claim from the OIDC token and verifies it against the `assertion.email` rule. If the agent's email is authorized for the requested repository, the rule evaluates to true.
+3. **The Exchange (KMS Signing):** Upon successful authorization, Minty interfaces with Google Cloud Key Management Service (KMS). Minty holds a reference to the GitHub App's private key stored securely in KMS. The private key is never exported or exposed to Minty. Instead, Minty constructs an authentication payload and invokes the KMS API to cryptographically sign it using secure hardware.
+4. **The Token Generation:** Armed with the KMS-signed JWT, Minty authenticates with the GitHub API on behalf of the configured GitHub App. GitHub verifies the signature and returns a short-lived installation access token scoped to the target repository.
+5. **The Delivery:** Minty returns this short-lived GitHub access token to the agent, which can then utilize it to perform repository operations such as pushing code or managing Pull Requests.
+
+## The GitHub App
+
+Minty itself does not natively possess access to any GitHub repositories. The **GitHub App** serves as the machine identity within GitHub that holds the necessary permissions.
+
+By installing the GitHub App into a target repository, explicit authorization is granted to that machine identity. Minty's role is strictly to ensure that only authorized internal workloads are permitted to generate tokens on behalf of the App.
+
+### Setting up the GitHub App
+
+1. Navigate to your GitHub Organization (or personal settings) -> **Developer Settings** -> **GitHub Apps** -> **New GitHub App**.
+2. Assign a name and configure the required repository permissions (e.g., `Contents: Read & write`, `Pull requests: Read & write`).
+3. Once created, note the **App ID**.
+4. Scroll down and click **Generate a private key**. This will download a `.pem` file to your local machine.
+5. Navigate to the target repository the agent is intended to manage, go to **Settings** -> **GitHub Apps**, and install the newly created App.
+
+### Provisioning Configuration Variables
+
+To deploy the agent with GitHub integration, the `vars.sh` file (used by the `provision.sh` script) must be populated with the details of your GitHub App.
+
+- `GITHUB_APP_ID`: The unique numeric ID of the GitHub App (found in the App's General Settings).
+- `GITHUB_ORG`: The name of the GitHub organization or user account where the repository is hosted.
+- `GITHUB_REPO`: The name of the target repository the agent will manage.
+- `GITHUB_PEM_PATH`: The absolute local file path to the downloaded `.pem` private key file. If provided, the provisioning script will automatically use the Minty CLI to import it into Google Cloud KMS. If omitted, the deployment will proceed but Minty will fail readiness probes until a key is manually imported.
+
+## Minty Limitations & GSA Tokens
+
+Minty was originally designed for integration with GitHub Actions, which inherently provides OIDC tokens containing a specific `"repository"` claim. Deploying Minty in GKE introduces specific constraints regarding this validation model:
+
+- **KSA Tokens are Unsupported:** Native Kubernetes Service Account (KSA) tokens do not support the injection of arbitrary custom claims such as `"repository"`. Consequently, Minty's default validation engine will reject KSA tokens due to the missing claim.
+- **GSA Tokens (The Solution):** To resolve this, Workload Identity is utilized to provide Google Service Account (GSA) OIDC tokens. Minty implements a specific exemption for tokens where the issuer is `https://accounts.google.com`. When processing a Google-issued token, Minty bypasses the `"repository"` claim requirement. Instead, it validates the caller's identity via the `assertion.email` rule and derives the target repository directly from the JSON POST payload.
+
+## Cryptographic Key Import via Minty CLI
+
+During provisioning, the scripts clone the `github-token-minter` repository to leverage its included CLI tool (`minty tools import-pk`) for uploading the GitHub `.pem` file to Google Cloud KMS.
+
+This approach is required due to the cryptographic wrapping prerequisites of the Google Cloud KMS API. Uploading an asymmetric private key natively via the Google Cloud CLI (`gcloud kms keys versions import`) strictly requires that the target key be explicitly converted from PKCS#1 into an unencrypted PKCS#8 format, and necessitates the provisioning of a separate KMS "Import Job" to facilitate secure RSA-OAEP wrapping.
+
+The Minty CLI abstracts this complex cryptographic workflow. It automatically provisions the KMS Import Job, securely reformats the PKCS#1 string into PKCS#8 in-memory, performs the RSA-OAEP wrapping, and uploads the payload securely to KMS, ensuring a robust and standardized key import process.
+
+## Manual Testing
+
+To manually verify the Token Minter integration, you can execute a debug pod running in the same namespace as the agent.
+
+1. Start an interactive debug pod containing `curl`:
+
+```bash
+kubectl run debug-box --rm -it \
+  --image=curlimages/curl \
+  --namespace=kubeagents-system \
+  --labels="app=platform-agent" \
+  --overrides='
+  {
+    "spec": {
+      "serviceAccountName": "kubeagents-platform-agent"
+    }
+  }' -- sh
+```
+
+2. Once inside the pod, obtain the Google Service Account OIDC token using the metadata server. The `audience` parameter must reflect the URL of the Minty service.
+3. Call the token minter using the retrieved token to request an installation access token.
+
+```bash
+# 1. Get the Google Service Account OIDC token
+AUDIENCE="http://github-token-minter.kubeagents-system.svc.cluster.local:8080"
+OIDC_TOKEN=$(curl -s -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${AUDIENCE}&format=full")
+
+# 2. Call the minter
+curl -i -X POST http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token \
+  -H "Content-Type: application/json" \
+  -H "X-OIDC-Token: $OIDC_TOKEN" \
+  -d '{
+    "org_name": "YOUR_GITHUB_ORG",
+    "repositories": ["YOUR_GITHUB_REPO"],
+    "scope": "platform-agent-scope"
+  }'
+```
+
+If successful, Minty will return a JSON payload containing the short-lived GitHub access token.

--- a/k8s-operator/config/integrations/github/configmap.yaml.template
+++ b/k8s-operator/config/integrations/github/configmap.yaml.template
@@ -6,11 +6,11 @@ data:
   ${GITHUB_ORG}-${GITHUB_REPO}.yaml: |
     version: 'minty.abcxyz.dev/v2'
     rule:
-      if: "assertion.iss == 'https://container.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/clusters/${CLUSTER}'"
+      if: "assertion.iss == 'https://accounts.google.com'"
     scope:
       platform-agent-scope:
         rule:
-          if: "assertion.sub == 'system:serviceaccount:kubeagents-system:kubeagents-platform-agent'"
+          if: "assertion.email in ['${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com', '${OPERATOR_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com', '${DEVTEAM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com']"
         repositories:
           - '${GITHUB_REPO}'
         permissions:

--- a/k8s-operator/config/integrations/github/deployment.yaml.template
+++ b/k8s-operator/config/integrations/github/deployment.yaml.template
@@ -14,7 +14,7 @@ spec:
       labels:
         app: github-token-minter
     spec:
-      serviceAccountName: github-token-minter-ksa
+      serviceAccountName: ${GITHUB_MINTER_KSA_NAME}
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
@@ -42,14 +42,14 @@ spec:
             - name: CONFIGS_DIR
               value: "/etc/minty"
             - name: ISSUER_ALLOWLIST
-              value: "https://container.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/clusters/${CLUSTER}"
+              value: "https://container.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/clusters/${CLUSTER_NAME},https://accounts.google.com"
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
                   name: github-app-credentials
                   key: app-id
             - name: KMS_KEY_NAME
-              value: "projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KEYRING}/cryptoKeys/${KEY}/cryptoKeyVersions/${KEY_VERSION}"
+              value: "projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KMS_KEYRING}/cryptoKeys/${KMS_KEY}/cryptoKeyVersions/${KMS_KEY_VERSION}"
             - name: SOURCE_SYSTEM_AUTH
               value: "gha://$(GITHUB_APP_ID)?kms_id=$(KMS_KEY_NAME)"
           livenessProbe:

--- a/k8s-operator/config/integrations/github/kustomization.yaml
+++ b/k8s-operator/config/integrations/github/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
-  - serviceaccount.yaml
-  - configmap.yaml
-  - deployment.yaml
+  - serviceaccount.yaml.template
+  - configmap.yaml.template
+  - deployment.yaml.template

--- a/k8s-operator/config/integrations/github/serviceaccount.yaml
+++ b/k8s-operator/config/integrations/github/serviceaccount.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: github-token-minter-ksa
-  annotations:
-    iam.gke.io/gcp-service-account: github-token-minter-sa@${PROJECT_ID}.iam.gserviceaccount.com
-automountServiceAccountToken: false

--- a/k8s-operator/config/integrations/github/serviceaccount.yaml.template
+++ b/k8s-operator/config/integrations/github/serviceaccount.yaml.template
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${GITHUB_MINTER_KSA_NAME}
+  annotations:
+    iam.gke.io/gcp-service-account: ${GITHUB_MINTER_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+automountServiceAccountToken: false

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -85,6 +85,30 @@ init_var() {
   fi
 }
 
+init_var_model_provider() {
+  init_var "MODEL_PROVIDER" "gemini" "Enter Model Provider (gemini, anthropic, chatgpt, openai)"
+
+  MODEL_PROVIDER=$(echo "$MODEL_PROVIDER" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+  if [[ ! "$MODEL_PROVIDER" =~ ^(gemini|anthropic|chatgpt|openai)$ ]]; then
+    print_error "Invalid Model Provider '$MODEL_PROVIDER'. Must be one of: gemini, anthropic, chatgpt, openai."
+    exit 1
+  fi
+
+  case "$MODEL_PROVIDER" in
+    chatgpt|openai)
+      DEFAULT_MODEL="gpt-5.4"
+      ;;
+    anthropic)
+      DEFAULT_MODEL="claude-sonnet-4-5-20250929"
+      ;;
+    *)
+      DEFAULT_MODEL="gemini-3.5-flash"
+      ;;
+  esac
+
+  init_var "MODEL_DEFAULT_NAME" "$DEFAULT_MODEL" "Enter Model Default Name"
+}
+
 load_state() {
   if [ ! -f "$VARS_FILE" ]; then
     echo "# SRE Sourced Variables for GKE & GCP Setup" > "$VARS_FILE"
@@ -99,6 +123,8 @@ load_state() {
   export DEVTEAM_AGENT_GSA_NAME="kubeagents-devteam-gsa"
   export CONTROLLER_KSA_NAME="kubeagents-controller"
   export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
+  export GITHUB_MINTER_KSA_NAME="kubeagents-github-minter"
+  export GITHUB_MINTER_GSA_NAME="kubeagents-github-minter-gsa"
 }
 
 ensure_teardown_state() {
@@ -113,6 +139,8 @@ ensure_teardown_state() {
     export DEVTEAM_AGENT_GSA_NAME="kubeagents-devteam-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
+    export GITHUB_MINTER_KSA_NAME="kubeagents-github-minter"
+    export GITHUB_MINTER_GSA_NAME="kubeagents-github-minter-gsa"
   else
     echo -e "  ${C_YELLOW}⚠ State file ${VARS_FILE} not found. Prompting for target values...${C_RESET}"
     local ACTIVE_PROJECT
@@ -150,6 +178,8 @@ ensure_teardown_state() {
     export DEVTEAM_AGENT_GSA_NAME="kubeagents-devteam-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
+    export GITHUB_MINTER_KSA_NAME="kubeagents-github-minter"
+    export GITHUB_MINTER_GSA_NAME="kubeagents-github-minter-gsa"
   fi
 }
 

--- a/k8s-operator/scripts/provision.sh
+++ b/k8s-operator/scripts/provision.sh
@@ -25,6 +25,8 @@ echo -e "${C_MAGENTA}${C_BOLD}🚀 Starting GKE Platform Agent provisioning pipe
 "${SCRIPT_DIR}/provision_04_gcp_k8s_secrets.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_05_gcp_gchat.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_06_deploy_platform_agent.sh" $DRY_RUN_ARG
+"${SCRIPT_DIR}/provision_08_deploy_litellm.sh" $DRY_RUN_ARG
+"${SCRIPT_DIR}/provision_09_deploy_github_minter.sh" $DRY_RUN_ARG
 
 echo -e "\n${C_MAGENTA}${C_BOLD}>>>  Infrastructure & Cloud Resources Provisioned Successfully!  <<<${C_RESET}"
 

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -23,6 +23,15 @@ DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
 
 init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 
+init_var "GITHUB_ORG" "" "Enter GitHub Org/Owner (optional, for GitHub Token Minter)"
+if [ -n "${GITHUB_ORG:-}" ]; then
+  init_var "GITHUB_REPO" "" "Enter GitHub Repo (for GitHub Token Minter)"
+  init_var "GITHUB_APP_ID" "" "Enter GitHub App ID (for GitHub Token Minter)"
+  init_var "KMS_KEYRING" "github-token-minter-keyring" "Enter KMS Keyring Name (for GitHub Token Minter)"
+  init_var "KMS_KEY" "github-token-minter-key" "Enter KMS Key Name (for GitHub Token Minter)"
+  init_var "GITHUB_PEM_PATH" "" "Enter GitHub App Private Key PEM path (optional, for KMS import)"
+fi
+
 # ─── Prerequisites Check ──────────────────────────────────────────────────────
 print_step "Checking Local Prerequisites"
 check_prereqs "gcloud" "kubectl"
@@ -155,7 +164,23 @@ execute_platform_agent() {
 }
 
 
-# Step 6: Annotate GKE ServiceAccounts & Restart Controller Manager Deployment
+# Step 6: Configure GitHub Token Minter IAM
+verify_github_minter_iam() {
+  if [ -z "${GITHUB_ORG:-}" ] || [ -z "${GITHUB_REPO:-}" ] || [ -z "${GITHUB_APP_ID:-}" ]; then
+    print_info "GitHub integration not configured. Skipping Minter IAM setup."
+    return 0
+  fi
+  verify_agent_iam "${GITHUB_MINTER_KSA_NAME}" "${GITHUB_MINTER_GSA_NAME}"
+}
+
+execute_github_minter_iam() {
+  if [ -z "${GITHUB_ORG:-}" ] || [ -z "${GITHUB_REPO:-}" ] || [ -z "${GITHUB_APP_ID:-}" ]; then
+    return 0
+  fi
+  execute_agent_iam "GitHub Token Minter" "${GITHUB_MINTER_KSA_NAME}" "${GITHUB_MINTER_GSA_NAME}"
+}
+
+# Step 7: Annotate GKE ServiceAccounts & Restart Controller Manager Deployment
 verify_annotations() {
   if [ "${DRY_RUN:-0}" -eq 1 ]; then
     return 1
@@ -175,6 +200,7 @@ execute_annotations() {
 run_step "1. Enable APIs" verify_apis execute_apis 10
 run_step "2. Configure Controller Workload Identity & GCP IAM" verify_controller execute_controller 5
 run_step "3. Configure Platform Agent Workload Identity & GCP IAM" verify_platform_agent execute_platform_agent 5
-run_step "4. Annotate GKE ServiceAccounts & Restart Deployment" verify_annotations execute_annotations 5
+run_step "4. Configure GitHub Token Minter Workload Identity" verify_github_minter_iam execute_github_minter_iam 5
+run_step "5. Annotate GKE ServiceAccounts & Restart Deployment" verify_annotations execute_annotations 5
 
 echo -e "\n${C_MAGENTA}${C_BOLD}>>>  Controller & Agent GCP Permissions Configured Successfully!  <<<${C_RESET}"

--- a/k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh
+++ b/k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh
@@ -33,27 +33,7 @@ init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 
 # Prompt for Model Provider and Default Name early to determine which API key is required
-init_var "MODEL_PROVIDER" "gemini" "Enter Model Provider (gemini, anthropic, chatgpt, openai)"
-
-MODEL_PROVIDER=$(echo "$MODEL_PROVIDER" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
-if [[ ! "$MODEL_PROVIDER" =~ ^(gemini|anthropic|chatgpt|openai)$ ]]; then
-  print_error "Invalid Model Provider '$MODEL_PROVIDER'. Must be one of: gemini, anthropic, chatgpt, openai."
-  exit 1
-fi
-
-case "$MODEL_PROVIDER" in
-  chatgpt|openai)
-    DEFAULT_MODEL="gpt-5.4"
-    ;;
-  anthropic)
-    DEFAULT_MODEL="claude-sonnet-4-5-20250929"
-    ;;
-  *)
-    DEFAULT_MODEL="gemini-3.5-flash"
-    ;;
-esac
-
-init_var "MODEL_DEFAULT_NAME" "$DEFAULT_MODEL" "Enter Model Default Name"
+init_var_model_provider
 
 # Securely prompt for Gemini API Key if Gemini is the provider and it's not set/placeholder
 if [ "$MODEL_PROVIDER" = "gemini" ]; then
@@ -144,6 +124,14 @@ execute_k8s_secrets() {
       --from-literal=OPENAI_API_KEY="$OPENAI_API_KEY" \
       --from-literal=ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
       --dry-run=client -o yaml | kubectl apply -f -
+
+  if [ -n "${GITHUB_APP_ID}" ]; then
+    print_info "Writing Kubernetes Secret 'github-app-credentials' into '$NAMESPACE'..."
+    kubectl create secret generic github-app-credentials \
+        --namespace="$NAMESPACE" \
+        --from-literal=app-id="${GITHUB_APP_ID}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+  fi
 }
 
 

--- a/k8s-operator/scripts/provision_08_deploy_litellm.sh
+++ b/k8s-operator/scripts/provision_08_deploy_litellm.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # ==============================================================================
-# 🤖 Step 6: Deploy PlatformAgent Custom Resource Manifest
+# 🤖 Step 8: Deploy LiteLLM Gateway
 # ==============================================================================
-# Idempotent script that connects to GKE, renders the platform-agent.yaml 
-# template, and deploys it to the cluster.
+# Idempotent script that connects to GKE and deploys the LiteLLM Gateway.
 # ==============================================================================
 
 set -e
@@ -35,15 +34,6 @@ init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var_model_provider
 
-# Map global state variables to expected template variables
-export GSA_NAME="${PLATFORM_AGENT_GSA_NAME}"
-export KSA_NAME="${PLATFORM_AGENT_KSA_NAME}"
-
-init_var "CHAT_SUB_NAME" "platform-agent-chat-events-sub" "Enter Pub/Sub Subscription Name"
-init_var "CHAT_TOPIC_NAME" "platform-agent-chat-events" "Enter Pub/Sub Topic Name"
-init_var "ALLOWED_USERS" "" "Enter Allowed Google Chat Users Emails (comma separated). Leaving it empty will allow all users."
-DEFAULT_AGENT_IMAGE="ghcr.io/gke-labs/kube-agents/platform-agent"
-init_var "AGENT_IMAGE" "$DEFAULT_AGENT_IMAGE" "Enter Platform Agent Image Path"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -58,34 +48,21 @@ execute_kubeconfig() {
   connect_cluster
 }
 
-
-# Step 2: Apply PlatformAgent Custom Resource
-verify_custom_resource() {
-  # Always return false to ensure configuration updates are applied to the Custom Resource
+# Step 2: Deploy LiteLLM Gateway
+verify_litellm() {
+  # Always return false to ensure that Kustomize builds and configs are applied idempotently on every run
   return 1
 }
-execute_custom_resource() {
-  print_info "Generating custom resource manifest 'platform-agent.yaml' from template..."
-  local CR_TEMPLATE="${SCRIPT_DIR}/platform-agent.yaml.template"
-  local CR_MANIFEST="${SCRIPT_DIR}/platform-agent.yaml"
-
-  if [ ! -f "$CR_TEMPLATE" ]; then
-    print_error "Custom resource template '$CR_TEMPLATE' not found!"
-    exit 1
-  fi
-
-  # Ensure variables are explicitly exported so envsubst can access them
-  export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME
-
-  envsubst < "$CR_TEMPLATE" > "$CR_MANIFEST"
-  
-  print_info "Applying 'platform-agent' Custom Resource to the GKE cluster..."
-  kubectl apply -f "$CR_MANIFEST"
+execute_litellm() {
+  print_info "Deploying LiteLLM Gateway into GKE..."
+  export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
+  make -C "${OPERATOR_DIR}" deploy-litellm || return 1
 }
+
 
 # ─── Execution Pipeline ───────────────────────────────────────────────────────
 run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0
-run_step "2. Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
+run_step "2. Deploy LiteLLM Gateway" verify_litellm execute_litellm 0
 
 # ─── Conclusion Checklist ─────────────────────────────────────────────────────
-echo -e "\n${C_GREEN}${C_BOLD}✓ PlatformAgent Custom Resource applied successfully to GKE!${C_RESET}"
+echo -e "\n${C_GREEN}${C_BOLD}✓ LiteLLM Gateway deployed successfully to GKE!${C_RESET}"

--- a/k8s-operator/scripts/provision_09_deploy_github_minter.sh
+++ b/k8s-operator/scripts/provision_09_deploy_github_minter.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 🤖 Step 9: Deploy GitHub Token Minter
+# ==============================================================================
+# Idempotent script that deploys the GitHub Token Minter.
+# ==============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
+VARS_FILE="${SCRIPT_DIR}/vars.sh"
+
+# ─── ANSI Colors ──────────────────────────────────────────────────────────────
+source "${SCRIPT_DIR}/common.sh" "$@"
+
+# ─── Prerequisites Check ──────────────────────────────────────────────────────
+print_step "Checking Local Prerequisites"
+check_prereqs "gcloud" "kubectl" "envsubst"
+
+# ─── Configuration & State Restoration ────────────────────────────────────────
+print_step "Setting up Configuration State for Agent Deployment"
+load_state
+
+ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
+DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
+
+init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
+init_var "REGION" "us-east4" "Enter GKE GCP Region"
+init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
+
+
+# ─── Step Implementations ─────────────────────────────────────────────────────
+
+# Step 1: Connect kubectl
+verify_kubeconfig() {
+  local current_ctx
+  current_ctx=$(kubectl config current-context 2>/dev/null || echo "")
+  [[ "$current_ctx" == *"${PROJECT_ID}"* && "$current_ctx" == *"${CLUSTER_NAME}"* ]] && \
+  kubectl get namespace "$NAMESPACE" >/dev/null 2>&1
+}
+
+execute_kubeconfig() {
+  connect_cluster
+}
+
+# Step 2: Enable KMS API
+verify_kms_api() {
+  local out=$(gcloud services list --enabled --project="$PROJECT_ID" --format="value(config.name)" 2>/dev/null || echo "")
+  echo "$out" | grep -q 'cloudkms.googleapis.com'
+}
+
+execute_kms_api() {
+  print_info "Enabling Cloud KMS API..."
+  gcloud services enable \
+      cloudkms.googleapis.com \
+      --project="$PROJECT_ID"
+}
+
+# Step 3: Deploy GitHub Token Minter
+verify_github_minter() {
+  if [ -z "${GITHUB_ORG:-}" ] || [ -z "${GITHUB_REPO:-}" ] || [ -z "${GITHUB_APP_ID:-}" ]; then
+    print_info "GitHub integration not configured. Skipping Minter deployment."
+    return 0
+  fi
+
+  # Always return false to ensure configuration updates (like KMS key changes)
+  # are applied to the Deployment workloads.
+  return 1
+}
+
+execute_github_minter() {
+  if [ -z "${GITHUB_ORG:-}" ] || [ -z "${GITHUB_REPO:-}" ] || [ -z "${GITHUB_APP_ID:-}" ]; then
+    return 0
+  fi
+
+  # Ensure KMS Keyring and Key exist.
+  print_info "Ensuring KMS Keyring '${KMS_KEYRING}' exists..."
+  if ! gcloud kms keyrings describe "${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+    gcloud kms keyrings create "${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" || return 1
+  fi
+
+  print_info "Ensuring KMS Key '${KMS_KEY}' exists..."
+  if ! gcloud kms keys describe "${KMS_KEY}" --location="${REGION}" --keyring="${KMS_KEYRING}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+    gcloud kms keys create "${KMS_KEY}" \
+        --location="${REGION}" \
+        --keyring="${KMS_KEYRING}" \
+        --purpose=asymmetric-signing \
+        --default-algorithm=rsa-sign-pkcs1-2048-sha256 \
+        --import-only \
+        --skip-initial-version-creation \
+        --project="${PROJECT_ID}" || return 1
+  fi
+
+  # Ensure the Minter GSA has signer permissions on the KMS key.
+  local gsa_email="${GITHUB_MINTER_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  print_info "Ensuring GSA has signer permissions on KMS key..."
+  gcloud kms keys add-iam-policy-binding "${KMS_KEY}" \
+      --location="${REGION}" \
+      --keyring="${KMS_KEYRING}" \
+      --member="serviceAccount:${gsa_email}" \
+      --role="roles/cloudkms.signerVerifier" \
+      --project="${PROJECT_ID}" \
+      --quiet >/dev/null || return 1
+
+  # Import PEM if provided and no version exists
+  local versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null)
+  if [ -z "$versions" ]; then
+    if [ -n "${GITHUB_PEM_PATH}" ] && [ -f "${GITHUB_PEM_PATH}" ]; then
+      if ! command -v go &>/dev/null; then
+        print_warning "Go is required to run the Minty CLI tool for importing the private key."
+        print_warning "Skipping automatic import. You must import the key manually later."
+      else
+        print_info "Importing GitHub Private Key PEM into KMS..."
+        
+        # We clone the Minty CLI here because it abstracts away all the complexity
+        # of uploading asymmetric private keys to KMS, making the process much
+        # more straightforward than using native gcloud commands.
+        local tmp_dir=$(mktemp -d)
+        print_info "Cloning github-token-minter CLI tool (v2.7.1) for secure cryptographic wrapping..."
+        if git clone --depth 1 --branch v2.7.1 https://github.com/abcxyz/github-token-minter.git "$tmp_dir" >/dev/null 2>&1; then
+          local abs_pem=$(realpath "${GITHUB_PEM_PATH}")
+          local import_success=0
+          (
+            cd "$tmp_dir"
+            for i in {1..6}; do
+              if go run ./cmd/minty tools import-pk \
+                  -project-id="${PROJECT_ID}" \
+                  -location="${REGION}" \
+                  -key-ring="${KMS_KEYRING}" \
+                  -key="${KMS_KEY}" \
+                  -private-key="@${abs_pem}"; then
+                exit 0
+              fi
+              echo "  [Retry $i/6] Waiting 5 seconds for KMS Import Job to become ACTIVE..."
+              sleep 5
+            done
+            exit 1
+          ) && import_success=1
+          rm -rf "$tmp_dir"
+          
+          if [ "$import_success" -eq 1 ]; then
+            print_success "Successfully imported GitHub Private Key to KMS via Minty CLI."
+          else
+            print_error "Failed to import GitHub Private Key to KMS. You must import it manually."
+          fi
+        else
+          rm -rf "$tmp_dir"
+          print_error "Failed to clone github-token-minter repo for CLI tools. You must import it manually."
+        fi
+      fi
+    else
+      print_warning "No GitHub Private Key PEM path provided or file not found."
+      print_warning "KMS Key '${KMS_KEY}' has no active version. Minter will fail to start until you import the key."
+      print_warning "You can import it later manually using Minty CLI:"
+      print_warning "  git clone --depth 1 --branch v2.7.1 https://github.com/abcxyz/github-token-minter.git /tmp/minty && cd /tmp/minty && go run ./cmd/minty tools import-pk -project-id=${PROJECT_ID} -location=${REGION} -key-ring=${KMS_KEYRING} -key=${KMS_KEY} -private-key=@/path/to/pem"
+    fi
+  fi
+
+  # Resolve the latest active (ENABLED) version number dynamically
+  print_info "Resolving active KMS key version number..."
+  local active_version
+  active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
+  
+  if [ -n "$active_version" ]; then
+    export KMS_KEY_VERSION="${active_version}"
+    print_success "Resolved active KMS key version: ${KMS_KEY_VERSION}"
+  else
+    print_warning "No active (ENABLED) version found for KMS Key '${KMS_KEY}'."
+    print_warning "Defaulting KMS_KEY_VERSION to '1'. The Token Minter deployment will fail its readiness probes until a key is imported."
+    export KMS_KEY_VERSION="1"
+  fi
+
+  print_info "Deploying GitHub Token Minter workloads..."
+  local GITHUB_INTEGRATION_DIR="${OPERATOR_DIR}/config/integrations/github"
+  
+  if [ -d "$GITHUB_INTEGRATION_DIR" ]; then
+    # Ensure all variables are exported for envsubst
+    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY KMS_KEY_VERSION GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME OPERATOR_AGENT_GSA_NAME DEVTEAM_AGENT_GSA_NAME
+    make -C "${OPERATOR_DIR}" deploy-github || return 1
+  else
+    print_error "GitHub integration directory not found at ${GITHUB_INTEGRATION_DIR}"
+    return 1
+  fi
+}
+
+
+# ─── Execution Pipeline ───────────────────────────────────────────────────────
+run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0
+run_step "2. Enable Cloud KMS API" verify_kms_api execute_kms_api 0
+run_step "3. Deploy GitHub Token Minter" verify_github_minter execute_github_minter 10
+
+# ─── Conclusion Checklist ─────────────────────────────────────────────────────
+echo -e "\n${C_GREEN}${C_BOLD}✓ GitHub Token Minter deployed successfully to GKE!${C_RESET}"

--- a/k8s-operator/scripts/teardown.sh
+++ b/k8s-operator/scripts/teardown.sh
@@ -27,8 +27,10 @@ if [ "$DRY_RUN" -eq 1 ]; then
   DRY_RUN_ARG="--dry-run"
 fi
 
-# Execute teardown steps in reverse order (06 down to 01)
+# Execute teardown steps in reverse order (09 down to 01)
 echo -e "\n${C_RED}${C_BOLD}🧹 Running Teardown Steps...${C_RESET}"
+"${SCRIPT_DIR}/teardown_09_deploy_github_minter.sh" --no-confirm $DRY_RUN_ARG || true
+"${SCRIPT_DIR}/teardown_08_deploy_litellm.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_06_deploy_platform_agent.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_05_gcp_gchat.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_04_gcp_k8s_secrets.sh" --no-confirm $DRY_RUN_ARG || true

--- a/k8s-operator/scripts/teardown_03_gcp_iam.sh
+++ b/k8s-operator/scripts/teardown_03_gcp_iam.sh
@@ -95,4 +95,7 @@ cleanup_agent_iam "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" \
 
 
 
+# Clean up GitHub Token Minter GSA
+cleanup_agent_iam "${GITHUB_MINTER_KSA_NAME}" "${GITHUB_MINTER_GSA_NAME}"
+
 echo -e "\n${C_GREEN}${C_BOLD}✅ Controller & Agent GCP IAM configurations fully cleaned up!${C_RESET}"

--- a/k8s-operator/scripts/teardown_04_gcp_k8s_secrets.sh
+++ b/k8s-operator/scripts/teardown_04_gcp_k8s_secrets.sh
@@ -55,6 +55,24 @@ if [ -n "$CLUSTER_EXISTS" ]; then
     else
       echo -e "  ${C_GREEN}✓ GKE Secret 'platform-agent-secrets' does not exist in namespace '${NAMESPACE}'.${C_RESET}"
     fi
+
+    # Clean up GitHub Minter Credentials Secret
+    MINTER_SECRET_EXISTS=""
+    if [ "${DRY_RUN:-0}" -ne 1 ]; then
+      MINTER_SECRET_EXISTS=$(kubectl get secret github-app-credentials -n "${NAMESPACE}" --ignore-not-found 2>/dev/null || echo "")
+    fi
+
+    if [ "${DRY_RUN:-0}" -eq 1 ] || [ -n "$MINTER_SECRET_EXISTS" ]; then
+      echo -e "  ${C_CYAN}ℹ Deleting GKE Secret 'github-app-credentials' from namespace '${NAMESPACE}'...${C_RESET}"
+      if [ "${DRY_RUN:-0}" -eq 1 ]; then
+        echo -e "  ${C_GREEN}[DRY-RUN] Would delete GKE Secret 'github-app-credentials' from namespace '${NAMESPACE}'.${C_RESET}"
+      else
+        kubectl delete secret github-app-credentials -n "${NAMESPACE}" --ignore-not-found || true
+        echo -e "  ${C_GREEN}✓ GKE Secret 'github-app-credentials' successfully deleted.${C_RESET}"
+      fi
+    else
+      echo -e "  ${C_GREEN}✓ GKE Secret 'github-app-credentials' does not exist in namespace '${NAMESPACE}'.${C_RESET}"
+    fi
   else
     echo -e "  ${C_GREEN}✓ Namespace '${NAMESPACE}' does not exist.${C_RESET}"
   fi

--- a/k8s-operator/scripts/teardown_06_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/teardown_06_deploy_platform_agent.sh
@@ -63,17 +63,7 @@ else
   echo -e "  ${C_GREEN}✓ CRD 'platformagents.kubeagents.x-k8s.io' is not registered. Skipping.${C_RESET}"
 fi
 
-# ─── Step 3: Undeploy LiteLLM Gateway ─────────────────────────────────────────
-echo -e "  ${C_CYAN}ℹ Undeploying LiteLLM Gateway...${C_RESET}"
-if [ "${DRY_RUN:-0}" -eq 1 ]; then
-  echo -e "  ${C_GREEN}[DRY-RUN] Would undeploy LiteLLM Gateway in namespace '${NAMESPACE}'.${C_RESET}"
-else
-  export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
-  make -C "${OPERATOR_DIR}" undeploy-litellm || true
-  echo -e "  ${C_GREEN}✓ LiteLLM Gateway undeploy command completed.${C_RESET}"
-fi
-
-# ─── Step 4: Clean up Local Manifest File ─────────────────────────────────────
+# ─── Step 3: Clean up Local Manifest File ─────────────────────────────────────
 local_yaml="${SCRIPT_DIR}/platform-agent.yaml"
 if [ -f "$local_yaml" ]; then
   if [ "${DRY_RUN:-0}" -eq 1 ]; then

--- a/k8s-operator/scripts/teardown_08_deploy_litellm.sh
+++ b/k8s-operator/scripts/teardown_08_deploy_litellm.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 🧹 Step 8: Teardown LiteLLM Gateway
+# ==============================================================================
+# Idempotent script to undeploy the LiteLLM gateway.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
+VARS_FILE="${SCRIPT_DIR}/vars.sh"
+
+# ─── ANSI Colors ──────────────────────────────────────────────────────────────
+source "${SCRIPT_DIR}/common.sh" "$@"
+
+# ─── Configuration State Restoration ──────────────────────────────────────────
+ensure_teardown_state
+
+# ─── Confirmation Prompt ──────────────────────────────────────────────────────
+confirm_action "This will permanently undeploy the LiteLLM Gateway." \
+  "GCP Project:$PROJECT_ID" \
+  "GKE Cluster:$CLUSTER_NAME" \
+  "Namespace:$NAMESPACE"
+
+gcloud config set project "$PROJECT_ID" --quiet
+
+# ─── Step 1: Connect to GKE Cluster ───────────────────────────────────────────
+CLUSTER_EXISTS=$(cluster_exists)
+if [ -n "$CLUSTER_EXISTS" ]; then
+  connect_cluster || true
+else
+  echo -e "  ${C_GREEN}✓ GKE cluster '${CLUSTER_NAME}' does not exist. Skipping LiteLLM Gateway cleanup.${C_RESET}"
+  exit 0
+fi
+
+
+# ─── Step 2: Undeploy LiteLLM Gateway ─────────────────────────────────────────
+echo -e "  ${C_CYAN}ℹ Undeploying LiteLLM Gateway...${C_RESET}"
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  echo -e "  ${C_GREEN}[DRY-RUN] Would undeploy LiteLLM Gateway in namespace '${NAMESPACE}'.${C_RESET}"
+else
+  export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
+  make -C "${OPERATOR_DIR}" undeploy-litellm || true
+  echo -e "  ${C_GREEN}✓ LiteLLM Gateway undeploy command completed.${C_RESET}"
+fi
+
+echo -e "\n${C_GREEN}${C_BOLD}✅ LiteLLM Gateway successfully undeployed!${C_RESET}"

--- a/k8s-operator/scripts/teardown_09_deploy_github_minter.sh
+++ b/k8s-operator/scripts/teardown_09_deploy_github_minter.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 🧹 Step 9: Teardown GitHub Token Minter
+# ==============================================================================
+# Idempotent script to clean up the GitHub Token Minter.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
+VARS_FILE="${SCRIPT_DIR}/vars.sh"
+
+# ─── ANSI Colors ──────────────────────────────────────────────────────────────
+source "${SCRIPT_DIR}/common.sh" "$@"
+
+# ─── Configuration State Restoration ──────────────────────────────────────────
+ensure_teardown_state
+
+# ─── Confirmation Prompt ──────────────────────────────────────────────────────
+confirm_action "This will permanently delete the GitHub Token Minter and destroy the KMS key versions." \
+  "GCP Project:$PROJECT_ID" \
+  "GKE Cluster:$CLUSTER_NAME" \
+  "Namespace:$NAMESPACE"
+
+gcloud config set project "$PROJECT_ID" --quiet
+
+# ─── Step 1: Connect to GKE Cluster ───────────────────────────────────────────
+CLUSTER_EXISTS=$(cluster_exists)
+if [ -n "$CLUSTER_EXISTS" ]; then
+  connect_cluster || true
+else
+  echo -e "  ${C_GREEN}✓ GKE cluster '${CLUSTER_NAME}' does not exist. Skipping custom resource cleanup.${C_RESET}"
+  exit 0
+fi
+
+
+# ─── Step 3.5: Undeploy GitHub Token Minter ───────────────────────────────────
+echo -e "  ${C_CYAN}ℹ Undeploying GitHub Token Minter workloads...${C_RESET}"
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  echo -e "  ${C_GREEN}[DRY-RUN] Would delete ConfigMap and Deployment for github-token-minter.${C_RESET}"
+else
+  GITHUB_INTEGRATION_DIR="${OPERATOR_DIR}/config/integrations/github"
+  if [ -d "$GITHUB_INTEGRATION_DIR" ]; then
+    # Export variables for envsubst
+    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME OPERATOR_AGENT_GSA_NAME DEVTEAM_AGENT_GSA_NAME
+    
+    active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
+    export KMS_KEY_VERSION="${active_version:-1}"
+    
+    make -C "${OPERATOR_DIR}" undeploy-github || true
+  else
+    # Fallback: raw kubectl deletion if manifests are missing
+    kubectl delete deployment/github-token-minter -n "${NAMESPACE}" --ignore-not-found=true || true
+    kubectl delete configmap/github-token-minter-config -n "${NAMESPACE}" --ignore-not-found=true || true
+    kubectl delete service/github-token-minter -n "${NAMESPACE}" --ignore-not-found=true || true
+    kubectl delete networkpolicy/github-token-minter-policy -n "${NAMESPACE}" --ignore-not-found=true || true
+  fi
+  echo -e "  ${C_GREEN}✓ GitHub Token Minter workloads undeployed.${C_RESET}"
+fi
+
+
+# ─── Step 5: Clean up GCP KMS Key (Disable & Destroy Versions) ─────────────────
+echo -e "  ${C_CYAN}ℹ Cleaning up GCP KMS Key '${KMS_KEY}'...${C_RESET}"
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  echo -e "  ${C_GREEN}[DRY-RUN] Would disable and schedule all versions of KMS Key '${KMS_KEY}' for destruction.${C_RESET}"
+else
+  versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --format="value(name)" 2>/dev/null || echo "")
+  
+  if [ -n "$versions" ]; then
+    for ver_path in $versions; do
+      ver_state=$(gcloud kms keys versions describe "$ver_path" --format="value(state)" 2>/dev/null || echo "")
+      
+      if [ "$ver_state" = "ENABLED" ]; then
+        print_info "Disabling KMS key version: $ver_path..."
+        gcloud kms keys versions disable "$ver_path" --quiet >/dev/null 2>&1 || true
+      fi
+      
+      if [ "$ver_state" != "DESTROYED" ] && [ "$ver_state" != "DESTROY_PENDING" ] && [ "$ver_state" != "IMPORT_FAILED" ]; then
+        print_info "Scheduling KMS key version for destruction: $ver_path..."
+        gcloud kms keys versions destroy "$ver_path" --quiet >/dev/null 2>&1 || true
+      fi
+    done
+    echo -e "  ${C_GREEN}✓ KMS Key versions scheduled for destruction.${C_RESET}"
+  else
+    echo -e "  ${C_GREEN}✓ KMS Key has no versions to clean up.${C_RESET}"
+  fi
+fi
+
+echo -e "\n${C_GREEN}${C_BOLD}✅ GitHub Token Minter successfully cleaned up!${C_RESET}"


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform Agent needs secure, short-lived access to GitHub repositories to perform automated tasks. To achieve this without storing long-lived, static GitHub tokens in the cluster, we are introducing the GitHub Token Minter (Minty) as a dedicated token broker. This PR automates the complete deployment lifecycle of Minty—from provisioning the necessary GCP IAM and KMS infrastructure to deploying the workloads in GKE and ensuring a clean teardown.

## What Changed

Integrated the GitHub Token Minter deployment into the existing provisioning and teardown bash scripts. This orchestrates setting up a dedicated Google Service Account with Workload Identity, securely importing the GitHub App private key into GCP KMS, and deploying the Minty manifests. Teardown scripts were also updated to delete these resources and schedule the KMS keys for destruction.

**Files:**

- `k8s-operator/scripts/provision_03_gcp_iam.sh`
- `k8s-operator/scripts/provision_04_gcp_k8s_secrets.sh`
- `k8s-operator/scripts/provision_06_deploy_platform_agent.sh`
- `k8s-operator/scripts/teardown_03_gcp_iam.sh`
- `k8s-operator/scripts/teardown_04_gcp_k8s_secrets.sh`
- `k8s-operator/scripts/teardown_06_deploy_platform_agent.sh`

**Added/Changed/Fixed:**

- **Added** IAM provisioning and teardown for the GitHub Token Minter GSA/KSA with Workload Identity bindings.
- **Added** creation and cleanup of the `github-app-credentials` Kubernetes Secret.
- **Added** automated GCP KMS KeyRing and Key creation for asymmetric signing.
- **Added** a secure import flow using the Minty CLI to correctly wrap and upload the GitHub App `.pem` private key to KMS.
- **Added** deployment logic for applying Minty's ConfigMap and Deployment manifests via `envsubst`.
- **Changed** teardown scripts to cleanly disable and schedule the associated KMS key versions for destruction upon cleanup.

## Why This Matters

- Ensures the Platform Agent has a secure, automated, and standardized mechanism to authenticate to GitHub using dynamically minted, tightly scoped installation tokens.
- Reduces manual infrastructure setup by fully automating the complex KMS asymmetric key formatting and import process.
- Ensures no orphaned resources (like IAM bindings, Secrets, or KMS versions) are left behind during cluster teardown, saving costs and maintaining security hygiene.

## Context

This builds on the recent integration of GitHub App authentication for the Kubernetes operator, moving the token generation responsibility out of the agent itself and into a dedicated, secure, centralized broker.

## Testing

- Verified provisioning scripts successfully create the KMS key, import the private key, and apply the Minty workloads.
- Verified teardown scripts properly disable/schedule KMS key versions for destruction and remove all associated Minty IAM/Secret resources.

---

**Rollout Note:** The KMS key import process clones the `github-token-minter` repo temporarily to leverage its CLI for secure PKCS#8 formatting and wrapping. If the GitHub App private key (`GITHUB_PEM_PATH`) is not provided during provisioning, Minty will deploy but fail its readiness probes until the key is manually imported to the KMS resource.