### PR TITLE
fix(ci): use filters syntax with regex in workflows OWNERS

### DIFF
--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,10 +1,4 @@
-per-file:
-  staging-redeploy-agent.yml:
+filters:
+  "staging-redeploy-.*\\.yml$":
     approvers:
-    - k8s-operator-owners
-  staging-redeploy-controller.yml:
-    approvers:
-    - k8s-operator-owners
-  staging-redeploy-integrations.yml:
-    approvers:
-    - k8s-operator-owners
+      - k8s-operator-owners


### PR DESCRIPTION
# Pull Request

## Why This Change

In Prow `OWNERS` files, path-based ownership rules use the `filters` map rather than `per-file`. Furthermore, the separate workflow rules can be simplified and combined into a single regular expression filter.

## What Changed

Replaced `per-file:` with `filters:` in `.github/workflows/OWNERS` and combined the individual staging redeploy workflow entries into a single regex condition matching `staging-redeploy-.*\.yml$`.

**Files:**

- `.github/workflows/OWNERS`

**Added/Changed/Fixed:**

- Changed path-based ownership syntax from `per-file` to `filters`.
- Combined `staging-redeploy-agent.yml`, `staging-redeploy-controller.yml`, and `staging-redeploy-integrations.yml` into a single regex condition `"staging-redeploy-.*\\.yml$"`.

## Why This Matters

- Aligns `OWNERS` file syntax with standard Prow specifications.
- Simplifies maintenance by consolidating multiple identical approval rules into a single regex pattern.

## Context

Follow-up to #263 which introduced staging redeploy workflow ownership.

## Testing

- Validated YAML syntax and formatting locally using Prettier (`npx prettier --write .github/workflows/OWNERS`).

---

Functional impact is low (only affects Prow PR approval routing for staging redeploy workflows).