### PR TITLE
docs: add uninstallation and teardown guide to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,18 +82,22 @@ Once installed and the heartbeat is active, the Platform Agent will begin monito
 
 ## Uninstallation & Teardown
 
-### Option A: Uninstall Platform Agent Only (Preserve GKE Cluster)
+### Option A: Uninstall Platform Agent Only (Preserve GKE Cluster & Operator)
 
-To remove the Platform Agent while leaving your underlying GKE cluster intact:
+To remove the Platform Agent while leaving your underlying GKE cluster and operator controller intact:
 
 1. **Remove Scheduled Heartbeat**: Delete or disable the recurring `1m` cron job in your agent harness.
 2. **Undeploy PlatformAgent Resource**:
    ```bash
-   kubectl delete platformagent platform --ignore-not-found=true
+   kubectl delete platformagent platform-agent -n kubeagents-system --ignore-not-found=true
+   ```
+   _Note: If deletion hangs due to controller finalizers or offline webhooks, force remove finalizers:_
+   ```bash
+   kubectl patch platformagent platform-agent -n kubeagents-system -p '{"metadata":{"finalizers":null}}' --type=merge
    ```
 3. **Delete Agent Secrets**:
    ```bash
-   kubectl delete secret platform-agent-secrets --ignore-not-found=true
+   kubectl delete secret platform-agent-secrets github-app-credentials -n kubeagents-system --ignore-not-found=true
    ```
 4. **Remove Harness Workspace**: Remove the `agents/platform` directory from your agent harness workspace.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,3 +79,31 @@ Configure a recurring scheduled task (cron) within your agent harness for the `p
 ## Post-Installation
 
 Once installed and the heartbeat is active, the Platform Agent will begin monitoring its state. You can interact with it directly to manage your Kubernetes clusters.
+
+## Uninstallation & Teardown
+
+### Option A: Uninstall Platform Agent Only (Preserve GKE Cluster)
+
+To remove the Platform Agent while leaving your underlying GKE cluster intact:
+
+1. **Remove Scheduled Heartbeat**: Delete or disable the recurring `1m` cron job in your agent harness.
+2. **Undeploy PlatformAgent Resource**:
+   ```bash
+   kubectl delete platformagent platform --ignore-not-found=true
+   ```
+3. **Delete Agent Secrets**:
+   ```bash
+   kubectl delete secret platform-agent-secrets --ignore-not-found=true
+   ```
+4. **Remove Harness Workspace**: Remove the `agents/platform` directory from your agent harness workspace.
+
+### Option B: Full Infrastructure Teardown & Deprovisioning
+
+To completely clean up all deployed resources (Platform Agent, Operator CRDs, LiteLLM, GitHub Token Minter, GCP IAM bindings, gVisor node pools, and GKE cluster):
+
+```bash
+cd k8s-operator/scripts
+./teardown.sh
+```
+
+For granular teardown options (e.g. removing specific components without destroying the cluster), refer to the [Teardown Scripts Reference](k8s-operator/scripts/README.md#teardown-steps).


### PR DESCRIPTION
# Pull Request

## Why This Change

Fixes #344.

Currently, `INSTALL.md` provides detailed instructions for installation, workspace setup, and scheduled heartbeat configuration, but lacks a dedicated section explaining uninstallation and teardown.

This PR adds an explicit `Uninstallation & Teardown` section to `INSTALL.md` covering both agent-only removal and complete infrastructure deprovisioning.

## Dependencies & Sequencing

- ⛔ **Blocked by #300, #290 & #341**: Must be merged after PR #300, PR #290, and PR #341 land. Keep as Draft PR until prerequisite documentation PRs merge.

## What Changed

**Files:**

- `INSTALL.md`

**Added/Changed/Fixed:**

- **Option A (Agent-Only Uninstallation)**: Added steps to safely remove the `PlatformAgent` Custom Resource (`kubectl delete platformagent platform`), secrets, workspace directory, and cron heartbeat while preserving GKE cluster infrastructure.
- **Option B (Full Infrastructure Teardown)**: Added instructions for executing `./k8s-operator/scripts/teardown.sh` for complete infrastructure, IAM, and cluster deprovisioning.

## Why This Matters

Provides clear operational guidance for developers and operators who need to soft-uninstall the agent or completely tear down resources without guesswork.

## Context

Closes #344

## Testing

- Formatted and checked with Prettier (`npx prettier --check INSTALL.md`).
