### PR TITLE
feat(platform): add main entrypoint to platform_mcp_server.py

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -515,3 +515,9 @@ def start_session_kv_server() -> None:
         log("Session KV server spawned successfully.")
     except Exception as exc:
         log(f"Failed to start Session KV server: {exc}")
+
+
+if __name__ == "__main__":
+    start_session_kv_server()
+    mcp.run()
+


### PR DESCRIPTION
Fixes the platform_control MCP server by adding the missing main entrypoint block. This ensures the server starts and listens on stdin, preventing immediate connection closed errors.