### PR TITLE
fix(platform): drop hardcoded singleton name in get_cc_operator_status

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -305,7 +305,6 @@ def get_cc_operator_status(project_id: str = "", cluster_name: str = "", locatio
     """
     cmd = [
         "kubectl", "get", "configconnectors.core.cnrm.cloud.google.com",
-        "configconnector",
         "-o", "json"
     ]
 

--- a/agents/platform/scripts/test_platform_mcp_server.py
+++ b/agents/platform/scripts/test_platform_mcp_server.py
@@ -125,7 +125,6 @@ class TestCcDiagnosticTools(unittest.TestCase):
         mock_run.assert_called_once_with(
             [
                 "kubectl", "get", "configconnectors.core.cnrm.cloud.google.com",
-                "configconnector",
                 "-o", "json"
             ],
             capture_output=True, text=True, check=True, timeout=30, env={"KUBECONFIG": "/tmp/test.yaml"}


### PR DESCRIPTION
The kubectl call assumed the ConfigConnector operator singleton is named `configconnector`. On GKE Config Controller — the managed offering this tool actually targets, per its docstring and `krmapihosting-system` namespace scope — the singleton is installed by GKE's `gke_addon_poststart` hook under the fully-qualified name `configconnector.core.cnrm.cloud.google.com`.

Result: every call to this tool against a real Config Controller cluster
failed with `Error from server (NotFound): configconnectors.core.cnrm.cloud.google.com "configconnector" not found`.

Fix: query the CRD type without a specific resource name. kubectl returns a List wrapper; `_strip_kubectl_noise` already handles both List (via `obj.get("items", [obj])`) and single-object shapes, so no downstream changes are needed. This also stops us from hardcoding either variant of the singleton name — the tool now works against any Config Connector install regardless of what the operator chose to call its own CR.

## Testing

Verified against a live GKE Config Controller cluster (kcc-cluster in us-east4-a, project stalhaali-gkedemos) whose ConfigConnector singleton is installed by gke_addon_poststart under the fully-qualified name
  configconnector.core.cnrm.cloud.google.com.

  - [x] Reproduced the bug (pre-fix behavior):
  kubectl get configconnectors.core.cnrm.cloud.google.com configconnector -o json
  - Returns Error from server (NotFound): configconnectors.core.cnrm.cloud.google.com "configconnector" not found. This is the exact command the tool was constructing before the fix, confirming every call against a
  Config Controller cluster would have failed.
  - [x] Verified the fix works:
  kubectl get configconnectors.core.cnrm.cloud.google.com -o json | jq '.items | length'
  - Returns 1 (the singleton), regardless of what the operator chose to name it.
  - [x] Confirmed downstream handling is unchanged. _strip_kubectl_noise already covers both response shapes via obj.get("items", [obj]), so the switch from single-object to List output requires no downstream code
  changes. Ran the fixed tool end-to-end and got the same operator status payload (healthy: true, spec.mode: namespaced) that a name-scoped query would have returned on a cluster where the name matched.
  - [x] Confirmed the naming variance is real GCP behavior, not an environment anomaly. kubectl get ... -o yaml --show-managed-fields on the singleton shows the spec block was written by manager: 
  gke_addon_poststart — GKE's own managed addon install pipeline. No kubectl-* field manager, so this is standard Google-managed Config Controller behavior, not a hand-installed variant. The fix therefore closes
  the tool for the entire class of Config Controller clusters, not just this one.

<!-- Close with a short note on functional impact, risk, or rollout. -->
