### PR TITLE
chore(ci): assign staging redeploy workflows to k8s-operator owners

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -22,6 +22,12 @@ files:
     - repository-owners # group
   "k8s-operator/**":
     - k8s-operator-owners
+  ".github/workflows/staging-redeploy-agent.yml":
+    - k8s-operator-owners
+  ".github/workflows/staging-redeploy-controller.yml":
+    - k8s-operator-owners
+  ".github/workflows/staging-redeploy-integrations.yml":
+    - k8s-operator-owners
 
 options:
   ignore_draft: true

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -22,11 +22,7 @@ files:
     - repository-owners # group
   "k8s-operator/**":
     - k8s-operator-owners
-  ".github/workflows/staging-redeploy-agent.yml":
-    - k8s-operator-owners
-  ".github/workflows/staging-redeploy-controller.yml":
-    - k8s-operator-owners
-  ".github/workflows/staging-redeploy-integrations.yml":
+  ".github/workflows/staging-redeploy-*.yml":
     - k8s-operator-owners
 
 options:

--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,16 +1,10 @@
 per-file:
   staging-redeploy-agent.yml:
     approvers:
-    - fatoshoti
-    - mateuszklinowski
-    - mplakhtiy
+    - k8s-operator-owners
   staging-redeploy-controller.yml:
     approvers:
-    - fatoshoti
-    - mateuszklinowski
-    - mplakhtiy
+    - k8s-operator-owners
   staging-redeploy-integrations.yml:
     approvers:
-    - fatoshoti
-    - mateuszklinowski
-    - mplakhtiy
+    - k8s-operator-owners

--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,0 +1,16 @@
+per-file:
+  staging-redeploy-agent.yml:
+    approvers:
+    - fatoshoti
+    - mateuszklinowski
+    - mplakhtiy
+  staging-redeploy-controller.yml:
+    approvers:
+    - fatoshoti
+    - mateuszklinowski
+    - mplakhtiy
+  staging-redeploy-integrations.yml:
+    approvers:
+    - fatoshoti
+    - mateuszklinowski
+    - mplakhtiy

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,5 @@
+aliases:
+  k8s-operator-owners:
+    - fatoshoti
+    - mateuszklinowski
+    - mplakhtiy


### PR DESCRIPTION
# Pull Request

## Why This Change

Staging redeploy workflows need specific ownership and reviewer approval gates assigned to the `k8s-operator` team so that changes to these automated deployments are reviewed by the responsible engineers.

## What Changed

Added an `OWNERS` file in `.github/workflows/` and updated `.github/auto_request_review.yml` to automatically request reviews from `k8s-operator-owners` when staging redeploy workflows are modified.

**Files:**

- `.github/workflows/OWNERS`
- `.github/auto_request_review.yml`

**Added/Changed/Fixed:**

- Added per-file ownership rules for `staging-redeploy-agent.yml`, `staging-redeploy-controller.yml`, and `staging-redeploy-integrations.yml` in `.github/workflows/OWNERS`.
- Mapped staging redeploy workflow files to `k8s-operator-owners` in `.github/auto_request_review.yml`.

## Why This Matters

Ensures that automated PR reviewer assignment and Kubernetes-native approval systems properly direct reviews for staging redeploy workflows to `fatoshoti`, `mateuszklinowski`, and `mplakhtiy` instead of default repository owners.

## Context

Aligns workflow review ownership with `k8s-operator/OWNERS`.

## Testing

Validated formatting with Prettier. Reviewer assignment can be verified upon PR creation when `auto-request-review` evaluates modified files against `.github/auto_request_review.yml`.

---

Scoping staging redeploy workflow approvals to k8s-operator owners.