### PR TITLE
feat(operator): grant cluster-wide read-only infrastructure RBAC permissions to operator agent

### DIFF
--- a/k8s-operator/config/agent_rbac/kustomization.yaml
+++ b/k8s-operator/config/agent_rbac/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
   - platformagent.yaml
+  - operatoragent.yaml

--- a/k8s-operator/config/agent_rbac/operatoragent.yaml
+++ b/k8s-operator/config/agent_rbac/operatoragent.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubeagents-operator-agent
   namespace: kubeagents-system
 ---
-# ── Read-Only Cluster-Scoped K8s RBAC Roles for Operator Agent ─────────────────
+# ── Read-Only Cluster-Scoped Infrastructure RBAC Role for Operator Agent ────────
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,35 +14,13 @@ rules:
     resources:
       - nodes
       - namespaces
-      - pods
-      - services
       - events
       - persistentvolumes
-      - serviceaccounts
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps"]
-    resources:
-      - deployments
-      - daemonsets
-      - statefulsets
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["networking.k8s.io"]
-    resources:
-      - networkpolicies
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["policy"]
-    resources:
-      - poddisruptionbudgets
     verbs: ["get", "list", "watch"]
   - apiGroups: ["metrics.k8s.io"]
     resources:
       - nodes
-      - pods
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["autoscaling"]
-    resources:
-      - horizontalpodautoscalers
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/k8s-operator/config/agent_rbac/operatoragent.yaml
+++ b/k8s-operator/config/agent_rbac/operatoragent.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubeagents-operator-agent
+  namespace: kubeagents-system
+---
+# ── Read-Only Cluster-Scoped K8s RBAC Roles for Operator Agent ─────────────────
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-agent-clusterrole
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - pods
+      - services
+      - events
+      - persistentvolumes
+      - serviceaccounts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - nodes
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operator-agent-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: kubeagents-operator-agent
+    namespace: kubeagents-system
+roleRef:
+  kind: ClusterRole
+  name: operator-agent-clusterrole
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
# Pull Request

## Why This Change

In cooperative multi-agent Kubernetes operations, the Cluster Operator Agent is responsible for auditing cluster-wide node CPU/memory capacity and infrastructure health. Previously, Operator Agent's K8s RBAC was defined as a namespace-scoped `Role` in `kubeagents-system`, which blocked it from inspecting cluster nodes and discovering registered tenant namespaces. Furthermore, its ServiceAccount name in static manifests (`operator-agent`) conflicted with the name required by Go controllers (`kubeagents-operator-agent`), and included unnecessary workload/pod permissions that violated least privilege.

## What Changed

Promotes Operator Agent RBAC to a cluster-wide read-only `ClusterRole` and `ClusterRoleBinding` strictly bounded to cluster infrastructure, while removing all workload and Pod permissions.

**Files:**

- `k8s-operator/config/agent_rbac/operatoragent.yaml`

**Added/Changed/Fixed:**

- Promoted `operator-agent-role` (`Role`) to `operator-agent-clusterrole` (`ClusterRole`) and `ClusterRoleBinding`.
- Granted read-only cluster infrastructure permissions (`["get", "list", "watch"]`) for `nodes`, `namespaces`, `persistentvolumes`, and `events`.
- Granted point-in-time metrics snapshot access (`["get", "list"]`) for `nodes.metrics.k8s.io` (excluding unsupported `watch` streaming verb against aggregated metrics servers).
- Stripped all workload and Pod permissions (`pods`, `deployments`, `statefulsets`, `daemonsets`, `poddisruptionbudgets`, `horizontalpodautoscalers`, `networkpolicies`, `services`, `serviceaccounts`) to enforce strict separation of concerns where workload inspection belongs exclusively to DevTeam Agent.
- Standardized `ServiceAccount` metadata name to `kubeagents-operator-agent` to match Go operator controllers (`operatoragent_manifests.go`).

## Why This Matters

- Enables Cluster Operator Agent to autonomously inspect cluster node memory/CPU headroom and discover registered tenant namespaces.
- Enforces strict least-privilege boundaries: if an Operator pod is compromised, the attacker cannot list or read developer workload Pods or inspect application namespaces.
- Resolves ServiceAccount lookup failures during dynamic Go operator controller provisioning.

## Context

Follow-up work from cluster upgrade risk assessment multi-agent negotiation trials.

## Testing

- **Formatting:** Verified via `npx prettier --check k8s-operator/config/agent_rbac/operatoragent.yaml` (Passed).
- **Go Compilation:** Verified via `(cd k8s-operator && go build ./...)` (Passed).

---

Functional impact is strictly limited to expanding Cluster Operator cluster infrastructure visibility while enforcing least privilege boundaries against developer workloads.