### PR TITLE
fix(scripts): remove unsupported 'condition' flag from pubsub iam binding

### DIFF
--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -134,7 +134,6 @@ execute_pubsub_setup() {
       --member="serviceAccount:chat-api-push@system.gserviceaccount.com" \
       --role="roles/pubsub.publisher" \
       --project="${PROJECT_ID}" \
-      --condition=None \
       --quiet >/dev/null || return 1
 
   local gsuite_sa="service-${PROJECT_NUMBER}@gcp-sa-gsuiteaddons.iam.gserviceaccount.com"
@@ -142,7 +141,6 @@ execute_pubsub_setup() {
       --member="serviceAccount:${gsuite_sa}" \
       --role="roles/pubsub.publisher" \
       --project="${PROJECT_ID}" \
-      --condition=None \
       --quiet >/dev/null || return 1
 }
 


### PR DESCRIPTION
# Pull Request

## Why This Change

During script execution, step "3. Provision Pub/Sub Routing (Inbound)" fails because the standard `gcloud` release track does not support the `--condition` flag for the `gcloud pubsub topics add-iam-policy-binding` command. This caused an Unrecognized Arguments error, blocking the provisioning workflow for Google Chat integration. 

## What Changed

Removed the unsupported `--condition=None` flag from the `gcloud pubsub topics` commands. 

Since Google Cloud IAM bindings create unconditional roles by default, omitting this flag achieves the exact same result (an unconditional role binding) without strictly requiring the `alpha` release track of the `gcloud` CLI tool.

**Files:**

- `scripts/provision_04_gcp_gchat.sh`

**Added/Changed/Fixed:**

- Fixed the `gcloud pubsub topics add-iam-policy-binding` executions by removing the `--condition=None` argument to ensure compatibility with standard `gcloud` environments.

## Why This Matters

- Unblocks the automated GCP infrastructure provisioning workflow.

## Context

Other scripts currently using `--condition=None` for different GCP resources (like IAM service accounts and KMS keys) remain unchanged as those specific commands support the flag in standard tracks.

## Testing

- Ran the modified `provision_04_gcp_gchat.sh` script to verify that the `pubsub topics add-iam-policy-binding` command executes successfully. 

---

This is a low-risk change that introduces no functional changes to IAM permissions. It strictly resolves a CLI invocation syntax mismatch and aligns the script with standard `gcloud` capabilities.