### PR TITLE
Migrate Platform Agent to s6-overlay & fix non-root execution

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -82,16 +82,16 @@ RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes pl
 
 
 
-# 5.8. Copy custom agent startup script
-COPY deploy/shared/docker-entrypoint.sh /usr/local/bin/agent-entrypoint
-RUN chmod 755 /usr/local/bin/agent-entrypoint
+# 5.8. Install custom agent setup script as s6 cont-init hook
+COPY deploy/shared/docker-entrypoint.sh /etc/cont-init.d/03-kube-agents-setup
+RUN chmod 755 /etc/cont-init.d/03-kube-agents-setup
 
 # 6. Expose ports shared by all agent gateways
 EXPOSE 8642
 EXPOSE 9119
 
 # 7. Execution lifecycle
-ENTRYPOINT ["/usr/local/bin/agent-entrypoint"]
+ENTRYPOINT ["/init"]
 CMD ["hermes", "gateway", "run"]
 
 

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -1,20 +1,9 @@
 #!/bin/sh
 set -e
 
-export TARGET_DIR="${PLATFORM_AGENT_HOME:-/opt/data}"
+export TARGET_DIR="${HERMES_HOME:-/opt/data}"
 export HERMES_HOME="$TARGET_DIR"
 export INSTALL_DIR="/opt/hermes"
-
-# Pre-export AGENT_BROWSER_EXECUTABLE_PATH before running stage2-hook.sh.
-# Why: Upstream stage2-hook.sh scans for Playwright's Chromium binary and
-# attempts to export it to s6-overlay by creating /run/s6/container_environment/.
-# In unprivileged Kubernetes Pods (RunAsNonRoot: true), /run is read-only or
-# root-owned, so stage2-hook.sh crashes on `mkdir -p /run/s6/` with Permission denied.
-# By pre-exporting AGENT_BROWSER_EXECUTABLE_PATH here, stage2-hook.sh detects
-# [ -z "$AGENT_BROWSER_EXECUTABLE_PATH" ] is false and cleanly skips writing to /run/s6/.
-if [ -z "$AGENT_BROWSER_EXECUTABLE_PATH" ] && [ -d "/opt/hermes/.playwright" ]; then
-    export AGENT_BROWSER_EXECUTABLE_PATH="$(find /opt/hermes/.playwright -type f -executable \( -name 'chrome' -o -name 'chromium' -o -name 'chrome-headless-shell' -o -name 'headless_shell' -o -name 'chromium-browser' \) 2>/dev/null | head -n 1)"
-fi
 
 # 1. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)
 if [ -d "/opt/defaults" ]; then

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -16,26 +16,24 @@ if [ -z "$AGENT_BROWSER_EXECUTABLE_PATH" ] && [ -d "/opt/hermes/.playwright" ]; 
     export AGENT_BROWSER_EXECUTABLE_PATH="$(find /opt/hermes/.playwright -type f -executable \( -name 'chrome' -o -name 'chromium' -o -name 'chrome-headless-shell' -o -name 'headless_shell' -o -name 'chromium-browser' \) 2>/dev/null | head -n 1)"
 fi
 
-# 1. Execute upstream container initialization natively (inherits 100% of upstream updates)
-if [ -f "/opt/hermes/docker/stage2-hook.sh" ]; then
-    /opt/hermes/docker/stage2-hook.sh
-fi
-
-# 2. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)
+# 1. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)
 if [ -d "/opt/defaults" ]; then
     mkdir -p "$TARGET_DIR"
     cp -ru /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || cp -rp /opt/defaults/. "$TARGET_DIR/" 2>/dev/null || true
 fi
 
-# 3. Enable OpenTelemetry plugin in active config.yaml (if writable)
+# 2. Enable OpenTelemetry plugin in active config.yaml (if writable)
 if [ -f "$TARGET_DIR/config.yaml" ] && [ -w "$TARGET_DIR/config.yaml" ]; then
     "$INSTALL_DIR/.venv/bin/python3" -c "import sys, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; enabled = c.setdefault('plugins', {}).setdefault('enabled', []); 'hermes_otel' not in enabled and enabled.append('hermes_otel'); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/config.yaml" 2>/dev/null || true
 fi
 
-# 4. Inject dynamic OpenTelemetry service name (if writable)
+# 3. Inject dynamic OpenTelemetry service name (if writable)
 if [ -f "$TARGET_DIR/plugins/hermes_otel/config.yaml" ] && [ -w "$TARGET_DIR/plugins/hermes_otel/config.yaml" ]; then
     "$INSTALL_DIR/.venv/bin/python3" -c "import sys, os, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; svc = os.getenv('OTEL_SERVICE_NAME'); attrs = c.setdefault('resource_attributes', {}); attrs.update({'service.name': svc}) if svc else attrs.pop('service.name', None); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/plugins/hermes_otel/config.yaml" 2>/dev/null || true
 fi
 
-# 5. Execute primary process
-exec "$@"
+
+
+
+
+

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -2,7 +2,6 @@
 set -e
 
 export TARGET_DIR="${HERMES_HOME:-/opt/data}"
-export HERMES_HOME="$TARGET_DIR"
 export INSTALL_DIR="/opt/hermes"
 
 # 1. Sync default agent files and subdirectories (plugins, SOUL.md, AGENTS.md, procedures, cron, scripts, governance)

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -31,9 +31,3 @@ fi
 if [ -f "$TARGET_DIR/plugins/hermes_otel/config.yaml" ] && [ -w "$TARGET_DIR/plugins/hermes_otel/config.yaml" ]; then
     "$INSTALL_DIR/.venv/bin/python3" -c "import sys, os, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; svc = os.getenv('OTEL_SERVICE_NAME'); attrs = c.setdefault('resource_attributes', {}); attrs.update({'service.name': svc}) if svc else attrs.pop('service.name', None); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/plugins/hermes_otel/config.yaml" 2>/dev/null || true
 fi
-
-
-
-
-
-

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -334,7 +334,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 
 	envVars := []corev1.EnvVar{
 		{
-			Name:  "PLATFORM_AGENT_HOME",
+			Name:  "HERMES_HOME",
 			Value: homeDir,
 		},
 		{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -342,11 +342,11 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			Value: strings.TrimSuffix(homeDir, "/") + "/home",
 		},
 		{
-			Name:  "PLATFORM_AGENT_DASHBOARD",
+			Name:  "HERMES_DASHBOARD",
 			Value: dashboardVal,
 		},
 		{
-			Name:  "PLATFORM_AGENT_PLUGINS_DEBUG",
+			Name:  "HERMES_PLUGINS_DEBUG",
 			Value: pluginsDebugVal,
 		},
 		{
@@ -360,6 +360,10 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		{
 			Name:  "SESSION_KV_DB_PATH",
 			Value: sessionKVDBPath,
+		},
+		{
+			Name:  "HERMES_DASHBOARD_HOST",
+			Value: "127.0.0.1",
 		},
 	}
 
@@ -497,6 +501,8 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		volumes = append(volumes, extraVolumes...)
 	}
 
+	allInitContainers := initContainers
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -526,7 +532,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 				},
 				Spec: corev1.PodSpec{
 					RuntimeClassName:   runtimeClassName,
-					InitContainers:     initContainers,
+					InitContainers:     allInitContainers,
 					ServiceAccountName: saName,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &fsGroup,
@@ -565,6 +571,10 @@ func buildBaseContainers(image string, pullPolicy corev1.PullPolicy, envVars []c
 			Name:      "system-metadata",
 			MountPath: path.Dir(sessionKVDBPath),
 			SubPath:   "session",
+		},
+		{
+			Name:      "tmp-run",
+			MountPath: "/run",
 		},
 	}
 
@@ -709,6 +719,15 @@ func buildDefaultVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volume {
 						Name: agent.Name + "-settings",
 					},
 					DefaultMode: ptr.To(int32(0644)),
+				},
+			},
+		},
+		{
+			Name: "tmp-run",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium:    corev1.StorageMediumMemory,
+					SizeLimit: ptr.To(resource.MustParse("64Mi")),
 				},
 			},
 		},

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -501,8 +501,6 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		volumes = append(volumes, extraVolumes...)
 	}
 
-	allInitContainers := initContainers
-
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -532,7 +530,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 				},
 				Spec: corev1.PodSpec{
 					RuntimeClassName:   runtimeClassName,
-					InitContainers:     allInitContainers,
+					InitContainers:     initContainers,
 					ServiceAccountName: saName,
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &fsGroup,

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -359,8 +359,8 @@ func TestBuildDeployment(t *testing.T) {
 		envMap[env.Name] = env
 	}
 
-	if envMap["PLATFORM_AGENT_HOME"].Value != "/var/agent" {
-		t.Errorf("expected PLATFORM_AGENT_HOME /var/agent, got %s", envMap["PLATFORM_AGENT_HOME"].Value)
+	if envMap["HERMES_HOME"].Value != "/var/agent" {
+		t.Errorf("expected HERMES_HOME /var/agent, got %s", envMap["HERMES_HOME"].Value)
 	}
 	if envMap["HOME"].Value != "/var/agent/home" {
 		t.Errorf("expected HOME /var/agent/home, got %s", envMap["HOME"].Value)

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -208,7 +208,7 @@ func TestBuildDeployment(t *testing.T) {
 							Value: "custom-value",
 						},
 						{
-							Name:  "PLATFORM_AGENT_DASHBOARD", // Overriding default
+							Name:  "HERMES_DASHBOARD", // Overriding default
 							Value: "0",
 						},
 						{
@@ -326,20 +326,20 @@ func TestBuildDeployment(t *testing.T) {
 	if len(dep.Spec.Template.Spec.InitContainers) != 2 {
 		t.Errorf("expected 2 init containers, got %d", len(dep.Spec.Template.Spec.InitContainers))
 	} else {
-		initC1 := dep.Spec.Template.Spec.InitContainers[0]
-		if initC1.Name != "init-git" {
-			t.Errorf("expected first init container name init-git, got %s", initC1.Name)
+		initC0 := dep.Spec.Template.Spec.InitContainers[0]
+		if initC0.Name != "init-git" {
+			t.Errorf("expected first init container name init-git, got %s", initC0.Name)
 		}
-		if initC1.Image != "git-image:latest" {
-			t.Errorf("expected first init container image git-image:latest, got %s", initC1.Image)
+		if initC0.Image != "git-image:latest" {
+			t.Errorf("expected first init container image git-image:latest, got %s", initC0.Image)
 		}
 
-		initC2 := dep.Spec.Template.Spec.InitContainers[1]
-		if initC2.Name != "init-bootstrap" {
-			t.Errorf("expected second init container name init-bootstrap, got %s", initC2.Name)
+		initC1 := dep.Spec.Template.Spec.InitContainers[1]
+		if initC1.Name != "init-bootstrap" {
+			t.Errorf("expected second init container name init-bootstrap, got %s", initC1.Name)
 		}
-		if initC2.Image != "busybox:1.36" {
-			t.Errorf("expected second init container image busybox:1.36, got %s", initC2.Image)
+		if initC1.Image != "busybox:1.36" {
+			t.Errorf("expected second init container image busybox:1.36, got %s", initC1.Image)
 		}
 	}
 
@@ -365,11 +365,11 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["HOME"].Value != "/var/agent/home" {
 		t.Errorf("expected HOME /var/agent/home, got %s", envMap["HOME"].Value)
 	}
-	if envMap["PLATFORM_AGENT_DASHBOARD"].Value != "0" {
-		t.Errorf("expected PLATFORM_AGENT_DASHBOARD to be overridden to 0, got %s", envMap["PLATFORM_AGENT_DASHBOARD"].Value)
+	if envMap["HERMES_DASHBOARD"].Value != "0" {
+		t.Errorf("expected HERMES_DASHBOARD to be overridden to 0, got %s", envMap["HERMES_DASHBOARD"].Value)
 	}
-	if envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value != "0" {
-		t.Errorf("expected PLATFORM_AGENT_PLUGINS_DEBUG 0, got %s", envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value)
+	if envMap["HERMES_PLUGINS_DEBUG"].Value != "0" {
+		t.Errorf("expected HERMES_PLUGINS_DEBUG 0, got %s", envMap["HERMES_PLUGINS_DEBUG"].Value)
 	}
 	if envMap["CUSTOM_VAR"].Value != "new-custom-value" {
 		t.Errorf("expected CUSTOM_VAR new-custom-value, got %s", envMap["CUSTOM_VAR"].Value)

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -313,9 +313,9 @@ spec:
               value: /opt/data
             - name: HOME
               value: /opt/data/home
-            - name: PLATFORM_AGENT_DASHBOARD
+            - name: HERMES_DASHBOARD
               value: "1"
-            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+            - name: HERMES_PLUGINS_DEBUG
               value: "0"
             - name: API_SERVER_ENABLED
               value: "true"
@@ -323,6 +323,8 @@ spec:
               value: 0.0.0.0
             - name: SESSION_KV_DB_PATH
               value: /var/lib/kube-agents/session/session_kv.db
+            - name: HERMES_DASHBOARD_HOST
+              value: 127.0.0.1
             - name: OTEL_SERVICE_NAME
               value: platformagent-gateway
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -383,6 +385,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /run
+              name: tmp-run
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
@@ -444,6 +448,10 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
+          name: tmp-run
 status: {}
 ---
 apiVersion: v1

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -309,7 +309,7 @@ spec:
     spec:
       containers:
         - env:
-            - name: PLATFORM_AGENT_HOME
+            - name: HERMES_HOME
               value: /opt/data
             - name: HOME
               value: /opt/data/home


### PR DESCRIPTION
# Pull Request

## Why This Change

Platform Agent needs to run under strict non-root security contexts in Kubernetes. When using `s6-overlay` in the base image, it requires a writable `/run` directory, which defaults to root-owned and read-only for non-root users. This PR migrates the Platform Agent to use `s6-overlay` as its init system directly and configures the deployment to allow it to boot successfully as non-root.

Additionally, environment variables are renamed to align with Hermes naming conventions.

## What Changed

**Files:**

- `deploy/docker/Dockerfile`
- `deploy/shared/docker-entrypoint.sh`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- Changed Dockerfile `ENTRYPOINT` to `/init` (s6-overlay).
- Moved custom setup script to `cont-init.d` hook.
- Added memory-backed `EmptyDir` volume (`tmp-run`) mounted to `/run` in Platform Agent deployment.
- Renamed env vars:
    - `PLATFORM_AGENT_HOME` -> `HERMES_HOME`
    - `PLATFORM_AGENT_DASHBOARD` -> `HERMES_DASHBOARD`
    - `PLATFORM_AGENT_PLUGINS_DEBUG` -> `HERMES_PLUGINS_DEBUG`
- Added `HERMES_DASHBOARD_HOST` (hardcoded to `127.0.0.1` for now).

## Why This Matters

Allows the Platform Agent to boot and run successfully in environments enforcing strict non-root policies (like GKE Autopilot or restricted namespaces) without requiring privileges escalation.

## Context

Inspiration for `tmpfs` mounting of `/run` was taken from the official Hermes repo: [docker.py](https://github.com/NousResearch/hermes-agent/blob/6dcbcd0277a2d5cf42c53a8a013f7ac18f931fa1/tools/environments/docker.py#L350).

## Testing

- Updated operator unit tests.
- Updated expected test data.

---

TAG=agy
CONV=db83fed0-4d05-4534-85cb-cfea464e70ee