### PR TITLE
fix(deploy): recursively sync all agent default configuration files at startup in docker-entrypoint.sh

### DIFF
--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -21,10 +21,10 @@ if [ -f "/opt/hermes/docker/stage2-hook.sh" ]; then
     /opt/hermes/docker/stage2-hook.sh
 fi
 
-# 2. Sync default plugins
-if [ -d "/opt/defaults/plugins" ]; then
-    mkdir -p "$TARGET_DIR/plugins"
-    cp -ru /opt/defaults/plugins/. "$TARGET_DIR/plugins/" 2>/dev/null || cp -rp /opt/defaults/plugins/. "$TARGET_DIR/plugins/" 2>/dev/null || true
+# 2. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)
+if [ -d "/opt/defaults" ]; then
+    mkdir -p "$TARGET_DIR"
+    cp -ru /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || cp -rp /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || true
 fi
 
 # 3. Enable OpenTelemetry plugin in active config.yaml (if writable)


### PR DESCRIPTION
# Pull Request

## Why This Change

When an agent container starts up with a mounted PersistentVolumeClaim (PVC) or emptyDir workspace at `/opt/data`, the existing startup script only synchronized `/opt/defaults/plugins`. As a result, critical runtime instructions such as `SOUL.md`, `AGENTS.md`, and operational procedures (`procedures/`) were left behind in `/opt/defaults/` and never copied into the agent's active runtime workspace.

## What Changed

Updated `deploy/shared/docker-entrypoint.sh` to recursively copy all default agent configuration files and subdirectories from `/opt/defaults/` into `$TARGET_DIR` (`/opt/data`) during initialization.

**Files:**

- `deploy/shared/docker-entrypoint.sh`

**Added/Changed/Fixed:**

- Replaced plugin-only copy (`cp -ru /opt/defaults/plugins/. "$TARGET_DIR/plugins/"`) with a recursive root sync (`cp -ru /opt/defaults/. "$TARGET_DIR/"`).
- Preserves update semantics (`-u`) so newer default blueprints from upgraded container images copy over without overwriting files modified at runtime.

## Why This Matters

- Ensures all agent tiers (Platform, Operator, DevTeam) receive their foundational SOUL instructions and SOP playbooks in persistent workspaces.
- Prevents unguided agent behavior or startup errors when launching in new Kubernetes namespaces or PVC environments.

## Context

Follow-up fix identified during the universal negotiation implementation (#220). Scoped into its own dedicated pull request following repository PR hygiene rules.

## Testing

- Verified shell script execution flow and fallback semantics (`cp -ru || cp -rp`).

---

Guarantees foundational agent SOUL blueprints and playbooks are present in persistent Kubernetes volumes at startup.
