### PR TITLE
test(e2e): add Google Chat Platform Agent E2E test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,10 @@ bin/
 .env.*
 !*.env.example
 k8s-operator/cover.out
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.venv/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -58,13 +58,16 @@ This directory contains the automated E2E test suite for verifying the **Hermes 
 ### 1. Service Account IAM Permissions (Google Chat & Specific Pub/Sub Topic)
 
 Any Service Account (or user identity) under which the E2E test script or CI/CD pipeline is executed must have the following least-privilege IAM permissions:
+
 1. **Pub/Sub Publishing (Topic-Specific)**: Role `roles/pubsub.publisher` bound directly on topic `platform-agent-chat-events`.
 2. **Google Chat API Access**: Role `roles/chat.admin` (or `roles/chat.import`) to post messages to Chat Spaces via API.
 
 > **Note**: A dedicated provisioning script will be added in a future PR to automatically create and configure this CI Service Account and its Workload Identity Federation bindings for GitHub Actions.
 
 ### 2. Google Chat Space Setup
+
 Before running tests, ensure your Google Chat Space is configured:
+
 1. **Create or select a Google Chat Space** (e.g. `$CHAT_SPACE_ID`).
 2. **Add the App**: Add your deployed Google Chat App to the target Space.
 3. **Add User Permissions**: For local test runs, ensure your user account (e.g. `@google.com`) is added as a member of the Space.
@@ -75,12 +78,16 @@ Before running tests, ensure your Google Chat Space is configured:
 ## 🛠️ Complete Step-by-Step Local Setup & Execution Guide
 
 ### Step 1: Install System Prerequisites
+
 Ensure the following tools are installed on your workstation:
+
 - **Google Cloud SDK (`gcloud` CLI)**: [Installation Guide](https://cloud.google.com/sdk/docs/install)
 - **Python 3.10+** and `pip`
 
 ### Step 2: Set Up Python Virtual Environment
+
 Navigate to the repository root directory and set up the virtual environment:
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
@@ -89,13 +96,16 @@ pip install -r tests/e2e/requirements.txt
 ```
 
 ### Step 3: Verify & Source SRE Environment Variables
+
 Source the environment variables script and set your target `CHAT_SPACE_ID`:
+
 ```bash
 source k8s-operator/scripts/vars.sh
 export CHAT_SPACE_ID="spaces/AAQAfrKMyng"
 ```
 
 Verify that key variables are set:
+
 ```bash
 echo "Project ID: $PROJECT_ID"
 echo "Project Number: $PROJECT_NUMBER"
@@ -103,6 +113,7 @@ echo "Chat Space ID: $CHAT_SPACE_ID"
 ```
 
 ### Step 4: Configure GCP Application Default Credentials (ADC)
+
 Set your active GCP quota project and authenticate your user credentials with required scopes:
 
 ```bash
@@ -114,7 +125,9 @@ gcloud auth application-default login --scopes="https://www.googleapis.com/auth/
 ```
 
 ### Step 5: Execute the E2E Test
+
 Run `pytest` to execute the end-to-end test suite:
+
 ```bash
 pytest tests/e2e/gchat_agent_test.py -v -s
 ```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,120 @@
+# Google Chat Agent End-to-End (E2E) Test Suite
+
+This directory contains the automated E2E test suite for verifying the **Hermes Platform Agent** integration with Google Chat.
+
+---
+
+## 📌 Architecture & Design Concept
+
+```
+┌─────────────────┐       1. Post Clean Prompt      ┌──────────────────────┐
+│  pytest runner  │────────────────────────────────>│ Google Chat Space API│
+└────────┬────────┘                                 └──────────┬───────────┘
+         │                                                     │
+         │ 2. Publish Chat Event w/ Thread ID                  │ 1b. Returns real
+         ▼                                                     │     Thread ID
+┌─────────────────────────────────┐                            │
+│ Pub/Sub Topic:                  │                            │
+│ platform-agent-chat-events      │                            │
+└────────┬────────────────────────┘                            │
+         │ 3. Pull Event                                       │
+         ▼                                                     │
+┌─────────────────────────────────┐                            │
+│  Hermes Agent (GKE Pod)         │                            │
+└────────┬────────────────────────┘                            │
+         │ 4. Execute Prompt & Post Reply                      │
+         └─────────────────────────────────────────────────────┼──────────────┐
+                                                               ▼              │
+                                                    ┌────────────────────┐    │
+                                                    │ Google Chat Space  │◄───┘
+                                                    └──────────┬─────────┘
+                                                               │ 5. Polls & asserts
+                                                               ▼    response "5"
+                                                    ┌────────────────────┐
+                                                    │  pytest runner     │
+                                                    └──────────┬─────────┘
+```
+
+### Why Hybrid Pub/Sub Triggering is Required (Google Chat API Limitation)
+
+1. **Google Chat API Event Suppression**:
+   Google Chat API strictly **does not generate Pub/Sub interaction events** for messages posted via the `spaces.messages.create` REST API. This behavior is designed by Google Cloud to prevent recursive looping where bots trigger themselves.
+
+2. **Mention Tagging Limitations in REST API**:
+   When posting via REST API using User OAuth credentials, `<users/ID>` tags do not run browser autocomplete. Google Chat replaces them with `@` anchors or strips them, which does not emit app notifications.
+
+3. **Our E2E Hybrid Solution**:
+   - **Step 1**: The test runner posts a clean prompt (`what is 2 + 3? [test_id: e2e-xxx]`) to the target Google Chat Space to establish a real Google Chat Space Thread ID (`spaces/{SPACE_ID}/threads/{THREAD_ID}`).
+   - **Step 2**: The test runner constructs a valid Google Chat event payload containing an authorized test runner identity (`e2e-runner@google.com`) and the real Thread ID, and publishes it directly to Pub/Sub topic `platform-agent-chat-events`.
+   - **Step 3**: The **Hermes Agent** running in GKE receives the event from Pub/Sub, validates sender authorization (`ALLOWED_USERS`), computes `"2 + 3 = 5"`, and posts the response into the real space thread.
+   - **Step 4**: The test runner polls the thread via Google Chat API and asserts the response contains `"5"`.
+
+---
+
+## ⚙️ Prerequisites & Infrastructure Setup
+
+> **IMPORTANT**: The test requires an active GCP project environment where the infrastructure has already been provisioned (e.g. via the main provisioning script `vars.sh` / `platform-agent.yaml`) and the Hermes Agent is running in GKE.
+
+### 1. Service Account IAM Permissions (Google Chat & Specific Pub/Sub Topic)
+
+Any Service Account (or user identity) under which the E2E test script or CI/CD pipeline is executed must have the following least-privilege IAM permissions:
+1. **Pub/Sub Publishing (Topic-Specific)**: Role `roles/pubsub.publisher` bound directly on topic `platform-agent-chat-events`.
+2. **Google Chat API Access**: Role `roles/chat.admin` (or `roles/chat.import`) to post messages to Chat Spaces via API.
+
+> **Note**: A dedicated provisioning script will be added in a future PR to automatically create and configure this CI Service Account and its Workload Identity Federation bindings for GitHub Actions.
+
+### 2. Google Chat Space Setup
+Before running tests, ensure your Google Chat Space is configured:
+1. **Create or select a Google Chat Space** (e.g. `$CHAT_SPACE_ID`).
+2. **Add the App**: Add your deployed Google Chat App to the target Space.
+3. **Add User Permissions**: For local test runs, ensure your user account (e.g. `@google.com`) is added as a member of the Space.
+4. **Configure `ALLOWED_USERS`**: Ensure the dedicated test identity (`e2e-runner`) or test user is listed under `allowedUsers` in `k8s-operator/scripts/platform-agent.yaml` / `vars.sh`.
+
+---
+
+## 🛠️ Complete Step-by-Step Local Setup & Execution Guide
+
+### Step 1: Install System Prerequisites
+Ensure the following tools are installed on your workstation:
+- **Google Cloud SDK (`gcloud` CLI)**: [Installation Guide](https://cloud.google.com/sdk/docs/install)
+- **Python 3.10+** and `pip`
+
+### Step 2: Set Up Python Virtual Environment
+Navigate to the repository root directory and set up the virtual environment:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r tests/e2e/requirements.txt
+```
+
+### Step 3: Verify & Source SRE Environment Variables
+Source the environment variables script and set your target `CHAT_SPACE_ID`:
+```bash
+source k8s-operator/scripts/vars.sh
+export CHAT_SPACE_ID="spaces/AAQAfrKMyng"
+```
+
+Verify that key variables are set:
+```bash
+echo "Project ID: $PROJECT_ID"
+echo "Project Number: $PROJECT_NUMBER"
+echo "Chat Space ID: $CHAT_SPACE_ID"
+```
+
+### Step 4: Configure GCP Application Default Credentials (ADC)
+Set your active GCP quota project and authenticate your user credentials with required scopes:
+
+```bash
+# Set Quota Project
+gcloud auth application-default set-quota-project "$PROJECT_ID"
+
+# Authenticate ADC with required Chat & Pub/Sub Scopes
+gcloud auth application-default login --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/chat.messages.create,https://www.googleapis.com/auth/chat.messages.readonly,https://www.googleapis.com/auth/chat.memberships.readonly,https://www.googleapis.com/auth/pubsub"
+```
+
+### Step 5: Execute the E2E Test
+Run `pytest` to execute the end-to-end test suite:
+```bash
+pytest tests/e2e/gchat_agent_test.py -v -s
+```

--- a/tests/e2e/gchat_agent_test.py
+++ b/tests/e2e/gchat_agent_test.py
@@ -37,7 +37,7 @@ CHAT_SPACE_ID: Optional[str] = os.environ.get("CHAT_SPACE_ID")
 CHAT_TOPIC_NAME: str = os.environ.get("CHAT_TOPIC_NAME", "platform-agent-chat-events")
 
 # Test Identity Resolution (Defaults to generic e2e-runner@google.com)
-USER_EMAIL_INPUT: str = os.environ.get("TEST_USER_EMAIL") or os.environ.get("ALLOWED_USERS", "e2e-runner@google.com")
+USER_EMAIL_INPUT: str = os.environ.get("TEST_USER_EMAIL") or os.environ.get("ALLOWED_USERS") or "e2e-runner@google.com"
 TEST_USER_EMAIL: str = USER_EMAIL_INPUT.split(",")[0].strip()
 if "@" not in TEST_USER_EMAIL:
     TEST_USER_EMAIL = f"{TEST_USER_EMAIL}@google.com"
@@ -173,7 +173,7 @@ def test_gchat_agent_math_response(chat_service: Resource, pubsub_service: Resou
         try:
             response: dict[str, Any] = chat_service.spaces().messages().list(
                 parent=CHAT_SPACE_ID,
-                pageSize=10,
+                pageSize=50,
                 orderBy="createTime desc"
             ).execute()
 
@@ -189,7 +189,7 @@ def test_gchat_agent_math_response(chat_service: Resource, pubsub_service: Resou
                 if "No home channel is set" in msg_text or "/sethome" in msg_text:
                     continue
 
-                if (msg_thread == thread_name or msg.get("createTime", "") > create_time) and re.search(r"\b5\b", msg_text):
+                if msg_thread == thread_name and re.search(r"\b5\b", msg_text):
                     received_response_text = msg_text
                     bot_response_found = True
                     print(f"\n[E2E Test SUCCESS] Received Bot Math Response: '{received_response_text}'")

--- a/tests/e2e/gchat_agent_test.py
+++ b/tests/e2e/gchat_agent_test.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Google Chat Agent E2E Test Suite.
+
+Sends a prompt message to a target Google Chat Space, triggers the Hermes Agent
+Pub/Sub event handler referencing the real space thread and authorized test identity,
+polls the Google Chat API for the agent's response, and asserts mathematical correctness.
+"""
+
+import base64
+
+import json
+
+import os
+
+import re
+
+import time
+
+from datetime import datetime, timezone
+
+from typing import Any, Optional
+
+import google.auth
+
+from google.auth.credentials import Credentials
+
+from googleapiclient.discovery import Resource, build
+
+from googleapiclient.errors import HttpError
+
+import pytest
+
+# Configuration from Environment Variables (read dynamically from vars.sh or CI environment)
+GCP_PROJECT_ID: Optional[str] = os.environ.get("GCP_PROJECT_ID") or os.environ.get("PROJECT_ID")
+CHAT_SPACE_ID: Optional[str] = os.environ.get("CHAT_SPACE_ID")
+CHAT_TOPIC_NAME: str = os.environ.get("CHAT_TOPIC_NAME", "platform-agent-chat-events")
+
+# Test Identity Resolution (Defaults to generic e2e-runner@google.com)
+USER_EMAIL_INPUT: str = os.environ.get("TEST_USER_EMAIL") or os.environ.get("ALLOWED_USERS", "e2e-runner@google.com")
+TEST_USER_EMAIL: str = USER_EMAIL_INPUT.split(",")[0].strip()
+if "@" not in TEST_USER_EMAIL:
+    TEST_USER_EMAIL = f"{TEST_USER_EMAIL}@google.com"
+
+TEST_USER_NAME: str = TEST_USER_EMAIL.split("@")[0]
+
+TEST_TIMEOUT_SEC: int = int(os.environ.get("TEST_TIMEOUT_SEC", "120"))
+POLL_INTERVAL_SEC: int = int(os.environ.get("POLL_INTERVAL_SEC", "5"))
+
+# Normalize CHAT_SPACE_ID format (e.g. AAQAfrKMyng -> spaces/AAQAfrKMyng)
+if CHAT_SPACE_ID and not CHAT_SPACE_ID.startswith("spaces/"):
+    CHAT_SPACE_ID = f"spaces/{CHAT_SPACE_ID}"
+
+SCOPES: list[str] = [
+    "https://www.googleapis.com/auth/chat.messages.create",
+    "https://www.googleapis.com/auth/chat.messages.readonly",
+    "https://www.googleapis.com/auth/chat.spaces.readonly",
+    "https://www.googleapis.com/auth/pubsub",
+    "https://www.googleapis.com/auth/cloud-platform",
+]
+
+
+@pytest.fixture(scope="module")
+def credentials() -> Credentials:
+    """Returns GCP credentials authenticated with required Chat and Pub/Sub scopes."""
+    creds, _ = google.auth.default(scopes=SCOPES)
+    return creds
+
+
+@pytest.fixture(scope="module")
+def chat_service(credentials: Credentials) -> Resource:
+    """Builds authenticated Google Chat API service for polling responses."""
+    if not CHAT_SPACE_ID:
+        pytest.fail(
+            "CHAT_SPACE_ID environment variable is required (e.g., spaces/AAQAfrKMyng)\n"
+            "Tip: SRE variables can be loaded by running 'source k8s-operator/scripts/vars.sh'"
+        )
+
+    return build("chat", "v1", credentials=credentials)
+
+
+@pytest.fixture(scope="module")
+def pubsub_service(credentials: Credentials) -> Resource:
+    """Builds authenticated Pub/Sub API service for triggering events."""
+    return build("pubsub", "v1", credentials=credentials)
+
+
+def test_gchat_agent_math_response(chat_service: Resource, pubsub_service: Resource) -> None:
+    """
+    End-to-End Test for Hermes Platform Agent:
+    1. Posts clean prompt message to Google Chat Space (creating a real space thread).
+    2. Triggers agent via Pub/Sub event referencing the real space thread and authorized test identity.
+    3. Polls space thread for agent response and asserts answer contains '5'.
+    """
+    if not GCP_PROJECT_ID:
+        pytest.fail("PROJECT_ID environment variable is required.")
+
+    timestamp_str: str = datetime.now(timezone.utc).strftime("%H:%M:%S UTC")
+    prompt_body: str = f"[E2E Test Started at {timestamp_str}] what is 2 + 3?"
+
+    print(f"\n[E2E Test] Target GCP Project: {GCP_PROJECT_ID}")
+    print(f"[E2E Test] Target Space: {CHAT_SPACE_ID}")
+    print(f"[E2E Test] Pub/Sub Topic: {CHAT_TOPIC_NAME}")
+    print(f"[E2E Test] Test Identity: {TEST_USER_EMAIL}")
+    print(f"[E2E Test] Chat UI Prompt: '{prompt_body}'")
+
+    # Step 1: Post clean prompt message to create real Google Chat space thread
+    try:
+        sent_message: dict[str, Any] = chat_service.spaces().messages().create(
+            parent=CHAT_SPACE_ID,
+            body={"text": prompt_body}
+        ).execute()
+    except HttpError as err:
+        pytest.fail(f"Failed to post message to Google Chat space: {err}")
+
+    message_name: str = sent_message.get("name", "")
+    thread_name: str = sent_message.get("thread", {}).get("name", "")
+    create_time: str = sent_message.get("createTime", "")
+    print(f"[E2E Test] Created Space Message: {message_name}")
+    print(f"[E2E Test] Created Space Thread: {thread_name}")
+
+    # Step 2: Publish MESSAGE Event to Pub/Sub referencing real thread & E2E test identity
+    topic_path: str = f"projects/{GCP_PROJECT_ID}/topics/{CHAT_TOPIC_NAME}"
+
+    chat_event_payload: dict[str, Any] = {
+        "type": "MESSAGE",
+        "eventTime": create_time,
+        "space": {
+            "name": CHAT_SPACE_ID,
+            "type": "SPACE"
+        },
+        "message": {
+            "name": message_name,
+            "text": prompt_body,
+            "argumentText": f" {prompt_body}",
+            "thread": {
+                "name": thread_name
+            },
+            "sender": {
+                "name": f"users/{TEST_USER_NAME}",
+                "displayName": TEST_USER_NAME,
+                "email": TEST_USER_EMAIL,
+                "type": "HUMAN"
+            }
+        }
+    }
+
+    encoded_data: str = base64.b64encode(json.dumps(chat_event_payload).encode("utf-8")).decode("utf-8")
+    pubsub_body: dict[str, Any] = {"messages": [{"data": encoded_data}]}
+
+    try:
+        pub_response: dict[str, Any] = pubsub_service.projects().topics().publish(
+            topic=topic_path,
+            body=pubsub_body
+        ).execute()
+        message_ids: list[str] = pub_response.get("messageIds", [])
+        print(f"[E2E Test] Triggered Agent via Pub/Sub (Message ID: {message_ids})")
+    except HttpError as err:
+        pytest.fail(f"Failed to publish event to Pub/Sub topic {CHAT_TOPIC_NAME}: {err}")
+
+    print(f"[E2E Test] Waiting for agent processing and response in thread {thread_name}...")
+
+    # Step 3: Poll space thread for agent's response
+    start_time: float = time.time()
+    bot_response_found: bool = False
+    received_response_text: str = ""
+
+    while time.time() - start_time < TEST_TIMEOUT_SEC:
+        time.sleep(POLL_INTERVAL_SEC)
+        elapsed: int = int(time.time() - start_time)
+        print(f"[E2E Test] Polling thread for bot response... ({elapsed}s / {TEST_TIMEOUT_SEC}s)")
+
+        try:
+            response: dict[str, Any] = chat_service.spaces().messages().list(
+                parent=CHAT_SPACE_ID,
+                pageSize=10,
+                orderBy="createTime desc"
+            ).execute()
+
+            for msg in response.get("messages", []):
+                # Only check messages posted by a BOT
+                if msg.get("sender", {}).get("type") != "BOT":
+                    continue
+
+                msg_thread: str = msg.get("thread", {}).get("name", "")
+                msg_text: str = msg.get("text", "")
+
+                # Ignore system setup notifications
+                if "No home channel is set" in msg_text or "/sethome" in msg_text:
+                    continue
+
+                if (msg_thread == thread_name or msg.get("createTime", "") > create_time) and re.search(r"\b5\b", msg_text):
+                    received_response_text = msg_text
+                    bot_response_found = True
+                    print(f"\n[E2E Test SUCCESS] Received Bot Math Response: '{received_response_text}'")
+                    break
+
+        except HttpError as err:
+            print(f"[E2E Test Warning] Polling error: {err}")
+
+        if bot_response_found:
+            break
+
+    # Step 4: Assertions
+    assert bot_response_found, f"Timed out after {TEST_TIMEOUT_SEC}s waiting for agent response in {CHAT_SPACE_ID}"
+    assert re.search(r"\b5\b", received_response_text), (
+        f"Expected response to contain '5', but got: '{received_response_text}'"
+    )
+    print("[E2E Test SUCCESS] Agent responded correctly with '5'.")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,4 @@
+pytest>=8.0.0
+google-api-python-client>=2.110.0
+google-auth>=2.25.0
+google-auth-httplib2>=0.2.0


### PR DESCRIPTION
# Pull Request

## Why This Change

It's the first change in the scope of making the env stable - later this test will be added to the CI/CD as part of the validation steps.

Adds an automated end-to-end (E2E) test suite for validating **Hermes Platform Agent** Google Chat integration. It enables local execution and verification of agent prompt handling via the Google Chat API and GCP Pub/Sub, ensuring functional correctness without requiring manual UI testing.

## What Changed

**Files:**
- `tests/e2e/gchat_agent_test.py`
- `tests/e2e/requirements.txt`
- `tests/e2e/README.md`
- `.gitignore`

**Added/Changed/Fixed:**

- **Added Automated E2E Test Suite (`tests/e2e/gchat_agent_test.py`)**: Implemented a `pytest` test that creates space threads via Google Chat API, triggers the agent via Pub/Sub event payloads, polls for responses, and asserts mathematical accuracy (`"2 + 3 = 5"`).
- **Generalized Environment Configuration**: variables are taken from environment variables (`vars.sh`) which can be potentially changed to CI/CD env.
- **Added E2E Documentation (`tests/e2e/README.md`)**: Wrote technical English documentation detailing hybrid Pub/Sub architecture, least-privilege IAM requirements, ADC setup, and step-by-step local execution instructions.
- **Updated `.gitignore`**: Added Python cache patterns (`__pycache__/`, `.pytest_cache/`, `.venv/`) to exclude local test artifacts.

## Why This Matters

- Enables rapid, automated local validation of agent responsiveness in Google Chat.
- Eliminates manual testing overhead for verifying LLM math and agent prompt handling.
- Provides a clean, modular foundation for future CI/CD pipeline integration.

## Context

- Relates to Platform Agent Google Chat integration testing.
- Workload Identity Federation (WIF) and dedicated CI Service Account provisioning for GitHub Actions will be introduced in an upcoming PR.

## Testing

- Executed local test suite using `pytest tests/e2e/gchat_agent_test.py -v -s` with own gcp project
- Confirmed test passes reliably (duration around 30 - 70 sec).
- Results: [CLI screen](https://screenshot.googleplex.com/8F4YAtn4L5T5SSH), [Chat screen](https://screenshot.googleplex.com/7qo37tStdKrGGMj)
