### PR TITLE
feat(operator): integrate Go event watcher daemon for sidecar alert triage

### DIFF
--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -464,9 +464,33 @@ def send_notification(message: str) -> str:
     Args:
         message: The plaintext or markdown-formatted message string to post.
     """
+    import urllib.request
+    import json
+    import os
+    
+    session_id = os.environ.get("HERMES_SESSION_ID")
+    target = "google_chat" # default fallback
+    
+    if session_id:
+        try:
+            # Query the local metadata server for thread info
+            url = f"http://127.0.0.1:8699/v1/sessions/{session_id}/metadata"
+            req = urllib.request.Request(url, method="GET")
+            with urllib.request.urlopen(req, timeout=3.0) as resp:
+                if resp.status == 200:
+                    meta = json.loads(resp.read().decode("utf-8"))
+                    thread_id = meta.get("thread_id")
+                    chat_id = meta.get("chat_id")
+                    if thread_id and chat_id:
+                        # Construct explicit target for send_message_tool
+                        target = f"google_chat:{chat_id}:{thread_id}"
+        except Exception as exc:
+            # Fail-open: log error but fall back to default target
+            print(f"Failed to resolve session metadata for threading: {exc}")
+
     try:
         res = subprocess.run(
-            ["hermes", "send", "--to", "google_chat", message],
+            ["hermes", "send", "--to", target, message],
             capture_output=True, text=True, check=True, env=_run_env()
         )
         return f"SUCCESS: Notification posted to Google Chat. Output: {res.stdout.strip()}"

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -457,7 +457,7 @@ def audit_log_searcher(project_id: str = "", cluster_name: str = "", location: s
 
 
 @mcp.tool()
-def send_notification(message: str, session_id: str | None = None) -> str:
+def send_notification(message: str, session_id: str) -> str:
     """
     Post a formatted alert or operational notification directly to the user's primary Google Chat home channel.
 

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -457,18 +457,18 @@ def audit_log_searcher(project_id: str = "", cluster_name: str = "", location: s
 
 
 @mcp.tool()
-def send_notification(message: str) -> str:
+def send_notification(message: str, session_id: str | None = None) -> str:
     """
     Post a formatted alert or operational notification directly to the user's primary Google Chat home channel.
 
     Args:
         message: The plaintext or markdown-formatted message string to post.
+        session_id: The active session ID (e.g. k8s-evt-XYZ) to route the notification as a threaded reply.
     """
     import urllib.request
     import json
     import os
     
-    session_id = os.environ.get("HERMES_SESSION_ID")
     target = "google_chat" # default fallback
     
     if session_id:

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -7,11 +7,13 @@ import json
 import os
 import sqlite3
 import subprocess
+import urllib.error
+import urllib.request
 import uuid
 from datetime import datetime
 from typing import Any, Dict
 
-from fastapi import FastAPI, HTTPException
+from fastapi import BackgroundTasks, FastAPI, HTTPException
 
 app = FastAPI()
 
@@ -54,8 +56,66 @@ def create_session() -> Dict[str, str]:
     return {"sessionID": session_id}
 
 
+def trigger_agent_troubleshooter(session_id: str, alert_msg: str) -> None:
+    """Post the warning alert to GChat, then call local gateway API to execute agent loop."""
+    # 1. Trigger the red alert warning to Google Chat
+    try:
+        subprocess.run(
+            ["hermes", "send", "--to", "google_chat", alert_msg],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to post warning alert: {exc.stderr}")
+
+    # 2. Call local gateway API to run troubleshooter
+    api_url = "http://localhost:8642"
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("API_SERVER_KEY", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    # Create session inside gateway if it doesn't exist
+    try:
+        req = urllib.request.Request(
+            f"{api_url}/api/sessions",
+            data=json.dumps({"session_id": session_id, "title": f"Triage {session_id}"}).encode("utf-8"),
+            headers=headers,
+            method="POST"
+        )
+        with urllib.request.urlopen(req) as resp:
+            pass
+    except urllib.error.HTTPError as exc:
+        if exc.code != 409:  # 409 Conflict means it already exists, which is fine
+            print(f"Failed to create gateway API session (code {exc.code}): {exc.read().decode()}")
+            return
+    except Exception as exc:
+        print(f"Failed to connect to gateway API server: {exc}")
+        return
+
+    # Trigger agent execution turn in the session
+    agent_query = (
+        f"Analyze the following Kubernetes event warning on cluster {os.environ.get('GKE_CLUSTER_NAME', 'platform-agent-host')}, "
+        f"perform root-cause analysis (check pod logs, describe resources, etc.), and post your final report to Google Chat:\n\n"
+        f"{alert_msg}"
+    )
+    try:
+        req = urllib.request.Request(
+            f"{api_url}/api/sessions/{session_id}/chat",
+            data=json.dumps({"message": agent_query}).encode("utf-8"),
+            headers=headers,
+            method="POST"
+        )
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                print(f"Gateway API chat execution failed (status {resp.status})")
+    except Exception as exc:
+        print(f"Failed to call gateway API chat execution: {exc}")
+
+
 @app.post("/sessions/{session_id}/inject")
-def inject_message(session_id: str, request_data: Dict[str, Any]) -> Dict[str, str]:
+def inject_message(session_id: str, request_data: Dict[str, Any], background_tasks: BackgroundTasks) -> Dict[str, str]:
     """Receive the event payload and notify the Platform Agent via Google Chat."""
     raw_message = request_data.get("message", "")
     if not raw_message:
@@ -83,18 +143,9 @@ def inject_message(session_id: str, request_data: Dict[str, Any]) -> Dict[str, s
         f"Starting autonomous troubleshooting run..."
     )
     
-    # Trigger the agent using the native 'hermes' command-line interface
-    try:
-        subprocess.run(
-            ["hermes", "send", "--to", "google_chat", alert_msg],
-            check=True,
-            capture_output=True,
-            text=True
-        )
-    except subprocess.CalledProcessError as exc:
-        print(f"Failed to dispatch to agent: {exc.stderr}")
-        raise HTTPException(status_code=500, detail=f"Failed to dispatch to agent: {exc.stderr}")
-        
+    # Delegate the heavy REST API call to FastAPI BackgroundTasks to keep response times sub-millisecond
+    background_tasks.add_task(trigger_agent_troubleshooter, session_id, alert_msg)
+    
     return {"status": "injected"}
 
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -121,7 +121,8 @@ def trigger_agent_troubleshooter(session_id: str, alert_msg: str) -> None:
     # Trigger agent execution turn in the session
     agent_query = (
         f"Analyze the following Kubernetes event warning on GKE cluster '{os.environ.get('GKE_CLUSTER_NAME', 'platform-agent-host')}' "
-        f"and perform root-cause analysis (inspect logs, describe the resource, check configuration issues, etc.).\n\n"
+        f"for the active session '{session_id}'.\n\n"
+        f"When calling your send_notification tool to report findings, you MUST pass this exact session ID: '{session_id}' as the session_id argument so it routes as a threaded reply to the warning alert.\n\n"
         f"When done, post your final diagnostic report to Google Chat (using your notification tool) formatted exactly like this:\n\n"
         f"🛠️ *Incident Triage Report* 🛠️\n\n"
         f"*1. Summary of Issue:*\n"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -58,16 +58,40 @@ def create_session() -> Dict[str, str]:
 
 def trigger_agent_troubleshooter(session_id: str, alert_msg: str) -> None:
     """Post the warning alert to GChat, then call local gateway API to execute agent loop."""
-    # 1. Trigger the red alert warning to Google Chat
+    # 1. Trigger the red alert warning to Google Chat with --json to parse message_id
+    thread_id = None
     try:
-        subprocess.run(
-            ["hermes", "send", "--to", "google_chat", alert_msg],
+        res = subprocess.run(
+            ["hermes", "send", "--json", "--to", "google_chat", alert_msg],
             check=True,
             capture_output=True,
             text=True
         )
-    except subprocess.CalledProcessError as exc:
-        print(f"Failed to post warning alert: {exc.stderr}")
+        payload = json.loads(res.stdout)
+        msg_id = payload.get("message_id", "")
+        if msg_id:
+            thread_id = msg_id.replace("/messages/", "/threads/")
+    except Exception as exc:
+        print(f"Failed to post warning alert or parse response: {exc}")
+
+    # Update metadata DB with the parsed thread ID
+    if thread_id:
+        try:
+            with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
+                row = conn.execute(
+                    "SELECT metadata FROM session_metadata WHERE session_id = ?",
+                    (session_id,)
+                ).fetchone()
+                if row:
+                    meta = json.loads(row[0])
+                    meta["thread_id"] = thread_id
+                    meta["chat_id"] = thread_id.split("/threads/")[0]
+                    conn.execute(
+                        "UPDATE session_metadata SET metadata = ? WHERE session_id = ?",
+                        (json.dumps(meta), session_id)
+                    )
+        except Exception as exc:
+            print(f"Failed to update session metadata with thread_id: {exc}")
 
     # 2. Call local gateway API to run troubleshooter
     api_url = "http://localhost:8642"
@@ -96,9 +120,20 @@ def trigger_agent_troubleshooter(session_id: str, alert_msg: str) -> None:
 
     # Trigger agent execution turn in the session
     agent_query = (
-        f"Analyze the following Kubernetes event warning on cluster {os.environ.get('GKE_CLUSTER_NAME', 'platform-agent-host')}, "
-        f"perform root-cause analysis (check pod logs, describe resources, etc.), and post your final report to Google Chat:\n\n"
-        f"{alert_msg}"
+        f"Analyze the following Kubernetes event warning on GKE cluster '{os.environ.get('GKE_CLUSTER_NAME', 'platform-agent-host')}' "
+        f"and perform root-cause analysis (inspect logs, describe the resource, check configuration issues, etc.).\n\n"
+        f"When done, post your final diagnostic report to Google Chat (using your notification tool) formatted exactly like this:\n\n"
+        f"🛠️ *Incident Triage Report* 🛠️\n\n"
+        f"*1. Summary of Issue:*\n"
+        f"<Brief description of what went wrong>\n\n"
+        f"*2. Root-Cause Analysis:*\n"
+        f"<Detailed findings, highlighting specific configuration values, log lines, or error codes>\n\n"
+        f"*3. Actionable Remediation:*\n"
+        f"<Clear, step-by-step commands or actions to fix the issue>\n\n"
+        f"🔗 *Observability & Debugging Links:*\n"
+        f"• [GKE Workload Console](https://console.cloud.google.com/kubernetes/workload/overview?project={os.environ.get('GCP_PROJECT', 'jayantid-gkedemos')})\n"
+        f"• [Cloud Logging Console](https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22?project={os.environ.get('GCP_PROJECT', 'jayantid-gkedemos')})\n\n"
+        f"---"
     )
     try:
         req = urllib.request.Request(
@@ -133,14 +168,14 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
     message = payload.get("message", "")
     count = payload.get("count", 1)
     
-    # Construct a notification alert
+    # Construct a pretty notification alert
     alert_msg = (
-        f"🚨 *[K8s Event Warning]*\n"
-        f"*Reason:* {event_reason}\n"
-        f"*Resource:* {namespace}/{object_kind}/{object_name}\n"
-        f"*Message:* {message}\n"
-        f"*Count:* {count}\n"
-        f"Starting autonomous troubleshooting run..."
+        f"🚨 *Kubernetes Event Alert* 🚨\n\n"
+        f"• *Resource:* `{namespace}/{object_kind}/{object_name}`\n"
+        f"• *Event Reason:* `{event_reason}`\n"
+        f"• *Warning Message:* {message}\n"
+        f"• *Occurrence Count:* {count}\n\n"
+        f"🔍 _Starting autonomous troubleshooting run inside GKE cluster..._"
     )
     
     # Delegate the heavy REST API call to FastAPI BackgroundTasks to keep response times sub-millisecond

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import subprocess
+import uuid
+from datetime import datetime
 from typing import Any, Dict
 
 from fastapi import FastAPI, HTTPException
@@ -35,6 +38,64 @@ def init_db() -> None:
 @app.get("/healthz")
 def healthz() -> Dict[str, str]:
     return {"status": "ok"}
+
+
+@app.post("/sessions", status_code=201)
+def create_session() -> Dict[str, str]:
+    """Create a new session ID for the incoming incident."""
+    session_id = f"k8s-evt-{uuid.uuid4().hex[:8]}"
+    
+    # Save the session to the local metadata DB
+    with sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0) as conn:
+        conn.execute(
+            "INSERT INTO session_metadata (session_id, metadata) VALUES (?, ?)",
+            (session_id, json.dumps({"platform": "k8s-watcher", "created_at": datetime.utcnow().isoformat()}))
+        )
+    return {"sessionID": session_id}
+
+
+@app.post("/sessions/{session_id}/inject")
+def inject_message(session_id: str, request_data: Dict[str, Any]) -> Dict[str, str]:
+    """Receive the event payload and notify the Platform Agent via Google Chat."""
+    raw_message = request_data.get("message", "")
+    if not raw_message:
+        raise HTTPException(status_code=400, detail="message field is required")
+        
+    try:
+        payload = json.loads(raw_message)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=f"Failed to parse inner payload JSON: {exc}")
+        
+    event_reason = payload.get("reason", "Unknown")
+    namespace = payload.get("namespace", "default")
+    object_kind = payload.get("kindOfObject", "Pod")
+    object_name = payload.get("name", "")
+    message = payload.get("message", "")
+    count = payload.get("count", 1)
+    
+    # Construct a notification alert
+    alert_msg = (
+        f"🚨 *[K8s Event Warning]*\n"
+        f"*Reason:* {event_reason}\n"
+        f"*Resource:* {namespace}/{object_kind}/{object_name}\n"
+        f"*Message:* {message}\n"
+        f"*Count:* {count}\n"
+        f"Starting autonomous troubleshooting run..."
+    )
+    
+    # Trigger the agent using the native 'hermes' command-line interface
+    try:
+        subprocess.run(
+            ["hermes", "send", "--to", "google_chat", alert_msg],
+            check=True,
+            capture_output=True,
+            text=True
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to dispatch to agent: {exc.stderr}")
+        raise HTTPException(status_code=500, detail=f"Failed to dispatch to agent: {exc.stderr}")
+        
+    return {"status": "injected"}
 
 
 @app.get("/v1/sessions/{session_id}/metadata")

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -70,7 +70,12 @@ def trigger_agent_troubleshooter(session_id: str, alert_msg: str) -> None:
         payload = json.loads(res.stdout)
         msg_id = payload.get("message_id", "")
         if msg_id:
-            thread_id = msg_id.replace("/messages/", "/threads/")
+            if "/messages/" in msg_id:
+                space_part, msg_part = msg_id.split("/messages/", 1)
+                thread_key = msg_part.split(".")[0]
+                thread_id = f"{space_part}/threads/{thread_key}"
+            else:
+                thread_id = msg_id
     except Exception as exc:
         print(f"Failed to post warning alert or parse response: {exc}")
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,12 @@
 # check=skip=InvalidDefaultArgInFrom
 ARG HERMES_AGENT_TAG
+
+FROM golang:1.25-alpine AS watcher-builder
+WORKDIR /workspace
+COPY k8s-operator/ /workspace/k8s-operator/
+WORKDIR /workspace/k8s-operator/cmd/k8s-event-watcher
+RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o k8s-event-watcher .
+
 FROM nousresearch/hermes-agent:${HERMES_AGENT_TAG} AS agent-base
 
 USER root
@@ -103,6 +110,7 @@ FROM agent-base AS platform
 COPY agents/platform/cron/ /opt/defaults/cron/
 COPY --chown=hermes:hermes agents/platform/defaults/ /opt/defaults/
 COPY agents/platform/scripts/ /opt/defaults/scripts/
+COPY --from=watcher-builder /workspace/k8s-operator/cmd/k8s-event-watcher/k8s-event-watcher /opt/defaults/scripts/k8s-event-watcher
 COPY agents/platform/governance/ /opt/defaults/governance/
 COPY agents/platform/SOUL.md /opt/defaults/SOUL.md
 COPY agents/platform/AGENTS.md /opt/defaults/AGENTS.md

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
 # Apply upstream PR #51567 patch to google_chat adapter to fix nested inline formatting leaks (GC0, GC1, etc.)
 RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
-    python3 -c "p = '/opt/hermes/plugins/platforms/google_chat/adapter.py'; c = open(p).read(); c = c.replace('r\"^spaces/[A-Za-z0-9_-]+/threads/[A-Za-z0-9_-]+$\"', 'r\"^spaces/[A-Za-z0-9_.-]+/threads/[A-Za-z0-9_.-]+$\"'); open(p, 'w').write(c)" && \
+    python3 -c 'p = "/opt/hermes/plugins/platforms/google_chat/adapter.py"; c = open(p).read(); c = c.replace("^spaces/[A-Za-z0-9_-]+/threads/[A-Za-z0-9_-]+$", "^spaces/[A-Za-z0-9_.-]+/threads/[A-Za-z0-9_.-]+$"); open(p, "w").write(c)' && \
     grep -q "spaces/\[A-Za-z0-9_\.-]\+/threads" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 # Copy custom send_message_tool.py to support google_chat target refs

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -65,7 +65,7 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
 RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     python3 -c 'p = "/opt/hermes/plugins/platforms/google_chat/adapter.py"; c = open(p).read(); c = c.replace("^spaces/[A-Za-z0-9_-]+/threads/[A-Za-z0-9_-]+$", "^spaces/[A-Za-z0-9_.-]+/threads/[A-Za-z0-9_.-]+$"); open(p, "w").write(c)' && \
-    grep -q "spaces/\[A-Za-z0-9_\.-]\+/threads" /opt/hermes/plugins/platforms/google_chat/adapter.py
+    grep -q "spaces/\[A-Za-z0-9_.-]" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 # Copy custom send_message_tool.py to support google_chat target refs
 COPY deploy/shared/send_message_tool.py /opt/hermes/tools/send_message_tool.py

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -65,6 +65,8 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
 RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
+# Copy custom send_message_tool.py to support google_chat target refs
+COPY deploy/shared/send_message_tool.py /opt/hermes/tools/send_message_tool.py
 
 # 4. Clone and build mcp-remote proxy
 RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -63,7 +63,9 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
 
 # Apply upstream PR #51567 patch to google_chat adapter to fix nested inline formatting leaks (GC0, GC1, etc.)
 RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
-    grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py
+    grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
+    python3 -c "p = '/opt/hermes/plugins/platforms/google_chat/adapter.py'; c = open(p).read(); c = c.replace('r\"^spaces/[A-Za-z0-9_-]+/threads/[A-Za-z0-9_-]+$\"', 'r\"^spaces/[A-Za-z0-9_.-]+/threads/[A-Za-z0-9_.-]+$\"'); open(p, 'w').write(c)" && \
+    grep -q "spaces/\[A-Za-z0-9_\.-]\+/threads" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 # Copy custom send_message_tool.py to support google_chat target refs
 COPY deploy/shared/send_message_tool.py /opt/hermes/tools/send_message_tool.py

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -65,7 +65,9 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
 RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed(list(placeholders.items())):/' /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     python3 -c 'p = "/opt/hermes/plugins/platforms/google_chat/adapter.py"; c = open(p).read(); c = c.replace("^spaces/[A-Za-z0-9_-]+/threads/[A-Za-z0-9_-]+$", "^spaces/[A-Za-z0-9_.-]+/threads/[A-Za-z0-9_.-]+$"); open(p, "w").write(c)' && \
-    grep -q "spaces/\[A-Za-z0-9_.-]" /opt/hermes/plugins/platforms/google_chat/adapter.py
+    grep -q "spaces/\[A-Za-z0-9_.-]" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
+    python3 -c 'p = "/opt/hermes/plugins/platforms/google_chat/adapter.py"; c = open(p).read(); c = c.replace("url = f\"https://chat.googleapis.com/v1/{chat_id}/messages\"", "url = f\"https://chat.googleapis.com/v1/{chat_id}/messages\"\n    if thread_id:\n        url += \"?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD\""); open(p, "w").write(c)' && \
+    grep -q "messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 # Copy custom send_message_tool.py to support google_chat target refs
 COPY deploy/shared/send_message_tool.py /opt/hermes/tools/send_message_tool.py

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -37,5 +37,26 @@ if [ -f "$TARGET_DIR/plugins/hermes_otel/config.yaml" ] && [ -w "$TARGET_DIR/plu
     "$INSTALL_DIR/.venv/bin/python3" -c "import sys, os, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; svc = os.getenv('OTEL_SERVICE_NAME'); attrs = c.setdefault('resource_attributes', {}); attrs.update({'service.name': svc}) if svc else attrs.pop('service.name', None); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/plugins/hermes_otel/config.yaml" 2>/dev/null || true
 fi
 
-# 5. Execute primary process
+# 5. Start background microservices (FastAPI proxy and Go Event Watcher)
+mkdir -p "$TARGET_DIR/logs"
+if [ -f "$TARGET_DIR/scripts/session_kv_server.py" ]; then
+    echo "Starting Session KV server on port 8699..."
+    "$INSTALL_DIR/.venv/bin/python3" -m uvicorn scripts.session_kv_server:app --app-dir "$TARGET_DIR" --host 0.0.0.0 --port 8699 >"$TARGET_DIR/logs/session_kv_server.log" 2>&1 &
+fi
+
+if [ -f "$TARGET_DIR/scripts/k8s-event-watcher" ]; then
+    echo "Starting k8s event watcher background service..."
+    chmod +x "$TARGET_DIR/scripts/k8s-event-watcher"
+    "$TARGET_DIR/scripts/k8s-event-watcher" \
+        --daemon-url=http://localhost:8699 \
+        --token-env=API_SERVER_KEY \
+        --mode=per-incident \
+        --owner=platform-agent \
+        --cluster-name="${GKE_CLUSTER_NAME:-platform-agent-host}" \
+        --dedup-window=5m \
+        --dedup-persist="$TARGET_DIR/watcher-dedup-cache.json" \
+        --unhealthy-min-count=3 >"$TARGET_DIR/logs/k8s-event-watcher.log" 2>&1 &
+fi
+
+# 6. Execute primary process
 exec "$@"

--- a/deploy/shared/send_message_tool.py
+++ b/deploy/shared/send_message_tool.py
@@ -1,0 +1,1810 @@
+"""Send Message Tool -- cross-channel messaging via platform APIs.
+
+Sends a message to a user or channel on any connected messaging platform
+(Telegram, Discord, Slack). Supports listing available targets and resolving
+human-friendly channel names to IDs. Works in both CLI and gateway contexts.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import ssl
+import time
+from email.utils import formatdate
+
+from agent.redact import redact_sensitive_text
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
+_FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
+# Slack conversation IDs: C (public channel), G (private/group channel), D (DM).
+# Must be uppercase alphanumeric, 9+ chars. User IDs (U...) and workspace IDs
+# (W...) are NOT valid chat.postMessage channel values — posting to them fails
+# because the API requires a conversation ID. To DM a user you must first call
+# conversations.open to obtain a D... ID. Without this gate, Slack IDs fall
+# through to channel-name resolution, which only matches by name and fails.
+_SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
+# Session-derived Slack thread targets use "<conversation_id>:<thread_ts>".
+_SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
+_WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+_YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+# Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
+_NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
+# Platforms that address recipients by phone number and accept E.164 format
+# (with a leading '+'). Without this, "+15551234567" fails the isdigit() check
+# below and falls through to channel-name resolution, which has no way to
+# resolve a raw phone number. Keeping the '+' preserves the E.164 form that
+# downstream adapters (signal, etc.) expect.
+_PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
+_E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# WhatsApp JIDs: group chats (<digits>@g.us), individual users
+# (<phone>@s.whatsapp.net), linked identities (<id>@lid), and broadcast /
+# newsletter chats. These are explicit native targets the bridge accepts
+# verbatim — they must NOT fall through to home-channel resolution.
+_WHATSAPP_JID_RE = re.compile(
+    r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
+    re.IGNORECASE,
+)
+# Email addresses — a valid email like "user@domain.com" should be treated as
+# an explicit target for the email platform, not fall through to channel-name
+# resolution which has no way to resolve a raw address.
+_EMAIL_TARGET_RE = re.compile(r"^\s*[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\s*$")
+# Most platforms read their home channel from "<PLATFORM>_HOME_CHANNEL", but a
+# few diverge. Email reads EMAIL_HOME_ADDRESS (see gateway/config.py), so the
+# generic "<PLATFORM>_HOME_CHANNEL" hint would point users at a variable that is
+# never read. Map the exceptions so the error guidance is actually actionable.
+_HOME_CHANNEL_ENV_OVERRIDES = {"email": "EMAIL_HOME_ADDRESS"}
+_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
+_AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
+_VOICE_EXTS = {".ogg", ".opus"}
+# Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio
+# formats either route through sendVoice (Opus/OGG) or fall back to
+# document delivery.
+_TELEGRAM_SEND_AUDIO_EXTS = {".mp3", ".m4a"}
+_URL_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:access_token|api[_-]?key|auth[_-]?token|token|signature|sig)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
+_GENERIC_SECRET_ASSIGN_RE = re.compile(
+    r"\b(access_token|api[_-]?key|auth[_-]?token|signature|sig)\s*=\s*([^\s,;]+)",
+    re.IGNORECASE,
+)
+
+
+def _sanitize_error_text(text) -> str:
+    """Redact secrets from error text before surfacing it to users/models."""
+    redacted = redact_sensitive_text(text)
+    redacted = _URL_SECRET_QUERY_RE.sub(lambda m: f"{m.group(1)}***", redacted)
+    redacted = _GENERIC_SECRET_ASSIGN_RE.sub(lambda m: f"{m.group(1)}=***", redacted)
+    return redacted
+
+
+def _error(message: str) -> dict:
+    """Build a standardized error payload with redacted content."""
+    return {"error": _sanitize_error_text(message)}
+
+
+def _display_chat_id(platform_name: str, chat_id: str) -> str:
+    """Return a result-safe chat identifier for tool transcripts/log consumers."""
+    if platform_name == "signal" and str(chat_id).startswith("group:"):
+        return "group:***"
+    return chat_id
+
+
+def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
+    retry_after = getattr(exc, "retry_after", None)
+    if retry_after is not None:
+        try:
+            return max(float(retry_after), 0.0)
+        except (TypeError, ValueError):
+            return 1.0
+
+    text = str(exc).lower()
+    if "timed out" in text or "timeout" in text:
+        return None
+    if (
+        "bad gateway" in text
+        or "502" in text
+        or "too many requests" in text
+        or "429" in text
+        or "service unavailable" in text
+        or "503" in text
+        or "gateway timeout" in text
+        or "504" in text
+    ):
+        return float(2 ** attempt)
+    return None
+
+
+async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs):
+    for attempt in range(attempts):
+        try:
+            return await bot.send_message(**kwargs)
+        except Exception as exc:
+            delay = _telegram_retry_delay(exc, attempt)
+            if delay is None or attempt >= attempts - 1:
+                raise
+            logger.warning(
+                "Transient Telegram send failure (attempt %d/%d), retrying in %.1fs: %s",
+                attempt + 1,
+                attempts,
+                delay,
+                _sanitize_error_text(exc),
+            )
+            await asyncio.sleep(delay)
+
+
+SEND_MESSAGE_SCHEMA = {
+    "name": "send_message",
+    "description": (
+        "Send a message to a connected messaging platform, or list available targets.\n\n"
+        "IMPORTANT: When the user asks to send to a specific channel or person "
+        "(not just a bare platform name), call send_message(action='list') FIRST to see "
+        "available targets, then send to the correct one.\n"
+        "If the user just says a platform name like 'send to telegram', send directly "
+        "to the home channel without listing first."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["send", "list", "react", "unreact"],
+                "description": "Action to perform. 'send' (default) sends a message. 'list' returns all available channels/contacts across connected platforms. 'react' attaches an emoji reaction to a message (platforms that support it, e.g. photon/iMessage tapbacks). 'unreact' retracts a previously-added reaction."
+            },
+            "target": {
+                "type": "string",
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org', 'ntfy:alerts-channel' (explicit ntfy topic), 'yuanbao:direct:<account_id>' (DM), 'yuanbao:group:<group_code>' (group chat)"
+            },
+            "message": {
+                "type": "string",
+                "description": "The message text to send. To send an image or file, include MEDIA:<local_path> (e.g. 'MEDIA:/tmp/report.pdf') in the message — the platform will deliver it as a native media attachment."
+            },
+            "emoji": {
+                "type": "string",
+                "description": "For action='react': the emoji to react with (e.g. '❤️'). On iMessage, ❤️👍👎😂‼️❓ render as native tapbacks; other emoji use custom-emoji reactions."
+            },
+            "message_id": {
+                "type": "string",
+                "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            }
+        },
+        "required": []
+    }
+}
+
+
+def send_message_tool(args, **kw):
+    """Handle cross-channel send_message tool calls."""
+    action = args.get("action", "send")
+
+    if action == "list":
+        return _handle_list()
+
+    if action == "react":
+        return _handle_react(args)
+
+    if action == "unreact":
+        return _handle_react(args, remove=True)
+
+    return _handle_send(args)
+
+
+def _handle_list():
+    """Return formatted list of available messaging targets."""
+    try:
+        from gateway.channel_directory import format_directory_for_display
+        return json.dumps({"targets": format_directory_for_display()})
+    except Exception as e:
+        return json.dumps(_error(f"Failed to load channel directory: {e}"))
+
+
+def _handle_react(args, remove=False):
+    """Attach (or with ``remove=True`` retract) an emoji reaction on a message
+    via a live gateway adapter.
+
+    Only adapters that expose ``add_reaction(chat_id, emoji, message_id)`` /
+    ``remove_reaction(chat_id, message_id)`` coroutines support this (e.g.
+    photon/iMessage tapbacks). Requires the gateway to be running in this
+    process — there is no standalone fallback, since reacting needs the
+    adapter's live message-id state.
+    """
+    target = args.get("target", "")
+    emoji = (args.get("emoji") or "").strip()
+    message_id = (args.get("message_id") or "").strip() or None
+    if not target or (not remove and not emoji):
+        return tool_error(
+            "Both 'target' and 'emoji' are required when action='react'"
+            if not remove
+            else "'target' is required when action='unreact'"
+        )
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    chat_id = None
+    if target_ref:
+        chat_id, _thread_id, _ = _parse_target_ref(platform_name, target_ref)
+        if not chat_id:
+            try:
+                from gateway.channel_directory import resolve_channel_name
+                resolved = resolve_channel_name(platform_name, target_ref)
+            except Exception:
+                resolved = None
+            # Opaque platform-native ids (e.g. photon space GUIDs like
+            # 'any;-;+1555...') match no parser pattern and no directory
+            # entry — pass them through verbatim; the adapter validates.
+            chat_id = resolved or target_ref
+
+    try:
+        from gateway.config import Platform, load_gateway_config
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        return tool_error(f"Unknown platform: {platform_name}")
+
+    if not chat_id:
+        try:
+            config = load_gateway_config()
+            home = config.get_home_channel(platform)
+        except Exception:
+            home = None
+        if not home:
+            return tool_error(
+                f"No chat specified and no home channel set for {platform_name}. "
+                f"Use '{platform_name}:chat_id'."
+            )
+        chat_id = home.chat_id
+
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+    adapter = runner.adapters.get(platform) if runner is not None else None
+    if adapter is None:
+        return tool_error(
+            f"Reactions require a live {platform_name} adapter in the running "
+            "gateway (not available from cron/standalone contexts)."
+        )
+    fn_name = "remove_reaction" if remove else "add_reaction"
+    react_fn = getattr(adapter, fn_name, None)
+    if not callable(react_fn):
+        return tool_error(
+            f"Platform '{platform_name}' does not support message reactions."
+        )
+
+    try:
+        from model_tools import _run_async
+        if remove:
+            result = _run_async(
+                react_fn(chat_id=chat_id, message_id=message_id)
+            )
+        else:
+            result = _run_async(
+                react_fn(chat_id=chat_id, emoji=emoji, message_id=message_id)
+            )
+    except Exception as e:
+        return json.dumps(_error(f"Reaction failed: {e}"))
+    if isinstance(result, dict):
+        return json.dumps(result)
+    return json.dumps({"success": bool(result)})
+
+
+def _handle_send(args):
+    """Send a message to a platform target."""
+    target = args.get("target", "")
+    message = args.get("message", "")
+    if not target or not message:
+        return tool_error("Both 'target' and 'message' are required when action='send'")
+
+    parts = target.split(":", 1)
+    platform_name = parts[0].strip().lower()
+    target_ref = parts[1].strip() if len(parts) > 1 else None
+    chat_id = None
+    thread_id = None
+
+    if target_ref:
+        chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+    else:
+        is_explicit = False
+
+    # Resolve human-friendly channel names to numeric IDs
+    if target_ref and not is_explicit:
+        try:
+            from gateway.channel_directory import resolve_channel_name
+            resolved = resolve_channel_name(platform_name, target_ref)
+            if resolved:
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+            else:
+                return json.dumps({
+                    "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                    f"Use send_message(action='list') to see available targets."
+                })
+        except Exception:
+            return json.dumps({
+                "error": f"Could not resolve '{target_ref}' on {platform_name}. "
+                f"Try using a numeric channel ID instead."
+            })
+
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return tool_error("Interrupted")
+
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+    except Exception as e:
+        return json.dumps(_error(f"Failed to load gateway config: {e}"))
+
+    # Accept any platform name — built-in names resolve to their enum
+    # member, plugin platform names create dynamic members via _missing_().
+    try:
+        platform = Platform(platform_name)
+    except (ValueError, KeyError):
+        return tool_error(f"Unknown platform: {platform_name}")
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        # Weixin can be configured purely via .env; synthesize a pconfig so
+        # send_message and cron delivery work without a gateway.yaml entry.
+        if platform_name == "weixin":
+            wx_token = os.getenv("WEIXIN_TOKEN", "").strip()
+            wx_account = os.getenv("WEIXIN_ACCOUNT_ID", "").strip()
+            if wx_token and wx_account:
+                from gateway.config import PlatformConfig
+                pconfig = PlatformConfig(
+                    enabled=True,
+                    token=wx_token,
+                    extra={
+                        "account_id": wx_account,
+                        "base_url": os.getenv("WEIXIN_BASE_URL", "").strip(),
+                        "cdn_base_url": os.getenv("WEIXIN_CDN_BASE_URL", "").strip(),
+                    },
+                )
+            else:
+                return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+        else:
+            return tool_error(f"Platform '{platform_name}' is not configured. Set up credentials in ~/.hermes/config.yaml or environment variables.")
+
+    from gateway.platforms.base import BasePlatformAdapter
+
+    # Capture [[as_document]] directive before extract_media strips it.
+    # Image-extension files in this batch will route through send_document
+    # instead of send_photo so the original bytes survive (e.g. info-graph
+    # JPGs where Telegram's sendPhoto recompresses to 1280px).
+    force_document_attachments = "[[as_document]]" in message
+
+    media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
+
+    used_home_channel = False
+    if not chat_id:
+        home = config.get_home_channel(platform)
+        if not home and platform_name == "weixin":
+            wx_home = os.getenv("WEIXIN_HOME_CHANNEL", "").strip()
+            if wx_home:
+                from gateway.config import HomeChannel
+                home = HomeChannel(platform=platform, chat_id=wx_home, name="Weixin Home")
+        if home:
+            chat_id = home.chat_id
+            used_home_channel = True
+        else:
+            home_env = _HOME_CHANNEL_ENV_OVERRIDES.get(
+                platform_name, f"{platform_name.upper()}_HOME_CHANNEL"
+            )
+            return json.dumps({
+                "error": f"No home channel set for {platform_name} to determine where to send the message. "
+                f"Either specify a channel directly with '{platform_name}:CHANNEL_NAME', "
+                f"or set a home channel via: hermes config set {home_env} <channel_id>"
+            })
+
+    duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
+    if duplicate_skip:
+        return json.dumps(duplicate_skip)
+
+    # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
+    if platform_name == "slack" and chat_id and chat_id.startswith("U"):
+        try:
+            import aiohttp
+            async def _open_slack_dm(token, user_id):
+                url = "https://slack.com/api/conversations.open"
+                headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+                async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+                    async with session.post(url, headers=headers, json={"users": [user_id]}) as resp:
+                        data = await resp.json()
+                        if data.get("ok"):
+                            return data["channel"]["id"]
+                        return None
+            from model_tools import _run_async
+            dm_channel = _run_async(_open_slack_dm(pconfig.token, chat_id))
+            if dm_channel:
+                chat_id = dm_channel
+            else:
+                return json.dumps({"error": f"Could not open DM with Slack user {chat_id}. Check bot permissions (im:write)."})
+        except Exception as e:
+            return json.dumps({"error": f"Failed to open Slack DM: {e}"})
+
+    try:
+        from model_tools import _run_async
+        result = _run_async(
+            _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_message,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document_attachments,
+            )
+        )
+        if used_home_channel and isinstance(result, dict) and result.get("success"):
+            result["note"] = f"Sent to {platform_name} home channel (chat_id: {chat_id})"
+
+        # Mirror the sent message into the target's gateway session
+        if isinstance(result, dict) and result.get("success") and mirror_text:
+            try:
+                from gateway.mirror import mirror_to_session
+                from gateway.session_context import get_session_env
+                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
+                user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+                if mirror_to_session(
+                    platform_name,
+                    chat_id,
+                    mirror_text,
+                    source_label=source_label,
+                    thread_id=thread_id,
+                    user_id=user_id,
+                ):
+                    result["mirrored"] = True
+            except Exception:
+                pass
+
+        if isinstance(result, dict) and "error" in result:
+            result["error"] = _sanitize_error_text(result["error"])
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _parse_target_ref(platform_name: str, target_ref: str):
+    """Parse a tool target into chat_id/thread_id and whether it is explicit."""
+    if platform_name == "telegram":
+        match = _TELEGRAM_TOPIC_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
+        from plugins.platforms.telegram.telegram_ids import (
+            parse_telegram_username_target,
+        )
+
+        username = parse_telegram_username_target(target_ref)
+        if username:
+            return username, None, True
+    if platform_name == "feishu":
+        match = _FEISHU_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
+    if platform_name == "discord":
+        match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
+    if platform_name == "slack":
+        match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
+        match = _SLACK_TARGET_RE.fullmatch(target_ref)
+        if match:
+            chat_id = match.group(1)
+            # Slack user IDs (U...) and workspace IDs (W...) are NOT valid
+            # explicit send targets — chat.postMessage rejects them. A DM
+            # must be opened first via conversations.open to get a D...
+            # conversation ID. Caller still gets the chat_id so the U→D
+            # resolution path in send_message() can run.
+            is_explicit = chat_id[0] not in {"U", "W"}
+            return chat_id, None, is_explicit
+    if platform_name == "matrix":
+        trimmed = target_ref.strip()
+        split_idx = trimmed.rfind(":$")
+        if split_idx > 0:
+            return trimmed[:split_idx], trimmed[split_idx + 1 :], True
+    if platform_name == "weixin":
+        match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "yuanbao":
+        match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+        if target_ref.strip().isdigit():
+            return f"group:{target_ref.strip()}", None, True
+        return None, None, False
+    if platform_name == "google_chat":
+        parts = target_ref.split(":")
+        if len(parts) == 2:
+            return parts[0].strip(), parts[1].strip(), True
+        elif len(parts) == 1:
+            val = parts[0].strip()
+            if "/messages/" in val:
+                thread_name = val.replace("/messages/", "/threads/")
+                space_name = val.split("/messages/")[0]
+                return space_name, thread_name, True
+            elif "/threads/" in val:
+                space_name = val.split("/threads/")[0]
+                return space_name, val, True
+            return val, None, True
+    if platform_name == "ntfy":
+        topic = target_ref.strip()
+        if topic:
+            return topic, None, True
+    if platform_name == "email":
+        match = _EMAIL_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return target_ref.strip(), None, True
+    if platform_name == "whatsapp":
+        # Native WhatsApp JIDs (group @g.us, user @s.whatsapp.net, @lid, etc.)
+        # are explicit targets — pass through verbatim. E.164 '+' numbers fall
+        # through to the _PHONE_PLATFORMS handler below.
+        if _WHATSAPP_JID_RE.fullmatch(target_ref):
+            return target_ref.strip(), None, True
+    stripped_target = target_ref.strip()
+    if platform_name == "signal" and stripped_target.startswith("group:"):
+        group_id = stripped_target[len("group:"):].strip()
+        if group_id:
+            return f"group:{group_id}", None, True
+        return None, None, False
+    if platform_name in _PHONE_PLATFORMS:
+        match = _E164_TARGET_RE.fullmatch(target_ref)
+        if match:
+            # Preserve the leading '+' — signal-cli and sms/whatsapp adapters
+            # expect E.164 format for direct recipients.
+            return target_ref.strip(), None, True
+    if target_ref.lstrip("-").isdigit():
+        return target_ref, None, True
+    # Matrix room IDs (start with !) and user IDs (start with @) are explicit
+    if platform_name == "matrix" and (target_ref.startswith("!") or target_ref.startswith("@")):
+        return target_ref, None, True
+    # XMPP JIDs (user@server or room@conference.server) are explicit
+    if platform_name == "xmpp" and "@" in target_ref:
+        return target_ref, None, True
+    return None, None, False
+
+
+def _describe_media_for_mirror(media_files):
+    """Return a human-readable mirror summary when a message only contains media."""
+    if not media_files:
+        return ""
+    if len(media_files) == 1:
+        media_path, is_voice = media_files[0]
+        ext = os.path.splitext(media_path)[1].lower()
+        if is_voice and ext in _VOICE_EXTS:
+            return "[Sent voice message]"
+        if ext in _IMAGE_EXTS:
+            return "[Sent image attachment]"
+        if ext in _VIDEO_EXTS:
+            return "[Sent video attachment]"
+        if ext in _AUDIO_EXTS:
+            return "[Sent audio attachment]"
+        return "[Sent document attachment]"
+    return f"[Sent {len(media_files)} media attachments]"
+
+
+def _get_cron_auto_delivery_target():
+    """Return the cron scheduler's auto-delivery target for the current run, if any."""
+    from gateway.session_context import get_session_env
+    platform = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
+    chat_id = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
+    if not platform or not chat_id:
+        return None
+    thread_id = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
+    return {
+        "platform": platform,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+    }
+
+
+def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id: str | None):
+    """Skip redundant cron send_message calls when the scheduler will auto-deliver there."""
+    auto_target = _get_cron_auto_delivery_target()
+    if not auto_target:
+        return None
+
+    same_target = (
+        auto_target["platform"] == platform_name
+        and str(auto_target["chat_id"]) == str(chat_id)
+        and auto_target.get("thread_id") == thread_id
+    )
+    if not same_target:
+        return None
+
+    target_label = f"{platform_name}:{chat_id}"
+    if thread_id is not None:
+        target_label += f":{thread_id}"
+
+    return {
+        "success": True,
+        "skipped": True,
+        "reason": "cron_auto_delivery_duplicate_target",
+        "target": target_label,
+        "note": (
+            f"Skipped send_message to {target_label}. This cron job will already auto-deliver "
+            "its final response to that same target. Put the intended user-facing content in "
+            "your final response instead, or use a different target if you want an additional message."
+        ),
+    }
+
+
+async def _send_via_adapter(
+    platform,
+    pconfig,
+    chat_id,
+    chunk,
+    *,
+    thread_id=None,
+    media_files=None,
+    force_document=False,
+):
+    """Send a message via a live gateway adapter, with a standalone fallback
+    for out-of-process callers (e.g. cron running separately from the gateway).
+
+    Order of attempts:
+      1. Live in-process adapter via ``_gateway_runner_ref()`` (the path that
+         existed before this change).
+      2. The plugin's ``standalone_sender_fn`` registered on its
+         ``PlatformEntry`` (used when the gateway is not in this process, so
+         the runner weakref is ``None``).
+      3. A descriptive error explaining both options.
+    """
+    platform_name = platform.value if hasattr(platform, "value") else str(platform)
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    if runner is not None:
+        try:
+            adapter = runner.adapters.get(platform)
+        except Exception:
+            adapter = None
+        if adapter is not None:
+            try:
+                metadata = {}
+                if thread_id:
+                    metadata["thread_id"] = thread_id
+                if platform_name == "ntfy" and chat_id:
+                    metadata["publish_topic"] = chat_id
+                if not metadata:
+                    metadata = None
+                result = await adapter.send(chat_id=chat_id, content=chunk, metadata=metadata)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                return {"error": f"Plugin platform send failed: {e}"}
+            if result.success:
+                return {"success": True, "message_id": result.message_id}
+            return {"error": f"Adapter send failed: {result.error}"}
+
+    entry = None
+    try:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get(platform_name)
+    except Exception:
+        entry = None
+
+    if entry is not None and entry.standalone_sender_fn is not None:
+        try:
+            result = await entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.debug("Plugin standalone send for %s raised", platform_name, exc_info=True)
+            return {"error": f"Plugin standalone send failed: {e}"}
+
+        if isinstance(result, dict) and (result.get("success") or result.get("error")):
+            return result
+        return {
+            "error": (
+                f"Plugin standalone send for '{platform_name}' returned an "
+                f"invalid result: expected a dict with 'success' or 'error' "
+                f"keys, got {type(result).__name__}"
+            )
+        }
+
+    return {
+        "error": (
+            f"No live adapter for platform '{platform_name}'. Is the gateway "
+            f"running with this platform connected? For out-of-process delivery "
+            f"(e.g. cron in a separate process), the platform plugin must "
+            f"register a standalone_sender_fn on its PlatformEntry."
+        )
+    }
+
+
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+    """Route a message to the appropriate platform sender.
+
+    Long messages are automatically chunked to fit within platform limits
+    using the same smart-splitting algorithm as the gateway adapters
+    (preserves code-block boundaries, adds part indicators).
+    """
+    from gateway.config import Platform
+
+    media_files = media_files or []
+
+    # Weixin handles text/media delivery inside its native helper and does not
+    # need the optional platform adapter imports below. Keep this branch early
+    # so a Weixin send is not blocked by unrelated optional dependencies (for
+    # example lark-oapi's heavy Feishu import path).
+    if platform == Platform.WEIXIN:
+        return await _send_weixin(pconfig, chat_id, message, media_files=media_files)
+
+    from gateway.platforms.base import BasePlatformAdapter, utf16_len
+
+    # Telegram adapter import is optional (requires python-telegram-bot)
+    try:
+        from plugins.platforms.telegram.adapter import TelegramAdapter
+        _telegram_available = True
+    except ImportError:
+        _telegram_available = False
+
+    # Feishu adapter migrated to a plugin (#41112); its max_message_length
+    # (8000) now flows through the registry fallback below.
+
+    media_files = media_files or []
+
+    # Slack mrkdwn formatting is applied inside the slack plugin's
+    # _standalone_send (the registry standalone_sender_fn) rather than here —
+    # the SlackAdapter moved to plugins/platforms/slack/ in #41112.
+
+    # Platform message length limits (from adapter class attributes for
+    # built-in platforms; from PlatformEntry.max_message_length for plugins,
+    # resolved via the registry fallback below — covers Slack and Feishu, both
+    # migrated to plugins in #41112).
+    _MAX_LENGTHS = {
+        Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
+    }
+
+    # Check plugin registry for max_message_length
+    if platform not in _MAX_LENGTHS:
+        try:
+            from gateway.platform_registry import platform_registry
+            entry = platform_registry.get(platform.value)
+            if entry and entry.max_message_length > 0:
+                _MAX_LENGTHS[platform] = entry.max_message_length
+        except Exception:
+            pass
+
+    # Smart-chunk the message to fit within platform limits.
+    # For short messages or platforms without a known limit this is a no-op.
+    # Telegram measures length in UTF-16 code units, not Unicode codepoints.
+    max_len = _MAX_LENGTHS.get(platform)
+    if max_len:
+        _len_fn = utf16_len if platform == Platform.TELEGRAM else None
+        chunks = BasePlatformAdapter.truncate_message(message, max_len, len_fn=_len_fn)
+    else:
+        chunks = [message]
+
+    # --- Telegram: special handling for media attachments ---
+    # _send_telegram now owns text chunking internally — it formats the full
+    # message (MarkdownV2/HTML) and then splits the *formatted* text on UTF-16
+    # length so escaping inflation can't push a chunk over Telegram's 4096
+    # limit (issue #28557). Pass the whole message in one call; media attaches
+    # after all text chunks.
+    if platform == Platform.TELEGRAM:
+        disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
+        return await _send_telegram(
+            pconfig.token,
+            chat_id,
+            message,
+            media_files=media_files,
+            thread_id=thread_id,
+            disable_link_previews=disable_link_previews,
+            force_document=force_document,
+        )
+
+    # --- Discord: chunked delivery via the registry's standalone_sender_fn.
+    # The plugin's ``_standalone_send`` (registered in
+    # plugins/platforms/discord/adapter.py) handles forum channels, threads,
+    # and multipart media uploads.  ``_send_via_adapter`` tries the live
+    # in-process adapter first via ``adapter.send()``, but Discord's elif
+    # historically went straight to the HTTP path; we preserve that by
+    # explicitly invoking the registry hook here so behavior is unchanged.
+    if platform == Platform.DISCORD:
+        from gateway.platform_registry import platform_registry
+        entry = platform_registry.get("discord")
+        if entry is None or entry.standalone_sender_fn is None:
+            return {"error": "Discord plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Matrix: route ALL sends through the native adapter so text is
+    # encrypted in E2EE rooms too (issue: text-only sends arrived with a red
+    # padlock because they took the raw-HTTP standalone path). The adapter
+    # reuses the live gateway's E2EE session when available (#46310) and falls
+    # back to an encryption-aware ephemeral adapter for standalone/cron. ---
+    if platform == Platform.MATRIX:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_matrix_via_adapter(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Signal: native attachment support via JSON-RPC attachments param ---
+    if platform == Platform.SIGNAL and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_signal(
+                pconfig.extra,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Yuanbao: native media attachment support via running gateway adapter ---
+    if platform == Platform.YUANBAO and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_yuanbao(
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Feishu: native media attachment support via the registry's
+    # standalone_sender_fn (plugins/platforms/feishu/adapter.py::_standalone_send). #41112
+    if platform == Platform.FEISHU and media_files:
+        from gateway.platform_registry import platform_registry as _pr_feishu
+        from hermes_cli.plugins import discover_plugins as _dp_feishu
+        _dp_feishu()
+        _feishu_entry = _pr_feishu.get("feishu")
+        if _feishu_entry is None or _feishu_entry.standalone_sender_fn is None:
+            return {"error": "Feishu plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _feishu_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- WhatsApp: native media attachment support via the registry's
+    # standalone_sender_fn (plugins/platforms/whatsapp/adapter.py::_standalone_send).
+    # The plugin uploads each file through the local Baileys bridge /send-media
+    # endpoint so images/videos/audio arrive as native bubbles, not documents. #41112
+    if platform == Platform.WHATSAPP and media_files:
+        from gateway.platform_registry import platform_registry as _pr_wa
+        from hermes_cli.plugins import discover_plugins as _dp_wa
+        _dp_wa()
+        _wa_entry = _pr_wa.get("whatsapp")
+        if _wa_entry is None or _wa_entry.standalone_sender_fn is None:
+            return {"error": "WhatsApp plugin not registered or missing standalone_sender_fn"}
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _wa_entry.standalone_sender_fn(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else None,
+                thread_id=thread_id,
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Non-media platforms ---
+    if media_files and not message.strip():
+        return {
+            "error": (
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp; "
+                f"target {platform.value} had only media attachments"
+            )
+        }
+    warning = None
+    if media_files:
+        warning = (
+            f"MEDIA attachments were omitted for {platform.value}; "
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu and whatsapp"
+        )
+
+    last_result = None
+    for chunk in chunks:
+        if platform == Platform.SLACK:
+            # Slack migrated to a bundled plugin (#41112); delivery flows
+            # through the registry's standalone_sender_fn, which applies
+            # mrkdwn formatting and posts via the Slack Web API.
+            from gateway.platform_registry import platform_registry
+            _slack_entry = platform_registry.get("slack")
+            if _slack_entry is None or _slack_entry.standalone_sender_fn is None:
+                result = {"error": "Slack plugin not registered or missing standalone_sender_fn"}
+            else:
+                result = await _slack_entry.standalone_sender_fn(
+                    pconfig, chat_id, chunk, thread_id=thread_id
+                )
+        elif platform == Platform.WHATSAPP:
+            result = await _registry_standalone_send("whatsapp", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.SIGNAL:
+            result = await _send_signal(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.EMAIL:
+            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.SMS:
+            result = await _registry_standalone_send("sms", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.DINGTALK:
+            result = await _registry_standalone_send("dingtalk", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.FEISHU:
+            result = await _registry_standalone_send("feishu", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.WECOM:
+            result = await _registry_standalone_send("wecom", pconfig, chat_id, chunk, thread_id)
+        elif platform == Platform.BLUEBUBBLES:
+            result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.QQBOT:
+            result = await _send_qqbot(pconfig, chat_id, chunk)
+        elif platform == Platform.YUANBAO:
+            result = await _send_yuanbao(chat_id, chunk)
+        else:
+            # Plugin platform: route through the gateway's live adapter if
+            # available, otherwise the plugin's standalone_sender_fn.
+            result = await _send_via_adapter(
+                platform,
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+
+        if isinstance(result, dict) and result.get("error"):
+            return result
+        last_result = result
+
+    if warning and isinstance(last_result, dict) and last_result.get("success"):
+        warnings = list(last_result.get("warnings", []))
+        warnings.append(warning)
+        last_result["warnings"] = warnings
+    return last_result
+
+
+def _is_telegram_thread_not_found(error: Exception) -> bool:
+    """Check if a Telegram error is a thread-not-found failure.
+
+    Matches the gateway adapter's ``_is_thread_not_found_error`` for
+    the standalone ``_send_telegram`` path (issue #27012).
+    """
+    return "thread not found" in str(error).lower()
+
+
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+    """Send via Telegram Bot API (one-shot, no polling needed).
+
+    Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
+    so that bold, links, and headers render correctly.  If the message
+    already contains HTML tags, it is sent with ``parse_mode='HTML'``
+    instead, bypassing MarkdownV2 conversion.
+    """
+    try:
+        from telegram import Bot
+        from telegram.constants import ParseMode
+
+        # Auto-detect HTML tags — if present, skip MarkdownV2 and send as HTML.
+        # Inspired by github.com/ashaney — PR #1568.
+        _has_html = bool(re.search(r'<[a-zA-Z/][^>]*>', message))
+
+        if _has_html:
+            formatted = message
+            send_parse_mode = ParseMode.HTML
+        else:
+            # Reuse the gateway adapter's format_message for markdown→MarkdownV2
+            try:
+                from plugins.platforms.telegram.adapter import TelegramAdapter
+                _adapter = TelegramAdapter.__new__(TelegramAdapter)
+                formatted = _adapter.format_message(message)
+            except Exception:
+                # Fallback: send as-is if formatting unavailable
+                formatted = message
+            send_parse_mode = ParseMode.MARKDOWN_V2
+
+        # Honour a configured proxy (telegram.proxy_url in config.yaml, exported
+        # as TELEGRAM_PROXY env var by load_gateway_config). Without this, the
+        # standalone send path bypasses the proxy and times out in regions
+        # where api.telegram.org is blocked. The in-gateway adapter does the
+        # same thing in gateway/platforms/telegram.py.
+        try:
+            from gateway.platforms.base import resolve_proxy_url
+            _tg_proxy = resolve_proxy_url("TELEGRAM_PROXY", target_hosts=["api.telegram.org"])
+        except Exception:
+            _tg_proxy = None
+        if _tg_proxy:
+            try:
+                from telegram.request import HTTPXRequest
+                logger.info("send_message: standalone Telegram send routed through proxy %s", _tg_proxy)
+                bot = Bot(
+                    token=token,
+                    request=HTTPXRequest(proxy=_tg_proxy),
+                    get_updates_request=HTTPXRequest(proxy=_tg_proxy),
+                )
+            except Exception as _proxy_err:
+                logger.warning("send_message: failed to attach Telegram proxy (%s), falling back to direct connection", _proxy_err)
+                bot = Bot(token=token)
+        else:
+            bot = Bot(token=token)
+        from plugins.platforms.telegram.telegram_ids import (
+            normalize_telegram_chat_id,
+        )
+
+        # Telegram accepts a numeric chat_id OR an @username string; normalize
+        # rather than force-int so username home channels don't crash (#13206).
+        int_chat_id = normalize_telegram_chat_id(chat_id)
+        media_files = media_files or []
+        thread_kwargs = {}
+        if thread_id is not None:
+            # Reuse the gateway adapter's General-topic mapping: in Telegram
+            # forum supergroups, the General topic is addressed as
+            # message_thread_id="1" on incoming updates, but Bot API
+            # sendMessage rejects message_thread_id=1 with "Message thread
+            # not found". The adapter's helper maps "1" to None for that
+            # reason; the send_message tool needs the same mapping or a
+            # send to a forum group's General topic always errors out
+            # (see issue #22267).
+            try:
+                from plugins.platforms.telegram.adapter import TelegramAdapter
+                effective_thread_id = TelegramAdapter._message_thread_id_for_send(
+                    str(thread_id)
+                )
+            except Exception:
+                # Fallback: explicit mapping in case the adapter import
+                # fails (e.g. python-telegram-bot missing in this venv).
+                effective_thread_id = (
+                    None if str(thread_id) == "1" else int(thread_id)
+                )
+            if effective_thread_id is not None:
+                thread_kwargs["message_thread_id"] = effective_thread_id
+        # disable_web_page_preview is only valid for send_message, not
+        # send_photo/send_video/etc.  Keep it separate so media sends
+        # don't inherit an invalid parameter (issue #27012).
+        text_kwargs = dict(thread_kwargs)
+        if disable_link_previews:
+            text_kwargs["disable_web_page_preview"] = True
+
+        last_msg = None
+        warnings = []
+
+        if formatted.strip():
+            # Chunk *after* formatting: MarkdownV2/HTML escaping inflates the
+            # text (each escaped char like `!`/`.`/`-` becomes `\!`/`\.`/`\-`),
+            # so a message that fit under 4096 UTF-16 units raw can exceed the
+            # Telegram limit once formatted and get rejected as "Message is too
+            # long". Sizing on the formatted text in UTF-16 units guarantees
+            # every chunk is deliverable. (issue #28557)
+            from gateway.platforms.base import BasePlatformAdapter, utf16_len
+
+            text_chunks = BasePlatformAdapter.truncate_message(
+                formatted, 4096, len_fn=utf16_len
+            )
+            for chunk in text_chunks:
+                try:
+                    last_msg = await _send_telegram_message_with_retry(
+                        bot,
+                        chat_id=int_chat_id, text=chunk,
+                        parse_mode=send_parse_mode, **text_kwargs
+                    )
+                except Exception as md_error:
+                    # Thread not found — retry without message_thread_id so the
+                    # message still delivers (matching the gateway adapter's
+                    # fallback behaviour, issue #27012).
+                    if _is_telegram_thread_not_found(md_error) and text_kwargs.get("message_thread_id") is not None:
+                        logger.warning(
+                            "Thread %s not found in _send_telegram, retrying without message_thread_id",
+                            text_kwargs.get("message_thread_id"),
+                        )
+                        text_kwargs.pop("message_thread_id", None)
+                        last_msg = await _send_telegram_message_with_retry(
+                            bot,
+                            chat_id=int_chat_id, text=chunk,
+                            parse_mode=send_parse_mode, **text_kwargs
+                        )
+                    elif "parse" in str(md_error).lower() or "markdown" in str(md_error).lower() or "html" in str(md_error).lower():
+                        logger.warning(
+                            "Parse mode %s failed in _send_telegram, falling back to plain text: %s",
+                            send_parse_mode,
+                            _sanitize_error_text(md_error),
+                        )
+                        if not _has_html:
+                            try:
+                                from plugins.platforms.telegram.adapter import _strip_mdv2
+                                plain = _strip_mdv2(chunk)
+                            except Exception:
+                                plain = chunk
+                        else:
+                            plain = chunk
+                        last_msg = await _send_telegram_message_with_retry(
+                            bot,
+                            chat_id=int_chat_id, text=plain,
+                            parse_mode=None, **text_kwargs
+                        )
+                    else:
+                        raise
+
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                warning = f"Media file not found, skipping: {media_path}"
+                logger.warning(warning)
+                warnings.append(warning)
+                continue
+
+            ext = os.path.splitext(media_path)[1].lower()
+            try:
+                with open(media_path, "rb") as f:
+                    media_kwargs = dict(thread_kwargs)
+                    try:
+                        if ext in _IMAGE_EXTS and not force_document:
+                            last_msg = await bot.send_photo(
+                                chat_id=int_chat_id, photo=f, **media_kwargs
+                            )
+                        elif ext in _VIDEO_EXTS:
+                            last_msg = await bot.send_video(
+                                chat_id=int_chat_id, video=f, **media_kwargs
+                            )
+                        elif ext in _VOICE_EXTS and is_voice:
+                            last_msg = await bot.send_voice(
+                                chat_id=int_chat_id, voice=f, **media_kwargs
+                            )
+                        elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                            last_msg = await bot.send_audio(
+                                chat_id=int_chat_id, audio=f, **media_kwargs
+                            )
+                        else:
+                            last_msg = await bot.send_document(
+                                chat_id=int_chat_id, document=f, **media_kwargs
+                            )
+                    except Exception as media_err:
+                        if _is_telegram_thread_not_found(media_err) and media_kwargs.get("message_thread_id"):
+                            # Thread not found for media — retry without
+                            # message_thread_id (issue #27012).
+                            logger.warning(
+                                "Thread %s not found for media send, retrying without message_thread_id",
+                                media_kwargs["message_thread_id"],
+                            )
+                            # Re-seek the file since the first attempt consumed it
+                            f.seek(0)
+                            media_kwargs.pop("message_thread_id", None)
+                            if ext in _IMAGE_EXTS and not force_document:
+                                last_msg = await bot.send_photo(
+                                    chat_id=int_chat_id, photo=f, **media_kwargs
+                                )
+                            elif ext in _VIDEO_EXTS:
+                                last_msg = await bot.send_video(
+                                    chat_id=int_chat_id, video=f, **media_kwargs
+                                )
+                            elif ext in _VOICE_EXTS and is_voice:
+                                last_msg = await bot.send_voice(
+                                    chat_id=int_chat_id, voice=f, **media_kwargs
+                                )
+                            elif ext in _TELEGRAM_SEND_AUDIO_EXTS:
+                                last_msg = await bot.send_audio(
+                                    chat_id=int_chat_id, audio=f, **media_kwargs
+                                )
+                            else:
+                                last_msg = await bot.send_document(
+                                    chat_id=int_chat_id, document=f, **media_kwargs
+                                )
+                        else:
+                            raise
+            except Exception as e:
+                warning = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
+                logger.error(warning)
+                warnings.append(warning)
+
+        if last_msg is None:
+            error = "No deliverable text or media remained after processing MEDIA tags"
+            if warnings:
+                return {"error": error, "warnings": warnings}
+            return {"error": error}
+
+        result = {
+            "success": True,
+            "platform": "telegram",
+            "chat_id": chat_id,
+            "message_id": str(last_msg.message_id),
+        }
+        if warnings:
+            result["warnings"] = warnings
+        return result
+    except ImportError:
+        return {"error": "python-telegram-bot not installed. Run: pip install python-telegram-bot"}
+    except Exception as e:
+        return _error(f"Telegram send failed: {e}")
+
+
+# _send_slack moved to the slack plugin as _standalone_send
+# (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
+
+
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+    """Dispatch a one-shot send through a migrated platform plugin's
+    standalone_sender_fn (registry hook).  Used for platforms whose adapter
+    moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
+    the legacy inline ``_send_<platform>`` helper now lives in the plugin as
+    ``_standalone_send`` and is reached via the platform registry.
+    """
+    from gateway.platform_registry import platform_registry
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins()  # idempotent — ensure the entry is registered
+    entry = platform_registry.get(platform_name)
+    if entry is None or entry.standalone_sender_fn is None:
+        return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+
+
+# _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,
+# wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+
+
+async def _send_signal(extra, chat_id, message, media_files=None):
+    """Send via signal-cli JSON-RPC API.
+
+    Supports both text-only and text-with-attachments (images/audio/documents).
+    Multi-attachment sends are chunked into batches of
+    SIGNAL_MAX_ATTACHMENTS_PER_MSG and metered by the process-wide
+    SignalAttachmentScheduler — same bucket the gateway adapter uses, so
+    sends from this tool and inbound-driven replies share rate-limit state.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return {"error": "httpx not installed"}
+
+    from gateway.platforms.signal_rate_limit import (
+        SIGNAL_BATCH_PACING_NOTICE_THRESHOLD,
+        SIGNAL_MAX_ATTACHMENTS_PER_MSG,
+        SIGNAL_RATE_LIMIT_MAX_ATTEMPTS,
+        _extract_retry_after_seconds,
+        _format_wait,
+        _is_signal_rate_limit_error,
+        _signal_send_timeout,
+        get_scheduler,
+    )
+    from gateway.platforms.signal_format import markdown_to_signal
+
+    try:
+        http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
+        account = extra.get("account", "")
+        if not account:
+            return {"error": "Signal account not configured"}
+
+        valid_media = media_files or []
+        attachment_paths = []
+        for media_path, _is_voice in valid_media:
+            if os.path.exists(media_path):
+                attachment_paths.append(media_path)
+            else:
+                logger.warning("Signal media file not found, skipping: %s", media_path)
+
+        # Chunk attachments. With no attachments we still emit one batch
+        # (text only). With attachments, the text rides on batch #0 so the
+        # caption isn't repeated across every chunk.
+        if attachment_paths:
+            att_batches = [
+                attachment_paths[i:i + SIGNAL_MAX_ATTACHMENTS_PER_MSG]
+                for i in range(0, len(attachment_paths), SIGNAL_MAX_ATTACHMENTS_PER_MSG)
+            ]
+        else:
+            att_batches = [[]]
+
+        plain_text, text_styles = markdown_to_signal(message)
+
+        async def _post(batch_attachments, batch_message):
+            params = {"account": account, "message": batch_message}
+            if batch_message and text_styles:
+                if len(text_styles) == 1:
+                    params["textStyle"] = text_styles[0]
+                else:
+                    params["textStyles"] = text_styles
+            if chat_id.startswith("group:"):
+                params["groupId"] = chat_id[6:]
+            else:
+                params["recipient"] = [chat_id]
+            if batch_attachments:
+                params["attachments"] = batch_attachments
+
+            payload = {
+                "jsonrpc": "2.0",
+                "method": "send",
+                "params": params,
+                "id": f"send_{int(time.time() * 1000)}",
+            }
+            timeout = _signal_send_timeout(len(batch_attachments) if batch_attachments else 0)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(f"{http_url}/api/v1/rpc", json=payload)
+                resp.raise_for_status()
+                return resp.json()
+
+        async def _send_inline_notice(text: str) -> None:
+            """Best-effort one-shot RPC for a user-facing pacing notice."""
+            notice_params = {"account": account, "message": text}
+            if chat_id.startswith("group:"):
+                notice_params["groupId"] = chat_id[6:]
+            else:
+                notice_params["recipient"] = [chat_id]
+            try:
+                async with httpx.AsyncClient(timeout=30.0) as _client:
+                    await _client.post(
+                        f"{http_url}/api/v1/rpc",
+                        json={
+                            "jsonrpc": "2.0",
+                            "method": "send",
+                            "params": notice_params,
+                            "id": f"notice_{int(time.time() * 1000)}",
+                        },
+                    )
+            except Exception as _e:
+                logger.warning("Signal: inline notice failed: %s", _e)
+
+        scheduler = get_scheduler()
+        logger.info(
+            "send_message Signal: scheduler state=%s, %d attachment(s) in %d batch(es)",
+            scheduler.state(), len(attachment_paths), len(att_batches),
+        )
+        failed_batches: list[int] = []
+        for idx, att_batch in enumerate(att_batches):
+            n = len(att_batch)
+            if n > 0:
+                estimated = scheduler.estimate_wait(n)
+                if estimated >= SIGNAL_BATCH_PACING_NOTICE_THRESHOLD:
+                    await _send_inline_notice(
+                        f"(More images coming — pausing ~{_format_wait(estimated)} "
+                        f"for Signal rate limit, batch {idx + 1}/{len(att_batches)}.)"
+                    )
+
+            batch_message = plain_text if idx == 0 else ""
+
+            for attempt in range(1, SIGNAL_RATE_LIMIT_MAX_ATTEMPTS + 1):
+                try:
+                    await scheduler.acquire(n)
+                    _rpc_t0 = time.monotonic()
+                    data = await _post(att_batch, batch_message)
+                    _rpc_duration = time.monotonic() - _rpc_t0
+                    if "error" not in data:
+                        await scheduler.report_rpc_duration(_rpc_duration, n)
+                        break
+
+                    err = data["error"]
+
+                    if not _is_signal_rate_limit_error(err):
+                        return _error(f"Signal RPC error on batch {idx + 1}/{len(att_batches)}: {err}")
+
+                    server_retry_after = _extract_retry_after_seconds(err)
+                    scheduler.feedback(server_retry_after, n)
+
+                    if attempt >= SIGNAL_RATE_LIMIT_MAX_ATTEMPTS:
+                        failed_batches.append(idx + 1)
+                        logger.error(
+                            "Signal: rate-limit retries exhausted on batch %d/%d "
+                            "(%d attachments lost, server retry_after=%s)",
+                            idx + 1, len(att_batches), n,
+                            f"{server_retry_after:.0f}s" if server_retry_after else "unknown",
+                        )
+                        break
+                    logger.warning(
+                        "Signal: rate-limited on batch %d/%d "
+                        "(attempt %d/%d, server retry_after=%s); "
+                        "scheduler will pace the retry",
+                        idx + 1, len(att_batches),
+                        attempt, SIGNAL_RATE_LIMIT_MAX_ATTEMPTS,
+                        f"{server_retry_after:.0f}s" if server_retry_after else "unknown",
+                    )
+                except Exception as e:
+                    if attempt >= SIGNAL_RATE_LIMIT_MAX_ATTEMPTS:
+                        failed_batches.append(idx + 1)
+                        logger.error(
+                            "Signal: send error on batch %d/%d after %d attempts: %s",
+                            idx + 1, len(att_batches), attempt, str(e)
+                        )
+                        break
+                    logger.warning(
+                        "Signal: transient error on batch %d/%d (attempt %d/%d): %s; will retry",
+                        idx + 1, len(att_batches), attempt, SIGNAL_RATE_LIMIT_MAX_ATTEMPTS, str(e)
+                    )
+
+        warnings = []
+        if len(attachment_paths) < len(valid_media):
+            warnings.append("Some media files were skipped (not found on disk)")
+        if failed_batches:
+            warnings.append(
+                f"Signal rate-limited {len(failed_batches)} batch(es) "
+                f"(#{', #'.join(str(b) for b in failed_batches)})"
+            )
+
+        if failed_batches and len(failed_batches) == len(att_batches):
+            return _error(
+                f"Signal: every batch ({len(att_batches)}) hit rate limit; "
+                f"no attachments delivered"
+            )
+
+        result = {"success": True, "platform": "signal", "chat_id": _display_chat_id("signal", chat_id)}
+        if warnings:
+            result["warnings"] = warnings
+        return result
+    except Exception as e:
+        return _error(f"Signal send failed: {e}")
+
+
+# _send_email moved to plugins/platforms/email/adapter.py::_standalone_send;
+# _send_sms moved to plugins/platforms/sms/adapter.py::_standalone_send. Both
+# wired via standalone_sender_fn, reached through _registry_standalone_send. #41112.
+
+
+# _send_matrix moved to plugins/platforms/matrix/adapter.py::_standalone_send,
+# wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+# (_send_matrix_via_adapter below stays — it's the native-media upload path.)
+
+
+async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
+    """Send via the Matrix adapter so native Matrix media uploads are preserved.
+
+    When a live gateway adapter is available (i.e. the tool runs inside a
+    running gateway), the persistent connection is reused — one olm/megolm
+    session for all sends.  This avoids per-message E2EE re-init storms
+    that exhaust recipient OTKs and silently drop messages (issue #46310).
+
+    Falls back to an ephemeral connect/disconnect cycle only when no gateway
+    is running (standalone cron, ``hermes send`` CLI).
+    """
+    media_files = media_files or []
+    metadata = {"thread_id": thread_id} if thread_id else None
+
+    # --- Try the live gateway adapter first (persistent E2EE session) ---
+    # Reusing the running gateway's already-connected adapter is the whole
+    # point of #46310: it avoids a per-send login + olm/megolm re-init + OTK
+    # claim that, under burst sends, exhausts recipient one-time keys and
+    # silently drops messages. The import is guarded narrowly (gateway code may
+    # be absent in some standalone contexts); a runner that *exists* but whose
+    # adapter lookup fails is logged rather than silently swallowed, because a
+    # silent fall-through here would re-introduce the exact reconnect storm
+    # this fix prevents.
+    live_adapter = None
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+    if runner is not None:
+        try:
+            from gateway.config import Platform
+            live_adapter = runner.adapters.get(Platform.MATRIX)
+        except Exception:
+            logger.warning(
+                "Matrix: live gateway adapter lookup failed; falling back to an "
+                "ephemeral connect (may re-init E2EE per send, see #46310)",
+                exc_info=True,
+            )
+            live_adapter = None
+
+    if live_adapter is not None:
+        # NOTE: the live adapter is owned by the gateway — we must NOT
+        # disconnect it. Correctness here depends on this branch returning
+        # before the ephemeral ``adapter`` is constructed below, so the
+        # ephemeral ``finally`` disconnect never touches the live session.
+        return await _matrix_send_core(
+            live_adapter, chat_id, message, media_files, metadata
+        )
+
+    # --- Fallback: ephemeral adapter (standalone / cron context) ---
+    try:
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+    except ImportError:
+        return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
+
+    adapter = MatrixAdapter(pconfig)
+    try:
+        connected = await adapter.connect()
+        if not connected:
+            return _error("Matrix connect failed")
+        return await _matrix_send_core(
+            adapter, chat_id, message, media_files, metadata
+        )
+    except Exception as e:
+        return _error(f"Matrix send failed: {e}")
+    finally:
+        try:
+            await adapter.disconnect()
+        except Exception:
+            pass
+
+
+async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
+    """Core send logic shared by live and ephemeral Matrix adapters."""
+    last_result = None
+
+    if message.strip():
+        last_result = await adapter.send(chat_id, message, metadata=metadata)
+        if not last_result.success:
+            return _error(f"Matrix send failed: {last_result.error}")
+
+    for media_path, is_voice in media_files:
+        if not os.path.exists(media_path):
+            return _error(f"Media file not found: {media_path}")
+
+        ext = os.path.splitext(media_path)[1].lower()
+        if ext in _IMAGE_EXTS:
+            last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+        elif ext in _VIDEO_EXTS:
+            last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
+        elif ext in _VOICE_EXTS and is_voice:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        elif ext in _AUDIO_EXTS:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        else:
+            last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+
+        if not last_result.success:
+            return _error(f"Matrix media send failed: {last_result.error}")
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+    return {
+        "success": True,
+        "platform": "matrix",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id,
+    }
+
+
+# _send_dingtalk moved to plugins/platforms/dingtalk/adapter.py::_standalone_send,
+# wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+
+
+# _send_wecom moved to plugins/platforms/wecom/adapter.py::_standalone_send,
+# wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+
+
+async def _send_weixin(pconfig, chat_id, message, media_files=None):
+    """Send via Weixin iLink using the native adapter helper."""
+    try:
+        from gateway.platforms.weixin import check_weixin_requirements, send_weixin_direct
+        if not check_weixin_requirements():
+            return {"error": "Weixin requirements not met. Need aiohttp + cryptography."}
+    except ImportError:
+        return {"error": "Weixin adapter not available."}
+
+    try:
+        return await send_weixin_direct(
+            extra=pconfig.extra,
+            token=pconfig.token,
+            chat_id=chat_id,
+            message=message,
+            media_files=media_files,
+        )
+    except Exception as e:
+        return _error(f"Weixin send failed: {e}")
+
+
+async def _send_bluebubbles(extra, chat_id, message):
+    """Send via BlueBubbles iMessage server using the adapter's REST API."""
+    try:
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
+        if not check_bluebubbles_requirements():
+            return {"error": "BlueBubbles requirements not met (need aiohttp + httpx)."}
+    except ImportError:
+        return {"error": "BlueBubbles adapter not available."}
+
+    try:
+        from gateway.config import PlatformConfig
+        pconfig = PlatformConfig(extra=extra)
+        adapter = BlueBubblesAdapter(pconfig)
+        connected = await adapter.connect()
+        if not connected:
+            return _error("BlueBubbles: failed to connect to server")
+        try:
+            result = await adapter.send(chat_id, message)
+            if not result.success:
+                return _error(f"BlueBubbles send failed: {result.error}")
+            return {"success": True, "platform": "bluebubbles", "chat_id": chat_id, "message_id": result.message_id}
+        finally:
+            await adapter.disconnect()
+    except Exception as e:
+        return _error(f"BlueBubbles send failed: {e}")
+
+
+# _send_feishu moved to plugins/platforms/feishu/adapter.py::_standalone_send,
+# wired via standalone_sender_fn and reached through _registry_standalone_send
+# (and the feishu media branch above). #41112.
+
+
+def _check_send_message():
+    """Gate send_message on gateway running (always available on messaging platforms).
+
+    Also passes for kanban workers — the dispatcher sets ``HERMES_KANBAN_TASK``
+    on every spawned worker, but those workers run with the assignee profile's
+    ``HERMES_HOME`` which has no ``gateway.pid``, so the gateway-running check
+    would fail even though the parent gateway is alive. Honoring the env var
+    lets workers call ``send_message`` to deliver rich content directly to the
+    originating chat (paired with ``kanban_complete`` for the short notifier
+    summary), which is the canonical pattern for any worker that needs to
+    reply with more than the ~200-char first-line truncation the kanban
+    notifier applies.
+    """
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    from gateway.session_context import get_session_env
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    if platform and platform != "local":
+        return True
+    try:
+        from gateway.status import is_gateway_running
+        return is_gateway_running()
+    except Exception:
+        return False
+
+
+async def _send_qqbot(pconfig, chat_id, message):
+    """Send via QQBot using the REST API directly (no WebSocket needed).
+
+    Uses the QQ Bot Open Platform REST endpoints to get an access token
+    and post a message. Supports guild channels, C2C (private) chats,
+    and group chats by trying the appropriate endpoints.
+    """
+    try:
+        import httpx
+    except ImportError:
+        return _error("QQBot direct send requires httpx. Run: pip install httpx")
+
+    extra = pconfig.extra or {}
+    appid = extra.get("app_id") or os.getenv("QQ_APP_ID", "")
+    secret = (pconfig.token or extra.get("client_secret")
+              or os.getenv("QQ_CLIENT_SECRET", ""))
+    if not appid or not secret:
+        return _error("QQBot: QQ_APP_ID / QQ_CLIENT_SECRET not configured.")
+
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            # Step 1: Get access token
+            token_resp = await client.post(
+                "https://bots.qq.com/app/getAppAccessToken",
+                json={"appId": str(appid), "clientSecret": str(secret)},
+            )
+            if token_resp.status_code != 200:
+                return _error(f"QQBot token request failed: {token_resp.status_code}")
+            token_data = token_resp.json()
+            access_token = token_data.get("access_token")
+            if not access_token:
+                return _error("QQBot: no access_token in response")
+
+            # Step 2: Send message via REST
+            # QQ Bot API has separate endpoints for channels, C2C, and groups.
+            # We try them in order: channel first, then fallback to C2C.
+            headers = {
+                "Authorization": f"QQBot {access_token}",
+                "Content-Type": "application/json",
+            }
+            payload = {"content": message[:4000], "msg_type": 0}
+
+            # Try channel endpoint first (works for guild channels)
+            url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"
+            resp = await client.post(url, json=payload, headers=headers)
+            if resp.status_code in {200, 201}:
+                data = resp.json()
+                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                        "message_id": data.get("id")}
+
+            # If channel endpoint failed (likely "频道不存在"), try C2C endpoint
+            url_c2c = f"https://api.sgroup.qq.com/v2/users/{chat_id}/messages"
+            resp_c2c = await client.post(url_c2c, json=payload, headers=headers)
+            if resp_c2c.status_code in {200, 201}:
+                data = resp_c2c.json()
+                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                        "message_id": data.get("id")}
+
+            # If C2C also failed, try group endpoint
+            url_group = f"https://api.sgroup.qq.com/v2/groups/{chat_id}/messages"
+            resp_group = await client.post(url_group, json=payload, headers=headers)
+            if resp_group.status_code in {200, 201}:
+                data = resp_group.json()
+                return {"success": True, "platform": "qqbot", "chat_id": chat_id,
+                        "message_id": data.get("id")}
+
+            # All endpoints failed — return the most informative error
+            return _error(f"QQBot send failed: channel={resp.status_code} c2c={resp_c2c.status_code} group={resp_group.status_code}")
+    except Exception as e:
+        return _error(f"QQBot send failed: {e}")
+
+
+async def _send_yuanbao(chat_id, message, media_files=None):
+    """Send via Yuanbao using the running gateway adapter's WebSocket connection.
+
+    Yuanbao uses a persistent WebSocket — unlike HTTP-based platforms, we
+    cannot create a throwaway client.  We obtain the running singleton from
+    the adapter module itself (``get_active_adapter``).
+
+    chat_id format:
+      - Group: "group:<group_code>"
+      - DM:    "direct:<account_id>" or just "<account_id>"
+    """
+    try:
+        from gateway.platforms.yuanbao import get_active_adapter, send_yuanbao_direct
+    except ImportError:
+        return _error("Yuanbao adapter module not available.")
+
+    adapter = get_active_adapter()
+    if adapter is None:
+        return _error(
+            "Yuanbao adapter is not running. "
+            "Start the gateway with yuanbao platform enabled first."
+        )
+
+    try:
+        return await send_yuanbao_direct(adapter, chat_id, message, media_files=media_files)
+    except Exception as e:
+        return _error(f"Yuanbao send failed: {e}")
+
+
+# --- Registry ---
+from tools.registry import tool_error
+
+# NOTE: ``send_message`` is intentionally NOT registered as an agent-callable
+# model tool. The agent should not decide on its own to fire off cross-platform
+# messages or reactions. The send engine in this module (``_send_to_platform``,
+# ``_send_via_adapter``, ``_parse_target_ref``, the per-platform ``_send_*``
+# helpers) remains the shared transport used by:
+#   - cron delivery (cron/scheduler.py)
+#   - the ``hermes send`` CLI command (hermes_cli/send_cmd.py)
+#   - the gateway kanban notifier (dashboard-toggled, outside agent control)
+#   - the standalone MCP server (mcp_serve.py), which is an opt-in surface
+# Those callers import the helpers directly; none of them need the registry
+# entry.

--- a/deploy/shared/send_message_tool.py
+++ b/deploy/shared/send_message_tool.py
@@ -530,8 +530,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         elif len(parts) == 1:
             val = parts[0].strip()
             if "/messages/" in val:
-                thread_name = val.replace("/messages/", "/threads/")
-                space_name = val.split("/messages/")[0]
+                space_name, msg_part = val.split("/messages/", 1)
+                thread_key = msg_part.split(".")[0]
+                thread_name = f"{space_name}/threads/{thread_key}"
                 return space_name, thread_name, True
             elif "/threads/" in val:
                 space_name = val.split("/threads/")[0]

--- a/k8s-operator/cmd/k8s-event-watcher/README.md
+++ b/k8s-operator/cmd/k8s-event-watcher/README.md
@@ -1,0 +1,49 @@
+# Design Proposal: GKE Event Watcher Integration
+
+## 1. Objective
+Enable the Platform Agent (`kube-agents`) to autonomously troubleshoot cluster health failures in real-time by streaming, filtering, and deduplicating Kubernetes warning events.
+
+---
+
+## 2. Proposed Architecture
+
+We propose integrating a Go-based `k8s-event-watcher` service as a **sidecar container** inside the `platform-agent` Pod.
+
+```mermaid
+graph TD
+    API[GKE API Server] -->|1. Realtime Watch Stream| Watcher[k8s-event-watcher Sidecar]
+    Watcher -->|2. Filter & Dedup| Watcher
+    Watcher -->|3. POST /sessions| Proxy[FastAPI session_kv_server]
+    Proxy -->|4. hermes send| Agent[platform-agent Gateway]
+```
+
+1. **Watch Stream:** The watcher container connects to GKE control plane API Server and streams warnings (`core/v1.Event`) in real-time.
+2. **Filter & Dedup:** It drops noise, filters events by allowlisted reasons, and groups occurrences of pod crash families (e.g. `ErrImagePull` -> `ImagePullBackOff`) within a 5-minute rolling window.
+3. **Local REST Bridge:** When a new failure family triggers, the sidecar POSTs to the local helper server `session_kv_server.py` (`http://localhost:8699`).
+4. **Hermes Alert:** The FastAPI server executes the local `hermes` CLI to kick off a new agent troubleshooting session.
+
+---
+
+## 3. Iterative Task Breakdown & Verification
+
+To allow progressive reviews and testing, the implementation is divided into four standalone steps:
+
+### Task 1: Check in the Go Watcher Code
+* **Action:** Merge Go source files (with OpenTelemetry dependencies stripped out) into `k8s-operator/cmd/k8s-event-watcher/`.
+* **Verification:** Compile and run locally in dry-run mode against your current kubectl context:
+  ```bash
+  cd k8s-operator/cmd/k8s-event-watcher && go build -o watcher .
+  ./watcher --dry-run --cluster-name=dev-cluster
+  ```
+
+### Task 2: Extend FastAPI Proxy Endpoints
+* **Action:** Implement `/sessions` and `/sessions/{session_id}/inject` endpoints inside `session_kv_server.py`.
+* **Verification:** Mock incoming alerts using local `curl` posts to the FastAPI listener port.
+
+### Task 3: Containerize the Watcher
+* **Action:** Add a multi-stage `Dockerfile.watcher` to package the compiled static binary into a scratch container.
+* **Verification:** Run `docker build -f deploy/docker/Dockerfile.watcher -t k8s-event-watcher:latest .`
+
+### Task 4: Deploy the Sidecar
+* **Action:** Define the sidecar container and volume mount inside `platform-agent.yaml.template` using the CRD's native `spec.deployment.sidecars` field.
+* **Verification:** Deploy and ensure the platform agent pod runs with 3 active containers (`platform-agent`, `fluent-bit`, `k8s-event-watcher`).

--- a/k8s-operator/cmd/k8s-event-watcher/dedup.go
+++ b/k8s-operator/cmd/k8s-event-watcher/dedup.go
@@ -1,0 +1,383 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+// dedupEntry holds the per-incident dedup state cached against an
+// EventKey. Bounded: the sidecar's cache is capped at maxDedupEntries
+// (LRU eviction) so a runaway cluster with tens of thousands of
+// distinct incidents doesn't OOM the sidecar.
+type dedupEntry struct {
+	// SessionID is the daemon-side session created by the first
+	// event in this window. Follow-up events for the same key
+	// route to this session via POST /sessions/<sid>/inject.
+	SessionID string `json:"session_id"`
+	// FirstSeen is when the sidecar first observed this key.
+	// Rolls forward when the window expires + a new event arrives.
+	FirstSeen time.Time `json:"first_seen"`
+	// LastSeen is the wall-clock time we last recorded REAL new
+	// activity for this key (replays do NOT advance it — see
+	// Observe). Used to compute retry-cooldown: the entry ages
+	// out when LastSeen + window < now.
+	LastSeen time.Time `json:"last_seen"`
+	// EventLastTS is the k8s Event's own LastTimestamp we last
+	// processed for this key. Enables idempotent replay handling:
+	// client-go informers periodically re-List all Events on
+	// watch-connection rotation (~15-25min in practice), which
+	// used to trigger spurious "new incident" fires. Comparing
+	// incoming event.LastTimestamp against this field lets us
+	// distinguish replay of already-seen activity (dedup) from
+	// genuinely new activity (real new events k8s aggregated
+	// into the same Event object since we last saw it).
+	EventLastTS time.Time `json:"event_last_ts"`
+	// Count is how many events the sidecar has seen for this key
+	// in the current window (the first event that created the
+	// session counts as 1). Reset when the window rolls.
+	Count int `json:"count"`
+}
+
+// dedupResult tells the caller what to do with the event that just
+// came in: kind==firstInWindow means create a session + inject;
+// kind==duplicate means suppress; kind==newIncident means the prior
+// window expired and this is a fresh incident (create new session).
+type dedupResult struct {
+	Kind      dedupResultKind
+	SessionID string // only set when Kind==duplicate; the existing session
+	Count     int    // window count (1 for first, N for duplicates)
+}
+
+type dedupResultKind int
+
+const (
+	// dedupNewIncident: no prior entry (or the prior window
+	// expired). Caller must create a new session and inject.
+	dedupNewIncident dedupResultKind = iota
+	// dedupDuplicate: an entry exists within the window. Caller
+	// suppresses this event; the count is bumped and available
+	// via dedupResult.Count.
+	dedupDuplicate
+)
+
+// dedupCache is the rolling-window dedup store. Backed by a map +
+// a mutex; bounded by LRU eviction at maxDedupEntries.
+type dedupCache struct {
+	mu      sync.Mutex
+	entries map[EventKey]*dedupEntry
+	window  time.Duration
+	max     int
+	// persistPath, when non-empty, causes Snapshot+Restore calls
+	// to read/write JSON at that path so the cache survives
+	// sidecar restart. Optional (nil disables persistence).
+	persistPath string
+	// now overrides time.Now for testing. nil = real clock.
+	now func() time.Time
+}
+
+// maxDedupEntries caps the sidecar's cache size. 10k is plenty for
+// any realistic single-cluster deployment (unique events per 5-min
+// window). LRU eviction beyond this bound.
+const maxDedupEntries = 10_000
+
+// newDedupCache constructs a cache with the supplied rolling window
+// duration. window must be > 0. persistPath is optional; empty
+// disables the on-disk cache.
+func newDedupCache(window time.Duration, persistPath string) (*dedupCache, error) {
+	if window <= 0 {
+		return nil, fmt.Errorf("dedup: window must be > 0 (got %s)", window)
+	}
+	c := &dedupCache{
+		entries:     make(map[EventKey]*dedupEntry),
+		window:      window,
+		max:         maxDedupEntries,
+		persistPath: persistPath,
+	}
+	if persistPath != "" {
+		if err := c.restore(); err != nil {
+			return nil, fmt.Errorf("dedup: restore from %s: %w", persistPath, err)
+		}
+	}
+	return c, nil
+}
+
+// clock returns the current time. Overridable for tests.
+func (c *dedupCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// reasonCanonical maps well-known secondary Event.Reason values to
+// their canonical primary reason for dedup-key computation. Two
+// events for the same target whose reasons are in the same family
+// collapse into one dedup entry — e.g. an ImagePullBackOff event
+// and an ErrImagePull event for the same pod count as ONE incident,
+// not two parallel sessions.
+//
+// The mapping is deliberately narrow — only well-known equivalences
+// where a single underlying failure emits multiple reason variants
+// from kubelet's retry cycle. Reasons not in this map are their
+// own canonical value.
+//
+// Rationale for each entry:
+//
+//   - ErrImagePull → ImagePullBackOff: kubelet emits ErrImagePull
+//     on the first failed pull attempt, then ImagePullBackOff once
+//     the exponential backoff kicks in. Same failure, two reason
+//     values within seconds.
+//   - BackOff → CrashLoopBackOff: BackOff accompanies both crash-
+//     loop and image-pull cycles. In practice, when it collides
+//     with an ImagePullBackOff for the same pod, that pod's
+//     ImagePullBackOff entry already exists so BackOff routes there
+//     via the CrashLoopBackOff canonical (which will be reset when
+//     the crash-loop entry expires). Yes, this is subtle. If a
+//     future variant wants to disambiguate, a `--reason-canonical`
+//     config override can drop or remap entries.
+//
+// Observed live during v2.6 GKE-troubleshoot demo drive: one
+// paymentservice ImagePullBackOff spawned 4 parallel sessions
+// (one per reason variant) at $0.28/session, 4× baseline spend
+// per incident. See go-steer/core-agent#219.
+var reasonCanonical = map[string]string{
+	"ErrImagePull": "ImagePullBackOff",
+	"BackOff":      "CrashLoopBackOff",
+}
+
+// canonicalizeReason returns the dedup-key reason for a given
+// Event.Reason value. Reasons not in reasonCanonical map to
+// themselves (no change).
+func canonicalizeReason(reason string) string {
+	if canonical, ok := reasonCanonical[reason]; ok {
+		return canonical
+	}
+	return reason
+}
+
+// Observe records that key was just seen with eventLastTS (the
+// k8s Event's own LastTimestamp). Returns a dedupResult telling the
+// caller whether this is a fresh incident (start a new session) or
+// a duplicate within the current window (suppress).
+//
+// The key's Reason is canonicalized (see reasonCanonical) so events
+// from the same underlying failure with different reason variants
+// (e.g. ImagePullBackOff vs ErrImagePull) collapse into one dedup
+// slot. The wire event's original Reason is preserved on the
+// inject payload — canonicalization is a dedup-only mechanism.
+//
+// Three cases, checked in order:
+//
+//  1. **Replay** — eventLastTS is not later than the recorded
+//     EventLastTS. This is the k8s Event object being re-delivered
+//     (informer watch-rotation triggers a re-List; kube-apiserver
+//     rotates watch connections every ~15-25min in practice). The
+//     activity is one we've already processed — dedup, do NOT
+//     advance LastSeen (retry cooldown continues to age from real
+//     activity time). Bump count so metrics stay accurate.
+//
+//  2. **New activity past cooldown** — eventLastTS is later AND
+//     wall-clock now is more than `window` past LastSeen. The prior
+//     session's cooldown has expired and k8s is still actively
+//     reporting the issue, so create a new session (retry safety
+//     net: if the previous agent-run failed to resolve the
+//     incident, the fresh reporting gives it another chance).
+//
+//  3. **New activity within cooldown** — eventLastTS is later,
+//     within the window. Real new k8s aggregation on top of an
+//     ongoing incident — dedup to the existing session, advance
+//     both LastSeen and EventLastTS.
+//
+// Contract: the caller MUST call BindSession after a successful
+// CreateSession call to attach the SessionID to the newly-created
+// entry, so subsequent duplicates can route to the same session.
+func (c *dedupCache) Observe(key EventKey, eventLastTS time.Time) dedupResult {
+	key.Reason = canonicalizeReason(key.Reason)
+	now := c.clock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		// First sighting for this key.
+		c.evictIfFull()
+		c.entries[key] = &dedupEntry{
+			FirstSeen:   now,
+			LastSeen:    now,
+			EventLastTS: eventLastTS,
+			Count:       1,
+		}
+		return dedupResult{Kind: dedupNewIncident, Count: 1}
+	}
+	if !eventLastTS.After(entry.EventLastTS) {
+		// Case 1: replay. Same activity we already processed;
+		// don't advance LastSeen (retry cooldown untouched).
+		entry.Count++
+		return dedupResult{Kind: dedupDuplicate, SessionID: entry.SessionID, Count: entry.Count}
+	}
+	if now.Sub(entry.LastSeen) > c.window {
+		// Case 2: retry safety net. Prior session's cooldown
+		// elapsed AND k8s is still reporting new activity —
+		// spin up a fresh session so an agent that failed to
+		// resolve the last one gets another attempt.
+		c.evictIfFull()
+		c.entries[key] = &dedupEntry{
+			FirstSeen:   now,
+			LastSeen:    now,
+			EventLastTS: eventLastTS,
+			Count:       1,
+		}
+		return dedupResult{Kind: dedupNewIncident, Count: 1}
+	}
+	// Case 3: new activity within cooldown → dedup + advance.
+	entry.Count++
+	entry.LastSeen = now
+	entry.EventLastTS = eventLastTS
+	return dedupResult{Kind: dedupDuplicate, SessionID: entry.SessionID, Count: entry.Count}
+}
+
+// BindSession attaches the SessionID from a successful CreateSession
+// call to the entry created by the preceding Observe. No-op if the
+// entry has since been evicted (window elapsed AND the LRU sweep
+// dropped it), which is a possible but harmless race.
+//
+// Applies the same reason canonicalization Observe does so a caller
+// that saw a `dedupNewIncident` result on one reason variant can
+// bind the session using the wire-level reason without having to
+// know about the family mapping.
+func (c *dedupCache) BindSession(key EventKey, sessionID string) {
+	key.Reason = canonicalizeReason(key.Reason)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if entry, ok := c.entries[key]; ok {
+		entry.SessionID = sessionID
+	}
+}
+
+// evictIfFull is called under lock. If the cache is at capacity,
+// evicts the LRU entry (lowest LastSeen). Bounded O(N) scan; called
+// only on new-incident cache-miss paths so amortized cost is fine.
+func (c *dedupCache) evictIfFull() {
+	if len(c.entries) < c.max {
+		return
+	}
+	var oldestKey EventKey
+	var oldestTs time.Time
+	first := true
+	for k, e := range c.entries {
+		if first || e.LastSeen.Before(oldestTs) {
+			oldestKey = k
+			oldestTs = e.LastSeen
+			first = false
+		}
+	}
+	delete(c.entries, oldestKey)
+}
+
+// Len returns the current cache size. Test / metrics helper.
+func (c *dedupCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.entries)
+}
+
+// Snapshot writes the current cache state to persistPath. Idempotent;
+// no-op when persistPath is empty. Callers should call this on
+// graceful shutdown (SIGTERM handler in main.go) and periodically
+// while running (e.g., every 30s ticker) so a crash doesn't lose
+// more than 30s of dedup state.
+//
+// Format: pretty-printed JSON — small enough that a human can
+// inspect it during incident debugging, and simple enough that the
+// on-disk shape doesn't need its own migration story.
+func (c *dedupCache) Snapshot() error {
+	if c.persistPath == "" {
+		return nil
+	}
+	c.mu.Lock()
+	// Copy under lock; encode outside so we don't hold the mutex
+	// during I/O.
+	snapshot := make(map[string]*dedupEntry, len(c.entries))
+	for k, v := range c.entries {
+		snapshot[serializeKey(k)] = v
+	}
+	c.mu.Unlock()
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("dedup: marshal snapshot: %w", err)
+	}
+	// Atomic write: temp file + rename so an interrupted write
+	// doesn't corrupt the persisted state.
+	tmp := c.persistPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("dedup: write %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, c.persistPath); err != nil {
+		return fmt.Errorf("dedup: rename %s → %s: %w", tmp, c.persistPath, err)
+	}
+	return nil
+}
+
+// restore reads persistPath (if it exists) and hydrates the cache.
+// Missing file is not an error — first-time startup has nothing to
+// restore. Called by newDedupCache during construction.
+func (c *dedupCache) restore() error {
+	data, err := os.ReadFile(c.persistPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil // first startup; nothing to restore
+		}
+		return fmt.Errorf("dedup: read %s: %w", c.persistPath, err)
+	}
+	var snapshot map[string]*dedupEntry
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		// Corrupt persist file: log and start fresh. Better than
+		// refusing to boot the sidecar. Caller can inspect the
+		// file if they care.
+		return fmt.Errorf("dedup: unmarshal snapshot (starting fresh): %w", err)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for keyStr, entry := range snapshot {
+		key, ok := deserializeKey(keyStr)
+		if !ok {
+			continue // silently skip malformed keys
+		}
+		c.entries[key] = entry
+	}
+	return nil
+}
+
+// serializeKey / deserializeKey encode an EventKey for use as a
+// JSON map key (which must be a string). Using a delimiter that
+// can't appear in a k8s UID (which is hex + hyphens) or an Event
+// reason (which is CamelCase alphanumeric).
+func serializeKey(k EventKey) string {
+	return k.UID + "|" + k.Reason
+}
+
+func deserializeKey(s string) (EventKey, bool) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '|' {
+			return EventKey{UID: s[:i], Reason: s[i+1:]}, true
+		}
+	}
+	return EventKey{}, false
+}

--- a/k8s-operator/cmd/k8s-event-watcher/filter.go
+++ b/k8s-operator/cmd/k8s-event-watcher/filter.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// defaultReasons is the shipped set of Event.Reason values that
+// trigger investigations. Chosen to cover the top-frequency real
+// failures per docs/k8s-event-agent-design.md §"Event filter
+// allow-list". Operators can override via --reason.
+var defaultReasons = []string{
+	"CrashLoopBackOff",
+	"ImagePullBackOff",
+	"ErrImagePull",
+	"OOMKilled",
+	"FailedMount",
+	"FailedScheduling",
+	"BackOff",
+	"Unhealthy",
+	"NetworkNotReady",
+	"NodeNotReady",
+	"Evicted",
+}
+
+// filterConfig captures the sidecar's per-event decision logic.
+// Constructed from CLI flags in main.go; injected into the filter
+// so tests can override each knob independently.
+type filterConfig struct {
+	// allowedReasons is the set of Event.Reason values that pass
+	// the filter. Case-sensitive match against Event.Reason
+	// (k8s uses CamelCase; case-insensitivity would only hide
+	// operator typos in configs).
+	allowedReasons map[string]struct{}
+	// allowedNamespaces, when non-empty, restricts firing to
+	// events from these namespaces. Empty = all namespaces.
+	// Applied AFTER excludedNamespaces (exclude wins).
+	allowedNamespaces map[string]struct{}
+	// excludedNamespaces suppresses events from these namespaces
+	// even if they'd otherwise pass. Applied before
+	// allowedNamespaces so operators can express "all except
+	// kube-system" without listing every included namespace.
+	excludedNamespaces map[string]struct{}
+	// unhealthyMinCount is the special case for the Unhealthy
+	// reason: probes flap constantly and firing on every one
+	// would drown the sidecar. Require the event's own Count
+	// (k8s Event.Count, which repeats-per-source) to reach this
+	// value before we pass it. Default 3.
+	unhealthyMinCount int
+}
+
+// newFilterConfig builds a filterConfig from CLI-shaped inputs.
+// Empty slices default to the shipped values; positive counts
+// default to their shipped defaults.
+func newFilterConfig(reasons []string, allowNamespaces, excludeNamespaces []string, unhealthyMinCount int) filterConfig {
+	if len(reasons) == 0 {
+		reasons = defaultReasons
+	}
+	if unhealthyMinCount <= 0 {
+		unhealthyMinCount = 3
+	}
+	fc := filterConfig{
+		allowedReasons:     stringSet(reasons),
+		allowedNamespaces:  stringSet(allowNamespaces),
+		excludedNamespaces: stringSet(excludeNamespaces),
+		unhealthyMinCount:  unhealthyMinCount,
+	}
+	return fc
+}
+
+// stringSet converts a []string to a set for O(1) membership tests.
+func stringSet(xs []string) map[string]struct{} {
+	if len(xs) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(xs))
+	for _, x := range xs {
+		if x == "" {
+			continue
+		}
+		out[x] = struct{}{}
+	}
+	return out
+}
+
+// filter decides whether a triage event should proceed to dedup +
+// inject. Pure function — same input, same output; no I/O.
+type filter struct {
+	cfg filterConfig
+}
+
+func newFilter(cfg filterConfig) *filter {
+	return &filter{cfg: cfg}
+}
+
+// Accept returns true if the event passes every filter rule. The
+// decision order is deliberate:
+//
+//  1. Reason must be in the allow-list (or the allow-list is empty
+//     meaning "everything" — but that's not a shipped default).
+//  2. Namespace must not be in excluded (exclude wins).
+//  3. Namespace must be in allowed (or allowed is empty = all).
+//  4. Unhealthy special case: repeat count must reach threshold.
+func (f *filter) Accept(ev TriageEvent) bool {
+	if f.cfg.allowedReasons != nil {
+		if _, ok := f.cfg.allowedReasons[ev.Key.Reason]; !ok {
+			return false
+		}
+	}
+	if len(f.cfg.excludedNamespaces) > 0 {
+		if _, excluded := f.cfg.excludedNamespaces[ev.Namespace]; excluded {
+			return false
+		}
+	}
+	if len(f.cfg.allowedNamespaces) > 0 {
+		if _, allowed := f.cfg.allowedNamespaces[ev.Namespace]; !allowed {
+			return false
+		}
+	}
+	if ev.Key.Reason == "Unhealthy" && ev.Count < f.cfg.unhealthyMinCount {
+		return false
+	}
+	return true
+}

--- a/k8s-operator/cmd/k8s-event-watcher/injector.go
+++ b/k8s-operator/cmd/k8s-event-watcher/injector.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// injectorConfig captures the daemon-side surface the sidecar posts
+// against. Constructed from CLI flags in main.go; injected into the
+// injector so tests can substitute their own httptest server.
+type injectorConfig struct {
+	// daemonURL is the base URL (scheme + host + port) — e.g.
+	// "http://127.0.0.1:7777" or "https://core-agent.example:7777".
+	// The injector appends the path components; callers pass a
+	// URL WITHOUT a trailing slash.
+	daemonURL string
+
+	// bearerToken authenticates the sidecar to the daemon. Loaded
+	// from an env var by main.go (`--token-env NAME`).
+	bearerToken string
+
+	// assertedCaller is the identity the daemon stamps as session
+	// Owner on POST /sessions. The sidecar must be listed in
+	// attach.multi_session.proxy_identities in the daemon config
+	// for this to be honored.
+	assertedCaller string
+
+	// httpClient lets tests swap in a *http.Client that talks to
+	// httptest.NewServer. Nil in production; main.go leaves it nil.
+	httpClient *http.Client
+}
+
+// injector wraps a small HTTP client that speaks the two daemon
+// endpoints the sidecar needs: POST /sessions (creates a new
+// per-incident session and returns the SessionID) and
+// POST /sessions/<sid>/inject (queues a message on that session's
+// inbox).
+type injector struct {
+	cfg    injectorConfig
+	client *http.Client
+}
+
+// newInjector constructs an injector from the config. Validates the
+// required fields early so misconfig fails fast.
+func newInjector(cfg injectorConfig) (*injector, error) {
+	if cfg.daemonURL == "" {
+		return nil, errors.New("injector: daemonURL is required")
+	}
+	if strings.HasSuffix(cfg.daemonURL, "/") {
+		return nil, fmt.Errorf("injector: daemonURL must not end with '/' (got %q)", cfg.daemonURL)
+	}
+	if cfg.bearerToken == "" {
+		return nil, errors.New("injector: bearerToken is required")
+	}
+	client := cfg.httpClient
+	if client == nil {
+		// Real production client with a modest timeout.
+		client = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+	return &injector{cfg: cfg, client: client}, nil
+}
+
+// createSessionResponse mirrors the JSON response shape for POST /sessions.
+type createSessionResponse struct {
+	AppName   string `json:"app"`
+	UserID    string `json:"user"`
+	SessionID string `json:"sessionID"`
+	URL       string `json:"url"`
+}
+
+// CreateSession asks the daemon to create a new session owned by
+// cfg.assertedCaller. Returns the new SessionID on success.
+func (i *injector) CreateSession(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, i.cfg.daemonURL+"/sessions", nil)
+	if err != nil {
+		return "", fmt.Errorf("injector: build POST /sessions: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+i.cfg.bearerToken)
+	if i.cfg.assertedCaller != "" {
+		req.Header.Set("X-Asserted-Caller", i.cfg.assertedCaller)
+	}
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("injector: POST /sessions: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return "", fmt.Errorf("injector: POST /sessions: status %d: %s", resp.StatusCode, string(body))
+	}
+	var payload createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("injector: decode POST /sessions response: %w", err)
+	}
+	if payload.SessionID == "" {
+		return "", errors.New("injector: POST /sessions returned empty sessionID")
+	}
+	return payload.SessionID, nil
+}
+
+// injectMessageRequest is the JSON body for POST /sessions/<sid>/inject.
+type injectMessageRequest struct {
+	Message string `json:"message"`
+}
+
+// Inject POSTs a payload to /sessions/<sid>/inject.
+func (i *injector) Inject(ctx context.Context, sessionID string, payload InjectPayload) error {
+	if sessionID == "" {
+		return errors.New("injector: Inject: sessionID is required")
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("injector: marshal payload: %w", err)
+	}
+	wrapped, err := json.Marshal(injectMessageRequest{Message: string(body)})
+	if err != nil {
+		return fmt.Errorf("injector: wrap inject envelope: %w", err)
+	}
+	url := i.cfg.daemonURL + "/sessions/" + sessionID + "/inject"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(wrapped))
+	if err != nil {
+		return fmt.Errorf("injector: build POST inject: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+i.cfg.bearerToken)
+	req.Header.Set("Content-Type", "application/json")
+	if i.cfg.assertedCaller != "" {
+		req.Header.Set("X-Asserted-Caller", i.cfg.assertedCaller)
+	}
+	resp, err := i.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("injector: POST inject: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("injector: POST inject: status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -1,0 +1,398 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// flags is the CLI-shaped config, parsed once in main and threaded
+// to the components. All fields match --flag-name in the design
+// doc's "Sidecar CLI" section.
+type flags struct {
+	daemonURL         string
+	tokenEnv          string
+	mode              string
+	targetSession     string
+	owner             string
+	reasons           string
+	namespaces        string
+	excludeNamespaces string
+	dedupWindow       time.Duration
+	dedupPersist      string
+	unhealthyMinCount int
+	inCluster         bool
+	kubeconfig        string
+	clusterName       string
+	logLevel          string
+	dryRun            bool
+	metricsAddr       string
+	snapshotInterval  time.Duration
+}
+
+// parseFlags reads argv into flags. Returns nil on --help (main
+// exits 0). Any other parse error surfaces as an error so main can
+// report + exit 2 (POSIX convention for CLI misuse).
+func parseFlags(args []string) (*flags, error) {
+	fs := flag.NewFlagSet("k8s-event-watcher", flag.ContinueOnError)
+	f := &flags{}
+
+	// Required.
+	fs.StringVar(&f.daemonURL, "daemon-url", "", "Base URL of the core-agent daemon (http://... or https://...). Required.")
+	fs.StringVar(&f.tokenEnv, "token-env", "", "Env var name holding the bearer token for the daemon. Required.")
+
+	// Session routing.
+	fs.StringVar(&f.mode, "mode", "per-incident", "Session routing mode: per-incident (create per (uid,reason)) or shared (all to --target-session).")
+	fs.StringVar(&f.targetSession, "target-session", "", "Required when --mode=shared: SessionID to post all injects to.")
+	fs.StringVar(&f.owner, "owner", "", "X-Asserted-Caller value for POST /sessions in per-incident mode. Sidecar must be in daemon's proxy_identities.")
+
+	// Event filtering.
+	fs.StringVar(&f.reasons, "reason", "", "Comma-separated allow-list of Event.Reason values. Empty = shipped default set.")
+	fs.StringVar(&f.namespaces, "namespace", "", "Comma-separated allow-list of namespaces. Empty = all namespaces.")
+	fs.StringVar(&f.excludeNamespaces, "exclude-namespace", "", "Comma-separated deny-list of namespaces.")
+
+	// Dedup.
+	fs.DurationVar(&f.dedupWindow, "dedup-window", 5*time.Minute, "Rolling window for (uid,reason) dedup.")
+	fs.StringVar(&f.dedupPersist, "dedup-persist", "", "Optional path to persist dedup cache across sidecar restart.")
+	fs.IntVar(&f.unhealthyMinCount, "unhealthy-min-count", 3, "Require this many consecutive Unhealthy events before firing.")
+
+	// Kubernetes client.
+	fs.BoolVar(&f.inCluster, "in-cluster", false, "Use in-cluster service account credentials. Auto-detected inside a pod.")
+	fs.StringVar(&f.kubeconfig, "kubeconfig", "", "Explicit kubeconfig path. Used outside a pod.")
+	fs.StringVar(&f.clusterName, "cluster-name", "", "Human-readable cluster name included in every inject payload.")
+
+	// Operational.
+	fs.StringVar(&f.logLevel, "log-level", "info", "One of: debug, info, warn, error.")
+	fs.BoolVar(&f.dryRun, "dry-run", false, "Print inject payloads to stdout without calling the daemon.")
+	fs.StringVar(&f.metricsAddr, "metrics-addr", "", "Prometheus /metrics + /healthz listener address (host:port). Empty = disabled.")
+	fs.DurationVar(&f.snapshotInterval, "snapshot-interval", 30*time.Second, "How often to persist the dedup cache when --dedup-persist is set. 0 = only on shutdown.")
+
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// validate checks flag combinations after parse. Called once from
+// main so misconfig fails before any network / API touching.
+func (f *flags) validate() error {
+	if !f.dryRun && f.daemonURL == "" {
+		return errors.New("--daemon-url is required (unless --dry-run)")
+	}
+	if !f.dryRun && f.tokenEnv == "" {
+		return errors.New("--token-env is required (unless --dry-run)")
+	}
+	if strings.HasSuffix(f.daemonURL, "/") {
+		return fmt.Errorf("--daemon-url must not end with '/' (got %q)", f.daemonURL)
+	}
+	switch f.mode {
+	case "per-incident":
+		if f.dryRun {
+			return nil
+		}
+		if f.owner == "" {
+			return errors.New("--owner is required in per-incident mode (must match a proxy identity in the daemon's users.json)")
+		}
+	case "shared":
+		if f.targetSession == "" {
+			return errors.New("--target-session is required in shared mode")
+		}
+	default:
+		return fmt.Errorf("--mode must be per-incident or shared (got %q)", f.mode)
+	}
+	if f.dedupWindow <= 0 {
+		return errors.New("--dedup-window must be > 0")
+	}
+	if f.snapshotInterval < 0 {
+		return errors.New("--snapshot-interval must be >= 0")
+	}
+	return nil
+}
+
+// splitCSV parses a comma-separated flag value. Empty strings after
+// split are dropped; whitespace around values trimmed.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// buildKubeClient constructs a kubernetes.Interface from the flags.
+// Precedence:
+//  1. Explicit --kubeconfig always wins (out-of-cluster ops).
+//  2. --in-cluster or auto-detected (KUBERNETES_SERVICE_HOST env
+//     var is set inside a pod).
+//  3. $KUBECONFIG env var → fallback to ~/.kube/config.
+func buildKubeClient(f *flags) (kubernetes.Interface, error) {
+	var (
+		cfg *rest.Config
+		err error
+	)
+	switch {
+	case f.kubeconfig != "":
+		cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
+		if err != nil {
+			return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)
+		}
+	case f.inCluster || os.Getenv("KUBERNETES_SERVICE_HOST") != "":
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("in-cluster config: %w", err)
+		}
+	default:
+		// Fallback to default kubeconfig search (KUBECONFIG env,
+		// then $HOME/.kube/config). Fine for local dev; a real
+		// deployment always sets --in-cluster or --kubeconfig.
+		loader := clientcmd.NewDefaultClientConfigLoadingRules()
+		cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, &clientcmd.ConfigOverrides{}).ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("default kubeconfig: %w", err)
+		}
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes client: %w", err)
+	}
+	return client, nil
+}
+
+// dispatcher is the pipeline that ties filter → dedup → injector +
+// metrics for one event. Implements eventDispatcher so watcher.go
+// can call Dispatch on it.
+type dispatcher struct {
+	filter    *filter
+	dedup     *dedupCache
+	injector  *injector
+	metrics   *metrics
+	cluster   string
+	mode      string // "per-incident" or "shared"
+	targetSid string // for shared mode
+	dryRun    bool
+	// injectLock serializes per-(app, sid) session creation +
+	// injects so two rapid-fire events for the same key don't
+	// both call CreateSession. Coarse-grained; a per-key map of
+	// mutexes would let concurrent keys parallelize but this
+	// path is nowhere near a bottleneck.
+	injectLock sync.Mutex
+}
+
+// Dispatch is the eventDispatcher entry point.
+func (d *dispatcher) Dispatch(ctx context.Context, ev TriageEvent) {
+	d.metrics.eventsSeen.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+	if !d.filter.Accept(ev) {
+		return
+	}
+	result := d.dedup.Observe(ev.Key, ev.LastSeen)
+	d.metrics.activeIncidents.Set(float64(d.dedup.Len()))
+	if result.Kind == dedupDuplicate {
+		d.metrics.eventsDedupSuppress.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+		log.Printf("dedup %s pod=%s/%s (count=%d, window active)",
+			ev.Key.Reason, ev.Namespace, ev.Name, result.Count)
+		return
+	}
+	// New incident: create or reuse a session, then inject.
+	d.injectLock.Lock()
+	defer d.injectLock.Unlock()
+	sid := d.targetSid
+	if d.mode == "per-incident" && !d.dryRun {
+		newSid, err := d.injector.CreateSession(ctx)
+		if err != nil {
+			log.Printf("dispatcher: create session for %s/%s: %v", ev.Namespace, ev.Name, err)
+			d.metrics.sessionCreates.WithLabelValues("error").Inc()
+			d.metrics.injectErrors.WithLabelValues(ev.Key.Reason, "session_create").Inc()
+			return
+		}
+		sid = newSid
+		d.metrics.sessionCreates.WithLabelValues("ok").Inc()
+		d.dedup.BindSession(ev.Key, sid)
+	}
+	payload := InjectPayload{
+		Kind:         injectKindEvent,
+		Reason:       ev.Key.Reason,
+		Namespace:    ev.Namespace,
+		KindOfObject: ev.KindOfObject,
+		Name:         ev.Name,
+		Container:    ev.Container,
+		UID:          ev.Key.UID,
+		Message:      ev.Message,
+		Count:        result.Count,
+		FirstSeen:    ev.FirstSeen,
+		LastSeen:     ev.LastSeen,
+		Cluster:      d.cluster,
+		Context: PayloadContext{
+			ControllerRef: ev.ControllerRef,
+			Node:          ev.Node,
+			Labels:        ev.Labels,
+		},
+	}
+	if d.dryRun {
+		out, _ := json.MarshalIndent(payload, "", "  ")
+		fmt.Printf("--- dry-run payload for session %q ---\n%s\n", sid, string(out))
+		d.metrics.eventsInjected.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+		log.Printf("would-fire %s pod=%s/%s (sid=%s, mode=%s, dry-run)",
+			ev.Key.Reason, ev.Namespace, ev.Name, sid, d.mode)
+		return
+	}
+	if err := d.injector.Inject(ctx, sid, payload); err != nil {
+		log.Printf("dispatcher: inject for %s/%s (sid=%s): %v", ev.Namespace, ev.Name, sid, err)
+		d.metrics.injectErrors.WithLabelValues(ev.Key.Reason, "inject").Inc()
+		return
+	}
+	d.metrics.eventsInjected.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
+	log.Printf("fire %s pod=%s/%s → sid=%s (mode=%s)",
+		ev.Key.Reason, ev.Namespace, ev.Name, sid, d.mode)
+}
+
+func main() {
+	if err := realMain(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, "k8s-event-watcher:", err)
+		os.Exit(1)
+	}
+}
+
+func realMain(argv []string) error {
+	f, err := parseFlags(argv)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return nil
+		}
+		return err
+	}
+	if err := f.validate(); err != nil {
+		return err
+	}
+
+	// Resolve bearer token from env (unless dry-run).
+	var token string
+	if !f.dryRun {
+		token = os.Getenv(f.tokenEnv)
+		if token == "" {
+			return fmt.Errorf("bearer token env var %s is empty", f.tokenEnv)
+		}
+	}
+
+	// Build components.
+	filterCfg := newFilterConfig(splitCSV(f.reasons), splitCSV(f.namespaces), splitCSV(f.excludeNamespaces), f.unhealthyMinCount)
+	filter := newFilter(filterCfg)
+
+	dedup, err := newDedupCache(f.dedupWindow, f.dedupPersist)
+	if err != nil {
+		return fmt.Errorf("dedup cache: %w", err)
+	}
+
+	m := newMetrics()
+
+	var inj *injector
+	if !f.dryRun {
+		inj, err = newInjector(injectorConfig{
+			daemonURL:      f.daemonURL,
+			bearerToken:    token,
+			assertedCaller: f.owner,
+		})
+		if err != nil {
+			return fmt.Errorf("injector: %w", err)
+		}
+	}
+
+	disp := &dispatcher{
+		filter:    filter,
+		dedup:     dedup,
+		injector:  inj,
+		metrics:   m,
+		cluster:   f.clusterName,
+		mode:      f.mode,
+		targetSid: f.targetSession,
+		dryRun:    f.dryRun,
+	}
+
+	// Root ctx cancelled on SIGINT / SIGTERM for graceful shutdown.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	// Start the metrics HTTP server (blocks on ctx in-goroutine).
+	go func() {
+		if err := serveMetrics(ctx, f.metricsAddr, m); err != nil {
+			log.Printf("metrics server: %v", err)
+		}
+	}()
+
+	// Start the periodic dedup-snapshot ticker if configured.
+	if f.dedupPersist != "" && f.snapshotInterval > 0 {
+		go runSnapshotLoop(ctx, dedup, f.snapshotInterval)
+	}
+
+	// Build the kube client.
+	if f.dryRun {
+		log.Printf("k8s-event-watcher: --dry-run: skipping kube client; would watch cluster %q", f.clusterName)
+		<-ctx.Done()
+		if err := dedup.Snapshot(); err != nil {
+			log.Printf("dedup snapshot on shutdown: %v", err)
+		}
+		return nil
+	}
+	client, err := buildKubeClient(f)
+	if err != nil {
+		return err
+	}
+
+	w := newWatcher(client, disp, f.clusterName, 0)
+	log.Printf("k8s-event-watcher: starting on cluster %q → daemon %s (mode=%s, owner=%s)",
+		f.clusterName, f.daemonURL, f.mode, f.owner)
+	err = w.Run(ctx)
+	if snapErr := dedup.Snapshot(); snapErr != nil {
+		log.Printf("dedup snapshot on shutdown: %v", snapErr)
+	}
+	return err
+}
+
+// runSnapshotLoop persists the dedup cache to disk on an interval.
+func runSnapshotLoop(ctx context.Context, cache *dedupCache, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := cache.Snapshot(); err != nil {
+				log.Printf("dedup snapshot: %v", err)
+			}
+		}
+	}
+}

--- a/k8s-operator/cmd/k8s-event-watcher/metrics.go
+++ b/k8s-operator/cmd/k8s-event-watcher/metrics.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// metrics bundles the sidecar's Prometheus counters + gauges. Kept
+// as a struct so the wiring is testable — tests can construct a
+// registry, wire metrics into it, and assert values without
+// stringifying Prometheus output.
+type metrics struct {
+	registry            *prometheus.Registry
+	eventsSeen          *prometheus.CounterVec
+	eventsInjected      *prometheus.CounterVec
+	eventsDedupSuppress *prometheus.CounterVec
+	injectErrors        *prometheus.CounterVec
+	sessionCreates      *prometheus.CounterVec
+	activeIncidents     prometheus.Gauge
+}
+
+// newMetrics registers all sidecar metrics against a fresh registry
+// and returns the bundle. Tests use this with an isolated registry;
+// main.go passes the resulting handler to promhttp.
+func newMetrics() *metrics {
+	reg := prometheus.NewRegistry()
+	m := &metrics{
+		registry: reg,
+		eventsSeen: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_seen_total",
+			Help: "Total k8s events observed by the informer, before filter.",
+		}, []string{"reason", "namespace"}),
+		eventsInjected: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_injected_total",
+			Help: "Total events that survived filter + dedup and were POSTed to the daemon.",
+		}, []string{"reason", "namespace"}),
+		eventsDedupSuppress: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_events_deduped_total",
+			Help: "Total events suppressed by the rolling-window dedup cache.",
+		}, []string{"reason", "namespace"}),
+		injectErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_inject_errors_total",
+			Help: "Total inject (or session-create) attempts that returned a non-2xx response or transport error.",
+		}, []string{"reason", "http_code"}),
+		sessionCreates: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "k8s_event_watcher_session_creates_total",
+			Help: "Total POST /sessions attempts, labeled by outcome.",
+		}, []string{"outcome"}),
+		activeIncidents: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "k8s_event_watcher_active_incidents",
+			Help: "Current number of incidents in the sidecar's dedup cache.",
+		}),
+	}
+	reg.MustRegister(
+		m.eventsSeen,
+		m.eventsInjected,
+		m.eventsDedupSuppress,
+		m.injectErrors,
+		m.sessionCreates,
+		m.activeIncidents,
+	)
+	return m
+}
+
+// serveMetrics starts a small HTTP server exposing /metrics on addr.
+// Blocks until ctx is cancelled; returns any listener error. Callers
+// start it in a goroutine and use ctx cancellation for shutdown.
+//
+// When addr == "" the server is skipped entirely (metrics still get
+// collected in-process; just not exposed). Useful for tests + tiny
+// deployments that don't have a Prometheus scraper.
+func serveMetrics(ctx context.Context, addr string, m *metrics) error {
+	if addr == "" {
+		<-ctx.Done()
+		return nil
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(m.registry, promhttp.HandlerOpts{}))
+	// Simple liveness probe — no /metrics dependency, so K8s can
+	// use it as a livenessProbe without conflating "prometheus is
+	// scraping" with "the process is up."
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	// Bind synchronously so port-in-use fails fast; then serve
+	// in a goroutine and let ctx cancellation drive shutdown.
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("metrics: listen %s: %w", addr, err)
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- server.Serve(ln) }()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}

--- a/k8s-operator/cmd/k8s-event-watcher/types.go
+++ b/k8s-operator/cmd/k8s-event-watcher/types.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command k8s-event-watcher is the v2.6 semi-autonomous-triage sidecar.
+// It watches Kubernetes Events via a client-go informer, filters to a
+// configured allow-list of Event.Reason values, dedupes duplicates
+// within a rolling window, and POSTs matched events to a core-agent
+// daemon's per-incident session endpoint. See
+// docs/k8s-event-agent-design.md for the full design.
+package main
+
+import "time"
+
+// EventKey uniquely identifies an incident for dedup purposes: the
+// (involvedObject.uid, reason) pair. Same pod + same failure mode =
+// same incident, regardless of how many event objects the k8s API
+// emits about it.
+type EventKey struct {
+	UID    string
+	Reason string
+}
+
+// TriageEvent is the internal representation the filter + dedup +
+// injector layers pass around. Derived from *corev1.Event by watcher.go
+// but carries no k8s.io/api types itself so unit tests can construct
+// it without a fake clientset.
+type TriageEvent struct {
+	Key           EventKey
+	Namespace     string
+	KindOfObject  string
+	Name          string
+	Container     string
+	Message       string
+	FirstSeen     time.Time
+	LastSeen      time.Time
+	ControllerRef string
+	Node          string
+	Labels        map[string]string
+	// Count is the k8s Event's own repeat-count field (how many times
+	// the source recorded this same event). The sidecar's own dedup
+	// counter is separate — see dedup.go.
+	Count int
+}
+
+// InjectPayload is the JSON body POSTed to
+// /sessions/<sid>/inject.message. Field names and casing mirror the
+// design doc's "Inject payload shape" section verbatim so playbook
+// skills can pattern-match against them.
+type InjectPayload struct {
+	Kind         string         `json:"kind"`
+	Reason       string         `json:"reason"`
+	Namespace    string         `json:"namespace"`
+	KindOfObject string         `json:"kind_of_object"`
+	Name         string         `json:"name"`
+	Container    string         `json:"container,omitempty"`
+	UID          string         `json:"uid"`
+	Message      string         `json:"message"`
+	Count        int            `json:"count"`
+	FirstSeen    time.Time      `json:"first_seen"`
+	LastSeen     time.Time      `json:"last_seen"`
+	Cluster      string         `json:"cluster"`
+	Context      PayloadContext `json:"context"`
+}
+
+// PayloadContext is the nested "context" object on InjectPayload.
+type PayloadContext struct {
+	ControllerRef string            `json:"controller_ref,omitempty"`
+	Node          string            `json:"node,omitempty"`
+	Labels        map[string]string `json:"labels,omitempty"`
+}
+
+// injectKind is the constant we stamp on every payload's "kind"
+// field. Skills match against this to distinguish k8s-triggered
+// injects from other signal sources (Cloud Monitoring, PagerDuty,
+// etc.) that would use different constants when they ship.
+const (
+	injectKindEvent    = "k8s-event"
+	injectKindFollowup = "k8s-event-followup"
+)

--- a/k8s-operator/cmd/k8s-event-watcher/watcher.go
+++ b/k8s-operator/cmd/k8s-event-watcher/watcher.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// eventDispatcher is the callback the watcher invokes for every k8s
+// event that arrives from the informer. Injected here (not called
+// from watcher.go) so tests can wire a stub that just records what
+// was dispatched.
+type eventDispatcher interface {
+	Dispatch(ctx context.Context, ev TriageEvent)
+}
+
+// watcher wires a client-go informer for core/v1.Events into an
+// eventDispatcher. The informer resyncs every resyncPeriod; on Add
+// (new event object) and Update (event count bump), the handler
+// converts the *corev1.Event to a TriageEvent and hands it to the
+// dispatcher.
+//
+// The dispatcher decides whether to filter/dedup/inject — watcher
+// itself is just the informer boilerplate.
+type watcher struct {
+	client       kubernetes.Interface
+	dispatcher   eventDispatcher
+	clusterName  string
+	resyncPeriod time.Duration
+}
+
+// newWatcher constructs a watcher. resyncPeriod == 0 disables the
+// periodic resync (informer only fires on real API events); non-zero
+// values re-fire every registered event through the handler at that
+// cadence — usually not what you want, so default 0 in main.go.
+func newWatcher(client kubernetes.Interface, dispatcher eventDispatcher, clusterName string, resyncPeriod time.Duration) *watcher {
+	return &watcher{
+		client:       client,
+		dispatcher:   dispatcher,
+		clusterName:  clusterName,
+		resyncPeriod: resyncPeriod,
+	}
+}
+
+// Run starts the informer + handler goroutines and blocks until ctx
+// is cancelled. Returns any startup error (e.g., initial list
+// failure); shutdown-path errors are logged but not returned so
+// callers can distinguish "startup failed, restart me" from "clean
+// shutdown."
+func (w *watcher) Run(ctx context.Context) error {
+	factory := informers.NewSharedInformerFactory(w.client, w.resyncPeriod)
+	eventInformer := factory.Core().V1().Events().Informer()
+
+	handler, err := eventInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			ev, ok := obj.(*corev1.Event)
+			if !ok {
+				log.Printf("watcher: unexpected object type on Add: %T", obj)
+				return
+			}
+			w.dispatch(ctx, ev)
+		},
+		UpdateFunc: func(_, newObj any) {
+			// Update fires when the k8s API bumps the Event's
+			// Count / LastTimestamp (kubelet reports a repeat).
+			// We treat each update as another observation so
+			// persistent failures continue to feed the dedup
+			// window's LastSeen bump.
+			ev, ok := newObj.(*corev1.Event)
+			if !ok {
+				log.Printf("watcher: unexpected object type on Update: %T", newObj)
+				return
+			}
+			w.dispatch(ctx, ev)
+		},
+		// No DeleteFunc — event deletion is not a signal we care
+		// about; the underlying incident may or may not be
+		// resolved and we don't want to trigger investigations
+		// on tombstones.
+	})
+	if err != nil {
+		return fmt.Errorf("watcher: register event handler: %w", err)
+	}
+	// Silence the client-go internal error log ("unknown object
+	// type in cache") on shutdown — cache.HandleCrash trips over
+	// ctx.Done races otherwise. The default panic handler still
+	// fires for real crashes.
+	runtime.ErrorHandlers = []runtime.ErrorHandler{
+		func(_ context.Context, err error, _ string, _ ...any) {
+			log.Printf("watcher: informer error: %v", err)
+		},
+	}
+
+	factory.Start(ctx.Done())
+	// WaitForCacheSync blocks until the initial list is done —
+	// without this, the first N events after startup would
+	// arrive without their prior Count/LastTimestamp, breaking
+	// the dedup logic.
+	if !cache.WaitForCacheSync(ctx.Done(), handler.HasSynced) {
+		return fmt.Errorf("watcher: cache sync failed (informer stopped before initial list completed)")
+	}
+	<-ctx.Done()
+	return nil
+}
+
+// dispatch converts a *corev1.Event to the internal TriageEvent
+// shape and hands it to the dispatcher. Extracted so both AddFunc
+// and UpdateFunc share one code path. The cluster name is added
+// downstream (dispatcher.Dispatch stamps it onto InjectPayload)
+// rather than TriageEvent so tests don't have to thread it through.
+func (w *watcher) dispatch(ctx context.Context, ev *corev1.Event) {
+	triage := toTriageEvent(ev)
+	w.dispatcher.Dispatch(ctx, triage)
+}
+
+// toTriageEvent flattens a *corev1.Event to the internal payload
+// shape. Timestamps prefer LastTimestamp (kubelet-set); fall back
+// to EventTime / CreationTimestamp per k8s API convention.
+func toTriageEvent(ev *corev1.Event) TriageEvent {
+	first := ev.FirstTimestamp.Time
+	if first.IsZero() {
+		first = ev.EventTime.Time
+	}
+	if first.IsZero() {
+		first = ev.CreationTimestamp.Time
+	}
+	last := ev.LastTimestamp.Time
+	if last.IsZero() {
+		last = ev.EventTime.Time
+	}
+	if last.IsZero() {
+		last = ev.CreationTimestamp.Time
+	}
+
+	// The event references its target via InvolvedObject.
+	// InvolvedObject.UID is what we key dedup on.
+	uid := string(ev.InvolvedObject.UID)
+
+	// ControllerRef: for a Pod, the parent ReplicaSet /
+	// Deployment / StatefulSet is on OwnerReferences. Populating
+	// this requires an additional Pod GET which we don't have
+	// in-hand here. Left empty; the recipe includes RBAC for
+	// pod GET so the agent can enrich via MCP if needed.
+	controllerRef := ""
+
+	return TriageEvent{
+		Key: EventKey{
+			UID:    uid,
+			Reason: ev.Reason,
+		},
+		Namespace:     ev.InvolvedObject.Namespace,
+		KindOfObject:  ev.InvolvedObject.Kind,
+		Name:          ev.InvolvedObject.Name,
+		Container:     ev.InvolvedObject.FieldPath,
+		Message:       truncateMessage(ev.Message),
+		FirstSeen:     first,
+		LastSeen:      last,
+		ControllerRef: controllerRef,
+		Node:          nodeFromSource(ev),
+		Labels:        labelsFromMeta(ev.ObjectMeta),
+		Count:         int(ev.Count),
+	}
+}
+
+// truncateMessage caps the payload's message field. K8s event
+// messages are supposed to be small but we've seen kubelet emit
+// multi-KB stack traces; playbook skills don't need more than a
+// few hundred bytes to categorize.
+func truncateMessage(msg string) string {
+	const max = 2048
+	if len(msg) <= max {
+		return msg
+	}
+	return msg[:max] + "... [truncated by k8s-event-watcher]"
+}
+
+// nodeFromSource pulls the node name out of an Event's Source or
+// ReportingController fields, whichever the API server populated.
+func nodeFromSource(ev *corev1.Event) string {
+	if ev.Source.Host != "" {
+		return ev.Source.Host
+	}
+	if ev.ReportingInstance != "" {
+		return ev.ReportingInstance
+	}
+	return ""
+}
+
+// labelsFromMeta returns a shallow copy of the event's own labels
+// (not the involved object's — that would require an extra API
+// call). Empty when no labels are set.
+func labelsFromMeta(m metav1.ObjectMeta) map[string]string {
+	if len(m.Labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m.Labels))
+	for k, v := range m.Labels {
+		out[k] = v
+	}
+	return out
+}


### PR DESCRIPTION
# Pull Request

## Why This Change

This PR integrates a Go-based Kubernetes event watcher daemon and uvicorn proxy inside the platform agent container to transition Kubernetes warning triage from a manual process to proactive, real-time diagnostic loops. Alerts are threaded directly inside GChat space threads to minimize noise.

## What Changed

- **Go Watcher Daemon:** Added `k8s-event-watcher` Go binary that watches warnings (e.g. `FailedScheduling`, `BackOff`) and invokes the FastAPI storage session REST API.
- **FastAPI Session Proxy:** Added session lifecycle endpoints to `session_kv_server.py` to record active alerts and map space thread IDs.
- **Threading Support:** Patched the standalone Google Chat adapter to utilize the `messageReplyOption` query parameter, forcing replies to map inside the warning alert thread.
- **Packaging:** Updated Dockerfile and entrypoint script to supervise and auto-start both background daemons.

**Files:**

- `k8s-operator/cmd/k8s-event-watcher/`
- `agents/platform/scripts/platform_mcp_server.py`
- `agents/platform/scripts/session_kv_server.py`
- `deploy/docker/Dockerfile`
- `deploy/shared/docker-entrypoint.sh`

## Why This Matters

This allows GKE clusters to be self-healing and auto-diagnosing. SRE team members get an instant red alert warning in GChat followed immediately by a threaded reply containing the diagnostic logs and actionable remediation steps.

## Context

This is a separate integration branch created to isolate the event watcher architecture cleanly from other GKE MCP experiments.

## Testing

Verified end-to-end inside a Kind/GKE sandbox by deploying scheduling failure test pods (`test-schedule-pod-10`) and verifying the threaded diagnostic report response in the GChat room.
