### PR TITLE
feature: configurable provision script setting for chat mode

### DIFF
--- a/k8s-operator/scripts/platform-agent.yaml.template
+++ b/k8s-operator/scripts/platform-agent.yaml.template
@@ -25,6 +25,7 @@ spec:
   integration:
     googleChat:
       enabled: true
+      mode: "${GOOGLE_CHAT_MODE}"
       projectId: "${PROJECT_ID}"
       topicName: "${CHAT_TOPIC_NAME}"
       subscriptionName: "${CHAT_SUB_NAME}"

--- a/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_06_deploy_platform_agent.sh
@@ -41,6 +41,7 @@ export KSA_NAME="${PLATFORM_AGENT_KSA_NAME}"
 
 init_var "CHAT_SUB_NAME" "platform-agent-chat-events-sub" "Enter Pub/Sub Subscription Name"
 init_var "CHAT_TOPIC_NAME" "platform-agent-chat-events" "Enter Pub/Sub Topic Name"
+init_var "GOOGLE_CHAT_MODE" "default" "Enter Google Chat Output Mode (default or debug)"
 init_var "ALLOWED_USERS" "" "Enter Allowed Google Chat Users Emails (comma separated). Leaving it empty will allow all users."
 DEFAULT_AGENT_IMAGE="ghcr.io/gke-labs/kube-agents/platform-agent"
 init_var "AGENT_IMAGE" "$DEFAULT_AGENT_IMAGE" "Enter Platform Agent Image Path"
@@ -75,7 +76,7 @@ execute_custom_resource() {
   fi
 
   # Ensure variables are explicitly exported so envsubst can access them
-  export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME
+  export PROJECT_ID REGION CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GSA_NAME CHAT_SUB_NAME CHAT_TOPIC_NAME GOOGLE_CHAT_MODE ALLOWED_USERS AGENT_IMAGE NAMESPACE KSA_NAME
 
   envsubst < "$CR_TEMPLATE" > "$CR_MANIFEST"
   


### PR DESCRIPTION
# Pull Request

## Why This Change

The `PlatformAgent` Custom Resource supports configuring the Google Chat output mode (`default` or `debug`), which controls output verbosity in Google Chat. Previously, the automated agent deployment script (`provision_06_deploy_platform_agent.sh`) and template (`platform-agent.yaml.template`) did not prompt for or substitute `GOOGLE_CHAT_MODE`, requiring manual manifest edits after running provisioning.

## What Changed

**Files:**

- [`k8s-operator/scripts/provision_06_deploy_platform_agent.sh`](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/scripts/provision_06_deploy_platform_agent.sh#L44)
- [`k8s-operator/scripts/platform-agent.yaml.template`](file:///usr/local/google/home/shalinibhatia/src/gke-agentic/kube-agents-webhook/k8s-operator/scripts/platform-agent.yaml.template#L28)

**Added/Changed/Fixed:**

- Added interactive variable initialization `GOOGLE_CHAT_MODE` with a default of `"default"` in `provision_06_deploy_platform_agent.sh`.
- Exported `GOOGLE_CHAT_MODE` into the script environment for `envsubst` substitution.
- Added `mode: "${GOOGLE_CHAT_MODE}"` under `spec.integration.googleChat` in `platform-agent.yaml.template`.

## Why This Matters

- Enables seamless configuration of Google Chat (`default` quiet mode vs `debug` mode) during `make gcp-provision` and provisioning script runs.
- Aligns the automated setup pipeline with the `PlatformAgent` CRD spec.

## Context

- Follow-up to PR #242 which added `mode` display configuration support to the Kubernetes operator.

## Testing

- **Go Operator Tests**: Ran `go test ./...` in `k8s-operator/` (all unit and controller tests pass cleanly).
- **Template Rendering**: Verified configuration during provision script run produces valid `PlatformAgent` YAML.

---

*Enables configurable Google Chat output mode during agent deployment with zero breaking changes.*
