### PR TITLE
feat(ci): add skeleton connection test script for prow smoke test

### DIFF
--- a/hack/ci-connection-test.sh
+++ b/hack/ci-connection-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIMEOUT="30s"
+
+echo "=== Verifying GKE Cluster Connectivity ==="
+kubectl cluster-info --request-timeout="${TIMEOUT}"
+
+echo "=== Verifying Namespace Access ==="
+kubectl get namespaces --request-timeout="${TIMEOUT}"
+
+echo "=== Connectivity Smoke Test Passed ==="


### PR DESCRIPTION
# Pull Request

## Why This Change
Register Skeleton Prow Job for smoke test to verify that CI test containers can securely authenticate and communicate with target test Kubernetes/GKE clusters

## What Changed

**Files:**
- `hack/ci-connection-test.sh`

**Added/Changed/Fixed:**
- Added a simple script in kube-agents that runs basic connectivity checks

## Why This Matters
- Provides the foundational connectivity verification script for incoming Prow presubmit smoke test jobs

## Context
Part of the ongoing DevEx initiatives to harden automated pull request verification and CI observability.

## Testing
Verified locally against a development GKE cluster; successfully retrieved control plane endpoints and namespace lists.

**Functional Impact & Risk**: Zero impact on production runtime or operator code. This is an additive CI/DevEx utility script located under  `hack/`. Risk is minimal.