### PR TITLE
fix(inference-replay): strip volatile timestamp field from cache key

### DIFF
--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -109,8 +109,23 @@ async def save_cache():
         except Exception as e:
             logger.error(f"Failed to save cache: {e}")
 
+# Per-message fields injected by clients (e.g. Hermes) that change every request
+# and would otherwise prevent any user-message body from ever cache-hitting.
+# Stripped only for hash computation — the original body is still forwarded upstream.
+_VOLATILE_MSG_FIELDS = {"timestamp"}
+
+
+def _canonicalize_for_hash(body: dict) -> dict:
+    canonical = json.loads(json.dumps(body))
+    for msg in canonical.get("messages", []):
+        if isinstance(msg, dict):
+            for field in _VOLATILE_MSG_FIELDS:
+                msg.pop(field, None)
+    return canonical
+
+
 def get_request_hash(body: dict) -> str:
-    canonical_json = json.dumps(body, sort_keys=True)
+    canonical_json = json.dumps(_canonicalize_for_hash(body), sort_keys=True)
     return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()
 
 async def replay_stream(lines):

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -117,10 +117,12 @@ _VOLATILE_MSG_FIELDS = {"timestamp"}
 
 def _canonicalize_for_hash(body: dict) -> dict:
     canonical = json.loads(json.dumps(body))
-    for msg in canonical.get("messages", []):
-        if isinstance(msg, dict):
-            for field in _VOLATILE_MSG_FIELDS:
-                msg.pop(field, None)
+    messages = canonical.get("messages")
+    if isinstance(messages, list):
+        for msg in messages:
+            if isinstance(msg, dict):
+                for field in _VOLATILE_MSG_FIELDS:
+                    msg.pop(field, None)
     return canonical
 
 


### PR DESCRIPTION

# Pull Request

## Why This Change

Hermes injects a fresh wall-clock timestamp on every message, which made every chat-completion body hash uniquely and prevented the replay cache from ever hitting on agent traffic. Direct curl callers were unaffected because they don't add the field.

Strip timestamp from each message before hashing only. The original body is still forwarded upstream and stored as the cache value, so replays return the same response the upstream produced.
## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  - examples/inference-replay/replay-proxy/replay_proxy.py

**Added/Changed/Fixed:**

  - Added _VOLATILE_MSG_FIELDS = {"timestamp"} allowlist of per-message fields
  that are stripped before computing the cache key.
  - Added _canonicalize_for_hash() helper that deep-copies the body and removes
  those fields from each message.
  - get_request_hash() now hashes the canonicalized body. The original request
  body is unchanged — it is still forwarded upstream on a miss and is still what
  the upstream response gets stored against.
  
## Why This Matters

  - The replay proxy hashes the full chat-completions request body
  (sha256(json.dumps(body, sort_keys=True))) to decide cache hit vs miss.
  - Hermes (the platform agent runtime) injects a fresh wall-clock timestamp
  float on every message it sends. Two semantically-identical requests therefore
  always produced different bytes and always missed.
  - Direct curl callers don't inject timestamp, so caching worked there — which
  made the problem look intermittent and agent-specific.
  - After this change, the user-message round-trip caches across runs, which
  means the downstream title-generation round-trip (which takes the assistant
  reply as input) also becomes deterministic and caches. The whole agent turn
  replays end-to-end.


## Context

  - Builds on #195 (feat(inference-replay): add togglable on/off mode to proxy),
  which introduced the recording/replay path this fix targets.
  - The allowlist pattern leaves room to add other client-injected volatile
  fields (request IDs, conversation IDs, etc.) as they show up, without
  re-architecting the hashing.
## Testing

manual verification
<!-- Close with a short note on functional impact, risk, or rollout. -->
