### PR TITLE
feat(operator): sync deploy/shared defaults to agent ConfigMap genera…

### DIFF
--- a/k8s-operator/internal/controller/devteamagent_manifests.go
+++ b/k8s-operator/internal/controller/devteamagent_manifests.go
@@ -68,6 +68,14 @@ func renderDevTeamConfigYAML(agent *agentv1alpha1.DevTeamAgent) string {
 			Backend string `json:"backend"`
 			Cwd     string `json:"cwd"`
 		} `json:"terminal"`
+		MCPServers       map[string]any      `json:"mcp_servers,omitempty"`
+		PlatformToolsets map[string][]string `json:"platform_toolsets,omitempty"`
+		Approvals        struct {
+			CronMode string `json:"cron_mode,omitempty"`
+		} `json:"approvals,omitempty"`
+		Web struct {
+			Backend string `json:"backend,omitempty"`
+		} `json:"web,omitempty"`
 		Plugins struct {
 			Enabled []string `json:"enabled"`
 		} `json:"plugins"`
@@ -80,6 +88,22 @@ func renderDevTeamConfigYAML(agent *agentv1alpha1.DevTeamAgent) string {
 	cfg.Model.APIKey = "none"
 	cfg.Terminal.Backend = "local"
 	cfg.Terminal.Cwd = cwd
+	cfg.MCPServers = map[string]any{
+		"agent_common": map[string]any{
+			"command": "/opt/hermes/.venv/bin/python3",
+			"args":    []string{"/opt/data/scripts/agent_common_server.py"},
+		},
+		"developer_knowledge": map[string]any{
+			"command": "node",
+			"args":    []string{"/opt/mcp-remote/dist/proxy.js", "https://developerknowledge.googleapis.com/mcp"},
+		},
+	}
+	cfg.PlatformToolsets = map[string][]string{
+		"cli":        {"hermes-cli", "mcp-agent_common", "mcp-developer_knowledge"},
+		"api_server": {"hermes-api-server", "mcp-agent_common", "mcp-developer_knowledge"},
+	}
+	cfg.Approvals.CronMode = "approve"
+	cfg.Web.Backend = "ddgs"
 	cfg.Plugins.Enabled = []string{"hermes_otel"}
 
 	data, err := yaml.Marshal(cfg)
@@ -185,6 +209,14 @@ func buildDevTeamDeployment(agent *agentv1alpha1.DevTeamAgent, configHash, fluen
 		{
 			Name:  "OTEL_SERVICE_NAME",
 			Value: agent.Name + "-gateway",
+		},
+		{
+			Name:  "API_SERVER_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "API_SERVER_HOST",
+			Value: "0.0.0.0",
 		},
 		{
 			Name:  "PLATFORM_API_URL",

--- a/k8s-operator/internal/controller/operatoragent_manifests.go
+++ b/k8s-operator/internal/controller/operatoragent_manifests.go
@@ -68,6 +68,14 @@ func renderOperatorConfigYAML(agent *agentv1alpha1.OperatorAgent) string {
 			Backend string `json:"backend"`
 			Cwd     string `json:"cwd"`
 		} `json:"terminal"`
+		MCPServers       map[string]any      `json:"mcp_servers,omitempty"`
+		PlatformToolsets map[string][]string `json:"platform_toolsets,omitempty"`
+		Approvals        struct {
+			CronMode string `json:"cron_mode,omitempty"`
+		} `json:"approvals,omitempty"`
+		Web struct {
+			Backend string `json:"backend,omitempty"`
+		} `json:"web,omitempty"`
 		Plugins struct {
 			Enabled []string `json:"enabled"`
 		} `json:"plugins"`
@@ -80,6 +88,22 @@ func renderOperatorConfigYAML(agent *agentv1alpha1.OperatorAgent) string {
 	cfg.Model.APIKey = "none"
 	cfg.Terminal.Backend = "local"
 	cfg.Terminal.Cwd = cwd
+	cfg.MCPServers = map[string]any{
+		"agent_common": map[string]any{
+			"command": "/opt/hermes/.venv/bin/python3",
+			"args":    []string{"/opt/data/scripts/agent_common_server.py"},
+		},
+		"developer_knowledge": map[string]any{
+			"command": "node",
+			"args":    []string{"/opt/mcp-remote/dist/proxy.js", "https://developerknowledge.googleapis.com/mcp"},
+		},
+	}
+	cfg.PlatformToolsets = map[string][]string{
+		"cli":        {"hermes-cli", "mcp-agent_common", "mcp-developer_knowledge"},
+		"api_server": {"hermes-api-server", "mcp-agent_common", "mcp-developer_knowledge"},
+	}
+	cfg.Approvals.CronMode = "approve"
+	cfg.Web.Backend = "ddgs"
 	cfg.Plugins.Enabled = []string{"hermes_otel"}
 
 	data, err := yaml.Marshal(cfg)

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -96,6 +96,14 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 			Backend string `json:"backend"`
 			Cwd     string `json:"cwd"`
 		} `json:"terminal"`
+		MCPServers       map[string]any      `json:"mcp_servers,omitempty"`
+		PlatformToolsets map[string][]string `json:"platform_toolsets,omitempty"`
+		Approvals        struct {
+			CronMode string `json:"cron_mode,omitempty"`
+		} `json:"approvals,omitempty"`
+		Web struct {
+			Backend string `json:"backend,omitempty"`
+		} `json:"web,omitempty"`
 		Platforms struct {
 			GoogleChat struct {
 				Enabled bool `json:"enabled"`
@@ -113,6 +121,36 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	cfg.Model.APIKey = "none"
 	cfg.Terminal.Backend = "local"
 	cfg.Terminal.Cwd = cwd
+	cfg.MCPServers = map[string]any{
+		"platform_control": map[string]any{
+			"command":         "/opt/hermes/.venv/bin/python3",
+			"args":            []string{"/opt/data/scripts/platform_mcp_server.py"},
+			"connect_timeout": 120,
+			"timeout":         300,
+			"env": map[string]string{
+				"KUBERNETES_SERVICE_HOST":       "${KUBERNETES_SERVICE_HOST}",
+				"KUBERNETES_SERVICE_PORT":       "${KUBERNETES_SERVICE_PORT}",
+				"HERMES_HOME":                   "${HERMES_HOME}",
+				"GOOGLE_CHAT_PROJECT_ID":        "${GOOGLE_CHAT_PROJECT_ID}",
+				"GOOGLE_CHAT_SUBSCRIPTION_NAME": "${GOOGLE_CHAT_SUBSCRIPTION_NAME}",
+				"API_SERVER_KEY":                "${API_SERVER_KEY}",
+			},
+		},
+		"agent_common": map[string]any{
+			"command": "/opt/hermes/.venv/bin/python3",
+			"args":    []string{"/opt/data/scripts/agent_common_server.py"},
+		},
+		"developer_knowledge": map[string]any{
+			"command": "node",
+			"args":    []string{"/opt/mcp-remote/dist/proxy.js", "https://developerknowledge.googleapis.com/mcp"},
+		},
+	}
+	cfg.PlatformToolsets = map[string][]string{
+		"cli":        {"hermes-cli", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge"},
+		"api_server": {"hermes-api-server", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge"},
+	}
+	cfg.Approvals.CronMode = "approve"
+	cfg.Web.Backend = "ddgs"
 	cfg.Plugins.Enabled = []string{"hermes_otel"}
 
 	if agent.Spec.Integration != nil && agent.Spec.Integration.GoogleChat != nil {
@@ -208,6 +246,14 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		{
 			Name:  "OTEL_SERVICE_NAME",
 			Value: agent.Name + "-gateway",
+		},
+		{
+			Name:  "API_SERVER_ENABLED",
+			Value: "true",
+		},
+		{
+			Name:  "API_SERVER_HOST",
+			Value: "0.0.0.0",
 		},
 	}
 

--- a/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
+++ b/k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml
@@ -107,18 +107,41 @@ data:
     - **Cluster Location:** us-central1
     - **Namespace:** devteam-app-ns
   config.yaml: |
+    approvals:
+      cron_mode: approve
+    mcp_servers:
+      agent_common:
+        args:
+        - /opt/data/scripts/agent_common_server.py
+        command: /opt/hermes/.venv/bin/python3
+      developer_knowledge:
+        args:
+        - /opt/mcp-remote/dist/proxy.js
+        - https://developerknowledge.googleapis.com/mcp
+        command: node
     model:
       api_key: none
       base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
       default: model-default
       model: model-default
       provider: custom
+    platform_toolsets:
+      api_server:
+      - hermes-api-server
+      - mcp-agent_common
+      - mcp-developer_knowledge
+      cli:
+      - hermes-cli
+      - mcp-agent_common
+      - mcp-developer_knowledge
     plugins:
       enabled:
       - hermes_otel
     terminal:
       backend: local
       cwd: /opt/data
+    web:
+      backend: ddgs
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -214,7 +237,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 9096e2c5460785f9a557074ecb6ca3ae50b4e62c0e7a5884a35250751c867ed0
+        kubeagents.x-k8s.io/config-hash: 4ee5ece17da4a5f709c0a778f622829b7d36cd8caa800f2653d5eab586d0143f
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
       creationTimestamp: null
       labels:
@@ -232,6 +255,10 @@ spec:
               value: "0"
             - name: OTEL_SERVICE_NAME
               value: devteam-agent-sample-gateway
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
             - name: PLATFORM_API_URL
               value: http://platform-agent.kubeagents-system.svc.cluster.local:8642/v1
             - name: GKE_CLUSTER_NAME

--- a/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
+++ b/k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml
@@ -65,18 +65,41 @@ data:
     - **Cluster Location:** us-central1
     - **Git Repo:** None
   config.yaml: |
+    approvals:
+      cron_mode: approve
+    mcp_servers:
+      agent_common:
+        args:
+        - /opt/data/scripts/agent_common_server.py
+        command: /opt/hermes/.venv/bin/python3
+      developer_knowledge:
+        args:
+        - /opt/mcp-remote/dist/proxy.js
+        - https://developerknowledge.googleapis.com/mcp
+        command: node
     model:
       api_key: none
       base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
       default: model-default
       model: model-default
       provider: custom
+    platform_toolsets:
+      api_server:
+      - hermes-api-server
+      - mcp-agent_common
+      - mcp-developer_knowledge
+      cli:
+      - hermes-cli
+      - mcp-agent_common
+      - mcp-developer_knowledge
     plugins:
       enabled:
       - hermes_otel
     terminal:
       backend: local
       cwd: /opt/data
+    web:
+      backend: ddgs
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -172,7 +195,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 6263eaf4277c61fdf4fd371be1689116a67a4fe453802b1e0c5d096d9cfea747
+        kubeagents.x-k8s.io/config-hash: 39a23800da8ded96b2d5f437c5d47c378f1cb83a66cb09c9715cfb8ed9bfa16b
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
       creationTimestamp: null
       labels:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -82,12 +82,48 @@ status: {}
 apiVersion: v1
 data:
   config.yaml: |
+    approvals:
+      cron_mode: approve
+    mcp_servers:
+      agent_common:
+        args:
+        - /opt/data/scripts/agent_common_server.py
+        command: /opt/hermes/.venv/bin/python3
+      developer_knowledge:
+        args:
+        - /opt/mcp-remote/dist/proxy.js
+        - https://developerknowledge.googleapis.com/mcp
+        command: node
+      platform_control:
+        args:
+        - /opt/data/scripts/platform_mcp_server.py
+        command: /opt/hermes/.venv/bin/python3
+        connect_timeout: 120
+        env:
+          API_SERVER_KEY: ${API_SERVER_KEY}
+          GOOGLE_CHAT_PROJECT_ID: ${GOOGLE_CHAT_PROJECT_ID}
+          GOOGLE_CHAT_SUBSCRIPTION_NAME: ${GOOGLE_CHAT_SUBSCRIPTION_NAME}
+          HERMES_HOME: ${HERMES_HOME}
+          KUBERNETES_SERVICE_HOST: ${KUBERNETES_SERVICE_HOST}
+          KUBERNETES_SERVICE_PORT: ${KUBERNETES_SERVICE_PORT}
+        timeout: 300
     model:
       api_key: none
       base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
       default: model-default
       model: model-default
       provider: custom
+    platform_toolsets:
+      api_server:
+      - hermes-api-server
+      - mcp-agent_common
+      - mcp-platform_control
+      - mcp-developer_knowledge
+      cli:
+      - hermes-cli
+      - mcp-agent_common
+      - mcp-platform_control
+      - mcp-developer_knowledge
     platforms:
       google_chat:
         enabled: true
@@ -97,6 +133,8 @@ data:
     terminal:
       backend: local
       cwd: /opt/data
+    web:
+      backend: ddgs
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -210,7 +248,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 029e3e097c8c21d4a9d86e6a599b34813165b4f0113cde02eff297e3162494a3
+        kubeagents.x-k8s.io/config-hash: 52136be633904adc957be02afbe4891ae909e2109889fe43956a7947485eb5d8
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null
@@ -229,6 +267,10 @@ spec:
               value: "0"
             - name: OTEL_SERVICE_NAME
               value: platformagent-gateway
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
             - name: GKE_CLUSTER_NAME
               value: cluster-a
             - name: GKE_LOCATION


### PR DESCRIPTION

# Pull Request

## Why This Change

In `deploy/shared/defaults/config.yaml`, the repository defines core framework defaults shared across all autonomous AI agent tiers (web search, inter-agent RPC, and toolset declarations). 

However, when the Kubernetes Operator (`k8s-operator`) deploys `DevTeamAgent`, `OperatorAgent`, or `PlatformAgent` Custom Resources, the controller manager synthesizes a live `ConfigMap` and mounts it directly to `/opt/data/config.yaml`. Because `/opt/data/config.yaml` takes precedence over `/opt/defaults/`, the Kubernetes pods were previously overriding and erasing all shared MCP servers and toolsets at runtime.

## What Changed

Synchronized the shared framework defaults from `deploy/shared/defaults/config.yaml` directly into the operator's programmatic ConfigMap generators.

**Files:**

- `k8s-operator/internal/controller/devteamagent_manifests.go`
- `k8s-operator/internal/controller/operatoragent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/testing/testdata/devteam/expected/devteamagent.yaml`
- `k8s-operator/internal/testing/testdata/operator/expected/operatoragent.yaml`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- Extended internal Go configuration structs with `MCPServers`, `PlatformToolsets`, `Approvals`, and `Web` dictionary fields.
- Injected `agent_common` (local RPC) and `developer_knowledge` (remote Google MCP) server definitions into all agent tiers.
- Explicitly listed `platform_toolsets` (`cli` and `api_server`) to bypass the upstream Hermes loader prefix filter bug.
- Enabled DuckDuckGo web search (`backend: ddgs`) and autonomous watchdog execution (`cron_mode: approve`) across all autogenerated ConfigMaps.

## Why This Matters

- **Observability & Auditing:** Cluster operators inspecting live Kubernetes ConfigMaps (`kubectl get configmap`) can now see 100% of the active MCP servers and toolsets directly in Kubernetes.
- **Parity Across Install Methods:** Eliminates configuration drift between agents installed via static Kustomize/Helm manifests versus dynamic Kubernetes Operator Custom Resources.

## Context

Follow-up synchronization work to ensure full capability parity across all agent deployment mechanisms in the harness.

## Testing

- **Automated Unit & Golden Tests:** Re-ran `go test ./...` across the operator suite. Confirmed 100% of controller, webhook, and golden integration tests pass.
- **Live GKE Verification:** Built and deployed `kubeagents-operator:latest` to a live GKE Autopilot cluster. Applied `PlatformAgent` CR and verified the live synthesized ConfigMap contains all synced MCP servers and toolsets.
- **PR Hygiene:** Rebased cleanly onto latest `main` (`b1dda16`). Confirmed zero whitespace-only or formatting-only line noise.

---

Functional impact is strictly additive to agent capabilities. Zero breaking changes to existing CRD schemas.