### PR TITLE
feat(platform): log every tool call and approval decision

### DIFF
--- a/agents/platform/config.yaml
+++ b/agents/platform/config.yaml
@@ -39,3 +39,4 @@ plugins:
     - hermes_otel
     - session_store
     - session_otel_bridge
+    - tool_call_audit

--- a/agents/platform/defaults/plugins/tool_call_audit/__init__.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/__init__.py
@@ -1,0 +1,3 @@
+from .plugin import register
+
+__all__ = ["register"]

--- a/agents/platform/defaults/plugins/tool_call_audit/audit.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/audit.py
@@ -1,0 +1,102 @@
+import json
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger("hermes.plugin.tool_call_audit")
+
+_PAYLOAD_LOG_LIMIT = 2000
+
+
+def _serialize(value: Any) -> str:
+    try:
+        serialized = json.dumps(value, default=str, sort_keys=True)
+    except Exception:
+        serialized = str(value)
+    if len(serialized) > _PAYLOAD_LOG_LIMIT:
+        return serialized[:_PAYLOAD_LOG_LIMIT] + "...(truncated)"
+    return serialized
+
+
+def _emit(event: str, fields: Dict[str, Any]) -> None:
+    record = {"audit_event": event, **fields}
+    logger.info(json.dumps(record, default=str, sort_keys=True))
+
+
+def log_pre_tool_call(
+    tool_name: str = "",
+    args: Optional[Dict[str, Any]] = None,
+    task_id: str = "",
+    **kwargs: Any,
+) -> None:
+    try:
+        _emit(
+            "tool_call_start",
+            {"tool_name": tool_name, "task_id": task_id, "args": _serialize(args or {})},
+        )
+    except Exception as exc:
+        logger.error("Error in tool_call_audit pre_tool_call hook: %s", exc, exc_info=True)
+
+
+def log_post_tool_call(
+    tool_name: str = "",
+    result: Any = None,
+    duration_ms: Optional[float] = None,
+    task_id: str = "",
+    **kwargs: Any,
+) -> None:
+    try:
+        _emit(
+            "tool_call_end",
+            {
+                "tool_name": tool_name,
+                "task_id": task_id,
+                "duration_ms": duration_ms,
+                "result": _serialize(result),
+            },
+        )
+    except Exception as exc:
+        logger.error("Error in tool_call_audit post_tool_call hook: %s", exc, exc_info=True)
+
+
+def log_pre_approval_request(
+    command: str = "",
+    description: str = "",
+    pattern_key: str = "",
+    surface: str = "",
+    **kwargs: Any,
+) -> None:
+    try:
+        _emit(
+            "approval_request",
+            {
+                "surface": surface,
+                "pattern_key": pattern_key,
+                "description": description,
+                "command": _serialize(command),
+            },
+        )
+    except Exception as exc:
+        logger.error("Error in tool_call_audit pre_approval_request hook: %s", exc, exc_info=True)
+
+
+def log_post_approval_response(
+    command: str = "",
+    description: str = "",
+    pattern_key: str = "",
+    surface: str = "",
+    choice: str = "",
+    **kwargs: Any,
+) -> None:
+    try:
+        _emit(
+            "approval_response",
+            {
+                "surface": surface,
+                "pattern_key": pattern_key,
+                "choice": choice,
+                "description": description,
+                "command": _serialize(command),
+            },
+        )
+    except Exception as exc:
+        logger.error("Error in tool_call_audit post_approval_response hook: %s", exc, exc_info=True)

--- a/agents/platform/defaults/plugins/tool_call_audit/plugin.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/plugin.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from .audit import (
+    log_post_approval_response,
+    log_post_tool_call,
+    log_pre_approval_request,
+    log_pre_tool_call,
+)
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_tool_call", log_pre_tool_call)
+    ctx.register_hook("post_tool_call", log_post_tool_call)
+    ctx.register_hook("pre_approval_request", log_pre_approval_request)
+    ctx.register_hook("post_approval_response", log_post_approval_response)

--- a/agents/platform/defaults/plugins/tool_call_audit/plugin.yaml
+++ b/agents/platform/defaults/plugins/tool_call_audit/plugin.yaml
@@ -1,0 +1,4 @@
+name: tool_call_audit
+version: 0.1.0
+description: Logs every tool call and approval decision to stdout as a structured audit trail.
+kind: standalone

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -170,7 +170,7 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	// Execution & Display UX configuration
 	cfg.Approvals.CronMode = "approve"
 	cfg.Web.Backend = "ddgs"
-	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge"}
+	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge", "tool_call_audit"}
 	cfg.Display.Platforms = map[string]map[string]any{}
 	cfg.Memory.MemoryEnabled = false
 	cfg.Memory.Provider = "multiuser_memory"

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -174,6 +174,7 @@ data:
       - hermes_otel
       - session_store
       - session_otel_bridge
+      - tool_call_audit
     terminal:
       backend: local
       cwd: /opt/data


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform Agent's MCP server and approval flow had no audit trail: individual tool calls (`verify_gke_cluster`, `send_notification`, etc.) and human approval decisions were not logged anywhere, a gap called out by the `.agents/skills/review-security-k8s-agents-audit-logs` review skill ("Require exact input/output logging for all invoked tools").

## What Changed

**Files:**

- `agents/platform/defaults/plugins/tool_call_audit/` (new plugin: `plugin.yaml`, `plugin.py`, `audit.py`, `__init__.py`)
- `agents/platform/config.yaml`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- Added a new `tool_call_audit` Hermes plugin, following the existing `session_store`/`session_otel_bridge` plugin pattern, that registers the `pre_tool_call`, `post_tool_call`, `pre_approval_request`, and `post_approval_response` hooks and emits one structured JSON log line per event to stdout.
- Enabled `tool_call_audit` in the plugin list in both `agents/platform/config.yaml` (dev/reference config) and `platformagent_manifests.go` (the Go builder that generates the actual runtime config baked into deployed `PlatformAgent` ConfigMaps).
- Updated the golden test fixture to match the new plugin list.

## Why This Matters

- Every tool invocation (name, args, result, duration) and every approval prompt/decision (command, pattern, surface, outcome) is now captured as a structured, queryable log line, ingested automatically by Cloud Logging (stdout, no extra infra, tamper-resistant).
- Closes a concrete gap between this repo's stated security posture and its actual behavior.

## Context

Investigated via the repo's own `review-security-k8s-agents-audit-logs` skill and Hermes' hooks documentation (https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks), which defines the `pre_tool_call`/`post_tool_call`/`pre_approval_request`/`post_approval_response` events used here.

## Testing

- `python3 -m py_compile` on the new plugin files passes.
- `npx prettier --check` passes on the touched YAML.
- Could not run `go build`/`go test` in this environment (no Go toolchain available) — please run `make test` in `k8s-operator/` to confirm the golden-file diff.

---

Draft PR — logging payload/format and log-sink choice (stdout vs. dedicated sink) are open for review before merge.