### PR TITLE
fix(platform): remove invalid --kubeconfig flag from get-credentials

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -247,8 +247,7 @@ def switch_kube_context(project_id: str, cluster_name: str, location: str) -> tu
     cmd = [
         "gcloud", "container", "clusters", "get-credentials", cluster_name,
         f"--location={location}",
-        f"--project={project_id}",
-        f"--kubeconfig={kubeconfig_path}"
+        f"--project={project_id}"
     ]
     try:
         subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=30, env=env)


### PR DESCRIPTION
`gcloud container clusters get-credentials` does not accept a `--kubeconfig` flag and rejects it with `unrecognized arguments`, which breaks every MCP tool that calls switch_kube_context (list_cc_healthchecks, get_cc_operator_status, list_cc_pods, get_cc_pod_diagnostics).

The KUBECONFIG environment variable is already set on the subprocess env dict (via _run_env({"KUBECONFIG": kubeconfig_path})), which is the supported mechanism for controlling where gcloud writes credentials.

**Files:**

  - agents/platform/scripts/platform_mcp_server.py


**Added/Changed/Fixed:**

  - Removed the invalid --kubeconfig={kubeconfig_path} flag from the gcloud container clusters get-credentials command in switch_kube_context. gcloud get-credentials does not accept this flag and rejects it with
  unrecognized arguments, which broke every MCP tool that goes through switch_kube_context (list_cc_healthchecks, get_cc_operator_status, list_cc_pods, get_cc_pod_diagnostics).
  - The KUBECONFIG environment variable is already set on the subprocess env (via _run_env({"KUBECONFIG": kubeconfig_path})), which is the supported mechanism for controlling where gcloud writes the kubeconfig.
  Behavior is unchanged; only the failing flag is removed.



## Testing

  - [ ] Ran an MCP tool that exercises switch_kube_context end-to-end against a live GKE cluster (e.g. list_cc_healthchecks with project_id, cluster_name, location) and confirmed it no longer fails with
  unrecognized arguments: --kubeconfig.
  - [ ] Verified that after the tool runs, the expected kubeconfig file is written to /tmp/kubeconfig_<project>_<cluster>_<location>.yaml (proves the KUBECONFIG env-var mechanism still directs gcloud to the
  intended path).
  - [ ] Confirmed kubectl calls that follow in the same tool invocation use that kubeconfig (i.e. no context-mismatch errors, results reflect the target cluster).



<!-- Close with a short note on functional impact, risk, or rollout. -->
