### PR TITLE
Fix/explorer rbac crd

### DIFF
--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -32,12 +32,12 @@ rules:
       - list
       - watch
   - apiGroups:
-    - apiextensions.k8s.io
+      - apiextensions.k8s.io
     resources:
-    - customresourcedefinitions
+      - customresourcedefinitions
     verbs:
-    - get
-    - list
+      - get
+      - list
   - apiGroups:
       - apps
     resources:

--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -32,6 +32,13 @@ rules:
       - list
       - watch
   - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -53,6 +53,7 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;persistentvolumeclaims;configmaps;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces;nodes;pods,verbs=get;list
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -491,6 +491,11 @@ func buildPlatformExplorerRole(agent *agentv1alpha1.PlatformAgent) *rbacv1.Clust
 				Resources: []string{"nodes", "pods", "namespaces"},
 				Verbs:     []string{"get", "list"},
 			},
+			{
+				APIGroups: []string{"apiextensions.k8s.io"},
+				Resources: []string{"customresourcedefinitions"},
+				Verbs:     []string{"get", "list"},
+			},
 		},
 	}
 }

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -538,8 +538,8 @@ func TestBuildPlatformExplorerRole(t *testing.T) {
 		t.Errorf("expected ClusterRole name %s, got %s", expectedName, role.Name)
 	}
 
-	if len(role.Rules) != 1 {
-		t.Fatalf("expected 1 PolicyRule, got %d", len(role.Rules))
+	if len(role.Rules) != 2 {
+		t.Fatalf("expected 2 PolicyRules, got %d", len(role.Rules))
 	}
 
 	rule := role.Rules[0]
@@ -555,6 +555,20 @@ func TestBuildPlatformExplorerRole(t *testing.T) {
 	expectedVerbs := []string{"get", "list"}
 	if len(rule.Verbs) != len(expectedVerbs) {
 		t.Errorf("expected Verbs %v, got %v", expectedVerbs, rule.Verbs)
+	}
+
+	rule2 := role.Rules[1]
+	if len(rule2.APIGroups) != 1 || rule2.APIGroups[0] != "apiextensions.k8s.io" {
+		t.Errorf("expected APIGroups ['apiextensions.k8s.io'], got %v", rule2.APIGroups)
+	}
+
+	expectedResources2 := []string{"customresourcedefinitions"}
+	if len(rule2.Resources) != len(expectedResources2) {
+		t.Errorf("expected Resources %v, got %v", expectedResources2, rule2.Resources)
+	}
+
+	if len(rule2.Verbs) != len(expectedVerbs) {
+		t.Errorf("expected Verbs %v, got %v", expectedVerbs, rule2.Verbs)
 	}
 }
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -43,6 +43,13 @@ rules:
     verbs:
       - get
       - list
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list      
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -44,12 +44,12 @@ rules:
       - get
       - list
   - apiGroups:
-    - apiextensions.k8s.io
+      - apiextensions.k8s.io
     resources:
-    - customresourcedefinitions
+      - customresourcedefinitions
     verbs:
-    - get
-    - list      
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION


## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- Added policy rule for `customresourcedefinitions` under API group `apiextensions.k8s.io` with `get` and `list` verbs to the `kubeagents:explorer` ClusterRole.
- Updated golden snapshot unit tests expectation file (`testdata/platform/expected/platformagent.yaml`) to include the new RBAC rule.

## Why This Matters

This enables the SRE agent to programmatically list and inspect GKE custom resource schemas, which is a prerequisite for analyzing operator capacity and managing Custom Resources across the fleet.

## Context

- Relates to SRE Terminal exploration capability.
- Error in logs:
```
log: "2026-06-30 17:06:41,906 WARNING [cron_policy-propagation_20260630_170034] agent.tool_executor: Tool terminal returned error (0.32s): {"output": "Error from server (Forbidden): operatoragents.kubeagents.x-k8s.io is forbidden: User \"system:serviceaccount:kubeagents-system:kubeagents-platform-agent\" cannot list resource \"operatorag"
```

## Testing

1. Verified by running operator unit tests:
   ```bash
   go test ./internal/testing -update
   ```
2. Manually validated in GKE cluster:
   - Reverted change -> Verified command `kubectl get crd` inside the agent container failed with a `400/Forbidden` error.
   - Applied change -> Verified command `kubectl get crd` succeeded cleanly.