### PR TITLE
fix(ci): source and verify GOOGLE_CHAT_MODE in staging agent redeploy

### DIFF
--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -30,11 +30,12 @@ jobs:
       GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
       MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
       MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
+      GOOGLE_CHAT_MODE: ${{ vars.GOOGLE_CHAT_MODE }}
       NAMESPACE: "kubeagents-system"
     steps:
       - name: Verify Env Variables
         run: |
-          for var in GCP_PROJECT_ID GCP_REGION GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT GKE_CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER; do
+          for var in GCP_PROJECT_ID GCP_REGION GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT GKE_CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER GOOGLE_CHAT_MODE; do
             if [ -z "${!var}" ]; then
               echo "::error::Required environment variable $var is not set."
               exit 1
@@ -53,6 +54,7 @@ jobs:
       GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
       MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
       MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
+      GOOGLE_CHAT_MODE: ${{ vars.GOOGLE_CHAT_MODE }}
       NAMESPACE: "kubeagents-system"
     steps:
       - name: Checkout code
@@ -94,8 +96,6 @@ jobs:
           PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
-          MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
-          MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
           AGENT_IMAGE: "${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}"
           CHAT_SUB_NAME: "platform-agent-chat-events-sub"
           CHAT_TOPIC_NAME: "platform-agent-chat-events"


### PR DESCRIPTION
# Pull Request

## Why This Change

The deployment script `k8s-operator/scripts/provision_06_deploy_platform_agent.sh` requires `GOOGLE_CHAT_MODE` to render the Platform Agent custom resource template. When omitted from the GitHub Actions environment, `init_var` attempts an interactive prompt (`read -r`), causing the non-interactive CI workflow to fail immediately under `set -e`. Additionally, several step-level environment variables were redundantly self-assigned despite already being present in the job environment.

## What Changed

**Files:**
- `.github/workflows/staging-redeploy-agent.yml`

**Added/Changed/Fixed:**
- Added `GOOGLE_CHAT_MODE: ${{ vars.GOOGLE_CHAT_MODE }}` to both `validate` and `deploy` job-level environment blocks.
- Added `GOOGLE_CHAT_MODE` to the `Verify Env Variables` loop in the `validate` job to ensure early validation failure if the variable is missing.
- Removed redundant step-level environment variable declarations (`MODEL_PROVIDER`, `MODEL_DEFAULT_NAME`) from the `Perform Agent Redeployment` step since they are cleanly inherited from the job-level environment.

## Why This Matters

- Prevents interactive prompt failures and workflow crashes during staging agent redeployments in GitHub Actions CI.
- Enforces fail-fast validation if required repository variables are missing.
- Eliminates duplicate YAML configuration and simplifies environment variable inheritance across steps.

## Context

- Aligns `staging-redeploy-agent.yml` with existing environment verification patterns across other staging deployment workflows.

## Testing

- Verified YAML syntax and formatting locally using `npx prettier --check .github/workflows/staging-redeploy-agent.yml`.

---

This change ensures reliable non-interactive execution in CI without functional risks to running workloads.

TAG=agy
CONV=1de991bf-796c-4a94-a9f3-233f4c57b8cd