### PR TITLE
feat(operator): add Go k8s-event-watcher component for sidecar triage

### DIFF
--- a/k8s-operator/cmd/k8s-event-watcher/README.md
+++ b/k8s-operator/cmd/k8s-event-watcher/README.md
@@ -7,19 +7,19 @@ Enable the Platform Agent (`kube-agents`) to autonomously troubleshoot cluster h
 
 ## 2. Proposed Architecture
 
-We propose integrating a Go-based `k8s-event-watcher` service as a **sidecar container** inside the `platform-agent` Pod.
+We propose integrating the Go-based `k8s-event-watcher` service as a **background process** inside the primary `platform-agent` container.
 
 ```mermaid
 graph TD
-    API[GKE API Server] -->|1. Realtime Watch Stream| Watcher[k8s-event-watcher Sidecar]
+    API[GKE API Server] -->|1. Realtime Watch Stream| Watcher[k8s-event-watcher Daemon]
     Watcher -->|2. Filter & Dedup| Watcher
     Watcher -->|3. POST /sessions| Proxy[FastAPI session_kv_server]
     Proxy -->|4. hermes send| Agent[platform-agent Gateway]
 ```
 
-1. **Watch Stream:** The watcher container connects to GKE control plane API Server and streams warnings (`core/v1.Event`) in real-time.
+1. **Watch Stream:** The watcher daemon connects to the GKE control plane API Server and streams warnings (`core/v1.Event`) in real-time.
 2. **Filter & Dedup:** It drops noise, filters events by allowlisted reasons, and groups occurrences of pod crash families (e.g. `ErrImagePull` -> `ImagePullBackOff`) within a 5-minute rolling window.
-3. **Local REST Bridge:** When a new failure family triggers, the sidecar POSTs to the local helper server `session_kv_server.py` (`http://localhost:8699`).
+3. **Local REST Bridge:** When a new failure family triggers, the watcher daemon POSTs to the local FastAPI helper server `session_kv_server.py` (`http://localhost:8699`).
 4. **Hermes Alert:** The FastAPI server executes the local `hermes` CLI to kick off a new agent troubleshooting session.
 
 ---
@@ -40,10 +40,14 @@ To allow progressive reviews and testing, the implementation is divided into fou
 * **Action:** Implement `/sessions` and `/sessions/{session_id}/inject` endpoints inside `session_kv_server.py`.
 * **Verification:** Mock incoming alerts using local `curl` posts to the FastAPI listener port.
 
-### Task 3: Containerize the Watcher
-* **Action:** Add a multi-stage `Dockerfile.watcher` to package the compiled static binary into a scratch container.
-* **Verification:** Run `docker build -f deploy/docker/Dockerfile.watcher -t k8s-event-watcher:latest .`
+### Task 3: Add Multi-Stage Compilation to Primary Dockerfile
+* **Action:** Update the main `Dockerfile` to compile the Go watcher binary and place it in the defaults scripts directory `/opt/defaults/scripts/k8s-event-watcher`.
+* **Verification:** Build the agent image:
+  ```bash
+  make dev-rebuild-agent ARGS="platform --local"
+  ```
+  Verify the image is generated with the compiled binary inside the scripts folder.
 
-### Task 4: Deploy the Sidecar
-* **Action:** Define the sidecar container and volume mount inside `platform-agent.yaml.template` using the CRD's native `spec.deployment.sidecars` field.
-* **Verification:** Deploy and ensure the platform agent pod runs with 3 active containers (`platform-agent`, `fluent-bit`, `k8s-event-watcher`).
+### Task 4: Configure Entrypoint Startup
+* **Action:** Configure both the FastAPI proxy and the Go watcher to start in the background on container boot in `deploy/shared/docker-entrypoint.sh`.
+* **Verification:** Rebuild and redeploy. Run `ps aux` inside the container and verify both background processes are active. Trigger a test event and check that a session is created and GChat alert sent.

--- a/k8s-operator/cmd/k8s-event-watcher/README.md
+++ b/k8s-operator/cmd/k8s-event-watcher/README.md
@@ -1,0 +1,49 @@
+# Design Proposal: GKE Event Watcher Integration
+
+## 1. Objective
+Enable the Platform Agent (`kube-agents`) to autonomously troubleshoot cluster health failures in real-time by streaming, filtering, and deduplicating Kubernetes warning events.
+
+---
+
+## 2. Proposed Architecture
+
+We propose integrating a Go-based `k8s-event-watcher` service as a **sidecar container** inside the `platform-agent` Pod.
+
+```mermaid
+graph TD
+    API[GKE API Server] -->|1. Realtime Watch Stream| Watcher[k8s-event-watcher Sidecar]
+    Watcher -->|2. Filter & Dedup| Watcher
+    Watcher -->|3. POST /sessions| Proxy[FastAPI session_kv_server]
+    Proxy -->|4. hermes send| Agent[platform-agent Gateway]
+```
+
+1. **Watch Stream:** The watcher container connects to GKE control plane API Server and streams warnings (`core/v1.Event`) in real-time.
+2. **Filter & Dedup:** It drops noise, filters events by allowlisted reasons, and groups occurrences of pod crash families (e.g. `ErrImagePull` -> `ImagePullBackOff`) within a 5-minute rolling window.
+3. **Local REST Bridge:** When a new failure family triggers, the sidecar POSTs to the local helper server `session_kv_server.py` (`http://localhost:8699`).
+4. **Hermes Alert:** The FastAPI server executes the local `hermes` CLI to kick off a new agent troubleshooting session.
+
+---
+
+## 3. Iterative Task Breakdown & Verification
+
+To allow progressive reviews and testing, the implementation is divided into four standalone steps:
+
+### Task 1: Check in the Go Watcher Code
+* **Action:** Merge Go source files (with OpenTelemetry dependencies stripped out) into `k8s-operator/cmd/k8s-event-watcher/`.
+* **Verification:** Compile and run locally in dry-run mode against your current kubectl context:
+  ```bash
+  cd k8s-operator/cmd/k8s-event-watcher && go build -o watcher .
+  ./watcher --dry-run --cluster-name=dev-cluster
+  ```
+
+### Task 2: Extend FastAPI Proxy Endpoints
+* **Action:** Implement `/sessions` and `/sessions/{session_id}/inject` endpoints inside `session_kv_server.py`.
+* **Verification:** Mock incoming alerts using local `curl` posts to the FastAPI listener port.
+
+### Task 3: Containerize the Watcher
+* **Action:** Add a multi-stage `Dockerfile.watcher` to package the compiled static binary into a scratch container.
+* **Verification:** Run `docker build -f deploy/docker/Dockerfile.watcher -t k8s-event-watcher:latest .`
+
+### Task 4: Deploy the Sidecar
+* **Action:** Define the sidecar container and volume mount inside `platform-agent.yaml.template` using the CRD's native `spec.deployment.sidecars` field.
+* **Verification:** Deploy and ensure the platform agent pod runs with 3 active containers (`platform-agent`, `fluent-bit`, `k8s-event-watcher`).

--- a/k8s-operator/cmd/k8s-event-watcher/dedup.go
+++ b/k8s-operator/cmd/k8s-event-watcher/dedup.go
@@ -1,0 +1,383 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// dedupEntry holds the per-incident dedup state cached against an
+// EventKey. Bounded: the sidecar's cache is capped at maxDedupEntries
+// (LRU eviction) so a runaway cluster with tens of thousands of
+// distinct incidents doesn't OOM the sidecar.
+type dedupEntry struct {
+	// SessionID is the daemon-side session created by the first
+	// event in this window. Follow-up events for the same key
+	// route to this session via POST /sessions/<sid>/inject.
+	SessionID string `json:"session_id"`
+	// FirstSeen is when the sidecar first observed this key.
+	// Rolls forward when the window expires + a new event arrives.
+	FirstSeen time.Time `json:"first_seen"`
+	// LastSeen is the wall-clock time we last recorded REAL new
+	// activity for this key (replays do NOT advance it — see
+	// Observe). Used to compute retry-cooldown: the entry ages
+	// out when LastSeen + window < now.
+	LastSeen time.Time `json:"last_seen"`
+	// EventLastTS is the k8s Event's own LastTimestamp we last
+	// processed for this key. Enables idempotent replay handling:
+	// client-go informers periodically re-List all Events on
+	// watch-connection rotation (~15-25min in practice), which
+	// used to trigger spurious "new incident" fires. Comparing
+	// incoming event.LastTimestamp against this field lets us
+	// distinguish replay of already-seen activity (dedup) from
+	// genuinely new activity (real new events k8s aggregated
+	// into the same Event object since we last saw it).
+	EventLastTS time.Time `json:"event_last_ts"`
+	// Count is how many events the sidecar has seen for this key
+	// in the current window (the first event that created the
+	// session counts as 1). Reset when the window rolls.
+	Count int `json:"count"`
+}
+
+// dedupResult tells the caller what to do with the event that just
+// came in: kind==firstInWindow means create a session + inject;
+// kind==duplicate means suppress; kind==newIncident means the prior
+// window expired and this is a fresh incident (create new session).
+type dedupResult struct {
+	Kind      dedupResultKind
+	SessionID string // only set when Kind==duplicate; the existing session
+	Count     int    // window count (1 for first, N for duplicates)
+}
+
+type dedupResultKind int
+
+const (
+	// dedupNewIncident: no prior entry (or the prior window
+	// expired). Caller must create a new session and inject.
+	dedupNewIncident dedupResultKind = iota
+	// dedupDuplicate: an entry exists within the window. Caller
+	// suppresses this event; the count is bumped and available
+	// via dedupResult.Count.
+	dedupDuplicate
+)
+
+// dedupCache is the rolling-window dedup store. Backed by a map +
+// a mutex; bounded by LRU eviction at maxDedupEntries.
+type dedupCache struct {
+	mu      sync.Mutex
+	entries map[EventKey]*dedupEntry
+	window  time.Duration
+	max     int
+	// persistPath, when non-empty, causes Snapshot+Restore calls
+	// to read/write JSON at that path so the cache survives
+	// sidecar restart. Optional (nil disables persistence).
+	persistPath string
+	// now overrides time.Now for testing. nil = real clock.
+	now func() time.Time
+}
+
+// maxDedupEntries caps the sidecar's cache size. 10k is plenty for
+// any realistic single-cluster deployment (unique events per 5-min
+// window). LRU eviction beyond this bound.
+const maxDedupEntries = 10_000
+
+// newDedupCache constructs a cache with the supplied rolling window
+// duration. window must be > 0. persistPath is optional; empty
+// disables the on-disk cache.
+func newDedupCache(window time.Duration, persistPath string) (*dedupCache, error) {
+	if window <= 0 {
+		return nil, fmt.Errorf("dedup: window must be > 0 (got %s)", window)
+	}
+	c := &dedupCache{
+		entries:     make(map[EventKey]*dedupEntry),
+		window:      window,
+		max:         maxDedupEntries,
+		persistPath: persistPath,
+	}
+	if persistPath != "" {
+		if err := c.restore(); err != nil {
+			return nil, fmt.Errorf("dedup: restore from %s: %w", persistPath, err)
+		}
+	}
+	return c, nil
+}
+
+// clock returns the current time. Overridable for tests.
+func (c *dedupCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// reasonCanonical maps well-known secondary Event.Reason values to
+// their canonical primary reason for dedup-key computation. Two
+// events for the same target whose reasons are in the same family
+// collapse into one dedup entry — e.g. an ImagePullBackOff event
+// and an ErrImagePull event for the same pod count as ONE incident,
+// not two parallel sessions.
+//
+// The mapping is deliberately narrow — only well-known equivalences
+// where a single underlying failure emits multiple reason variants
+// from kubelet's retry cycle. Reasons not in this map are their
+// own canonical value.
+//
+// Rationale for each entry:
+//
+//   - ErrImagePull → ImagePullBackOff: kubelet emits ErrImagePull
+//     on the first failed pull attempt, then ImagePullBackOff once
+//     the exponential backoff kicks in. Same failure, two reason
+//     values within seconds.
+//   - BackOff → CrashLoopBackOff: BackOff accompanies both crash-
+//     loop and image-pull cycles. In practice, when it collides
+//     with an ImagePullBackOff for the same pod, that pod's
+//     ImagePullBackOff entry already exists so BackOff routes there
+//     via the CrashLoopBackOff canonical (which will be reset when
+//     the crash-loop entry expires). Yes, this is subtle. If a
+//     future variant wants to disambiguate, a `--reason-canonical`
+//     config override can drop or remap entries.
+//
+// Observed live during v2.6 GKE-troubleshoot demo drive: one
+// paymentservice ImagePullBackOff spawned 4 parallel sessions
+// (one per reason variant) at $0.28/session, 4× baseline spend
+// per incident. See go-steer/core-agent#219.
+var reasonCanonical = map[string]string{
+	"ErrImagePull": "ImagePullBackOff",
+	"BackOff":      "CrashLoopBackOff",
+}
+
+// canonicalizeReason returns the dedup-key reason for a given
+// Event.Reason value. Reasons not in reasonCanonical map to
+// themselves (no change).
+func canonicalizeReason(reason string) string {
+	if canonical, ok := reasonCanonical[reason]; ok {
+		return canonical
+	}
+	return reason
+}
+
+// Observe records that key was just seen with eventLastTS (the
+// k8s Event's own LastTimestamp). Returns a dedupResult telling the
+// caller whether this is a fresh incident (start a new session) or
+// a duplicate within the current window (suppress).
+//
+// The key's Reason is canonicalized (see reasonCanonical) so events
+// from the same underlying failure with different reason variants
+// (e.g. ImagePullBackOff vs ErrImagePull) collapse into one dedup
+// slot. The wire event's original Reason is preserved on the
+// inject payload — canonicalization is a dedup-only mechanism.
+//
+// Three cases, checked in order:
+//
+//  1. **Replay** — eventLastTS is not later than the recorded
+//     EventLastTS. This is the k8s Event object being re-delivered
+//     (informer watch-rotation triggers a re-List; kube-apiserver
+//     rotates watch connections every ~15-25min in practice). The
+//     activity is one we've already processed — dedup, do NOT
+//     advance LastSeen (retry cooldown continues to age from real
+//     activity time). Bump count so metrics stay accurate.
+//
+//  2. **New activity past cooldown** — eventLastTS is later AND
+//     wall-clock now is more than `window` past LastSeen. The prior
+//     session's cooldown has expired and k8s is still actively
+//     reporting the issue, so create a new session (retry safety
+//     net: if the previous agent-run failed to resolve the
+//     incident, the fresh reporting gives it another chance).
+//
+//  3. **New activity within cooldown** — eventLastTS is later,
+//     within the window. Real new k8s aggregation on top of an
+//     ongoing incident — dedup to the existing session, advance
+//     both LastSeen and EventLastTS.
+//
+// Contract: the caller MUST call BindSession after a successful
+// CreateSession call to attach the SessionID to the newly-created
+// entry, so subsequent duplicates can route to the same session.
+func (c *dedupCache) Observe(key EventKey, eventLastTS time.Time) dedupResult {
+	key.Reason = canonicalizeReason(key.Reason)
+	now := c.clock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		// First sighting for this key.
+		c.evictIfFull()
+		c.entries[key] = &dedupEntry{
+			FirstSeen:   now,
+			LastSeen:    now,
+			EventLastTS: eventLastTS,
+			Count:       1,
+		}
+		return dedupResult{Kind: dedupNewIncident, Count: 1}
+	}
+	if !eventLastTS.After(entry.EventLastTS) {
+		// Case 1: replay. Same activity we already processed;
+		// don't advance LastSeen (retry cooldown untouched).
+		entry.Count++
+		return dedupResult{Kind: dedupDuplicate, SessionID: entry.SessionID, Count: entry.Count}
+	}
+	if now.Sub(entry.LastSeen) > c.window {
+		// Case 2: retry safety net. Prior session's cooldown
+		// elapsed AND k8s is still reporting new activity —
+		// spin up a fresh session so an agent that failed to
+		// resolve the last one gets another attempt.
+		c.evictIfFull()
+		c.entries[key] = &dedupEntry{
+			FirstSeen:   now,
+			LastSeen:    now,
+			EventLastTS: eventLastTS,
+			Count:       1,
+		}
+		return dedupResult{Kind: dedupNewIncident, Count: 1}
+	}
+	// Case 3: new activity within cooldown → dedup + advance.
+	entry.Count++
+	entry.LastSeen = now
+	entry.EventLastTS = eventLastTS
+	return dedupResult{Kind: dedupDuplicate, SessionID: entry.SessionID, Count: entry.Count}
+}
+
+// BindSession attaches the SessionID from a successful CreateSession
+// call to the entry created by the preceding Observe. No-op if the
+// entry has since been evicted (window elapsed AND the LRU sweep
+// dropped it), which is a possible but harmless race.
+//
+// Applies the same reason canonicalization Observe does so a caller
+// that saw a `dedupNewIncident` result on one reason variant can
+// bind the session using the wire-level reason without having to
+// know about the family mapping.
+func (c *dedupCache) BindSession(key EventKey, sessionID string) {
+	key.Reason = canonicalizeReason(key.Reason)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry, ok := c.entries[key]; ok {
+		entry.SessionID = sessionID
+	}
+}
+
+// evictIfFull is called under lock. If the cache is at capacity,
+// evicts the LRU entry (lowest LastSeen). Bounded O(N) scan; called
+// only on new-incident cache-miss paths so amortized cost is fine.
+func (c *dedupCache) evictIfFull() {
+	if len(c.entries) < c.max {
+		return
+	}
+	var oldestKey EventKey
+	var oldestTs time.Time
+	first := true
+	for k, e := range c.entries {
+		if first || e.LastSeen.Before(oldestTs) {
+			oldestKey = k
+			oldestTs = e.LastSeen
+			first = false
+		}
+	}
+	delete(c.entries, oldestKey)
+}
+
+// Len returns the current cache size. Test / metrics helper.
+func (c *dedupCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// Snapshot writes the current cache state to persistPath. Idempotent;
+// no-op when persistPath is empty. Callers should call this on
+// graceful shutdown (SIGTERM handler in main.go) and periodically
+// while running (e.g., every 30s ticker) so a crash doesn't lose
+// more than 30s of dedup state.
+//
+// Format: pretty-printed JSON — small enough that a human can
+// inspect it during incident debugging, and simple enough that the
+// on-disk shape doesn't need its own migration story.
+func (c *dedupCache) Snapshot() error {
+	if c.persistPath == "" {
+		return nil
+	}
+	c.mu.Lock()
+	// Copy under lock; encode outside so we don't hold the mutex
+	// during I/O.
+	snapshot := make(map[string]*dedupEntry, len(c.entries))
+	for k, v := range c.entries {
+		snapshot[serializeKey(k)] = v
+	}
+	c.mu.Unlock()
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("dedup: marshal snapshot: %w", err)
+	}
+	// Atomic write: temp file + rename so an interrupted write
+	// doesn't corrupt the persisted state.
+	tmp := c.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("dedup: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, c.persistPath); err != nil {
+		return fmt.Errorf("dedup: rename %s → %s: %w", tmp, c.persistPath, err)
+	}
+	return nil
+}
+
+// restore reads persistPath (if it exists) and hydrates the cache.
+// Missing file is not an error — first-time startup has nothing to
+// restore. Called by newDedupCache during construction.
+func (c *dedupCache) restore() error {
+	data, err := os.ReadFile(c.persistPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // first startup; nothing to restore
+		}
+		return fmt.Errorf("dedup: read %s: %w", c.persistPath, err)
+	}
+	var snapshot map[string]*dedupEntry
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		// Corrupt persist file: log and start fresh. Better than
+		// refusing to boot the sidecar. Caller can inspect the
+		// file if they care.
+		return fmt.Errorf("dedup: unmarshal snapshot (starting fresh): %w", err)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for keyStr, entry := range snapshot {
+		key, ok := deserializeKey(keyStr)
+		if !ok {
+			continue // silently skip malformed keys
+		}
+		c.entries[key] = entry
+	}
+	return nil
+}
+
+// serializeKey / deserializeKey encode an EventKey for use as a
+// JSON map key (which must be a string). Using a delimiter that
+// can't appear in a k8s UID (which is hex + hyphens) or an Event
+// reason (which is CamelCase alphanumeric).
+func serializeKey(k EventKey) string {
+	return k.UID + "|" + k.Reason
+}
+
+func deserializeKey(s string) (EventKey, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '|' {
+			return EventKey{UID: s[:i], Reason: s[i+1:]}, true
+		}
+	}
+	return EventKey{}, false
+}

--- a/k8s-operator/cmd/k8s-event-watcher/filter.go
+++ b/k8s-operator/cmd/k8s-event-watcher/filter.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// defaultReasons is the shipped set of Event.Reason values that
+// trigger investigations. Chosen to cover the top-frequency real
+// failures per docs/k8s-event-agent-design.md §"Event filter
+// allow-list". Operators can override via --reason.
+var defaultReasons = []string{
+	"CrashLoopBackOff",
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"OOMKilled",
+	"FailedMount",
+	"FailedScheduling",
+	"BackOff",
+	"Unhealthy",
+	"NetworkNotReady",
+	"NodeNotReady",
+	"Evicted",
+}
+
+// filterConfig captures the sidecar's per-event decision logic.
+// Constructed from CLI flags in main.go; injected into the filter
+// so tests can override each knob independently.
+type filterConfig struct {
+	// allowedReasons is the set of Event.Reason values that pass
+	// the filter. Case-sensitive match against Event.Reason
+	// (k8s uses CamelCase; case-insensitivity would only hide
+	// operator typos in configs).
+	allowedReasons map[string]struct{}
+	// allowedNamespaces, when non-empty, restricts firing to
+	// events from these namespaces. Empty = all namespaces.
+	// Applied AFTER excludedNamespaces (exclude wins).
+	allowedNamespaces map[string]struct{}
+	// excludedNamespaces suppresses events from these namespaces
+	// even if they'd otherwise pass. Applied before
+	// allowedNamespaces so operators can express "all except
+	// kube-system" without listing every included namespace.
+	excludedNamespaces map[string]struct{}
+	// unhealthyMinCount is the special case for the Unhealthy
+	// reason: probes flap constantly and firing on every one
+	// would drown the sidecar. Require the event's own Count
+	// (k8s Event.Count, which repeats-per-source) to reach this
+	// value before we pass it. Default 3.
+	unhealthyMinCount int
+}
+
+// newFilterConfig builds a filterConfig from CLI-shaped inputs.
+// Empty slices default to the shipped values; positive counts
+// default to their shipped defaults.
+func newFilterConfig(reasons []string, allowNamespaces, excludeNamespaces []string, unhealthyMinCount int) filterConfig {
+	if len(reasons) == 0 {
+		reasons = defaultReasons
+	}
+	if unhealthyMinCount <= 0 {
+		unhealthyMinCount = 3
+	}
+	fc := filterConfig{
+		allowedReasons:     stringSet(reasons),
+		allowedNamespaces:  stringSet(allowNamespaces),
+		excludedNamespaces: stringSet(excludeNamespaces),
+		unhealthyMinCount:  unhealthyMinCount,
+	}
+	return fc
+}
+
+// stringSet converts a []string to a set for O(1) membership tests.
+func stringSet(xs []string) map[string]struct{} {
+	if len(xs) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(xs))
+	for _, x := range xs {
+		if x == "" {
+			continue
+		}
+		out[x] = struct{}{}
+	}
+	return out
+}
+
+// filter decides whether a triage event should proceed to dedup +
+// inject. Pure function — same input, same output; no I/O.
+type filter struct {
+	cfg filterConfig
+}
+
+func newFilter(cfg filterConfig) *filter {
+	return &filter{cfg: cfg}
+}
+
+// Accept returns true if the event passes every filter rule. The
+// decision order is deliberate:
+//
+//  1. Reason must be in the allow-list (or the allow-list is empty
+//     meaning "everything" — but that's not a shipped default).
+//  2. Namespace must not be in excluded (exclude wins).
+//  3. Namespace must be in allowed (or allowed is empty = all).
+//  4. Unhealthy special case: repeat count must reach threshold.
+func (f *filter) Accept(ev TriageEvent) bool {
+	if f.cfg.allowedReasons != nil {
+		if _, ok := f.cfg.allowedReasons[ev.Key.Reason]; !ok {
+			return false
+		}
+	}
+	if len(f.cfg.excludedNamespaces) > 0 {
+		if _, excluded := f.cfg.excludedNamespaces[ev.Namespace]; excluded {
+			return false
+		}
+	}
+	if len(f.cfg.allowedNamespaces) > 0 {
+		if _, allowed := f.cfg.allowedNamespaces[ev.Namespace]; !allowed {
+			return false
+		}
+	}
+	if ev.Key.Reason == "Unhealthy" && ev.Count < f.cfg.unhealthyMinCount {
+		return false
+	}
+	return true
+}

--- a/k8s-operator/cmd/k8s-event-watcher/injector.go
+++ b/k8s-operator/cmd/k8s-event-watcher/injector.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// injectorConfig captures the daemon-side surface the sidecar posts
+// against. Constructed from CLI flags in main.go; injected into the
+// injector so tests can substitute their own httptest server.
+type injectorConfig struct {
+	// daemonURL is the base URL (scheme + host + port) — e.g.
+	// "http://127.0.0.1:7777" or "https://core-agent.example:7777".
+	// The injector appends the path components; callers pass a
+	// URL WITHOUT a trailing slash.
+	daemonURL string
+
+	// bearerToken authenticates the sidecar to the daemon. Loaded
+	// from an env var by main.go (`--token-env NAME`).
+	bearerToken string
+
+	// assertedCaller is the identity the daemon stamps as session
+	// Owner on POST /sessions. The sidecar must be listed in
+	// attach.multi_session.proxy_identities in the daemon config
+	// for this to be honored.
+	assertedCaller string
+
+	// httpClient lets tests swap in a *http.Client that talks to
+	// httptest.NewServer. Nil in production; main.go leaves it nil.
+	httpClient *http.Client
+}
+
+// injector wraps a small HTTP client that speaks the two daemon
+// endpoints the sidecar needs: POST /sessions (creates a new
+// per-incident session and returns the SessionID) and
+// POST /sessions/<sid>/inject (queues a message on that session's
+// inbox).
+type injector struct {
+	cfg    injectorConfig
+	client *http.Client
+}
+
+// newInjector constructs an injector from the config. Validates the
+// required fields early so misconfig fails fast.
+func newInjector(cfg injectorConfig) (*injector, error) {
+	if cfg.daemonURL == "" {
+		return nil, errors.New("injector: daemonURL is required")
+	}
+	if strings.HasSuffix(cfg.daemonURL, "/") {
+		return nil, fmt.Errorf("injector: daemonURL must not end with '/' (got %q)", cfg.daemonURL)
+	}
+	if cfg.bearerToken == "" {
+		return nil, errors.New("injector: bearerToken is required")
+	}
+	client := cfg.httpClient
+	if client == nil {
+		// Real production client with a modest timeout.
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+	return &injector{cfg: cfg, client: client}, nil
+}
+
+// createSessionResponse mirrors the JSON response shape for POST /sessions.
+type createSessionResponse struct {
+	AppName   string `json:"app"`
+	UserID    string `json:"user"`
+	SessionID string `json:"sessionID"`
+	URL       string `json:"url"`
+}
+
+// CreateSession asks the daemon to create a new session owned by
+// cfg.assertedCaller. Returns the new SessionID on success.
+func (i *injector) CreateSession(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, i.cfg.daemonURL+"/sessions", nil)
+	if err != nil {
+		return "", fmt.Errorf("injector: build POST /sessions: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+i.cfg.bearerToken)
+	if i.cfg.assertedCaller != "" {
+		req.Header.Set("X-Asserted-Caller", i.cfg.assertedCaller)
+	}
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("injector: POST /sessions: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("injector: POST /sessions: status %d: %s", resp.StatusCode, string(body))
+	}
+	var payload createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("injector: decode POST /sessions response: %w", err)
+	}
+	if payload.SessionID == "" {
+		return "", errors.New("injector: POST /sessions returned empty sessionID")
+	}
+	return payload.SessionID, nil
+}
+
+// injectMessageRequest is the JSON body for POST /sessions/<sid>/inject.
+type injectMessageRequest struct {
+	Message string `json:"message"`
+}
+
+// Inject POSTs a payload to /sessions/<sid>/inject.
+func (i *injector) Inject(ctx context.Context, sessionID string, payload InjectPayload) error {
+	if sessionID == "" {
+		return errors.New("injector: Inject: sessionID is required")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("injector: marshal payload: %w", err)
+	}
+	wrapped, err := json.Marshal(injectMessageRequest{Message: string(body)})
+	if err != nil {
+		return fmt.Errorf("injector: wrap inject envelope: %w", err)
+	}
+	url := i.cfg.daemonURL + "/sessions/" + sessionID + "/inject"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wrapped))
+	if err != nil {
+		return fmt.Errorf("injector: build POST inject: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+i.cfg.bearerToken)
+	req.Header.Set("Content-Type", "application/json")
+	if i.cfg.assertedCaller != "" {
+		req.Header.Set("X-Asserted-Caller", i.cfg.assertedCaller)
+	}
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("injector: POST inject: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("injector: POST inject: status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// flags is the CLI-shaped config, parsed once in main and threaded
+// to the components. All fields match --flag-name in the design
+// doc's "Sidecar CLI" section.
+type flags struct {
+	daemonURL         string
+	tokenEnv          string
+	mode              string
+	targetSession     string
+	owner             string
+	reasons           string
+	namespaces        string
+	excludeNamespaces string
+	dedupWindow       time.Duration
+	dedupPersist      string
+	unhealthyMinCount int
+	inCluster         bool
+	kubeconfig        string
+	clusterName       string
+	logLevel          string
+	dryRun            bool
+	metricsAddr       string
+	snapshotInterval  time.Duration
+}
+
+// parseFlags reads argv into flags. Returns nil on --help (main
+// exits 0). Any other parse error surfaces as an error so main can
+// report + exit 2 (POSIX convention for CLI misuse).
+func parseFlags(args []string) (*flags, error) {
+	fs := flag.NewFlagSet("k8s-event-watcher", flag.ContinueOnError)
+	f := &flags{}
+
+	// Required.
+	fs.StringVar(&f.daemonURL, "daemon-url", "", "Base URL of the core-agent daemon (http://... or https://...). Required.")
+	fs.StringVar(&f.tokenEnv, "token-env", "", "Env var name holding the bearer token for the daemon. Required.")
+
+	// Session routing.
+	fs.StringVar(&f.mode, "mode", "per-incident", "Session routing mode: per-incident (create per (uid,reason)) or shared (all to --target-session).")
+	fs.StringVar(&f.targetSession, "target-session", "", "Required when --mode=shared: SessionID to post all injects to.")
+	fs.StringVar(&f.owner, "owner", "", "X-Asserted-Caller value for POST /sessions in per-incident mode. Sidecar must be in daemon's proxy_identities.")
+
+	// Event filtering.
+	fs.StringVar(&f.reasons, "reason", "", "Comma-separated allow-list of Event.Reason values. Empty = shipped default set.")
+	fs.StringVar(&f.namespaces, "namespace", "", "Comma-separated allow-list of namespaces. Empty = all namespaces.")
+	fs.StringVar(&f.excludeNamespaces, "exclude-namespace", "", "Comma-separated deny-list of namespaces.")
+
+	// Dedup.
+	fs.DurationVar(&f.dedupWindow, "dedup-window", 5*time.Minute, "Rolling window for (uid,reason) dedup.")
+	fs.StringVar(&f.dedupPersist, "dedup-persist", "", "Optional path to persist dedup cache across sidecar restart.")
+	fs.IntVar(&f.unhealthyMinCount, "unhealthy-min-count", 3, "Require this many consecutive Unhealthy events before firing.")
+
+	// Kubernetes client.
+	fs.BoolVar(&f.inCluster, "in-cluster", false, "Use in-cluster service account credentials. Auto-detected inside a pod.")
+	fs.StringVar(&f.kubeconfig, "kubeconfig", "", "Explicit kubeconfig path. Used outside a pod.")
+	fs.StringVar(&f.clusterName, "cluster-name", "", "Human-readable cluster name included in every inject payload.")
+
+	// Operational.
+	fs.StringVar(&f.logLevel, "log-level", "info", "One of: debug, info, warn, error.")
+	fs.BoolVar(&f.dryRun, "dry-run", false, "Print inject payloads to stdout without calling the daemon.")
+	fs.StringVar(&f.metricsAddr, "metrics-addr", "", "Prometheus /metrics + /healthz listener address (host:port). Empty = disabled.")
+	fs.DurationVar(&f.snapshotInterval, "snapshot-interval", 30*time.Second, "How often to persist the dedup cache when --dedup-persist is set. 0 = only on shutdown.")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// validate checks flag combinations after parse. Called once from
+// main so misconfig fails before any network / API touching.
+func (f *flags) validate() error {
+	if !f.dryRun && f.daemonURL == "" {
+		return errors.New("--daemon-url is required (unless --dry-run)")
+	}
+	if !f.dryRun && f.tokenEnv == "" {
+		return errors.New("--token-env is required (unless --dry-run)")
+	}
+	if strings.HasSuffix(f.daemonURL, "/") {
+		return fmt.Errorf("--daemon-url must not end with '/' (got %q)", f.daemonURL)
+	}
+	switch f.mode {
+	case "per-incident":
+		if f.dryRun {
+			return nil
+		}
+		if f.owner == "" {
+			return errors.New("--owner is required in per-incident mode (must match a proxy identity in the daemon's users.json)")
+		}
+	case "shared":
+		if f.targetSession == "" {
+			return errors.New("--target-session is required in shared mode")
+		}
+	default:
+		return fmt.Errorf("--mode must be per-incident or shared (got %q)", f.mode)
+	}
+	if f.dedupWindow <= 0 {
+		return errors.New("--dedup-window must be > 0")
+	}
+	if f.snapshotInterval < 0 {
+		return errors.New("--snapshot-interval must be >= 0")
+	}
+	return nil
+}
+
+// splitCSV parses a comma-separated flag value. Empty strings after
+// split are dropped; whitespace around values trimmed.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// buildKubeClient constructs a kubernetes.Interface from the flags.
+// Precedence:
+//  1. Explicit --kubeconfig always wins (out-of-cluster ops).
+//  2. --in-cluster or auto-detected (KUBERNETES_SERVICE_HOST env
+//     var is set inside a pod).
+//  3. $KUBECONFIG env var → fallback to ~/.kube/config.
+func buildKubeClient(f *flags) (kubernetes.Interface, error) {
+	var (
+		cfg *rest.Config
+		err error
+	)
+	switch {
+	case f.kubeconfig != "":
+		cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)
+		}
+	case f.inCluster || os.Getenv("KUBERNETES_SERVICE_HOST") != "":
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("in-cluster config: %w", err)
+		}
+	default:
+		// Fallback to default kubeconfig search (KUBECONFIG env,
+		// then $HOME/.kube/config). Fine for local dev; a real
+		// deployment always sets --in-cluster or --kubeconfig.
+		loader := clientcmd.NewDefaultClientConfigLoadingRules()
+		cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("default kubeconfig: %w", err)
+		}
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+	return client, nil
+}
+
+// dispatcher is the pipeline that ties filter → dedup → injector +
+// metrics for one event. Implements eventDispatcher so watcher.go
+// can call Dispatch on it.
+type dispatcher struct {
+	filter    *filter
+	dedup     *dedupCache
+	injector  *injector
+	metrics   *metrics
+	cluster   string
+	mode      string // "per-incident" or "shared"
+	targetSid string // for shared mode
+	dryRun    bool
+	// injectLock serializes per-(app, sid) session creation +
+	// injects so two rapid-fire events for the same key don't
+	// both call CreateSession. Coarse-grained; a per-key map of
+	// mutexes would let concurrent keys parallelize but this
+	// path is nowhere near a bottleneck.
+	injectLock sync.Mutex
+}
+
+// Dispatch is the eventDispatcher entry point.
+func (d *dispatcher) Dispatch(ctx context.Context, ev TriageEvent) {
+	d.metrics.eventsSeen.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+	if !d.filter.Accept(ev) {
+		return
+	}
+	result := d.dedup.Observe(ev.Key, ev.LastSeen)
+	d.metrics.activeIncidents.Set(float64(d.dedup.Len()))
+	if result.Kind == dedupDuplicate {
+		d.metrics.eventsDedupSuppress.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+		log.Printf("dedup %s pod=%s/%s (count=%d, window active)",
+			ev.Key.Reason, ev.Namespace, ev.Name, result.Count)
+		return
+	}
+	// New incident: create or reuse a session, then inject.
+	d.injectLock.Lock()
+	defer d.injectLock.Unlock()
+	sid := d.targetSid
+	if d.mode == "per-incident" && !d.dryRun {
+		newSid, err := d.injector.CreateSession(ctx)
+		if err != nil {
+			log.Printf("dispatcher: create session for %s/%s: %v", ev.Namespace, ev.Name, err)
+			d.metrics.sessionCreates.WithLabelValues("error").Inc()
+			d.metrics.injectErrors.WithLabelValues(ev.Key.Reason, "session_create").Inc()
+			return
+		}
+		sid = newSid
+		d.metrics.sessionCreates.WithLabelValues("ok").Inc()
+		d.dedup.BindSession(ev.Key, sid)
+	}
+	payload := InjectPayload{
+		Kind:         injectKindEvent,
+		Reason:       ev.Key.Reason,
+		Namespace:    ev.Namespace,
+		KindOfObject: ev.KindOfObject,
+		Name:         ev.Name,
+		Container:    ev.Container,
+		UID:          ev.Key.UID,
+		Message:      ev.Message,
+		Count:        result.Count,
+		FirstSeen:    ev.FirstSeen,
+		LastSeen:     ev.LastSeen,
+		Cluster:      d.cluster,
+		Context: PayloadContext{
+			ControllerRef: ev.ControllerRef,
+			Node:          ev.Node,
+			Labels:        ev.Labels,
+		},
+	}
+	if d.dryRun {
+		out, _ := json.MarshalIndent(payload, "", "  ")
+		fmt.Printf("--- dry-run payload for session %q ---\n%s\n", sid, string(out))
+		d.metrics.eventsInjected.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+		log.Printf("would-fire %s pod=%s/%s (sid=%s, mode=%s, dry-run)",
+			ev.Key.Reason, ev.Namespace, ev.Name, sid, d.mode)
+		return
+	}
+	if err := d.injector.Inject(ctx, sid, payload); err != nil {
+		log.Printf("dispatcher: inject for %s/%s (sid=%s): %v", ev.Namespace, ev.Name, sid, err)
+		d.metrics.injectErrors.WithLabelValues(ev.Key.Reason, "inject").Inc()
+		return
+	}
+	d.metrics.eventsInjected.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+	log.Printf("fire %s pod=%s/%s → sid=%s (mode=%s)",
+		ev.Key.Reason, ev.Namespace, ev.Name, sid, d.mode)
+}
+
+func main() {
+	if err := realMain(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "k8s-event-watcher:", err)
+		os.Exit(1)
+	}
+}
+
+func realMain(argv []string) error {
+	f, err := parseFlags(argv)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if err := f.validate(); err != nil {
+		return err
+	}
+
+	// Resolve bearer token from env (unless dry-run).
+	var token string
+	if !f.dryRun {
+		token = os.Getenv(f.tokenEnv)
+		if token == "" {
+			return fmt.Errorf("bearer token env var %s is empty", f.tokenEnv)
+		}
+	}
+
+	// Build components.
+	filterCfg := newFilterConfig(splitCSV(f.reasons), splitCSV(f.namespaces), splitCSV(f.excludeNamespaces), f.unhealthyMinCount)
+	filter := newFilter(filterCfg)
+
+	dedup, err := newDedupCache(f.dedupWindow, f.dedupPersist)
+	if err != nil {
+		return fmt.Errorf("dedup cache: %w", err)
+	}
+
+	m := newMetrics()
+
+	var inj *injector
+	if !f.dryRun {
+		inj, err = newInjector(injectorConfig{
+			daemonURL:      f.daemonURL,
+			bearerToken:    token,
+			assertedCaller: f.owner,
+		})
+		if err != nil {
+			return fmt.Errorf("injector: %w", err)
+		}
+	}
+
+	disp := &dispatcher{
+		filter:    filter,
+		dedup:     dedup,
+		injector:  inj,
+		metrics:   m,
+		cluster:   f.clusterName,
+		mode:      f.mode,
+		targetSid: f.targetSession,
+		dryRun:    f.dryRun,
+	}
+
+	// Root ctx cancelled on SIGINT / SIGTERM for graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Start the metrics HTTP server (blocks on ctx in-goroutine).
+	go func() {
+		if err := serveMetrics(ctx, f.metricsAddr, m); err != nil {
+			log.Printf("metrics server: %v", err)
+		}
+	}()
+
+	// Start the periodic dedup-snapshot ticker if configured.
+	if f.dedupPersist != "" && f.snapshotInterval > 0 {
+		go runSnapshotLoop(ctx, dedup, f.snapshotInterval)
+	}
+
+	// Build the kube client.
+	if f.dryRun {
+		log.Printf("k8s-event-watcher: --dry-run: skipping kube client; would watch cluster %q", f.clusterName)
+		<-ctx.Done()
+		if err := dedup.Snapshot(); err != nil {
+			log.Printf("dedup snapshot on shutdown: %v", err)
+		}
+		return nil
+	}
+	client, err := buildKubeClient(f)
+	if err != nil {
+		return err
+	}
+
+	w := newWatcher(client, disp, f.clusterName, 0)
+	log.Printf("k8s-event-watcher: starting on cluster %q → daemon %s (mode=%s, owner=%s)",
+		f.clusterName, f.daemonURL, f.mode, f.owner)
+	err = w.Run(ctx)
+	if snapErr := dedup.Snapshot(); snapErr != nil {
+		log.Printf("dedup snapshot on shutdown: %v", snapErr)
+	}
+	return err
+}
+
+// runSnapshotLoop persists the dedup cache to disk on an interval.
+func runSnapshotLoop(ctx context.Context, cache *dedupCache, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := cache.Snapshot(); err != nil {
+				log.Printf("dedup snapshot: %v", err)
+			}
+		}
+	}
+}

--- a/k8s-operator/cmd/k8s-event-watcher/metrics.go
+++ b/k8s-operator/cmd/k8s-event-watcher/metrics.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// metrics bundles the sidecar's Prometheus counters + gauges. Kept
+// as a struct so the wiring is testable — tests can construct a
+// registry, wire metrics into it, and assert values without
+// stringifying Prometheus output.
+type metrics struct {
+	registry            *prometheus.Registry
+	eventsSeen          *prometheus.CounterVec
+	eventsInjected      *prometheus.CounterVec
+	eventsDedupSuppress *prometheus.CounterVec
+	injectErrors        *prometheus.CounterVec
+	sessionCreates      *prometheus.CounterVec
+	activeIncidents     prometheus.Gauge
+}
+
+// newMetrics registers all sidecar metrics against a fresh registry
+// and returns the bundle. Tests use this with an isolated registry;
+// main.go passes the resulting handler to promhttp.
+func newMetrics() *metrics {
+	reg := prometheus.NewRegistry()
+	m := &metrics{
+		registry: reg,
+		eventsSeen: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_seen_total",
+			Help: "Total k8s events observed by the informer, before filter.",
+		}, []string{"reason", "namespace"}),
+		eventsInjected: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_injected_total",
+			Help: "Total events that survived filter + dedup and were POSTed to the daemon.",
+		}, []string{"reason", "namespace"}),
+		eventsDedupSuppress: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_deduped_total",
+			Help: "Total events suppressed by the rolling-window dedup cache.",
+		}, []string{"reason", "namespace"}),
+		injectErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_inject_errors_total",
+			Help: "Total inject (or session-create) attempts that returned a non-2xx response or transport error.",
+		}, []string{"reason", "http_code"}),
+		sessionCreates: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_session_creates_total",
+			Help: "Total POST /sessions attempts, labeled by outcome.",
+		}, []string{"outcome"}),
+		activeIncidents: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "k8s_event_watcher_active_incidents",
+			Help: "Current number of incidents in the sidecar's dedup cache.",
+		}),
+	}
+	reg.MustRegister(
+		m.eventsSeen,
+		m.eventsInjected,
+		m.eventsDedupSuppress,
+		m.injectErrors,
+		m.sessionCreates,
+		m.activeIncidents,
+	)
+	return m
+}
+
+// serveMetrics starts a small HTTP server exposing /metrics on addr.
+// Blocks until ctx is cancelled; returns any listener error. Callers
+// start it in a goroutine and use ctx cancellation for shutdown.
+//
+// When addr == "" the server is skipped entirely (metrics still get
+// collected in-process; just not exposed). Useful for tests + tiny
+// deployments that don't have a Prometheus scraper.
+func serveMetrics(ctx context.Context, addr string, m *metrics) error {
+	if addr == "" {
+		<-ctx.Done()
+		return nil
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}))
+	// Simple liveness probe — no /metrics dependency, so K8s can
+	// use it as a livenessProbe without conflating "prometheus is
+	// scraping" with "the process is up."
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	// Bind synchronously so port-in-use fails fast; then serve
+	// in a goroutine and let ctx cancellation drive shutdown.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("metrics: listen %s: %w", addr, err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Serve(ln) }()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}

--- a/k8s-operator/cmd/k8s-event-watcher/types.go
+++ b/k8s-operator/cmd/k8s-event-watcher/types.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command k8s-event-watcher is the v2.6 semi-autonomous-triage sidecar.
+// It watches Kubernetes Events via a client-go informer, filters to a
+// configured allow-list of Event.Reason values, dedupes duplicates
+// within a rolling window, and POSTs matched events to a core-agent
+// daemon's per-incident session endpoint. See
+// docs/k8s-event-agent-design.md for the full design.
+package main
+
+import "time"
+
+// EventKey uniquely identifies an incident for dedup purposes: the
+// (involvedObject.uid, reason) pair. Same pod + same failure mode =
+// same incident, regardless of how many event objects the k8s API
+// emits about it.
+type EventKey struct {
+	UID    string
+	Reason string
+}
+
+// TriageEvent is the internal representation the filter + dedup +
+// injector layers pass around. Derived from *corev1.Event by watcher.go
+// but carries no k8s.io/api types itself so unit tests can construct
+// it without a fake clientset.
+type TriageEvent struct {
+	Key           EventKey
+	Namespace     string
+	KindOfObject  string
+	Name          string
+	Container     string
+	Message       string
+	FirstSeen     time.Time
+	LastSeen      time.Time
+	ControllerRef string
+	Node          string
+	Labels        map[string]string
+	// Count is the k8s Event's own repeat-count field (how many times
+	// the source recorded this same event). The sidecar's own dedup
+	// counter is separate — see dedup.go.
+	Count int
+}
+
+// InjectPayload is the JSON body POSTed to
+// /sessions/<sid>/inject.message. Field names and casing mirror the
+// design doc's "Inject payload shape" section verbatim so playbook
+// skills can pattern-match against them.
+type InjectPayload struct {
+	Kind         string         `json:"kind"`
+	Reason       string         `json:"reason"`
+	Namespace    string         `json:"namespace"`
+	KindOfObject string         `json:"kind_of_object"`
+	Name         string         `json:"name"`
+	Container    string         `json:"container,omitempty"`
+	UID          string         `json:"uid"`
+	Message      string         `json:"message"`
+	Count        int            `json:"count"`
+	FirstSeen    time.Time      `json:"first_seen"`
+	LastSeen     time.Time      `json:"last_seen"`
+	Cluster      string         `json:"cluster"`
+	Context      PayloadContext `json:"context"`
+}
+
+// PayloadContext is the nested "context" object on InjectPayload.
+type PayloadContext struct {
+	ControllerRef string            `json:"controller_ref,omitempty"`
+	Node          string            `json:"node,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+}
+
+// injectKind is the constant we stamp on every payload's "kind"
+// field. Skills match against this to distinguish k8s-triggered
+// injects from other signal sources (Cloud Monitoring, PagerDuty,
+// etc.) that would use different constants when they ship.
+const (
+	injectKindEvent    = "k8s-event"
+	injectKindFollowup = "k8s-event-followup"
+)

--- a/k8s-operator/cmd/k8s-event-watcher/watcher.go
+++ b/k8s-operator/cmd/k8s-event-watcher/watcher.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// eventDispatcher is the callback the watcher invokes for every k8s
+// event that arrives from the informer. Injected here (not called
+// from watcher.go) so tests can wire a stub that just records what
+// was dispatched.
+type eventDispatcher interface {
+	Dispatch(ctx context.Context, ev TriageEvent)
+}
+
+// watcher wires a client-go informer for core/v1.Events into an
+// eventDispatcher. The informer resyncs every resyncPeriod; on Add
+// (new event object) and Update (event count bump), the handler
+// converts the *corev1.Event to a TriageEvent and hands it to the
+// dispatcher.
+//
+// The dispatcher decides whether to filter/dedup/inject — watcher
+// itself is just the informer boilerplate.
+type watcher struct {
+	client       kubernetes.Interface
+	dispatcher   eventDispatcher
+	clusterName  string
+	resyncPeriod time.Duration
+}
+
+// newWatcher constructs a watcher. resyncPeriod == 0 disables the
+// periodic resync (informer only fires on real API events); non-zero
+// values re-fire every registered event through the handler at that
+// cadence — usually not what you want, so default 0 in main.go.
+func newWatcher(client kubernetes.Interface, dispatcher eventDispatcher, clusterName string, resyncPeriod time.Duration) *watcher {
+	return &watcher{
+		client:       client,
+		dispatcher:   dispatcher,
+		clusterName:  clusterName,
+		resyncPeriod: resyncPeriod,
+	}
+}
+
+// Run starts the informer + handler goroutines and blocks until ctx
+// is cancelled. Returns any startup error (e.g., initial list
+// failure); shutdown-path errors are logged but not returned so
+// callers can distinguish "startup failed, restart me" from "clean
+// shutdown."
+func (w *watcher) Run(ctx context.Context) error {
+	factory := informers.NewSharedInformerFactory(w.client, w.resyncPeriod)
+	eventInformer := factory.Core().V1().Events().Informer()
+
+	handler, err := eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			ev, ok := obj.(*corev1.Event)
+			if !ok {
+				log.Printf("watcher: unexpected object type on Add: %T", obj)
+				return
+			}
+			w.dispatch(ctx, ev)
+		},
+		UpdateFunc: func(_, newObj any) {
+			// Update fires when the k8s API bumps the Event's
+			// Count / LastTimestamp (kubelet reports a repeat).
+			// We treat each update as another observation so
+			// persistent failures continue to feed the dedup
+			// window's LastSeen bump.
+			ev, ok := newObj.(*corev1.Event)
+			if !ok {
+				log.Printf("watcher: unexpected object type on Update: %T", newObj)
+				return
+			}
+			w.dispatch(ctx, ev)
+		},
+		// No DeleteFunc — event deletion is not a signal we care
+		// about; the underlying incident may or may not be
+		// resolved and we don't want to trigger investigations
+		// on tombstones.
+	})
+	if err != nil {
+		return fmt.Errorf("watcher: register event handler: %w", err)
+	}
+	// Silence the client-go internal error log ("unknown object
+	// type in cache") on shutdown — cache.HandleCrash trips over
+	// ctx.Done races otherwise. The default panic handler still
+	// fires for real crashes.
+	runtime.ErrorHandlers = []runtime.ErrorHandler{
+		func(_ context.Context, err error, _ string, _ ...any) {
+			log.Printf("watcher: informer error: %v", err)
+		},
+	}
+
+	factory.Start(ctx.Done())
+	// WaitForCacheSync blocks until the initial list is done —
+	// without this, the first N events after startup would
+	// arrive without their prior Count/LastTimestamp, breaking
+	// the dedup logic.
+	if !cache.WaitForCacheSync(ctx.Done(), handler.HasSynced) {
+		return fmt.Errorf("watcher: cache sync failed (informer stopped before initial list completed)")
+	}
+	<-ctx.Done()
+	return nil
+}
+
+// dispatch converts a *corev1.Event to the internal TriageEvent
+// shape and hands it to the dispatcher. Extracted so both AddFunc
+// and UpdateFunc share one code path. The cluster name is added
+// downstream (dispatcher.Dispatch stamps it onto InjectPayload)
+// rather than TriageEvent so tests don't have to thread it through.
+func (w *watcher) dispatch(ctx context.Context, ev *corev1.Event) {
+	triage := toTriageEvent(ev)
+	w.dispatcher.Dispatch(ctx, triage)
+}
+
+// toTriageEvent flattens a *corev1.Event to the internal payload
+// shape. Timestamps prefer LastTimestamp (kubelet-set); fall back
+// to EventTime / CreationTimestamp per k8s API convention.
+func toTriageEvent(ev *corev1.Event) TriageEvent {
+	first := ev.FirstTimestamp.Time
+	if first.IsZero() {
+		first = ev.EventTime.Time
+	}
+	if first.IsZero() {
+		first = ev.CreationTimestamp.Time
+	}
+	last := ev.LastTimestamp.Time
+	if last.IsZero() {
+		last = ev.EventTime.Time
+	}
+	if last.IsZero() {
+		last = ev.CreationTimestamp.Time
+	}
+
+	// The event references its target via InvolvedObject.
+	// InvolvedObject.UID is what we key dedup on.
+	uid := string(ev.InvolvedObject.UID)
+
+	// ControllerRef: for a Pod, the parent ReplicaSet /
+	// Deployment / StatefulSet is on OwnerReferences. Populating
+	// this requires an additional Pod GET which we don't have
+	// in-hand here. Left empty; the recipe includes RBAC for
+	// pod GET so the agent can enrich via MCP if needed.
+	controllerRef := ""
+
+	return TriageEvent{
+		Key: EventKey{
+			UID:    uid,
+			Reason: ev.Reason,
+		},
+		Namespace:     ev.InvolvedObject.Namespace,
+		KindOfObject:  ev.InvolvedObject.Kind,
+		Name:          ev.InvolvedObject.Name,
+		Container:     ev.InvolvedObject.FieldPath,
+		Message:       truncateMessage(ev.Message),
+		FirstSeen:     first,
+		LastSeen:      last,
+		ControllerRef: controllerRef,
+		Node:          nodeFromSource(ev),
+		Labels:        labelsFromMeta(ev.ObjectMeta),
+		Count:         int(ev.Count),
+	}
+}
+
+// truncateMessage caps the payload's message field. K8s event
+// messages are supposed to be small but we've seen kubelet emit
+// multi-KB stack traces; playbook skills don't need more than a
+// few hundred bytes to categorize.
+func truncateMessage(msg string) string {
+	const max = 2048
+	if len(msg) <= max {
+		return msg
+	}
+	return msg[:max] + "... [truncated by k8s-event-watcher]"
+}
+
+// nodeFromSource pulls the node name out of an Event's Source or
+// ReportingController fields, whichever the API server populated.
+func nodeFromSource(ev *corev1.Event) string {
+	if ev.Source.Host != "" {
+		return ev.Source.Host
+	}
+	if ev.ReportingInstance != "" {
+		return ev.ReportingInstance
+	}
+	return ""
+}
+
+// labelsFromMeta returns a shallow copy of the event's own labels
+// (not the involved object's — that would require an extra API
+// call). Empty when no labels are set.
+func labelsFromMeta(m metav1.ObjectMeta) map[string]string {
+	if len(m.Labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m.Labels))
+	for k, v := range m.Labels {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
# Pull Request

## Why This Change
This PR begins the implementation of the GKE Event Watcher sidecar integration (Task 1 of the integration plan). It introduces the core Go-based `k8s-event-watcher` service, which watches cluster warning events in real-time, filters them based on configured reasons, and deduplicates resource crash loops to prepare autonomous agent troubleshooting runs.

To ensure high-fidelity team reviews, we stripped all OpenTelemetry custom dependency setups, allowing the watcher component to compile natively inside the operator build tree.

## What Changed
Added the event watcher source files and the integration README document.

**Files:**
- `k8s-operator/cmd/k8s-event-watcher/README.md` (Integration Plan & Design Proposal)
- `k8s-operator/cmd/k8s-event-watcher/main.go`
- `k8s-operator/cmd/k8s-event-watcher/injector.go`
- `k8s-operator/cmd/k8s-event-watcher/watcher.go`
- `k8s-operator/cmd/k8s-event-watcher/dedup.go`
- `k8s-operator/cmd/k8s-event-watcher/filter.go`
- `k8s-operator/cmd/k8s-event-watcher/types.go`
- `k8s-operator/cmd/k8s-event-watcher/metrics.go`

**Added/Changed/Fixed:**
- Added the `k8s-event-watcher` command component under `k8s-operator/cmd/`.

## Why This Matters
This forms the foundational component of our real-time, event-driven autonomous troubleshooting pipeline. Getting this checked in and reviewed ensures the architecture is aligned before we start extending the agent's internal FastAPI helper routes and deploying the container.

## Context
First step of GKE event poller integration.

## Testing
Validated local compilation and run in dry-run mode:
```bash
cd k8s-operator/cmd/k8s-event-watcher
go build -o watcher .
./watcher --dry-run --cluster-name=dev-cluster
```
