### PR TITLE
fix(lp-004): scope bind verb to specific ClusterRoles via resourceNames

### DIFF
--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -90,7 +90,6 @@ rules:
       - clusterrolebindings
       - clusterroles
     verbs:
-      - bind
       - create
       - delete
       - get
@@ -98,3 +97,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+    resourceNames:
+      - view
+      - kubeagents:explorer
+    verbs:
+      - bind

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -56,7 +56,8 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;persistentvolumeclaims;configmaps;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces;nodes;pods;events;persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=view;kubeagents:explorer,verbs=bind
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
 func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -149,7 +150,7 @@ func (r *PlatformAgentReconciler) handleDeletion(ctx context.Context, agent *age
 	if controllerutil.ContainsFinalizer(agent, platformAgentFinalizer) {
 		viewerBindingName := fmt.Sprintf("kubeagents:viewer:%s:%s", agent.Namespace, agent.Name)
 		explorerBindingName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
-		explorerRoleName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
+		explorerRoleName := "kubeagents:explorer"
 
 		// Delete Viewer ClusterRoleBinding
 		crbViewer := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: viewerBindingName}}

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -150,7 +150,6 @@ func (r *PlatformAgentReconciler) handleDeletion(ctx context.Context, agent *age
 	if controllerutil.ContainsFinalizer(agent, platformAgentFinalizer) {
 		viewerBindingName := fmt.Sprintf("kubeagents:viewer:%s:%s", agent.Namespace, agent.Name)
 		explorerBindingName := fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name)
-		explorerRoleName := "kubeagents:explorer"
 
 		// Delete Viewer ClusterRoleBinding
 		crbViewer := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: viewerBindingName}}
@@ -161,12 +160,6 @@ func (r *PlatformAgentReconciler) handleDeletion(ctx context.Context, agent *age
 		// Delete Explorer ClusterRoleBinding
 		crbExplorer := &rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: explorerBindingName}}
 		if err := client.IgnoreNotFound(r.Delete(ctx, crbExplorer)); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		// Delete Explorer ClusterRole
-		crExplorer := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: explorerRoleName}}
-		if err := client.IgnoreNotFound(r.Delete(ctx, crExplorer)); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/k8s-operator/internal/controller/platformagent_controller_test.go
+++ b/k8s-operator/internal/controller/platformagent_controller_test.go
@@ -213,10 +213,16 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 		t.Fatalf("expected NotFound error, got: %v", err)
 	}
 
-	// Verify RBAC roles are deleted
+	// Verify shared ClusterRole persists (other agents may depend on it)
 	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer"}, explorerRole)
+	if err != nil {
+		t.Errorf("expected shared ClusterRole to persist after deletion, got: %v", err)
+	}
+
+	// Verify per-agent ClusterRoleBindings are deleted
+	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer:test-ns:test-agent"}, crbExplorer)
 	if err == nil {
-		t.Errorf("expected ClusterRole to be deleted")
+		t.Errorf("expected per-agent ClusterRoleBinding to be deleted")
 	}
 }
 

--- a/k8s-operator/internal/controller/platformagent_controller_test.go
+++ b/k8s-operator/internal/controller/platformagent_controller_test.go
@@ -179,7 +179,7 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 
 	// RBAC
 	explorerRole := &rbacv1.ClusterRole{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer:test-ns:test-agent"}, explorerRole); err != nil {
+	if err := cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer"}, explorerRole); err != nil {
 		t.Errorf("failed to get ClusterRole: %v", err)
 	}
 
@@ -214,7 +214,7 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 	}
 
 	// Verify RBAC roles are deleted
-	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer:test-ns:test-agent"}, explorerRole)
+	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer"}, explorerRole)
 	if err == nil {
 		t.Errorf("expected ClusterRole to be deleted")
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -723,7 +723,7 @@ func buildPlatformExplorerRole(agent *agentv1alpha1.PlatformAgent) *rbacv1.Clust
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("kubeagents:explorer:%s:%s", agent.Namespace, agent.Name),
+			Name: "kubeagents:explorer",
 		},
 		Rules: []rbacv1.PolicyRule{
 			{

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -839,7 +839,7 @@ func TestBuildPlatformExplorerRole(t *testing.T) {
 	}
 
 	role := buildPlatformExplorerRole(agent)
-	expectedName := "kubeagents:explorer:test-ns:test-agent"
+	expectedName := "kubeagents:explorer"
 	if role.Name != expectedName {
 		t.Errorf("expected ClusterRole name %s, got %s", expectedName, role.Name)
 	}

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -32,7 +32,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: kubeagents:explorer:kubeagents-system:platformagent
+  name: kubeagents:explorer
 rules:
   - apiGroups:
       - ""
@@ -59,7 +59,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeagents:explorer:kubeagents-system:platformagent
+  name: kubeagents:explorer
 subjects:
   - kind: ServiceAccount
     name: kubeagents-platform-agent


### PR DESCRIPTION
## Fixes #331 — LP-004 (Critical)

### The Problem

The operator controller ClusterRole grants an **unrestricted** `bind` verb on `clusterroles` — if the operator is compromised, an attacker can bind any ClusterRole (including `cluster-admin`) to any subject.

### The Fix

Three changes:

1. **`role.yaml`** — Split the single RBAC entry into two:
   - CRUD verbs on `clusterroles`/`clusterrolebindings` (no `bind`)
   - `bind` verb on `clusterroles` scoped via `resourceNames: ["view", "kubeagents:explorer"]`

2. **`platformagent_manifests.go`** — Made the explorer ClusterRole name static (`kubeagents:explorer`) since its permissions are uniform across all agents (read-only node/pod/namespace/CRD access). Previously used a per-agent dynamic name (`kubeagents:explorer:<ns>:<name>`), which prevented `resourceNames` scoping.

3. **Controller marker + tests** — Updated kubebuilder marker and test expectations to match.

### Security Impact

| Before | After |
|--------|-------|
| `bind` on ALL clusterroles | `bind` only on `["view", "kubeagents:explorer"]` |
| Compromised operator → cluster-admin escalation | Compromised operator → can only bind low-privilege read-only roles |
| No `resourceNames` scoping | Explicit allow-list of bindable ClusterRoles |