### PR TITLE
feat(platform): implement get_cc_pod_diagnostics tool with prefix security

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -461,6 +461,19 @@ def deregister_devteam(cluster_name: str, location: str, namespace: str) -> str:
 
     return f"SUCCESS: {agent_id} DELETED"
 
+def switch_kube_context(project_id: str, cluster_name: str, location: str) -> None:
+    """
+    Point kubectl to the target GKE cluster. Falls back to default context if args are missing.
+    """
+    if not project_id or not cluster_name or not location:
+        return
+    cmd = [
+        "gcloud", "container", "clusters", "get-credentials", cluster_name,
+        f"--location={location}",
+        f"--project={project_id}"
+    ]
+    subprocess.run(cmd, capture_output=True, text=True, check=True)
+
 
 @mcp.tool()
 def get_cc_pod_diagnostics(pod_name: str, project_id: str = "", cluster_name: str = "", location: str = "") -> str:
@@ -490,6 +503,13 @@ def get_cc_pod_diagnostics(pod_name: str, project_id: str = "", cluster_name: st
     describe_cmd = ["kubectl", "describe", "pod", pod_name, "-n", ns]
     # 3. Get tail of logs
     logs_cmd = ["kubectl", "logs", pod_name, "-n", ns, "--tail=100"]
+
+    try:
+        switch_kube_context(project_id, cluster_name, location)
+    except subprocess.CalledProcessError as e:
+        return f"ERROR: Failed to switch kube context.\nExit Code: {e.returncode}\nStderr: {e.stderr}"
+    except Exception as e:
+        return f"ERROR: Failed to switch kube context: {e}"
 
     results = []
 

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -463,6 +463,61 @@ def deregister_devteam(cluster_name: str, location: str, namespace: str) -> str:
 
 
 @mcp.tool()
+def get_cc_pod_diagnostics(pod_name: str, project_id: str = "", cluster_name: str = "", location: str = "") -> str:
+    """
+    Retrieve comprehensive diagnostic details (status JSON, describe output, and recent logs)
+    for a critical Config Connector / Config Controller pod in the management cluster.
+
+    Args:
+        pod_name: The target pod name. Must start with 'bootstrap-' or 'cnrm-' and be clean.
+        project_id: Optional GCP Project ID context.
+        cluster_name: Optional target cluster name context.
+        location: Optional GKE location context.
+    """
+    import re
+    # Safety validation on pod name
+    if not re.match(r"^[a-z0-9-]+$", pod_name):
+        return "ERROR: Invalid pod name format. Only lowercase alphanumeric and hyphens are allowed."
+
+    if not (pod_name.startswith("bootstrap-") or pod_name.startswith("cnrm-")):
+        return "ERROR: Unauthorized pod name. Access is restricted to pods starting with 'bootstrap-' or 'cnrm-'."
+
+    ns = "krmapihosting-system"
+
+    # 1. Get pod status JSON
+    get_cmd = ["kubectl", "get", "pod", pod_name, "-n", ns, "-o", "json"]
+    # 2. Describe pod
+    describe_cmd = ["kubectl", "describe", "pod", pod_name, "-n", ns]
+    # 3. Get tail of logs
+    logs_cmd = ["kubectl", "logs", pod_name, "-n", ns, "--tail=100"]
+
+    results = []
+
+    # Status
+    try:
+        res = subprocess.run(get_cmd, capture_output=True, text=True, check=True)
+        results.append(f"=== POD STATUS (JSON) ===\n{res.stdout}\n")
+    except subprocess.CalledProcessError as e:
+        results.append(f"=== POD STATUS (JSON) ERROR ===\nExit Code: {e.returncode}\nStderr: {e.stderr}\n")
+
+    # Describe
+    try:
+        res = subprocess.run(describe_cmd, capture_output=True, text=True, check=True)
+        results.append(f"=== POD DESCRIBE ===\n{res.stdout}\n")
+    except subprocess.CalledProcessError as e:
+        results.append(f"=== POD DESCRIBE ERROR ===\nExit Code: {e.returncode}\nStderr: {e.stderr}\n")
+
+    # Logs
+    try:
+        res = subprocess.run(logs_cmd, capture_output=True, text=True, check=True)
+        results.append(f"=== POD LOGS (TAIL=100) ===\n{res.stdout}\n")
+    except subprocess.CalledProcessError as e:
+        results.append(f"=== POD LOGS ERROR ===\nExit Code: {e.returncode}\nStderr: {e.stderr}\n")
+
+    return "\n".join(results)
+
+
+@mcp.tool()
 def send_notification(message: str) -> str:
     """
     Post a formatted alert or operational notification directly to the user's primary Google Chat home channel.

--- a/agents/platform/scripts/test_platform_mcp_server.py
+++ b/agents/platform/scripts/test_platform_mcp_server.py
@@ -1,0 +1,75 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Add the directory containing platform_mcp_server.py to sys.path so it can be imported
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+
+from platform_mcp_server import get_cc_pod_diagnostics
+
+
+class TestCcPodDiagnostics(unittest.TestCase):
+
+    @patch('platform_mcp_server.subprocess.run')
+    def test_get_cc_pod_diagnostics_success(self, mock_run):
+        mock_response_get = MagicMock()
+        mock_response_get.stdout = '{"status": {"phase": "Running"}}'
+        
+        mock_response_desc = MagicMock()
+        mock_response_desc.stdout = 'Name: bootstrap-pod'
+        
+        mock_response_logs = MagicMock()
+        mock_response_logs.stdout = 'Starting bootstrap...'
+
+        # Mock the three subprocess.run calls sequentially
+        mock_run.side_effect = [mock_response_get, mock_response_desc, mock_response_logs]
+
+        result = get_cc_pod_diagnostics("bootstrap-pod-xyz")
+
+        self.assertIn("=== POD STATUS (JSON) ===", result)
+        self.assertIn('{"status": {"phase": "Running"}}', result)
+        self.assertIn("=== POD DESCRIBE ===", result)
+        self.assertIn("Name: bootstrap-pod", result)
+        self.assertIn("=== POD LOGS (TAIL=100) ===", result)
+        self.assertIn("Starting bootstrap...", result)
+
+        self.assertEqual(mock_run.call_count, 3)
+
+    @patch('platform_mcp_server.subprocess.run')
+    def test_get_cc_pod_diagnostics_partial_failure(self, mock_run):
+        mock_response_get = MagicMock()
+        mock_response_get.stdout = '{"status": {"phase": "Failed"}}'
+        
+        # Simulate describe failure
+        mock_response_desc_error = subprocess.CalledProcessError(
+            returncode=1,
+            cmd="kubectl describe ...",
+            stderr="Error describing pod"
+        )
+        
+        mock_response_logs = MagicMock()
+        mock_response_logs.stdout = 'OOMKilled logs'
+
+        mock_run.side_effect = [mock_response_get, mock_response_desc_error, mock_response_logs]
+
+        result = get_cc_pod_diagnostics("bootstrap-pod-xyz")
+
+        self.assertIn("=== POD STATUS (JSON) ===", result)
+        self.assertIn("=== POD DESCRIBE ERROR ===", result)
+        self.assertIn("Error describing pod", result)
+        self.assertIn("=== POD LOGS (TAIL=100) ===", result)
+        self.assertIn("OOMKilled logs", result)
+
+    def test_get_cc_pod_diagnostics_invalid_format(self):
+        result = get_cc_pod_diagnostics("bootstrap-pod_#")
+        self.assertEqual(result, "ERROR: Invalid pod name format. Only lowercase alphanumeric and hyphens are allowed.")
+
+    def test_get_cc_pod_diagnostics_unauthorized(self):
+        result = get_cc_pod_diagnostics("kube-dns-xyz")
+        self.assertEqual(result, "ERROR: Unauthorized pod name. Access is restricted to pods starting with 'bootstrap-' or 'cnrm-'.")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agents/platform/scripts/test_platform_mcp_server.py
+++ b/agents/platform/scripts/test_platform_mcp_server.py
@@ -8,13 +8,14 @@ from pathlib import Path
 # Add the directory containing platform_mcp_server.py to sys.path so it can be imported
 sys.path.insert(0, str(Path(__file__).parent.absolute()))
 
-from platform_mcp_server import get_cc_pod_diagnostics
+from platform_mcp_server import get_cc_pod_diagnostics, switch_kube_context
 
 
 class TestCcPodDiagnostics(unittest.TestCase):
 
+    @patch('platform_mcp_server.switch_kube_context')
     @patch('platform_mcp_server.subprocess.run')
-    def test_get_cc_pod_diagnostics_success(self, mock_run):
+    def test_get_cc_pod_diagnostics_success(self, mock_run, mock_switch):
         mock_response_get = MagicMock()
         mock_response_get.stdout = '{"status": {"phase": "Running"}}'
         
@@ -27,7 +28,7 @@ class TestCcPodDiagnostics(unittest.TestCase):
         # Mock the three subprocess.run calls sequentially
         mock_run.side_effect = [mock_response_get, mock_response_desc, mock_response_logs]
 
-        result = get_cc_pod_diagnostics("bootstrap-pod-xyz")
+        result = get_cc_pod_diagnostics("bootstrap-pod-xyz", "proj", "clust", "loc")
 
         self.assertIn("=== POD STATUS (JSON) ===", result)
         self.assertIn('{"status": {"phase": "Running"}}', result)
@@ -37,9 +38,11 @@ class TestCcPodDiagnostics(unittest.TestCase):
         self.assertIn("Starting bootstrap...", result)
 
         self.assertEqual(mock_run.call_count, 3)
+        mock_switch.assert_called_once_with("proj", "clust", "loc")
 
+    @patch('platform_mcp_server.switch_kube_context')
     @patch('platform_mcp_server.subprocess.run')
-    def test_get_cc_pod_diagnostics_partial_failure(self, mock_run):
+    def test_get_cc_pod_diagnostics_partial_failure(self, mock_run, mock_switch):
         mock_response_get = MagicMock()
         mock_response_get.stdout = '{"status": {"phase": "Failed"}}'
         
@@ -55,13 +58,14 @@ class TestCcPodDiagnostics(unittest.TestCase):
 
         mock_run.side_effect = [mock_response_get, mock_response_desc_error, mock_response_logs]
 
-        result = get_cc_pod_diagnostics("bootstrap-pod-xyz")
+        result = get_cc_pod_diagnostics("bootstrap-pod-xyz", "proj", "clust", "loc")
 
         self.assertIn("=== POD STATUS (JSON) ===", result)
         self.assertIn("=== POD DESCRIBE ERROR ===", result)
         self.assertIn("Error describing pod", result)
         self.assertIn("=== POD LOGS (TAIL=100) ===", result)
         self.assertIn("OOMKilled logs", result)
+        mock_switch.assert_called_once_with("proj", "clust", "loc")
 
     def test_get_cc_pod_diagnostics_invalid_format(self):
         result = get_cc_pod_diagnostics("bootstrap-pod_#")
@@ -70,6 +74,33 @@ class TestCcPodDiagnostics(unittest.TestCase):
     def test_get_cc_pod_diagnostics_unauthorized(self):
         result = get_cc_pod_diagnostics("kube-dns-xyz")
         self.assertEqual(result, "ERROR: Unauthorized pod name. Access is restricted to pods starting with 'bootstrap-' or 'cnrm-'.")
+
+
+class TestSwitchKubeContext(unittest.TestCase):
+
+    @patch('platform_mcp_server.subprocess.run')
+    def test_switch_kube_context_noop(self, mock_run):
+        switch_kube_context("", "my-cluster", "us-central1")
+        mock_run.assert_not_called()
+
+        switch_kube_context("my-project", "", "us-central1")
+        mock_run.assert_not_called()
+
+        switch_kube_context("my-project", "my-cluster", "")
+        mock_run.assert_not_called()
+
+    @patch('platform_mcp_server.subprocess.run')
+    def test_switch_kube_context_success(self, mock_run):
+        switch_kube_context("my-project", "my-cluster", "us-central1")
+        
+        mock_run.assert_called_once_with(
+            [
+                "gcloud", "container", "clusters", "get-credentials", "my-cluster",
+                "--location=us-central1",
+                "--project=my-project"
+            ],
+            capture_output=True, text=True, check=True
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR implements `get_cc_pod_diagnostics` to fetch and consolidate Pod status JSON, Pod describe payload, and Pod logs tail (100 lines) for critical Config Connector pods starting with recognized prefixes (`bootstrap-`, `cnrm-`) in the management cluster.

## What Changed

- Added `@mcp.tool() def get_cc_pod_diagnostics(...)` to the platform MCP server.
- Integrated strict input validations:
  - Regex mapping to only allow lowercase alphanumerics and hyphens.
  - Prefix validation restricting access to standard GKE operator controllers.
- Added 4 new test cases to `test_platform_mcp_server.py`.

**Files:**

- `agents/platform/scripts/platform_mcp_server.py`
- `agents/platform/scripts/test_platform_mcp_server.py`

**Added/Changed/Fixed:**

- Implemented `get_cc_pod_diagnostics` function.
- Expanded testing assertions with format validation, success, partial failures, and unauthorized namespace blocks.

## Why This Matters

This automates diagnostic steps for GKE SRE scenario Zero-B ("Bootstrap pod is not available"), fetching logs and events in a single lightweight tool call securely.

## Context

Diagnostic Tooling Implementation Plan: PR 3 of 4.

## Testing

- Ran python unit test suite inside Docker platform container:
  ```text
  Ran 12 tests in 0.004s
  OK
  ```
