### PR TITLE
feat(operator): add memory provider config to platform agent manifest

### DIFF
--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -107,6 +107,11 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 		Web struct {
 			Backend string `json:"backend,omitempty"`
 		} `json:"web,omitempty"`
+		Memory struct {
+			MemoryEnabled      bool   `json:"memory_enabled"`
+			Provider           string `json:"provider"`
+			UserProfileEnabled bool   `json:"user_profile_enabled"`
+		} `json:"memory"`
 		Platforms struct {
 			GoogleChat struct {
 				Enabled bool `json:"enabled"`
@@ -167,6 +172,9 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	cfg.Web.Backend = "ddgs"
 	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge"}
 	cfg.Display.Platforms = map[string]map[string]any{}
+	cfg.Memory.MemoryEnabled = false
+	cfg.Memory.Provider = "multiuser_memory"
+	cfg.Memory.UserProfileEnabled = false
 
 	if agent.Spec.Integration != nil {
 		if gchat := agent.Spec.Integration.GoogleChat; gchat != nil {

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -143,6 +143,10 @@ data:
           KUBERNETES_SERVICE_HOST: ${KUBERNETES_SERVICE_HOST}
           KUBERNETES_SERVICE_PORT: ${KUBERNETES_SERVICE_PORT}
         timeout: 300
+    memory:
+      memory_enabled: false
+      provider: multiuser_memory
+      user_profile_enabled: false
     model:
       api_key: none
       base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
@@ -288,7 +292,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 5e10376dffc6d671db97c37ef2fda38624838051aba5faf4cde7fb44fdc4e433
+        kubeagents.x-k8s.io/config-hash: 3980ce3f0e013e8b27a93590270972958c7f2dc7426f3364754b2fd1702e8896
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null


### PR DESCRIPTION
# Pull Request

## Why This Change

When `PlatformAgent` custom resources are deployed or reconciled by the Kubernetes operator (`kubeagents-controller-manager`), the `renderConfigYAML()` struct inside `platformagent_manifests.go` only defined `Model`, `Terminal`, `MCPServers`, `PlatformToolsets`, `Approvals`, `Web`, `Platforms`, `Plugins`, and `Display` fields. Because it omitted `Memory` from the Go struct definition, any live `config.yaml` generated by the operator (`and written to the platformagent-config ConfigMap / PVC`) completely stripped out the `memory` section (`memory_enabled`, `provider`, `user_profile_enabled`), preventing `multiuser_memory` from being configured when installed or reconciled via `make`.

This PR enabled `multiuser_memory` plugin implemented in https://github.com/gke-labs/kube-agents/pull/266

## What Changed

Added `Memory` struct definition (`MemoryEnabled`, `Provider`, `UserProfileEnabled`) to `renderConfigYAML()` inside `platformagent_manifests.go` and populated its default values (`provider: multiuser_memory`). Updated corresponding operator golden test manifests (`expected/platformagent.yaml`) with minimal diffs (only the 4 added memory config lines right above `model:` and the single updated `config-hash` annotation).

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- **Added** `Memory` struct definition to `renderConfigYAML()` (`k8s-operator/internal/controller/platformagent_manifests.go`) containing `memory_enabled` (bool), `provider` (string), and `user_profile_enabled` (bool).
- **Added** default `Memory` configuration initialization (`MemoryEnabled = false`, `Provider = "multiuser_memory"`, `UserProfileEnabled = false`) right under display/plugin defaults.
- **Updated** expected golden manifest `expected/platformagent.yaml` with exact, minimal insertion of the `memory:` block right above `model:` (`preserving exact existing YAML indentation and ordering across all other fields`).

## Why This Matters

- Ensures that whenever `PlatformAgent/platform-agent` is installed or reconciled via `make` (`or by the live Kubernetes operator`), `/opt/data/config.yaml` on the pod contains the complete `memory:` section matching `agents/platform/config.yaml`.
- Guarantees `multiuser_memory` plugin configuration (`isolating USER.md per user_id while keeping MEMORY.md global`) is preserved on cluster reconciliation without being wiped out by `renderConfigYAML()`.

## Context

Follow-up to PR #266 (`feat(platform): implement per-user memory isolation plugin (#266)`), which added the `multiuser_memory` plugin code (`__init__.py`) and `agents/platform/config.yaml` configuration but omitted the Go struct field required for operator manifest generation.

## Testing

- Ran `go test ./...` across all packages in `k8s-operator/` (`api/v1alpha1`, `internal/controller`, `internal/testing`, `internal/webhook`).
- Verified exact 1-to-1 match on golden tests (`TestAgentsGolden/PlatformAgent`) with minimal git diff (`6 insertions(+), 1 deletion(-)` on `expected/platformagent.yaml`).

---

Functional Impact: Fixes missing `memory` configuration in operator-generated `config.yaml` manifests. Risk: Low (defaults `memory_enabled: false` to match repository defaults). Rollout: Automatic upon next operator image push (`ghcr.io/gke-labs/kube-agents/k8s-operator:latest`) and deployment.

TAG=agy
CONV=f3167daf-9586-47c4-aead-9453f3f0079e
