### PR TITLE
feat(ci): deploy staging platform agent via provision script with dynamic image tagging

### DIFF
--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -96,7 +96,10 @@ jobs:
           PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
-          AGENT_IMAGE: "${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}"
+          MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
+          MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
+          AGENT_IMAGE: "${{ env.IMAGE_REPO }}"
+          AGENT_TAG: "${{ github.sha }}"
           CHAT_SUB_NAME: "platform-agent-chat-events-sub"
           CHAT_TOPIC_NAME: "platform-agent-chat-events"
           ALLOWED_USERS: ""

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -99,7 +99,7 @@ jobs:
           AGENT_IMAGE: "${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}"
           CHAT_SUB_NAME: "platform-agent-chat-events-sub"
           CHAT_TOPIC_NAME: "platform-agent-chat-events"
-          ALLOWED_USERS: "[]"
+          ALLOWED_USERS: ""
         run: |
           echo "Redeploying platform-agent via provision_06 with image: $AGENT_IMAGE"
           cd k8s-operator

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -88,8 +88,8 @@ jobs:
           TAG_NAME: ${{ github.event.workflow_run.head_sha }}
         run: |
           REPO_DOWNCASE=$(echo "$REPO_NAME" | tr '[:upper:]' '[:lower:]')
-          echo "IMAGE_REPO=ghcr.io/${REPO_DOWNCASE}/${PACKAGE_NAME}" >> "$GITHUB_ENV"
-          echo "IMAGE_TAG=${TAG_NAME}" >> "$GITHUB_ENV"
+          echo "AGENT_IMAGE=ghcr.io/${REPO_DOWNCASE}/${PACKAGE_NAME}" >> "$GITHUB_ENV"
+          echo "AGENT_TAG=${TAG_NAME}" >> "$GITHUB_ENV"
 
       - name: Perform Agent Redeployment
         env:
@@ -98,13 +98,13 @@ jobs:
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
           MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
           MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
-          AGENT_IMAGE: "${{ env.IMAGE_REPO }}"
-          AGENT_TAG: "${{ github.sha }}"
+          AGENT_IMAGE: "${{ env.AGENT_IMAGE }}"
+          AGENT_TAG: "${{ env.AGENT_TAG }}"
           CHAT_SUB_NAME: "platform-agent-chat-events-sub"
           CHAT_TOPIC_NAME: "platform-agent-chat-events"
           ALLOWED_USERS: ""
         run: |
-          echo "Redeploying platform-agent via provision_06 with image: $AGENT_IMAGE"
+          echo "Redeploying platform-agent via provision_06 with image: ${AGENT_IMAGE}:${AGENT_TAG}"
           cd k8s-operator
           make gcp-provision-06-deploy ARGS="--no-confirm"
 

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -96,8 +96,6 @@ jobs:
           PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
-          MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
-          MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
           AGENT_IMAGE: "${{ env.AGENT_IMAGE }}"
           AGENT_TAG: "${{ env.AGENT_TAG }}"
           CHAT_SUB_NAME: "platform-agent-chat-events-sub"

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -97,9 +97,9 @@ jobs:
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
           AGENT_IMAGE: "${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}"
-          CHAT_SUB_NAME: "platform-agent-chat-events-sub"
-          CHAT_TOPIC_NAME: "platform-agent-chat-events"
-          ALLOWED_USERS: "[]"
+          CHAT_SUB_NAME: ${{ vars.CHAT_SUB_NAME }}
+          CHAT_TOPIC_NAME: ${{ vars.CHAT_TOPIC_NAME }}
+          ALLOWED_USERS: ${{ vars.ALLOWED_USERS }}
         run: |
           echo "Redeploying platform-agent via provision_06 with image: $AGENT_IMAGE"
           cd k8s-operator

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -97,9 +97,9 @@ jobs:
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
           AGENT_IMAGE: "${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}"
-          CHAT_SUB_NAME: ${{ vars.CHAT_SUB_NAME }}
-          CHAT_TOPIC_NAME: ${{ vars.CHAT_TOPIC_NAME }}
-          ALLOWED_USERS: ${{ vars.ALLOWED_USERS }}
+          CHAT_SUB_NAME: "platform-agent-chat-events-sub"
+          CHAT_TOPIC_NAME: "platform-agent-chat-events"
+          ALLOWED_USERS: "[]"
         run: |
           echo "Redeploying platform-agent via provision_06 with image: $AGENT_IMAGE"
           cd k8s-operator

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -166,7 +166,7 @@ ensure_teardown_state() {
     echo -e "  ${C_YELLOW}⚠ State file ${VARS_FILE} not found. Prompting for target values...${C_RESET}"
     local ACTIVE_PROJECT
     ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
-    if [ "${DRY_RUN:-0}" -eq 1 ] || [ "${NO_CONFIRM:-0}" -eq 1 ] || [ "${CI:-false}" = "true" ]; then
+    if [ "${DRY_RUN:-0}" -eq 1 ]; then
       export PROJECT_ID="${ACTIVE_PROJECT:-dummy-project}"
       export REGION="us-east4"
       export CLUSTER_NAME="platform-agent-host"

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -100,7 +100,7 @@ init_var() {
   # Use declare -p to avoid prompting again for variables defined with empty values
   if ! declare -p "$var_name" &>/dev/null; then
     local final_val
-    if [ "${DRY_RUN:-0}" -eq 1 ] || [ "${NO_CONFIRM:-0}" -eq 1 ] || is_ci_pipeline; then
+    if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
       final_val="$default_val"
     else
       echo -ne "  ${C_CYAN}${prompt_msg} [${C_WHITE}${default_val}${C_CYAN}]: ${C_RESET}"

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -100,7 +100,7 @@ init_var() {
   # Use declare -p to avoid prompting again for variables defined with empty values
   if ! declare -p "$var_name" &>/dev/null; then
     local final_val
-    if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
+    if [ "${DRY_RUN:-0}" -eq 1 ] || [ "${NO_CONFIRM:-0}" -eq 1 ] || is_ci_pipeline; then
       final_val="$default_val"
     else
       echo -ne "  ${C_CYAN}${prompt_msg} [${C_WHITE}${default_val}${C_CYAN}]: ${C_RESET}"
@@ -166,7 +166,7 @@ ensure_teardown_state() {
     echo -e "  ${C_YELLOW}⚠ State file ${VARS_FILE} not found. Prompting for target values...${C_RESET}"
     local ACTIVE_PROJECT
     ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
-    if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    if [ "${DRY_RUN:-0}" -eq 1 ] || [ "${NO_CONFIRM:-0}" -eq 1 ] || [ "${CI:-false}" = "true" ]; then
       export PROJECT_ID="${ACTIVE_PROJECT:-dummy-project}"
       export REGION="us-east4"
       export CLUSTER_NAME="platform-agent-host"

--- a/k8s-operator/scripts/platform-agent.yaml.template
+++ b/k8s-operator/scripts/platform-agent.yaml.template
@@ -16,7 +16,7 @@ spec:
         key: API_SERVER_KEY
   deployment:
     image: "${AGENT_IMAGE}"
-    tag: "latest"
+    tag: "${AGENT_TAG}"
     imagePullPolicy: Always
   security:
     serviceAccountName: "${KSA_NAME}"

--- a/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
@@ -45,6 +45,7 @@ init_var "GOOGLE_CHAT_MODE" "default" "Enter Google Chat Output Mode (default or
 init_var "ALLOWED_USERS" "" "Enter Allowed Google Chat Users Emails (comma separated). Leaving it empty will allow all users."
 DEFAULT_AGENT_IMAGE="ghcr.io/gke-labs/kube-agents/platform-agent"
 init_var "AGENT_IMAGE" "$DEFAULT_AGENT_IMAGE" "Enter Platform Agent Image Path"
+init_var "AGENT_TAG" "latest" "Enter Platform Agent Image Tag"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ execute_custom_resource() {
   fi
 
   # Ensure variables are explicitly exported so envsubst can access them
-  export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME GOOGLE_CHAT_MODE ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME
+  export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME GOOGLE_CHAT_MODE ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME AGENT_TAG
 
   envsubst < "$CR_TEMPLATE" > "$CR_MANIFEST"
   


### PR DESCRIPTION
# Pull Request

## Why This Change

The staging agent redeployment workflow previously used a direct `kubectl patch` command to update the `PlatformAgent` custom resource. This bypassed standard provisioning scripts and hardcoded image tags to `latest`. To standardize staging deployments with our GitOps and provisioning workflows, the workflow needs to invoke `make gcp-provision-06-deploy` and support dynamic image tagging based on the commit SHA.

## What Changed

**Files:**

- `.github/workflows/staging-redeploy-agent.yml`
- `k8s-operator/scripts/platform-agent.yaml.template`
- `k8s-operator/scripts/provision_06_deploy_platform_agent.sh`

**Added/Changed/Fixed:**

- **Workflow Redeployment Step:** Replaced direct `kubectl patch` with `make gcp-provision-06-deploy ARGS="--no-confirm"` in `k8s-operator/`, setting up Go and exporting required GCP and agent environment variables.
- **Dynamic Image Tagging:** Configured `AGENT_TAG: "${{ github.sha }}"` in the GitHub Actions workflow and updated `platform-agent.yaml.template` to use `${AGENT_TAG}` instead of hardcoded `latest`.
- **Provision Script Update:** Added `AGENT_TAG` initialization (defaulting to `latest`) and exported it in `provision_06_deploy_platform_agent.sh` so `envsubst` can substitute it when generating the CR manifest.
- **Enhanced Rollout Verification:** Added detailed debug logging (`kubectl describe`, pod logs) if deployment rollout verification fails.
- **Hardcoded Chat Events Configuration:** Standardized `CHAT_SUB_NAME`, `CHAT_TOPIC_NAME`, and `ALLOWED_USERS` in the staging redeploy environment variables.

## Why This Matters

- Standardizes CI/CD redeployment to use the exact same provisioning scripts and templates used in manual and scripted setups.
- Ensures staging deployments run against immutable commit SHAs (`${{ github.sha }}`) rather than mutable `latest` tags, improving reproducibility and debugging.
- Provides immediate and automated debug log output in GitHub Actions if a rollout fails.

## Context

Follow-up to staging deployment standardization efforts and #228.

## Testing

- Verified script syntax and compatibility with `envsubst` variable replacement.
- Tested locally that `provision_06_deploy_platform_agent.sh` defaults `AGENT_TAG` to `latest` when not specified.

---

Rollout impact is low risk and scoped exclusively to staging environment agent redeployment workflows and provisioning script templates.