### PR TITLE
feat: Add Inference Replay to installation script

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -30,3 +30,10 @@ jobs:
           tags: platform-agent:latest
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      - name: Build Replay Proxy
+        uses: docker/build-push-action@v7
+        with:
+          context: examples/inference-replay/replay-proxy
+          push: false
+          tags: replay-proxy:latest

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -48,9 +48,21 @@ jobs:
           DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      - name: Build and Push Replay Proxy (GCP Cloud Build)
+        id: gcp-replay-proxy
+        run: |
+          gcloud builds submit examples/inference-replay/replay-proxy \
+            --tag=${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}
+          gcloud artifacts docker tags add \
+            ${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }} \
+            ${{ env.GCP_REGISTRY }}/replay-proxy:latest
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign the images
         run: |
           cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/replay-proxy@${{ steps.gcp-replay-proxy.outputs.digest }}"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -49,9 +49,20 @@ jobs:
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
+      - name: Build and Push Replay Proxy (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-replay-proxy
+        with:
+          context: examples/inference-replay/replay-proxy
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:${{ github.sha }}
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign the images
         run: |
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy@${{ steps.build-replay-proxy.outputs.digest }}"

--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -109,6 +109,14 @@ undeploy-litellm: kustomize ## Undeploy LiteLLM integration.
 		$(KUSTOMIZE) build config/integrations/litellm/base | envsubst '$$NAMESPACE $$MODEL_PROVIDER $$MODEL_DEFAULT_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -; \
 	fi
 
+.PHONY: deploy-inference-replay
+deploy-inference-replay: kustomize ## Deploy Inference Replay proxy integration.
+	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE $$REPLAY_MODE' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
+
+.PHONY: undeploy-inference-replay
+undeploy-inference-replay: kustomize ## Undeploy Inference Replay proxy integration.
+	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE $$REPLAY_MODE' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
+
 .PHONY: deploy-github
 deploy-github: kustomize ## Deploy GitHub integration.
 	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -

--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -111,11 +111,11 @@ undeploy-litellm: kustomize ## Undeploy LiteLLM integration.
 
 .PHONY: deploy-inference-replay
 deploy-inference-replay: kustomize ## Deploy Inference Replay proxy integration.
-	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE $$REPLAY_MODE' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
 
 .PHONY: undeploy-inference-replay
 undeploy-inference-replay: kustomize ## Undeploy Inference Replay proxy integration.
-	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE $$REPLAY_MODE' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/inference-replay/base | envsubst '$$NAMESPACE $$REPLAY_IMAGE' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
 
 .PHONY: deploy-github
 deploy-github: kustomize ## Deploy GitHub integration.

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -98,7 +98,7 @@ graph TD
 
 10. **[provision_10_deploy_inference_replay.sh](scripts/provision_10_deploy_inference_replay.sh)**:
     - Opt-in step (skipped unless `INFERENCE_REPLAY_ENABLED=true`).
-    - Deploys the Inference Replay proxy in front of the LiteLLM gateway: a PVC-backed cache, a renamed `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service that routes through the proxy. Defaults to `REPLAY_MODE=off` (pure pass-through).
+    - Deploys the Inference Replay proxy in front of the LiteLLM gateway: a PVC-backed cache, a renamed `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service that routes through the proxy. Always installs in pass-through mode (`mode=off`); toggle to `on` at runtime via `kubectl patch configmap inference-replay-config`.
     - For background and usage, see the [Inference Replay README](../examples/inference-replay/README.md).
 
 #### Fast Local Development & Testing

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -40,7 +40,7 @@ Or execute the master script directly from the scripts folder:
 
 #### How it Works & Modular Sub-scripts
 
-The master [provision.sh](scripts/provision.sh) script orchestrates eight modular sub-scripts sequentially. Each sub-script is idempotent: it verifies the state of its resources before executing any action. If a resource already exists or a step was already completed, it is skipped.
+The master [provision.sh](scripts/provision.sh) script orchestrates nine modular sub-scripts sequentially. Each sub-script is idempotent: it verifies the state of its resources before executing any action. If a resource already exists or a step was already completed, it is skipped.
 
 ```mermaid
 graph TD
@@ -53,6 +53,7 @@ graph TD
     A --> H[provision_07_deploy_platform_agent.sh]
     A --> I[provision_08_deploy_litellm.sh]
     A --> J[provision_09_deploy_github_minter.sh]
+    A --> K[provision_10_deploy_inference_replay.sh]
 ```
 
 1. **[provision_01_gcp_cluster.sh](scripts/provision_01_gcp_cluster.sh)**:
@@ -94,6 +95,11 @@ graph TD
    - Sets up Google Cloud KMS keyrings and keys for token signing.
    - Deploys the GitHub Token Minter into the cluster with its authorization configs.
    - For detailed configuration instructions, see the [GitHub Token Minter README](config/integrations/github/README.md).
+
+10. **[provision_10_deploy_inference_replay.sh](scripts/provision_10_deploy_inference_replay.sh)**:
+    - Opt-in step (skipped unless `INFERENCE_REPLAY_ENABLED=true`).
+    - Deploys the Inference Replay proxy in front of the LiteLLM gateway: a PVC-backed cache, a renamed `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service that routes through the proxy. Defaults to `REPLAY_MODE=off` (pure pass-through).
+    - For background and usage, see the [Inference Replay README](../examples/inference-replay/README.md).
 
 #### Fast Local Development & Testing
 

--- a/k8s-operator/config/integrations/inference-replay/base/configmap.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/configmap.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: inference-replay-config
-data:
-  mode: "${REPLAY_MODE}"

--- a/k8s-operator/config/integrations/inference-replay/base/configmap.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inference-replay-config
+data:
+  mode: "${REPLAY_MODE}"

--- a/k8s-operator/config/integrations/inference-replay/base/deployment.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: standalone-replay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: standalone-replay
+  template:
+    metadata:
+      labels:
+        app: standalone-replay
+    spec:
+      containers:
+        - name: replay-proxy-container
+          image: ${REPLAY_IMAGE}
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          env:
+            - name: INFERENCE_URL
+              value: "http://litellm-gateway.${NAMESPACE}.svc.cluster.local"
+            - name: CACHE_FILE
+              value: "/data/replay_cache.json"
+            - name: MODE_FILE
+              value: "/etc/replay/mode"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "1Gi"
+          volumeMounts:
+            - name: cache-volume
+              mountPath: /data
+            - name: mode-config
+              mountPath: /etc/replay
+              readOnly: true
+      volumes:
+        - name: cache-volume
+          persistentVolumeClaim:
+            claimName: standalone-replay-pvc
+        - name: mode-config
+          configMap:
+            name: inference-replay-config

--- a/k8s-operator/config/integrations/inference-replay/base/kustomization.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - pvc.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service-gateway.yaml
+  - service.yaml

--- a/k8s-operator/config/integrations/inference-replay/base/kustomization.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/kustomization.yaml
@@ -1,6 +1,12 @@
 resources:
   - pvc.yaml
-  - configmap.yaml
   - deployment.yaml
   - service-gateway.yaml
   - service.yaml
+
+configMapGenerator:
+  - name: inference-replay-config
+    literals:
+      - mode=off
+    options:
+      disableNameSuffixHash: true

--- a/k8s-operator/config/integrations/inference-replay/base/pvc.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: standalone-replay-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-gateway
+spec:
+  selector:
+    app: litellm
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 4000
+  type: ClusterIP

--- a/k8s-operator/config/integrations/inference-replay/base/service.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm
+spec:
+  selector:
+    app: standalone-replay
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -57,8 +57,8 @@ When any script is run:
    - Deploys the GitHub Token Minter into the cluster.
 10. **[provision_10_deploy_inference_replay.sh](provision_10_deploy_inference_replay.sh)**
     - Opt-in via `INFERENCE_REPLAY_ENABLED=true`; otherwise skipped.
-    - Prompts for `REPLAY_IMAGE` (the proxy container image) and `REPLAY_MODE` (`off`|`on`).
-    - Deploys the Inference Replay proxy: PVC + ConfigMap (mode), Deployment, a `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service routing traffic through the proxy.
+    - Prompts for `REPLAY_IMAGE` (the proxy container image).
+    - Deploys the Inference Replay proxy: PVC + ConfigMap (mode=off pass-through), Deployment, a `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service routing traffic through the proxy. Toggle caching on at runtime via `kubectl patch configmap inference-replay-config -n <ns> --type merge -p '{"data":{"mode":"on"}}'`.
 
 ### Auxiliary & Development Scripts (`dev/`)
 

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -66,7 +66,7 @@ When any script is run:
 
 ### Teardown Steps
 
-- **[teardown_10_deploy_inference_replay.sh](teardown_10_deploy_inference_replay.sh)**: Conditionally executed by master teardown if `INFERENCE_REPLAY_ENABLED=true`; undeploys the proxy (including the cache PVC) and re-applies the LiteLLM base to restore the original `litellm` Service.
+- **[teardown_10_deploy_inference_replay.sh](teardown_10_deploy_inference_replay.sh)**: Always executed by master teardown; undeploys the proxy (including the cache PVC) if present and re-applies the LiteLLM Service manifest to restore the original selector. Idempotent no-op if the proxy was never deployed.
 - **[teardown_09_deploy_github_minter.sh](teardown_09_deploy_github_minter.sh)**: Cleans up the GitHub Token Minter deployment, GSAs, and KMS resources.
 - **[teardown_08_deploy_litellm.sh](teardown_08_deploy_litellm.sh)**: Undeploys the LiteLLM Gateway from the cluster.
 - **[teardown_07_deploy_platform_agent.sh](teardown_07_deploy_platform_agent.sh)**: Safely deletes the `PlatformAgent` Custom Resource and cleans up local manifests.

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -18,8 +18,8 @@ When any script is run:
 
 ### Orchestration Scripts
 
-- **[provision.sh](provision.sh)**: Master script that coordinates the execution of all core provisioning steps (01 to 09).
-- **[teardown.sh](teardown.sh)**: Master script that coordinates the teardown steps in reverse order (09 down to 01, conditionally including auxiliary scripts).
+- **[provision.sh](provision.sh)**: Master script that coordinates the execution of all core provisioning steps (01 to 10).
+- **[teardown.sh](teardown.sh)**: Master script that coordinates the teardown steps in reverse order (10 down to 01, conditionally including auxiliary scripts).
 
 ### Provisioning Steps
 
@@ -55,6 +55,10 @@ When any script is run:
 9. **[provision_09_deploy_github_minter.sh](provision_09_deploy_github_minter.sh)**
    - Sets up Google Cloud KMS keyrings and keys for token signing.
    - Deploys the GitHub Token Minter into the cluster.
+10. **[provision_10_deploy_inference_replay.sh](provision_10_deploy_inference_replay.sh)**
+    - Opt-in via `INFERENCE_REPLAY_ENABLED=true`; otherwise skipped.
+    - Prompts for `REPLAY_IMAGE` (the proxy container image) and `REPLAY_MODE` (`off`|`on`).
+    - Deploys the Inference Replay proxy: PVC + ConfigMap (mode), Deployment, a `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service routing traffic through the proxy.
 
 ### Auxiliary & Development Scripts (`dev/`)
 
@@ -62,6 +66,7 @@ When any script is run:
 
 ### Teardown Steps
 
+- **[teardown_10_deploy_inference_replay.sh](teardown_10_deploy_inference_replay.sh)**: Conditionally executed by master teardown if `INFERENCE_REPLAY_ENABLED=true`; undeploys the proxy (including the cache PVC) and re-applies the LiteLLM base to restore the original `litellm` Service.
 - **[teardown_09_deploy_github_minter.sh](teardown_09_deploy_github_minter.sh)**: Cleans up the GitHub Token Minter deployment, GSAs, and KMS resources.
 - **[teardown_08_deploy_litellm.sh](teardown_08_deploy_litellm.sh)**: Undeploys the LiteLLM Gateway from the cluster.
 - **[teardown_07_deploy_platform_agent.sh](teardown_07_deploy_platform_agent.sh)**: Safely deletes the `PlatformAgent` Custom Resource and cleans up local manifests.

--- a/k8s-operator/scripts/provision.sh
+++ b/k8s-operator/scripts/provision.sh
@@ -34,6 +34,7 @@ fi
 "${SCRIPT_DIR}/provision_07_deploy_platform_agent.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_08_deploy_litellm.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_09_deploy_github_minter.sh" $DRY_RUN_ARG
+"${SCRIPT_DIR}/provision_10_deploy_inference_replay.sh" $DRY_RUN_ARG
 
 echo -e "\n${C_MAGENTA}${C_BOLD}>>>  Infrastructure & Cloud Resources Provisioned Successfully!  <<<${C_RESET}"
 

--- a/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 🤖 Step 10: Deploy Inference Replay Proxy (optional)
+# ==============================================================================
+# Idempotent script that deploys the Inference Replay proxy in front of the
+# LiteLLM gateway. Skipped unless INFERENCE_REPLAY_ENABLED=true.
+#
+# The proxy intercepts the `litellm` Service so agents need no configuration
+# changes. With REPLAY_MODE=off (default) it is a pure pass-through; flip the
+# `inference-replay-config` ConfigMap to `on` to start recording/replaying.
+# ==============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
+VARS_FILE="${SCRIPT_DIR}/vars.sh"
+
+# ─── ANSI Colors ──────────────────────────────────────────────────────────────
+source "${SCRIPT_DIR}/common.sh" "$@"
+
+# ─── Opt-In Gate ──────────────────────────────────────────────────────────────
+init_var "INFERENCE_REPLAY_ENABLED" "false" "Deploy Inference Replay proxy? (true/false)"
+if [ "${INFERENCE_REPLAY_ENABLED}" != "true" ]; then
+  echo -e "  ${C_CYAN}ℹ Skipping Inference Replay (INFERENCE_REPLAY_ENABLED=${INFERENCE_REPLAY_ENABLED}).${C_RESET}"
+  exit 0
+fi
+
+# ─── Prerequisites Check ──────────────────────────────────────────────────────
+print_step "Checking Local Prerequisites"
+check_prereqs "gcloud" "kubectl" "envsubst"
+
+# ─── Configuration & State Restoration ────────────────────────────────────────
+print_step "Setting up Configuration State for Inference Replay Deployment"
+load_state
+
+ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
+DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
+
+init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
+init_var "REGION" "us-east4" "Enter GKE GCP Region"
+init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
+init_var "REPLAY_IMAGE" "us-east4-docker.pkg.dev/${PROJECT_ID}/kube-agents/replay-proxy:latest" "Enter Replay Proxy container image"
+init_var "REPLAY_MODE" "off" "Initial replay mode (off|on)"
+
+if [[ ! "$REPLAY_MODE" =~ ^(off|on)$ ]]; then
+  print_error "Invalid REPLAY_MODE '$REPLAY_MODE'. Must be 'off' or 'on'."
+  exit 1
+fi
+
+# ─── Step Implementations ─────────────────────────────────────────────────────
+
+# Step 1: Connect kubectl
+verify_kubeconfig() {
+  local current_ctx
+  current_ctx=$(kubectl config current-context 2>/dev/null || echo "")
+  [[ "$current_ctx" == *"${PROJECT_ID}"* && "$current_ctx" == *"${CLUSTER_NAME}"* ]] && \
+  kubectl get namespace "$NAMESPACE" >/dev/null 2>&1
+}
+execute_kubeconfig() {
+  connect_cluster
+}
+
+# Step 2: Deploy Inference Replay proxy
+verify_inference_replay() {
+  # Always return false to ensure that Kustomize builds and configs are applied idempotently on every run
+  return 1
+}
+execute_inference_replay() {
+  print_info "Deploying Inference Replay proxy into GKE (image=${REPLAY_IMAGE}, mode=${REPLAY_MODE})..."
+  export NAMESPACE REPLAY_IMAGE REPLAY_MODE
+  make -C "${OPERATOR_DIR}" deploy-inference-replay || return 1
+}
+
+# ─── Execution Pipeline ───────────────────────────────────────────────────────
+run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0
+run_step "2. Deploy Inference Replay Proxy" verify_inference_replay execute_inference_replay 0
+
+# ─── Conclusion Checklist ─────────────────────────────────────────────────────
+echo -e "\n${C_GREEN}${C_BOLD}✓ Inference Replay Proxy deployed successfully to GKE!${C_RESET}"
+echo -e "  ${C_CYAN}ℹ Current mode: ${C_WHITE}${REPLAY_MODE}${C_RESET}"
+echo -e "  ${C_CYAN}ℹ Toggle on/off at runtime (no pod restart):${C_RESET}"
+echo -e "      ${C_WHITE}kubectl patch configmap inference-replay-config -n ${NAMESPACE} --type merge -p '{\"data\":{\"mode\":\"on\"}}'${C_RESET}"

--- a/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
@@ -45,12 +45,6 @@ init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var "REPLAY_IMAGE" "us-east4-docker.pkg.dev/${PROJECT_ID}/kube-agents/replay-proxy:latest" "Enter Replay Proxy container image"
-init_var "REPLAY_MODE" "off" "Initial replay mode (off|on)"
-
-if [[ ! "$REPLAY_MODE" =~ ^(off|on)$ ]]; then
-  print_error "Invalid REPLAY_MODE '$REPLAY_MODE'. Must be 'off' or 'on'."
-  exit 1
-fi
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -71,8 +65,8 @@ verify_inference_replay() {
   return 1
 }
 execute_inference_replay() {
-  print_info "Deploying Inference Replay proxy into GKE (image=${REPLAY_IMAGE}, mode=${REPLAY_MODE})..."
-  export NAMESPACE REPLAY_IMAGE REPLAY_MODE
+  print_info "Deploying Inference Replay proxy into GKE (image=${REPLAY_IMAGE})..."
+  export NAMESPACE REPLAY_IMAGE
   make -C "${OPERATOR_DIR}" deploy-inference-replay || return 1
 }
 
@@ -82,6 +76,5 @@ run_step "2. Deploy Inference Replay Proxy" verify_inference_replay execute_infe
 
 # ─── Conclusion Checklist ─────────────────────────────────────────────────────
 echo -e "\n${C_GREEN}${C_BOLD}✓ Inference Replay Proxy deployed successfully to GKE!${C_RESET}"
-echo -e "  ${C_CYAN}ℹ Current mode: ${C_WHITE}${REPLAY_MODE}${C_RESET}"
-echo -e "  ${C_CYAN}ℹ Toggle on/off at runtime (no pod restart):${C_RESET}"
+echo -e "  ${C_CYAN}ℹ Deployed in pass-through mode (mode=off). Toggle on at runtime (no pod restart):${C_RESET}"
 echo -e "      ${C_WHITE}kubectl patch configmap inference-replay-config -n ${NAMESPACE} --type merge -p '{\"data\":{\"mode\":\"on\"}}'${C_RESET}"

--- a/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_10_deploy_inference_replay.sh
@@ -44,7 +44,7 @@ DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
 init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
-init_var "REPLAY_IMAGE" "us-east4-docker.pkg.dev/${PROJECT_ID}/kube-agents/replay-proxy:latest" "Enter Replay Proxy container image"
+init_var "REPLAY_IMAGE" "ghcr.io/gke-labs/kube-agents/replay-proxy:latest" "Enter Replay Proxy container image"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 

--- a/k8s-operator/scripts/teardown.sh
+++ b/k8s-operator/scripts/teardown.sh
@@ -29,9 +29,7 @@ fi
 
 # Execute teardown steps in reverse order (10 down to 01)
 echo -e "\n${C_RED}${C_BOLD}🧹 Running Teardown Steps...${C_RESET}"
-if [ "${INFERENCE_REPLAY_ENABLED:-false}" = "true" ]; then
-  "${SCRIPT_DIR}/teardown_10_deploy_inference_replay.sh" --no-confirm $DRY_RUN_ARG || true
-fi
+"${SCRIPT_DIR}/teardown_10_deploy_inference_replay.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_09_deploy_github_minter.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_08_deploy_litellm.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_07_deploy_platform_agent.sh" --no-confirm $DRY_RUN_ARG || true

--- a/k8s-operator/scripts/teardown.sh
+++ b/k8s-operator/scripts/teardown.sh
@@ -27,8 +27,11 @@ if [ "$DRY_RUN" -eq 1 ]; then
   DRY_RUN_ARG="--dry-run"
 fi
 
-# Execute teardown steps in reverse order (09 down to 01)
+# Execute teardown steps in reverse order (10 down to 01)
 echo -e "\n${C_RED}${C_BOLD}🧹 Running Teardown Steps...${C_RESET}"
+if [ "${INFERENCE_REPLAY_ENABLED:-false}" = "true" ]; then
+  "${SCRIPT_DIR}/teardown_10_deploy_inference_replay.sh" --no-confirm $DRY_RUN_ARG || true
+fi
 "${SCRIPT_DIR}/teardown_09_deploy_github_minter.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_08_deploy_litellm.sh" --no-confirm $DRY_RUN_ARG || true
 "${SCRIPT_DIR}/teardown_07_deploy_platform_agent.sh" --no-confirm $DRY_RUN_ARG || true

--- a/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
@@ -55,15 +55,19 @@ fi
 
 # ─── Step 3: Restore original LiteLLM Service ─────────────────────────────────
 # The proxy overrides the `litellm` Service to forward to itself. Removing the
-# proxy also removes that Service, so we re-apply the LiteLLM base to bring the
-# original Service back. Safe no-op when LiteLLM was never deployed.
+# proxy also removes that Service, so we re-apply just the LiteLLM Service
+# manifest to bring the original selector back. Applying only the Service
+# (rather than `make deploy-litellm`) avoids re-running envsubst over the
+# LiteLLM ConfigMap, which templates ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
+# and would silently corrupt the running LiteLLM if those vars are unset.
+# Safe no-op when LiteLLM was never deployed.
+LITELLM_SERVICE_MANIFEST="${OPERATOR_DIR}/config/integrations/litellm/base/service.yaml"
 if [ "${DRY_RUN:-0}" -eq 1 ]; then
-  echo -e "  ${C_GREEN}[DRY-RUN] Would re-apply LiteLLM base to restore the original Service.${C_RESET}"
+  echo -e "  ${C_GREEN}[DRY-RUN] Would re-apply ${LITELLM_SERVICE_MANIFEST} to restore the original Service.${C_RESET}"
 else
   if kubectl get deployment litellm -n "$NAMESPACE" >/dev/null 2>&1; then
     print_info "Restoring original LiteLLM Service..."
-    export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
-    make -C "${OPERATOR_DIR}" deploy-litellm || true
+    kubectl apply -n "$NAMESPACE" -f "$LITELLM_SERVICE_MANIFEST" || true
   fi
 fi
 

--- a/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
@@ -22,10 +22,9 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 # ─── Configuration State Restoration ──────────────────────────────────────────
 ensure_teardown_state
 
-# Default values used only for envsubst expansion during delete; their concrete
-# values do not affect which resources are removed.
+# Default value used only for envsubst expansion during delete; its concrete
+# value does not affect which resources are removed.
 export REPLAY_IMAGE="${REPLAY_IMAGE:-placeholder}"
-export REPLAY_MODE="${REPLAY_MODE:-off}"
 
 # ─── Confirmation Prompt ──────────────────────────────────────────────────────
 confirm_action "This will permanently undeploy the Inference Replay Proxy. The persistent cache (PVC) will be deleted." \
@@ -49,7 +48,7 @@ echo -e "  ${C_CYAN}ℹ Undeploying Inference Replay Proxy...${C_RESET}"
 if [ "${DRY_RUN:-0}" -eq 1 ]; then
   echo -e "  ${C_GREEN}[DRY-RUN] Would undeploy Inference Replay Proxy in namespace '${NAMESPACE}'.${C_RESET}"
 else
-  export NAMESPACE REPLAY_IMAGE REPLAY_MODE
+  export NAMESPACE REPLAY_IMAGE
   make -C "${OPERATOR_DIR}" undeploy-inference-replay ignore-not-found=true || true
   echo -e "  ${C_GREEN}✓ Inference Replay Proxy undeploy command completed.${C_RESET}"
 fi

--- a/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/teardown_10_deploy_inference_replay.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 🧹 Step 10: Teardown Inference Replay Proxy
+# ==============================================================================
+# Idempotent script to undeploy the Inference Replay proxy and restore the
+# original LiteLLM Service. Safe to run even when the proxy was never deployed.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$SCRIPT_DIR" == */scripts ]]; then
+  OPERATOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+else
+  OPERATOR_DIR="${SCRIPT_DIR}"
+fi
+VARS_FILE="${SCRIPT_DIR}/vars.sh"
+
+# ─── ANSI Colors ──────────────────────────────────────────────────────────────
+source "${SCRIPT_DIR}/common.sh" "$@"
+
+# ─── Configuration State Restoration ──────────────────────────────────────────
+ensure_teardown_state
+
+# Default values used only for envsubst expansion during delete; their concrete
+# values do not affect which resources are removed.
+export REPLAY_IMAGE="${REPLAY_IMAGE:-placeholder}"
+export REPLAY_MODE="${REPLAY_MODE:-off}"
+
+# ─── Confirmation Prompt ──────────────────────────────────────────────────────
+confirm_action "This will permanently undeploy the Inference Replay Proxy. The persistent cache (PVC) will be deleted." \
+  "GCP Project:$PROJECT_ID" \
+  "GKE Cluster:$CLUSTER_NAME" \
+  "Namespace:$NAMESPACE"
+
+gcloud config set project "$PROJECT_ID" --quiet
+
+# ─── Step 1: Connect to GKE Cluster ───────────────────────────────────────────
+CLUSTER_EXISTS=$(cluster_exists)
+if [ -n "$CLUSTER_EXISTS" ]; then
+  connect_cluster || true
+else
+  echo -e "  ${C_GREEN}✓ GKE cluster '${CLUSTER_NAME}' does not exist. Skipping Inference Replay cleanup.${C_RESET}"
+  exit 0
+fi
+
+# ─── Step 2: Undeploy Inference Replay Proxy ──────────────────────────────────
+echo -e "  ${C_CYAN}ℹ Undeploying Inference Replay Proxy...${C_RESET}"
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  echo -e "  ${C_GREEN}[DRY-RUN] Would undeploy Inference Replay Proxy in namespace '${NAMESPACE}'.${C_RESET}"
+else
+  export NAMESPACE REPLAY_IMAGE REPLAY_MODE
+  make -C "${OPERATOR_DIR}" undeploy-inference-replay ignore-not-found=true || true
+  echo -e "  ${C_GREEN}✓ Inference Replay Proxy undeploy command completed.${C_RESET}"
+fi
+
+# ─── Step 3: Restore original LiteLLM Service ─────────────────────────────────
+# The proxy overrides the `litellm` Service to forward to itself. Removing the
+# proxy also removes that Service, so we re-apply the LiteLLM base to bring the
+# original Service back. Safe no-op when LiteLLM was never deployed.
+if [ "${DRY_RUN:-0}" -eq 1 ]; then
+  echo -e "  ${C_GREEN}[DRY-RUN] Would re-apply LiteLLM base to restore the original Service.${C_RESET}"
+else
+  if kubectl get deployment litellm -n "$NAMESPACE" >/dev/null 2>&1; then
+    print_info "Restoring original LiteLLM Service..."
+    export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
+    make -C "${OPERATOR_DIR}" deploy-litellm || true
+  fi
+fi
+
+echo -e "\n${C_GREEN}${C_BOLD}✅ Inference Replay Proxy successfully undeployed!${C_RESET}"


### PR DESCRIPTION
# Pull Request

## Why This Change

The Inference Replay proxy has been sitting in `examples/inference-replay/` requiring hand-run `kubectl apply` steps and a manual image build to use. To actually adopt it — for deterministic agent runs, cost savings on repeat prompts, offline replay of past trajectories — it needs to be part of the standard install flow the way every other component (LiteLLM, PlatformAgent, GitHub Minter, etc.) already is.
## What Changed

Adds an opt-in **Step 10** to the provision/teardown pipeline. When `INFERENCE_REPLAY_ENABLED=true`, the installer deploys the proxy in front of the LiteLLM gateway in safe pass-through mode (`mode=off`); recording is toggled at runtime via `kubectl patch` on the ConfigMap (hot-reloads in ~1s, no pod restart). Also wires the proxy image into the existing image-publish CI so a fresh install with the flag "just works" once merged — no manual `docker build` step needed.

**Files:**


  - `k8s-operator/config/integrations/inference-replay/base/` — new kustomize
  base (PVC, Deployment, `litellm-gateway` + intercepting `litellm` Services,
  `configMapGenerator` for mode)
  - `k8s-operator/Makefile` — `deploy-inference-replay` /
  `undeploy-inference-replay` targets
  - `k8s-operator/scripts/provision_10_deploy_inference_replay.sh` — opt-in
  provision step
  - `k8s-operator/scripts/teardown_10_deploy_inference_replay.sh` — matching
  teardown; re-applies the LiteLLM base to restore the original `litellm`
  Service
  - `k8s-operator/scripts/provision.sh` + `teardown.sh` — wire the new step into
  the master orchestrators (teardown gated on `INFERENCE_REPLAY_ENABLED`)
  - `k8s-operator/README.md` + `k8s-operator/scripts/README.md` — pipeline
  diagram and step docs updated
  - `.github/workflows/docker-publish-ghcr.yml` — publish
  `ghcr.io/gke-labs/kube-agents/replay-proxy:{latest,<sha>}` on push to main,
  cosign-sign the digest
  - `.github/workflows/docker-publish-gcp.yml` — mirror to
  `us-docker.pkg.dev/kube-agents-prow/kube-agents/replay-proxy` via Cloud Build
  - `.github/workflows/docker-build.yml` — PR-time build validation

**Added/Changed/Fixed:**

  - **Added**: Opt-in step 10 in the provision pipeline
  (`INFERENCE_REPLAY_ENABLED=true`), kustomize base under
  `config/integrations/inference-replay/`, matching Makefile deploy/undeploy
  targets, CI publish + PR build for the replay-proxy image.
  - **Changed**: `REPLAY_IMAGE` defaults to
  `ghcr.io/gke-labs/kube-agents/replay-proxy:latest` (mirroring how
  `provision_06` defaults the platform agent to a public GHCR image). Teardown
  re-applies the LiteLLM base so removing the proxy leaves the original
  `litellm` Service intact.
  - **Fixed**: Switched from a raw `ConfigMap` template to kustomize's
  `configMapGenerator`. The raw template's `mode: "${REPLAY_MODE}"` had its
  quotes stripped by kustomize's YAML canonicalization; envsubst produced plain
  `off`; kubectl's YAML 1.1 parser then coerced it to boolean `false`, blowing
  up `kubectl apply` with a type mismatch. The generator quotes YAML 1.1 boolean
  literals correctly. As part of this, `REPLAY_MODE` is dropped from install —
  every install starts in `mode=off` and the user toggles at runtime, which
  matches the intended UX anyway.

-

## Testing

  - Ran full `./k8s-operator/scripts/provision.sh` end-to-end on a fresh GKE
  project (`stalhaali-gkedemos`) with `INFERENCE_REPLAY_ENABLED=true` and
  `REPLAY_IMAGE` pointing at a locally-built (Cloud Build) image.


