### PR TITLE
feat: Add pre_gateway_dispatch hook to audit plugin

### DIFF
--- a/agents/platform/defaults/plugins/tool_call_audit/audit.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/audit.py
@@ -104,3 +104,42 @@ def log_post_approval_response(
         )
     except Exception as exc:
         logger.error("Error in tool_call_audit post_approval_response hook: %s", exc, exc_info=True)
+
+
+def log_pre_gateway_dispatch(
+    event: Any,
+    gateway: Any = None,
+    session_store: Any = None,
+    **kwargs: Any,
+) -> None:
+    try:
+        source = getattr(event, "source", None)
+        session_id = ""
+        if source is not None and session_store is not None:
+            try:
+                session_entry = session_store.get_or_create_session(source)
+                session_id = getattr(session_entry, "session_id", "") or ""
+            except Exception:
+                pass
+
+        text = getattr(event, "text", "") or ""
+        platform = ""
+        user_id = ""
+        if source is not None:
+            platform_obj = getattr(source, "platform", "")
+            if platform_obj:
+                platform = getattr(platform_obj, "value", None) or str(platform_obj)
+            user_id = getattr(source, "user_id", "") or ""
+
+        _emit(
+            "gateway_dispatch",
+            {
+                "session_id": session_id,
+                "platform": platform,
+                "user_id": user_id,
+                "text": _serialize(text),
+            },
+        )
+    except Exception as exc:
+        logger.error("Error in tool_call_audit pre_gateway_dispatch hook: %s", exc, exc_info=True)
+

--- a/agents/platform/defaults/plugins/tool_call_audit/audit.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/audit.py
@@ -126,9 +126,8 @@ def log_pre_gateway_dispatch(
         platform = ""
         user_id = ""
         if source is not None:
-            platform_obj = getattr(source, "platform", "")
-            if platform_obj:
-                platform = getattr(platform_obj, "value", None) or str(platform_obj)
+            platform_obj = getattr(source, "platform", "") or ""
+            platform = getattr(platform_obj, "value", None) or str(platform_obj)
             user_id = getattr(source, "user_id", "") or ""
 
         _emit(

--- a/agents/platform/defaults/plugins/tool_call_audit/plugin.py
+++ b/agents/platform/defaults/plugins/tool_call_audit/plugin.py
@@ -4,6 +4,7 @@ from .audit import (
     log_post_approval_response,
     log_post_tool_call,
     log_pre_approval_request,
+    log_pre_gateway_dispatch,
     log_pre_tool_call,
 )
 
@@ -13,3 +14,5 @@ def register(ctx: Any) -> None:
     ctx.register_hook("post_tool_call", log_post_tool_call)
     ctx.register_hook("pre_approval_request", log_pre_approval_request)
     ctx.register_hook("post_approval_response", log_post_approval_response)
+    ctx.register_hook("pre_gateway_dispatch", log_pre_gateway_dispatch)
+


### PR DESCRIPTION
# Pull Request

## Why This Change

The user requested to add a `pre_gateway_dispatch` event hook to the audit plugin.
This change enables auditing of `/approve` messages (and other outbound communication) before they are dispatched to the gateway.

## What Changed

Added the implementation of `log_pre_gateway_dispatch` in the `tool_call_audit` plugin and registered it.

**Files:**

- `agents/platform/defaults/plugins/tool_call_audit/audit.py`
- `agents/platform/defaults/plugins/tool_call_audit/plugin.py`

**Added/Changed/Fixed:**

- Implemented `log_pre_gateway_dispatch` in `audit.py` to extract and log session, platform, user, and text info from dispatch events.
- Registered the `pre_gateway_dispatch` hook with `log_pre_gateway_dispatch` in `plugin.py`.

## Why This Matters

This ensures that we have a structured audit trail of all messages dispatched to the gateway, which is critical for compliance and security auditing, especially for actions like approvals.

## Context

This addresses the user request to audit `/approve` messages.

## Testing

I created a scratch script that mocked the context, gateway, and session store, and verified that:
- The hook registers correctly.
- The hook is called and logs the expected output.
- The hook handles different event shapes (e.g., when platform is an object vs. string, or when source is None) without throwing exceptions.

---

TAG=agy
CONV=c9eefe75-a7d0-4caa-ac27-97764bd0b06c
