### PR TITLE
docs(minty): clarify Token Minter GitOps purpose in provision script

### DIFF
--- a/k8s-operator/config/integrations/github/README.md
+++ b/k8s-operator/config/integrations/github/README.md
@@ -1,6 +1,6 @@
 # GitHub Token Minter (Minty) Integration
 
-This directory contains the configuration and deployment manifests for integrating the **GitHub Token Minter (Minty)** broker into the cluster. This integration allows agents to securely request short-lived GitHub access tokens without storing long-lived, static credentials.
+This directory contains the configuration and deployment manifests for integrating the **GitHub Token Minter (Minty)** broker into the cluster. This integration allows agents to securely request short-lived GitHub access tokens without storing long-lived, static credentials, enabling them to safely perform write operations on the Kubernetes infrastructure via GitOps.
 
 ## How It All Works
 
@@ -10,7 +10,7 @@ Minty acts as a secure broker between Google Cloud IAM (Workload Identity) and G
 2. **The Verification:** Minty evaluates the request against its local rules (provided by `configmap.yaml`). It extracts the `"email"` claim from the OIDC token and verifies it against the `assertion.email` rule. If the agent's email is authorized for the requested repository, the rule evaluates to true.
 3. **The Exchange (KMS Signing):** Upon successful authorization, Minty interfaces with Google Cloud Key Management Service (KMS). Minty holds a reference to the GitHub App's private key stored securely in KMS. The private key is never exported or exposed to Minty. Instead, Minty constructs an authentication payload and invokes the KMS API to cryptographically sign it using secure hardware.
 4. **The Token Generation:** Armed with the KMS-signed JWT, Minty authenticates with the GitHub API on behalf of the configured GitHub App. GitHub verifies the signature and returns a short-lived installation access token scoped to the target repository.
-5. **The Delivery:** Minty returns this short-lived GitHub access token to the agent, which can then utilize it to perform repository operations such as pushing code or managing Pull Requests.
+5. **The Delivery:** Minty returns this short-lived GitHub access token to the agent, which can then utilize it to perform write operations on the Kubernetes infrastructure via GitOps (e.g., by pushing configuration changes or managing Pull Requests).
 
 ## The GitHub App
 

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -23,6 +23,12 @@ DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
 
 init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 
+if [ -z "${GITHUB_ORG:-}" ]; then
+  print_info "The GitHub Token Minter acts as a secure bridge allowing the GKE Agent to access GitHub."
+  print_info "We collect the GitHub Org/Owner and Repository to configure authorization rules, ensuring that"
+  print_info "only the GKE Agent's GCP Service Account can request GitHub access tokens for this specific repository."
+  print_info "The GKE Agent will use this repository to perform write operations on the Kubernetes infrastructure using GitOps."
+fi
 init_var "GITHUB_ORG" "" "Enter GitHub Org/Owner (optional, for GitHub Token Minter)"
 if [ -n "${GITHUB_ORG:-}" ]; then
   init_var "GITHUB_REPO" "" "Enter GitHub Repo (for GitHub Token Minter)"


### PR DESCRIPTION
# Pull Request

## Why This Change

Improves the provisioning setup flow by providing clear, inline context regarding the purpose of collecting GitHub organization and repository details.

## What Changed

**Files:**

- `k8s-operator/scripts/provision_03_gcp_iam.sh`
- `k8s-operator/config/integrations/github/README.md`

**Added/Changed/Fixed:**

- Added a description block in `provision_03_gcp_iam.sh` that explains how the GitHub repository details are used to configure authorization rules for GKE Agent GitOps write operations.
- Updated the GitHub Minter integration `README.md` to align with GKE Agent terminology and document the GitOps flow.

## Why This Matters

- Better guides the installer by explaining why GitHub credentials are requested and how they are used securely.

## Context

Enhancement to the infrastructure provisioning workflow.

## Testing

Ran provision script, verified that it works and that updated description is displayed.

---

No risk, documentation and text changes only.