### PR TITLE
fix(platform): fail closed when API_SERVER_KEY is unconfigured

### DIFF
--- a/agents/platform/scripts/agent_common_server.py
+++ b/agents/platform/scripts/agent_common_server.py
@@ -26,7 +26,15 @@ SESSION_MANAGER = SessionManager()
 
 def resolve_agent_credentials(agent_id: str) -> tuple[str, str]:
     """Retrieve the target agent's endpoint and shared API key."""
-    api_key = os.environ.get("API_SERVER_KEY") or "none"
+    api_key = os.environ.get("API_SERVER_KEY", "").strip()
+    if not api_key:
+        # Fail closed: never fall back to a guessable literal (e.g. "none").
+        # A missing secret means the deployment is misconfigured; refuse to
+        # send an inter-agent request that would authenticate as a known value.
+        raise ValueError(
+            "ERROR [500]: API_SERVER_KEY is not configured; refusing to send an "
+            "unauthenticated inter-agent request."
+        )
 
     if agent_id.lower() == "platform":
         endpoint = os.environ.get("PLATFORM_API_URL") or "platform-agent.agent-system.svc.cluster.local:8642"

--- a/agents/platform/scripts/test_agent_common_server.py
+++ b/agents/platform/scripts/test_agent_common_server.py
@@ -1,27 +1,43 @@
+import importlib
 import os
 import sys
+import types
 import unittest
 from pathlib import Path
 
 # Add the directory containing agent_common_server.py to sys.path so it can be imported.
 sys.path.insert(0, str(Path(__file__).parent.absolute()))
 
-# agent_common_server pulls in FastMCP / pydantic / session_manager at import time.
-# The credential logic under test needs none of them, so fall back to lightweight
-# stubs when the real packages aren't importable (i.e. outside the hermes venv).
-try:
-    import agent_common_server  # noqa: F401
-except Exception:
-    import types
-    for _name in ("mcp", "mcp.server", "mcp.server.fastmcp", "pydantic", "session_manager"):
-        sys.modules[_name] = types.ModuleType(_name)
-    sys.modules["mcp.server.fastmcp"].FastMCP = lambda *a, **k: types.SimpleNamespace(
-        tool=lambda *a, **k: (lambda f: f), run=lambda: None)
-    sys.modules["pydantic"].Field = lambda *a, **k: None
-    sys.modules["session_manager"].SessionManager = object
-    import agent_common_server  # noqa: F401
 
-from agent_common_server import resolve_agent_credentials
+def _load_agent_common_server():
+    """Import the module under test.
+
+    These tests are not wired into CI, and the credential logic under test
+    (resolve_agent_credentials) depends only on the stdlib. When the hermes
+    runtime deps (FastMCP / pydantic / session_manager) aren't importable, fall
+    back to minimal stubs so the module still imports in a bare checkout. Each
+    stub package sets __path__ so it is treated as a real package.
+    """
+    try:
+        return importlib.import_module("agent_common_server")
+    except Exception:
+        mcp = types.ModuleType("mcp"); mcp.__path__ = []
+        mcp_server = types.ModuleType("mcp.server"); mcp_server.__path__ = []
+        fastmcp = types.ModuleType("mcp.server.fastmcp")
+        fastmcp.FastMCP = lambda *a, **k: types.SimpleNamespace(
+            tool=lambda *a, **k: (lambda f: f), run=lambda: None)
+        pydantic = types.ModuleType("pydantic")
+        pydantic.Field = lambda *a, **k: None
+        session_manager = types.ModuleType("session_manager")
+        session_manager.SessionManager = object
+        sys.modules.update({
+            "mcp": mcp, "mcp.server": mcp_server, "mcp.server.fastmcp": fastmcp,
+            "pydantic": pydantic, "session_manager": session_manager,
+        })
+        return importlib.import_module("agent_common_server")
+
+
+resolve_agent_credentials = _load_agent_common_server().resolve_agent_credentials
 
 
 class TestResolveAgentCredentials(unittest.TestCase):
@@ -53,15 +69,12 @@ class TestResolveAgentCredentials(unittest.TestCase):
             resolve_agent_credentials("platform")
 
     def test_never_falls_back_to_none_literal(self):
-        """The regression pin: an unconfigured key must not yield the literal 'none'."""
+        """Regression pin: an unconfigured key must fail closed — raise, never
+        yield the guessable literal 'none'."""
         os.environ.pop("API_SERVER_KEY", None)
-        try:
-            _, api_key = resolve_agent_credentials("platform")
-        except ValueError:
-            return  # failing closed is the correct behavior
-        self.assertNotEqual(
-            api_key, "none",
-            "must never authenticate with the guessable literal 'none'")
+        with self.assertRaises(ValueError) as ctx:
+            resolve_agent_credentials("platform")
+        self.assertIn("API_SERVER_KEY is not configured", str(ctx.exception))
 
     def test_returns_endpoint_and_key_when_set(self):
         os.environ["API_SERVER_KEY"] = "s3cret"

--- a/agents/platform/scripts/test_agent_common_server.py
+++ b/agents/platform/scripts/test_agent_common_server.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+
+# Add the directory containing agent_common_server.py to sys.path so it can be imported.
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+
+# agent_common_server pulls in FastMCP / pydantic / session_manager at import time.
+# The credential logic under test needs none of them, so fall back to lightweight
+# stubs when the real packages aren't importable (i.e. outside the hermes venv).
+try:
+    import agent_common_server  # noqa: F401
+except Exception:
+    import types
+    for _name in ("mcp", "mcp.server", "mcp.server.fastmcp", "pydantic", "session_manager"):
+        sys.modules[_name] = types.ModuleType(_name)
+    sys.modules["mcp.server.fastmcp"].FastMCP = lambda *a, **k: types.SimpleNamespace(
+        tool=lambda *a, **k: (lambda f: f), run=lambda: None)
+    sys.modules["pydantic"].Field = lambda *a, **k: None
+    sys.modules["session_manager"].SessionManager = object
+    import agent_common_server  # noqa: F401
+
+from agent_common_server import resolve_agent_credentials
+
+
+class TestResolveAgentCredentials(unittest.TestCase):
+    """API_SERVER_KEY must fail closed — never silently authenticate as a
+    guessable literal when the shared secret is unconfigured (MCP-001)."""
+
+    def setUp(self):
+        self._saved = os.environ.get("API_SERVER_KEY")
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop("API_SERVER_KEY", None)
+        else:
+            os.environ["API_SERVER_KEY"] = self._saved
+
+    def test_raises_when_key_unset(self):
+        os.environ.pop("API_SERVER_KEY", None)
+        with self.assertRaises(ValueError):
+            resolve_agent_credentials("platform")
+
+    def test_raises_when_key_empty(self):
+        os.environ["API_SERVER_KEY"] = ""
+        with self.assertRaises(ValueError):
+            resolve_agent_credentials("platform")
+
+    def test_raises_when_key_whitespace(self):
+        os.environ["API_SERVER_KEY"] = "   "
+        with self.assertRaises(ValueError):
+            resolve_agent_credentials("platform")
+
+    def test_never_falls_back_to_none_literal(self):
+        """The regression pin: an unconfigured key must not yield the literal 'none'."""
+        os.environ.pop("API_SERVER_KEY", None)
+        try:
+            _, api_key = resolve_agent_credentials("platform")
+        except ValueError:
+            return  # failing closed is the correct behavior
+        self.assertNotEqual(
+            api_key, "none",
+            "must never authenticate with the guessable literal 'none'")
+
+    def test_returns_endpoint_and_key_when_set(self):
+        os.environ["API_SERVER_KEY"] = "s3cret"
+        endpoint, api_key = resolve_agent_credentials("platform")
+        self.assertEqual(api_key, "s3cret")
+        self.assertIn("8642", endpoint)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #330.

### Problem

`resolve_agent_credentials` fell back to the literal string `"none"` when `API_SERVER_KEY` was unset or empty:

```python
api_key = os.environ.get("API_SERVER_KEY") or "none"
```

That key is sent as `Authorization: Bearer {api_key}` on `call_agent` requests to the platform agent (`hermes-api-server`, `:8642`). A **fail-open** pattern: under any misconfiguration that leaves the secret empty, the client silently authenticates inter-agent traffic with a guessable literal instead of failing — a forgeable `Bearer none` on the ClusterIP service.

### Change

Fail **closed**: if `API_SERVER_KEY` is unset/empty/whitespace, raise a clear error instead of substituting a literal. `call_agent` already wraps `resolve_agent_credentials` in try/except and returns the error string, so a misconfigured deployment surfaces a clear operator-facing error rather than sending a forged request — no new failure paths.

`.strip()` also closes the whitespace-only variant.

### Tests

Adds `agents/platform/scripts/test_agent_common_server.py` (unittest, matching the existing `test_platform_mcp_server.py` style). Covers unset / empty / whitespace keys raising, a happy-path resolution, and a regression pin that the resolver never yields the literal `"none"`. The test guards its imports so it runs both inside the hermes venv and in a bare environment.

```
Ran 5 tests in 0.000s
OK
```

### Context

Found via a structured security audit of this repo (finding **MCP-001**).