### PR TITLE
feat(operator): restrict OperatorAgent remote permissions to match static manifest

### DIFF
--- a/k8s-operator/internal/controller/operatoragent_controller.go
+++ b/k8s-operator/internal/controller/operatoragent_controller.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -283,10 +284,38 @@ func (r *OperatorAgentReconciler) reconcileRemoteResources(ctx context.Context, 
 		remoteIdentity = agent.Spec.Security.RemoteIdentitySubject
 	}
 
-	// 4. Bind cluster-admin directly to the remote identity on the remote cluster
+	// 4. Reconcile ClusterRole on target cluster
+	rules := []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"nodes", "namespaces", "pods", "services", "events", "persistentvolumes", "serviceaccounts"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"apps"},
+			Resources: []string{"deployments", "daemonsets", "statefulsets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"networking.k8s.io"},
+			Resources: []string{"networkpolicies"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+		{
+			APIGroups: []string{"policy"},
+			Resources: []string{"poddisruptionbudgets"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
+	}
+	remoteRoleName := "operator-agent-role"
+	if err := reconcileClusterRole(ctx, remoteClient, remoteRoleName, rules); err != nil {
+		return err
+	}
+
+	// 5. Bind the custom ClusterRole directly to the remote identity on the remote cluster
 	if remoteIdentity != "" {
-		remoteAdminRBName := "operator-agent-gsa-admin-rolebinding"
-		if err := reconcileClusterRoleBindingToUser(ctx, remoteClient, remoteAdminRBName, remoteIdentity, "cluster-admin"); err != nil {
+		remoteGsaRBName := "operator-agent-gsa-rolebinding"
+		if err := reconcileClusterRoleBindingToUser(ctx, remoteClient, remoteGsaRBName, remoteIdentity, remoteRoleName); err != nil {
 			return err
 		}
 	}

--- a/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
+++ b/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
@@ -7,14 +7,61 @@ spec: {}
 status: {}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: operator-agent-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - namespaces
+      - pods
+      - services
+      - events
+      - persistentvolumes
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
-  name: operator-agent-gsa-admin-rolebinding
+  name: operator-agent-gsa-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: operator-agent-role
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User


### PR DESCRIPTION
## Why This Change

Previously, the operator was configured to grant full  cluster-admin  access to the  OperatorAgent  on remote clusters. This wide access was introduced without a specific justification and posed a significant security risk.

For security reasons and to adhere to the Principle of Least Privilege, this PR restricts the agent's remote permissions back to the "Strict Read-Only" model defined in the original static manifests.

The source of the config was taken from [the old static manifest](https://github.com/gke-labs/kube-agents/blob/801f01424f10d6f239c5f761c223e391674e3086/deploy/kustomize/operator/deployment.yaml#L175-L201) used for that agent.

## What Changed

Files:

- k8s-operator/internal/controller/operatoragent_controller.go
- k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml

Added/Changed/Fixed:

- Replaced the remote  cluster-admin  binding with a custom remote  ClusterRole  ( operator-agent-role ).
- Configured specific read-only permissions ( get ,  list ,  watch ) for nodes, namespaces, pods, services, events, persistentvolumes, serviceaccounts, deployments, daemonsets, statefulsets, networkpolicies, and poddisruptionbudgets.
- Renamed the remote ClusterRoleBinding to  operator-agent-gsa-rolebinding  to reflect that it is no longer an admin binding.
- Updated the expected golden test file for  OperatorAgent  to include the new  ClusterRole  and the updated binding, preserving original indentation.

## Why This Matters

This significantly improves the security posture of the operator by ensuring the  OperatorAgent  only has the minimum necessary permissions required to monitor remote clusters, limiting the blast radius in case of a compromise.

## Context

This change restores the remote cluster permissions to the same state as they were in the original static deployment manifest ( deploy/kustomize/operator/deployment.yaml ).

## Testing

Affected golden file was updated and validated
──────
This change reduces the permissions of the  OperatorAgent  on remote clusters. While it improves security, it should be verified that the agent does not require write access for any of its current operations (the original static manifest suggests read-only is sufficient).