### PR TITLE
test(operator): add golden integration tests for PlatformAgent

### DIFF
--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -57,6 +57,15 @@ func TestAgentsGolden(t *testing.T) {
 				return &controller.OperatorAgentReconciler{Client: c, Scheme: s}
 			},
 		},
+		{
+			name:         "PlatformAgent",
+			inputPath:    filepath.Join("..", "..", "examples", "platformagent.yaml"),
+			expectedPath: filepath.Join("testdata", "platform", "expected", "platformagent.yaml"),
+			newAgent:     func() client.Object { return &agentv1alpha1.PlatformAgent{} },
+			newReconciler: func(c client.Client, s *runtime.Scheme) reconcile.Reconciler {
+				return &controller.PlatformAgentReconciler{Client: c, Scheme: s}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
+++ b/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
@@ -33,6 +33,9 @@ data:
       default: model-default
       model: model-default
       provider: custom
+    plugins:
+      enabled:
+      - hermes_otel
     terminal:
       backend: local
       cwd: /opt/data
@@ -71,6 +74,14 @@ data:
         Path_Key          file_path
 
     [FILTER]
+        Name          parser
+        Match         agent.logs
+        Key_Name      log
+        Parser        gchat_event
+        Reserve_Data  On
+        Preserve_Key  On
+
+    [FILTER]
         Name              record_modifier
         Match             agent.logs
         Record            app agent
@@ -80,6 +91,11 @@ data:
         Name              stdout
         Match             agent.logs
         Format            json_lines
+  parsers.conf: |
+    [PARSER]
+        Name    gchat_event
+        Format  regex
+        Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -118,19 +134,14 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: ed243c16c4b4ac5dfacb8942cf80650ec654a88acc0c88ca963f476369de6e4f
-        kubeagents.x-k8s.io/fluent-bit-config-hash: 2c70fde063d683710561f5cda42ec406d81907c9e33c7a27c24e77587c7e517b
+        kubeagents.x-k8s.io/config-hash: 9096e2c5460785f9a557074ecb6ca3ae50b4e62c0e7a5884a35250751c867ed0
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
       creationTimestamp: null
       labels:
         app: devteam-agent-autopilot-cluster-1-us-central1-devteam-app-ns-gateway
     spec:
       containers:
-        - args:
-            - gateway
-            - run
-          command:
-            - hermes
-          env:
+        - env:
             - name: PLATFORM_AGENT_HOME
               value: /opt/data
             - name: HOME
@@ -214,12 +225,16 @@ spec:
               name: fluent-bit-config
               readOnly: true
               subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
             - mountPath: /fluent-bit/state
               name: fluent-bit-state
       securityContext:
-        fsGroup: 1000
+        fsGroup: 10000
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-devteam-agent

--- a/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
+++ b/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
@@ -28,6 +28,9 @@ data:
       default: model-default
       model: model-default
       provider: custom
+    plugins:
+      enabled:
+      - hermes_otel
     terminal:
       backend: local
       cwd: /opt/data
@@ -66,6 +69,14 @@ data:
         Path_Key          file_path
 
     [FILTER]
+        Name          parser
+        Match         agent.logs
+        Key_Name      log
+        Parser        gchat_event
+        Reserve_Data  On
+        Preserve_Key  On
+
+    [FILTER]
         Name              record_modifier
         Match             agent.logs
         Record            app agent
@@ -75,6 +86,11 @@ data:
         Name              stdout
         Match             agent.logs
         Format            json_lines
+  parsers.conf: |
+    [PARSER]
+        Name    gchat_event
+        Format  regex
+        Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -113,19 +129,14 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: b2620ec7a605c6fc0fdc86db6128e9f2540b704e59f279eebbcb34e8c3d1ffc5
-        kubeagents.x-k8s.io/fluent-bit-config-hash: 2c70fde063d683710561f5cda42ec406d81907c9e33c7a27c24e77587c7e517b
+        kubeagents.x-k8s.io/config-hash: 2153c9ac44cdf1fe8829469d12641c98c3d465cf7e6cb135ceee4ed3d218e019
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
       creationTimestamp: null
       labels:
         app: operator-agent-autopilot-cluster-1-us-central1-gateway
     spec:
       containers:
-        - args:
-            - gateway
-            - run
-          command:
-            - hermes
-          env:
+        - env:
             - name: PLATFORM_AGENT_HOME
               value: /opt/data
             - name: HOME
@@ -204,12 +215,16 @@ spec:
               name: fluent-bit-config
               readOnly: true
               subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
             - mountPath: /fluent-bit/state
               name: fluent-bit-state
       securityContext:
-        fsGroup: 1000
+        fsGroup: 10000
         runAsNonRoot: true
-        runAsUser: 1000
+        runAsUser: 10000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-operator-agent

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -1,0 +1,320 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubeagents:viewer:kubeagents-system:platformagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubeagents:explorer:kubeagents-system:platformagent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubeagents:explorer:kubeagents-system:platformagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeagents:explorer:kubeagents-system:platformagent
+subjects:
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: platformagent-data
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+status: {}
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    model:
+      api_key: none
+      base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
+      default: model-default
+      model: model-default
+      provider: custom
+    platforms:
+      google_chat:
+        enabled: true
+    plugins:
+      enabled:
+      - hermes_otel
+    terminal:
+      backend: local
+      cwd: /opt/data
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+---
+apiVersion: v1
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/fluent-bit.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name          parser
+        Match         agent.logs
+        Key_Name      log
+        Parser        gchat_event
+        Reserve_Data  On
+        Preserve_Key  On
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+  parsers.conf: |
+    [PARSER]
+        Name    gchat_event
+        Format  regex
+        Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-fluent-bit-config
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: platformagent-gateway
+  name: platformagent-gateway
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platformagent-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubeagents.x-k8s.io/config-hash: 029e3e097c8c21d4a9d86e6a599b34813165b4f0113cde02eff297e3162494a3
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
+      creationTimestamp: null
+      labels:
+        app: platformagent-gateway
+    spec:
+      containers:
+      - env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_DASHBOARD
+          value: "1"
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: OTEL_SERVICE_NAME
+          value: platformagent-gateway
+        - name: GKE_CLUSTER_NAME
+          value: cluster-a
+        - name: GKE_LOCATION
+          value: us-central1-a
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-key
+              name: platformagent-secrets
+        - name: GOOGLE_CHAT_PROJECT_ID
+          value: ai-platform-1-464114
+        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+          value: projects/ai-platform-1-464114/subscriptions/kubeagents-google-chat-events-sub
+        - name: GOOGLE_CHAT_ALLOWED_USERS
+        - name: GOOGLE_CHAT_HOME_CHANNEL
+        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+          value: "true"
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: platform-agent-config-vol
+          subPath: config.yaml
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/etc/parsers.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: parsers.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
+      securityContext:
+        fsGroup: 10000
+        runAsNonRoot: true
+        runAsUser: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubeagents-platform-agent
+      volumes:
+      - name: platform-agent-data-vol
+        persistentVolumeClaim:
+          claimName: platformagent-data
+      - configMap:
+          defaultMode: 493
+          name: platformagent-config
+        name: platform-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: platformagent-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: platformagent
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+spec:
+  ports:
+  - name: api
+    port: 8642
+    targetPort: api
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
+  selector:
+    app: platformagent-gateway
+status:
+  loadBalancer: {}


### PR DESCRIPTION
# Pull Request

## Why This Change

This change completes the operator integration test suite by adding golden file coverage for the `PlatformAgent`. Additionally, it updates the existing `DevTeamAgent` and `OperatorAgent` golden files to align with recent updates to the controllers on `main` (such as custom security context configurations and Fluent Bit parsers).

## What Changed

**Files:**

- [k8s-operator/internal/testing/golden_test.go](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/testing/golden_test.go)
- [k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml)
- [k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml)
- [k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml)

**Added/Changed/Fixed:**

- **Added PlatformAgent golden tests**: Registered `PlatformAgent` to run under the golden test suite using `examples/platformagent.yaml` as the input.
- **Generated platform expected YAML**: Created the master baseline manifest containing the exact resource graph generated for `PlatformAgent` (including cluster roles, bindings, PVC, configmaps, deployment, and service).
- **Synchronized existing goldens**: Applied the latest functional additions from `main` (user identity Fluent Bit parsers, config-hashes, and `fsGroup`/`runAsUser` ID transitions to `10000`) to the `DevTeamAgent` and `OperatorAgent` expected YAMLs while carefully maintaining their original 4-space layout formatting.

## Why This Matters

- Ensures any accidental changes to the `PlatformAgent` manifest generation logic will be caught instantly.
- Keeps integration tests green on the latest `main` branch by correcting stale expected baselines.

## Context

- Follows up on PR #206 (which introduced the golden testing framework).

## Testing

### Local Run
```bash
go test -C k8s-operator -v ./internal/testing/...
```

### Kubebuilder Recommended Run
This is the recommended way to run the tests via make (also used in presubmit/CI hooks):
```bash
make -C k8s-operator test
```
All tests compiled, ran in parallel, and passed.

### Updating Golden Baselines
To update the expected golden files (for example, if you change the controller logic and the generated manifests change), run:
```bash
go test -C k8s-operator -v ./internal/testing/... -update
```
