### PR TITLE
refactor(auth): replace plaintext git store with `gh auth setup-git`

### DIFF
--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -14,7 +14,6 @@ import sys
 import time
 import urllib.request
 import urllib.error
-from pathlib import Path
 
 TOKEN_BROKER_URL = os.getenv("TOKEN_BROKER_URL", "http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token")
 
@@ -111,21 +110,16 @@ def refresh_git_credentials(target_repo: str = None) -> str:
     if not token:
         raise RuntimeError("Token received from Minty is empty")
 
-    # 2. Configure Git with strict owner-only (0600) permissions to protect the plaintext token
-    subprocess.run(["git", "config", "--global", "credential.helper", "store"], check=True)
-    creds_file = Path.home() / ".git-credentials"
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    mode = 0o600
-    with os.fdopen(os.open(creds_file, flags, mode), "w", encoding="utf-8") as f:
-        f.write(f"https://x-access-token:{token}@github.com\n")
-    
-    # 3. Configure GitHub CLI
+    # 2. Configure GitHub CLI to securely cache the token in its internal state.
     env = os.environ.copy()
     if "GITHUB_TOKEN" in env:
         del env["GITHUB_TOKEN"]
     if "GH_TOKEN" in env:
         del env["GH_TOKEN"]
     subprocess.run(["gh", "auth", "login", "--with-token"], input=token, text=True, env=env, check=True)
+    
+    # 3. Configure Git to use gh as the credential helper
+    subprocess.run(["gh", "auth", "setup-git"], env=env, check=True)
     
     log("Git credentials store successfully refreshed from Token Broker! Token cached.")
     return token


### PR DESCRIPTION
# Pull Request

## Why This Change

The agent's authentication flow currently relies on manually formatting and writing raw installation tokens into a plaintext `~/.git-credentials` file, paired with a generic Git `store` configuration. This approach is somewhat brittle and splits our authentication state: the `gh` CLI authenticates one way, and `git` authenticates another. 

This PR refactors the authentication logic to unify the auth state. By delegating all Git operations directly to the GitHub CLI's internal credential manager, we can simplify the script, improve security, and rely on officially supported tooling rather than manual file operations.

## What Changed

Refactored `github_token_refresh.py` to seamlessly bridge Git's authentication directly to the GitHub CLI shell natively. 

**Files:**

- `agents/platform/scripts/github_token_refresh.py`

**Added/Changed/Fixed:**

- **Removed:** Manual string formatting, file permission management, and creation of the plaintext `~/.git-credentials` store.
- **Removed:** Global configuration of Git's legacy `credential.helper store`.
- **Added:** A single, clean `gh auth setup-git` invocation to officially register `gh` as the host-scoped credential helper.
- **Changed:** Swapped the ordering of the CLI login and Git setup steps so that `gh` first logs in, and then it's set up to be used for auth.

## Why This Matters

- **Code Simplification & Robustness:** Eliminates brittle manual file parsing/writing logic, replacing it with a standardized, native CLI handshake sequence that requires less maintenance.
- **Improved Security:** High-privilege tokens are no longer written into plaintext `.git-credentials` files on the host disk.
- **Prevents Subsystem Conflicts:** As a beneficial side effect, using native host-scoped `gh` delegation avoids a corner-case bug where Git would accidentally parse stale cached credentials which sporadically caused `git push` runs to fail.

## Context

This is a structural cleanup of the authentication pipeline fueling the Kubernetes platform agent (specifically the `submit-suggestion` skill).

## Testing

- Validated by asking the agent to run the updated version of the script inside agent environment.

---

**Rollout & Risk:** Low risk. No functional changes to the end-to-end GitOps workflow. This strictly modernizes the internal bridging between Git and GitHub CLI.