### PR TITLE
fix(platform): match k8s_cluster resource.type in audit_log_searcher

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -427,7 +427,7 @@ def audit_log_searcher(project_id: str = "", cluster_name: str = "", location: s
         return "ERROR: Could not resolve GCP Project ID. Please specify 'project_id'."
 
     filters = [
-        'resource.type="gke_cluster"',
+        '(resource.type="k8s_cluster" OR resource.type="gke_cluster")',
         'protoPayload.methodName:delete',
         '"deployments/bootstrap"'
     ]


### PR DESCRIPTION
Bootstrap deployment deletions are Kubernetes API server audit events, which Cloud Audit Logs record under `resource.type="k8s_cluster"`, not `resource.type="gke_cluster"` (the latter covers GKE cluster-manager lifecycle events like create/patch/delete of the cluster itself). The existing filter only matched `gke_cluster`, so genuine `deployments/bootstrap` deletions never surfaced and the tool always returned an empty result.

Widen the filter to accept either resource type. Parens wrap the OR group so the AND/OR precedence is right — otherwise the trailing `AND methodName:delete AND "deployments/bootstrap"` would only bind to the `gke_cluster` half and every `k8s_cluster` event would slip through.

## What Changed

  Fixes a filter bug in the audit_log_searcher MCP tool that made it return zero results for the case it was designed to catch (manual deployments/bootstrap deletion in a Config Controller cluster).

**Files:**

  - agents/platform/scripts/platform_mcp_server.py


## Testing

  Verified against a real cluster by running the equivalent gcloud logging read manually with the new filter:

  gcloud logging read \
    '(resource.type="k8s_cluster" OR resource.type="gke_cluster") AND protoPayload.methodName:delete AND "deployments/bootstrap" AND resource.labels.cluster_name="kcc-cluster" AND
  resource.labels.location="us-east4-a"' \
    --project=stalhaali-gkedemos --freshness=7d --limit=5 --format=json

  - [x] Returned the two expected deployments/bootstrap deletion events (one by a user principal, one by the platform GSA) with resource.type="k8s_cluster", confirming these events could not have matched the
  pre-fix filter.
  - [x] Confirmed that with the previous filter (resource.type="gke_cluster" only), the query returns no results for the same time window — reproducing the bug.
  - [x] Verified filter precedence by inspecting the constructed filter_expr — the parens keep the OR group scoped so the AND-joined methodName:delete and "deployments/bootstrap" constraints apply to both resource
  types.


<!-- Close with a short note on functional impact, risk, or rollout. -->
