### PR TITLE
fix(scripts): persist enablement variables and skip prompts if already set

### DIFF
--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -99,6 +99,9 @@ save_var() {
   local var_name=$1
   local var_val=$2
   export "${var_name}=${var_val}"
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    return 0
+  fi
   if [ -f "$VARS_FILE" ]; then
     grep -E -v "^[[:space:]]*export[[:space:]]+${var_name}=" "$VARS_FILE" > "$VARS_FILE.tmp" 2>/dev/null || true
     mv "$VARS_FILE.tmp" "$VARS_FILE"
@@ -157,10 +160,12 @@ init_var_model_provider() {
 }
 
 load_state() {
-  if [ ! -f "$VARS_FILE" ]; then
+  if [ -f "$VARS_FILE" ]; then
+    source "$VARS_FILE"
+  elif [ "${DRY_RUN:-0}" -ne 1 ]; then
     echo "# SRE Sourced Variables for GKE & GCP Setup" > "$VARS_FILE"
+    source "$VARS_FILE"
   fi
-  source "$VARS_FILE"
   export NAMESPACE="kubeagents-system"
   export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
   export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"

--- a/k8s-operator/scripts/provision.sh
+++ b/k8s-operator/scripts/provision.sh
@@ -20,12 +20,7 @@ fi
 echo -e "${C_MAGENTA}${C_BOLD}🚀 Starting GKE Platform Agent provisioning pipeline...${C_RESET}"
 
 "${SCRIPT_DIR}/provision_01_gcp_cluster.sh" $DRY_RUN_ARG
-init_var "ENABLE_GVISOR" "false" "Enable GKE Sandbox (gVisor) runtime isolation? (true/false)"
-if [[ "$ENABLE_GVISOR" =~ ^(true|yes|1)$ ]]; then
-  "${SCRIPT_DIR}/provision_01a_gvisor_nodepool.sh" $DRY_RUN_ARG
-else
-  echo -e "${C_YELLOW}Skipping gVisor node pool provisioning (ENABLE_GVISOR=${ENABLE_GVISOR}).${C_RESET}"
-fi
+"${SCRIPT_DIR}/provision_01a_gvisor_nodepool.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_02_gcp_gke_operator.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_03_gcp_iam.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_04_gcp_gchat.sh" $DRY_RUN_ARG

--- a/k8s-operator/scripts/provision_01a_gvisor_nodepool.sh
+++ b/k8s-operator/scripts/provision_01a_gvisor_nodepool.sh
@@ -26,6 +26,12 @@ check_prereqs "gcloud" "kubectl"
 print_step "Setting up Configuration State"
 load_state
 
+init_var "ENABLE_GVISOR" "false" "Enable GKE Sandbox (gVisor) runtime isolation? (true/false)"
+if [[ ! "$ENABLE_GVISOR" =~ ^(true|yes|1)$ ]]; then
+  print_info "Skipping gVisor node pool provisioning (ENABLE_GVISOR=${ENABLE_GVISOR})."
+  exit 0
+fi
+
 ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
 DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
 

--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -22,25 +22,21 @@ check_prereqs "gcloud"
 print_step "Setting up Configuration State for GChat Setup"
 load_state
 
-if [ "${DRY_RUN:-0}" -eq 1 ]; then
-  export GOOGLE_CHAT_ENABLED="${GOOGLE_CHAT_ENABLED:-false}"
-else
-  current_gc_val="${GOOGLE_CHAT_ENABLED:-false}"
-  default_gc_prompt="y/N"
-  if [ "$current_gc_val" = "true" ]; then
-    default_gc_prompt="Y/n"
-  fi
-  echo -ne "  ${C_CYAN}Do you want to enable Google Chat integration? (${default_gc_prompt}): ${C_RESET}"
-  read -r REPLY_GC
-  if [ -z "$REPLY_GC" ]; then
-    export GOOGLE_CHAT_ENABLED="$current_gc_val"
-  elif [[ "$REPLY_GC" =~ ^[Yy]$ ]]; then
-    export GOOGLE_CHAT_ENABLED="true"
-  else
+if [ -z "${GOOGLE_CHAT_ENABLED:-}" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
     export GOOGLE_CHAT_ENABLED="false"
+  else
+    echo -ne "  ${C_CYAN}Do you want to enable Google Chat integration? (y/N): ${C_RESET}"
+    read -r REPLY_GC
+    if [[ "$REPLY_GC" =~ ^[Yy]$ ]]; then
+      export GOOGLE_CHAT_ENABLED="true"
+    else
+      export GOOGLE_CHAT_ENABLED="false"
+    fi
   fi
+  save_var "GOOGLE_CHAT_ENABLED" "${GOOGLE_CHAT_ENABLED}"
 fi
-save_var "GOOGLE_CHAT_ENABLED" "${GOOGLE_CHAT_ENABLED}"
+
 
 if [ "${GOOGLE_CHAT_ENABLED}" != "true" ]; then
   print_info "Google Chat integration is disabled. Skipping Google Chat Pub/Sub setup."

--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -22,20 +22,8 @@ check_prereqs "gcloud"
 print_step "Setting up Configuration State for GChat Setup"
 load_state
 
-if [ -z "${GOOGLE_CHAT_ENABLED:-}" ]; then
-  if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    export GOOGLE_CHAT_ENABLED="false"
-  else
-    echo -ne "  ${C_CYAN}Do you want to enable Google Chat integration? (y/N): ${C_RESET}"
-    read -r REPLY_GC
-    if [[ "$REPLY_GC" =~ ^[Yy]$ ]]; then
-      export GOOGLE_CHAT_ENABLED="true"
-    else
-      export GOOGLE_CHAT_ENABLED="false"
-    fi
-  fi
-  save_var "GOOGLE_CHAT_ENABLED" "${GOOGLE_CHAT_ENABLED}"
-fi
+init_var "GOOGLE_CHAT_ENABLED" "false" "Enable Google Chat integration? (true/false)"
+
 
 
 if [ "${GOOGLE_CHAT_ENABLED}" != "true" ]; then

--- a/k8s-operator/scripts/provision_05_slack.sh
+++ b/k8s-operator/scripts/provision_05_slack.sh
@@ -15,20 +15,8 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 print_step "Setting up Configuration State for Slack Integration"
 load_state
 
-if [ -z "${SLACK_ENABLED:-}" ]; then
-  if [ "${DRY_RUN:-0}" -eq 1 ]; then
-    export SLACK_ENABLED="false"
-  else
-    echo -ne "  ${C_CYAN}Do you want to enable Slack integration? (y/N): ${C_RESET}"
-    read -r REPLY_SLACK
-    if [[ "$REPLY_SLACK" =~ ^[Yy]$ ]]; then
-      export SLACK_ENABLED="true"
-    else
-      export SLACK_ENABLED="false"
-    fi
-  fi
-  save_var "SLACK_ENABLED" "${SLACK_ENABLED}"
-fi
+init_var "SLACK_ENABLED" "false" "Enable Slack integration? (true/false)"
+
 
 
 if [ "${SLACK_ENABLED}" != "true" ]; then

--- a/k8s-operator/scripts/provision_05_slack.sh
+++ b/k8s-operator/scripts/provision_05_slack.sh
@@ -15,25 +15,21 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 print_step "Setting up Configuration State for Slack Integration"
 load_state
 
-if [ "${DRY_RUN:-0}" -eq 1 ]; then
-  export SLACK_ENABLED="${SLACK_ENABLED:-false}"
-else
-  current_slack_val="${SLACK_ENABLED:-false}"
-  default_slack_prompt="y/N"
-  if [ "$current_slack_val" = "true" ]; then
-    default_slack_prompt="Y/n"
-  fi
-  echo -ne "  ${C_CYAN}Do you want to enable Slack integration? (${default_slack_prompt}): ${C_RESET}"
-  read -r REPLY_SLACK
-  if [ -z "$REPLY_SLACK" ]; then
-    export SLACK_ENABLED="$current_slack_val"
-  elif [[ "$REPLY_SLACK" =~ ^[Yy]$ ]]; then
-    export SLACK_ENABLED="true"
-  else
+if [ -z "${SLACK_ENABLED:-}" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
     export SLACK_ENABLED="false"
+  else
+    echo -ne "  ${C_CYAN}Do you want to enable Slack integration? (y/N): ${C_RESET}"
+    read -r REPLY_SLACK
+    if [[ "$REPLY_SLACK" =~ ^[Yy]$ ]]; then
+      export SLACK_ENABLED="true"
+    else
+      export SLACK_ENABLED="false"
+    fi
   fi
+  save_var "SLACK_ENABLED" "${SLACK_ENABLED}"
 fi
-save_var "SLACK_ENABLED" "${SLACK_ENABLED}"
+
 
 if [ "${SLACK_ENABLED}" != "true" ]; then
   print_info "Slack integration is disabled. Skipping Slack token setup."


### PR DESCRIPTION
# Pull Request

## Why This Change

During GKE Platform Agent provisioning, running `provision.sh` would re-prompt for previously saved configuration selections (like `ENABLE_GVISOR`, `GOOGLE_CHAT_ENABLED`, and `SLACK_ENABLED`) instead of using the values already saved in `vars.sh`. This occurred because the scripts did not check if these variables were already set before prompting. If the prompts were accepted with defaults (or run non-interactively), it would also overwrite the saved values in `vars.sh`, breaking idempotency.

Additionally, running the scripts in dry-run mode would previously create or modify the `vars.sh` file, which should remain clean during a dry-run.

## What Changed

Moved state loading and prompt logic to be more idempotent and localized. Refactored the custom prompt blocks for Google Chat and Slack enablement to reuse the common `init_var` helper function from `common.sh`, aligning them with how other configuration variables (like `ENABLE_GVISOR`) are handled. Added dry-run safety to state management.

**Files:**

- [common.sh](file:///usr/local/google/home/dharb/projects/3rd_party/google/kube-agents/k8s-operator/scripts/common.sh)
- [provision.sh](file:///usr/local/google/home/dharb/projects/3rd_party/google/kube-agents/k8s-operator/scripts/provision.sh)
- [provision_01a_gvisor_nodepool.sh](file:///usr/local/google/home/dharb/projects/3rd_party/google/kube-agents/k8s-operator/scripts/provision_01a_gvisor_nodepool.sh)
- [provision_04_gcp_gchat.sh](file:///usr/local/google/home/dharb/projects/3rd_party/google/kube-agents/k8s-operator/scripts/provision_04_gcp_gchat.sh)
- [provision_05_slack.sh](file:///usr/local/google/home/dharb/projects/3rd_party/google/kube-agents/k8s-operator/scripts/provision_05_slack.sh)

**Added/Changed/Fixed:**

- **common.sh:**
  - Updated `save_var` to return early if `DRY_RUN` is enabled, preventing any writes to `vars.sh`.
  - Updated `load_state` to avoid creating `vars.sh` if it doesn't exist and `DRY_RUN` is enabled.
- **provision.sh:** Reverted global state loading; now calls `provision_01a_gvisor_nodepool.sh` unconditionally.
- **provision_01a_gvisor_nodepool.sh:** Added state loading (`load_state`), and wrapped the `ENABLE_GVISOR` prompt/early exit check. It now skips provisioning and exits 0 if `ENABLE_GVISOR` is false.
- **provision_04_gcp_gchat.sh:** Refactored `GOOGLE_CHAT_ENABLED` prompt to reuse the common `init_var` helper.
- **provision_05_slack.sh:** Refactored `SLACK_ENABLED` prompt to reuse the common `init_var` helper.

## Why This Matters

This ensures the provisioning pipeline is idempotent and safe. Subsequent runs of `provision.sh` will respect and preserve previously saved configurations in `vars.sh` instead of re-prompting. Furthermore, dry-runs are now completely side-effect-free regarding the local `vars.sh` file.

Reusing the common `init_var` function also reduces code duplication and ensures a consistent user experience and behavior across all configuration variables.

## Context

Addresses issues with configuring optional components (gVisor, GChat, Slack) where selections were lost or re-prompted on rerun, and ensures dry-run doesn't leave dirty local state.

## Testing

Ran dry-run tests (`provision.sh --dry-run`):
- Verified that if `vars.sh` does not exist, it is NOT created during dry-run.
- Verified that if `vars.sh` exists, it is NOT modified during dry-run.
- Verified that if `ENABLE_GVISOR=false`, it is skipped. If `true`, it is executed (dry-run).
- Verified that if `GOOGLE_CHAT_ENABLED=true` and `SLACK_ENABLED=false`, GChat setup runs (without prompting) and Slack setup is skipped (without prompting).
- Verified that in all cases, the values in `vars.sh` are preserved.

---

Low risk, script-only changes.
