### PR TITLE
fix(ci): pass github repo variables to agent redeployment action

### DIFF
--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -64,6 +64,8 @@ jobs:
       SLACK_HOME_CHANNEL: ${{ vars.SLACK_HOME_CHANNEL }}
       SLACK_HOME_CHANNEL_NAME: ${{ vars.SLACK_HOME_CHANNEL_NAME }}
       NAMESPACE: "${{vars.NAMESPACE}}"
+      GITHUB_ORG: ${{ vars.GH_ORG }}
+      GITHUB_REPO: ${{ vars.GH_REPO }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7


### PR DESCRIPTION
# Pull Request

## Why This Change

In the previous PR, we updated our bash provisioning scripts to construct the platform agent's configured GitHub repository string dynamically from `GITHUB_ORG` and `GITHUB_REPO`. While this worked well locally, we failed to map these variables within our GitHub Actions CI/CD workflows, meaning they were left empty during remote deployments. This caused the agent's `SETTINGS.md` to fall back to having `Git Repo: None`.

## What Changed

Added the missing environment variable mapping to the agent redeployment workflow, properly translating the `GH_` prefixed configuration variables into the `GITHUB_` footprint that the provisioning scripts expect.

**Files:**

- `.github/workflows/staging-redeploy-agent.yml`

**Added/Changed/Fixed:**

- **Fixed:** Added `GITHUB_ORG` and `GITHUB_REPO` maps to the `deploy` job environment block within the staging agent workflow, explicitly pulling from `vars.GH_ORG` and `vars.GH_REPO` to bypass GitHub Action's naming constraints. 

## Why This Matters

- CI/CD will no longer strip out repository targeting when executing agent updates.
- Ensures the platform agent successfully connects to the appropriate GitOps environment rather than failing its clone loop with `None`.

## Context

Follow-up fix to our token minter architecture changes wherein remote deployments were evaluating the target repo differently than local runs due to missing GitHub Action variable bridges.

## Testing

- N/A - Straightforward GitHub Actions CI YAML mapping fix. Verified the bash environment footprint in previous logs to confirm the missing injection. 

---
