### PR TITLE
chore(litellm): upgrade litellm image to v1.92.0

### DIFF
--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.88.2
+          image: ghcr.io/berriai/litellm:v1.92.0
           args: ["--config", "/app/config.yaml"]
           env:
             - name: CHATGPT_TOKEN_DIR

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.88.2
+          image: ghcr.io/berriai/litellm:v1.92.0
           args: ["--config", "/app/config.yaml"]
           env:
             - name: GEMINI_API_KEY

--- a/k8s-operator/config/integrations/litellm/base/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.88.2
+          image: ghcr.io/berriai/litellm:v1.92.0
           args: ["--config", "/app/config.yaml"]
           resources:
             requests:

--- a/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
+++ b/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
@@ -145,7 +145,7 @@ litellmGateway:
   replicaCount: 1
   image:
     repository: "ghcr.io/berriai/litellm"
-    tag: "v1.86.0"
+    tag: "v1.92.0"
   modelProvider: "gemini"
   modelName: "gemini-3.5-flash"
   useDummySecret: true


### PR DESCRIPTION
# Pull Request

## Why This Change

The user requested to update all litellm image references in the repo to v1.92.0, including examples.

## What Changed

Updated litellm image tags in Kustomize base deployment, Helm workload-bundle values, and example deployments.

**Files:**

- `k8s-operator/config/integrations/litellm/base/deployment.yaml`
- `k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml`
- `examples/litellm-chatgpt-subscription/deployment.yaml`
- `examples/litellm-gemini/deployment.yaml`

**Added/Changed/Fixed:**

- Updated `ghcr.io/berriai/litellm` image tag from `v1.88.2` to `v1.92.0` in `k8s-operator/config/integrations/litellm/base/deployment.yaml`
- Updated `ghcr.io/berriai/litellm` image tag from `v1.86.0` to `v1.92.0` in `k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml`
- Updated `ghcr.io/berriai/litellm` image tag from `v1.88.2` to `v1.92.0` in `examples/litellm-chatgpt-subscription/deployment.yaml`
- Updated `ghcr.io/berriai/litellm` image tag from `v1.88.2` to `v1.92.0` in `examples/litellm-gemini/deployment.yaml`

## Why This Matters

Keeps the litellm component and examples up to date with the requested version.

## Context

Requested by user.

## Testing

Ran `make -C k8s-operator build` to ensure the operator still builds.
Checked formatting with prettier.

---

TAG=agy
CONV=138a4914-1da4-4c12-a73e-372b7268e6dd
