### PR TITLE
feat(ci): add manual trigger and secrets job to integrations redeploy workflow

### DIFF
--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -69,6 +69,8 @@ jobs:
     concurrency:
       group: staging-redeploy-secrets
       cancel-in-progress: true
+    env:
+      NAMESPACE: ${{ vars.NAMESPACE }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -121,25 +123,8 @@ jobs:
       group: staging-redeploy-litellm
       cancel-in-progress: true
     env:
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-      GCP_REGION: ${{ vars.GCP_REGION }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
-      MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
-      MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
-      NAMESPACE: "kubeagents-system"
+      NAMESPACE: ${{ vars.NAMESPACE }}
     steps:
-      - name: Verify Env Variables
-        shell: bash
-        run: |
-          for var in GCP_PROJECT_ID GCP_REGION GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT GKE_CLUSTER_NAME MODEL_DEFAULT_NAME MODEL_PROVIDER; do
-            if [ -z "${!var}" ]; then
-              echo "::error::Required environment variable $var is not set."
-              exit 1
-            fi
-          done
-
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -152,23 +137,23 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           token_format: "access_token"
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to GKE
         uses: google-github-actions/get-gke-credentials@v3
         with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
-          location: ${{ env.GCP_REGION }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
+          cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
+          location: ${{ vars.GCP_REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Perform LiteLLM Redeployment
         env:
-          PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
-          REGION: ${{ env.GCP_REGION }}
-          CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
-          MODEL_PROVIDER: ${{ env.MODEL_PROVIDER }}
-          MODEL_DEFAULT_NAME: ${{ env.MODEL_DEFAULT_NAME }}
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          REGION: ${{ vars.GCP_REGION }}
+          CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+          MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
+          MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
         run: |
           echo "Redeploying LiteLLM gateway via provision_08"
           cd k8s-operator
@@ -235,29 +220,9 @@ jobs:
       group: staging-redeploy-github
       cancel-in-progress: true
     env:
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-      GCP_REGION: ${{ vars.GCP_REGION }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
-      GITHUB_ORG: ${{ vars.GH_ORG }}
-      GITHUB_REPO: ${{ vars.GH_REPO }}
-      GITHUB_APP_ID: ${{ vars.GH_APP_ID}}
       GITHUB_PEM_PATH: "/tmp/github_app_pem_path"
-      KMS_KEYRING: ${{ vars.KMS_KEYRING }}
-      KMS_KEY: ${{ vars.KMS_KEY }}
-      NAMESPACE: "kubeagents-system"
+      NAMESPACE: ${{ vars.NAMESPACE }}
     steps:
-      - name: Verify Env Variables
-        shell: bash
-        run: |
-          for var in GCP_PROJECT_ID GCP_REGION GCP_WORKLOAD_IDENTITY_PROVIDER GCP_SERVICE_ACCOUNT GKE_CLUSTER_NAME GITHUB_ORG GITHUB_REPO GITHUB_APP_ID KMS_KEYRING KMS_KEY; do
-            if [ -z "${!var}" ]; then
-              echo "::error::Required environment variable $var is not set."
-              exit 1
-            fi
-          done
-
       - name: Checkout code
         uses: actions/checkout@v7
 
@@ -270,15 +235,15 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           token_format: "access_token"
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to GKE
         uses: google-github-actions/get-gke-credentials@v3
         with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
-          location: ${{ env.GCP_REGION }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
+          cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
+          location: ${{ vars.GCP_REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
 
       - name: Create GitHub Private Key PEM File
         env:
@@ -293,9 +258,9 @@ jobs:
 
       - name: Perform GitHub Token Minter Redeployment
         env:
-          PROJECT_ID: ${{ env.GCP_PROJECT_ID }}
-          REGION: ${{ env.GCP_REGION }}
-          CLUSTER_NAME: ${{ env.GKE_CLUSTER_NAME }}
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          REGION: ${{ vars.GCP_REGION }}
+          CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
         run: |
           echo "Redeploying GitHub Token Minter via provision_09"
           cd k8s-operator

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -9,6 +9,16 @@ on:
       - "k8s-operator/scripts/provision_08_deploy_litellm.sh"
       - "k8s-operator/scripts/provision_09_deploy_github_minter.sh"
       - "k8s-operator/Makefile"
+  workflow_dispatch:
+    inputs:
+      deploy_litellm:
+        description: "Redeploy LiteLLM Integration"
+        type: boolean
+        default: true
+      deploy_github:
+        description: "Redeploy GitHub Minter Integration"
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -19,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'gke-labs/kube-agents'
     outputs:
-      litellm: ${{ steps.filter.outputs.litellm }}
-      github: ${{ steps.filter.outputs.github }}
+      litellm: ${{ steps.set-targets.outputs.litellm }}
+      github: ${{ steps.set-targets.outputs.github }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -39,9 +49,71 @@ jobs:
               - 'k8s-operator/scripts/provision_09_deploy_github_minter.sh'
               - 'k8s-operator/Makefile'
 
+      - name: Determine target deployments
+        id: set-targets
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "litellm=${{ github.event.inputs.deploy_litellm }}" >> "$GITHUB_OUTPUT"
+            echo "github=${{ github.event.inputs.deploy_github }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "litellm=${{ steps.filter.outputs.litellm }}" >> "$GITHUB_OUTPUT"
+            echo "github=${{ steps.filter.outputs.github }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  provision-secrets:
+    name: Provision Kubernetes Secrets
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.litellm == 'true' || needs.detect-changes.outputs.github == 'true' }}
+    runs-on: ubuntu-latest
+    environment: staging
+    concurrency:
+      group: staging-redeploy-secrets
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "k8s-operator/go.mod"
+
+      - name: Authenticate to Google Cloud via WIF
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: "access_token"
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Authenticate to GKE
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
+          location: ${{ vars.GCP_REGION }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Perform Secrets Provisioning
+        env:
+          PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          REGION: ${{ vars.GCP_REGION }}
+          CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+          MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
+          MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          API_SERVER_KEY: ${{ secrets.API_SERVER_KEY }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
+          GITHUB_APP_ID: ${{ vars.GH_APP_ID }}
+        run: |
+          echo "Provisioning secrets via provision_06"
+          cd k8s-operator
+          make gcp-provision-06-secrets ARGS="--no-confirm"
+
   deploy-litellm:
     name: Redeploy LiteLLM Gateway Integration
-    needs: detect-changes
+    needs: [detect-changes, provision-secrets]
     if: ${{ needs.detect-changes.outputs.litellm == 'true' }}
     runs-on: ubuntu-latest
     environment: staging
@@ -155,7 +227,7 @@ jobs:
 
   deploy-github:
     name: Redeploy GitHub Token Minter Integration
-    needs: [detect-changes, check-github-config]
+    needs: [detect-changes, provision-secrets, check-github-config]
     if: ${{ needs.detect-changes.outputs.github == 'true' && needs.check-github-config.outputs.configured == 'true' }}
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -107,7 +107,7 @@ jobs:
           API_SERVER_KEY: ${{ secrets.API_SERVER_KEY }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_APP_TOKEN: ${{ secrets.SLACK_APP_TOKEN }}
-          GITHUB_APP_ID: ${{ vars.GH_APP_ID }}
+          GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
         run: |
           echo "Provisioning secrets via provision_06"
           cd k8s-operator
@@ -185,7 +185,7 @@ jobs:
         env:
           GH_ORG: ${{ vars.GH_ORG }}
           GH_REPO: ${{ vars.GH_REPO }}
-          GH_APP_ID: ${{ vars.GH_APP_ID }}
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
         run: |
           missing=()
           for var in GH_ORG GH_REPO GH_APP_ID; do

--- a/k8s-operator/scripts/provision_06_gcp_k8s_secrets.sh
+++ b/k8s-operator/scripts/provision_06_gcp_k8s_secrets.sh
@@ -38,8 +38,8 @@ init_var_model_provider
 # Securely prompt for Gemini API Key if Gemini is the provider and it's not set/placeholder
 if [ "$MODEL_PROVIDER" = "gemini" ]; then
   if [ -z "${GEMINI_API_KEY:-}" ] || [ "${GEMINI_API_KEY}" = "placeholder" ]; then
-    if [ "${DRY_RUN:-0}" -eq 1 ]; then
-      save_var "GEMINI_API_KEY" "placeholder"
+    if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
+      save_var "GEMINI_API_KEY" "${GEMINI_API_KEY:-placeholder}"
     else
       echo -ne "  ${C_CYAN}Enter your GEMINI_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
       read -s -r INPUT_KEY
@@ -54,8 +54,8 @@ fi
 # Securely prompt for OpenAI API Key if OpenAI is the provider and it's not set/placeholder
 if [ "$MODEL_PROVIDER" = "openai" ]; then
   if [ -z "${OPENAI_API_KEY:-}" ] || [ "${OPENAI_API_KEY}" = "placeholder" ]; then
-    if [ "${DRY_RUN:-0}" -eq 1 ]; then
-      save_var "OPENAI_API_KEY" "placeholder"
+    if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
+      save_var "OPENAI_API_KEY" "${OPENAI_API_KEY:-placeholder}"
     else
       echo -ne "  ${C_CYAN}Enter your OPENAI_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
       read -s -r INPUT_KEY
@@ -70,8 +70,8 @@ fi
 # Securely prompt for Anthropic API Key if Anthropic is the provider and it's not set/placeholder
 if [ "$MODEL_PROVIDER" = "anthropic" ]; then
   if [ -z "${ANTHROPIC_API_KEY:-}" ] || [ "${ANTHROPIC_API_KEY}" = "placeholder" ]; then
-    if [ "${DRY_RUN:-0}" -eq 1 ]; then
-      save_var "ANTHROPIC_API_KEY" "placeholder"
+    if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
+      save_var "ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY:-placeholder}"
     else
       echo -ne "  ${C_CYAN}Enter your ANTHROPIC_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
       read -s -r INPUT_KEY


### PR DESCRIPTION
# Pull Request

## Why This Change

Enable manual triggers (`workflow_dispatch`) per integration job in the staging redeploy integrations workflow, and introduce a prerequisite `provision-secrets` job running `provision_06_gcp_k8s_secrets.sh` to ensure Kubernetes secrets are configured prior to LiteLLM and GitHub minter redeployments.

## What Changed

**Files:**

- `.github/workflows/staging-redeploy-integrations.yml`
- `k8s-operator/scripts/provision_06_gcp_k8s_secrets.sh`

**Added/Changed/Fixed:**

- Added `workflow_dispatch` trigger with per-job inputs (`deploy_litellm`, `deploy_github`) to `.github/workflows/staging-redeploy-integrations.yml`.
- Added prerequisite `provision-secrets` job executing `make gcp-provision-06-secrets ARGS="--no-confirm"`.
- Updated `provision_06_gcp_k8s_secrets.sh` to check `is_ci_pipeline` for non-interactive execution.
- Simplified job environments using `vars.NAMESPACE` and direct `vars.*` references.

## Why This Matters

Allows targeted manual execution of integration redeployments while guaranteeing prerequisites and secrets synchronization in GKE.

## Context

Enhances staging deployment operations and manual workflow controls.

## Testing

- Verified YAML formatting with Prettier.
- Verified bash syntax (`bash -n`).