### PR TITLE
fix(gateway): apply upstream PR #51567 patch to google_chat adapter

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -55,7 +55,8 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     opentelemetry-exporter-otlp-proto-http
 
 # Apply upstream PR #51567 patch to google_chat adapter to fix nested inline formatting leaks (GC0, GC1, etc.)
-RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py
+RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
+    grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 
 # 4. Clone and build mcp-remote proxy

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -54,6 +54,9 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     opentelemetry-sdk \
     opentelemetry-exporter-otlp-proto-http
 
+# Apply upstream PR #51567 patch to google_chat adapter to fix nested inline formatting leaks (GC0, GC1, etc.)
+RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py
+
 
 # 4. Clone and build mcp-remote proxy
 RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \


### PR DESCRIPTION
# Pull Request

## Why This Change

When `Hermes` communicates across the Google Chat platform adapter (`plugins/platforms/google_chat/adapter.py`), nested inline formatting elements (`e.g., **\`broker-dbbb484c5-d8p9w\`**`) cause placeholder tokens (`e.g., GC0, GC1, GC2`) to leak directly into user-facing chat messages. This occurs because `_ph()` restores protected regions in forward dictionary insertion order (`placeholders.items()`), leaving outer or nested placeholders unparsed.

## What Changed

Applied upstream fix (`NousResearch/hermes-agent#51567`) inside `deploy/docker/Dockerfile` to ensure `placeholders.items()` are restored in reverse order of creation during container image build time (`[agent-base 6/14]`).

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- **Added** `RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py` right during image build immediately following `hermes-agent[google_chat]` package installation (`Dockerfile`).

## Why This Matters

- Completely eliminates leaked internal placeholder tokens (`GC0`, `GC1`, `GC2`) when rendering complex markdown and status summaries inside Google Chat.
- Preserves accurate nested formatting (`bold inline code, links within lists, table highlights`).

## Context

Codifies upstream pull request (`NousResearch/hermes-agent#51567`) directly into our container build lifecycle (`Dockerfile`) so our GKE platform agents immediately benefit from the bug fix prior to upstream PyPI release.

## Testing

- Built platform agent Docker image (`sha256:9c3bccc6...`) and deployed onto live GKE pod `platform-agent-gateway-9574b474f-rjmq4`.
- Verified `grep "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py` returns exact match inside `/opt/hermes` inside the running container.
- Verified Google Chat output renders status summaries cleanly without leaking `GC*` placeholder strings.

---

Functional Impact: Resolves Google Chat formatting bugs by applying `reversed(list(placeholders.items()))` during Docker build. Risk: Low. Rollout: Automatic on next container deployment.

TAG=agy
CONV=f3167daf-9586-47c4-aead-9453f3f0079e
