### PR TITLE
feat(skills): add Day 0, 1, and 2 GKE obtainability skills with stock…

### DIFF
--- a/agents/platform/skills/gke-obtainability-day0/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day0/SKILL.md
@@ -10,6 +10,7 @@ This skill guides you through designing high-obtainability Google Kubernetes Eng
 ## Core Design Principles
 
 ### 1. Multi-Zonal Placement & Targeting
+
 Never restrict workloads or `ComputeClass` specifications to a single zone unless strict data residency or physical hardware constraints mandate it. Single-zone placement creates a single point of failure for capacity obtainability.
 
 - **Rule:** Always list multiple zones within the target region when defining `location.zones` in a `ComputeClass`.
@@ -23,6 +24,7 @@ Never restrict workloads or `ComputeClass` specifications to a single zone unles
   ```
 
 ### 2. Multi-Tiered ComputeClass Priorities (Spot with On-Demand Fallback)
+
 When utilizing Spot VMs (`spot: true`) for cost optimization, always define a secondary priority level targeting standard On-Demand VMs (`spot: false`) within the same or alternative machine families.
 
 - **Rule:** Priority 1 requests Spot capacity; Priority 2 provides the On-Demand safety net.
@@ -45,6 +47,7 @@ When utilizing Spot VMs (`spot: true`) for cost optimization, always define a se
   ```
 
 ### 3. Active Migration for Cost Recovery
+
 When workloads fall back to On-Demand VMs during a Spot stockout, enable active migration so GKE automatically returns the pods to Spot instances as soon as capacity recovers.
 
 - **Rule:** Set `spec.activeMigration.optimizeRulePriority: true` in your `ComputeClass`.
@@ -56,6 +59,7 @@ When workloads fall back to On-Demand VMs during a Spot stockout, enable active 
   ```
 
 ### 4. Guaranteed Capacity with Reservation Affinity
+
 For mission-critical workloads or specialized hardware (such as `nvidia-l4`, `nvidia-h100`, or Cloud TPUs), design manifests to explicitly consume pre-purchased Google Cloud Capacity Reservations or Future Reservations (DASP).
 
 - **Rule:** Configure `reservationAffinity` in the `ComputeClass` priorities or node configuration.
@@ -74,6 +78,7 @@ For mission-critical workloads or specialized hardware (such as `nvidia-l4`, `nv
   ```
 
 ### 5. Anti-Rigidity & Scheduling Boundaries
+
 Avoid hardcoded pod `nodeSelector` definitions that lock workloads to specific hostnames or rigid zonal labels (`kubernetes.io/hostname` or a single `topology.kubernetes.io/zone`).
 
 - **Rule:** Use `ComputeClass` tolerations and selectors (`cloud.google.com/compute-class: "<class-name>"`) alongside `HorizontalPodAutoscaler` (HPA) specifications for all deployments exceeding 3 replicas.
@@ -121,6 +126,7 @@ spec:
 ```
 
 ## Checklist Before Day 1 Hand-Off
+
 1. [ ] Does the `ComputeClass` list at least 2 or 3 availability zones?
 2. [ ] Is every `spot: true` rule paired with a `spot: false` fallback (or an alternative machine family)?
 3. [ ] Is `activeMigration.optimizeRulePriority: true` enabled?

--- a/agents/platform/skills/gke-obtainability-day0/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day0/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: gke-obtainability-day0
+description: Guidance and design workflows for proactively architecting GKE workloads and compute configurations for capacity obtainability before deployment (Day 0). Use when designing ComputeClasses, node selection strategies, Spot fallback rules, and capacity reservations to prevent stockouts.
+---
+
+# GKE Obtainability: Day 0 (Proactive Architecture & Design)
+
+This skill guides you through designing high-obtainability Google Kubernetes Engine (GKE) workloads and infrastructure specifications before deployment. Proactive Day 0 architecture ensures workloads can reliably acquire physical compute resources (CPUs, Memory, GPUs, TPUs, and Spot VMs) across Google Cloud zones without encountering `FailedScheduling` bottlenecks or `ZONE_RESOURCE_POOL_EXHAUSTED` stockouts.
+
+## Core Design Principles
+
+### 1. Multi-Zonal Placement & Targeting
+Never restrict workloads or `ComputeClass` specifications to a single zone unless strict data residency or physical hardware constraints mandate it. Single-zone placement creates a single point of failure for capacity obtainability.
+
+- **Rule:** Always list multiple zones within the target region when defining `location.zones` in a `ComputeClass`.
+- **Example:**
+  ```yaml
+  location:
+    zones:
+      - us-central1-a
+      - us-central1-b
+      - us-central1-c
+  ```
+
+### 2. Multi-Tiered ComputeClass Priorities (Spot with On-Demand Fallback)
+When utilizing Spot VMs (`spot: true`) for cost optimization, always define a secondary priority level targeting standard On-Demand VMs (`spot: false`) within the same or alternative machine families.
+
+- **Rule:** Priority 1 requests Spot capacity; Priority 2 provides the On-Demand safety net.
+- **Example:**
+  ```yaml
+  apiVersion: cloud.google.com/v1
+  kind: ComputeClass
+  metadata:
+    name: spot-obtainable-pool
+  spec:
+    nodePoolAutoCreation:
+      enabled: true
+    priorities:
+      # Priority 1: High-priority Spot VM request
+      - machineFamily: n4
+        spot: true
+      # Priority 2: Automatic On-Demand fallback if Spot is stocked out
+      - machineFamily: n4
+        spot: false
+  ```
+
+### 3. Active Migration for Cost Recovery
+When workloads fall back to On-Demand VMs during a Spot stockout, enable active migration so GKE automatically returns the pods to Spot instances as soon as capacity recovers.
+
+- **Rule:** Set `spec.activeMigration.optimizeRulePriority: true` in your `ComputeClass`.
+- **Example:**
+  ```yaml
+  spec:
+    activeMigration:
+      optimizeRulePriority: true
+  ```
+
+### 4. Guaranteed Capacity with Reservation Affinity
+For mission-critical workloads or specialized hardware (such as `nvidia-l4`, `nvidia-h100`, or Cloud TPUs), design manifests to explicitly consume pre-purchased Google Cloud Capacity Reservations or Future Reservations (DASP).
+
+- **Rule:** Configure `reservationAffinity` in the `ComputeClass` priorities or node configuration.
+- **Example (`SPECIFIC_RESERVATION`):**
+  ```yaml
+  priorities:
+    - machineFamily: g2
+      gpu:
+        type: nvidia-l4
+        count: 1
+      reservationAffinity:
+        consumeReservationType: SPECIFIC_RESERVATION
+        key: compute.googleapis.com/reservation-name
+        values:
+          - projects/my-project/reservations/prod-l4-gpu-pool
+  ```
+
+### 5. Anti-Rigidity & Scheduling Boundaries
+Avoid hardcoded pod `nodeSelector` definitions that lock workloads to specific hostnames or rigid zonal labels (`kubernetes.io/hostname` or a single `topology.kubernetes.io/zone`).
+
+- **Rule:** Use `ComputeClass` tolerations and selectors (`cloud.google.com/compute-class: "<class-name>"`) alongside `HorizontalPodAutoscaler` (HPA) specifications for all deployments exceeding 3 replicas.
+
+---
+
+## Complete Day 0 Reference Template
+
+Use this copy-pasteable template when generating high-obtainability `ComputeClass` manifests:
+
+```yaml
+apiVersion: cloud.google.com/v1
+kind: ComputeClass
+metadata:
+  name: obtainable-ai-workload
+  namespace: default
+spec:
+  nodePoolAutoCreation:
+    enabled: true
+  activeMigration:
+    optimizeRulePriority: true
+  priorities:
+    # Priority 1: Target primary Spot GPU instances across 3 zones
+    - machineFamily: g2
+      spot: true
+      gpu:
+        type: nvidia-l4
+        count: 1
+      location:
+        zones:
+          - us-central1-a
+          - us-central1-b
+          - us-central1-c
+    # Priority 2: Fallback to On-Demand GPU instances across 3 zones
+    - machineFamily: g2
+      spot: false
+      gpu:
+        type: nvidia-l4
+        count: 1
+      location:
+        zones:
+          - us-central1-a
+          - us-central1-b
+          - us-central1-c
+```
+
+## Checklist Before Day 1 Hand-Off
+1. [ ] Does the `ComputeClass` list at least 2 or 3 availability zones?
+2. [ ] Is every `spot: true` rule paired with a `spot: false` fallback (or an alternative machine family)?
+3. [ ] Is `activeMigration.optimizeRulePriority: true` enabled?
+4. [ ] If using specialized GPUs/TPUs, is `reservationAffinity` configured to consume dedicated reservations?
+5. [ ] Do all target Deployments have an associated `HorizontalPodAutoscaler` (HPA)?

--- a/agents/platform/skills/gke-obtainability-day0/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day0/SKILL.md
@@ -58,11 +58,11 @@ When workloads fall back to On-Demand VMs during a Spot stockout, enable active 
       optimizeRulePriority: true
   ```
 
-### 4. Guaranteed Capacity with Reservation Affinity
+### 4. Guaranteed Capacity with the reservations Field
 
 For mission-critical workloads or specialized hardware (such as `nvidia-l4`, `nvidia-h100`, or Cloud TPUs), design manifests to explicitly consume pre-purchased Google Cloud Capacity Reservations or Future Reservations (DASP).
 
-- **Rule:** Configure `reservationAffinity` in the `ComputeClass` priorities or node configuration.
+- **Rule:** Configure the `reservations` field in the `ComputeClass` priorities.
 - **Example (`SPECIFIC_RESERVATION`):**
   ```yaml
   priorities:
@@ -70,11 +70,11 @@ For mission-critical workloads or specialized hardware (such as `nvidia-l4`, `nv
       gpu:
         type: nvidia-l4
         count: 1
-      reservationAffinity:
+      reservations:
         consumeReservationType: SPECIFIC_RESERVATION
-        key: compute.googleapis.com/reservation-name
+        key: projects/my-project/reservations/prod-l4-gpu-pool
         values:
-          - projects/my-project/reservations/prod-l4-gpu-pool
+          - prod-l4-gpu-pool
   ```
 
 ### 5. Anti-Rigidity & Scheduling Boundaries
@@ -130,5 +130,5 @@ spec:
 1. [ ] Does the `ComputeClass` list at least 2 or 3 availability zones?
 2. [ ] Is every `spot: true` rule paired with a `spot: false` fallback (or an alternative machine family)?
 3. [ ] Is `activeMigration.optimizeRulePriority: true` enabled?
-4. [ ] If using specialized GPUs/TPUs, is `reservationAffinity` configured to consume dedicated reservations?
+4. [ ] If using specialized GPUs/TPUs, is the `reservations` field configured in the `ComputeClass` to consume dedicated reservations?
 5. [ ] Do all target Deployments have an associated `HorizontalPodAutoscaler` (HPA)?

--- a/agents/platform/skills/gke-obtainability-day1/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day1/SKILL.md
@@ -10,9 +10,11 @@ This skill guides you through verifying capacity obtainability during initial wo
 ## Verification Workflow
 
 ### Step 1: Verify Workload Rollout & Pod Scheduling States
+
 Immediately after applying workload manifests or `ComputeClass` definitions, inspect the rollout progression and active pod phases across the cluster.
 
 **Commands:**
+
 ```bash
 # 1. Check deployment rollout progression
 kubectl rollout status deployment/<workload_name> -n <namespace> --timeout=60s
@@ -25,6 +27,7 @@ kubectl get events -n <namespace> --field-selector reason=FailedScheduling --sor
 ```
 
 #### Diagnostic Decision Tree:
+
 - **All Pods Running (`status.phase=Running`):** Capacity has been successfully obtained. Proceed to **Step 2**.
 - **Pods Stuck in `Pending` (`FailedScheduling`):**
   - Look for message patterns: `0/X nodes are available: X Insufficient cpu / memory / nvidia.com/gpu`.
@@ -37,9 +40,11 @@ kubectl get events -n <namespace> --field-selector reason=FailedScheduling --sor
 ---
 
 ### Step 2: Validate ComputeClass Auto-Provisioning & Node Creation
+
 Confirm that `ComputeClass` specifications or auto-created node pools have initialized healthy underlying Google Compute Engine (GCE) instances.
 
 **Commands:**
+
 ```bash
 # 1. List active nodes allocated to the target ComputeClass
 kubectl get nodes -l cloud.google.com/compute-class=<class_name> -o wide
@@ -49,15 +54,18 @@ kubectl describe nodes -l cloud.google.com/compute-class=<class_name> | grep -E 
 ```
 
 #### Validation Checks:
+
 - Confirm node zone distribution matches the Day 0 specification across multiple availability zones.
 - Verify whether the provisioned instances are running on Spot capacity (`cloud.google.com/gke-spot=true`) or On-Demand fallback capacity (`cloud.google.com/gke-spot=false`).
 
 ---
 
 ### Step 3: Verify Quota & Capacity Reservation Consumption
+
 Verify that newly provisioned nodes or workloads are actively drawing from designated capacity reservations and remain safely within Google Cloud project quotas.
 
 **Commands:**
+
 ```bash
 # 1. Inspect capacity reservation utilization across project regions
 gcloud compute reservations list --project=<project_id> --format="table(name,zone,specificReservation.instanceProperties.machineType,specificReservation.count,specificReservation.inUseCount)"
@@ -67,13 +75,16 @@ gcloud compute project-info describe --project=<project_id> --format="json(quota
 ```
 
 #### Validation Checks:
+
 - **Reservation Affinity Match:** If the workload targets a capacity reservation (`SPECIFIC_RESERVATION`), verify that `specificReservation.inUseCount` has incremented by the expected node count. If `inUseCount` remains `0` while pods are pending, verify node pool `reservationAffinity` syntax.
 - **Quota Headroom:** Ensure that total usage across `CPUS_ALL_REGIONS`, `NVIDIA_L4_GPUS`, or `PREEMPTIBLE_CPUS` remains below 85% of the total limit to allow safe autoscaling headroom.
 
 ---
 
 ## Day 1 Remediation Quick-Check
+
 If verification fails during rollout:
+
 1. **Missing Tolerations/Selectors:** Ensure the Pod manifest specifies `nodeSelector: cloud.google.com/compute-class: "<class-name>"` or valid tolerations for Spot/GPU taints.
 2. **Invalid Priority Syntax:** Validate that the `ComputeClass` `machineFamily` and `gpu.type` combinations are supported in the selected target region (`gcloud compute accelerator-types list --filter="zone:<zone>"`).
 3. **Escalate to Day 2:** If syntax and selectors are valid but instances fail to provision, execute the **Day 2 Stockout RCA (`gke-obtainability-day2`)** to classify zonal hardware exhaustion vs. quota ceilings.

--- a/agents/platform/skills/gke-obtainability-day1/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day1/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: gke-obtainability-day1
+description: Workflows for verifying compute capacity obtainability during initial workload rollout and cluster deployment (Day 1). Use when validating that GKE node pools, ComputeClass auto-provisioning, and autoscaling policies successfully acquire physical hardware capacity during rollout.
+---
+
+# GKE Obtainability: Day 1 (Deployment & Provisioning Verification)
+
+This skill guides you through verifying capacity obtainability during initial workload deployments, cluster spin-ups, and node pool rollouts (`Day 1`). It provides structured diagnostic and validation steps to confirm that GKE node pools, `ComputeClass` auto-provisioning, and autoscalers successfully obtain physical Google Cloud hardware capacity without hitting quota ceilings or early scheduling bottlenecks.
+
+## Verification Workflow
+
+### Step 1: Verify Workload Rollout & Pod Scheduling States
+Immediately after applying workload manifests or `ComputeClass` definitions, inspect the rollout progression and active pod phases across the cluster.
+
+**Commands:**
+```bash
+# 1. Check deployment rollout progression
+kubectl rollout status deployment/<workload_name> -n <namespace> --timeout=60s
+
+# 2. Query any pods stuck in Pending phase
+kubectl get pods -n <namespace> --field-selector=status.phase=Pending -o wide
+
+# 3. Inspect recent scheduling events in the namespace
+kubectl get events -n <namespace> --field-selector reason=FailedScheduling --sort-by='.metadata.creationTimestamp'
+```
+
+#### Diagnostic Decision Tree:
+- **All Pods Running (`status.phase=Running`):** Capacity has been successfully obtained. Proceed to **Step 2**.
+- **Pods Stuck in `Pending` (`FailedScheduling`):**
+  - Look for message patterns: `0/X nodes are available: X Insufficient cpu / memory / nvidia.com/gpu`.
+  - Check if Cluster Autoscaler or Node Auto-Provisioning (NAP) has triggered:
+    ```bash
+    kubectl get events -n kube-system --field-selector reason=TriggeredScaleUp --sort-by='.metadata.creationTimestamp'
+    ```
+  - If node provisioning is rejected right at initial deployment, transition immediately to the **Day 2 Stockout Investigation & Very Specific RCA Skill (`gke-obtainability-day2`)**.
+
+---
+
+### Step 2: Validate ComputeClass Auto-Provisioning & Node Creation
+Confirm that `ComputeClass` specifications or auto-created node pools have initialized healthy underlying Google Compute Engine (GCE) instances.
+
+**Commands:**
+```bash
+# 1. List active nodes allocated to the target ComputeClass
+kubectl get nodes -l cloud.google.com/compute-class=<class_name> -o wide
+
+# 2. Check node readiness and capacity allocations
+kubectl describe nodes -l cloud.google.com/compute-class=<class_name> | grep -E "Name:|Allocated resources:|cpu |memory |nvidia.com/gpu"
+```
+
+#### Validation Checks:
+- Confirm node zone distribution matches the Day 0 specification across multiple availability zones.
+- Verify whether the provisioned instances are running on Spot capacity (`cloud.google.com/gke-spot=true`) or On-Demand fallback capacity (`cloud.google.com/gke-spot=false`).
+
+---
+
+### Step 3: Verify Quota & Capacity Reservation Consumption
+Verify that newly provisioned nodes or workloads are actively drawing from designated capacity reservations and remain safely within Google Cloud project quotas.
+
+**Commands:**
+```bash
+# 1. Inspect capacity reservation utilization across project regions
+gcloud compute reservations list --project=<project_id> --format="table(name,zone,specificReservation.instanceProperties.machineType,specificReservation.count,specificReservation.inUseCount)"
+
+# 2. Check active GCE regional quota headroom (e.g., CPUS, GPUS, IN_USE_ADDRESSES)
+gcloud compute project-info describe --project=<project_id> --format="json(quotas)"
+```
+
+#### Validation Checks:
+- **Reservation Affinity Match:** If the workload targets a capacity reservation (`SPECIFIC_RESERVATION`), verify that `specificReservation.inUseCount` has incremented by the expected node count. If `inUseCount` remains `0` while pods are pending, verify node pool `reservationAffinity` syntax.
+- **Quota Headroom:** Ensure that total usage across `CPUS_ALL_REGIONS`, `NVIDIA_L4_GPUS`, or `PREEMPTIBLE_CPUS` remains below 85% of the total limit to allow safe autoscaling headroom.
+
+---
+
+## Day 1 Remediation Quick-Check
+If verification fails during rollout:
+1. **Missing Tolerations/Selectors:** Ensure the Pod manifest specifies `nodeSelector: cloud.google.com/compute-class: "<class-name>"` or valid tolerations for Spot/GPU taints.
+2. **Invalid Priority Syntax:** Validate that the `ComputeClass` `machineFamily` and `gpu.type` combinations are supported in the selected target region (`gcloud compute accelerator-types list --filter="zone:<zone>"`).
+3. **Escalate to Day 2:** If syntax and selectors are valid but instances fail to provision, execute the **Day 2 Stockout RCA (`gke-obtainability-day2`)** to classify zonal hardware exhaustion vs. quota ceilings.

--- a/agents/platform/skills/gke-obtainability-day1/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day1/SKILL.md
@@ -76,7 +76,7 @@ gcloud compute project-info describe --project=<project_id> --format="json(quota
 
 #### Validation Checks:
 
-- **Reservation Affinity Match:** If the workload targets a capacity reservation (`SPECIFIC_RESERVATION`), verify that `specificReservation.inUseCount` has incremented by the expected node count. If `inUseCount` remains `0` while pods are pending, verify node pool `reservationAffinity` syntax.
+- **Reservation Affinity Match:** If the workload targets a capacity reservation (`SPECIFIC_RESERVATION`), verify that `specificReservation.inUseCount` has incremented by the expected node count. If `inUseCount` remains `0` while pods are pending, verify node pool `reservationAffinity` syntax (or the `reservations` field syntax in your `ComputeClass` specification).
 - **Quota Headroom:** Ensure that total usage across `CPUS_ALL_REGIONS`, `NVIDIA_L4_GPUS`, or `PREEMPTIBLE_CPUS` remains below 85% of the total limit to allow safe autoscaling headroom.
 
 ---

--- a/agents/platform/skills/gke-obtainability-day2/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day2/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: gke-obtainability-day2
+description: Systematic Standard Operating Procedure (SOP) for Day 2 operations: investigating GKE compute stockouts (FailedScheduling, ZONE_RESOURCE_POOL_EXHAUSTED) and conducting granular Root Cause Analysis (RCA) and GitOps remediation.
+---
+
+# GKE Obtainability: Day 2 (Stockout Investigation & Very Specific RCA)
+
+Use this skill during active Day 2 production operations when Google Kubernetes Engine (GKE) workloads fail to scale or schedule due to capacity constraints (`FailedScheduling`, `ZONE_RESOURCE_POOL_EXHAUSTED`, `Scale-up failed`). This skill enforces a deep-dive cloud infrastructure investigation and delivers a **Very Specific Root Cause Analysis (RCA)** before generating precise GitOps YAML remediation patches.
+
+---
+
+## 🔍 Diagnostic Investigation Workflow
+
+### Step 1: Inspect Pod Scheduling Rejection Events
+When pods remain stuck in `Pending` state, capture the exact scheduling error and node availability breakdown.
+
+**Diagnostic Commands:**
+```bash
+# 1. Query pods stuck in Pending state
+kubectl get pods -n <namespace> --field-selector=status.phase=Pending -o wide
+
+# 2. Extract precise FailedScheduling event strings
+kubectl get events -n <namespace> --field-selector reason=FailedScheduling --sort-by='.metadata.creationTimestamp'
+```
+
+- If events report `0/X nodes are available: X Insufficient cpu / memory / nvidia.com/gpu`, the cluster lacks active node headroom and is attempting to provision new instances via Cluster Autoscaler or `ComputeClass` Node Auto-Provisioning. Proceed immediately to **Step 2**.
+
+---
+
+### Step 2: Deep-Dive Cloud Logging for GCE API Errors (`ZONE_RESOURCE_POOL_EXHAUSTED`)
+Query Google Cloud Logging directly to inspect underlying Google Compute Engine (GCE) API rejections and Cluster Autoscaler scale-up failures within a 1-hour window around the failure timestamp.
+
+**Diagnostic Command:**
+```bash
+gcloud logging read 'resource.type="k8s_cluster" AND (jsonPayload.reason="ZONE_RESOURCE_POOL_EXHAUSTED" OR jsonPayload.reason="ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS" OR jsonPayload.reason="QUOTA_EXCEEDED" OR textPayload=~"Scale-up failed" OR textPayload=~"NotTriggeredScaleUp")' --limit=25 --format="json" --project=<project_id>
+```
+
+#### Key Payload Fields to Extract:
+- `jsonPayload.reason`: Exact rejection code (e.g., `ZONE_RESOURCE_POOL_EXHAUSTED`).
+- `jsonPayload.resourceDescription.machineType` or `machineFamily`: Exact VM family rejected (`g2-standard-8`, `nvidia-l4`).
+- `jsonPayload.resourceDescription.zone`: Exact data center zone where the stockout occurred (`us-central1-a`).
+
+---
+
+### Step 3: Audit GCP Project Quotas vs. Active Usage
+Verify whether the scale-up rejection is caused by a project API quota ceiling rather than a zonal hardware shortage.
+
+**Diagnostic Command:**
+```bash
+gcloud compute project-info describe --project=<project_id> --format="json(quotas)"
+```
+
+- Filter and inspect relevant limits (`CPUS_ALL_REGIONS`, `NVIDIA_L4_GPUS`, `PREEMPTIBLE_CPUS`, `IN_USE_ADDRESSES`). Compare `usage` against `limit`.
+
+---
+
+### Step 4: Audit Capacity Reservation Status & Affinity
+Check if the project has guaranteed, pre-paid idle capacity reserved (`gcloud compute reservations`) that the GKE workloads or node pools are failing to consume due to incorrect affinity settings.
+
+**Diagnostic Command:**
+```bash
+gcloud compute reservations list --project=<project_id> --format="table(name,zone,specificReservation.instanceProperties.machineType,specificReservation.count,specificReservation.inUseCount)"
+```
+
+---
+
+## 🚨 Granular Root Cause Classification (Very Specific RCA Decision Tree)
+
+Based on the evidence collected in Steps 1–4, classify the root cause into **one of the four exact buckets below**. Never provide generic or ambiguous advice. Always format your output with clear proof and exact actionable fixes.
+
+### Bucket 1: True Zonal Hardware Stockout (`ZONE_RESOURCE_POOL_EXHAUSTED`)
+- **Evidence:** Cloud Logging explicitly reports `ZONE_RESOURCE_POOL_EXHAUSTED` (or `_WITH_DETAILS`) for machine type `$MACHINE_TYPE` (`$RESOURCE`) in zone `$ZONE`. Project quota has available headroom.
+- **Very Specific RCA Output:**
+  > 🔴 **Hardware Stockout Confirmed:** Google Cloud physical data center zone `$ZONE` currently has 0 available instances of `$MACHINE_TYPE` (`$RESOURCE`).
+- **Actionable Remediation:**
+  1. Generate a GitOps YAML patch for the target `ComputeClass` adding secondary fallback zones (`$REGION-b`, `$REGION-c`) or alternative machine families (`c3`, `a2`) to `spec.priorities`.
+  2. If running on standard node pools, recommend deploying a secondary regional or multi-zonal node pool.
+
+### Bucket 2: Spot VM Preemption / Exhaustion Without Fallback
+- **Evidence:** Workload or `ComputeClass` strictly demands Spot instances (`cloud.google.com/gke-spot: "true"` or `spot: true` only). Cloud Logging shows Spot scale-up rejection (`ZONE_RESOURCE_POOL_EXHAUSTED` on preemptible pool), and no On-Demand fallback priority exists.
+- **Very Specific RCA Output:**
+  > 🟡 **Spot Pool Exhaustion:** Spot VM capacity for `$MACHINE_TYPE` in `$ZONE` is exhausted, and the workload/ComputeClass lacks an On-Demand (`spot: false`) fallback rule.
+- **Actionable Remediation:**
+  1. Generate a GitOps YAML patch adding a secondary priority level targeting `spot: false` within the `ComputeClass`.
+  2. Ensure `spec.activeMigration.optimizeRulePriority: true` is enabled so the workload automatically returns to Spot when capacity recovers.
+
+### Bucket 3: GCP Project Quota Ceiling Hit (`QUOTA_EXCEEDED`)
+- **Evidence:** Cloud Logging reports `QUOTA_EXCEEDED` or `Limit '$QUOTA_NAME' exceeded`. `gcloud compute project-info describe` confirms `usage == limit` for that resource (`$QUOTA_NAME`).
+- **Very Specific RCA Output:**
+  > 🟠 **Project Quota Ceiling Exceeded:** This is NOT a hardware stockout. Your GCP project `$PROJECT_ID` has reached its API quota limit of `$LIMIT` for `$QUOTA_NAME`.
+- **Actionable Remediation:**
+  1. Provide the exact instructions to request a quota increase via Google Cloud Console (`IAM & Admin > Quotas`).
+  2. If quota is available in an adjacent region, generate a recommendation to shift non-critical workloads or multi-region deployments to that region.
+
+### Bucket 4: Capacity Reservation Mismatch (`reservationAffinity`)
+- **Evidence:** `gcloud compute reservations list` reveals idle capacity (`specificReservation.inUseCount < specificReservation.count`) for the required machine type/GPU, but `kubectl describe node/pod` reveals `reservationAffinity: NO_RESERVATION` or a mismatched reservation name.
+- **Very Specific RCA Output:**
+  > 🟣 **Reservation Mismatch:** `$IDLE_COUNT` idle `$MACHINE_TYPE` instances exist in capacity reservation `$RESERVATION_NAME`, but the workload/ComputeClass is configured with `reservationAffinity: NO_RESERVATION` and cannot consume them.
+- **Actionable Remediation:**
+  1. Generate a GitOps YAML patch updating the `ComputeClass` or node pool configuration to set `consumeReservationType: SPECIFIC_RESERVATION` pointing directly to `$RESERVATION_NAME`.
+
+---
+
+## Step 5: GitOps Remediation Boundary
+Following the inviolable GitOps boundary of `kube-agents`:
+1. **Never apply patches directly to live production clusters.**
+2. Synthesize your **Very Specific RCA** clearly in your report.
+3. Generate the corrected YAML manifest patch corresponding to the identified bucket.
+4. Open or update a Git branch and Pull Request (PR) on GitHub containing the remediation patch for human SRE review and merge.

--- a/agents/platform/skills/gke-obtainability-day2/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day2/SKILL.md
@@ -12,9 +12,11 @@ Use this skill during active Day 2 production operations when Google Kubernetes 
 ## 🔍 Diagnostic Investigation Workflow
 
 ### Step 1: Inspect Pod Scheduling Rejection Events
+
 When pods remain stuck in `Pending` state, capture the exact scheduling error and node availability breakdown.
 
 **Diagnostic Commands:**
+
 ```bash
 # 1. Query pods stuck in Pending state
 kubectl get pods -n <namespace> --field-selector=status.phase=Pending -o wide
@@ -28,14 +30,17 @@ kubectl get events -n <namespace> --field-selector reason=FailedScheduling --sor
 ---
 
 ### Step 2: Deep-Dive Cloud Logging for GCE API Errors (`ZONE_RESOURCE_POOL_EXHAUSTED`)
+
 Query Google Cloud Logging directly to inspect underlying Google Compute Engine (GCE) API rejections and Cluster Autoscaler scale-up failures within a 1-hour window around the failure timestamp.
 
 **Diagnostic Command:**
+
 ```bash
 gcloud logging read 'resource.type="k8s_cluster" AND (jsonPayload.reason="ZONE_RESOURCE_POOL_EXHAUSTED" OR jsonPayload.reason="ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS" OR jsonPayload.reason="QUOTA_EXCEEDED" OR textPayload=~"Scale-up failed" OR textPayload=~"NotTriggeredScaleUp")' --limit=25 --format="json" --project=<project_id>
 ```
 
 #### Key Payload Fields to Extract:
+
 - `jsonPayload.reason`: Exact rejection code (e.g., `ZONE_RESOURCE_POOL_EXHAUSTED`).
 - `jsonPayload.resourceDescription.machineType` or `machineFamily`: Exact VM family rejected (`g2-standard-8`, `nvidia-l4`).
 - `jsonPayload.resourceDescription.zone`: Exact data center zone where the stockout occurred (`us-central1-a`).
@@ -43,9 +48,11 @@ gcloud logging read 'resource.type="k8s_cluster" AND (jsonPayload.reason="ZONE_R
 ---
 
 ### Step 3: Audit GCP Project Quotas vs. Active Usage
+
 Verify whether the scale-up rejection is caused by a project API quota ceiling rather than a zonal hardware shortage.
 
 **Diagnostic Command:**
+
 ```bash
 gcloud compute project-info describe --project=<project_id> --format="json(quotas)"
 ```
@@ -55,9 +62,11 @@ gcloud compute project-info describe --project=<project_id> --format="json(quota
 ---
 
 ### Step 4: Audit Capacity Reservation Status & Affinity
+
 Check if the project has guaranteed, pre-paid idle capacity reserved (`gcloud compute reservations`) that the GKE workloads or node pools are failing to consume due to incorrect affinity settings.
 
 **Diagnostic Command:**
+
 ```bash
 gcloud compute reservations list --project=<project_id> --format="table(name,zone,specificReservation.instanceProperties.machineType,specificReservation.count,specificReservation.inUseCount)"
 ```
@@ -69,6 +78,7 @@ gcloud compute reservations list --project=<project_id> --format="table(name,zon
 Based on the evidence collected in Steps 1–4, classify the root cause into **one of the four exact buckets below**. Never provide generic or ambiguous advice. Always format your output with clear proof and exact actionable fixes.
 
 ### Bucket 1: True Zonal Hardware Stockout (`ZONE_RESOURCE_POOL_EXHAUSTED`)
+
 - **Evidence:** Cloud Logging explicitly reports `ZONE_RESOURCE_POOL_EXHAUSTED` (or `_WITH_DETAILS`) for machine type `$MACHINE_TYPE` (`$RESOURCE`) in zone `$ZONE`. Project quota has available headroom.
 - **Very Specific RCA Output:**
   > 🔴 **Hardware Stockout Confirmed:** Google Cloud physical data center zone `$ZONE` currently has 0 available instances of `$MACHINE_TYPE` (`$RESOURCE`).
@@ -77,6 +87,7 @@ Based on the evidence collected in Steps 1–4, classify the root cause into **o
   2. If running on standard node pools, recommend deploying a secondary regional or multi-zonal node pool.
 
 ### Bucket 2: Spot VM Preemption / Exhaustion Without Fallback
+
 - **Evidence:** Workload or `ComputeClass` strictly demands Spot instances (`cloud.google.com/gke-spot: "true"` or `spot: true` only). Cloud Logging shows Spot scale-up rejection (`ZONE_RESOURCE_POOL_EXHAUSTED` on preemptible pool), and no On-Demand fallback priority exists.
 - **Very Specific RCA Output:**
   > 🟡 **Spot Pool Exhaustion:** Spot VM capacity for `$MACHINE_TYPE` in `$ZONE` is exhausted, and the workload/ComputeClass lacks an On-Demand (`spot: false`) fallback rule.
@@ -85,6 +96,7 @@ Based on the evidence collected in Steps 1–4, classify the root cause into **o
   2. Ensure `spec.activeMigration.optimizeRulePriority: true` is enabled so the workload automatically returns to Spot when capacity recovers.
 
 ### Bucket 3: GCP Project Quota Ceiling Hit (`QUOTA_EXCEEDED`)
+
 - **Evidence:** Cloud Logging reports `QUOTA_EXCEEDED` or `Limit '$QUOTA_NAME' exceeded`. `gcloud compute project-info describe` confirms `usage == limit` for that resource (`$QUOTA_NAME`).
 - **Very Specific RCA Output:**
   > 🟠 **Project Quota Ceiling Exceeded:** This is NOT a hardware stockout. Your GCP project `$PROJECT_ID` has reached its API quota limit of `$LIMIT` for `$QUOTA_NAME`.
@@ -93,6 +105,7 @@ Based on the evidence collected in Steps 1–4, classify the root cause into **o
   2. If quota is available in an adjacent region, generate a recommendation to shift non-critical workloads or multi-region deployments to that region.
 
 ### Bucket 4: Capacity Reservation Mismatch (`reservationAffinity`)
+
 - **Evidence:** `gcloud compute reservations list` reveals idle capacity (`specificReservation.inUseCount < specificReservation.count`) for the required machine type/GPU, but `kubectl describe node/pod` reveals `reservationAffinity: NO_RESERVATION` or a mismatched reservation name.
 - **Very Specific RCA Output:**
   > 🟣 **Reservation Mismatch:** `$IDLE_COUNT` idle `$MACHINE_TYPE` instances exist in capacity reservation `$RESERVATION_NAME`, but the workload/ComputeClass is configured with `reservationAffinity: NO_RESERVATION` and cannot consume them.
@@ -102,7 +115,9 @@ Based on the evidence collected in Steps 1–4, classify the root cause into **o
 ---
 
 ## Step 5: GitOps Remediation Boundary
+
 Following the inviolable GitOps boundary of `kube-agents`:
+
 1. **Never apply patches directly to live production clusters.**
 2. Synthesize your **Very Specific RCA** clearly in your report.
 3. Generate the corrected YAML manifest patch corresponding to the identified bucket.

--- a/agents/platform/skills/gke-obtainability-day2/SKILL.md
+++ b/agents/platform/skills/gke-obtainability-day2/SKILL.md
@@ -104,13 +104,13 @@ Based on the evidence collected in Steps 1–4, classify the root cause into **o
   1. Provide the exact instructions to request a quota increase via Google Cloud Console (`IAM & Admin > Quotas`).
   2. If quota is available in an adjacent region, generate a recommendation to shift non-critical workloads or multi-region deployments to that region.
 
-### Bucket 4: Capacity Reservation Mismatch (`reservationAffinity`)
+### Bucket 4: Capacity Reservation Mismatch (`reservations` / `reservationAffinity`)
 
-- **Evidence:** `gcloud compute reservations list` reveals idle capacity (`specificReservation.inUseCount < specificReservation.count`) for the required machine type/GPU, but `kubectl describe node/pod` reveals `reservationAffinity: NO_RESERVATION` or a mismatched reservation name.
+- **Evidence:** `gcloud compute reservations list` reveals idle capacity (`specificReservation.inUseCount < specificReservation.count`) for the required machine type/GPU, but `kubectl describe node/pod` reveals `reservationAffinity: NO_RESERVATION` (or `reservations.consumeReservationType: NO_RESERVATION` in the `ComputeClass`) or a mismatched reservation name.
 - **Very Specific RCA Output:**
-  > 🟣 **Reservation Mismatch:** `$IDLE_COUNT` idle `$MACHINE_TYPE` instances exist in capacity reservation `$RESERVATION_NAME`, but the workload/ComputeClass is configured with `reservationAffinity: NO_RESERVATION` and cannot consume them.
+  > 🟣 **Reservation Mismatch:** `$IDLE_COUNT` idle `$MACHINE_TYPE` instances exist in capacity reservation `$RESERVATION_NAME`, but the workload/ComputeClass is configured with `reservationAffinity: NO_RESERVATION` (or `reservations.consumeReservationType: NO_RESERVATION` in the `ComputeClass`) and cannot consume them.
 - **Actionable Remediation:**
-  1. Generate a GitOps YAML patch updating the `ComputeClass` or node pool configuration to set `consumeReservationType: SPECIFIC_RESERVATION` pointing directly to `$RESERVATION_NAME`.
+  1. Generate a GitOps YAML patch updating the `ComputeClass` (by setting `reservations.consumeReservationType: SPECIFIC_RESERVATION` pointing directly to `$RESERVATION_NAME`) or node pool configuration (`reservationAffinity`).
 
 ---
 


### PR DESCRIPTION

# Pull Request

## Why This Change

Currently, when a GKE workload encounters compute capacity constraints or node provisioning rejections (`FailedScheduling`, `0/X nodes are available: Insufficient cpu/gpu`), the platform agent's general troubleshooting skills stop at surface-level Kubernetes symptoms. The agent lacks structured guidance across the **Day 0, Day 1, and Day 2** lifecycle to proactively design for compute obtainability, verify rollout capacity drawdowns, or execute deep-dive cloud infrastructure investigations during zonal hardware stockouts (`Stockout investigate, very specific RCA`).

## What Changed

Added three comprehensive AI agent skill blueprints (`SKILL.md`) covering the end-to-end GKE compute obtainability lifecycle under `agents/platform/skills/`.

**Files:**

- `agents/platform/skills/gke-obtainability-day0/SKILL.md`
- `agents/platform/skills/gke-obtainability-day1/SKILL.md`
- `agents/platform/skills/gke-obtainability-day2/SKILL.md`

**Added/Changed/Fixed:**

- **Added Day 0 Proactive Architecture Skill (`gke-obtainability-day0`):** Enforces multi-zonal `location.zones` placement, multi-tiered `ComputeClass` fallback priorities (`spot: true` -> `spot: false`), `activeMigration.optimizeRulePriority: true` for Spot cost recovery, and `reservationAffinity` (`SPECIFIC_RESERVATION`) for guaranteed GPU/TPU capacity.
- **Added Day 1 Deployment Verification Skill (`gke-obtainability-day1`):** Provides diagnostic workflows to inspect rollout progression (`kubectl rollout status`), verify `ComputeClass` auto-provisioned nodes across availability zones, and validate live capacity reservation drawdowns (`gcloud compute reservations list`) and project quota headroom (`gcloud compute project-info describe`).
- **Added Day 2 Stockout Investigation & Specific RCA Skill (`gke-obtainability-day2`):** Codifies the missing `"Stockout investigate, very specific RCA"` capability. Instructs the agent to query Cloud Logging (`ZONE_RESOURCE_POOL_EXHAUSTED`, `Scale-up failed`) and classify failures into 4 specific root cause buckets (Hardware Stockout vs. Spot Preemption vs. Quota Ceiling vs. Reservation Mismatch), outputting exact evidence-backed RCAs and GitOps YAML patches without generic guesswork.

## Why This Matters

- **Elevates AI Troubleshooting to Senior SRE Capabilities:** Moves the agent beyond generic advice (*"try scaling up your nodes"*) to exact cloud infrastructure investigation and precise Root Cause Analysis.
- **Prevents Production Outages:** Proactively structures manifests on Day 0 so workloads gracefully fall back across zones and instance types during unexpected zonal hardware shortages or Spot preemptions.
- **Enforces GitOps Safety:** Guarantees all Day 2 remediations are generated as declarative YAML patches submitted via Pull Requests rather than applied ad-hoc to live production clusters.

## Context

- Relates to `kube-agents` capacity obtainability and proactive SRE governance initiatives.
- Complements existing capacity and troubleshooting assets (`agents/platform/skills/gke-compute-class-creator`, `agents/platform/skills/gke-workload-troubleshooting`, and `agents/platform/governance/obtainability_audit_sop.md`).

## Testing
- **Google Chat:** Verified the execution of "Daily Self-Maintenance & Skill Quality Audit" in strict accordance with /opt/data/governance/self_maintenance_audit_sop.md.
- **Formatting Check:** Verified YAML frontmatter (`name`, `description`) and Markdown structure across all three new skill files comply with `AGENTS.md` skill documentation guidelines.
- **Git Status & Cleanliness:** Confirmed changes are strictly scoped to the requested obtainability skills (`3 files changed, 316 insertions(+)`).

---

**Functional Impact / Risk / Rollout:** Zero runtime risk to existing cluster services; these additions introduce read-only agent instruction skills (`SKILL.md`) that will be loaded dynamically by the Platform Agent when diagnosing or designing compute resources.