### PR TITLE
fix(otel): expose backend config under user home

### DIFF
--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -35,6 +35,15 @@ fi
 # 4. Inject dynamic OpenTelemetry service name (if writable)
 if [ -f "$TARGET_DIR/plugins/hermes_otel/config.yaml" ] && [ -w "$TARGET_DIR/plugins/hermes_otel/config.yaml" ]; then
     "$INSTALL_DIR/.venv/bin/python3" -c "import sys, os, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; svc = os.getenv('OTEL_SERVICE_NAME'); attrs = c.setdefault('resource_attributes', {}); attrs.update({'service.name': svc}) if svc else attrs.pop('service.name', None); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/plugins/hermes_otel/config.yaml" 2>/dev/null || true
+
+    # hermes-otel resolves config below ~/.hermes even when HERMES_HOME points
+    # elsewhere. Expose the generated config at both locations.
+    OTEL_CONFIG="$TARGET_DIR/plugins/hermes_otel/config.yaml"
+    OTEL_COMPAT_CONFIG="$HOME/.hermes/plugins/hermes_otel/config.yaml"
+    mkdir -p "$(dirname "$OTEL_COMPAT_CONFIG")"
+    if [ ! "$OTEL_CONFIG" -ef "$OTEL_COMPAT_CONFIG" ]; then
+        ln -sf "$OTEL_CONFIG" "$OTEL_COMPAT_CONFIG"
+    fi
 fi
 
 # 5. Execute primary process


### PR DESCRIPTION
# Pull Request

## Why This Change

The operator redirects `HOME` to `<agent-home>/home`, while `hermes-otel` reads its configuration from `~/.hermes/plugins/hermes_otel/config.yaml`. The entrypoint generated the OTLP backend configuration under `$HERMES_HOME/plugins`, so the plugin could not find it and silently ran in live-only mode instead of exporting traces to Cloud Trace.

## What Changed

Expose the generated `hermes-otel` configuration at the path the plugin reads by creating a symlink under `$HOME/.hermes`.

**Files:**

- `deploy/shared/docker-entrypoint.sh`

**Added/Changed/Fixed:**

- Link the generated OTLP configuration into the plugin's `~/.hermes` configuration path.

## Why This Matters

- Restores Platform Agent trace export through the GKE managed OpenTelemetry collector to Cloud Trace.

## Context

The mismatch was introduced when the operator began setting a separate writable `HOME`; local OTel storage continued working, which hid the export failure.

## Testing

- `sh -n deploy/shared/docker-entrypoint.sh`
- `git diff --check`
- Built and deployed the Platform Agent image to GKE.
- Verified startup discovered the `gke-managed-otel` backend instead of entering live-only mode.
- Emitted a three-span Hermes trace and retrieved it successfully from the Cloud Trace API.

---

This is a narrow path-compatibility fix; no tracing schema or collector configuration changes.