### PR TITLE
chore: add iam.roleViewer and iam.securityReviewer roles to agent service accounts

### DIFF
--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -140,7 +140,10 @@ verify_platform_agent() {
       "roles/container.admin" \
       "roles/monitoring.admin" \
       "roles/logging.admin" \
-      "roles/iam.serviceAccountUser"
+      "roles/iam.serviceAccountUser" \
+      "roles/iam.roleViewer" \
+      "roles/iam.securityReviewer"
+
 }
 execute_platform_agent() {
   execute_agent_iam "Platform Agent" "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" \
@@ -148,7 +151,9 @@ execute_platform_agent() {
       "roles/container.admin" \
       "roles/monitoring.admin" \
       "roles/logging.admin" \
-      "roles/iam.serviceAccountUser"
+      "roles/iam.serviceAccountUser" \
+      "roles/iam.roleViewer" \
+      "roles/iam.securityReviewer"
 }
 
 

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -141,7 +141,6 @@ verify_platform_agent() {
       "roles/monitoring.admin" \
       "roles/logging.admin" \
       "roles/iam.serviceAccountUser" \
-      "roles/iam.roleViewer" \
       "roles/iam.securityReviewer"
 
 }
@@ -152,7 +151,6 @@ execute_platform_agent() {
       "roles/monitoring.admin" \
       "roles/logging.admin" \
       "roles/iam.serviceAccountUser" \
-      "roles/iam.roleViewer" \
       "roles/iam.securityReviewer"
 }
 


### PR DESCRIPTION

# Pull Request

## Why This Change

Agent can now query to see what roles it has

## What Changed

new permissions added

**Files:**

- `k8s-operator/scripts/provision_03_gcp_iam.sh`

## Testing

Manual