### PR TITLE
feat(platform): add Google Chat session OTel attribution

### DIFF
--- a/agents/platform/config.yaml
+++ b/agents/platform/config.yaml
@@ -28,3 +28,9 @@ platform_toolsets:
     - mcp-agent_common
     - mcp-platform_control
     - mcp-developer_knowledge
+
+plugins:
+  enabled:
+    - hermes_otel
+    - session_store
+    - session_otel_bridge

--- a/agents/platform/defaults/plugins/session_otel_bridge/__init__.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import register
+
+__all__ = ["register"]

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -24,6 +24,7 @@ class OtelSessionBridge:
     def __init__(self, db_path: Optional[Path] = None) -> None:
         hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
         self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(hermes_home / "session_kv.db")))
+        self._span_attribute_cache: Dict[str, dict] = {}
 
     def install(self) -> None:
         tracer = get_tracer()
@@ -55,6 +56,9 @@ class OtelSessionBridge:
 
     def _span_attributes_for_session(self, session_id: str) -> dict:
         session_id = self._sanitize_session_id(session_id)
+        if session_id in self._span_attribute_cache:
+            return dict(self._span_attribute_cache[session_id])
+
         metadata = self._metadata_for_session(session_id)
         if not metadata:
             return {}
@@ -73,11 +77,14 @@ class OtelSessionBridge:
             "chat.thread_id": metadata.get("thread_id") or "",
             "chat.platform": platform,
         }
-        return {
+        span_attributes = {
             key: value
             for key, value in attributes.items()
             if key in self.SPAN_ATTRIBUTE_NAMES and value is not None and value != ""
         }
+        if span_attributes:
+            self._span_attribute_cache[session_id] = dict(span_attributes)
+        return span_attributes
 
     def _metadata_for_session(self, session_id: str) -> Dict[str, Any]:
         if not session_id or not self.db_path.exists():

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -27,13 +27,17 @@ class OtelSessionBridge:
         self._original_start_span: Optional[Callable[..., Any]] = None
         self._start_span_signature: Optional[Signature] = None
 
-    def install(self) -> None:
+    def patch_tracer(self) -> None:
         tracer = get_tracer()
         if getattr(tracer, self.INSTALLED_FLAG, False):
             return
 
         self._original_start_span = tracer.start_span
         self._start_span_signature = signature(tracer.start_span)
+        self._validate_start_span_signature(self._start_span_signature)
+        # Hermes does not currently expose a span-attribute provider hook. Patch
+        # the Hermes OTel tracer method once so every future span gets fixed
+        # session metadata while preserving Hermes' own session_id handling.
         tracer.start_span = self.start_span
         setattr(tracer, self.INSTALLED_FLAG, True)
 
@@ -49,6 +53,16 @@ class OtelSessionBridge:
             attributes,
         )
         return self._original_start_span(*bound.args, **bound.kwargs)
+
+    def _validate_start_span_signature(self, start_span_signature: Signature) -> None:
+        parameters = start_span_signature.parameters
+        required_parameters = ("session_id", "attributes")
+        missing = [name for name in required_parameters if name not in parameters]
+        if missing:
+            raise RuntimeError(
+                "Hermes OTel start_span signature is missing required parameter(s): "
+                + ", ".join(missing)
+            )
 
     def _merge_fixed_session_attributes(self, session_id: str, attributes: Optional[dict]) -> dict:
         attrs = dict(attributes or {})

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Dict, Optional
 
 from hermes_plugins.hermes_otel.tracer import get_tracer
 
+DEFAULT_SESSION_KV_DB_PATH = "/var/lib/kube-agents/session/session_kv.db"
+
 
 class OtelSessionBridge:
     """Attach fixed session metadata to Hermes OTel spans."""
@@ -22,8 +24,7 @@ class OtelSessionBridge:
     )
 
     def __init__(self, db_path: Optional[Path] = None) -> None:
-        hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
-        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(hermes_home / "session_kv.db")))
+        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", DEFAULT_SESSION_KV_DB_PATH))
         self._original_start_span: Optional[Callable[..., Any]] = None
         self._start_span_signature: Optional[Signature] = None
 

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -1,9 +1,9 @@
 import json
 import os
 import sqlite3
-from inspect import signature
+from inspect import Signature, signature
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from hermes_plugins.hermes_otel.tracer import get_tracer
 
@@ -24,27 +24,31 @@ class OtelSessionBridge:
     def __init__(self, db_path: Optional[Path] = None) -> None:
         hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
         self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(hermes_home / "session_kv.db")))
+        self._original_start_span: Optional[Callable[..., Any]] = None
+        self._start_span_signature: Optional[Signature] = None
 
     def install(self) -> None:
         tracer = get_tracer()
         if getattr(tracer, self.INSTALLED_FLAG, False):
             return
 
-        original_start_span = tracer.start_span
-        start_span_signature = signature(original_start_span)
-
-        def start_span_with_session_attributes(*args: Any, **kwargs: Any) -> Any:
-            bound = start_span_signature.bind_partial(*args, **kwargs)
-            session_id = self._sanitize_session_id(bound.arguments.get("session_id"))
-            attributes = bound.arguments.get("attributes")
-            bound.arguments["attributes"] = self._merge_fixed_session_attributes(
-                session_id,
-                attributes,
-            )
-            return original_start_span(*bound.args, **bound.kwargs)
-
-        tracer.start_span = start_span_with_session_attributes
+        self._original_start_span = tracer.start_span
+        self._start_span_signature = signature(tracer.start_span)
+        tracer.start_span = self.start_span
         setattr(tracer, self.INSTALLED_FLAG, True)
+
+    def start_span(self, *args: Any, **kwargs: Any) -> Any:
+        if self._original_start_span is None or self._start_span_signature is None:
+            raise RuntimeError("session OTel bridge is not installed")
+
+        bound = self._start_span_signature.bind_partial(*args, **kwargs)
+        session_id = self._sanitize_session_id(bound.arguments.get("session_id"))
+        attributes = bound.arguments.get("attributes")
+        bound.arguments["attributes"] = self._merge_fixed_session_attributes(
+            session_id,
+            attributes,
+        )
+        return self._original_start_span(*bound.args, **bound.kwargs)
 
     def _merge_fixed_session_attributes(self, session_id: str, attributes: Optional[dict]) -> dict:
         attrs = dict(attributes or {})

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -1,0 +1,109 @@
+import json
+import os
+import sqlite3
+from inspect import signature
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_plugins.hermes_otel.tracer import get_tracer
+
+
+class OtelSessionBridge:
+    """Attach fixed session metadata to Hermes OTel spans."""
+
+    INSTALLED_FLAG = "_session_otel_bridge_installed"
+    SPAN_ATTRIBUTE_NAMES = (
+        "session.id",
+        "user.id",
+        "hermes.sender.id",
+        "chat.id",
+        "chat.thread_id",
+        "chat.platform",
+    )
+
+    def __init__(self, db_path: Optional[Path] = None) -> None:
+        hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
+        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(hermes_home / "session_kv.db")))
+
+    def install(self) -> None:
+        tracer = get_tracer()
+        if getattr(tracer, self.INSTALLED_FLAG, False):
+            return
+
+        original_start_span = tracer.start_span
+        start_span_signature = signature(original_start_span)
+
+        def start_span_with_session_attributes(*args: Any, **kwargs: Any) -> Any:
+            bound = start_span_signature.bind_partial(*args, **kwargs)
+            session_id = self._sanitize_session_id(bound.arguments.get("session_id"))
+            attributes = bound.arguments.get("attributes")
+            bound.arguments["attributes"] = self._merge_fixed_session_attributes(
+                session_id,
+                attributes,
+            )
+            return original_start_span(*bound.args, **bound.kwargs)
+
+        tracer.start_span = start_span_with_session_attributes
+        setattr(tracer, self.INSTALLED_FLAG, True)
+
+    def _merge_fixed_session_attributes(self, session_id: str, attributes: Optional[dict]) -> dict:
+        attrs = dict(attributes or {})
+        session_attrs = self._span_attributes_for_session(session_id)
+        if session_attrs:
+            attrs.update(session_attrs)
+        return attrs
+
+    def _span_attributes_for_session(self, session_id: str) -> dict:
+        session_id = self._sanitize_session_id(session_id)
+        metadata = self._metadata_for_session(session_id)
+        if not metadata:
+            return {}
+
+        platform = metadata.get("platform") or ""
+        sender_id = metadata.get("user_id") or metadata.get("user_email") or ""
+        user_id = sender_id
+        if user_id and platform and ":" not in str(user_id):
+            user_id = f"{platform}:{user_id}"
+
+        attributes = {
+            "session.id": session_id,
+            "user.id": user_id,
+            "hermes.sender.id": sender_id,
+            "chat.id": metadata.get("chat_id") or "",
+            "chat.thread_id": metadata.get("thread_id") or "",
+            "chat.platform": platform,
+        }
+        return {
+            key: value
+            for key, value in attributes.items()
+            if key in self.SPAN_ATTRIBUTE_NAMES and value is not None and value != ""
+        }
+
+    def _metadata_for_session(self, session_id: str) -> Dict[str, Any]:
+        if not session_id or not self.db_path.exists():
+            return {}
+
+        conn = None
+        try:
+            conn = sqlite3.connect(str(self.db_path), timeout=2.0)
+            row = conn.execute(
+                "SELECT metadata FROM session_metadata WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        except Exception:
+            return {}
+        finally:
+            if conn is not None:
+                conn.close()
+
+        if not row:
+            return {}
+
+        try:
+            metadata = json.loads(row[0])
+            return metadata if isinstance(metadata, dict) else {}
+        except Exception:
+            return {}
+
+    def _sanitize_session_id(self, value: object) -> str:
+        return "".join(c for c in str(value or "") if c.isalnum() or c in "-_.").strip()

--- a/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/bridge.py
@@ -24,7 +24,6 @@ class OtelSessionBridge:
     def __init__(self, db_path: Optional[Path] = None) -> None:
         hermes_home = Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
         self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(hermes_home / "session_kv.db")))
-        self._span_attribute_cache: Dict[str, dict] = {}
 
     def install(self) -> None:
         tracer = get_tracer()
@@ -56,9 +55,6 @@ class OtelSessionBridge:
 
     def _span_attributes_for_session(self, session_id: str) -> dict:
         session_id = self._sanitize_session_id(session_id)
-        if session_id in self._span_attribute_cache:
-            return dict(self._span_attribute_cache[session_id])
-
         metadata = self._metadata_for_session(session_id)
         if not metadata:
             return {}
@@ -77,14 +73,11 @@ class OtelSessionBridge:
             "chat.thread_id": metadata.get("thread_id") or "",
             "chat.platform": platform,
         }
-        span_attributes = {
+        return {
             key: value
             for key, value in attributes.items()
             if key in self.SPAN_ATTRIBUTE_NAMES and value is not None and value != ""
         }
-        if span_attributes:
-            self._span_attribute_cache[session_id] = dict(span_attributes)
-        return span_attributes
 
     def _metadata_for_session(self, session_id: str) -> Dict[str, Any]:
         if not session_id or not self.db_path.exists():

--- a/agents/platform/defaults/plugins/session_otel_bridge/plugin.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/plugin.py
@@ -8,7 +8,7 @@ logger = logging.getLogger("hermes.plugin.session_otel_bridge")
 
 def register(ctx: Any) -> None:
     try:
-        OtelSessionBridge().install()
+        OtelSessionBridge().patch_tracer()
         logger.info("Installed session OTel bridge")
     except Exception as exc:
         logger.error("Failed to install session OTel bridge: %s", exc, exc_info=True)

--- a/agents/platform/defaults/plugins/session_otel_bridge/plugin.py
+++ b/agents/platform/defaults/plugins/session_otel_bridge/plugin.py
@@ -1,0 +1,15 @@
+import logging
+from typing import Any
+
+from .bridge import OtelSessionBridge
+
+logger = logging.getLogger("hermes.plugin.session_otel_bridge")
+
+
+def register(ctx: Any) -> None:
+    try:
+        OtelSessionBridge().install()
+        logger.info("Installed session OTel bridge")
+    except Exception as exc:
+        logger.error("Failed to install session OTel bridge: %s", exc, exc_info=True)
+        raise

--- a/agents/platform/defaults/plugins/session_otel_bridge/plugin.yaml
+++ b/agents/platform/defaults/plugins/session_otel_bridge/plugin.yaml
@@ -1,0 +1,4 @@
+name: session_otel_bridge
+version: 0.1.0
+description: Adds fixed session metadata from session_kv.db to Hermes OTel spans.
+kind: standalone

--- a/agents/platform/defaults/plugins/session_store/__init__.py
+++ b/agents/platform/defaults/plugins/session_store/__init__.py
@@ -1,3 +1,3 @@
-from .store import register
+from .plugin import register
 
 __all__ = ["register"]

--- a/agents/platform/defaults/plugins/session_store/__init__.py
+++ b/agents/platform/defaults/plugins/session_store/__init__.py
@@ -1,0 +1,3 @@
+from .store import register
+
+__all__ = ["register"]

--- a/agents/platform/defaults/plugins/session_store/plugin.py
+++ b/agents/platform/defaults/plugins/session_store/plugin.py
@@ -1,0 +1,7 @@
+from typing import Any
+
+from .store import log_event_to_db
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_gateway_dispatch", log_event_to_db)

--- a/agents/platform/defaults/plugins/session_store/plugin.yaml
+++ b/agents/platform/defaults/plugins/session_store/plugin.yaml
@@ -1,0 +1,4 @@
+name: session_store
+version: 1.0.0
+description: Persist gateway session metadata for cross-agent attribution.
+kind: standalone

--- a/agents/platform/defaults/plugins/session_store/store.py
+++ b/agents/platform/defaults/plugins/session_store/store.py
@@ -1,0 +1,174 @@
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("hermes.plugin.session_store")
+
+DEFAULT_SESSION_KV_DB_PATH = "/opt/data/session_kv.db"
+DEFAULT_RETENTION_DAYS = 7
+
+
+class SessionMetadata:
+    """Fixed metadata retained for a Hermes session."""
+
+    KEYS = (
+        "session_id",
+        "platform",
+        "user_id",
+        "user_email",
+        "user_resource",
+        "chat_id",
+        "thread_id",
+        "updated_at",
+    )
+
+    def __init__(
+        self,
+        session_id: str,
+        platform: str = "",
+        user_id: str = "",
+        user_email: str = "",
+        user_resource: str = "",
+        chat_id: str = "",
+        thread_id: str = "",
+        updated_at: str = "",
+    ) -> None:
+        self.session_id = session_id
+        self.platform = platform
+        self.user_id = user_id
+        self.user_email = user_email
+        self.user_resource = user_resource
+        self.chat_id = chat_id
+        self.thread_id = thread_id
+        self.updated_at = updated_at or datetime.now(timezone.utc).isoformat()
+
+    @classmethod
+    def from_event(cls, event: Any, session_id: str) -> "SessionMetadata":
+        source = getattr(event, "source", None)
+        if source is None:
+            return cls(session_id=session_id)
+
+        platform = _platform_value(source)
+        user_id = getattr(source, "user_id", None) or ""
+        user_resource = getattr(source, "user_id_alt", None) or ""
+
+        return cls(
+            session_id=session_id,
+            platform=platform,
+            user_id=user_id,
+            user_email=user_id if platform == "google_chat" else "",
+            user_resource=user_resource,
+            chat_id=getattr(source, "chat_id", None) or "",
+            thread_id=getattr(source, "thread_id", None) or "",
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "session_id": self.session_id,
+            "platform": self.platform,
+            "user_id": self.user_id,
+            "user_email": self.user_email,
+            "user_resource": self.user_resource,
+            "chat_id": self.chat_id,
+            "thread_id": self.thread_id,
+            "updated_at": self.updated_at,
+        }
+        return {
+            key: value
+            for key, value in data.items()
+            if key in self.KEYS and value is not None and value != ""
+        }
+
+
+def _session_kv_db_path() -> str:
+    return os.getenv("SESSION_KV_DB_PATH", DEFAULT_SESSION_KV_DB_PATH)
+
+
+def _retention_days() -> int:
+    raw = os.getenv("SESSION_KV_RETENTION_DAYS", str(DEFAULT_RETENTION_DAYS))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_RETENTION_DAYS
+
+
+def _platform_value(source: Any) -> str:
+    platform = getattr(source, "platform", "") or ""
+    return getattr(platform, "value", None) or str(platform)
+
+
+def write_session_metadata(session_id: str, metadata: Dict[str, Any]) -> None:
+    if not session_id:
+        return
+
+    db_path = _session_kv_db_path()
+    conn: Optional[sqlite3.Connection] = None
+    try:
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_metadata (
+                session_id TEXT PRIMARY KEY,
+                metadata TEXT NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO session_metadata
+                (session_id, metadata, updated_at)
+            VALUES (?, ?, CURRENT_TIMESTAMP)
+            """,
+            (session_id, json.dumps(metadata, sort_keys=True)),
+        )
+        conn.execute(
+            "DELETE FROM session_metadata WHERE updated_at < datetime('now', ?)",
+            (f"-{_retention_days()} days",),
+        )
+        conn.commit()
+    except Exception as exc:
+        logger.error(
+            "Failed to write session metadata for session %s: %s",
+            session_id,
+            exc,
+            exc_info=True,
+        )
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def log_event_to_db(
+    event: Any,
+    gateway: Any,
+    session_store: Any,
+    **kwargs: Any,
+) -> Optional[Dict[str, str]]:
+    """Persist session metadata before Hermes dispatches a gateway message."""
+    try:
+        source = getattr(event, "source", None)
+        if source is None:
+            return None
+
+        session_entry = session_store.get_or_create_session(source)
+        session_id = getattr(session_entry, "session_id", "") or ""
+        metadata = SessionMetadata.from_event(event, session_id)
+        write_session_metadata(session_id, metadata.to_dict())
+    except Exception as exc:
+        logger.error(
+            "Error in session_store pre_gateway_dispatch hook: %s",
+            exc,
+            exc_info=True,
+        )
+
+    return None
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_gateway_dispatch", log_event_to_db)

--- a/agents/platform/defaults/plugins/session_store/store.py
+++ b/agents/platform/defaults/plugins/session_store/store.py
@@ -107,7 +107,9 @@ def write_session_metadata(session_id: str, metadata: Dict[str, Any]) -> None:
     db_path = _session_kv_db_path()
     conn: Optional[sqlite3.Connection] = None
     try:
-        os.makedirs(os.path.dirname(db_path), exist_ok=True)
+        db_dir = os.path.dirname(db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
         conn = sqlite3.connect(db_path, timeout=5.0)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(

--- a/agents/platform/defaults/plugins/session_store/store.py
+++ b/agents/platform/defaults/plugins/session_store/store.py
@@ -215,6 +215,3 @@ def log_event_to_db(
 
     return None
 
-
-def register(ctx: Any) -> None:
-    ctx.register_hook("pre_gateway_dispatch", log_event_to_db)

--- a/agents/platform/defaults/plugins/session_store/store.py
+++ b/agents/platform/defaults/plugins/session_store/store.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger("hermes.plugin.session_store")
 
-DEFAULT_SESSION_KV_DB_PATH = "/opt/data/session_kv.db"
+DEFAULT_SESSION_KV_DB_PATH = "/var/lib/kube-agents/session/session_kv.db"
 DEFAULT_RETENTION_DAYS = 7
 CREATE_SESSION_METADATA_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS session_metadata (
@@ -214,4 +214,3 @@ def log_event_to_db(
         )
 
     return None
-

--- a/agents/platform/defaults/plugins/session_store/store.py
+++ b/agents/platform/defaults/plugins/session_store/store.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -9,6 +10,13 @@ logger = logging.getLogger("hermes.plugin.session_store")
 
 DEFAULT_SESSION_KV_DB_PATH = "/opt/data/session_kv.db"
 DEFAULT_RETENTION_DAYS = 7
+CREATE_SESSION_METADATA_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS session_metadata (
+    session_id TEXT PRIMARY KEY,
+    metadata TEXT NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
 
 
 class SessionMetadata:
@@ -100,40 +108,79 @@ def _platform_value(source: Any) -> str:
     return getattr(platform, "value", None) or str(platform)
 
 
+class SessionMetadataStore:
+    """Thread-safe lazy SQLite connection for session metadata writes."""
+
+    _conn: Optional[sqlite3.Connection] = None
+    _db_path = ""
+    _lock = threading.RLock()
+
+    @classmethod
+    def get_db_connection(cls) -> sqlite3.Connection:
+        db_path = _session_kv_db_path()
+        with cls._lock:
+            if cls._conn is None or cls._db_path != db_path:
+                cls._close_unlocked()
+                cls._conn = cls._open_connection(db_path)
+                cls._db_path = db_path
+            return cls._conn
+
+    @classmethod
+    def write(cls, session_id: str, metadata: Dict[str, Any]) -> None:
+        payload = json.dumps(metadata, sort_keys=True)
+        for attempt in range(2):
+            with cls._lock:
+                conn = cls.get_db_connection()
+                try:
+                    conn.execute(
+                        """
+                        INSERT OR REPLACE INTO session_metadata
+                            (session_id, metadata, updated_at)
+                        VALUES (?, ?, CURRENT_TIMESTAMP)
+                        """,
+                        (session_id, payload),
+                    )
+                    conn.execute(
+                        "DELETE FROM session_metadata WHERE updated_at < datetime('now', ?)",
+                        (f"-{_retention_days()} days",),
+                    )
+                    conn.commit()
+                    return
+                except sqlite3.Error:
+                    cls._close_unlocked()
+                    if attempt == 1:
+                        raise
+
+    @classmethod
+    def _open_connection(cls, db_path: str) -> sqlite3.Connection:
+        db_dir = os.path.dirname(db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+        conn = sqlite3.connect(db_path, timeout=5.0, check_same_thread=False)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.commit()
+        conn.execute(CREATE_SESSION_METADATA_TABLE_SQL)
+        conn.commit()
+        return conn
+
+    @classmethod
+    def _close_unlocked(cls) -> None:
+        if cls._conn is not None:
+            try:
+                cls._conn.close()
+            except sqlite3.Error:
+                pass
+            finally:
+                cls._conn = None
+                cls._db_path = ""
+
+
 def write_session_metadata(session_id: str, metadata: Dict[str, Any]) -> None:
     if not session_id:
         return
 
-    db_path = _session_kv_db_path()
-    conn: Optional[sqlite3.Connection] = None
     try:
-        db_dir = os.path.dirname(db_path)
-        if db_dir:
-            os.makedirs(db_dir, exist_ok=True)
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        conn.execute("PRAGMA journal_mode=WAL")
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS session_metadata (
-                session_id TEXT PRIMARY KEY,
-                metadata TEXT NOT NULL,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        conn.execute(
-            """
-            INSERT OR REPLACE INTO session_metadata
-                (session_id, metadata, updated_at)
-            VALUES (?, ?, CURRENT_TIMESTAMP)
-            """,
-            (session_id, json.dumps(metadata, sort_keys=True)),
-        )
-        conn.execute(
-            "DELETE FROM session_metadata WHERE updated_at < datetime('now', ?)",
-            (f"-{_retention_days()} days",),
-        )
-        conn.commit()
+        SessionMetadataStore.write(session_id, metadata)
     except Exception as exc:
         logger.error(
             "Failed to write session metadata for session %s: %s",
@@ -141,9 +188,6 @@ def write_session_metadata(session_id: str, metadata: Dict[str, Any]) -> None:
             exc,
             exc_info=True,
         )
-    finally:
-        if conn is not None:
-            conn.close()
 
 
 def log_event_to_db(

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from datetime import datetime
 from mcp.server.fastmcp import FastMCP
 
+DEFAULT_SESSION_KV_DB_PATH = "/var/lib/kube-agents/session/session_kv.db"
+
 # Initialize the FastMCP server
 mcp = FastMCP("GKE Platform Control Plane")
 
@@ -192,7 +194,6 @@ def start_session_kv_server() -> None:
                 log(f"Session KV server is already running on port {port}.")
                 return
 
-        hermes_home = get_hermes_home()
         app_dir = Path(__file__).resolve().parent.parent
         log(f"Starting Session KV server on port {port}.")
         subprocess.Popen(
@@ -214,14 +215,9 @@ def start_session_kv_server() -> None:
             start_new_session=True,
             env={
                 **os.environ,
-                "SESSION_KV_DB_PATH": str(hermes_home / "session_kv.db"),
+                "SESSION_KV_DB_PATH": os.environ.get("SESSION_KV_DB_PATH", DEFAULT_SESSION_KV_DB_PATH),
             },
         )
         log("Session KV server spawned successfully.")
     except Exception as exc:
         log(f"Failed to start Session KV server: {exc}")
-
-
-if __name__ == "__main__":
-    start_session_kv_server()
-    mcp.run()

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -193,6 +193,7 @@ def start_session_kv_server() -> None:
                 return
 
         hermes_home = get_hermes_home()
+        app_dir = Path(__file__).resolve().parent.parent
         log(f"Starting Session KV server on port {port}.")
         subprocess.Popen(
             [
@@ -201,13 +202,13 @@ def start_session_kv_server() -> None:
                 "uvicorn",
                 "scripts.session_kv_server:app",
                 "--app-dir",
-                str(hermes_home),
+                str(app_dir),
                 "--host",
                 "0.0.0.0",
                 "--port",
                 str(port),
             ],
-            cwd=str(hermes_home),
+            cwd=str(app_dir),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             start_new_session=True,

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import socket
 import sys
 import urllib.request
 import urllib.error
@@ -180,5 +181,46 @@ def send_notification(message: str) -> str:
     except Exception as e:
         return f"ERROR: {e}"
 
+
+def start_session_kv_server() -> None:
+    """Start the session metadata HTTP resolver when the MCP server starts."""
+    try:
+        port = 8699
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1)
+            if sock.connect_ex(("127.0.0.1", port)) == 0:
+                log(f"Session KV server is already running on port {port}.")
+                return
+
+        hermes_home = get_hermes_home()
+        log(f"Starting Session KV server on port {port}.")
+        subprocess.Popen(
+            [
+                "/opt/hermes/.venv/bin/python3",
+                "-m",
+                "uvicorn",
+                "scripts.session_kv_server:app",
+                "--app-dir",
+                str(hermes_home),
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(port),
+            ],
+            cwd=str(hermes_home),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env={
+                **os.environ,
+                "SESSION_KV_DB_PATH": str(hermes_home / "session_kv.db"),
+            },
+        )
+        log("Session KV server spawned successfully.")
+    except Exception as exc:
+        log(f"Failed to start Session KV server: {exc}")
+
+
 if __name__ == "__main__":
+    start_session_kv_server()
     mcp.run()

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -56,14 +56,17 @@ def get_metadata(session_id: str) -> Dict[str, Any]:
 
 
 @app.get("/v1/sessions")
-def list_sessions() -> Dict[str, Any]:
+def list_sessions(limit: int = 100) -> Dict[str, Any]:
+    limit = max(1, min(limit, 1000))
     with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
         rows = conn.execute(
             """
             SELECT session_id, metadata, updated_at
             FROM session_metadata
             ORDER BY updated_at DESC
-            """
+            LIMIT ?
+            """,
+            (limit,),
         ).fetchall()
 
     sessions = []

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -16,7 +16,9 @@ SESSION_KV_DB_PATH = os.getenv("SESSION_KV_DB_PATH", "/opt/data/session_kv.db")
 
 
 def init_db() -> None:
-    os.makedirs(os.path.dirname(SESSION_KV_DB_PATH), exist_ok=True)
+    db_dir = os.path.dirname(SESSION_KV_DB_PATH)
+    if db_dir:
+        os.makedirs(db_dir, exist_ok=True)
     with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute(

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, HTTPException
 
 app = FastAPI()
 
-SESSION_KV_DB_PATH = os.getenv("SESSION_KV_DB_PATH", "/opt/data/session_kv.db")
+SESSION_KV_DB_PATH = os.getenv("SESSION_KV_DB_PATH", "/var/lib/kube-agents/session/session_kv.db")
 
 
 def init_db() -> None:

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Small HTTP resolver for platform session metadata."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from typing import Any, Dict
+
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+SESSION_KV_DB_PATH = os.getenv("SESSION_KV_DB_PATH", "/opt/data/session_kv.db")
+
+
+def init_db() -> None:
+    os.makedirs(os.path.dirname(SESSION_KV_DB_PATH), exist_ok=True)
+    with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS session_metadata (
+                session_id TEXT PRIMARY KEY,
+                metadata TEXT NOT NULL,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/v1/sessions/{session_id}/metadata")
+def get_metadata(session_id: str) -> Dict[str, Any]:
+    if not session_id:
+        raise HTTPException(status_code=400, detail="session_id is required")
+
+    with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
+        row = conn.execute(
+            "SELECT metadata FROM session_metadata WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+
+    if not row:
+        raise HTTPException(status_code=404, detail="Session metadata not found")
+
+    try:
+        return json.loads(row[0])
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Data decoding failure: {exc}")
+
+
+@app.get("/v1/sessions")
+def list_sessions() -> Dict[str, Any]:
+    with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
+        rows = conn.execute(
+            """
+            SELECT session_id, metadata, updated_at
+            FROM session_metadata
+            ORDER BY updated_at DESC
+            """
+        ).fetchall()
+
+    sessions = []
+    for session_id, metadata, updated_at in rows:
+        try:
+            parsed = json.loads(metadata)
+        except Exception:
+            parsed = {}
+        sessions.append(
+            {
+                "session_id": session_id,
+                "metadata": parsed,
+                "updated_at": updated_at,
+            }
+        )
+    return {"sessions": sessions}
+
+
+init_db()

--- a/agents/shared/defaults/scripts/agent_common_server.py
+++ b/agents/shared/defaults/scripts/agent_common_server.py
@@ -11,12 +11,16 @@ from pathlib import Path
 from typing import Annotated
 from pydantic import Field
 from mcp.server.fastmcp import FastMCP
+from session_manager import SessionManager
 
 # Initialize the FastMCP server
 mcp = FastMCP("Agent Common")
 
 def log(msg: str):
     print(f"[COMMON-MCP] {msg}", file=sys.stderr)
+
+
+SESSION_MANAGER = SessionManager()
 
 
 def get_hermes_home() -> Path:
@@ -77,6 +81,8 @@ def call_agent(
     Directly and securely execute a synchronous, token-authorized completions API call
     to the Platform Agent across the fleet (only 'platform' is a valid target).
     """
+    context = SESSION_MANAGER.current_context(session_id)
+
     try:
         endpoint, api_key = resolve_agent_credentials(target_agent_id)
     except Exception as e:
@@ -94,11 +100,7 @@ def call_agent(
         "Content-Type": "application/json",
         "Authorization": f"Bearer {api_key}"
     }
-    if session_id:
-        # Sanitize session_id
-        clean_session_id = "".join(c for c in str(session_id) if c.isalnum() or c in "-_.").strip()
-        if clean_session_id:
-            headers["X-Hermes-Session-Id"] = clean_session_id
+    headers.update(SESSION_MANAGER.delegation_headers(context))
 
     payload = {
         "model": "hermes-agent",

--- a/agents/shared/defaults/scripts/session_manager.py
+++ b/agents/shared/defaults/scripts/session_manager.py
@@ -4,6 +4,8 @@ import sqlite3
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+DEFAULT_SESSION_KV_DB_PATH = "/var/lib/kube-agents/session/session_kv.db"
+
 
 class SessionManager:
     """Resolve Hermes session metadata from the session_kv store."""
@@ -32,7 +34,7 @@ class SessionManager:
         db_path: Optional[Path] = None,
     ) -> None:
         self.hermes_home = hermes_home or Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
-        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(self.hermes_home / "session_kv.db")))
+        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", DEFAULT_SESSION_KV_DB_PATH))
 
     def sanitize_session_id(self, value: object) -> str:
         return "".join(c for c in str(value or "") if c.isalnum() or c in "-_.").strip()

--- a/agents/shared/defaults/scripts/session_manager.py
+++ b/agents/shared/defaults/scripts/session_manager.py
@@ -1,0 +1,120 @@
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class SessionManager:
+    """Resolve Hermes session metadata from the session_kv store."""
+
+    SESSION_METADATA_KEYS = (
+        "session_id",
+        "platform",
+        "user_id",
+        "user_email",
+        "user_resource",
+        "chat_id",
+        "thread_id",
+        "updated_at",
+    )
+
+    ENV_SESSION_KEYS = (
+        "HERMES_SESSION_ID",
+        "SESSION_ID",
+        "X_HERMES_SESSION_ID",
+        "HERMES_CURRENT_SESSION_ID",
+    )
+
+    def __init__(
+        self,
+        hermes_home: Optional[Path] = None,
+        db_path: Optional[Path] = None,
+    ) -> None:
+        self.hermes_home = hermes_home or Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")))
+        self.db_path = db_path or Path(os.environ.get("SESSION_KV_DB_PATH", str(self.hermes_home / "session_kv.db")))
+
+    def sanitize_session_id(self, value: object) -> str:
+        return "".join(c for c in str(value or "") if c.isalnum() or c in "-_.").strip()
+
+    def session_id_from_env(self) -> str:
+        for key in self.ENV_SESSION_KEYS:
+            session_id = self.sanitize_session_id(os.environ.get(key))
+            if session_id:
+                return session_id
+        return ""
+
+    def metadata_for_session(self, session_id: str) -> Dict[str, Any]:
+        session_id = self.sanitize_session_id(session_id)
+        if not session_id or not self.db_path.exists():
+            return {}
+
+        conn = None
+        try:
+            conn = sqlite3.connect(str(self.db_path), timeout=2.0)
+            row = conn.execute(
+                "SELECT metadata FROM session_metadata WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        except Exception:
+            return {}
+        finally:
+            if conn is not None:
+                conn.close()
+
+        if not row:
+            return {}
+
+        try:
+            metadata = json.loads(row[0])
+            return metadata if isinstance(metadata, dict) else {}
+        except Exception:
+            return {}
+
+    def current_context(
+        self,
+        explicit_session_id: str = "",
+    ) -> Dict[str, Any]:
+        session_id = (
+            self.session_id_from_env()
+            or self.sanitize_session_id(explicit_session_id)
+        )
+        metadata = self.metadata_for_session(session_id)
+        platform = metadata.get("platform") or ""
+        sender_id = metadata.get("user_id") or metadata.get("user_email") or ""
+        user_id = os.environ.get("HERMES_USER_ID") or os.environ.get("HERMES_SENDER_ID") or sender_id
+        if user_id and platform and ":" not in str(user_id):
+            user_id = f"{platform}:{user_id}"
+
+        return {
+            "session_id": session_id,
+            "user_id": user_id,
+            "sender_id": os.environ.get("HERMES_SENDER_ID") or sender_id,
+            "chat_id": metadata.get("chat_id") or "",
+            "thread_id": metadata.get("thread_id") or "",
+            "metadata": metadata,
+        }
+
+    def delegation_headers(self, context: Dict[str, Any]) -> Dict[str, str]:
+        metadata = context.get("metadata", {})
+        headers: Dict[str, str] = {}
+        if context.get("session_id"):
+            headers["X-Hermes-Session-Id"] = str(context["session_id"])
+        if context.get("user_id"):
+            headers["X-Hermes-User-Id"] = str(context["user_id"])
+        if context.get("sender_id"):
+            headers["X-Hermes-Sender-Id"] = str(context["sender_id"])
+        if metadata.get("user_email"):
+            headers["X-Hermes-User-Email"] = str(metadata["user_email"])
+        if context.get("chat_id"):
+            headers["X-Hermes-Chat-Id"] = str(context["chat_id"])
+        if context.get("thread_id"):
+            headers["X-Hermes-Thread-Id"] = str(context["thread_id"])
+        return headers
+
+    def filter_session_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            key: metadata[key]
+            for key in self.SESSION_METADATA_KEYS
+            if key in metadata and metadata[key] is not None
+        }

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -100,6 +100,7 @@ FROM agent-base AS platform
 
 # Setup platform specific defaults from consolidated configs
 COPY agents/platform/cron/ /opt/defaults/cron/
+COPY --chown=hermes:hermes agents/platform/defaults/ /opt/defaults/
 COPY agents/platform/scripts/ /opt/defaults/scripts/
 COPY agents/platform/governance/ /opt/defaults/governance/
 COPY agents/platform/SOUL.md /opt/defaults/SOUL.md

--- a/docs/gchat-session-metadata-data-flow.md
+++ b/docs/gchat-session-metadata-data-flow.md
@@ -19,7 +19,7 @@ Google Chat event
   -> Hermes Google Chat adapter
   -> Hermes session_id
   -> session_store plugin
-  -> /opt/data/session_kv.db
+  -> /var/lib/kube-agents/session/session_kv.db
   -> session_otel_bridge
   -> Hermes OTel span attributes
 ```
@@ -37,7 +37,7 @@ On each gateway message, it:
 2. Calls Hermes `session_store.get_or_create_session(source)`.
 3. Reads the resulting Hermes `session_id`.
 4. Builds a plugin-local `SessionMetadata` object from `event.source`.
-5. Writes `session_id -> metadata` into `/opt/data/session_kv.db`.
+5. Writes `session_id -> metadata` into `/var/lib/kube-agents/session/session_kv.db`.
 
 The plugin does not create spans and does not modify OTel.
 
@@ -105,7 +105,7 @@ starts. There is no separate Kubernetes sidecar for it.
 SQLite database:
 
 ```text
-/opt/data/session_kv.db
+/var/lib/kube-agents/session/session_kv.db
 ```
 
 Table:
@@ -185,7 +185,7 @@ kubectl -n kubeagents-system exec "$POD" -c platform-agent -- \
   /opt/hermes/.venv/bin/python3 - <<'PY'
 import json, sqlite3
 
-with sqlite3.connect("/opt/data/session_kv.db") as conn:
+with sqlite3.connect("/var/lib/kube-agents/session/session_kv.db") as conn:
     rows = conn.execute(
         """
         SELECT session_id, metadata, updated_at

--- a/docs/gchat-session-metadata-data-flow.md
+++ b/docs/gchat-session-metadata-data-flow.md
@@ -1,0 +1,259 @@
+# Google Chat Session Metadata Data Flow
+
+This document describes the final attribution path from a Google Chat message to
+Hermes OpenTelemetry spans.
+
+## Overview
+
+The raw Google Chat Pub/Sub event contains the sender and Chat conversation
+metadata, but it does not contain a Hermes `session_id`.
+
+Hermes creates or resolves the `session_id` after the Google Chat adapter
+converts the raw event into a gateway message. The `session_store` plugin then
+persists the mapping from that Hermes session to the Google Chat sender. The
+`session_otel_bridge` plugin uses that mapping to add fixed identity attributes
+to Hermes OTel spans.
+
+```text
+Google Chat event
+  -> Hermes Google Chat adapter
+  -> Hermes session_id
+  -> session_store plugin
+  -> /opt/data/session_kv.db
+  -> session_otel_bridge
+  -> Hermes OTel span attributes
+```
+
+## Components
+
+### session_store
+
+`session_store` is a Hermes plugin enabled in `agents/platform/config.yaml`.
+It registers the `pre_gateway_dispatch` hook.
+
+On each gateway message, it:
+
+1. Reads `event.source` from the parsed Hermes message.
+2. Calls Hermes `session_store.get_or_create_session(source)`.
+3. Reads the resulting Hermes `session_id`.
+4. Builds a plugin-local `SessionMetadata` object from `event.source`.
+5. Writes `session_id -> metadata` into `/opt/data/session_kv.db`.
+
+The plugin does not create spans and does not modify OTel.
+
+### SessionMetadata
+
+`SessionMetadata` is a plugin-local class in `session_store`. It defines the
+fixed metadata retained for a Hermes session.
+
+It owns:
+
+- the fixed session metadata allowlist
+- conversion from Hermes `event.source` to stored metadata
+
+It does not scan arbitrary dictionaries, tool arguments, span attributes, or
+model-provided payloads to discover identity.
+
+For session storage, it keeps only this fixed metadata allowlist:
+
+```text
+session_id
+platform
+user_id
+user_email
+user_resource
+chat_id
+thread_id
+updated_at
+```
+
+These keys are platform-neutral. For Google Chat, the Chat space is stored as
+`chat_id`; there is no separate `google_chat_id` key.
+
+### session_otel_bridge
+
+`session_otel_bridge` is a Hermes plugin enabled after `hermes_otel`.
+
+At plugin registration time, it installs a wrapper around the Hermes OTel
+tracer's `start_span` method. For each span, the wrapper:
+
+1. Reads the explicit `session_id` argument passed to `start_span`.
+2. Reads the matching metadata row from `session_kv.db`.
+3. Maps that metadata to the bridge-owned fixed span attribute allowlist.
+4. Calls the original Hermes OTel `start_span`.
+
+The bridge intentionally does not infer identity from existing span attributes
+or other dynamic payloads. It only uses the explicit `session_id` passed by
+Hermes OTel.
+
+### session_kv_server
+
+`session_kv_server.py` exposes a small HTTP resolver for the same
+`session_kv.db` data:
+
+```text
+GET /v1/sessions/{session_id}/metadata
+GET /v1/sessions
+GET /healthz
+```
+
+`platform_mcp_server.py` starts this resolver when the platform MCP server
+starts. There is no separate Kubernetes sidecar for it.
+
+## Stored Data
+
+SQLite database:
+
+```text
+/opt/data/session_kv.db
+```
+
+Table:
+
+```text
+session_metadata(
+  session_id TEXT PRIMARY KEY,
+  metadata TEXT NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+```
+
+Example metadata, anonymized:
+
+```json
+{
+  "session_id": "20260702_153830_50074bf0",
+  "platform": "google_chat",
+  "user_id": "user@example.com",
+  "user_email": "user@example.com",
+  "user_resource": "users/REDACTED",
+  "chat_id": "spaces/REDACTED",
+  "thread_id": "",
+  "updated_at": "2026-07-02T18:22:31Z"
+}
+```
+
+## OTel Attributes
+
+When a matching session row exists, `session_otel_bridge` adds these fixed
+attributes to Hermes OTel spans:
+
+```text
+session.id
+user.id
+hermes.sender.id
+chat.id
+chat.thread_id
+chat.platform
+```
+
+Example attributes, anonymized:
+
+```json
+{
+  "session.id": "20260702_153830_50074bf0",
+  "user.id": "google_chat:user@example.com",
+  "hermes.sender.id": "user@example.com",
+  "chat.id": "spaces/REDACTED",
+  "chat.platform": "google_chat"
+}
+```
+
+## Delegation
+
+When `agent_common_server.py` delegates to another agent, it uses
+`SessionManager` to forward the same session context as headers:
+
+```text
+X-Hermes-Session-Id
+X-Hermes-User-Id
+X-Hermes-Sender-Id
+X-Hermes-User-Email
+X-Hermes-Chat-Id
+X-Hermes-Thread-Id
+```
+
+This allows downstream agents to preserve attribution when they receive the
+session context.
+
+## Verification
+
+Check the persisted session mapping:
+
+```bash
+kubectl -n kubeagents-system exec "$POD" -c platform-agent -- \
+  /opt/hermes/.venv/bin/python3 - <<'PY'
+import json, sqlite3
+
+with sqlite3.connect("/opt/data/session_kv.db") as conn:
+    rows = conn.execute(
+        """
+        SELECT session_id, metadata, updated_at
+        FROM session_metadata
+        ORDER BY updated_at DESC
+        LIMIT 10
+        """
+    )
+    for session_id, metadata, updated_at in rows:
+        print(session_id, updated_at)
+        print(json.dumps(json.loads(metadata), indent=2))
+PY
+```
+
+Check local Hermes OTel rows:
+
+```bash
+SESSION_ID="<session_id>"
+
+kubectl -n kubeagents-system exec "$POD" -c platform-agent -- \
+  env SESSION_ID="$SESSION_ID" /opt/hermes/.venv/bin/python3 - <<'PY'
+import json, os, sqlite3
+
+session_id = os.environ["SESSION_ID"]
+
+with sqlite3.connect("/opt/data/plugins/hermes_otel/live.db") as conn:
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT seq, kind, data FROM events WHERE data LIKE ? ORDER BY seq",
+        (f"%{session_id}%",),
+    )
+    for row in rows:
+        data = json.loads(row["data"])
+        attrs = data.get("attrs") or data.get("attributes") or {}
+        print(json.dumps({
+            "seq": row["seq"],
+            "kind": row["kind"],
+            "name": data.get("name"),
+            "trace_id": data.get("trace_id"),
+            "span_id": data.get("span_id"),
+            "attrs": attrs,
+        }, sort_keys=True))
+PY
+```
+
+Check Cloud Trace export by `trace_id`:
+
+```bash
+PROJECT_ID="<project>"
+TRACE_ID="<trace_id>"
+
+curl -s \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  "https://cloudtrace.googleapis.com/v1/projects/${PROJECT_ID}/traces/${TRACE_ID}" \
+  | jq '.spans[] | {name, spanId, labels}'
+```
+
+## Reliability Notes
+
+- The authoritative ingress mapping uses Hermes runtime session state, not a
+  model-supplied tool parameter.
+- The raw Google Chat event does not carry a Hermes `session_id`; the mapping is
+  created after Hermes resolves the session.
+- Attribution is limited to fixed fields we explicitly persist and format:
+  `session_id`, Google Chat sender identity, Google Chat space/thread, and
+  delegation headers. The code does not dynamically parse arbitrary attributes
+  for user identity.
+- OTel enrichment depends on `hermes_otel`, `session_store`, and
+  `session_otel_bridge` all being enabled.
+- Remote systems can only preserve attribution if they receive and honor the
+  forwarded session headers.

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -178,7 +178,18 @@ func (r *PlatformAgentReconciler) reconcileServiceAccount(ctx context.Context, a
 }
 
 func (r *PlatformAgentReconciler) reconcilePVC(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
-	pvc := buildPVC(agent)
+	for _, pvc := range []*corev1.PersistentVolumeClaim{
+		buildPVC(agent),
+		buildSystemPVC(agent),
+	} {
+		if err := r.reconcilePersistentVolumeClaim(ctx, agent, pvc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *PlatformAgentReconciler) reconcilePersistentVolumeClaim(ctx context.Context, agent *agentv1alpha1.PlatformAgent, pvc *corev1.PersistentVolumeClaim) error {
 	if err := ctrl.SetControllerReference(agent, pvc, r.Scheme); err != nil {
 		return err
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -164,7 +164,7 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	// Execution & Display UX configuration
 	cfg.Approvals.CronMode = "approve"
 	cfg.Web.Backend = "ddgs"
-	cfg.Plugins.Enabled = []string{"hermes_otel"}
+	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge"}
 	cfg.Display.Platforms = map[string]map[string]any{}
 
 	if agent.Spec.Integration != nil {

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -36,6 +36,7 @@ import (
 )
 
 const defaultPlatformAgentSecrets = "platform-agent-secrets"
+const sessionKVDBPath = "/var/lib/kube-agents/session/session_kv.db"
 
 // buildConfigMap generates the ConfigMap manifest containing config.yaml
 func buildConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
@@ -234,6 +235,27 @@ func buildPVC(agent *agentv1alpha1.PlatformAgent) *corev1.PersistentVolumeClaim 
 	}
 }
 
+func buildSystemPVC(agent *agentv1alpha1.PlatformAgent) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system-metadata",
+			Namespace: agent.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+}
+
 // buildDeployment generates the Deployment manifest for the agent payload
 func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash string) *appsv1.Deployment {
 	replicas := int32(1)
@@ -299,6 +321,10 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		{
 			Name:  "API_SERVER_HOST",
 			Value: "0.0.0.0",
+		},
+		{
+			Name:  "SESSION_KV_DB_PATH",
+			Value: sessionKVDBPath,
 		},
 	}
 
@@ -489,6 +515,11 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 									SubPath:   "SETTINGS.md",
 									ReadOnly:  true,
 								},
+								{
+									Name:      "system-metadata",
+									MountPath: path.Dir(sessionKVDBPath),
+									SubPath:   "session",
+								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: ptr.To(false),
@@ -582,6 +613,14 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 							Name: "fluent-bit-state",
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "system-metadata",
+							VolumeSource: corev1.VolumeSource{
+								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "system-metadata",
+								},
 							},
 						},
 						{

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -140,6 +140,24 @@ func TestBuildPVC(t *testing.T) {
 	}
 }
 
+func TestBuildSystemPVC(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-agent",
+			Namespace: "test-ns",
+		},
+	}
+
+	pvc := buildSystemPVC(agent)
+	if pvc.Name != "system-metadata" {
+		t.Errorf("expected PVC name system-metadata, got %s", pvc.Name)
+	}
+	storageReq := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	if storageReq.String() != "1Gi" {
+		t.Errorf("expected storage request 1Gi, got %s", storageReq.String())
+	}
+}
+
 func TestBuildDeployment(t *testing.T) {
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -288,6 +306,9 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["API_SERVER_HOST"].Value != "0.0.0.0" {
 		t.Errorf("expected API_SERVER_HOST 0.0.0.0, got %s", envMap["API_SERVER_HOST"].Value)
 	}
+	if envMap["SESSION_KV_DB_PATH"].Value != "/var/lib/kube-agents/session/session_kv.db" {
+		t.Errorf("expected SESSION_KV_DB_PATH /var/lib/kube-agents/session/session_kv.db, got %s", envMap["SESSION_KV_DB_PATH"].Value)
+	}
 
 	// Verify volume mounts
 	mountsMap := make(map[string]corev1.VolumeMount)
@@ -307,6 +328,13 @@ func TestBuildDeployment(t *testing.T) {
 		if !m.ReadOnly {
 			t.Errorf("expected settings-volume to be read-only")
 		}
+	}
+	if _, ok := mountsMap["system-metadata"]; !ok {
+		t.Errorf("expected system-metadata mount, not found")
+	} else if mountsMap["system-metadata"].MountPath != "/var/lib/kube-agents/session" {
+		t.Errorf("expected system-metadata mount path /var/lib/kube-agents/session, got %s", mountsMap["system-metadata"].MountPath)
+	} else if mountsMap["system-metadata"].SubPath != "session" {
+		t.Errorf("expected system-metadata subpath session, got %s", mountsMap["system-metadata"].SubPath)
 	}
 
 	// Verify Fluent Bit container
@@ -328,6 +356,16 @@ func TestBuildDeployment(t *testing.T) {
 	}
 	if _, ok := volumesMap["fluent-bit-state"]; !ok {
 		t.Errorf("expected fluent-bit-state volume, not found")
+	}
+	if _, ok := volumesMap["system-metadata"]; !ok {
+		t.Errorf("expected system-metadata volume, not found")
+	} else {
+		v := volumesMap["system-metadata"]
+		if v.PersistentVolumeClaim == nil {
+			t.Errorf("expected system-metadata to be a PVC")
+		} else if v.PersistentVolumeClaim.ClaimName != "system-metadata" {
+			t.Errorf("expected system-metadata claim system-metadata, got %s", v.PersistentVolumeClaim.ClaimName)
+		}
 	}
 
 	if _, ok := volumesMap["settings-volume"]; !ok {

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -87,6 +87,27 @@ spec:
 status: {}
 ---
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: system-metadata
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+status: {}
+---
+apiVersion: v1
 data:
   config.yaml: |
     approvals:
@@ -267,7 +288,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 70d239347863fcc7e9caac7e754a4f539ae87eaab20fa7df0aafb0dc240fd20c
+        kubeagents.x-k8s.io/config-hash: 5e10376dffc6d671db97c37ef2fda38624838051aba5faf4cde7fb44fdc4e433
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null
@@ -290,6 +311,8 @@ spec:
               value: "true"
             - name: API_SERVER_HOST
               value: 0.0.0.0
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
             - name: GKE_CLUSTER_NAME
               value: cluster-a
             - name: GKE_LOCATION
@@ -337,6 +360,9 @@ spec:
               name: settings-volume
               readOnly: true
               subPath: SETTINGS.md
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
@@ -391,6 +417,9 @@ spec:
           name: fluent-bit-config
         - emptyDir: {}
           name: fluent-bit-state
+        - name: system-metadata
+          persistentVolumeClaim:
+            claimName: system-metadata
         - configMap:
             defaultMode: 420
             name: platformagent-settings

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -147,6 +147,8 @@ data:
     plugins:
       enabled:
       - hermes_otel
+      - session_store
+      - session_otel_bridge
     terminal:
       backend: local
       cwd: /opt/data


### PR DESCRIPTION
# Pull Request

## Why This Change

Platform agent activity traces need to be attributable back to the Google Chat user and conversation that initiated the work. The Google Chat ingress event already carries the authenticated sender and Chat space metadata, but downstream OTel spans did not consistently include that identity context.

## What Changed

**Files:**

- `agents/platform/defaults/plugins/session_store/*`
- `agents/platform/defaults/plugins/session_otel_bridge/*`
- `agents/platform/scripts/session_kv_server.py`
- `agents/platform/scripts/platform_mcp_server.py`
- `agents/shared/defaults/scripts/agent_common_server.py`
- `agents/shared/defaults/scripts/session_manager.py`
- `agents/platform/config.yaml`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `docs/gchat-session-metadata-data-flow.md`

**Added/Changed/Fixed:**

- Added a `session_store` Hermes plugin that persists fixed session metadata from the initial gateway event into `session_kv.db`.
- Added a `session_otel_bridge` Hermes plugin that enriches Hermes OTel spans with fixed session identity attributes from `session_kv.db`.
- Added `session_kv_server.py` and platform MCP startup wiring, matching the existing platform MCP server startup pattern.
- Added shared `SessionManager` support so delegated agent calls can inherit session/user/chat headers.
- Enabled `session_store` and `session_otel_bridge` for PlatformAgent config generation.
- Documented the end-to-end data flow from Google Chat ingress through session storage and OTel span enrichment.

## Why This Matters

This gives audit reviewers a direct chain from an inbound chat request to the agent/tool activity performed on that user's behalf. Google Chat is the currently validated ingress path, but the session metadata model is intentionally chat-platform agnostic: `SessionMetadata.from_event()` reads common Hermes source fields such as `platform`, `user_id`, `user_id_alt`, `chat_id`, and `thread_id` via `getattr(...)`. Any future chat integration can participate by populating those source fields before `pre_gateway_dispatch`; the same `session_store` and `session_otel_bridge` path will then emit attributes such as `session.id`, `user.id`, `hermes.sender.id`, `chat.id`, and `chat.platform` for trace-based audit investigation.

## Context

This follows the session metadata approach validated against the live platform agent pod. The implementation keeps Google Chat-specific extraction at ingress time, stores normalized `chat_id`/`thread_id` metadata, and limits OTel enrichment to a fixed attribute set.


## OTel Enrichment Design Choice

There are two viable ways to carry the new session identity fields (`session.id`, `user.id`, `hermes.sender.id`, `chat.id`, `chat.platform`, etc.) into OTel spans:

1. Re-implement or fork the behavior provided by `hermes_plugins.hermes_otel`, including span creation, parent/child tracking, live store behavior, exporter integration, and existing Hermes OTel semantics.
2. Reuse the existing `hermes_plugins.hermes_otel` implementation and patch its `start_span` entry point so the fixed session metadata is merged into span attributes before Hermes OTel creates the span.

This PR chooses the second path. Re-implementing Hermes OTel would duplicate a large amount of existing tracer behavior and increase the risk of diverging from Hermes' span hierarchy, exporter, and live trace behavior. The bridge keeps Hermes OTel as the source of truth for span creation and only adds the missing attribution fields.

Because Hermes OTel does not currently expose a dedicated span-attribute provider hook, the bridge patches `tracer.start_span` during plugin registration. The patch is intentionally narrow: it validates the expected Hermes OTel `start_span` signature, preserves the original method, forwards the original `session_id`, and only merges a fixed allowlist of session attributes.

## Testing

- Ran Python syntax checks for the touched plugins and scripts:
  ```bash
  python3 -m py_compile agents/platform/defaults/plugins/session_otel_bridge/bridge.py agents/platform/defaults/plugins/session_otel_bridge/plugin.py agents/platform/defaults/plugins/session_store/store.py agents/platform/scripts/session_kv_server.py agents/platform/scripts/platform_mcp_server.py agents/shared/defaults/scripts/agent_common_server.py agents/shared/defaults/scripts/session_manager.py
  ```
- Ran a local bridge smoke test with the Hermes plugin import namespace mocked.
- Ran operator controller tests:
  ```bash
  go test -count=1 ./internal/controller/...
  ```
- Ran Markdown formatting:
  ```bash
  npx prettier --write docs/gchat-session-metadata-data-flow.md
  ```
- Deployed to the live platform agent pod and verified real Google Chat initiated activity produced enriched OTel spans, including tool spans for `kubectl` actions against `sahara-01`.

---

This change is scoped to session attribution and OTel enrichment for the PlatformAgent path.


