### PR TITLE
Add link to the slack configuration guide in the readme and slack script

### DIFF
--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -43,6 +43,7 @@ When any script is run:
    - Sets up the Pub/Sub Topic and Subscription for Google Chat events.
 5. **[provision_05_slack.sh](provision_05_slack.sh)**
    - Configures Slack integration parameters, bot tokens, and home channel settings.
+   - **Note:** You must create a Slack App and obtain tokens before running this. [See the Slack App Setup Guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack).
 6. **[provision_06_gcp_k8s_secrets.sh](provision_06_gcp_k8s_secrets.sh)**
    - Prompts for/reads the `MODEL_PROVIDER` and corresponding `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`.
    - Creates the Kubernetes Secret (`platform-agent-secrets`) directly in the target GKE namespace.

--- a/k8s-operator/scripts/provision_05_slack.sh
+++ b/k8s-operator/scripts/provision_05_slack.sh
@@ -29,6 +29,14 @@ if [ "${SLACK_ENABLED}" != "true" ]; then
   exit 0
 fi
 
+# ==============================================================================
+# ADD THE HELPER LINKS HERE
+# ==============================================================================
+print_info "To generate these tokens, you must create a Slack App and install it to your workspace."
+print_info "Follow the Setup Guide here: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack"
+echo ""
+# ==============================================================================
+
 loop_add_tokens() {
   local var_name=$1
   local token_prefix=$2

--- a/k8s-operator/scripts/provision_05_slack.sh
+++ b/k8s-operator/scripts/provision_05_slack.sh
@@ -29,13 +29,10 @@ if [ "${SLACK_ENABLED}" != "true" ]; then
   exit 0
 fi
 
-# ==============================================================================
-# ADD THE HELPER LINKS HERE
-# ==============================================================================
+# Slack App Setup Instructions
 print_info "To generate these tokens, you must create a Slack App and install it to your workspace."
 print_info "Follow the Setup Guide here: https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack"
 echo ""
-# ==============================================================================
 
 loop_add_tokens() {
   local var_name=$1


### PR DESCRIPTION
# Pull Request

Adding the links to the user guide on creating slack apps in the README from k8s-operator and in the provision_05_slack script