### PR TITLE
fix(deploy): force copy default agent files in entrypoint without update check

### DIFF
--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -24,7 +24,7 @@ fi
 # 2. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)
 if [ -d "/opt/defaults" ]; then
     mkdir -p "$TARGET_DIR"
-    cp -ru /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || cp -rp /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || true
+    cp -rf /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || cp -r /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || true
 fi
 
 # 3. Enable OpenTelemetry plugin in active config.yaml (if writable)


### PR DESCRIPTION
# Pull Request

## Why This Change

When the Platform Agent container boots on a fresh or persistent volume (`/opt/data`), `docker-entrypoint.sh` executes the upstream `stage2-hook.sh` initialization script before syncing defaults (`/opt/defaults/`). Because `stage2-hook.sh` dynamically generates a default 514-byte `SOUL.md` inside `/opt/data/` if one does not exist, the newly generated file receives the current runtime timestamp (`now`).

When Step 2 (`cp -ru /opt/defaults/. /opt/data/`) runs immediately afterward, `cp -u` compares the modification timestamp of `/opt/defaults/SOUL.md` (set during `docker build`) against `/opt/data/SOUL.md` (`now`). Because the runtime file has a newer timestamp, `cp -ru` skips copying, causing the Platform Agent to run with the generic upstream persona instead of our authoritative custom persona (`agents/platform/SOUL.md`).

## What Changed

**Files:**

- `deploy/shared/docker-entrypoint.sh`

**Added/Changed/Fixed:**

- Replaced `cp -ru` with `cp -rf` (and `cp -rp` with `cp -r` on the fallback) when copying `/opt/defaults/` to `$TARGET_DIR`. This ensures authoritative files from the container image (`SOUL.md`, `AGENTS.md`, `scripts/`, `cron/`) unconditionally overwrite any existing files or starter files created at boot time by `stage2-hook.sh` without timestamp comparison checks.

## Why This Matters

- Guarantees that every deployment or container restart consistently runs with the intended, authoritative `SOUL.md` persona and scripts baked into the newly deployed container image.
- Prevents subtle runtime discrepancies where older image timestamps (`mtime`) fail to overwrite existing files on PersistentVolumes during image updates or rollbacks.

## Context

Tested empirically in Kubernetes on GKE (`agent-system` namespace) using a custom `PlatformAgent` instance and PVC (`test-soul-pvc`). Verified via `stat` and `ls -l --time-style=full-iso` that `/opt/defaults/SOUL.md` (14,471 bytes) was previously bypassed due to its older build timestamp (`14:43:39`) versus `/opt/data/SOUL.md` (`16:05:45` boot timestamp).

## Testing

- **Locally / Empirical K8s Execution:** Deployed test Pod mounting `test-soul-pvc`, inspected `stat` and directory contents before and after entrypoint execution, verifying that `SOUL.md` inside `/opt/data/` is now properly updated to the 14,471-byte custom persona.

---

Functional impact: Resolves silent persona overrides at container startup. Low risk; only applies to `/opt/defaults` sync step during entrypoint initialization.
