### PR TITLE
feat(platform): enable GKE One MCP server

### DIFF
--- a/agents/platform/config.yaml
+++ b/agents/platform/config.yaml
@@ -14,6 +14,11 @@ mcp_servers:
       GOOGLE_CHAT_PROJECT_ID: "${GOOGLE_CHAT_PROJECT_ID}"
       GOOGLE_CHAT_SUBSCRIPTION_NAME: "${GOOGLE_CHAT_SUBSCRIPTION_NAME}"
       API_SERVER_KEY: "${API_SERVER_KEY}"
+  gke:
+    command: "node"
+    args:
+      - "/opt/mcp-remote/dist/proxy.js"
+      - "https://container.googleapis.com/mcp"
 
 # Explicitly list platform_toolsets
 # platform_toolsets is a reserved framework key in Hermes.

--- a/agents/platform/config.yaml
+++ b/agents/platform/config.yaml
@@ -23,11 +23,13 @@ platform_toolsets:
     - mcp-agent_common
     - mcp-platform_control
     - mcp-developer_knowledge
+    - mcp-gke
   api_server:
     - hermes-api-server
     - mcp-agent_common
     - mcp-platform_control
     - mcp-developer_knowledge
+    - mcp-gke
 
 memory:
   memory_enabled: false

--- a/deploy/shared/defaults/config.yaml
+++ b/deploy/shared/defaults/config.yaml
@@ -16,6 +16,11 @@ mcp_servers:
     args:
       - "/opt/mcp-remote/dist/proxy.js"
       - "https://developerknowledge.googleapis.com/mcp"
+  gke:
+    command: "node"
+    args:
+      - "/opt/mcp-remote/dist/proxy.js"
+      - "https://container.googleapis.com/mcp"
 
 # Explicitly list platform_toolsets to bypass the upstream Hermes CLI/API loader prefix mapping bug.
 # platform_toolsets is a reserved framework key in Hermes. Other reserved top-level keys
@@ -28,10 +33,12 @@ platform_toolsets:
     - hermes-cli
     - mcp-agent_common
     - mcp-developer_knowledge
+    - mcp-gke
   api_server:
     - hermes-api-server
     - mcp-agent_common
     - mcp-developer_knowledge
+    - mcp-gke
 
 # Approval settings. Allow dangerous commands to execute autonomously in cron watchdogs.
 approvals:

--- a/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
+++ b/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
@@ -3624,16 +3624,16 @@ spec:
                         PodAnnotations specifies custom annotations to apply
                         to the generated Pod template.
                       type: object
-                    scaleToZero:
-                      description:
-                        ScaleToZero scales the deployment replicas to 0 when
-                        true (useful for saving costs during idle periods).
-                      type: boolean
                     runtimeClassName:
                       description:
                         RuntimeClassName specifies the Pod runtime class
                         (e.g. "gvisor").
                       type: string
+                    scaleToZero:
+                      description:
+                        ScaleToZero scales the deployment replicas to 0 when
+                        true (useful for saving costs during idle periods).
+                      type: boolean
                     sidecarVolumes:
                       description:
                         SidecarVolumes specifies custom volumes to mount

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -161,10 +161,14 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 			"command": "node",
 			"args":    []string{"/opt/mcp-remote/dist/proxy.js", "https://developerknowledge.googleapis.com/mcp"},
 		},
+		"gke": map[string]any{
+			"command": "node",
+			"args":    []string{"/opt/mcp-remote/dist/proxy.js", "https://container.googleapis.com/mcp"},
+		},
 	}
 	cfg.PlatformToolsets = map[string][]string{
-		"cli":        {"hermes-cli", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge"},
-		"api_server": {"hermes-api-server", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge"},
+		"cli":        {"hermes-cli", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge", "mcp-gke"},
+		"api_server": {"hermes-api-server", "mcp-agent_common", "mcp-platform_control", "mcp-developer_knowledge", "mcp-gke"},
 	}
 
 	// Execution & Display UX configuration

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -941,3 +941,4 @@ func TestGetConfigMapHash(t *testing.T) {
 		t.Errorf("expected different hashes for different configmap data")
 	}
 }
+

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -941,4 +941,3 @@ func TestGetConfigMapHash(t *testing.T) {
 		t.Errorf("expected different hashes for different configmap data")
 	}
 }
-

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - pods
-      - namespaces
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -72,15 +72,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -93,15 +93,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -181,6 +181,7 @@ data:
       - hermes_otel
       - session_store
       - session_otel_bridge
+      - tool_call_audit
     terminal:
       backend: local
       cwd: /opt/data
@@ -192,12 +193,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -249,12 +250,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -267,12 +268,12 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -283,12 +284,12 @@ metadata:
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   replicas: 1
   selector:
@@ -299,7 +300,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 450b25f87ba8404d8c6a1aec372382a3f996e1900bcace17238fec15017cdc59
+        kubeagents.x-k8s.io/config-hash: 268343ffef4f80b81b57e301ed60eff3d7f738da032b97d0644d60b15d88d3ad
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null
@@ -307,108 +308,108 @@ spec:
         app: platformagent-gateway
     spec:
       containers:
-        - env:
-            - name: PLATFORM_AGENT_HOME
-              value: /opt/data
-            - name: HOME
-              value: /opt/data/home
-            - name: PLATFORM_AGENT_DASHBOARD
-              value: "1"
-            - name: PLATFORM_AGENT_PLUGINS_DEBUG
-              value: "0"
-            - name: OTEL_SERVICE_NAME
-              value: platformagent-gateway
-            - name: API_SERVER_ENABLED
-              value: "true"
-            - name: API_SERVER_HOST
-              value: 0.0.0.0
-            - name: SESSION_KV_DB_PATH
-              value: /var/lib/kube-agents/session/session_kv.db
-            - name: GKE_CLUSTER_NAME
-              value: cluster-a
-            - name: GKE_LOCATION
-              value: us-central1-a
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
-            - name: GOOGLE_CHAT_PROJECT_ID
-              value: kube-agents-gkedemos
-            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-            - name: GOOGLE_CHAT_ALLOWED_USERS
-            - name: GOOGLE_CHAT_HOME_CHANNEL
-            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-              value: "true"
-            - name: TOKEN_BROKER_URL
-              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: platform-agent
-          ports:
-            - containerPort: 9119
-              name: dashboard
-            - containerPort: 8642
-              name: api
-          resources:
-            limits:
-              cpu: "2"
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 2Gi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-            - mountPath: /opt/data/config.yaml
-              name: platform-agent-config-vol
-              subPath: config.yaml
-            - mountPath: /opt/data/SETTINGS.md
-              name: settings-volume
-              readOnly: true
-              subPath: SETTINGS.md
-            - mountPath: /var/lib/kube-agents/session
-              name: system-metadata
-              subPath: session
-        - args:
-            - -c
-            - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
-          name: fluent-bit
-          resources:
-            limits:
-              cpu: 500m
-              ephemeral-storage: 1Gi
-              memory: 256Mi
-            requests:
-              cpu: 100m
-              ephemeral-storage: 1Gi
-              memory: 128Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-              readOnly: true
-            - mountPath: /fluent-bit/etc/fluent-bit.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: fluent-bit.conf
-            - mountPath: /fluent-bit/etc/parsers.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: parsers.conf
-            - mountPath: /fluent-bit/state
-              name: fluent-bit-state
+      - env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_DASHBOARD
+          value: "1"
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: OTEL_SERVICE_NAME
+          value: platformagent-gateway
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: API_SERVER_HOST
+          value: 0.0.0.0
+        - name: SESSION_KV_DB_PATH
+          value: /var/lib/kube-agents/session/session_kv.db
+        - name: GKE_CLUSTER_NAME
+          value: cluster-a
+        - name: GKE_LOCATION
+          value: us-central1-a
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-key
+              name: platformagent-secrets
+        - name: GOOGLE_CHAT_PROJECT_ID
+          value: kube-agents-gkedemos
+        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+        - name: GOOGLE_CHAT_ALLOWED_USERS
+        - name: GOOGLE_CHAT_HOME_CHANNEL
+        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+          value: "true"
+        - name: TOKEN_BROKER_URL
+          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: platform-agent-config-vol
+          subPath: config.yaml
+        - mountPath: /opt/data/SETTINGS.md
+          name: settings-volume
+          readOnly: true
+          subPath: SETTINGS.md
+        - mountPath: /var/lib/kube-agents/session
+          name: system-metadata
+          subPath: session
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/etc/parsers.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: parsers.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -417,26 +418,26 @@ spec:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
       volumes:
-        - name: platform-agent-data-vol
-          persistentVolumeClaim:
-            claimName: platformagent-data
-        - configMap:
-            defaultMode: 493
-            name: platformagent-config
-          name: platform-agent-config-vol
-        - configMap:
-            defaultMode: 420
-            name: platformagent-fluent-bit-config
-          name: fluent-bit-config
-        - emptyDir: {}
-          name: fluent-bit-state
-        - name: system-metadata
-          persistentVolumeClaim:
-            claimName: system-metadata
-        - configMap:
-            defaultMode: 420
-            name: platformagent-settings
-          name: settings-volume
+      - name: platform-agent-data-vol
+        persistentVolumeClaim:
+          claimName: platformagent-data
+      - configMap:
+          defaultMode: 493
+          name: platformagent-config
+        name: platform-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: platformagent-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+      - name: system-metadata
+        persistentVolumeClaim:
+          claimName: system-metadata
+      - configMap:
+          defaultMode: 420
+          name: platformagent-settings
+        name: settings-volume
 status: {}
 ---
 apiVersion: v1
@@ -446,20 +447,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   ports:
-    - name: api
-      port: 8642
-      targetPort: api
-    - name: dashboard
-      port: 9119
-      targetPort: dashboard
+  - name: api
+    port: 8642
+    targetPort: api
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - pods
-  - namespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -72,15 +72,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -93,15 +93,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -193,12 +193,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -250,12 +250,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -268,12 +268,12 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -284,12 +284,12 @@ metadata:
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   replicas: 1
   selector:
@@ -308,108 +308,108 @@ spec:
         app: platformagent-gateway
     spec:
       containers:
-      - env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: PLATFORM_AGENT_DASHBOARD
-          value: "1"
-        - name: PLATFORM_AGENT_PLUGINS_DEBUG
-          value: "0"
-        - name: OTEL_SERVICE_NAME
-          value: platformagent-gateway
-        - name: API_SERVER_ENABLED
-          value: "true"
-        - name: API_SERVER_HOST
-          value: 0.0.0.0
-        - name: SESSION_KV_DB_PATH
-          value: /var/lib/kube-agents/session/session_kv.db
-        - name: GKE_CLUSTER_NAME
-          value: cluster-a
-        - name: GKE_LOCATION
-          value: us-central1-a
-        - name: API_SERVER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: api-key
-              name: platformagent-secrets
-        - name: GOOGLE_CHAT_PROJECT_ID
-          value: kube-agents-gkedemos
-        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-        - name: GOOGLE_CHAT_ALLOWED_USERS
-        - name: GOOGLE_CHAT_HOME_CHANNEL
-        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-          value: "true"
-        - name: TOKEN_BROKER_URL
-          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: platform-agent
-        ports:
-        - containerPort: 9119
-          name: dashboard
-        - containerPort: 8642
-          name: api
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 2Gi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-        - mountPath: /opt/data/config.yaml
-          name: platform-agent-config-vol
-          subPath: config.yaml
-        - mountPath: /opt/data/SETTINGS.md
-          name: settings-volume
-          readOnly: true
-          subPath: SETTINGS.md
-        - mountPath: /var/lib/kube-agents/session
-          name: system-metadata
-          subPath: session
-      - args:
-        - -c
-        - /fluent-bit/etc/fluent-bit.conf
-        image: fluent/fluent-bit:5.0.7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 500m
-            ephemeral-storage: 1Gi
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 1Gi
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-          readOnly: true
-        - mountPath: /fluent-bit/etc/fluent-bit.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: fluent-bit.conf
-        - mountPath: /fluent-bit/etc/parsers.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: parsers.conf
-        - mountPath: /fluent-bit/state
-          name: fluent-bit-state
+        - env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_DASHBOARD
+              value: "1"
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: OTEL_SERVICE_NAME
+              value: platformagent-gateway
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+            - name: GKE_CLUSTER_NAME
+              value: cluster-a
+            - name: GKE_LOCATION
+              value: us-central1-a
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: GOOGLE_CHAT_ALLOWED_USERS
+            - name: GOOGLE_CHAT_HOME_CHANNEL
+            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+              value: "true"
+            - name: TOKEN_BROKER_URL
+              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: platform-agent
+          ports:
+            - containerPort: 9119
+              name: dashboard
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: platform-agent-config-vol
+              subPath: config.yaml
+            - mountPath: /opt/data/SETTINGS.md
+              name: settings-volume
+              readOnly: true
+              subPath: SETTINGS.md
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -418,26 +418,26 @@ spec:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
       volumes:
-      - name: platform-agent-data-vol
-        persistentVolumeClaim:
-          claimName: platformagent-data
-      - configMap:
-          defaultMode: 493
-          name: platformagent-config
-        name: platform-agent-config-vol
-      - configMap:
-          defaultMode: 420
-          name: platformagent-fluent-bit-config
-        name: fluent-bit-config
-      - emptyDir: {}
-        name: fluent-bit-state
-      - name: system-metadata
-        persistentVolumeClaim:
-          claimName: system-metadata
-      - configMap:
-          defaultMode: 420
-          name: platformagent-settings
-        name: settings-volume
+        - name: platform-agent-data-vol
+          persistentVolumeClaim:
+            claimName: platformagent-data
+        - configMap:
+            defaultMode: 493
+            name: platformagent-config
+          name: platform-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: platformagent-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
+        - name: system-metadata
+          persistentVolumeClaim:
+            claimName: system-metadata
+        - configMap:
+            defaultMode: 420
+            name: platformagent-settings
+          name: settings-volume
 status: {}
 ---
 apiVersion: v1
@@ -447,20 +447,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   ports:
-  - name: api
-    port: 8642
-    targetPort: api
-  - name: dashboard
-    port: 9119
-    targetPort: dashboard
+    - name: api
+      port: 8642
+      targetPort: api
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -130,6 +130,11 @@ data:
         - /opt/mcp-remote/dist/proxy.js
         - https://developerknowledge.googleapis.com/mcp
         command: node
+      gke:
+        args:
+        - /opt/mcp-remote/dist/proxy.js
+        - https://container.googleapis.com/mcp
+        command: node
       platform_control:
         args:
         - /opt/data/scripts/platform_mcp_server.py
@@ -159,11 +164,13 @@ data:
       - mcp-agent_common
       - mcp-platform_control
       - mcp-developer_knowledge
+      - mcp-gke
       cli:
       - hermes-cli
       - mcp-agent_common
       - mcp-platform_control
       - mcp-developer_knowledge
+      - mcp-gke
     platforms:
       google_chat:
         enabled: true
@@ -174,7 +181,6 @@ data:
       - hermes_otel
       - session_store
       - session_otel_bridge
-      - tool_call_audit
     terminal:
       backend: local
       cwd: /opt/data
@@ -293,7 +299,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 58cf47f298a952545a633dfbf1a6bfe4d52a28194cc11ce9dd723852ff254014
+        kubeagents.x-k8s.io/config-hash: 450b25f87ba8404d8c6a1aec372382a3f996e1900bcace17238fec15017cdc59
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -148,6 +148,7 @@ get_platform_agent_roles() {
     "roles/logging.viewer"
     "roles/iam.serviceAccountUser"
     "roles/iam.securityReviewer"
+    "roles/mcp.toolUser"
   )
   local gke_admin_roles=(
     "roles/container.clusterAdmin"
@@ -156,6 +157,7 @@ get_platform_agent_roles() {
     "roles/logging.admin"
     "roles/iam.serviceAccountUser"
     "roles/iam.securityReviewer"
+    "roles/mcp.toolUser"
   )
 
   case "${PLATFORM_AGENT_PERMISSION_SET:-gke-admin}" in

--- a/k8s-operator/scripts/teardown_03_gcp_iam.sh
+++ b/k8s-operator/scripts/teardown_03_gcp_iam.sh
@@ -92,6 +92,7 @@ platform_roles=(
     "roles/iam.serviceAccountUser"
     "roles/iam.securityReviewer"
     "roles/aiplatform.user"
+    "roles/mcp.toolUser"
 )
 if [ -n "${PLATFORM_AGENT_CUSTOM_ROLES:-}" ]; then
   custom_roles_str=""


### PR DESCRIPTION
# Pull Request

## Why This Change

We want to enable GKE One MCP (the hosted Model Context Protocol server on GKE) for Kubeagents. This allows the Platform Agent to interact with and manage Google Kubernetes Engine (GKE) clusters using the standardized MCP protocol instead of relying on parsing `kubectl` and `gcloud` CLI commands.

## What Changed

Added the `gke` MCP server definition pointing to `https://container.googleapis.com/mcp` bridged via `mcp-remote` proxy. Enabled `mcp-gke` toolset inside `platform_toolsets` configurations.

**Files:**

- `agents/platform/config.yaml`: Added `mcp-gke` to `platform_toolsets` for the local configuration.
- `deploy/shared/defaults/config.yaml`: Added `gke` to `mcp_servers` and `mcp-gke` to `platform_toolsets` for the base configuration.
- `k8s-operator/internal/controller/platformagent_manifests.go`: Added `gke` server definition and `mcp-gke` toolset to dynamically generated config.yaml in PlatformAgent manifests.
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`: Updated the golden tests expected configuration.
- `k8s-operator/scripts/provision_03_gcp_iam.sh`: Added `roles/mcp.toolUser` IAM role to the Platform Agent GCP service account to authorize GKE MCP tool calls.

**Added/Changed/Fixed:**

- Added `gke` MCP server and `mcp-gke` toolset globally.
- Configured necessary IAM permissions for GKE MCP authorization.

## Why This Matters

This transitions the Platform Agent towards GKE APIs and structured MCP tools, allowing cleaner, more secure, and robust interactions with Kubernetes.

## Context

None.

## Testing

1. Ran `make test` inside `k8s-operator/`, and all tests passed (including the updated golden files).
2. Deployed the updated operator and platform agent. Verified GKE MCP tools were discovered and registered successfully (44 tools registered from 4 servers).
3. Executed a test query to list clusters, and verified that the agent natively calls the GKE MCP tool `mcp_gke_list_clusters` instead of falling back to running `gcloud` commands via `execute_code`.

Trajectory:
```json
[
  {
    "name": "mcp_gke_list_clusters",
    "args": {
      "parent": "projects/jayantid-gkedemos/locations/us-central1"
    },
    "result": null,
    "status": "called"
  }
]
```
