### PR TITLE
Test: add golden tests for DevTeamAgent and OperatorAgent

### DIFF
--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -559,4 +559,3 @@ func buildPlatformService(agent *agentv1alpha1.PlatformAgent) *corev1.Service {
 		},
 	}
 }
-

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -57,7 +57,6 @@ func TestAgentsGolden(t *testing.T) {
 				return &controller.OperatorAgentReconciler{Client: c, Scheme: s}
 			},
 		},
-
 	}
 
 	for _, tt := range tests {

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -1,0 +1,77 @@
+package testing
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+	"github.com/gke-labs/kube-agents/k8s-operator/internal/controller"
+	"github.com/gke-labs/kube-agents/k8s-operator/internal/testing/testutil"
+)
+
+var (
+	update     = flag.Bool("update", false, "update golden files")
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = agentv1alpha1.AddToScheme(testScheme)
+	_ = corev1.AddToScheme(testScheme)
+	_ = appsv1.AddToScheme(testScheme)
+	_ = rbacv1.AddToScheme(testScheme)
+}
+
+func TestAgentsGolden(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		inputPath     string
+		expectedPath  string
+		newAgent      func() client.Object
+		newReconciler func(client.Client, *runtime.Scheme) reconcile.Reconciler
+	}{
+		{
+			name:         "DevTeamAgent",
+			inputPath:    filepath.Join("..", "..", "examples", "devteamagent.yaml"),
+			expectedPath: filepath.Join("testdata", "devteam", "expected", "devteamagent.yaml"),
+			newAgent:     func() client.Object { return &agentv1alpha1.DevTeamAgent{} },
+			newReconciler: func(c client.Client, s *runtime.Scheme) reconcile.Reconciler {
+				return &controller.DevTeamAgentReconciler{Client: c, Scheme: s}
+			},
+		},
+		{
+			name:         "OperatorAgent",
+			inputPath:    filepath.Join("..", "..", "examples", "operatoragent.yaml"),
+			expectedPath: filepath.Join("testdata", "operator", "expected", "operatoragent.yaml"),
+			newAgent:     func() client.Object { return &agentv1alpha1.OperatorAgent{} },
+			newReconciler: func(c client.Client, s *runtime.Scheme) reconcile.Reconciler {
+				return &controller.OperatorAgentReconciler{Client: c, Scheme: s}
+			},
+		},
+
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			testutil.RunGoldenTest(
+				t,
+				tt.inputPath,
+				tt.expectedPath,
+				*update,
+				testScheme,
+				tt.newAgent,
+				tt.newReconciler,
+			)
+		})
+	}
+}

--- a/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
+++ b/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
@@ -5,15 +5,15 @@ metadata:
   name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-data
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: DevTeamAgent
-    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DevTeamAgent
+      name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -42,12 +42,12 @@ metadata:
   name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: DevTeamAgent
-    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DevTeamAgent
+      name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -86,12 +86,12 @@ metadata:
   name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: DevTeamAgent
-    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DevTeamAgent
+      name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+      uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -102,12 +102,12 @@ metadata:
   name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: DevTeamAgent
-    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DevTeamAgent
+      name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+      uid: ""
 spec:
   replicas: 1
   selector:
@@ -125,97 +125,97 @@ spec:
         app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
     spec:
       containers:
-      - args:
-        - gateway
-        - run
-        command:
-        - hermes
-        env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: PLATFORM_AGENT_DASHBOARD
-          value: "0"
-        - name: PLATFORM_AGENT_PLUGINS_DEBUG
-          value: "0"
-        - name: OTEL_SERVICE_NAME
-          value: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
-        - name: API_SERVER_ENABLED
-          value: "true"
-        - name: API_SERVER_HOST
-          value: 0.0.0.0
-        - name: PLATFORM_API_URL
-          value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
-        - name: GKE_CLUSTER_NAME
-          value: autopilot-cluster-1
-        - name: GKE_LOCATION
-          value: us-central1
-        - name: GKE_NAMESPACE
-          value: devteam-app-ns
-        - name: API_SERVER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: API_SERVER_KEY
-              name: platform-agent-secrets
-        image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/devteam-agent:latest
-        imagePullPolicy: Always
-        name: devteam-agent
-        ports:
-        - containerPort: 9119
-          name: dashboard
-        - containerPort: 8642
-          name: api
-        resources:
-          limits:
-            cpu: 500m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 512Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: devteam-agent-data-vol
-        - mountPath: /opt/data/config.yaml
-          name: devteam-agent-config-vol
-          subPath: config.yaml
-        - mountPath: /opt/data/SETTINGS.md
-          name: devteam-agent-config-vol
-          subPath: SETTINGS.md
-      - args:
-        - -c
-        - /fluent-bit/etc/fluent-bit.conf
-        image: fluent/fluent-bit:5.0.7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 500m
-            ephemeral-storage: 1Gi
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 1Gi
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: devteam-agent-data-vol
-          readOnly: true
-        - mountPath: /fluent-bit/etc/fluent-bit.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: fluent-bit.conf
-        - mountPath: /fluent-bit/state
-          name: fluent-bit-state
+        - args:
+            - gateway
+            - run
+          command:
+            - hermes
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_DASHBOARD
+              value: "0"
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: OTEL_SERVICE_NAME
+              value: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
+            - name: PLATFORM_API_URL
+              value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
+            - name: GKE_CLUSTER_NAME
+              value: autopilot-cluster-1
+            - name: GKE_LOCATION
+              value: us-central1
+            - name: GKE_NAMESPACE
+              value: devteam-app-ns
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SERVER_KEY
+                  name: platform-agent-secrets
+          image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/devteam-agent:latest
+          imagePullPolicy: Always
+          name: devteam-agent
+          ports:
+            - containerPort: 9119
+              name: dashboard
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: devteam-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: devteam-agent-config-vol
+              subPath: config.yaml
+            - mountPath: /opt/data/SETTINGS.md
+              name: devteam-agent-config-vol
+              subPath: SETTINGS.md
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: devteam-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
       securityContext:
         fsGroup: 1000
         runAsNonRoot: true
@@ -224,19 +224,19 @@ spec:
           type: RuntimeDefault
       serviceAccountName: kubeagents-devteam-agent
       volumes:
-      - name: devteam-agent-data-vol
-        persistentVolumeClaim:
-          claimName: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-data
-      - configMap:
-          defaultMode: 493
-          name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-config
-        name: devteam-agent-config-vol
-      - configMap:
-          defaultMode: 420
-          name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-fluent-bit-config
-        name: fluent-bit-config
-      - emptyDir: {}
-        name: fluent-bit-state
+        - name: devteam-agent-data-vol
+          persistentVolumeClaim:
+            claimName: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-data
+        - configMap:
+            defaultMode: 493
+            name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-config
+          name: devteam-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
 status: {}
 ---
 apiVersion: v1
@@ -246,20 +246,20 @@ metadata:
   name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: DevTeamAgent
-    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: DevTeamAgent
+      name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+      uid: ""
 spec:
   ports:
-  - name: api
-    port: 8642
-    targetPort: api
-  - name: dashboard
-    port: 9119
-    targetPort: dashboard
+    - name: api
+      port: 8642
+      targetPort: api
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
   selector:
     app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
+++ b/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-data
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DevTeamAgent
+    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+    uid: ""
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+status: {}
+---
+apiVersion: v1
+data:
+  SETTINGS.md: |
+    # GKE Scope Configuration
+    - **Cluster Name:** autopilot-cluster-1
+    - **Cluster Location:** us-central1
+    - **Namespace:** devteam-app-ns
+  config.yaml: |
+    model:
+      api_key: none
+      base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
+      default: model-default
+      model: model-default
+      provider: custom
+    terminal:
+      backend: local
+      cwd: /opt/data
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DevTeamAgent
+    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+    uid: ""
+---
+apiVersion: v1
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/fluent-bit.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-fluent-bit-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DevTeamAgent
+    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+  name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DevTeamAgent
+    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+    uid: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubeagents.x-k8s.io/config-hash: ed243c16c4b4ac5dfacb8942cf80650ec654a88acc0c88ca963f476369de6e4f
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 2c70fde063d683710561f5cda42ec406d81907c9e33c7a27c24e77587c7e517b
+      creationTimestamp: null
+      labels:
+        app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+    spec:
+      containers:
+      - args:
+        - gateway
+        - run
+        command:
+        - hermes
+        env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_DASHBOARD
+          value: "0"
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: OTEL_SERVICE_NAME
+          value: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: API_SERVER_HOST
+          value: 0.0.0.0
+        - name: PLATFORM_API_URL
+          value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
+        - name: GKE_CLUSTER_NAME
+          value: autopilot-cluster-1
+        - name: GKE_LOCATION
+          value: us-central1
+        - name: GKE_NAMESPACE
+          value: devteam-app-ns
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: API_SERVER_KEY
+              name: platform-agent-secrets
+        image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/devteam-agent:latest
+        imagePullPolicy: Always
+        name: devteam-agent
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: devteam-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: devteam-agent-config-vol
+          subPath: config.yaml
+        - mountPath: /opt/data/SETTINGS.md
+          name: devteam-agent-config-vol
+          subPath: SETTINGS.md
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: devteam-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubeagents-devteam-agent
+      volumes:
+      - name: devteam-agent-data-vol
+        persistentVolumeClaim:
+          claimName: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-data
+      - configMap:
+          defaultMode: 493
+          name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-config
+        name: devteam-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: DevTeamAgent
+    name: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns
+    uid: ""
+spec:
+  ports:
+  - name: api
+    port: 8642
+    targetPort: api
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
+  selector:
+    app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
+status:
+  loadBalancer: {}

--- a/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
+++ b/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
@@ -5,15 +5,15 @@ metadata:
   name: operator-agent-autopilot-cluster-1-us-central1-data
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: OperatorAgent
-    name: operator-agent-autopilot-cluster-1-us-central1
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: OperatorAgent
+      name: operator-agent-autopilot-cluster-1-us-central1
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -37,12 +37,12 @@ metadata:
   name: operator-agent-autopilot-cluster-1-us-central1-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: OperatorAgent
-    name: operator-agent-autopilot-cluster-1-us-central1
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: OperatorAgent
+      name: operator-agent-autopilot-cluster-1-us-central1
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -81,12 +81,12 @@ metadata:
   name: operator-agent-autopilot-cluster-1-us-central1-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: OperatorAgent
-    name: operator-agent-autopilot-cluster-1-us-central1
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: OperatorAgent
+      name: operator-agent-autopilot-cluster-1-us-central1
+      uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -97,12 +97,12 @@ metadata:
   name: operator-agent-autopilot-cluster-1-us-central1-gateway
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: OperatorAgent
-    name: operator-agent-autopilot-cluster-1-us-central1
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: OperatorAgent
+      name: operator-agent-autopilot-cluster-1-us-central1
+      uid: ""
 spec:
   replicas: 1
   selector:
@@ -120,92 +120,92 @@ spec:
         app: operator-agent-autopilot-cluster-1-us-central1-gateway
     spec:
       containers:
-      - args:
-        - gateway
-        - run
-        command:
-        - hermes
-        env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: PLATFORM_AGENT_DASHBOARD
-          value: "0"
-        - name: PLATFORM_AGENT_PLUGINS_DEBUG
-          value: "0"
-        - name: OTEL_SERVICE_NAME
-          value: operator-agent-autopilot-cluster-1-us-central1-gateway
-        - name: API_SERVER_ENABLED
-          value: "true"
-        - name: API_SERVER_HOST
-          value: 0.0.0.0
-        - name: PLATFORM_API_URL
-          value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
-        - name: GKE_CLUSTER_NAME
-          value: autopilot-cluster-1
-        - name: GKE_LOCATION
-          value: us-central1
-        - name: API_SERVER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: API_SERVER_KEY
-              name: platform-agent-secrets
-        image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/operator-agent:latest
-        imagePullPolicy: Always
-        name: operator-agent
-        ports:
-        - containerPort: 9119
-          name: dashboard
-        - containerPort: 8642
-          name: api
-        resources:
-          limits:
-            cpu: 500m
-            memory: 1Gi
-          requests:
-            cpu: 100m
-            memory: 512Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: operator-agent-data-vol
-        - mountPath: /opt/data/config.yaml
-          name: operator-agent-config-vol
-          subPath: config.yaml
-      - args:
-        - -c
-        - /fluent-bit/etc/fluent-bit.conf
-        image: fluent/fluent-bit:5.0.7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 500m
-            ephemeral-storage: 1Gi
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 1Gi
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: operator-agent-data-vol
-          readOnly: true
-        - mountPath: /fluent-bit/etc/fluent-bit.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: fluent-bit.conf
-        - mountPath: /fluent-bit/state
-          name: fluent-bit-state
+        - args:
+            - gateway
+            - run
+          command:
+            - hermes
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_DASHBOARD
+              value: "0"
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: OTEL_SERVICE_NAME
+              value: operator-agent-autopilot-cluster-1-us-central1-gateway
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
+            - name: PLATFORM_API_URL
+              value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
+            - name: GKE_CLUSTER_NAME
+              value: autopilot-cluster-1
+            - name: GKE_LOCATION
+              value: us-central1
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: API_SERVER_KEY
+                  name: platform-agent-secrets
+          image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/operator-agent:latest
+          imagePullPolicy: Always
+          name: operator-agent
+          ports:
+            - containerPort: 9119
+              name: dashboard
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: operator-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: operator-agent-config-vol
+              subPath: config.yaml
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: operator-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
       securityContext:
         fsGroup: 1000
         runAsNonRoot: true
@@ -214,19 +214,19 @@ spec:
           type: RuntimeDefault
       serviceAccountName: kubeagents-operator-agent
       volumes:
-      - name: operator-agent-data-vol
-        persistentVolumeClaim:
-          claimName: operator-agent-autopilot-cluster-1-us-central1-data
-      - configMap:
-          defaultMode: 493
-          name: operator-agent-autopilot-cluster-1-us-central1-config
-        name: operator-agent-config-vol
-      - configMap:
-          defaultMode: 420
-          name: operator-agent-autopilot-cluster-1-us-central1-fluent-bit-config
-        name: fluent-bit-config
-      - emptyDir: {}
-        name: fluent-bit-state
+        - name: operator-agent-data-vol
+          persistentVolumeClaim:
+            claimName: operator-agent-autopilot-cluster-1-us-central1-data
+        - configMap:
+            defaultMode: 493
+            name: operator-agent-autopilot-cluster-1-us-central1-config
+          name: operator-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: operator-agent-autopilot-cluster-1-us-central1-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
 status: {}
 ---
 apiVersion: v1
@@ -236,20 +236,20 @@ metadata:
   name: operator-agent-autopilot-cluster-1-us-central1
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: OperatorAgent
-    name: operator-agent-autopilot-cluster-1-us-central1
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: OperatorAgent
+      name: operator-agent-autopilot-cluster-1-us-central1
+      uid: ""
 spec:
   ports:
-  - name: api
-    port: 8642
-    targetPort: api
-  - name: dashboard
-    port: 9119
-    targetPort: dashboard
+    - name: api
+      port: 8642
+      targetPort: api
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
   selector:
     app: operator-agent-autopilot-cluster-1-us-central1-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
+++ b/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
@@ -1,0 +1,256 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: operator-agent-autopilot-cluster-1-us-central1-data
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OperatorAgent
+    name: operator-agent-autopilot-cluster-1-us-central1
+    uid: ""
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+status: {}
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    model:
+      api_key: none
+      base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
+      default: model-default
+      model: model-default
+      provider: custom
+    terminal:
+      backend: local
+      cwd: /opt/data
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: operator-agent-autopilot-cluster-1-us-central1-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OperatorAgent
+    name: operator-agent-autopilot-cluster-1-us-central1
+    uid: ""
+---
+apiVersion: v1
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/fluent-bit.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: operator-agent-autopilot-cluster-1-us-central1-fluent-bit-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OperatorAgent
+    name: operator-agent-autopilot-cluster-1-us-central1
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operator-agent-autopilot-cluster-1-us-central1-gateway
+  name: operator-agent-autopilot-cluster-1-us-central1-gateway
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OperatorAgent
+    name: operator-agent-autopilot-cluster-1-us-central1
+    uid: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operator-agent-autopilot-cluster-1-us-central1-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubeagents.x-k8s.io/config-hash: b2620ec7a605c6fc0fdc86db6128e9f2540b704e59f279eebbcb34e8c3d1ffc5
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 2c70fde063d683710561f5cda42ec406d81907c9e33c7a27c24e77587c7e517b
+      creationTimestamp: null
+      labels:
+        app: operator-agent-autopilot-cluster-1-us-central1-gateway
+    spec:
+      containers:
+      - args:
+        - gateway
+        - run
+        command:
+        - hermes
+        env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_DASHBOARD
+          value: "0"
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: OTEL_SERVICE_NAME
+          value: operator-agent-autopilot-cluster-1-us-central1-gateway
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: API_SERVER_HOST
+          value: 0.0.0.0
+        - name: PLATFORM_API_URL
+          value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
+        - name: GKE_CLUSTER_NAME
+          value: autopilot-cluster-1
+        - name: GKE_LOCATION
+          value: us-central1
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: API_SERVER_KEY
+              name: platform-agent-secrets
+        image: us-central1-docker.pkg.dev/kube-agents-gke/kubeagents-operator-repo/operator-agent:latest
+        imagePullPolicy: Always
+        name: operator-agent
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: operator-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: operator-agent-config-vol
+          subPath: config.yaml
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: operator-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
+      securityContext:
+        fsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubeagents-operator-agent
+      volumes:
+      - name: operator-agent-data-vol
+        persistentVolumeClaim:
+          claimName: operator-agent-autopilot-cluster-1-us-central1-data
+      - configMap:
+          defaultMode: 493
+          name: operator-agent-autopilot-cluster-1-us-central1-config
+        name: operator-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: operator-agent-autopilot-cluster-1-us-central1-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: operator-agent-autopilot-cluster-1-us-central1
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: OperatorAgent
+    name: operator-agent-autopilot-cluster-1-us-central1
+    uid: ""
+spec:
+  ports:
+  - name: api
+    port: 8642
+    targetPort: api
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
+  selector:
+    app: operator-agent-autopilot-cluster-1-us-central1-gateway
+status:
+  loadBalancer: {}

--- a/k8s-operator/internal/testing/testutil/testutil.go
+++ b/k8s-operator/internal/testing/testutil/testutil.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -54,7 +55,6 @@ func (c *TrackingClient) IsMutated() bool {
 }
 
 func (c *TrackingClient) track(obj client.Object) {
-	c.mutated = true
 	copied := obj.DeepCopyObject().(client.Object)
 
 	// Populate TypeMeta dynamically using the scheme
@@ -70,14 +70,56 @@ func (c *TrackingClient) track(obj client.Object) {
 	)
 
 	if key == c.ignoreKey {
+		c.mutated = true // Still mark as mutated for the loop if the target CR itself is updated (e.g. finalizers)
 		return
 	}
 
+	// Clean volatile fields for comparison
+	cleanCopied := copied.DeepCopyObject().(client.Object)
+	cleanCopied.SetResourceVersion("")
+	cleanCopied.SetUID("")
+	cleanCopied.SetCreationTimestamp(metav1.Time{})
+
 	if idx, exists := c.indices[key]; exists {
+		existingClean := c.objects[idx].DeepCopyObject().(client.Object)
+		existingClean.SetResourceVersion("")
+		existingClean.SetUID("")
+		existingClean.SetCreationTimestamp(metav1.Time{})
+
+		if reflect.DeepEqual(cleanCopied, existingClean) {
+			// No semantic change, don't mark as mutated, just update the stored object
+			c.objects[idx] = copied
+			return
+		}
 		c.objects[idx] = copied
 	} else {
 		c.indices[key] = len(c.objects)
 		c.objects = append(c.objects, copied)
+	}
+	c.mutated = true
+}
+
+func (c *TrackingClient) untrack(obj client.Object) {
+	c.mutated = true
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	var kind string
+	if err == nil {
+		kind = gvk.Kind
+	} else {
+		kind = obj.GetObjectKind().GroupVersionKind().Kind
+	}
+	key := fmt.Sprintf("%s/%s/%s", kind, obj.GetNamespace(), obj.GetName())
+	if idx, exists := c.indices[key]; exists {
+		c.objects = append(c.objects[:idx], c.objects[idx+1:]...)
+		delete(c.indices, key)
+		for i := idx; i < len(c.objects); i++ {
+			k := fmt.Sprintf("%s/%s/%s",
+				c.objects[i].GetObjectKind().GroupVersionKind().Kind,
+				c.objects[i].GetNamespace(),
+				c.objects[i].GetName(),
+			)
+			c.indices[k] = i
+		}
 	}
 }
 
@@ -99,6 +141,8 @@ func (c *TrackingClient) Update(ctx context.Context, obj client.Object, opts ...
 
 func (c *TrackingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 	// Server-Side Apply fallback for fake client
+	// NOTE: This fallback replaces the entire object with the patch object 'obj'.
+	// If partial patches are used in the future, this will cause data loss of other fields.
 	if patch.Type() == types.ApplyPatchType {
 		key := client.ObjectKeyFromObject(obj)
 		existing := obj.DeepCopyObject().(client.Object)
@@ -124,6 +168,14 @@ func (c *TrackingClient) Patch(ctx context.Context, obj client.Object, patch cli
 	err := c.Client.Patch(ctx, obj, patch, opts...)
 	if err == nil {
 		c.track(obj)
+	}
+	return err
+}
+
+func (c *TrackingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	err := c.Client.Delete(ctx, obj, opts...)
+	if err == nil {
+		c.untrack(obj)
 	}
 	return err
 }
@@ -195,6 +247,7 @@ func RunOperatorReconcile(
 	}
 
 	maxIterations := 5
+	stabilized := false
 	for i := 0; i < maxIterations; i++ {
 		trackerClient.ResetMutated()
 		_, err := reconciler.Reconcile(ctx, req)
@@ -202,8 +255,12 @@ func RunOperatorReconcile(
 			return nil, err
 		}
 		if !trackerClient.IsMutated() {
+			stabilized = true
 			break
 		}
+	}
+	if !stabilized {
+		return nil, fmt.Errorf("reconciliation did not stabilize after %d iterations; possible infinite loop", maxIterations)
 	}
 
 	return trackerClient.GetObjects(), nil
@@ -258,6 +315,7 @@ func CompareGolden(t *testing.T, actual string, expectedPath string, update bool
 }
 
 func parseMultiDocYAML(t *testing.T, data string) []interface{} {
+	data = strings.ReplaceAll(data, "\r\n", "\n")
 	parts := strings.Split(data, "\n---\n")
 	var docs []interface{}
 	for _, part := range parts {

--- a/k8s-operator/internal/testing/testutil/testutil.go
+++ b/k8s-operator/internal/testing/testutil/testutil.go
@@ -24,10 +24,10 @@ import (
 // (Create, Update, Patch) to collect modified resources in their insertion/generation order.
 type TrackingClient struct {
 	client.Client
-	objects []client.Object
-	indices map[string]int
-	scheme  *runtime.Scheme
-	mutated bool
+	objects   []client.Object
+	indices   map[string]int
+	scheme    *runtime.Scheme
+	mutated   bool
 	ignoreKey string
 }
 

--- a/k8s-operator/internal/testing/testutil/testutil.go
+++ b/k8s-operator/internal/testing/testutil/testutil.go
@@ -1,0 +1,275 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+)
+
+// TrackingClient wraps a client.Client and intercepts all mutation operations
+// (Create, Update, Patch) to collect modified resources in their insertion/generation order.
+type TrackingClient struct {
+	client.Client
+	objects []client.Object
+	indices map[string]int
+	scheme  *runtime.Scheme
+	mutated bool
+	ignoreKey string
+}
+
+func NewTrackingClient(inner client.Client, scheme *runtime.Scheme, ignoreObj client.Object) *TrackingClient {
+	gvk, err := apiutil.GVKForObject(ignoreObj, scheme)
+	var ignoreKey string
+	if err == nil {
+		ignoreKey = fmt.Sprintf("%s/%s/%s", gvk.Kind, ignoreObj.GetNamespace(), ignoreObj.GetName())
+	}
+	return &TrackingClient{
+		Client:    inner,
+		indices:   make(map[string]int),
+		scheme:    scheme,
+		ignoreKey: ignoreKey,
+	}
+}
+
+func (c *TrackingClient) ResetMutated() {
+	c.mutated = false
+}
+
+func (c *TrackingClient) IsMutated() bool {
+	return c.mutated
+}
+
+func (c *TrackingClient) track(obj client.Object) {
+	c.mutated = true
+	copied := obj.DeepCopyObject().(client.Object)
+
+	// Populate TypeMeta dynamically using the scheme
+	gvk, err := apiutil.GVKForObject(copied, c.scheme)
+	if err == nil {
+		copied.GetObjectKind().SetGroupVersionKind(gvk)
+	}
+
+	key := fmt.Sprintf("%s/%s/%s",
+		copied.GetObjectKind().GroupVersionKind().Kind,
+		copied.GetNamespace(),
+		copied.GetName(),
+	)
+
+	if key == c.ignoreKey {
+		return
+	}
+
+	if idx, exists := c.indices[key]; exists {
+		c.objects[idx] = copied
+	} else {
+		c.indices[key] = len(c.objects)
+		c.objects = append(c.objects, copied)
+	}
+}
+
+func (c *TrackingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	err := c.Client.Create(ctx, obj, opts...)
+	if err == nil {
+		c.track(obj)
+	}
+	return err
+}
+
+func (c *TrackingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	err := c.Client.Update(ctx, obj, opts...)
+	if err == nil {
+		c.track(obj)
+	}
+	return err
+}
+
+func (c *TrackingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	// Server-Side Apply fallback for fake client
+	if patch.Type() == types.ApplyPatchType {
+		key := client.ObjectKeyFromObject(obj)
+		existing := obj.DeepCopyObject().(client.Object)
+		err := c.Client.Get(ctx, key, existing)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				createErr := c.Client.Create(ctx, obj)
+				if createErr == nil {
+					c.track(obj)
+				}
+				return createErr
+			}
+			return err
+		}
+		obj.SetResourceVersion(existing.GetResourceVersion())
+		updateErr := c.Client.Update(ctx, obj)
+		if updateErr == nil {
+			c.track(obj)
+		}
+		return updateErr
+	}
+
+	err := c.Client.Patch(ctx, obj, patch, opts...)
+	if err == nil {
+		c.track(obj)
+	}
+	return err
+}
+
+func (c *TrackingClient) GetObjects() []client.Object {
+	return c.objects
+}
+
+// RunGoldenTest runs the complete data-driven golden file integration test for any agent type.
+func RunGoldenTest(
+	t *testing.T,
+	inputPath, expectedPath string,
+	update bool,
+	scheme *runtime.Scheme,
+	newAgent func() client.Object,
+	newReconciler func(c client.Client, s *runtime.Scheme) reconcile.Reconciler,
+) {
+	t.Run(filepath.Base(inputPath), func(t *testing.T) {
+		// Read input CRD
+		inputData, err := os.ReadFile(inputPath)
+		if err != nil {
+			t.Fatalf("failed to read input file: %v", err)
+		}
+
+		// Parse CRD
+		agent := newAgent()
+		if err := yaml.Unmarshal(inputData, agent); err != nil {
+			t.Fatalf("failed to unmarshal input CRD: %v", err)
+		}
+
+		ctx := context.Background()
+
+		// Run the operator reconciliation loop
+		resources, err := RunOperatorReconcile(ctx, scheme, agent, newReconciler)
+		if err != nil {
+			t.Fatalf("operator reconciliation failed: %v", err)
+		}
+
+		// Clean up volatile metadata and marshal resources to YAML string
+		output := CleanAndMarshalResources(t, resources)
+
+		// Compare with expected golden files
+		CompareGolden(t, output, expectedPath, update)
+	})
+}
+
+// RunOperatorReconcile simulates a single reconciler execution run against a fake API server for any agent type.
+func RunOperatorReconcile(
+	ctx context.Context,
+	scheme *runtime.Scheme,
+	agent client.Object,
+	newReconciler func(c client.Client, s *runtime.Scheme) reconcile.Reconciler,
+) ([]client.Object, error) {
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent).
+		WithStatusSubresource(agent).
+		Build()
+
+	trackerClient := NewTrackingClient(fakeClient, scheme, agent)
+
+	reconciler := newReconciler(trackerClient, scheme)
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      agent.GetName(),
+			Namespace: agent.GetNamespace(),
+		},
+	}
+
+	maxIterations := 5
+	for i := 0; i < maxIterations; i++ {
+		trackerClient.ResetMutated()
+		_, err := reconciler.Reconcile(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		if !trackerClient.IsMutated() {
+			break
+		}
+	}
+
+	return trackerClient.GetObjects(), nil
+}
+
+// CleanAndMarshalResources cleans up volatile runtime fields and marshals objects to a multi-doc YAML string
+func CleanAndMarshalResources(t *testing.T, resources []client.Object) string {
+	var renderedManifests []string
+	for _, res := range resources {
+		// Clean up runtime fields that controller-runtime sets
+		res.SetResourceVersion("")
+		res.SetUID("")
+		res.SetCreationTimestamp(metav1.Time{})
+
+		yamlBytes, err := yaml.Marshal(res)
+		if err != nil {
+			t.Fatalf("failed to marshal resource: %v", err)
+		}
+		renderedManifests = append(renderedManifests, string(yamlBytes))
+	}
+	return strings.Join(renderedManifests, "---\n")
+}
+
+// CompareGolden compares actual output with expected golden file semantically
+func CompareGolden(t *testing.T, actual string, expectedPath string, update bool) {
+	if update {
+		expectedDir := filepath.Dir(expectedPath)
+		if err := os.MkdirAll(expectedDir, 0755); err != nil {
+			t.Fatalf("failed to create expected directory: %v", err)
+		}
+		if err := os.WriteFile(expectedPath, []byte(actual), 0644); err != nil {
+			t.Fatalf("failed to write expected golden file: %v", err)
+		}
+		t.Logf("updated golden file: %s", expectedPath)
+		return
+	}
+
+	expectedData, err := os.ReadFile(expectedPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("expected golden file %s does not exist. Run tests with -update flag to generate it.", expectedPath)
+		}
+		t.Fatalf("failed to read expected golden file: %v", err)
+	}
+
+	expectedDocs := parseMultiDocYAML(t, string(expectedData))
+	actualDocs := parseMultiDocYAML(t, actual)
+
+	if diff := cmp.Diff(expectedDocs, actualDocs); diff != "" {
+		t.Errorf("manifests mismatch (-expected +actual):\n%s", diff)
+	}
+}
+
+func parseMultiDocYAML(t *testing.T, data string) []interface{} {
+	parts := strings.Split(data, "\n---\n")
+	var docs []interface{}
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		var doc interface{}
+		if err := yaml.Unmarshal([]byte(part), &doc); err != nil {
+			t.Fatalf("failed to parse YAML doc: %v\nContent:\n%s", err, part)
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

We need to verify that our Kubernetes controllers (`DevTeamAgent` and `OperatorAgent`) correctly reconcile their Custom Resources and generate the expected Kubernetes manifests (PVCs,
ConfigMaps, Deployments, Services, RBAC). A structured golden-file testing framework allows us to assert the exact output of the controllers against expected samples.

This change establishes a clean, reusable, and extendable pattern for integration testing of Kubernetes controllers in this project.

## What Changed

- Re-structured `DevTeamAgent` tests into a table-driven test suite in `golden_test.go` to easily support multiple agents.
- Simplified the testing utility in `testutil.go` by removing generics and using `client.Object` directly.
- Improved the test runner (`RunOperatorReconcile`) to simulate a real Kubernetes control loop, running reconciliation cycles until the state stabilizes (necessary for controllers
  with multi-step reconciliation).
- Updated the tracking client to filter out the target CR itself from the tracked output, keeping the golden files focused strictly on the generated resources.
- Added tests and generated golden files for the `OperatorAgent` and `DevteamAgent`.

**Files:**

- `k8s-operator/internal/testing/golden_test.go`
- `k8s-operator/internal/testing/testutil/testutil.go`
- `k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml`
- `k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml`

**Added/Changed/Fixed:**

- **Added**: `golden_test.go` (table-driven test suite)
- **Added**: `testdata/operator/expected/operatoragent.yaml` (golden files for OperatorAgent)
- **Added**: `testutil.go` (support for multi-step reconciliation and output filtering)
- **Added**: `testdata/devteam/expected/devteamagent.yaml` (regenerated without target CR)

## Why This Matters

It ensures that any changes to controller logic can be easily verified against expected resource outputs, preventing regressions. The structure makes it trivial to add tests for new agents in the future.

## Context

Part of establishing robust integration testing patterns for the Kubernetes operators.

## Testing

```bash
# local run
go test -C k8s-operator -v ./internal/testing/...

# the recommended way to run by kubebuilder (also can be used in presubmit/etc. hooks)
make -C k8s-operator test
```
All tests compiled, ran in parallel, and passed.

To update the expected golden files (for example, if you change the controller logic and the generated manifests change), you can run the test command with the  -update  flag:

```bash
go test -C k8s-operator -v ./internal/testing/... -update
```
──────
Functional impact is limited to development tests. Risk is low.