### PR TITLE
fix(operator): append condition=None to gcloud iam policy binding 

### DIFF
--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -89,6 +89,7 @@ execute_agent_iam() {
     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${gsa_email}" \
         --role="${role}" \
+        --condition=None \
         --quiet >/dev/null || return 1
   done
   
@@ -98,6 +99,7 @@ execute_agent_iam() {
       --role="roles/iam.workloadIdentityUser" \
       --member="${wi_member}" \
       --project="${PROJECT_ID}" \
+      --condition=None \
       --quiet >/dev/null || return 1
 }
 

--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -134,6 +134,7 @@ execute_pubsub_setup() {
       --member="serviceAccount:chat-api-push@system.gserviceaccount.com" \
       --role="roles/pubsub.publisher" \
       --project="${PROJECT_ID}" \
+      --condition=None \
       --quiet >/dev/null || return 1
 
   local gsuite_sa="service-${PROJECT_NUMBER}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
@@ -141,6 +142,7 @@ execute_pubsub_setup() {
       --member="serviceAccount:${gsuite_sa}" \
       --role="roles/pubsub.publisher" \
       --project="${PROJECT_ID}" \
+      --condition=None \
       --quiet >/dev/null || return 1
 }
 

--- a/k8s-operator/scripts/provision_09_deploy_github_minter.sh
+++ b/k8s-operator/scripts/provision_09_deploy_github_minter.sh
@@ -108,6 +108,7 @@ execute_github_minter() {
       --member="serviceAccount:${gsa_email}" \
       --role="roles/cloudkms.signerVerifier" \
       --project="${PROJECT_ID}" \
+      --condition=None \
       --quiet >/dev/null || return 1
 
   # Import PEM if provided and no version exists


### PR DESCRIPTION
# Pull Request

## Why This Change

Whenever a Google Cloud project or Pub/Sub topic already has conditional IAM policy bindings attached (`such as organization-level IAM condition policies, time-bound access rules, or prior test deployments`), executing standard `gcloud ... add-iam-policy-binding` commands without explicitly specifying a condition parameter fails with:
`ERROR: Policy contains conditional bindings. To add a non-conditional binding, specify --condition=None`.

This caused our automation scripts (`make gcp-provision` and `k8s-operator/scripts/*`) to abort midway during fresh cluster deployments whenever existing IAM policies contained conditions.

## What Changed

We explicitly appended `--condition=None` to all `gcloud add-iam-policy-binding` invocations across our GCP IAM and integration setup scripts.

**Files:**

- `k8s-operator/scripts/provision_03_gcp_iam.sh`
- `k8s-operator/scripts/provision_04_gcp_gchat.sh`
- `k8s-operator/scripts/provision_09_deploy_github_minter.sh`

**Added/Changed/Fixed:**

- **Project & Workload Identity Roles (`provision_03_gcp_iam.sh`)**: Added `--condition=None` when binding project-level service account roles (`roles/aiplatform.user`, `roles/cloudkms.cryptoKeyEncrypterDecrypter`, etc.) and when binding `roles/iam.workloadIdentityUser` to Kubernetes service accounts.
- **Pub/Sub Publisher Roles (`provision_04_gcp_gchat.sh`)**: Added `--condition=None` when granting `roles/pubsub.publisher` to `chat-api-push@system.gserviceaccount.com` and GSuite addon service accounts on the Google Chat Pub/Sub topic.
- **Cloud KMS Signer/Verifier Role (`provision_09_deploy_github_minter.sh`)**: Added `--condition=None` when binding `roles/cloudkms.signerVerifier` to the `github-token-minter` service account on the target KMS key.

## Why This Matters

- **Idempotent Provisioning**: Ensures `make gcp-provision` and individual provisioning scripts run cleanly and repeatably on any GCP environment, regardless of whether conditional IAM policies exist on the project.
- **Eliminates Manual IAM Intervention**: Prevents script execution halts requiring users to manually debug `gcloud` conditional policy requirements.

## Testing

- **Local Execution Verification**: Executed `provision_03_gcp_iam.sh`, `provision_04_gcp_gchat.sh`, and `provision_09_deploy_github_minter.sh` against project `agentic-harness-demo`. Verified all `add-iam-policy-binding --condition=None` commands return exit code `0` (`Updated IAM policy for project/resource`).
- **Clean Git Hygiene**: Verified zero unintended file modifications or formatting diffs.

---

This is a low-risk, pure shell script reliability improvement ensuring smooth cluster onboarding across all GCP environments.
