### PR TITLE
feat(operator): structure Google Chat user identity and session ID in Fluent Bit logs

### DIFF
--- a/k8s-operator/internal/controller/devteamagent_manifests.go
+++ b/k8s-operator/internal/controller/devteamagent_manifests.go
@@ -462,7 +462,7 @@ func buildDevTeamFluentBitConfigMap(agent *agentv1alpha1.DevTeamAgent) *corev1.C
 			"parsers.conf": `[PARSER]
     Name    gchat_event
     Format  regex
-    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
 `,
 		},
 	}

--- a/k8s-operator/internal/controller/devteamagent_manifests.go
+++ b/k8s-operator/internal/controller/devteamagent_manifests.go
@@ -348,6 +348,12 @@ func buildDevTeamDeployment(agent *agentv1alpha1.DevTeamAgent, configHash, fluen
 									ReadOnly:  true,
 								},
 								{
+									Name:      "fluent-bit-config",
+									MountPath: "/fluent-bit/etc/parsers.conf",
+									SubPath:   "parsers.conf",
+									ReadOnly:  true,
+								},
+								{
 									Name:      "fluent-bit-state",
 									MountPath: "/fluent-bit/state",
 								},
@@ -435,6 +441,14 @@ func buildDevTeamFluentBitConfigMap(agent *agentv1alpha1.DevTeamAgent) *corev1.C
     Path_Key          file_path
 
 [FILTER]
+    Name          parser
+    Match         agent.logs
+    Key_Name      log
+    Parser        gchat_event
+    Reserve_Data  On
+    Preserve_Key  On
+
+[FILTER]
     Name              record_modifier
     Match             agent.logs
     Record            app agent
@@ -444,6 +458,11 @@ func buildDevTeamFluentBitConfigMap(agent *agentv1alpha1.DevTeamAgent) *corev1.C
     Name              stdout
     Match             agent.logs
     Format            json_lines
+`,
+			"parsers.conf": `[PARSER]
+    Name    gchat_event
+    Format  regex
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
 `,
 		},
 	}

--- a/k8s-operator/internal/controller/operatoragent_manifests.go
+++ b/k8s-operator/internal/controller/operatoragent_manifests.go
@@ -433,7 +433,7 @@ func buildOperatorFluentBitConfigMap(agent *agentv1alpha1.OperatorAgent) *corev1
 			"parsers.conf": `[PARSER]
     Name    gchat_event
     Format  regex
-    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
 `,
 		},
 	}

--- a/k8s-operator/internal/controller/operatoragent_manifests.go
+++ b/k8s-operator/internal/controller/operatoragent_manifests.go
@@ -319,6 +319,12 @@ func buildOperatorDeployment(agent *agentv1alpha1.OperatorAgent, configHash, flu
 									ReadOnly:  true,
 								},
 								{
+									Name:      "fluent-bit-config",
+									MountPath: "/fluent-bit/etc/parsers.conf",
+									SubPath:   "parsers.conf",
+									ReadOnly:  true,
+								},
+								{
 									Name:      "fluent-bit-state",
 									MountPath: "/fluent-bit/state",
 								},
@@ -406,6 +412,14 @@ func buildOperatorFluentBitConfigMap(agent *agentv1alpha1.OperatorAgent) *corev1
     Path_Key          file_path
 
 [FILTER]
+    Name          parser
+    Match         agent.logs
+    Key_Name      log
+    Parser        gchat_event
+    Reserve_Data  On
+    Preserve_Key  On
+
+[FILTER]
     Name              record_modifier
     Match             agent.logs
     Record            app agent
@@ -415,6 +429,11 @@ func buildOperatorFluentBitConfigMap(agent *agentv1alpha1.OperatorAgent) *corev1
     Name              stdout
     Match             agent.logs
     Format            json_lines
+`,
+			"parsers.conf": `[PARSER]
+    Name    gchat_event
+    Format  regex
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
 `,
 		},
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -542,7 +542,7 @@ func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigM
 			"parsers.conf": `[PARSER]
     Name    gchat_event
     Format  regex
-    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
 `,
 		},
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -365,6 +365,12 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 									ReadOnly:  true,
 								},
 								{
+									Name:      "fluent-bit-config",
+									MountPath: "/fluent-bit/etc/parsers.conf",
+									SubPath:   "parsers.conf",
+									ReadOnly:  true,
+								},
+								{
 									Name:      "fluent-bit-state",
 									MountPath: "/fluent-bit/state",
 								},
@@ -515,6 +521,14 @@ func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigM
     Path_Key          file_path
 
 [FILTER]
+    Name          parser
+    Match         agent.logs
+    Key_Name      log
+    Parser        gchat_event
+    Reserve_Data  On
+    Preserve_Key  On
+
+[FILTER]
     Name              record_modifier
     Match             agent.logs
     Record            app agent
@@ -524,6 +538,11 @@ func buildFluentBitConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigM
     Name              stdout
     Match             agent.logs
     Format            json_lines
+`,
+			"parsers.conf": `[PARSER]
+    Name    gchat_event
+    Format  regex
+    Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)
 `,
 		},
 	}
@@ -559,4 +578,3 @@ func buildPlatformService(agent *agentv1alpha1.PlatformAgent) *corev1.Service {
 		},
 	}
 }
-


### PR DESCRIPTION
# Pull Request

## Why This Change

Google Chat events carry the user identity and session ID in their raw payloads, and the agent emits log lines containing these attributes (e.g. `User=alice@example.com, Session=session_id`). However, they are currently logged as unstructured text, making them difficult to query or filter in Cloud Logging.

By parsing these attributes into structured fields using a Fluent Bit filter, we can make the Google Chat user identity (`gchat_user`) and conversation session (`gchat_session`) queryable downstream, providing an audit trail for agent actions triggered by chat interactions.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/operatoragent_manifests.go`
- `k8s-operator/internal/controller/devteamagent_manifests.go`

**Added/Changed/Fixed:**

- Mounted `parsers.conf` as a ConfigMap volume mount to `/fluent-bit/etc/parsers.conf` in the Fluent Bit sidecar container.
- Added a `gchat_event` regex parser in `parsers.conf` ConfigMap data to extract `User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>\S+)`.
- Configured a `parser` filter in `fluent-bit.conf` ConfigMap data to parse matching fields in `agent.logs` with the `gchat_event` parser while preserving other log fields.

## Why This Matters

Structured fields in Cloud Logging allow instant filtering, dashboard creation, and auditing of user-initiated actions, improving operational security and auditability.

## Context

Ref: `architecture.md` & `gchat-user-audit-logging-assessment.md`

## Testing

- Verified that operator code compiles successfully with `make build`.
- Ran unit tests successfully with `make test`.
