### PR TITLE
fix(cron): reduce github issue resolver execution frequency

### DIFF
--- a/agents/platform/cron/jobs.json
+++ b/agents/platform/cron/jobs.json
@@ -113,8 +113,8 @@
       "name": "GitHub Issue Resolver",
       "schedule": {
         "kind": "cron",
-        "expr": "* * * * *",
-        "display": "* * * * *"
+        "expr": "*/30 * * * *",
+        "display": "*/30 * * * *"
       },
       "prompt": "Run the github-issue-resolver skill to poll, triage, investigate, and resolve unaddressed open issues on our target repository strictly according to the skill's safety red lines, scope constraints, and turn completion checklist.",
       "skills": ["github-issue-resolver"],


### PR DESCRIPTION
# Pull Request

## Why This Change

The GitHub Issue Resolver cron job was previously running every minute. This PR changes the schedule to run every 30 minutes to reduce execution frequency and API overhead.

## What Changed

**Files:**

- `agents/platform/cron/jobs.json`

**Added/Changed/Fixed:**

- Updated `github-issue-resolver` cron schedule `expr` and `display` from `* * * * *` to `*/30 * * * *`.

## Why This Matters

- Reduces resource consumption and rate-limiting risk from running issue resolution every minute.

## Context

- Lowering frequency of GitHub issue resolver execution.

## Testing

- Validated JSON format with `python3 -m json.tool`.

TAG=agy
CONV=00f7a7ba-906e-45ac-ae07-7d8aad8b7f81