### PR TITLE
fix(ci): update staging redeploy workflows to match renumbered provision scripts

### DIFF
--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -102,9 +102,9 @@ jobs:
           CHAT_TOPIC_NAME: "platform-agent-chat-events"
           ALLOWED_USERS: ""
         run: |
-          echo "Redeploying platform-agent via provision_06 with image: ${AGENT_IMAGE}:${AGENT_TAG}"
+          echo "Redeploying platform-agent via provision_07 with image: ${AGENT_IMAGE}:${AGENT_TAG}"
           cd k8s-operator
-          make gcp-provision-06-deploy ARGS="--no-confirm"
+          make gcp-provision-07-deploy ARGS="--no-confirm"
 
       - name: Verify Agent Deployment Rollout
         run: |

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -6,8 +6,8 @@ on:
       - main
     paths:
       - "k8s-operator/config/integrations/**"
-      - "k8s-operator/scripts/provision_07_deploy_litellm.sh"
-      - "k8s-operator/scripts/provision_08_deploy_github_minter.sh"
+      - "k8s-operator/scripts/provision_08_deploy_litellm.sh"
+      - "k8s-operator/scripts/provision_09_deploy_github_minter.sh"
       - "k8s-operator/Makefile"
 
 permissions:
@@ -32,11 +32,11 @@ jobs:
           filters: |
             litellm:
               - 'k8s-operator/config/integrations/litellm/**'
-              - 'k8s-operator/scripts/provision_07_deploy_litellm.sh'
+              - 'k8s-operator/scripts/provision_08_deploy_litellm.sh'
               - 'k8s-operator/Makefile'
             github:
               - 'k8s-operator/config/integrations/github/**'
-              - 'k8s-operator/scripts/provision_08_deploy_github_minter.sh'
+              - 'k8s-operator/scripts/provision_09_deploy_github_minter.sh'
               - 'k8s-operator/Makefile'
 
   deploy-litellm:
@@ -98,9 +98,9 @@ jobs:
           MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
           MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
         run: |
-          echo "Redeploying LiteLLM gateway via provision_07"
+          echo "Redeploying LiteLLM gateway via provision_08"
           cd k8s-operator
-          make gcp-provision-07-litellm ARGS="--no-confirm"
+          make gcp-provision-08-litellm ARGS="--no-confirm"
 
       - name: Verify LiteLLM Deployment Rollout
         run: |
@@ -225,9 +225,9 @@ jobs:
           REGION: ${{ env.GCP_REGION }}
           CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
         run: |
-          echo "Redeploying GitHub Token Minter via provision_08"
+          echo "Redeploying GitHub Token Minter via provision_09"
           cd k8s-operator
-          make gcp-provision-08-github ARGS="--no-confirm"
+          make gcp-provision-09-github ARGS="--no-confirm"
 
       - name: Verify GitHub Token Minter Deployment Rollout
         run: |


### PR DESCRIPTION
# Pull Request

## Why This Change

Due to a script renumbering when `provision_06_gcp_k8s_secrets.sh` was introduced as Step 6, the subsequent deployment scripts and Makefile targets shifted from `06/07/08` to `07/08/09`:
- Step 7: `provision_07_deploy_platform_agent.sh` (`gcp-provision-07-deploy`)
- Step 8: `provision_08_deploy_litellm.sh` (`gcp-provision-08-litellm`)
- Step 9: `provision_09_deploy_github_minter.sh` (`gcp-provision-09-github`)

The staging redeploy workflows were still referencing the outdated step numbers (`06`, `07`, `08`), which would cause staging deployments and path-filtered workflow triggers to fail or miss changes.

## What Changed

Updated the staging redeploy workflows to reference the correct script paths and Makefile targets matching `k8s-operator/Makefile` and current script numbering.

**Files:**

- `.github/workflows/staging-redeploy-agent.yml`
- `.github/workflows/staging-redeploy-integrations.yml`

**Added/Changed/Fixed:**

- Fixed `staging-redeploy-agent.yml` to call `make gcp-provision-07-deploy` instead of `gcp-provision-06-deploy`.
- Fixed `staging-redeploy-integrations.yml` path filters to trigger on changes to `provision_08_deploy_litellm.sh` and `provision_09_deploy_github_minter.sh`.
- Fixed `staging-redeploy-integrations.yml` LiteLLM redeployment job to call `make gcp-provision-08-litellm`.
- Fixed `staging-redeploy-integrations.yml` GitHub Token Minter redeployment job to call `make gcp-provision-09-github`.
- Verified `staging-redeploy-controller.yml` already correctly references `provision_02` and `make gcp-provision-02-operator`.

## Why This Matters

- Ensures automated staging redeployments trigger correctly when integration scripts are updated.
- Fixes CI/CD deployment failures caused by referencing non-existent Makefile targets and scripts.

## Context

- Relates to recent script renumbering in `k8s-operator/scripts/` where `provision_06_gcp_k8s_secrets.sh` was inserted.

## Testing

- Validated YAML syntax and formatting locally using `npx prettier --check .`.

---

Ensures reliable CI/CD staging deployments with zero breaking changes or functional impact to application runtime behavior.