### PR TITLE
Fix error in KMS key ring creation

### DIFF
--- a/k8s-operator/scripts/provision_09_deploy_github_minter.sh
+++ b/k8s-operator/scripts/provision_09_deploy_github_minter.sh
@@ -35,7 +35,6 @@ init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var "KMS_KEYRING" "github-token-minter-keyring" "Enter Cloud KMS Keyring Name"
 init_var "KMS_KEY" "github-token-minter-key" "Enter Cloud KMS Key Name"
 
-
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
 # Step 1: Connect kubectl
@@ -108,6 +107,8 @@ execute_github_minter() {
       --role="roles/cloudkms.signerVerifier" \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
+  
+  export GOOGLE_CLOUD_QUOTA_PROJECT="${PROJECT_ID}"
 
   # Import PEM if provided and no version exists
   local versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null)

--- a/k8s-operator/scripts/provision_09_deploy_github_minter.sh
+++ b/k8s-operator/scripts/provision_09_deploy_github_minter.sh
@@ -35,6 +35,8 @@ init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var "KMS_KEYRING" "github-token-minter-keyring" "Enter Cloud KMS Keyring Name"
 init_var "KMS_KEY" "github-token-minter-key" "Enter Cloud KMS Key Name"
 
+export GOOGLE_CLOUD_QUOTA_PROJECT="${PROJECT_ID}"
+
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
 # Step 1: Connect kubectl
@@ -107,8 +109,6 @@ execute_github_minter() {
       --role="roles/cloudkms.signerVerifier" \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
-  
-  export GOOGLE_CLOUD_QUOTA_PROJECT="${PROJECT_ID}"
 
   # Import PEM if provided and no version exists
   local versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null)


### PR DESCRIPTION
Fix for provision_09_deploy_github_minter

Problem description:
If GOOGLE_CLOUD_QUOTA_PROJECT was set to a different project than the one that we try to install to, that project would be used when trying to check if the key ring was created successfully, resulting in an error that looks like this ""error":"encountered error when creating/getting key ring: failed to query key ring with parent \"projects/sergiu-demoproj/locations/us-east4\" and id \"github-token-minter-keyring-1\": rpc error: code = PermissionDenied desc = Cloud Key Management Service (KMS) API has not been used in project kube-agents-gke before or it is disabled."

Solution
Add a step that syncs the GOOGLE_CLOUD_QUOTA_PROJECT with PROJECT_ID