### PR TITLE
feat(platform): isolate agent credentials behind Envoy sidecar

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,6 +18,7 @@ __pycache__/
 node_modules/
 .venv/
 venv/
+k8s-operator/bin/
 
 # Local configuration files (except tracked default .env)
 .env

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -59,6 +59,16 @@ jobs:
           DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      - name: Build and Push Credential Sidecar (GCP Cloud Build)
+        id: gcp-credential-proxy
+        run: |
+          gcloud builds submit \
+            --config=deploy/docker/cloudbuild.yaml \
+            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/credential-proxy:latest,_TARGET=credential-proxy,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            .
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
@@ -66,3 +76,4 @@ jobs:
         run: |
           cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"
           cosign sign --yes "${{ env.GCP_REGISTRY }}/replay-proxy@${{ steps.gcp-replay-proxy.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/credential-proxy@${{ steps.gcp-credential-proxy.outputs.digest }}"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -59,6 +59,20 @@ jobs:
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:${{ github.sha }}
 
+      - name: Build and Push Credential Sidecar (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-credential-proxy
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          target: credential-proxy
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
@@ -66,3 +80,4 @@ jobs:
         run: |
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy@${{ steps.build-replay-proxy.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy@${{ steps.build-credential-proxy.outputs.digest }}"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO ?= $(eval REPO := $(LOCATION)-docker.pkg.dev/$(shell gcloud config get core
 
 BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
 
-.PHONY: default docker-build docker-build-agents docker-push docker-push-agents dev-rebuild-agent status prettier-check prettier-write validate
+.PHONY: default docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write validate
 
 AGENTS := $(notdir $(patsubst %/,%,$(wildcard agents/*/)))
 
@@ -13,20 +13,26 @@ AGENTS := $(notdir $(patsubst %/,%,$(wildcard agents/*/)))
 default: docker-build
 
 # Docker builds
-docker-build: docker-build-agents
+docker-build: docker-build-agents docker-build-credential-proxy
 docker-build-agents: $(foreach agent,$(AGENTS),docker-build-$(agent))
 
 .PHONY: $(foreach agent,$(AGENTS),docker-build-$(agent))
 $(foreach agent,$(AGENTS),docker-build-$(agent)): docker-build-%:
 	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target $* -t $(REPO)/$*-agent:latest -f deploy/docker/Dockerfile .
 
+docker-build-credential-proxy:
+	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target credential-proxy -t $(REPO)/credential-proxy:latest -f deploy/docker/Dockerfile .
+
 # Docker pushes
-docker-push: docker-push-agents
+docker-push: docker-push-agents docker-push-credential-proxy
 docker-push-agents: $(foreach agent,$(AGENTS),docker-push-$(agent))
 
 .PHONY: $(foreach agent,$(AGENTS),docker-push-$(agent))
 $(foreach agent,$(AGENTS),docker-push-$(agent)): docker-push-%: docker-build-%
 	docker push $(REPO)/$*-agent:latest
+
+docker-push-credential-proxy: docker-build-credential-proxy
+	docker push $(REPO)/credential-proxy:latest
 
 dev-rebuild-agent: ## Fast local iteration: rebuild and redeploy an agent image (e.g. make dev-rebuild-agent ARGS="platform").
 	@$(MAKE) -C k8s-operator dev-rebuild-agent ARGS="$(ARGS)"
@@ -50,7 +56,6 @@ validate:
 	else \
 		echo "Validation passed: No skills found in invalid paths."; \
 	fi
-
 
 
 

--- a/agents/platform/SOUL.md
+++ b/agents/platform/SOUL.md
@@ -115,6 +115,6 @@ If you cannot answer all three questions with concrete, quoted ground-truth evid
 The `kube-agents` harness deployment architecture consists of:
 
 - **Kubernetes Operator (`k8s-operator`)**: Written in Go (Kubebuilder), running in the GKE cluster. It defines and manages the lifecycle of the agent custom resource (`PlatformAgent`).
-- **PlatformAgent**: Deployed by the operator as a gateway pod (running `nousresearch/hermes-agent`). Handles fleet-wide multi-tenancy configurations and global RBAC.
+- **PlatformAgent**: Deployed by the operator in a credential-free sandbox pod (running `nousresearch/hermes-agent`) paired with a credential proxy. Handles fleet-wide multi-tenancy configurations and global RBAC.
 - **Inference Service**: An LLM provider proxy exposing a unified Completions API endpoint to the agents. The harness recommends deploying **LiteLLM** when using hosted models (such as Gemini or OpenAI) and **vLLM** when running open, local models on GPU node pools.
 - **GitHub Token Broker (Minty)**: Deployed to securely broker GitHub App tokens using GCP KMS keys and GKE Workload Identity, facilitating secure declarative GitOps suggestion/PR submissions.

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -1,0 +1,1009 @@
+#!/usr/bin/env python3
+"""Credential proxy for restricted credentialed CLI execution."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hmac
+import http.client
+import io
+import json
+import logging
+import os
+import queue
+import re
+import shlex
+import signal
+import shutil
+import socketserver
+import subprocess
+import threading
+import time
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+LOGGER = logging.getLogger("credential-proxy")
+
+
+class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """HTTP server over a private Unix socket used behind Envoy."""
+
+    daemon_threads = True
+
+
+class AgentAPIProxyHandler(BaseHTTPRequestHandler):
+    """Authenticate the external PlatformAgent API without sharing its key."""
+
+    external_key: str
+    upstream_key: str
+    upstream_host = "127.0.0.1"
+    upstream_port = 8642
+    max_request_bytes = 10 * 1024 * 1024
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def _proxy(self) -> None:
+        supplied = self.headers.get("Authorization", "")
+        expected = f"Bearer {self.external_key}"
+        if not hmac.compare_digest(supplied, expected):
+            self.send_error(HTTPStatus.UNAUTHORIZED)
+            return
+        if self.headers.get("Transfer-Encoding"):
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return
+        if content_length < 0 or content_length > self.max_request_bytes:
+            self.send_error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+            return
+        body = self.rfile.read(content_length) if content_length else None
+        headers = {
+            name: value
+            for name, value in self.headers.items()
+            if name.lower()
+            not in {
+                "authorization",
+                "connection",
+                "content-length",
+                "host",
+                "proxy-authorization",
+                "transfer-encoding",
+                "upgrade",
+            }
+        }
+        headers["Authorization"] = f"Bearer {self.upstream_key}"
+        if body is not None:
+            headers["Content-Length"] = str(len(body))
+
+        upstream = http.client.HTTPConnection(
+            self.upstream_host, self.upstream_port, timeout=300
+        )
+        response_started = False
+        try:
+            upstream.request(self.command, self.path, body=body, headers=headers)
+            response = upstream.getresponse()
+            self.send_response(response.status, response.reason)
+            for name, value in response.getheaders():
+                if name.lower() not in {
+                    "connection",
+                    "keep-alive",
+                    "proxy-authenticate",
+                    "transfer-encoding",
+                    "upgrade",
+                }:
+                    self.send_header(name, value)
+            self.send_header("Connection", "close")
+            self.end_headers()
+            response_started = True
+            while chunk := response.read(64 * 1024):
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except (ConnectionError, TimeoutError, OSError, http.client.HTTPException):
+            LOGGER.warning("PlatformAgent API upstream request failed", exc_info=True)
+            if not response_started:
+                self.send_error(HTTPStatus.BAD_GATEWAY)
+            self.close_connection = True
+        finally:
+            upstream.close()
+
+    def log_message(self, message: str, *args: Any) -> None:
+        LOGGER.info("agent-api " + message, *args)
+
+
+class GoogleChatRelay:
+    """Credentialed Google Chat/Pub/Sub transport for a credential-free agent."""
+
+    SCOPES = (
+        "https://www.googleapis.com/auth/chat.bot",
+        "https://www.googleapis.com/auth/pubsub",
+    )
+
+    def __init__(self, project_id: str, subscription_name: str) -> None:
+        import google.auth
+        from google.cloud import pubsub_v1
+        from googleapiclient.discovery import build
+
+        credentials, _ = google.auth.default(scopes=self.SCOPES)
+        self.subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
+        self.subscription_path = (
+            subscription_name
+            if subscription_name.startswith("projects/")
+            else self.subscriber.subscription_path(project_id, subscription_name)
+        )
+        self.chat = build("chat", "v1", credentials=credentials, cache_discovery=False)
+        self._receipts: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
+        from google.api_core import retry
+        from google.api_core.exceptions import DeadlineExceeded
+
+        try:
+            response = self.subscriber.pull(
+                request={"subscription": self.subscription_path, "max_messages": 1},
+                retry=retry.Retry(deadline=max(timeout_seconds, 1)),
+                timeout=max(timeout_seconds, 1),
+            )
+        except DeadlineExceeded:
+            return None
+        if not response.received_messages:
+            return None
+        received = response.received_messages[0]
+        receipt = str(uuid.uuid4())
+        with self._lock:
+            self._receipts[receipt] = received.ack_id
+        return {
+            "receipt": receipt,
+            "data": base64.b64encode(received.message.data).decode("ascii"),
+            "attributes": dict(received.message.attributes),
+            "messageId": received.message.message_id,
+        }
+
+    def settle(self, receipt: str, acknowledge: bool) -> bool:
+        with self._lock:
+            ack_id = self._receipts.pop(receipt, None)
+        if ack_id is None:
+            return False
+        if acknowledge:
+            self.subscriber.acknowledge(
+                request={"subscription": self.subscription_path, "ack_ids": [ack_id]}
+            )
+        else:
+            self.subscriber.modify_ack_deadline(
+                request={
+                    "subscription": self.subscription_path,
+                    "ack_ids": [ack_id],
+                    "ack_deadline_seconds": 0,
+                }
+            )
+        return True
+
+    def api_call(
+        self, resource: list[str], method: str, arguments: dict[str, Any]
+    ) -> Any:
+        target = self.chat
+        for name in resource:
+            if not isinstance(name, str) or not name or name.startswith("_"):
+                raise ValueError("invalid Google Chat API resource")
+            target = getattr(target, name)()
+        if not method or method.startswith("_"):
+            raise ValueError("invalid Google Chat API method")
+        operation = getattr(target, method)(**arguments)
+        return operation.execute()
+
+
+class SlackRelay:
+    """Credentialed Slack Socket Mode and Web API transport."""
+
+    def __init__(
+        self, bot_tokens: str, app_token: str, max_file_bytes: int = 20 * 1024 * 1024
+    ) -> None:
+        from slack_sdk import WebClient
+        from slack_sdk.socket_mode import SocketModeClient
+
+        tokens = [token.strip() for token in bot_tokens.split(",") if token.strip()]
+        if not tokens or not app_token:
+            raise ValueError("Slack bot and app tokens are required")
+        self.max_file_bytes = max_file_bytes
+        self.clients: dict[str, Any] = {}
+        self.workspaces: list[dict[str, str]] = []
+        self.primary_client = None
+        for token in tokens:
+            client = WebClient(token=token)
+            try:
+                identity = client.auth_test()
+            except Exception as exc:
+                LOGGER.error(
+                    "Slack bot token authentication failed type=%s",
+                    type(exc).__name__,
+                )
+                continue
+            team_id = str(identity.get("team_id", ""))
+            if not team_id:
+                LOGGER.error("Slack bot token authentication returned no team ID")
+                continue
+            if self.primary_client is None:
+                self.primary_client = client
+            self.clients[team_id] = client
+            self.workspaces.append(
+                {
+                    "teamId": team_id,
+                    "teamName": str(identity.get("team", "")),
+                    "botUserId": str(identity.get("user_id", "")),
+                    "botName": str(identity.get("user", "")),
+                }
+            )
+        if self.primary_client is None:
+            raise RuntimeError("no Slack bot token could be authenticated")
+        self._events: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._receipts: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self.socket_client = SocketModeClient(
+            app_token=app_token, web_client=self.primary_client
+        )
+        self.socket_client.socket_mode_request_listeners.append(self._on_event)
+        self.socket_client.connect()
+
+    def _on_event(self, client: Any, request: Any) -> None:
+        from slack_sdk.socket_mode.response import SocketModeResponse
+
+        client.send_socket_mode_response(
+            SocketModeResponse(envelope_id=request.envelope_id)
+        )
+        self._events.put(
+            {
+                "type": str(request.type),
+                "payload": request.payload,
+            }
+        )
+
+    def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
+        try:
+            event = self._events.get(timeout=max(timeout_seconds, 1))
+        except queue.Empty:
+            return None
+        receipt = str(uuid.uuid4())
+        with self._lock:
+            self._receipts[receipt] = event
+        return {"receipt": receipt, **event}
+
+    def settle(self, receipt: str, acknowledge: bool) -> bool:
+        with self._lock:
+            event = self._receipts.pop(receipt, None)
+        if event is None:
+            return False
+        if not acknowledge:
+            self._events.put(event)
+        return True
+
+    def bootstrap(self) -> list[dict[str, str]]:
+        return self.workspaces
+
+    def _client(self, team_id: str) -> Any:
+        return self.clients.get(team_id) or self.primary_client
+
+    def _decode_argument(self, value: Any) -> Any:
+        if isinstance(value, list):
+            return [self._decode_argument(item) for item in value]
+        if isinstance(value, dict):
+            if set(value).issubset({"__bytesBase64"}) and "__bytesBase64" in value:
+                content = base64.b64decode(value["__bytesBase64"], validate=True)
+                if len(content) > self.max_file_bytes:
+                    raise ValueError("Slack upload exceeds relay size limit")
+                return content
+            if "__fileBase64" in value:
+                content = base64.b64decode(value["__fileBase64"], validate=True)
+                if len(content) > self.max_file_bytes:
+                    raise ValueError("Slack upload exceeds relay size limit")
+                stream = io.BytesIO(content)
+                stream.name = str(value.get("filename", "upload"))
+                return stream
+            return {key: self._decode_argument(item) for key, item in value.items()}
+        return value
+
+    def api_call(
+        self, team_id: str, method: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        if not method or method.startswith("_"):
+            raise ValueError("Slack API method is not available through the relay")
+        response = self._client(team_id).api_call(
+            method, **self._decode_argument(arguments)
+        )
+        return dict(response)
+
+    def download(self, team_id: str, url: str) -> bytes:
+        def is_slack_url(value: str) -> bool:
+            parsed = urllib.parse.urlparse(value)
+            hostname = (parsed.hostname or "").lower()
+            return parsed.scheme == "https" and (
+                hostname == "slack.com" or hostname.endswith(".slack.com")
+            )
+
+        if not is_slack_url(url):
+            raise ValueError("Slack file URL must use HTTPS on a slack.com host")
+
+        class SlackRedirectHandler(urllib.request.HTTPRedirectHandler):
+            def redirect_request(
+                self,
+                request: Any,
+                file_pointer: Any,
+                code: int,
+                message: str,
+                headers: Any,
+                new_url: str,
+            ) -> Any:
+                if not is_slack_url(new_url):
+                    raise ValueError("Slack file redirect left slack.com")
+                return super().redirect_request(
+                    request, file_pointer, code, message, headers, new_url
+                )
+
+        token = self._client(team_id).token
+        request = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {token}"}
+        )
+        opener = urllib.request.build_opener(SlackRedirectHandler())
+        with opener.open(request, timeout=30) as response:
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" in content_type.lower():
+                raise ValueError("Slack returned HTML instead of file content")
+            content = response.read(self.max_file_bytes + 1)
+        if len(content) > self.max_file_bytes:
+            raise ValueError("Slack file exceeds relay size limit")
+        return content
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+class Policy:
+    def __init__(self, rules: list[Rule], blocked_message: str) -> None:
+        self.rules = rules
+        self.blocked_message = blocked_message
+
+    @classmethod
+    def load(cls, path: str) -> "Policy":
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        blocked_message = payload.get(
+            "blockedMessage", "Command blocked for security reasons."
+        )
+        rules = []
+        for item in payload.get("rules", []):
+            rules.append(
+                Rule(
+                    rule_id=item["id"],
+                    pattern=re.compile(item["pattern"], re.IGNORECASE | re.MULTILINE),
+                    message=item.get("message", blocked_message),
+                )
+            )
+        return cls(rules=rules, blocked_message=blocked_message)
+
+    def blocked_by(self, argv: list[str]) -> Rule | None:
+        command = shlex.join(argv)
+        return next((rule for rule in self.rules if rule.pattern.search(command)), None)
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+    truncated: bool
+    timed_out: bool
+
+
+class CommandExecutor:
+    ALLOWED_EXECUTABLES = ("gcloud", "kubectl", "gh", "git")
+
+    def __init__(
+        self, timeout_seconds: int, max_output_bytes: int, state_dir: str
+    ) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.max_output_bytes = max_output_bytes
+        self.state_dir = Path(state_dir)
+        self.home_dir = self.state_dir / "home"
+        self.workspace_dir = Path(
+            os.getenv("CREDENTIAL_PROXY_WORKSPACE_ROOT", str(self.state_dir / "workspace"))
+        ).resolve()
+        self.tmp_dir = self.state_dir / "tmp"
+        self.config_dir = self.home_dir / ".config"
+        self.cache_dir = self.home_dir / ".cache"
+        self.local_state_dir = self.home_dir / ".local" / "state"
+        self.kube_dir = self.home_dir / ".kube"
+        for path in (
+            self.home_dir,
+            self.workspace_dir,
+            self.tmp_dir,
+            self.config_dir,
+            self.cache_dir,
+            self.local_state_dir,
+            self.kube_dir,
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        trusted_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        self.executables = {
+            name: shutil.which(name, path=trusted_path)
+            for name in self.ALLOWED_EXECUTABLES
+        }
+        self.environment = {
+            "PATH": trusted_path,
+            "HOME": str(self.home_dir),
+            "TMPDIR": str(self.tmp_dir),
+            "XDG_CONFIG_HOME": str(self.config_dir),
+            "XDG_CACHE_HOME": str(self.cache_dir),
+            "XDG_STATE_HOME": str(self.local_state_dir),
+            "CLOUDSDK_CONFIG": str(self.config_dir / "gcloud"),
+            "GH_CONFIG_DIR": str(self.config_dir / "gh"),
+            "KUBECONFIG": str(self.home_dir / ".kube" / "config"),
+            "CLOUDSDK_CORE_DISABLE_PROMPTS": "1",
+        }
+        # Forward only variables required by supported credential clients. Chat
+        # tokens and proxy control variables must never enter an agent-selected
+        # subprocess, even though that subprocess runs in the sidecar.
+        for name in (
+            "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "NO_PROXY",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+            "REQUESTS_CA_BUNDLE",
+            "LANG",
+            "LC_ALL",
+            "TOKEN_BROKER_URL",
+            "KSA_TOKEN_FILE",
+        ):
+            if name in os.environ:
+                self.environment[name] = os.environ[name]
+
+    def bootstrap(self, command: str) -> None:
+        """Prepare the trusted shell profile without interpreting later commands."""
+        if not command.strip():
+            return
+        bootstrap_environment = self.environment.copy()
+        for name in (
+            "GKE_PROJECT_ID",
+            "GKE_CLUSTER_NAME",
+            "GKE_LOCATION",
+            "KUBE_CONTEXT_NAME",
+            "KUBE_DEFAULT_NAMESPACE",
+        ):
+            if name in os.environ:
+                bootstrap_environment[name] = os.environ[name]
+        result = subprocess.run(
+            ["/bin/bash", "--noprofile", "--norc", "-c", command],
+            cwd=self.workspace_dir,
+            env=bootstrap_environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=max(self.timeout_seconds, 120),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"credential proxy shell bootstrap failed with exit code {result.returncode}"
+            )
+
+    def execute(
+        self,
+        argv: list[str],
+        stdin: str | None = None,
+        cwd: str | None = None,
+    ) -> ExecutionResult:
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(argument, str) for argument in argv)
+        ):
+            raise ValueError("argv must be a non-empty list of strings")
+        executable = argv[0]
+        if executable not in self.ALLOWED_EXECUTABLES:
+            raise ValueError("executable is not supported by the credential proxy")
+        executable_path = self.executables.get(executable)
+        if not executable_path:
+            raise RuntimeError(f"supported executable is unavailable: {executable}")
+        return self._execute([executable_path, *argv[1:]], stdin=stdin, cwd=cwd)
+
+    def execute_internal(
+        self, argv: list[str], cwd: str | None = None
+    ) -> ExecutionResult:
+        """Run a trusted, operator-defined helper that is not agent selectable."""
+        return self._execute(argv, cwd=cwd)
+
+    def _execute(
+        self,
+        argv: list[str],
+        stdin: str | None = None,
+        cwd: str | None = None,
+    ) -> ExecutionResult:
+        started = time.monotonic()
+        timed_out = False
+        command_cwd = self.workspace_dir
+        if cwd:
+            requested_cwd = Path(cwd).resolve()
+            if requested_cwd != self.workspace_dir and self.workspace_dir not in requested_cwd.parents:
+                raise ValueError("working directory is outside the shared workspace")
+            command_cwd = requested_cwd
+        process = subprocess.Popen(
+            argv,
+            cwd=command_cwd,
+            env=self.environment.copy(),
+            stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout_bytes, stderr_bytes = process.communicate(
+                input=stdin.encode("utf-8") if stdin is not None else None,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            stdout_bytes, stderr_bytes = process.communicate()
+
+        stdout_bytes, stdout_truncated = self._truncate(stdout_bytes)
+        stderr_bytes, stderr_truncated = self._truncate(stderr_bytes)
+        duration_ms = int((time.monotonic() - started) * 1000)
+        return ExecutionResult(
+            exit_code=124 if timed_out else process.returncode,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            duration_ms=duration_ms,
+            truncated=stdout_truncated or stderr_truncated,
+            timed_out=timed_out,
+        )
+
+    def _truncate(self, value: bytes) -> tuple[bytes, bool]:
+        if len(value) <= self.max_output_bytes:
+            return value, False
+        return value[: self.max_output_bytes], True
+
+
+class CredentialProxyHandler(BaseHTTPRequestHandler):
+    policy: Policy
+    executor: CommandExecutor
+    max_request_bytes: int
+    slack_max_request_bytes: int
+    chat_relay: GoogleChatRelay | None = None
+    slack_relay: SlackRelay | None = None
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.startswith("/v1/chat/slack/events"):
+            if self.slack_relay is None:
+                self._json(
+                    HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack relay disabled"}
+                )
+                return
+            try:
+                self._json(HTTPStatus.OK, {"event": self.slack_relay.pull()})
+            except Exception as exc:
+                LOGGER.warning("Slack event pull failed: %s", type(exc).__name__)
+                self._json(
+                    HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack event pull failed"}
+                )
+            return
+        if self.path.startswith("/v1/chat/events"):
+            if self.chat_relay is None:
+                self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat relay disabled"})
+                return
+            try:
+                event = self.chat_relay.pull()
+                self._json(HTTPStatus.OK, {"event": event})
+            except Exception as exc:
+                LOGGER.warning("chat event pull failed: %s", type(exc).__name__)
+                self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat event pull failed"})
+            return
+        if self.path != "/healthz":
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+            return
+        self._json(HTTPStatus.OK, {"status": "ok"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.startswith("/v1/chat/slack/"):
+            self._handle_slack_post()
+            return
+        if self.path.startswith("/v1/chat/"):
+            self._handle_chat_post()
+            return
+        if self.path == "/v1/github/refresh":
+            self._handle_github_refresh()
+            return
+        if self.path != "/v1/exec":
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+            return
+
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": "invalid content length"})
+            return
+        if content_length <= 0 or content_length > self.max_request_bytes:
+            self._json(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                {"error": "command request exceeds configured size limit"},
+            )
+            return
+
+        try:
+            payload = json.loads(self.rfile.read(content_length))
+            argv = payload["argv"]
+            if (
+                not isinstance(argv, list)
+                or not argv
+                or not all(isinstance(argument, str) for argument in argv)
+            ):
+                raise ValueError("argv must be a non-empty list of strings")
+            stdin = payload.get("stdin")
+            if stdin is not None and not isinstance(stdin, str):
+                raise ValueError("stdin must be a string")
+            cwd = payload.get("cwd")
+            if cwd is not None and not isinstance(cwd, str):
+                raise ValueError("cwd must be a string")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        request_id = str(payload.get("requestId", ""))
+        if argv[0] not in CommandExecutor.ALLOWED_EXECUTABLES:
+            LOGGER.warning(
+                "executable blocked request_id=%s executable=%s",
+                request_id,
+                argv[0],
+            )
+            self._json(
+                HTTPStatus.FORBIDDEN,
+                {
+                    "status": "blocked",
+                    "code": "SECURITY_POLICY_BLOCKED",
+                    "rule": "executable.allowlist",
+                    "message": "Executable is not supported by the credential proxy.",
+                },
+            )
+            return
+        rule = self.policy.blocked_by(argv)
+        if rule is not None:
+            LOGGER.warning(
+                "command blocked request_id=%s rule=%s", request_id, rule.rule_id
+            )
+            self._json(
+                HTTPStatus.FORBIDDEN,
+                {
+                    "status": "blocked",
+                    "code": "SECURITY_POLICY_BLOCKED",
+                    "rule": rule.rule_id,
+                    "message": rule.message,
+                },
+            )
+            return
+
+        try:
+            result = self.executor.execute(argv, stdin=stdin, cwd=cwd)
+        except Exception as exc:
+            LOGGER.exception(
+                "command failed request_id=%s type=%s",
+                request_id,
+                type(exc).__name__,
+            )
+            self._json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": "credential proxy command execution failed"},
+            )
+            return
+        LOGGER.info(
+            "command complete request_id=%s exit_code=%d duration_ms=%d truncated=%s",
+            request_id,
+            result.exit_code,
+            result.duration_ms,
+            result.truncated,
+        )
+        self._json(
+            HTTPStatus.OK,
+            {
+                "status": "completed",
+                "exitCode": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "durationMs": result.duration_ms,
+                "truncated": result.truncated,
+                "timedOut": result.timed_out,
+            },
+        )
+
+    def _handle_github_refresh(self) -> None:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            if content_length <= 0 or content_length > self.max_request_bytes:
+                raise ValueError("invalid request size")
+            payload = json.loads(self.rfile.read(content_length))
+            repository = payload["repository"]
+            if not isinstance(repository, str) or not re.fullmatch(
+                r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+            ):
+                raise ValueError("repository must be owner/name")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        try:
+            result = self.executor.execute_internal(
+                ["/opt/defaults/scripts/github_token_refresh.py", repository]
+            )
+        except Exception as exc:
+            LOGGER.warning("GitHub credential refresh failed: %s", type(exc).__name__)
+            self._json(
+                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
+            )
+            return
+        if result.exit_code != 0:
+            LOGGER.warning("GitHub credential refresh exited %d", result.exit_code)
+            self._json(
+                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
+            )
+            return
+        self._json(HTTPStatus.OK, {"status": "refreshed"})
+
+    def _read_json_body(self, max_bytes: int | None = None) -> dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        if content_length <= 0 or content_length > (
+            max_bytes or self.max_request_bytes
+        ):
+            raise ValueError("request exceeds configured size limit")
+        payload = json.loads(self.rfile.read(content_length))
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be an object")
+        return payload
+
+    def _handle_chat_post(self) -> None:
+        if self.chat_relay is None:
+            self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat relay disabled"})
+            return
+        try:
+            payload = self._read_json_body()
+            if self.path == "/v1/chat/events/ack":
+                ok = self.chat_relay.settle(str(payload.get("receipt", "")), True)
+                self._json(HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok})
+                return
+            if self.path == "/v1/chat/events/nack":
+                ok = self.chat_relay.settle(str(payload.get("receipt", "")), False)
+                self._json(HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok})
+                return
+            if self.path == "/v1/chat/api":
+                resource = payload.get("resource", [])
+                arguments = payload.get("arguments", {})
+                if not isinstance(resource, list) or not isinstance(arguments, dict):
+                    raise ValueError("resource must be a list and arguments an object")
+                result = self.chat_relay.api_call(
+                    resource,
+                    str(payload.get("method", "")),
+                    arguments,
+                )
+                self._json(HTTPStatus.OK, {"response": result})
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception as exc:
+            LOGGER.warning("chat relay operation failed path=%s type=%s", self.path, type(exc).__name__)
+            self._json(HTTPStatus.BAD_GATEWAY, {"error": "Google Chat operation failed"})
+
+    def _handle_slack_post(self) -> None:
+        if self.slack_relay is None:
+            self._json(
+                HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack relay disabled"}
+            )
+            return
+        try:
+            payload = self._read_json_body(self.slack_max_request_bytes)
+            if self.path == "/v1/chat/slack/bootstrap":
+                self._json(
+                    HTTPStatus.OK,
+                    {"workspaces": self.slack_relay.bootstrap()},
+                )
+                return
+            if self.path == "/v1/chat/slack/events/ack":
+                ok = self.slack_relay.settle(str(payload.get("receipt", "")), True)
+                self._json(
+                    HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok}
+                )
+                return
+            if self.path == "/v1/chat/slack/events/nack":
+                ok = self.slack_relay.settle(str(payload.get("receipt", "")), False)
+                self._json(
+                    HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok}
+                )
+                return
+            if self.path == "/v1/chat/slack/api":
+                arguments = payload.get("arguments", {})
+                if not isinstance(arguments, dict):
+                    raise ValueError("arguments must be an object")
+                result = self.slack_relay.api_call(
+                    str(payload.get("teamId", "")),
+                    str(payload.get("method", "")),
+                    arguments,
+                )
+                self._json(HTTPStatus.OK, {"response": result})
+                return
+            if self.path == "/v1/chat/slack/files/download":
+                content = self.slack_relay.download(
+                    str(payload.get("teamId", "")), str(payload["url"])
+                )
+                self._json(
+                    HTTPStatus.OK,
+                    {"data": base64.b64encode(content).decode("ascii")},
+                )
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception as exc:
+            LOGGER.warning(
+                "Slack relay operation failed path=%s type=%s",
+                self.path,
+                type(exc).__name__,
+            )
+            self._json(HTTPStatus.BAD_GATEWAY, {"error": "Slack operation failed"})
+
+    def log_message(self, message: str, *args: Any) -> None:
+        LOGGER.info("http " + message, *args)
+
+    def _json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def serve(args: argparse.Namespace) -> None:
+    CredentialProxyHandler.policy = Policy.load(args.policy)
+    executor = CommandExecutor(
+        timeout_seconds=args.timeout_seconds,
+        max_output_bytes=args.max_output_bytes,
+        state_dir=args.state_dir,
+    )
+    executor.bootstrap(os.getenv("CREDENTIAL_PROXY_BOOTSTRAP_COMMAND", ""))
+    CredentialProxyHandler.executor = executor
+    CredentialProxyHandler.max_request_bytes = args.max_request_bytes
+    CredentialProxyHandler.slack_max_request_bytes = int(
+        os.getenv("SLACK_RELAY_MAX_REQUEST_BYTES", str(28 * 1024 * 1024))
+    )
+    chat_project = os.getenv("GOOGLE_CHAT_PROJECT_ID", "").strip()
+    chat_subscription = os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME", "").strip()
+    if chat_project and chat_subscription:
+        CredentialProxyHandler.chat_relay = GoogleChatRelay(
+            chat_project, chat_subscription
+        )
+        LOGGER.info("Google Chat relay enabled project=%s subscription=<redacted>", chat_project)
+    slack_bot_tokens = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    slack_app_token = os.getenv("SLACK_APP_TOKEN", "").strip()
+    if slack_bot_tokens and slack_app_token:
+        def initialize_slack_relay() -> None:
+            while CredentialProxyHandler.slack_relay is None:
+                try:
+                    relay = SlackRelay(
+                        slack_bot_tokens,
+                        slack_app_token,
+                        max_file_bytes=int(
+                            os.getenv(
+                                "SLACK_RELAY_MAX_FILE_BYTES", str(20 * 1024 * 1024)
+                            )
+                        ),
+                    )
+                except Exception as exc:
+                    LOGGER.error(
+                        "Slack relay initialization failed; retrying type=%s",
+                        type(exc).__name__,
+                    )
+                    time.sleep(30)
+                else:
+                    CredentialProxyHandler.slack_relay = relay
+                    LOGGER.info(
+                        "Slack relay enabled workspaces=%d",
+                        len(relay.bootstrap()),
+                    )
+
+        threading.Thread(target=initialize_slack_relay, daemon=True).start()
+    AgentAPIProxyHandler.external_key = os.getenv("API_SERVER_EXTERNAL_KEY", "").strip()
+    if not AgentAPIProxyHandler.external_key:
+        raise RuntimeError("API_SERVER_EXTERNAL_KEY must be configured")
+    AgentAPIProxyHandler.upstream_key = os.getenv(
+        "AGENT_API_UPSTREAM_KEY", "cluster-internal-trusted"
+    )
+    api_server = ThreadingHTTPServer(
+        ("0.0.0.0", int(os.getenv("AGENT_API_PROXY_PORT", "8643"))),
+        AgentAPIProxyHandler,
+    )
+    threading.Thread(target=api_server.serve_forever, daemon=True).start()
+    LOGGER.info("authenticated PlatformAgent API proxy listening on port 8643")
+    if args.unix_socket:
+        socket_path = Path(args.unix_socket)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        server = ThreadingUnixHTTPServer(str(socket_path), CredentialProxyHandler)
+        LOGGER.info("credential proxy listening on unix socket %s", socket_path)
+    else:
+        server = ThreadingHTTPServer((args.host, args.port), CredentialProxyHandler)
+        LOGGER.info("credential proxy listening on %s:%d", args.host, args.port)
+    server.serve_forever()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--policy",
+        default=os.getenv(
+            "CREDENTIAL_PROXY_POLICY", "/etc/credential-proxy/policy.json"
+        ),
+    )
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument(
+        "--port", type=int, default=int(os.getenv("CREDENTIAL_PROXY_PORT", "8765"))
+    )
+    parser.add_argument(
+        "--unix-socket", default=os.getenv("CREDENTIAL_PROXY_UNIX_SOCKET", "")
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_TIMEOUT_SECONDS", "300")),
+    )
+    parser.add_argument(
+        "--max-request-bytes",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_MAX_REQUEST_BYTES", "1048576")),
+    )
+    parser.add_argument(
+        "--max-output-bytes",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_MAX_OUTPUT_BYTES", "4194304")),
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=os.getenv("CREDENTIAL_PROXY_STATE_DIR", "/var/lib/credential-proxy"),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    serve(parse_args())

--- a/agents/platform/scripts/credential_proxy_client.py
+++ b/agents/platform/scripts/credential_proxy_client.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Submit a supported CLI argv vector to the paired credential proxy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+
+def execute(
+    endpoint: str,
+    argv: list[str],
+    stdin: str | None = None,
+) -> int:
+    request_payload = {
+        "requestId": str(uuid.uuid4()),
+        "argv": argv,
+        "cwd": os.getcwd(),
+    }
+    if stdin is not None:
+        request_payload["stdin"] = stdin
+    body = json.dumps(
+        request_payload,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint.rstrip("/") + "/v1/exec",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        payload = json.load(exc)
+        if payload.get("code") == "SECURITY_POLICY_BLOCKED":
+            print(
+                payload.get("message", "Command blocked for security reasons."),
+                file=sys.stderr,
+            )
+            print(f"policy rule: {payload.get('rule', 'unknown')}", file=sys.stderr)
+            return 126
+        print(payload.get("error", str(exc)), file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"credential proxy unavailable: {exc.reason}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(payload.get("stdout", ""))
+    sys.stderr.write(payload.get("stderr", ""))
+    if payload.get("truncated"):
+        print("credential proxy output truncated", file=sys.stderr)
+    return int(payload.get("exitCode", 1))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("CREDENTIAL_PROXY_URL"),
+        required=os.getenv("CREDENTIAL_PROXY_URL") is None,
+    )
+    parser.add_argument(
+        "executable",
+        choices=("kubectl", "gcloud", "gh", "git"),
+    )
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    invoked_as = os.path.basename(sys.argv[0])
+    if invoked_as in {"kubectl", "gcloud", "gh", "git"}:
+        endpoint = os.getenv("CREDENTIAL_PROXY_URL")
+        if endpoint is None:
+            print("CREDENTIAL_PROXY_URL is not configured", file=sys.stderr)
+            raise SystemExit(1)
+        argv = [invoked_as, *sys.argv[1:]]
+        # Do not consume inherited stdin here. MCP and other stdio-based parent
+        # processes may have a protocol stream on fd 0. Pipelines and
+        # redirections remain local to the sandbox shell around this wrapper.
+        stdin = None
+    else:
+        args = parse_args()
+        endpoint = args.endpoint
+        argv = [args.executable, *args.arguments]
+        stdin = None
+    raise SystemExit(
+        execute(
+            endpoint,
+            argv,
+            stdin=stdin,
+        )
+    )

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -2,9 +2,8 @@
 """
 GKE Platform Agent — Secure GitHub Token Refresher (Broker Client)
 
-This script queries the internal cluster-local Token Broker to retrieve
-a short-lived (1-hour), repository-scoped installation token, and securely
-caches it inside the git credentials store and GitHub CLI.
+In the agent sandbox this script asks the credential sidecar to refresh. Only
+the sidecar queries Minty and caches the short-lived repository-scoped token.
 """
 
 import json
@@ -48,6 +47,27 @@ def get_current_git_repo() -> str:
 
 def refresh_git_credentials(target_repo: str = None) -> str:
     """Query local Minty, retrieve token, and cache inside git credentials."""
+    repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
+    if not repository or "/" not in repository:
+        raise RuntimeError("Could not identify target repository as owner/name")
+
+    proxy_url = os.getenv("CREDENTIAL_PROXY_URL", "").strip()
+    if proxy_url:
+        request = urllib.request.Request(
+            proxy_url.rstrip("/") + "/v1/github/refresh",
+            data=json.dumps({"repository": repository}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                if response.status != 200:
+                    raise RuntimeError("credential sidecar rejected refresh")
+        except Exception as exc:
+            raise RuntimeError("Credential sidecar failed to refresh GitHub auth") from exc
+        log(f"GitHub credentials refreshed in credential sidecar for {repository}.")
+        return ""
+
     # 1. Retrieve Google OIDC identity token via gcloud external command
     oidc_token = None
     try:
@@ -71,12 +91,6 @@ def refresh_git_credentials(target_repo: str = None) -> str:
         raise RuntimeError("Retrieved Google OIDC token via gcloud is empty")
 
     # 2. Dynamically identify target repository from workspace git remote or parameter
-    repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
-    if not repository:
-        raise RuntimeError("Could not identify target repository (no argument passed and no local git config found)")
-    if "/" not in repository:
-        raise RuntimeError(f"Invalid repository format: {repository}")
-
     org_name, repo_name = repository.split("/", 1)
 
     headers = {

--- a/agents/platform/scripts/google_chat_relay_patch.py
+++ b/agents/platform/scripts/google_chat_relay_patch.py
@@ -1,0 +1,177 @@
+"""Credential-free Google Chat transport for Hermes' bundled adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+
+LOGGER = logging.getLogger("google-chat-relay-patch")
+
+
+def install() -> None:
+    relay_url = os.getenv("GOOGLE_CHAT_RELAY_URL", "").rstrip("/")
+    if not relay_url:
+        return
+
+    def request(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            relay_url + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="GET" if body is None else "POST",
+        )
+        with urllib.request.urlopen(req, timeout=35) as response:
+            return json.load(response)
+
+    class RelayMessage:
+        """Pub/Sub-shaped message that settles an opaque proxy receipt."""
+
+        def __init__(self, event: dict[str, Any]) -> None:
+            self.data = base64.b64decode(event["data"], validate=True)
+            self.attributes = event.get("attributes") or {}
+            self.message_id = str(event.get("messageId", ""))
+            self._receipt = str(event["receipt"])
+            self._settled = False
+
+        def _settle(self, acknowledge: bool) -> None:
+            if self._settled:
+                return
+            path = "/v1/chat/events/ack" if acknowledge else "/v1/chat/events/nack"
+            request(path, {"receipt": self._receipt})
+            self._settled = True
+
+        def ack(self) -> None:
+            self._settle(True)
+
+        def nack(self) -> None:
+            self._settle(False)
+
+    class RemoteRequest:
+        def __init__(
+            self, resource: list[str], method: str, arguments: dict[str, Any]
+        ) -> None:
+            self.resource = resource
+            self.method = method
+            self.arguments = arguments
+
+        def execute(self, **_kwargs: Any) -> Any:
+            response = request(
+                "/v1/chat/api",
+                {
+                    "resource": self.resource,
+                    "method": self.method,
+                    "arguments": self.arguments,
+                },
+            )
+            return response.get("response")
+
+    class RemoteResource:
+        """googleapiclient discovery-resource-shaped remote facade."""
+
+        def __init__(self, resource: list[str] | None = None) -> None:
+            self.resource = resource or []
+
+        def __getattr__(self, name: str) -> Any:
+            if name.startswith("_"):
+                raise AttributeError(name)
+
+            def invoke(**arguments: Any) -> Any:
+                if arguments:
+                    return RemoteRequest(self.resource, name, arguments)
+                return RemoteResource([*self.resource, name])
+
+            return invoke
+
+    async def relay_loop(self: Any) -> None:
+        while not self._shutting_down:
+            message: RelayMessage | None = None
+            try:
+                response = await asyncio.to_thread(request, "/v1/chat/events")
+                event = response.get("event")
+                if not event:
+                    continue
+                message = RelayMessage(event)
+                await asyncio.to_thread(self._on_pubsub_message, message)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.warning("Google Chat relay receive failed", exc_info=True)
+                if message is not None:
+                    try:
+                        await asyncio.to_thread(message.nack)
+                    except Exception:
+                        pass
+                await asyncio.sleep(2)
+
+    def patch_adapter_class(adapter_class: type[Any]) -> None:
+        if getattr(adapter_class, "_credential_proxy_relay_patched", False):
+            return
+        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
+            self._loop = asyncio.get_running_loop()
+            self._shutting_down = False
+            self._chat_api = RemoteResource()
+            try:
+                await asyncio.to_thread(self._thread_count_store.load)
+            except Exception:
+                LOGGER.warning("Google Chat thread state load failed", exc_info=True)
+            self._bot_user_id = self._load_cached_bot_id()
+            self._relay_task = asyncio.create_task(relay_loop(self))
+            self._mark_connected()
+            LOGGER.info("Google Chat connected through credential proxy relay")
+            return True
+
+        async def disconnect(self: Any) -> None:
+            self._shutting_down = True
+            task = getattr(self, "_relay_task", None)
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            self._chat_api = None
+            self._mark_disconnected()
+
+        def new_authed_http(self: Any) -> Any:
+            return None
+
+        async def setup_files(
+            self: Any,
+            chat_id: str,
+            thread_id: str | None,
+            raw_text: str,
+            sender_email: str | None = None,
+        ) -> bool:
+            await self.send(
+                chat_id,
+                "File attachment setup is unavailable through the credential proxy.",
+                metadata={"thread_id": thread_id} if thread_id else None,
+            )
+            return True
+
+        adapter_class.connect = connect
+        adapter_class.disconnect = disconnect
+        adapter_class._new_authed_http = new_authed_http
+        adapter_class._handle_setup_files_command = setup_files
+        adapter_class._credential_proxy_relay_patched = True
+
+    from gateway.platform_registry import PlatformRegistry
+
+    original_registry_create = PlatformRegistry.create_adapter
+    if not getattr(PlatformRegistry, "_credential_proxy_relay_patched", False):
+
+        def create_adapter(self: Any, name: str, config: Any) -> Any:
+            adapter = original_registry_create(self, name, config)
+            if name == "google_chat" and adapter is not None:
+                patch_adapter_class(type(adapter))
+            return adapter
+
+        PlatformRegistry.create_adapter = create_adapter
+        PlatformRegistry._credential_proxy_relay_patched = True

--- a/agents/platform/scripts/sitecustomize.py
+++ b/agents/platform/scripts/sitecustomize.py
@@ -1,0 +1,24 @@
+"""Runtime patches for the platform agent image."""
+
+import os
+
+if os.getenv("GOOGLE_CHAT_RELAY_URL"):
+    try:
+        from google_chat_relay_patch import install
+
+        install()
+    except ModuleNotFoundError as exc:
+        # Credential-free wrapper scripts use the system Python, which can see
+        # this directory through PYTHONPATH but not Hermes' gateway packages.
+        # The long-lived Hermes process uses its venv and applies the patch.
+        if exc.name not in {"gateway", "plugins"}:
+            raise
+
+if os.getenv("SLACK_RELAY_URL"):
+    try:
+        from slack_relay_patch import install
+
+        install()
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"gateway", "plugins"}:
+            raise

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -1,0 +1,316 @@
+"""Credential-free Slack SDK transport for Hermes' bundled adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+LOGGER = logging.getLogger("slack-relay-patch")
+DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+
+
+def read_upload(path: Path, max_file_bytes: int) -> bytes:
+    """Read an upload without allowing it to grow past the relay limit."""
+    if path.stat().st_size > max_file_bytes:
+        raise ValueError("Slack upload exceeds relay size limit")
+    with path.open("rb") as upload:
+        content = upload.read(max_file_bytes + 1)
+    if len(content) > max_file_bytes:
+        raise ValueError("Slack upload exceeds relay size limit")
+    return content
+
+
+def install() -> None:
+    relay_url = os.getenv("SLACK_RELAY_URL", "").rstrip("/")
+    if not relay_url:
+        return
+    try:
+        max_file_bytes = int(
+            os.getenv("SLACK_RELAY_MAX_FILE_BYTES", str(DEFAULT_MAX_FILE_BYTES))
+        )
+    except ValueError:
+        LOGGER.warning("Invalid Slack relay file limit; using the default")
+        max_file_bytes = DEFAULT_MAX_FILE_BYTES
+
+    def request(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            relay_url + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="GET" if body is None else "POST",
+        )
+        with urllib.request.urlopen(req, timeout=35) as response:
+            return json.load(response)
+
+    def json_value(value: Any, *, file_value: bool = False) -> Any:
+        if isinstance(value, bytes):
+            if len(value) > max_file_bytes:
+                raise ValueError("Slack upload exceeds relay size limit")
+            return {"__bytesBase64": base64.b64encode(value).decode("ascii")}
+        if hasattr(value, "read"):
+            content = value.read(max_file_bytes + 1)
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            if len(content) > max_file_bytes:
+                raise ValueError("Slack upload exceeds relay size limit")
+            return {
+                "__fileBase64": base64.b64encode(content).decode("ascii"),
+                "filename": Path(getattr(value, "name", "upload")).name,
+            }
+        if file_value and isinstance(value, (str, Path)):
+            path = Path(value)
+            return {
+                "__fileBase64": base64.b64encode(
+                    read_upload(path, max_file_bytes)
+                ).decode("ascii"),
+                "filename": path.name,
+            }
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, dict):
+            return {
+                key: json_value(item, file_value=file_value)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [json_value(item, file_value=file_value) for item in value]
+        return value
+
+    async def relay_loop(self: Any) -> None:
+        from slack_bolt.adapter.socket_mode.async_internals import run_async_bolt_app
+        from slack_sdk.socket_mode.request import SocketModeRequest
+
+        while self._running:
+            receipt = ""
+            try:
+                response = await asyncio.to_thread(request, "/v1/chat/slack/events")
+                event = response.get("event")
+                if not event:
+                    continue
+                receipt = str(event["receipt"])
+                socket_request = SocketModeRequest(
+                    type=str(event.get("type", "")),
+                    envelope_id=receipt,
+                    payload=event.get("payload") or {},
+                )
+                await run_async_bolt_app(self._app, socket_request)
+                await asyncio.to_thread(
+                    request, "/v1/chat/slack/events/ack", {"receipt": receipt}
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.warning("Slack relay receive failed", exc_info=True)
+                if receipt:
+                    try:
+                        await asyncio.to_thread(
+                            request,
+                            "/v1/chat/slack/events/nack",
+                            {"receipt": receipt},
+                        )
+                    except Exception:
+                        pass
+                await asyncio.sleep(2)
+
+    def patch_adapter_class(adapter_class: type[Any]) -> None:
+        if getattr(adapter_class, "_credential_proxy_relay_patched", False):
+            return
+
+        module = sys.modules[adapter_class.__module__]
+        real_async_app = module.AsyncApp
+        real_async_client = module.AsyncWebClient
+        original_connect = adapter_class.connect
+        original_disconnect = adapter_class.disconnect
+
+        class RemoteSlackClient(real_async_client):
+            """Slack SDK client whose generic API calls execute in the proxy."""
+
+            def __init__(self, token: str | None = None, **_kwargs: Any) -> None:
+                placeholder = token or "relay:"
+                super().__init__(token=placeholder)
+                self.team_id = (
+                    placeholder.split(":", 1)[1]
+                    if placeholder.startswith("relay:")
+                    else ""
+                )
+
+            async def api_call(
+                self,
+                api_method: str,
+                *,
+                http_verb: str = "POST",
+                files: dict[str, Any] | None = None,
+                data: Any = None,
+                params: dict[str, Any] | None = None,
+                json: dict[str, Any] | None = None,
+                headers: dict[str, Any] | None = None,
+                auth: dict[str, Any] | None = None,
+            ) -> Any:
+                arguments = {
+                    "http_verb": http_verb,
+                    "files": json_value(files, file_value=True) if files else None,
+                    "data": json_value(data) if data is not None else None,
+                    "params": json_value(params) if params else None,
+                    "json": json_value(json) if json else None,
+                    "headers": json_value(headers) if headers else None,
+                    "auth": json_value(auth) if auth else None,
+                }
+                response = await asyncio.to_thread(
+                    request,
+                    "/v1/chat/slack/api",
+                    {
+                        "teamId": self.team_id,
+                        "method": api_method,
+                        "arguments": {
+                            key: value
+                            for key, value in arguments.items()
+                            if value is not None
+                        },
+                    },
+                )
+                return response.get("response") or {}
+
+        def remote_client_factory(
+            token: str | None = None, **kwargs: Any
+        ) -> RemoteSlackClient:
+            return RemoteSlackClient(token=token, **kwargs)
+
+        def remote_app_factory(
+            *_args: Any, token: str | None = None, **kwargs: Any
+        ) -> Any:
+            kwargs.pop("client", None)
+            kwargs["request_verification_enabled"] = False
+            return real_async_app(
+                client=RemoteSlackClient(token=token),
+                **kwargs,
+            )
+
+        module.AsyncWebClient = remote_client_factory
+        module.AsyncApp = remote_app_factory
+
+        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
+            bootstrap = await asyncio.to_thread(
+                request, "/v1/chat/slack/bootstrap", {}
+            )
+            workspaces = bootstrap.get("workspaces") or []
+            if not workspaces:
+                LOGGER.error("Slack credential proxy has no authenticated workspace")
+                return False
+            first_connect = not hasattr(
+                self, "_credential_proxy_original_slack_token"
+            )
+            if first_connect:
+                self._credential_proxy_original_slack_token = self.config.token
+                self._credential_proxy_original_slack_app_token = os.environ.get(
+                    "SLACK_APP_TOKEN"
+                )
+            self.config.token = ",".join(
+                "relay:" + str(workspace.get("teamId", ""))
+                for workspace in workspaces
+            )
+            os.environ["SLACK_APP_TOKEN"] = "relay"
+            self._shutting_down = False
+            try:
+                connected = await original_connect(self, is_reconnect=is_reconnect)
+            except Exception:
+                if first_connect:
+                    restore_slack_placeholders(self)
+                raise
+            if not connected and first_connect:
+                restore_slack_placeholders(self)
+            return connected
+
+        async def disconnect(self: Any) -> None:
+            self._shutting_down = True
+            try:
+                await original_disconnect(self)
+            finally:
+                restore_slack_placeholders(self)
+
+        def restore_slack_placeholders(self: Any) -> None:
+            if not hasattr(self, "_credential_proxy_original_slack_token"):
+                return
+            self.config.token = self._credential_proxy_original_slack_token
+            original_app_token = self._credential_proxy_original_slack_app_token
+            if original_app_token is None:
+                os.environ.pop("SLACK_APP_TOKEN", None)
+            else:
+                os.environ["SLACK_APP_TOKEN"] = original_app_token
+            del self._credential_proxy_original_slack_token
+            del self._credential_proxy_original_slack_app_token
+
+        def start_transport(self: Any) -> None:
+            task = asyncio.create_task(relay_loop(self))
+            self._socket_mode_task = task
+            self._relay_task = task
+
+        async def stop_transport(self: Any) -> None:
+            task = getattr(self, "_relay_task", None)
+            self._relay_task = None
+            self._socket_mode_task = None
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        def no_watchdog(self: Any) -> None:
+            return None
+
+        async def download(
+            self: Any, url: str, ext: str, audio: bool = False, team_id: str = ""
+        ) -> str:
+            response = await asyncio.to_thread(
+                request,
+                "/v1/chat/slack/files/download",
+                {"url": url, "teamId": team_id},
+            )
+            content = base64.b64decode(response["data"])
+            if audio:
+                from gateway.platforms.base import cache_audio_from_bytes
+
+                return cache_audio_from_bytes(content, ext)
+            from gateway.platforms.base import cache_image_from_bytes
+
+            return cache_image_from_bytes(content, ext)
+
+        async def download_bytes(self: Any, url: str, team_id: str = "") -> bytes:
+            response = await asyncio.to_thread(
+                request,
+                "/v1/chat/slack/files/download",
+                {"url": url, "teamId": team_id},
+            )
+            return base64.b64decode(response["data"])
+
+        adapter_class.connect = connect
+        adapter_class.disconnect = disconnect
+        adapter_class._start_socket_mode_handler = start_transport
+        adapter_class._stop_socket_mode_handler = stop_transport
+        adapter_class._ensure_socket_watchdog = no_watchdog
+        adapter_class._download_slack_file = download
+        adapter_class._download_slack_file_bytes = download_bytes
+        adapter_class._credential_proxy_relay_patched = True
+
+    from gateway.platform_registry import PlatformRegistry
+
+    original_registry_create = PlatformRegistry.create_adapter
+    if not getattr(PlatformRegistry, "_slack_credential_proxy_relay_patched", False):
+
+        def create_adapter(self: Any, name: str, config: Any) -> Any:
+            adapter = original_registry_create(self, name, config)
+            if name == "slack" and adapter is not None:
+                patch_adapter_class(type(adapter))
+            return adapter
+
+        PlatformRegistry.create_adapter = create_adapter
+        PlatformRegistry._slack_credential_proxy_relay_patched = True

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -1,0 +1,335 @@
+import json
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+import unittest
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+from credential_proxy import (
+    AgentAPIProxyHandler,
+    CommandExecutor,
+    GoogleChatRelay,
+    Policy,
+    SlackRelay,
+)
+from slack_relay_patch import read_upload
+
+
+class AgentAPIProxyTest(unittest.TestCase):
+    def setUp(self):
+        self.received_authorization = ""
+        owner = self
+
+        class UpstreamHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                owner.received_authorization = self.headers.get("Authorization", "")
+                body = b"proxied"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, _message, *_args):
+                return
+
+        self.upstream = ThreadingHTTPServer(("127.0.0.1", 0), UpstreamHandler)
+        AgentAPIProxyHandler.external_key = "external-secret"
+        AgentAPIProxyHandler.upstream_key = "internal-sentinel"
+        AgentAPIProxyHandler.upstream_port = self.upstream.server_port
+        self.proxy = ThreadingHTTPServer(("127.0.0.1", 0), AgentAPIProxyHandler)
+        for server in (self.upstream, self.proxy):
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    def tearDown(self):
+        self.proxy.shutdown()
+        self.upstream.shutdown()
+        self.proxy.server_close()
+        self.upstream.server_close()
+
+    def test_replaces_external_api_key_before_forwarding(self):
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.proxy.server_port}/health",
+            headers={"Authorization": "Bearer external-secret"},
+        )
+        with urllib.request.urlopen(request) as response:
+            self.assertEqual(b"proxied", response.read())
+        self.assertEqual("Bearer internal-sentinel", self.received_authorization)
+
+    def test_rejects_invalid_external_api_key(self):
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.proxy.server_port}/health",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        with self.assertRaises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request)
+        self.assertEqual(401, raised.exception.code)
+        self.assertEqual("", self.received_authorization)
+
+
+class PolicyTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.policy_path = Path(self.temp_dir.name) / "policy.json"
+        self.policy_path.write_text(
+            json.dumps(
+                {
+                    "blockedMessage": "Command blocked for security reasons.",
+                    "rules": [
+                        {
+                            "id": "gcp.access-token-disclosure",
+                            "pattern": r"\bgcloud\s+auth\s+print-access-token\b",
+                        },
+                        {
+                            "id": "github.token-disclosure",
+                            "pattern": r"\bgh\s+auth\s+token\b",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.policy = Policy.load(str(self.policy_path))
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_blocks_configured_command(self):
+        rule = self.policy.blocked_by(["gcloud", "auth", "print-access-token"])
+        self.assertIsNotNone(rule)
+        self.assertEqual("gcp.access-token-disclosure", rule.rule_id)
+
+    def test_allows_supported_command(self):
+        self.assertIsNone(self.policy.blocked_by(["kubectl", "get", "pods"]))
+
+
+class CommandExecutorTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def executor(self, timeout_seconds=5):
+        return CommandExecutor(
+            timeout_seconds=timeout_seconds,
+            max_output_bytes=1024,
+            state_dir=self.temp_dir.name,
+        )
+
+    def test_rejects_unsupported_executable(self):
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            self.executor().execute(["env"])
+
+    def test_rejects_shell_command_string(self):
+        with self.assertRaisesRegex(ValueError, "list of strings"):
+            self.executor().execute("gcloud auth list")
+
+    def test_rejects_working_directory_outside_shared_workspace(self):
+        with self.assertRaisesRegex(ValueError, "outside the shared workspace"):
+            self.executor().execute(["git", "status"], cwd="/")
+
+    def test_timeout_kills_command(self):
+        result = self.executor(timeout_seconds=1).execute_internal(["/bin/sleep", "10"])
+        self.assertTrue(result.timed_out)
+        self.assertEqual(124, result.exit_code)
+
+    def test_timeout_handles_process_group_exit_race(self):
+        process = mock.Mock(pid=123, returncode=0)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["command"], 1),
+            (b"", b""),
+        ]
+        with (
+            mock.patch("credential_proxy.subprocess.Popen", return_value=process),
+            mock.patch("credential_proxy.os.killpg", side_effect=ProcessLookupError),
+        ):
+            result = self.executor(timeout_seconds=1).execute_internal(["command"])
+        self.assertTrue(result.timed_out)
+        self.assertEqual(124, result.exit_code)
+
+    def test_command_environment_excludes_sidecar_tokens(self):
+        import os
+
+        previous = os.environ.get("SLACK_BOT_TOKEN")
+        os.environ["SLACK_BOT_TOKEN"] = "must-not-be-forwarded"
+        try:
+            executor = self.executor()
+        finally:
+            if previous is None:
+                del os.environ["SLACK_BOT_TOKEN"]
+            else:
+                os.environ["SLACK_BOT_TOKEN"] = previous
+        self.assertNotIn("SLACK_BOT_TOKEN", executor.environment)
+        self.assertEqual(str(Path(self.temp_dir.name) / "home"), executor.environment["HOME"])
+
+    def test_bootstrap_prepares_profile_for_later_commands(self):
+        import os
+
+        previous = os.environ.get("GKE_PROJECT_ID")
+        os.environ["GKE_PROJECT_ID"] = "bootstrap-project"
+        try:
+            executor = self.executor()
+            executor.bootstrap(
+                'printf "%s" "$GKE_PROJECT_ID" > "$HOME/bootstrap-state"'
+            )
+        finally:
+            if previous is None:
+                del os.environ["GKE_PROJECT_ID"]
+            else:
+                os.environ["GKE_PROJECT_ID"] = previous
+        self.assertTrue((Path(self.temp_dir.name) / "home" / "bootstrap-state").exists())
+        self.assertEqual(
+            "bootstrap-project",
+            (Path(self.temp_dir.name) / "home" / "bootstrap-state").read_text(),
+        )
+        self.assertNotIn("GKE_PROJECT_ID", executor.environment)
+
+    def test_bootstrap_failure_does_not_return_command_output(self):
+        with self.assertRaisesRegex(RuntimeError, "exit code 9") as raised:
+            self.executor().bootstrap("printf secret >&2; exit 9")
+        self.assertNotIn("secret", str(raised.exception))
+
+
+class GoogleChatRelayTest(unittest.TestCase):
+    class FakeRequest:
+        def __init__(self, response):
+            self.response = response
+
+        def execute(self):
+            return self.response
+
+    class FakeResource:
+        def __init__(self, calls, path=()):
+            self.calls = calls
+            self.path = path
+
+        def __getattr__(self, name):
+            def invoke(**arguments):
+                if not arguments:
+                    return GoogleChatRelayTest.FakeResource(
+                        self.calls, (*self.path, name)
+                    )
+                self.calls.append((self.path, name, arguments))
+                return GoogleChatRelayTest.FakeRequest(
+                    {"path": self.path, "method": name, "arguments": arguments}
+                )
+
+            return invoke
+
+    def test_forwards_unknown_resource_method_and_body_unchanged(self):
+        calls = []
+        relay = GoogleChatRelay.__new__(GoogleChatRelay)
+        relay.chat = self.FakeResource(calls)
+        arguments = {"body": {"futureSchema": {"nested": [1, 2, 3]}}}
+
+        result = relay.api_call(
+            ["futureResource", "messages"], "futureMethod", arguments
+        )
+
+        self.assertEqual(
+            [(("futureResource", "messages"), "futureMethod", arguments)], calls
+        )
+        self.assertEqual(arguments, result["arguments"])
+
+
+class SlackRelayTest(unittest.TestCase):
+    class FakeClient:
+        token = "xoxb-not-returned"
+
+        def api_call(self, method, **arguments):
+            return {"ok": True, "method": method, "arguments": arguments}
+
+    def relay(self):
+        relay = SlackRelay.__new__(SlackRelay)
+        relay.primary_client = self.FakeClient()
+        relay.clients = {"T123": relay.primary_client}
+        relay.workspaces = [{"teamId": "T123", "botUserId": "U123", "botName": "agent"}]
+        relay._events = queue.Queue()
+        relay._receipts = {}
+        import threading
+
+        relay._lock = threading.Lock()
+        return relay
+
+    def slack_modules(self):
+        class FakeWebClient:
+            def __init__(self, token):
+                self.token = token
+
+            def auth_test(self):
+                if self.token == "invalid":
+                    raise RuntimeError("authentication failed")
+                return {
+                    "team_id": "T123",
+                    "team": "workspace",
+                    "user_id": "U123",
+                    "user": "agent",
+                }
+
+        class FakeSocketModeClient:
+            def __init__(self, app_token, web_client):
+                self.app_token = app_token
+                self.web_client = web_client
+                self.socket_mode_request_listeners = []
+
+            def connect(self):
+                return None
+
+        slack_sdk = types.ModuleType("slack_sdk")
+        slack_sdk.WebClient = FakeWebClient
+        socket_mode = types.ModuleType("slack_sdk.socket_mode")
+        socket_mode.SocketModeClient = FakeSocketModeClient
+        return {"slack_sdk": slack_sdk, "slack_sdk.socket_mode": socket_mode}
+
+    def test_initialization_skips_invalid_token_when_another_is_valid(self):
+        with mock.patch.dict(sys.modules, self.slack_modules()):
+            relay = SlackRelay("invalid,valid", "app-token")
+        self.assertEqual("valid", relay.primary_client.token)
+        self.assertEqual("T123", relay.bootstrap()[0]["teamId"])
+
+    def test_initialization_rejects_all_invalid_tokens(self):
+        with mock.patch.dict(sys.modules, self.slack_modules()):
+            with self.assertRaisesRegex(RuntimeError, "no Slack bot token"):
+                SlackRelay("invalid", "app-token")
+
+    def test_forwards_unknown_web_api_method_and_arguments_unchanged(self):
+        arguments = {"json": {"futureSchema": {"nested": [1, 2, 3]}}}
+        result = self.relay().api_call(
+            "T123", "future.method", arguments
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual("future.method", result["method"])
+        self.assertEqual(arguments, result["arguments"])
+        self.assertNotIn("token", json.dumps(result))
+
+    def test_nack_requeues_event(self):
+        relay = self.relay()
+        relay._events.put({"type": "events_api", "payload": {"event": {}}})
+        event = relay.pull(timeout_seconds=1)
+        self.assertTrue(relay.settle(event["receipt"], acknowledge=False))
+        retried = relay.pull(timeout_seconds=1)
+        self.assertEqual("events_api", retried["type"])
+
+    def test_upload_reader_rejects_oversized_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "upload"
+            path.write_bytes(b"12345")
+            with self.assertRaisesRegex(ValueError, "size limit"):
+                read_upload(path, 4)
+
+    def test_upload_reader_accepts_file_at_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "upload"
+            path.write_bytes(b"1234")
+            self.assertEqual(b"1234", read_upload(path, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from github_token_refresh import refresh_git_credentials
+
+
+class GitHubTokenRefreshTest(unittest.TestCase):
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_delegates_without_receiving_token(self, urlopen, run):
+        response = MagicMock()
+        response.__enter__.return_value.status = 200
+        urlopen.return_value = response
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            token = refresh_git_credentials("owner/repository")
+
+        self.assertEqual("", token)
+        run.assert_not_called()
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            "http://127.0.0.1:8765/v1/github/refresh", request.full_url
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
+++ b/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
@@ -25,7 +25,7 @@ def push_branch(branch_name: str):
     log(f"Pushing active branch '{branch_name}' securely to origin...")
     subprocess.run(["git", "push", "-f", "origin", branch_name], check=True)
 
-def create_pull_request(token: str, branch: str, title: str, body: str) -> str:
+def create_pull_request(branch: str, title: str, body: str) -> str:
     """Submit the Pull Request securely using the GitHub CLI (gh)."""
     log(f"Submitting GitOps Pull Request for branch '{branch}'...")
     
@@ -51,13 +51,13 @@ def main():
     
     try:
         # Secure dynamic token exchange & Git/gh credentials configuration
-        token = refresh_git_credentials()
+        refresh_git_credentials()
         
         # Git branch pushing
         push_branch(args.branch)
         
         # Submit Pull Request
-        pr_url = create_pull_request(token, args.branch, args.title, args.body)
+        pr_url = create_pull_request(args.branch, args.title, args.body)
         log(f"PR SUBMITTED SUCCESSFULLY! 🏆 URL: {pr_url}")
         
         # Print raw URL to stdout for the MCP tool to parse

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,8 @@
 # check=skip=InvalidDefaultArgInFrom
 ARG HERMES_AGENT_TAG
+ARG ENVOY_VERSION=v1.38.0
+FROM envoyproxy/envoy:${ENVOY_VERSION} AS envoy-bin
+
 FROM nousresearch/hermes-agent:${HERMES_AGENT_TAG} AS agent-base
 
 USER root
@@ -10,7 +13,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dnsutils \
-    git \
     gnupg \
     iputils-ping \
     jq \
@@ -20,20 +22,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository
-RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y \
-    google-cloud-cli \
-    google-cloud-cli-gke-gcloud-auth-plugin \
-    kubectl \
-    && rm -rf /var/lib/apt/lists/*
-
-# 3. Install GitHub CLI (gh), yq, k9s, and helm
+# 2. Install credential-free utility CLIs used by the sandbox.
 RUN ARCH=$(dpkg --print-architecture) && \
-    curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" \
-    && dpkg -i /tmp/gh.deb \
-    && rm /tmp/gh.deb && \
     curl -sSLf -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_${ARCH}" && \
     chmod +x /usr/local/bin/yq && \
     curl -sSLf -o /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/download/v0.51.0/k9s_Linux_${ARCH}.tar.gz" && \
@@ -50,6 +40,7 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     google-auth \
     google-cloud-pubsub \
     "hermes-agent[google_chat]" \
+    "hermes-agent[slack]" \
     opentelemetry-api \
     opentelemetry-sdk \
     opentelemetry-exporter-otlp-proto-http
@@ -59,8 +50,10 @@ RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed
     grep -q "reversed(list(placeholders.items()))" /opt/hermes/plugins/platforms/google_chat/adapter.py
 
 
-# 4. Clone and build mcp-remote proxy
-RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \
+# 3. Clone and build mcp-remote proxy. Git is a build-only dependency here;
+# the sandbox runtime exposes only the credential-proxy Git wrapper.
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \
     cd /opt/mcp-remote && \
     git checkout 2ff8f16753d8c744e6982b99e6ed5ab62f44f311 && \
     npm install && \
@@ -80,11 +73,26 @@ RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes pl
     HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins enable hermes_otel && \
     /opt/hermes/.venv/bin/python3 -c "import yaml, pathlib; p = pathlib.Path('/opt/defaults/plugins/hermes_otel/config.yaml'); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; c['backends'] = [{'name': 'gke-managed-otel', 'type': 'otlp', 'endpoint': 'http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces'}]; p.write_text(yaml.safe_dump(c))"
 
-
+# Remove the build-only clone dependency after all plugin installation is done.
+RUN apt-get purge -y git && apt-get autoremove -y && \
+	rm -rf /var/lib/apt/lists/* && \
+	for binary in gcloud kubectl gh git; do \
+		if command -v "${binary}" >/dev/null 2>&1; then \
+			echo "unexpected credential-aware CLI in sandbox image: ${binary}" >&2; \
+			exit 1; \
+		fi; \
+	done
 
 # 5.8. Copy custom agent startup script
 COPY deploy/shared/docker-entrypoint.sh /usr/local/bin/agent-entrypoint
-RUN chmod 755 /usr/local/bin/agent-entrypoint
+COPY deploy/shared/credential-proxy-path.sh /etc/profile.d/credential-proxy-path.sh
+COPY agents/platform/scripts/credential_proxy_client.py /usr/local/bin/credential-proxy-exec
+RUN chmod 755 /usr/local/bin/agent-entrypoint /usr/local/bin/credential-proxy-exec /etc/profile.d/credential-proxy-path.sh && \
+    mkdir -p /opt/credential-proxy/bin && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/kubectl && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/gcloud && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/gh && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/git
 
 # 6. Expose ports shared by all agent gateways
 EXPOSE 8642
@@ -133,3 +141,29 @@ RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills /opt/hermes/plugins 
     find /opt/hermes/plugins -type f -exec chmod 644 {} + && \
     find /opt/defaults/scripts -type f -exec chmod 755 {} + 2>/dev/null && \
     find /opt/hermes/skills -path '*/scripts/*' -type f -exec chmod 755 {} + 2>/dev/null || true
+
+
+# --- CREDENTIAL PROXY TARGET ---
+# Only this image contains the real credential-aware CLIs. The platform target
+# above contains wrappers with the same names and cannot execute locally.
+FROM platform AS credential-proxy
+
+USER root
+
+COPY --from=envoy-bin /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --chmod=0644 deploy/shared/envoy-credential-proxy.yaml /etc/envoy/envoy-credential-proxy.yaml
+COPY deploy/shared/envoy-credential-sidecar.sh /usr/local/bin/envoy-credential-sidecar
+
+RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y \
+      git \
+      google-cloud-cli \
+      google-cloud-cli-gke-gcloud-auth-plugin \
+      kubectl && \
+    ARCH=$(dpkg --print-architecture) && \
+    curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" && \
+    dpkg -i /tmp/gh.deb && \
+    rm -f /tmp/gh.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 755 /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar

--- a/deploy/shared/credential-proxy-path.sh
+++ b/deploy/shared/credential-proxy-path.sh
@@ -1,0 +1,3 @@
+# Login shells are used by the agent terminal executor. Keep credential-aware
+# CLI names ahead of the native binaries that exist only for the paired proxy.
+export PATH="/opt/credential-proxy/bin:${PATH}"

--- a/deploy/shared/envoy-credential-proxy.yaml
+++ b/deploy/shared/envoy-credential-proxy.yaml
@@ -1,0 +1,44 @@
+static_resources:
+  listeners:
+    - name: credential_proxy
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8765
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: credential_proxy
+                route_config:
+                  name: credential_proxy
+                  virtual_hosts:
+                    - name: credential_proxy
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: credential_runtime
+                            timeout: 0s
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: credential_runtime
+      connect_timeout: 1s
+      type: STATIC
+      load_assignment:
+        cluster_name: credential_runtime
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /var/run/credential-proxy/backend.sock
+
+admin:
+  address:
+    pipe:
+      path: /var/run/credential-proxy/envoy-admin.sock

--- a/deploy/shared/envoy-credential-sidecar.sh
+++ b/deploy/shared/envoy-credential-sidecar.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_pid=""
+envoy_pid=""
+
+terminate() {
+  [[ -z "${runtime_pid}" ]] || kill "${runtime_pid}" 2>/dev/null || true
+  [[ -z "${envoy_pid}" ]] || kill "${envoy_pid}" 2>/dev/null || true
+}
+trap terminate EXIT INT TERM
+
+/opt/hermes/.venv/bin/python3 /opt/defaults/scripts/credential_proxy.py &
+runtime_pid=$!
+
+/usr/local/bin/envoy --config-path /etc/envoy/envoy-credential-proxy.yaml --log-level info &
+envoy_pid=$!
+
+wait -n "${runtime_pid}" "${envoy_pid}"

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -1,0 +1,264 @@
+# PlatformAgent Credential Isolation
+
+## Summary
+
+### Goal
+
+The PlatformAgent sandbox container must not receive API keys, access tokens,
+refresh tokens, or Kubernetes ServiceAccount tokens through its environment or
+filesystem.
+
+Credential values returned by an approved tool call are an accepted risk. For
+example, an approved `gcloud auth print-access-token` response may expose a
+token to the agent. Preventing that disclosure is not part of this design.
+
+### Design
+
+Each PlatformAgent runs as one long-lived Pod with these managed containers:
+
+1. `platform-agent`: the untrusted agent sandbox.
+2. `envoy-credential-proxy`: Envoy plus the credentialed command and chat
+   runtime.
+3. `fluent-bit`: log forwarding.
+
+The sandbox calls wrappers for `gcloud`, `kubectl`, `gh`, and `git`. Wrappers
+send a structured argument vector to Envoy at `127.0.0.1:8765`. Envoy forwards
+requests over a private Unix socket to the credential runtime. Slack and Google
+Chat use the same local relay.
+
+Only the credential sidecar receives secret environment variables, credential
+state volumes, and the explicitly projected Kubernetes ServiceAccount (KSA)
+token. It also authenticates callers of the PlatformAgent API before forwarding
+requests with a non-secret internal sentinel. Pod-wide automatic KSA token
+mounting is disabled.
+
+### Guarantee
+
+The operator does not place managed credentials in the sandbox container's:
+
+- environment;
+- root filesystem;
+- persistent agent volume; or
+- mounted ServiceAccount token path.
+
+`spec.deployment.env` is applied to the credential sidecar because it may
+contain credentials. Four allowlisted OpenTelemetry settings may also be copied
+to the sandbox, but only as literal values; all `valueFrom` sources are rejected.
+Reserved proxy, runtime-loader, and shell-startup variables cannot override the
+operator's managed values.
+
+### Limitation
+
+Containers in one Pod share a network namespace and one Pod identity. The
+sandbox does not have the KSA token file, but it can technically reach the GKE
+metadata server used by the credential sidecar. A Pod-level NetworkPolicy
+cannot block metadata for one container while allowing it for another.
+
+This design therefore meets the scoped filesystem-and-environment goal, but it
+does not provide the stronger identity boundary of separate Pods. It assumes
+the agent does not deliberately request credentials from the metadata server.
+
+## Scope
+
+### In scope
+
+- PlatformAgent only.
+- Credentials managed by the operator.
+- CLI forwarding for `gcloud`, `kubectl`, `gh`, and `git`.
+- Slack and Google Chat credentialed relays.
+- PlatformAgent API bearer-key termination in the credential sidecar.
+- GitHub installation tokens minted through Minty.
+- Sidecar health, lifecycle, rollout, and migration from the former proxy Pod.
+
+### Out of scope
+
+- Preventing credentials from appearing in approved command or tool output.
+- Preventing an approved credentialed command from deliberately copying a
+  credential into the shared workspace. Such credential disclosure and tool
+  side effects require a separate approval/policy design.
+- Preventing deliberate access to the shared Pod identity or metadata server.
+- Arbitrary user-supplied init containers, sidecars, volumes, and mounts. These
+  are trusted configuration and may intentionally weaken isolation.
+- OperatorAgent and DevTeamAgent.
+- General data-exfiltration prevention.
+
+## Architecture
+
+```text
+PlatformAgent Pod
+
+  platform-agent
+    credential-free env and mounts
+    CLI wrappers / chat adapters
+              |
+              | HTTP on 127.0.0.1:8765
+              v
+  envoy-credential-proxy
+    Envoy listener
+              |
+              | private Unix socket
+              v
+    credential runtime
+    real CLIs, Slack/Chat clients, Minty client
+    secret env, KSA token, private temporary state
+```
+
+Envoy is the only listener for credentialed tool and chat requests. The
+credential runtime listens on a Unix socket mounted only in the sidecar, so the
+sandbox cannot bypass Envoy by calling the runtime directly. A separate sidecar
+listener authenticates the existing PlatformAgent API on port 8643 and forwards
+to the sandbox API on loopback using a non-secret sentinel.
+
+The containers have the same lifecycle because they are part of the same
+Deployment and Pod. If the sidecar is not ready, the Pod is not ready. If either
+Envoy or the credential runtime exits, the sidecar exits and Kubernetes restarts
+it.
+
+## Credential Placement
+
+| Data                            | Sandbox     | Credential sidecar        |
+| ------------------------------- | ----------- | ------------------------- |
+| `spec.deployment.env`           | No          | Yes                       |
+| Slack tokens                    | No          | Yes, Secret-backed env    |
+| PlatformAgent external API key  | No          | Yes, Secret-backed env    |
+| Automatic KSA token mount       | Disabled    | Disabled                  |
+| Explicit projected KSA token    | Not mounted | Read-only, one-hour token |
+| gcloud/kubectl configuration    | No          | Private `emptyDir`        |
+| GitHub installation token/cache | No          | Private `emptyDir`        |
+| Agent workspace                 | Yes         | Yes, for proxied commands |
+
+The projected token uses the audience `kubeagents-credential-proxy`, expires
+after one hour, and is mounted only at
+`/var/run/secrets/kubeagents/serviceaccount/token` in the credential sidecar.
+Deleting a default token during startup is intentionally not used: projected
+tokens rotate, and mount-time exclusion is reliable.
+
+## Request Paths
+
+### CLI commands
+
+The sandbox image contains wrapper binaries instead of credential-aware CLI
+binaries. A wrapper sends the executable name and argument array to the local
+proxy. The credential runtime directly executes the corresponding real CLI and
+returns output and exit status. It never evaluates an agent-supplied shell
+command.
+
+Only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy also rejects
+known credential-disclosure, credential-replacement, and self-modification
+operations. Pipelines and redirections are interpreted by the sandbox shell
+around an individual wrapper invocation, so they cannot execute inside the
+credential sidecar. Requests that cannot be represented safely fail closed,
+including:
+
+- interactive TTY programs and password prompts;
+- arbitrary binary or unbounded streaming input/output;
+- file paths that refer to sandbox-only files;
+- background processes or commands that outlive the request; and
+- commands exceeding request, output, or timeout limits.
+
+Standard input and full-duplex streaming require a future bounded protocol; the
+wrapper does not silently consume an inherited protocol stream.
+
+### Chat
+
+Slack and Google Chat adapters send credential-free request payloads to Envoy.
+The credential runtime owns platform tokens and performs the external API call.
+Allowlisted users, payload size limits, and file size limits are enforced by the
+relay.
+
+### PlatformAgent API
+
+The Kubernetes Service sends API traffic to port 8643 on the credential
+sidecar. The sidecar validates the configured external bearer key and replaces
+it with the sandbox's fixed, non-secret sentinel before forwarding to port 8642.
+Existing API clients retain bearer-key authentication without placing the real
+key in the sandbox.
+
+### GitHub and Minty
+
+The credential sidecar obtains a Google OIDC identity token and calls Minty.
+Minty validates CEL authorization rules for the authenticated agent identity and
+requested repository, then brokers a repository-scoped GitHub installation
+token with a maximum one-hour lifetime. The GitHub App private key remains in
+Cloud KMS and signing uses `AsymmetricSign`.
+
+The workspace is mounted at the same path in both containers so proxied Git
+commands operate on the agent's repository. Git authentication, CLI config, and
+token caches remain on a separate sidecar-only volume. The sandbox receives
+only command output, never a mounted Git credential file.
+
+## Kubernetes Details
+
+- The Pod uses the configured PlatformAgent KSA for the credential sidecar's
+  Workload Identity.
+- `automountServiceAccountToken: false` applies to the Pod.
+- A projected ServiceAccount token volume is mounted only by the credential
+  sidecar.
+- Secret and credential-state volumes are mounted only by the credential
+  sidecar.
+- The sandbox and sidecar run non-root, drop all Linux capabilities, disallow
+  privilege escalation, and use the runtime-default seccomp profile.
+- The credential sidecar root filesystem is read-only; writable state uses
+  bounded `emptyDir` volumes.
+- A policy ConfigMap hash is placed on the Pod template to trigger rollout when
+  command policy changes.
+- The operator reports Ready only when the combined Pod is ready.
+
+## Deployment and Migration
+
+The operator always creates the sandbox and Envoy credential sidecar together
+in the existing `<agent>-gateway` Deployment and retains the existing
+`<agent>-data` PVC. Before the sandbox starts, a managed init container removes
+legacy gcloud, GitHub, Git, Kubernetes, AWS, Azure, Docker, npm, and Python
+credential files from that PVC. This preserves agent state without carrying
+credentials forward from an older deployment. It deletes operator-owned
+resources from the abandoned two-Pod design:
+
+- `<agent>-credential-proxy` Deployment;
+- `<agent>-credential-proxy` Service;
+- `<agent>-sandbox` ServiceAccount; and
+- `<agent>-sandbox-metadata-deny` NetworkPolicy.
+
+Deletion refuses to remove resources not owned by the PlatformAgent.
+
+The credential-sidecar image contains Envoy, the real credential-aware CLIs,
+and the credential runtime. The sandbox image contains only the wrappers for
+those CLI names.
+
+## Tradeoffs
+
+Benefits:
+
+- one Deployment and one Pod lifecycle;
+- no managed credential env or files in the sandbox container;
+- no separate proxy Service or cross-Pod availability coordination;
+- a single local surface for CLI and chat policy; and
+- credentials remain usable without adding real cloud CLIs to the sandbox.
+
+Costs:
+
+- no hard network or identity boundary between the sandbox and sidecar;
+- a custom command-forwarding protocol must be maintained;
+- interactive, streaming, and file-based CLI behavior is limited; and
+- each new service needs an explicit proxy integration and policy.
+
+If deliberate metadata or Pod-identity access becomes in scope, this design
+must return to separate Pods or use a node/runtime mechanism that enforces
+per-container network identity.
+
+## Verification
+
+CI and deployment tests should assert that:
+
+1. the sandbox has no Secret-backed env, `spec.deployment.env`, secret volume,
+   credential-state volume, or ServiceAccount token mount;
+2. only the credential sidecar mounts the projected KSA token and proxy state;
+3. only the credential sidecar receives Slack tokens and deployment env;
+4. wrapper URLs resolve to `127.0.0.1:8765`;
+5. Envoy can reach the Unix-socket backend and `/healthz` reflects both;
+6. unsupported executables, raw shell requests, and blocked disclosure commands
+   fail closed;
+7. the old proxy Deployment and Service are absent after reconciliation; and
+8. the external PlatformAgent API key is accepted by the sidecar and replaced
+   before forwarding to the loopback-only sandbox API; and
+9. Pod readiness fails when either Envoy or the credential runtime fails.

--- a/k8s-operator/.dockerignore
+++ b/k8s-operator/.dockerignore
@@ -1,0 +1,4 @@
+.git
+bin/
+cover.out
+*.test

--- a/k8s-operator/.gcloudignore
+++ b/k8s-operator/.gcloudignore
@@ -1,0 +1,5 @@
+.gcloudignore
+.git
+bin/
+cover.out
+*.test

--- a/k8s-operator/config/integrations/github/deployment.yaml.template
+++ b/k8s-operator/config/integrations/github/deployment.yaml.template
@@ -113,7 +113,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app: platform-agent
+              kubeagents.x-k8s.io/has-credential-proxy: "true"
       ports:
         - protocol: TCP
           port: 8080

--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -77,6 +77,18 @@ rules:
       - patch
       - update
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - node.k8s.io
     resources:
       - runtimeclasses

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	nodev1 "k8s.io/api/node/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -56,6 +57,7 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;persistentvolumeclaims;configmaps;services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces;nodes;pods;events;persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings,verbs=get;list;watch;create;update;patch;delete;bind
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
@@ -88,7 +90,6 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.reconcileServiceAccount(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
-
 	// 3b. Reconcile RBAC (ClusterRole and ClusterRoleBindings)
 	if err := r.reconcileRBAC(ctx, instance); err != nil {
 		return ctrl.Result{}, err
@@ -117,6 +118,11 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	proxyPolicyHash, err := r.reconcileCredentialProxyPolicyConfigMap(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// 6. Validate RuntimeClass if specified
 	if err := r.validateRuntimeClass(ctx, instance); err != nil {
 		if errors.IsNotFound(err) {
@@ -131,8 +137,8 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to validate RuntimeClass: %w", err)
 	}
 
-	// 7. Reconcile Deployment (with pod template hash annotation)
-	if err := r.reconcileDeployment(ctx, instance, configMapHash, fluentBitHash, settingsHash); err != nil {
+	// 7. Reconcile the Agent Sandbox Pod with its Envoy credential sidecar.
+	if err := r.reconcileDeployment(ctx, instance, configMapHash, fluentBitHash, settingsHash, proxyPolicyHash); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -140,8 +146,11 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.reconcileService(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
+	if err := r.deleteLegacyCredentialProxyResources(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
-	// 7. Update status phase to Ready
+	// 9. Update status phase to Ready
 	return ctrl.Result{}, r.updateStatusReady(ctx, instance)
 }
 
@@ -277,12 +286,47 @@ func (r *PlatformAgentReconciler) reconcileSettingsConfigMap(ctx context.Context
 	return hash, nil
 }
 
-func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsHash string) error {
-	dep := buildDeployment(agent, configHash, fluentBitHash, settingsHash)
+func (r *PlatformAgentReconciler) reconcileCredentialProxyPolicyConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) (string, error) {
+	cm := buildCredentialProxyPolicyConfigMap(agent)
+	if err := ctrl.SetControllerReference(agent, cm, r.Scheme); err != nil {
+		return "", err
+	}
+	if err := r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller")); err != nil {
+		return "", err
+	}
+	return getConfigMapHash(cm)
+}
+
+func (r *PlatformAgentReconciler) reconcileDeployment(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsHash, policyHash string) error {
+	dep := buildDeployment(agent, configHash, fluentBitHash, settingsHash, policyHash)
 	if err := ctrl.SetControllerReference(agent, dep, r.Scheme); err != nil {
 		return err
 	}
 	return r.Patch(ctx, dep, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+}
+
+func (r *PlatformAgentReconciler) deleteLegacyCredentialProxyResources(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	resources := []client.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox", Namespace: agent.Namespace}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox-metadata-deny", Namespace: agent.Namespace}},
+	}
+	for _, resource := range resources {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			continue
+		}
+		if !metav1.IsControlledBy(resource, agent) {
+			return fmt.Errorf("refusing to delete unowned legacy %T %s/%s", resource, resource.GetNamespace(), resource.GetName())
+		}
+		if err := client.IgnoreNotFound(r.Delete(ctx, resource)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *PlatformAgentReconciler) reconcileService(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
@@ -318,7 +362,7 @@ func (r *PlatformAgentReconciler) reconcileRBAC(ctx context.Context, agent *agen
 }
 
 func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
-	// Fetch actual Deployment
+	// Fetch the PlatformAgent Deployment.
 	dep := &appsv1.Deployment{}
 	errDep := r.Get(ctx, types.NamespacedName{Namespace: agent.Namespace, Name: agent.Name + "-gateway"}, dep)
 	if errDep != nil && !errors.IsNotFound(errDep) {
@@ -364,7 +408,7 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 		newPhase = "Ready"
 		condStatus = metav1.ConditionTrue
 		condReason = "Reconciled"
-		condMsg = "Agent deployment and resources are fully reconciled"
+		condMsg = "Agent sandbox and Envoy credential sidecar are fully reconciled"
 	} else if errDep == nil {
 		if phaseOverride, reasonOverride, msgOverride := r.getDeploymentStatusDetails(ctx, agent, dep); reasonOverride != "Provisioning" {
 			newPhase = phaseOverride
@@ -489,6 +533,7 @@ func (r *PlatformAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(
 			&rbacv1.ClusterRoleBinding{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/k8s-operator/internal/controller/platformagent_controller_test.go
+++ b/k8s-operator/internal/controller/platformagent_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	nodev1 "k8s.io/api/node/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -168,6 +169,9 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 			t.Errorf("expected Deployment to have container named 'platform-agent'")
 		}
 	}
+	if len(dep.Spec.Template.Spec.Containers) < 3 || dep.Spec.Template.Spec.Containers[2].Name != "envoy-credential-proxy" {
+		t.Errorf("expected Deployment to contain Envoy credential sidecar")
+	}
 
 	// Service
 	svc := &corev1.Service{}
@@ -217,6 +221,39 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer:test-ns:test-agent"}, explorerRole)
 	if err == nil {
 		t.Errorf("expected ClusterRole to be deleted")
+	}
+}
+
+func TestDeleteLegacyCredentialProxyResources(t *testing.T) {
+	scheme := setupScheme()
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns", UID: types.UID("agent-uid")},
+	}
+	ownerReference := metav1.OwnerReference{
+		APIVersion: agentv1alpha1.GroupVersion.String(),
+		Kind:       "PlatformAgent",
+		Name:       agent.Name,
+		UID:        agent.UID,
+		Controller: ptr.To(true),
+	}
+	objects := []client.Object{
+		agent,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox-metadata-deny", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &PlatformAgentReconciler{Client: cl, Scheme: scheme}
+
+	if err := r.deleteLegacyCredentialProxyResources(context.Background(), agent); err != nil {
+		t.Fatalf("deleteLegacyCredentialProxyResources failed: %v", err)
+	}
+	for _, object := range objects[1:] {
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(object), object)
+		if !errors.IsNotFound(err) {
+			t.Errorf("expected legacy %T to be deleted, got %v", object, err)
+		}
 	}
 }
 
@@ -436,7 +473,7 @@ func TestPlatformAgentReconciler_Reconcile_PodUnschedulable(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-agent-unschedulable-gateway-pod",
+			Name:      "test-agent-unschedulable-sandbox-pod",
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				"app": "test-agent-unschedulable-gateway",
@@ -520,7 +557,7 @@ func TestPlatformAgentReconciler_Reconcile_PodUnschedulable(t *testing.T) {
 		t.Fatalf("expected Ready condition False with reason PodUnschedulable, got %v", cond)
 	}
 
-	expectedMsg := "Pod test-agent-unschedulable-gateway-pod is waiting to be scheduled because no nodes in the cluster match the requested RuntimeClass 'gvisor'. For GKE Standard, enable GKE Sandbox by provisioning a gVisor node pool."
+	expectedMsg := "Pod test-agent-unschedulable-sandbox-pod is waiting to be scheduled because no nodes in the cluster match the requested RuntimeClass 'gvisor'. For GKE Standard, enable GKE Sandbox by provisioning a gVisor node pool."
 	if cond.Message != expectedMsg {
 		t.Errorf("expected polished condition message:\n%q\ngot:\n%q", expectedMsg, cond.Message)
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -37,6 +37,22 @@ import (
 
 const defaultPlatformAgentSecrets = "platform-agent-secrets"
 const sessionKVDBPath = "/var/lib/kube-agents/session/session_kv.db"
+const credentialProxyPort = 8765
+
+const credentialProxyPolicyJSON = `{
+  "apiVersion": "cli.proxy.kubeagents.io/v1alpha1",
+  "blockedMessage": "Command blocked for security reasons.",
+  "rules": [
+    {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\s+auth\\s+(?:application-default\\s+)?print-(?:access|identity)-token\\b"},
+    {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\s+config\\s+config-helper\\b"},
+    {"id":"github.token-disclosure","pattern":"\\bgh\\s+auth\\s+token\\b|\\bgh\\s+auth\\s+status\\b[^;&|\\n]*--show-token\\b"},
+    {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\s+create\\s+token\\b|\\bkubectl\\s+config\\s+view\\b[^;&|\\n]*--raw\\b"},
+    {"id":"git.credential-disclosure","pattern":"\\bgit\\s+credential\\s+fill\\b"},
+    {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\s+auth\\s+(?:login|activate-service-account)\\b|\\bgcloud\\s+auth\\s+application-default\\s+login\\b"},
+    {"id":"github.credential-replacement","pattern":"\\bgh\\s+auth\\s+(?:login|refresh|switch|logout)\\b"},
+    {"id":"tool.self-modification","pattern":"\\bgcloud\\s+components\\s+(?:install|update|remove)\\b|\\bgh\\s+extension\\s+(?:install|upgrade|remove)\\b"}
+  ]
+}`
 
 // buildConfigMap generates the ConfigMap manifest containing config.yaml
 func buildConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
@@ -280,8 +296,8 @@ func buildSystemPVC(agent *agentv1alpha1.PlatformAgent) *corev1.PersistentVolume
 	}
 }
 
-// buildDeployment generates the Deployment manifest for the agent payload
-func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash string) *appsv1.Deployment {
+// buildDeployment generates the credential-free Agent Sandbox Deployment.
+func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string) *appsv1.Deployment {
 	replicas, strategy := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
 	// UID/GID 10000 matches the canonical unprivileged 'hermes' runtime user created in NousResearch/hermes-agent upstream Dockerfile
 	fsGroup := int64(10000)
@@ -317,6 +333,9 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.AgentHome != "" {
 		homeDir = agent.Spec.Harness.Hermes.AgentHome
 	}
+	// The data PVC survives upgrades. Remove credential files written by older,
+	// credentialed deployments before the agent sandbox can mount the PVC.
+	initContainers = append([]corev1.Container{buildSandboxCredentialCleanup(image, pullPolicy)}, initContainers...)
 
 	dashboardVal := "0"
 	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.DashboardEnabled != nil {
@@ -355,7 +374,13 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 		},
 		{
 			Name:  "API_SERVER_HOST",
-			Value: "0.0.0.0",
+			Value: "127.0.0.1",
+		},
+		{
+			// The sidecar authenticates external callers and replaces their bearer
+			// key with this non-secret loopback sentinel.
+			Name:  "API_SERVER_KEY",
+			Value: "cluster-internal-trusted",
 		},
 		{
 			Name:  "SESSION_KV_DB_PATH",
@@ -364,6 +389,9 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	}
 
 	envVars = append(envVars, otelTelemetryEnvVars("platform", agent.Name, agent.Namespace)...)
+	if agent.Spec.Deployment != nil {
+		envVars = mergeEnvVars(envVars, safeSandboxEnvOverrides(agent.Spec.Deployment.Env))
+	}
 
 	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.BrowserArgs) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
@@ -373,6 +401,12 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	}
 
 	if agent.Spec.Harness != nil {
+		if agent.Spec.Harness.ProjectID != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "GKE_PROJECT_ID",
+				Value: agent.Spec.Harness.ProjectID,
+			})
+		}
 		if agent.Spec.Harness.ClusterName != "" {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  "GKE_CLUSTER_NAME",
@@ -385,19 +419,30 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 				Value: agent.Spec.Harness.Location,
 			})
 		}
-		if agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.ApiServerSecretRef != nil {
+		if agent.Spec.Harness.ProjectID != "" && agent.Spec.Harness.Location != "" && agent.Spec.Harness.ClusterName != "" {
 			envVars = append(envVars, corev1.EnvVar{
-				Name: "API_SERVER_KEY",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: agent.Spec.Harness.Hermes.ApiServerSecretRef,
-				},
+				Name: "KUBE_CONTEXT_NAME",
+				Value: fmt.Sprintf(
+					"gke_%s_%s_%s",
+					agent.Spec.Harness.ProjectID,
+					agent.Spec.Harness.Location,
+					agent.Spec.Harness.ClusterName,
+				),
 			})
 		}
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "KUBE_DEFAULT_NAMESPACE",
+			Value: agent.Namespace,
+		})
 	}
 
 	if integration := agent.Spec.Integration; integration != nil {
 		if gchat := integration.GoogleChat; gchat != nil && gchat.Enabled != nil && *gchat.Enabled {
 			envVars = append(envVars, []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_CHAT_RELAY_URL",
+					Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
+				},
 				{
 					Name:  "GOOGLE_CHAT_PROJECT_ID",
 					Value: gchat.ProjectID,
@@ -427,16 +472,10 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			}
 		}
 		if slack := integration.Slack; slack != nil && slack.Enabled != nil && *slack.Enabled {
-			envVars = append(envVars,
-				corev1.EnvVar{
-					Name:      "SLACK_BOT_TOKEN",
-					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.BotTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_BOT_TOKEN")},
-				},
-				corev1.EnvVar{
-					Name:      "SLACK_APP_TOKEN",
-					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.AppTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_APP_TOKEN")},
-				},
-			)
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "SLACK_RELAY_URL",
+				Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
+			})
 			allowAllSlack := len(slack.AllowedUsers) == 0 || (len(slack.AllowedUsers) == 1 && slack.AllowedUsers[0] == "")
 			if allowAllSlack {
 				envVars = append(envVars, corev1.EnvVar{
@@ -465,13 +504,17 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	}
 
 	envVars = append(envVars, corev1.EnvVar{
-		Name:  "TOKEN_BROKER_URL",
-		Value: fmt.Sprintf("http://github-token-minter.%s.svc.cluster.local:8080/token", agent.Namespace),
+		Name:  "CREDENTIAL_PROXY_URL",
+		Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
 	})
-
-	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.Env) > 0 {
-		envVars = mergeEnvVars(envVars, agent.Spec.Deployment.Env)
-	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PATH",
+		Value: "/opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	})
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PYTHONPATH",
+		Value: "/opt/defaults/scripts",
+	})
 
 	var runtimeClassName *string
 	if agent.Spec.Deployment != nil {
@@ -479,17 +522,19 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	}
 
 	containers := buildBaseContainers(image, pullPolicy, envVars, homeDir, extraVolumeMounts)
+	containers = append(containers, buildCredentialProxySidecar(agent, homeDir))
 	defaultAnnotations := map[string]string{
 		"kubeagents.x-k8s.io/config-hash":            configHash,
 		"kubeagents.x-k8s.io/fluent-bit-config-hash": fluentBitHash,
 		"kubeagents.x-k8s.io/settings-config-hash":   settingsConfigHash,
+		"kubeagents.x-k8s.io/proxy-policy-hash":      policyHash,
 	}
-
 	if len(sidecars) > 0 {
 		containers = append(containers, sidecars...)
 	}
 
 	volumes := buildDefaultVolumes(agent)
+	volumes = append(volumes, buildCredentialProxyVolumes(agent)...)
 	if len(sidecarVolumes) > 0 {
 		volumes = append(volumes, sidecarVolumes...)
 	}
@@ -507,6 +552,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			Namespace: agent.Namespace,
 			Labels: map[string]string{
 				"app": agent.Name + "-gateway",
+				"kubeagents.x-k8s.io/has-credential-proxy": "true",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -521,13 +567,15 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": agent.Name + "-gateway",
+						"kubeagents.x-k8s.io/has-credential-proxy": "true",
 					},
 					Annotations: mergeAnnotations(defaultAnnotations, podAnnotations),
 				},
 				Spec: corev1.PodSpec{
-					RuntimeClassName:   runtimeClassName,
-					InitContainers:     initContainers,
-					ServiceAccountName: saName,
+					RuntimeClassName:             runtimeClassName,
+					InitContainers:               initContainers,
+					ServiceAccountName:           saName,
+					AutomountServiceAccountToken: ptr.To(false),
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: &fsGroup,
 						// UID 10000 matches canonical 'hermes' runtime user in upstream image (NousResearch/hermes-agent Dockerfile line 92)
@@ -543,29 +591,248 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 	}
 }
 
-// buildDefaultContainers generates the default containers for PlatformAgent
+func buildSandboxCredentialCleanup(image string, pullPolicy corev1.PullPolicy) corev1.Container {
+	return corev1.Container{
+		Name:            "sandbox-credential-cleanup",
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"sh", "-ec"},
+		Args: []string{`rm -rf -- \
+  /workspace/home/.config/gcloud \
+  /workspace/home/.config/gh \
+  /workspace/home/.aws/credentials \
+  /workspace/home/.aws/cli/cache \
+  /workspace/home/.aws/sso/cache \
+  /workspace/home/.azure \
+  /workspace/home/.docker/config.json \
+  /workspace/home/.git-credentials \
+  /workspace/home/.hermes/.env \
+  /workspace/home/.kube/config \
+  /workspace/home/.netrc \
+  /workspace/home/.npmrc \
+  /workspace/home/.pypirc`},
+		VolumeMounts: []corev1.VolumeMount{{Name: "platform-agent-data-vol", MountPath: "/workspace"}},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+func buildCredentialProxyPolicyConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name + "-credential-proxy-policy",
+			Namespace: agent.Namespace,
+		},
+		Data: map[string]string{"policy.json": credentialProxyPolicyJSON},
+	}
+}
+
+// buildCredentialProxySidecar returns the Envoy-fronted credential runtime.
+// Its environment and volume mounts are intentionally disjoint from the agent
+// container even though both containers share a Pod network namespace.
+func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir string) corev1.Container {
+	image := resolveCredentialProxyImage(agent.Spec.Deployment)
+	pullPolicy := corev1.PullAlways
+	if agent.Spec.Deployment != nil && agent.Spec.Deployment.ImagePullPolicy != nil {
+		pullPolicy = *agent.Spec.Deployment.ImagePullPolicy
+	}
+	envVars := buildCredentialProxyEnv(agent)
+	envVars = append(envVars, corev1.EnvVar{Name: "CREDENTIAL_PROXY_WORKSPACE_ROOT", Value: homeDir})
+	return corev1.Container{
+		Name:            "envoy-credential-proxy",
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"/usr/local/bin/envoy-credential-sidecar"},
+		Env:             envVars,
+		Ports: []corev1.ContainerPort{
+			{Name: "cred-proxy", ContainerPort: credentialProxyPort},
+			{Name: "api", ContainerPort: 8643},
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: []string{
+				"curl", "--fail", "--silent", "--show-error", "http://127.0.0.1:8765/healthz",
+			}}},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("2Gi"), corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "credential-proxy-policy", MountPath: "/etc/credential-proxy/policy.json", SubPath: "policy.json", ReadOnly: true},
+			{Name: "credential-proxy-tmp", MountPath: "/tmp"},
+			{Name: "credential-proxy-state", MountPath: "/var/lib/credential-proxy"},
+			{Name: "credential-proxy-runtime", MountPath: "/var/run/credential-proxy"},
+			{Name: "credential-proxy-ksa-token", MountPath: "/var/run/secrets/kubeagents/serviceaccount", ReadOnly: true},
+			{Name: "platform-agent-data-vol", MountPath: homeDir},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false), ReadOnlyRootFilesystem: ptr.To(true), Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+func buildCredentialProxyEnv(agent *agentv1alpha1.PlatformAgent) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		{Name: "PLATFORM_AGENT_HOME", Value: "/tmp/credential-proxy"},
+		{Name: "HOME", Value: "/tmp/credential-proxy/home"},
+		{Name: "CREDENTIAL_PROXY_POLICY", Value: "/etc/credential-proxy/policy.json"},
+		{Name: "CREDENTIAL_PROXY_STATE_DIR", Value: "/var/lib/credential-proxy"},
+		{Name: "CREDENTIAL_PROXY_UNIX_SOCKET", Value: "/var/run/credential-proxy/backend.sock"},
+		{Name: "KSA_TOKEN_FILE", Value: "/var/run/secrets/kubeagents/serviceaccount/token"},
+		{Name: "TOKEN_BROKER_URL", Value: fmt.Sprintf("http://github-token-minter.%s.svc.cluster.local:8080/token", agent.Namespace)},
+		{Name: "AGENT_API_PROXY_PORT", Value: "8643"},
+		{Name: "AGENT_API_UPSTREAM_KEY", Value: "cluster-internal-trusted"},
+	}
+	apiServerSecretRef := defaultSecretRef(nil, defaultPlatformAgentSecrets, "API_SERVER_KEY")
+	if harness := agent.Spec.Harness; harness != nil && harness.Hermes != nil && harness.Hermes.ApiServerSecretRef != nil {
+		apiServerSecretRef = harness.Hermes.ApiServerSecretRef
+	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name: "API_SERVER_EXTERNAL_KEY",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: apiServerSecretRef,
+		},
+	})
+	if harness := agent.Spec.Harness; harness != nil && harness.ProjectID != "" && harness.Location != "" && harness.ClusterName != "" {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: "GKE_PROJECT_ID", Value: harness.ProjectID}, corev1.EnvVar{Name: "GKE_CLUSTER_NAME", Value: harness.ClusterName}, corev1.EnvVar{Name: "GKE_LOCATION", Value: harness.Location},
+			corev1.EnvVar{Name: "KUBE_CONTEXT_NAME", Value: fmt.Sprintf("gke_%s_%s_%s", harness.ProjectID, harness.Location, harness.ClusterName)}, corev1.EnvVar{Name: "KUBE_DEFAULT_NAMESPACE", Value: agent.Namespace},
+			corev1.EnvVar{Name: "CREDENTIAL_PROXY_BOOTSTRAP_COMMAND", Value: `gcloud config set project "$GKE_PROJECT_ID" >/dev/null &&
+gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location "$GKE_LOCATION" --project "$GKE_PROJECT_ID" &&
+kubectl config use-context "$KUBE_CONTEXT_NAME" >/dev/null &&
+kubectl config set-context "$KUBE_CONTEXT_NAME" --namespace="$KUBE_DEFAULT_NAMESPACE" >/dev/null`},
+		)
+	}
+	if integration := agent.Spec.Integration; integration != nil {
+		if gchat := integration.GoogleChat; gchat != nil && gchat.Enabled != nil && *gchat.Enabled {
+			envVars = append(envVars, corev1.EnvVar{Name: "GOOGLE_CHAT_PROJECT_ID", Value: gchat.ProjectID}, corev1.EnvVar{Name: "GOOGLE_CHAT_SUBSCRIPTION_NAME", Value: fmt.Sprintf("projects/%s/subscriptions/%s", gchat.ProjectID, gchat.SubscriptionName)})
+		}
+		if slack := integration.Slack; slack != nil && slack.Enabled != nil && *slack.Enabled {
+			envVars = append(envVars,
+				corev1.EnvVar{Name: "SLACK_BOT_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.BotTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_BOT_TOKEN")}},
+				corev1.EnvVar{Name: "SLACK_APP_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.AppTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_APP_TOKEN")}},
+			)
+		}
+	}
+	if agent.Spec.Deployment != nil {
+		envVars = mergeCredentialProxyEnv(envVars, agent.Spec.Deployment.Env)
+	}
+	return envVars
+}
+
+func mergeCredentialProxyEnv(managed, custom []corev1.EnvVar) []corev1.EnvVar {
+	reserved := map[string]struct{}{
+		"PATH": {}, "PYTHONPATH": {}, "ENV": {}, "BASH_ENV": {},
+		"LD_PRELOAD": {}, "LD_LIBRARY_PATH": {},
+	}
+	for _, env := range managed {
+		reserved[env.Name] = struct{}{}
+	}
+	for _, name := range []string{
+		"CREDENTIAL_PROXY_BOOTSTRAP_COMMAND",
+		"CREDENTIAL_PROXY_MAX_OUTPUT_BYTES",
+		"CREDENTIAL_PROXY_MAX_REQUEST_BYTES",
+		"CREDENTIAL_PROXY_POLICY",
+		"CREDENTIAL_PROXY_PORT",
+		"CREDENTIAL_PROXY_STATE_DIR",
+		"CREDENTIAL_PROXY_TIMEOUT_SECONDS",
+		"CREDENTIAL_PROXY_UNIX_SOCKET",
+		"CREDENTIAL_PROXY_WORKSPACE_ROOT",
+		"KSA_TOKEN_FILE",
+		"TOKEN_BROKER_URL",
+	} {
+		reserved[name] = struct{}{}
+	}
+
+	result := append([]corev1.EnvVar{}, managed...)
+	for _, env := range custom {
+		if _, found := reserved[env.Name]; !found {
+			result = append(result, env)
+		}
+	}
+	return result
+}
+
+// safeSandboxEnvOverrides preserves non-secret telemetry customization without
+// copying arbitrary deployment environment variables into the agent sandbox.
+func safeSandboxEnvOverrides(custom []corev1.EnvVar) []corev1.EnvVar {
+	allowed := map[string]struct{}{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": {},
+		"OTEL_EXPORTER_OTLP_PROTOCOL": {},
+		"OTEL_RESOURCE_ATTRIBUTES":    {},
+		"OTEL_SERVICE_NAME":           {},
+	}
+	var result []corev1.EnvVar
+	for _, env := range custom {
+		// Only literal telemetry settings are safe to copy. A ValueFrom source can
+		// reference a Secret even when its environment variable name is allowlisted.
+		if _, ok := allowed[env.Name]; ok && env.ValueFrom == nil {
+			result = append(result, env)
+		}
+	}
+	return result
+}
+
+func buildCredentialProxyVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volume {
+	return []corev1.Volume{
+		{Name: "credential-proxy-policy", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: agent.Name + "-credential-proxy-policy"}}}},
+		{Name: "credential-proxy-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("2Gi"))}}},
+		{Name: "credential-proxy-state", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("5Gi"))}}},
+		{Name: "credential-proxy-runtime", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory, SizeLimit: ptr.To(resource.MustParse("16Mi"))}}},
+		{Name: "credential-proxy-ksa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+			DefaultMode: ptr.To(int32(0400)),
+			Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+				Audience: "kubeagents-credential-proxy", ExpirationSeconds: ptr.To(int64(3600)), Path: "token",
+			}}},
+		}}},
+	}
+}
+
+func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) string {
+	image := defaultPlatformAgentImage
+	if deployment != nil && deployment.Image != "" {
+		image = deployment.Image
+	}
+	lastSlash := strings.LastIndex(image, "/")
+	prefix, name := "", image
+	if lastSlash >= 0 {
+		prefix, name = image[:lastSlash+1], image[lastSlash+1:]
+	}
+	suffix := ""
+	if digest := strings.Index(name, "@"); digest >= 0 {
+		suffix, name = name[digest:], name[:digest]
+	} else if tag := strings.LastIndex(name, ":"); tag >= 0 {
+		suffix, name = name[tag:], name[:tag]
+	}
+	if name == "platform-agent" {
+		name = "credential-proxy"
+	} else {
+		name += "-credential-proxy"
+	}
+	if deployment != nil && deployment.Tag != nil && *deployment.Tag != "" {
+		return prefix + name + ":" + *deployment.Tag
+	}
+	if suffix == "" {
+		suffix = ":latest"
+	}
+	return prefix + name + suffix
+}
+
+// buildBaseContainers generates the default containers for PlatformAgent.
 func buildBaseContainers(image string, pullPolicy corev1.PullPolicy, envVars []corev1.EnvVar, homeDir string, extraVolumeMounts []corev1.VolumeMount) []corev1.Container {
 	defaultPlatformAgentVolumeMounts := []corev1.VolumeMount{
-		{
-			Name:      "platform-agent-data-vol",
-			MountPath: homeDir,
-		},
-		{
-			Name:      "platform-agent-config-vol",
-			MountPath: fmt.Sprintf("%s/config.yaml", homeDir),
-			SubPath:   "config.yaml",
-		},
-		{
-			Name:      "settings-volume",
-			MountPath: path.Join(homeDir, "SETTINGS.md"),
-			SubPath:   "SETTINGS.md",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "system-metadata",
-			MountPath: path.Dir(sessionKVDBPath),
-			SubPath:   "session",
-		},
+		{Name: "platform-agent-data-vol", MountPath: homeDir},
+		{Name: "platform-agent-config-vol", MountPath: fmt.Sprintf("%s/config.yaml", homeDir), SubPath: "config.yaml"},
+		{Name: "settings-volume", MountPath: path.Join(homeDir, "SETTINGS.md"), SubPath: "SETTINGS.md", ReadOnly: true},
+		{Name: "system-metadata", MountPath: path.Dir(sessionKVDBPath), SubPath: "session"},
 	}
 
 	return []corev1.Container{
@@ -579,7 +846,7 @@ func buildBaseContainers(image string, pullPolicy corev1.PullPolicy, envVars []c
 					ContainerPort: 9119,
 				},
 				{
-					Name:          "api",
+					Name:          "agent-api",
 					ContainerPort: 8642,
 				},
 			},

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -215,6 +215,14 @@ func TestBuildDeployment(t *testing.T) {
 							Name:  "CUSTOM_VAR", // Duplicate custom var, should override previous
 							Value: "new-custom-value",
 						},
+						{
+							Name:  "CREDENTIAL_PROXY_STATE_DIR",
+							Value: "/var/agent/exposed-proxy-state",
+						},
+						{
+							Name:  "BASH_ENV",
+							Value: "/var/agent/untrusted-shell-profile",
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -289,7 +297,7 @@ func TestBuildDeployment(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 
 	if dep.Name != "my-agent-gateway" {
 		t.Errorf("expected deployment name my-agent-gateway, got %s", dep.Name)
@@ -310,11 +318,20 @@ func TestBuildDeployment(t *testing.T) {
 	if dep.Spec.Template.Spec.RuntimeClassName == nil || *dep.Spec.Template.Spec.RuntimeClassName != "gvisor" {
 		t.Errorf("expected RuntimeClassName gvisor, got %v", dep.Spec.Template.Spec.RuntimeClassName)
 	}
+	if dep.Spec.Template.Spec.ServiceAccountName != "custom-sa" {
+		t.Errorf("expected shared pod service account custom-sa, got %s", dep.Spec.Template.Spec.ServiceAccountName)
+	}
+	if dep.Spec.Template.Spec.AutomountServiceAccountToken == nil || *dep.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Errorf("expected sandbox service account token automount to be disabled")
+	}
 
-	if len(dep.Spec.Template.Spec.Containers) != 3 {
-		t.Errorf("expected 3 containers, got %d", len(dep.Spec.Template.Spec.Containers))
+	if len(dep.Spec.Template.Spec.Containers) != 4 {
+		t.Errorf("expected 4 containers, got %d", len(dep.Spec.Template.Spec.Containers))
 	} else {
-		sidecarC := dep.Spec.Template.Spec.Containers[2]
+		if dep.Spec.Template.Spec.Containers[2].Name != "envoy-credential-proxy" {
+			t.Errorf("expected managed Envoy sidecar, got %s", dep.Spec.Template.Spec.Containers[2].Name)
+		}
+		sidecarC := dep.Spec.Template.Spec.Containers[3]
 		if sidecarC.Name != "my-sidecar" {
 			t.Errorf("expected sidecar name my-sidecar, got %s", sidecarC.Name)
 		}
@@ -323,10 +340,18 @@ func TestBuildDeployment(t *testing.T) {
 		}
 	}
 
-	if len(dep.Spec.Template.Spec.InitContainers) != 2 {
-		t.Errorf("expected 2 init containers, got %d", len(dep.Spec.Template.Spec.InitContainers))
+	if len(dep.Spec.Template.Spec.InitContainers) != 3 {
+		t.Errorf("expected managed cleanup plus 2 configured init containers, got %d", len(dep.Spec.Template.Spec.InitContainers))
 	} else {
-		initC1 := dep.Spec.Template.Spec.InitContainers[0]
+		cleanup := dep.Spec.Template.Spec.InitContainers[0]
+		if cleanup.Name != "sandbox-credential-cleanup" {
+			t.Errorf("expected managed credential cleanup first, got %s", cleanup.Name)
+		}
+		if len(cleanup.VolumeMounts) != 1 || cleanup.VolumeMounts[0].Name != "platform-agent-data-vol" {
+			t.Errorf("expected cleanup to mount the agent data PVC")
+		}
+
+		initC1 := dep.Spec.Template.Spec.InitContainers[1]
 		if initC1.Name != "init-git" {
 			t.Errorf("expected first init container name init-git, got %s", initC1.Name)
 		}
@@ -334,7 +359,7 @@ func TestBuildDeployment(t *testing.T) {
 			t.Errorf("expected first init container image git-image:latest, got %s", initC1.Image)
 		}
 
-		initC2 := dep.Spec.Template.Spec.InitContainers[1]
+		initC2 := dep.Spec.Template.Spec.InitContainers[2]
 		if initC2.Name != "init-bootstrap" {
 			t.Errorf("expected second init container name init-bootstrap, got %s", initC2.Name)
 		}
@@ -355,6 +380,9 @@ func TestBuildDeployment(t *testing.T) {
 		if seen[env.Name] {
 			t.Errorf("duplicate env var found: %s", env.Name)
 		}
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+			t.Errorf("sandbox must not receive Secret-backed environment variable %s", env.Name)
+		}
 		seen[env.Name] = true
 		envMap[env.Name] = env
 	}
@@ -365,20 +393,54 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["HOME"].Value != "/var/agent/home" {
 		t.Errorf("expected HOME /var/agent/home, got %s", envMap["HOME"].Value)
 	}
-	if envMap["PLATFORM_AGENT_DASHBOARD"].Value != "0" {
-		t.Errorf("expected PLATFORM_AGENT_DASHBOARD to be overridden to 0, got %s", envMap["PLATFORM_AGENT_DASHBOARD"].Value)
+	if envMap["PLATFORM_AGENT_DASHBOARD"].Value != "1" {
+		t.Errorf("expected sandbox PLATFORM_AGENT_DASHBOARD 1, got %s", envMap["PLATFORM_AGENT_DASHBOARD"].Value)
 	}
 	if envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value != "0" {
 		t.Errorf("expected PLATFORM_AGENT_PLUGINS_DEBUG 0, got %s", envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value)
 	}
-	if envMap["CUSTOM_VAR"].Value != "new-custom-value" {
-		t.Errorf("expected CUSTOM_VAR new-custom-value, got %s", envMap["CUSTOM_VAR"].Value)
+	if _, ok := envMap["CUSTOM_VAR"]; ok {
+		t.Error("expected spec.deployment.env CUSTOM_VAR to be absent from sandbox")
 	}
 	if envMap["AGENT_BROWSER_ARGS"].Value != "--no-sandbox --disable-gpu" {
 		t.Errorf("expected AGENT_BROWSER_ARGS --no-sandbox --disable-gpu, got %s", envMap["AGENT_BROWSER_ARGS"].Value)
 	}
-	if envMap["TOKEN_BROKER_URL"].Value != "http://github-token-minter.my-ns.svc.cluster.local:8080/token" {
-		t.Errorf("expected TOKEN_BROKER_URL http://github-token-minter.my-ns.svc.cluster.local:8080/token, got %s", envMap["TOKEN_BROKER_URL"].Value)
+	if envMap["CREDENTIAL_PROXY_URL"].Value != "http://127.0.0.1:8765" {
+		t.Errorf("expected localhost Envoy CREDENTIAL_PROXY_URL, got %s", envMap["CREDENTIAL_PROXY_URL"].Value)
+	}
+	proxyEnv := make(map[string]corev1.EnvVar)
+	for _, env := range dep.Spec.Template.Spec.Containers[2].Env {
+		proxyEnv[env.Name] = env
+	}
+	if proxyEnv["CUSTOM_VAR"].Value != "new-custom-value" || proxyEnv["PLATFORM_AGENT_DASHBOARD"].Value != "0" {
+		t.Errorf("expected spec.deployment.env only on credential sidecar, got %#v", proxyEnv)
+	}
+	if proxyEnv["CREDENTIAL_PROXY_STATE_DIR"].Value != "/var/lib/credential-proxy" {
+		t.Errorf("reserved proxy state directory was overridden: %#v", proxyEnv["CREDENTIAL_PROXY_STATE_DIR"])
+	}
+	if _, found := proxyEnv["BASH_ENV"]; found {
+		t.Errorf("expected unsafe shell environment override to be rejected")
+	}
+	apiKeyRef := proxyEnv["API_SERVER_EXTERNAL_KEY"].ValueFrom.SecretKeyRef
+	if apiKeyRef.Name != "secrets" || apiKeyRef.Key != "api-key" {
+		t.Errorf("expected external API key only in credential sidecar, got %#v", apiKeyRef)
+	}
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == "credential-proxy-ksa-token" || strings.Contains(mount.MountPath, "serviceaccount") {
+			t.Errorf("sandbox must not mount a ServiceAccount token: %#v", mount)
+		}
+	}
+	proxyHasTokenMount := false
+	for _, mount := range dep.Spec.Template.Spec.Containers[2].VolumeMounts {
+		if mount.Name == "credential-proxy-ksa-token" && mount.ReadOnly {
+			proxyHasTokenMount = true
+		}
+	}
+	if !proxyHasTokenMount {
+		t.Error("expected projected KSA token to be mounted only by credential sidecar")
+	}
+	if !strings.HasPrefix(envMap["PATH"].Value, "/opt/credential-proxy/bin:") {
+		t.Errorf("expected sandbox PATH to prefer credential proxy shims, got %s", envMap["PATH"].Value)
 	}
 	if envMap["GKE_CLUSTER_NAME"].Value != "gke-cluster" {
 		t.Errorf("expected GKE_CLUSTER_NAME gke-cluster, got %s", envMap["GKE_CLUSTER_NAME"].Value)
@@ -386,8 +448,8 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["GKE_LOCATION"].Value != "us-east1" {
 		t.Errorf("expected GKE_LOCATION us-east1, got %s", envMap["GKE_LOCATION"].Value)
 	}
-	if envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name != "secrets" {
-		t.Errorf("expected API_SERVER_KEY SecretRef secrets, got %s", envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name)
+	if envMap["API_SERVER_KEY"].Value != "cluster-internal-trusted" || envMap["API_SERVER_KEY"].ValueFrom != nil {
+		t.Errorf("expected non-secret cluster trust sentinel, got %#v", envMap["API_SERVER_KEY"])
 	}
 	if _, ok := envMap["GEMINI_API_KEY"]; ok {
 		t.Errorf("expected GEMINI_API_KEY to not be set on platform agent container")
@@ -407,8 +469,8 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["API_SERVER_ENABLED"].Value != "true" {
 		t.Errorf("expected API_SERVER_ENABLED true, got %s", envMap["API_SERVER_ENABLED"].Value)
 	}
-	if envMap["API_SERVER_HOST"].Value != "0.0.0.0" {
-		t.Errorf("expected API_SERVER_HOST 0.0.0.0, got %s", envMap["API_SERVER_HOST"].Value)
+	if envMap["API_SERVER_HOST"].Value != "127.0.0.1" {
+		t.Errorf("expected API_SERVER_HOST 127.0.0.1, got %s", envMap["API_SERVER_HOST"].Value)
 	}
 	if envMap["SESSION_KV_DB_PATH"].Value != "/var/lib/kube-agents/session/session_kv.db" {
 		t.Errorf("expected SESSION_KV_DB_PATH /var/lib/kube-agents/session/session_kv.db, got %s", envMap["SESSION_KV_DB_PATH"].Value)
@@ -418,6 +480,11 @@ func TestBuildDeployment(t *testing.T) {
 	mountsMap := make(map[string]corev1.VolumeMount)
 	for _, m := range container.VolumeMounts {
 		mountsMap[m.Name] = m
+	}
+	for _, volume := range dep.Spec.Template.Spec.Volumes {
+		if _, mounted := mountsMap[volume.Name]; mounted && volume.Secret != nil {
+			t.Errorf("sandbox must not mount Secret volume %s", volume.Name)
+		}
 	}
 	if _, ok := mountsMap["settings-volume"]; !ok {
 		t.Errorf("expected settings-volume mount, not found")
@@ -518,6 +585,98 @@ func TestBuildDeployment(t *testing.T) {
 	}
 }
 
+func TestSafeSandboxEnvOverridesRejectsValueFrom(t *testing.T) {
+	custom := []corev1.EnvVar{
+		{Name: "OTEL_SERVICE_NAME", Value: "platform-agent"},
+		{
+			Name: "OTEL_EXPORTER_OTLP_ENDPOINT",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry-secret"},
+				Key:                  "endpoint",
+			}},
+		},
+		{
+			Name: "OTEL_RESOURCE_ATTRIBUTES",
+			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['telemetry']",
+			}},
+		},
+	}
+
+	got := safeSandboxEnvOverrides(custom)
+	if len(got) != 1 || got[0].Name != "OTEL_SERVICE_NAME" || got[0].Value != "platform-agent" {
+		t.Fatalf("expected only literal allowlisted telemetry env, got %#v", got)
+	}
+}
+
+func TestBuildCredentialProxySidecar(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Harness: &agentv1alpha1.HarnessSpec{
+				ProjectID:   "example-project",
+				ClusterName: "example-cluster",
+				Location:    "us-central1",
+			},
+			AgentSpec: agentv1alpha1.AgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{Image: "example/platform-agent", Tag: ptr.To("v1")},
+				Security:   &agentv1alpha1.SecuritySpec{ServiceAccountName: "credential-sa"},
+			},
+		},
+	}
+
+	policy := buildCredentialProxyPolicyConfigMap(agent)
+	if policy.Name != "test-agent-credential-proxy-policy" || !strings.Contains(policy.Data["policy.json"], "github.token-disclosure") {
+		t.Fatalf("unexpected credential proxy policy: %#v", policy)
+	}
+
+	container := buildCredentialProxySidecar(agent, "/opt/hermes")
+	if container.Name != "envoy-credential-proxy" || container.Image != "example/credential-proxy:v1" {
+		t.Errorf("unexpected proxy container: %#v", container)
+	}
+	if len(container.Command) != 1 || container.Command[0] != "/usr/local/bin/envoy-credential-sidecar" {
+		t.Errorf("unexpected proxy command: %v", container.Command)
+	}
+	env := make(map[string]corev1.EnvVar)
+	for _, item := range container.Env {
+		env[item.Name] = item
+	}
+	if env["CREDENTIAL_PROXY_STATE_DIR"].Value != "/var/lib/credential-proxy" {
+		t.Errorf("expected private proxy state directory, got %#v", env["CREDENTIAL_PROXY_STATE_DIR"])
+	}
+	if env["KUBE_CONTEXT_NAME"].Value != "gke_example-project_us-central1_example-cluster" {
+		t.Errorf("expected proxy Kubernetes context, got %#v", env["KUBE_CONTEXT_NAME"])
+	}
+	if env["KUBE_DEFAULT_NAMESPACE"].Value != "test-ns" {
+		t.Errorf("expected proxy default namespace, got %#v", env["KUBE_DEFAULT_NAMESPACE"])
+	}
+	bootstrap := env["CREDENTIAL_PROXY_BOOTSTRAP_COMMAND"].Value
+	for _, expected := range []string{"gcloud config set project", "gcloud container clusters get-credentials", "kubectl config use-context", "kubectl config set-context"} {
+		if !strings.Contains(bootstrap, expected) {
+			t.Errorf("expected generic shell bootstrap to contain %q, got %q", expected, bootstrap)
+		}
+	}
+	stateMounted := false
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == "credential-proxy-state" && mount.MountPath == "/var/lib/credential-proxy" {
+			stateMounted = true
+		}
+	}
+	if !stateMounted {
+		t.Errorf("expected private proxy state volume mount, got %#v", container.VolumeMounts)
+	}
+
+}
+
+func TestResolveCredentialProxyImagePreservesTag(t *testing.T) {
+	if got := resolveCredentialProxyImage(nil); got != "ghcr.io/gke-labs/kube-agents/credential-proxy:latest" {
+		t.Fatalf("unexpected default credential sidecar image: %s", got)
+	}
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: "example/platform-agent"}); got != "example/credential-proxy:latest" {
+		t.Fatalf("expected explicit latest tag for untagged sidecar image: %s", got)
+	}
+}
+
 func TestBuildDeploymentGoogleChatAllowedUsersEmpty(t *testing.T) {
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{
@@ -542,7 +701,7 @@ func TestBuildDeploymentGoogleChatAllowedUsersEmpty(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {
@@ -583,18 +742,21 @@ func TestBuildDeploymentSlackIntegration(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {
 		envMap[env.Name] = env
 	}
 
-	if envMap["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || envMap["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Key != "bot-token-key" {
-		t.Errorf("expected SLACK_BOT_TOKEN custom-slack-secret/bot-token-key, got %v", envMap["SLACK_BOT_TOKEN"].ValueFrom)
+	if _, ok := envMap["SLACK_BOT_TOKEN"]; ok {
+		t.Error("expected SLACK_BOT_TOKEN to be absent from sandbox")
 	}
-	if envMap["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || envMap["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Key != "app-token-key" {
-		t.Errorf("expected SLACK_APP_TOKEN custom-slack-secret/app-token-key, got %v", envMap["SLACK_APP_TOKEN"].ValueFrom)
+	if _, ok := envMap["SLACK_APP_TOKEN"]; ok {
+		t.Error("expected SLACK_APP_TOKEN to be absent from sandbox")
+	}
+	if envMap["SLACK_RELAY_URL"].Value != "http://127.0.0.1:8765" {
+		t.Errorf("expected credential-free Slack relay URL, got %v", envMap["SLACK_RELAY_URL"])
 	}
 	if envMap["SLACK_ALLOWED_USERS"].Value != "U123,U456" {
 		t.Errorf("expected SLACK_ALLOWED_USERS U123,U456, got %s", envMap["SLACK_ALLOWED_USERS"].Value)
@@ -604,6 +766,17 @@ func TestBuildDeploymentSlackIntegration(t *testing.T) {
 	}
 	if envMap["SLACK_HOME_CHANNEL_NAME"].Value != "general" {
 		t.Errorf("expected SLACK_HOME_CHANNEL_NAME general, got %s", envMap["SLACK_HOME_CHANNEL_NAME"].Value)
+	}
+
+	proxyEnv := make(map[string]corev1.EnvVar)
+	for _, env := range buildCredentialProxySidecar(agent, "/opt/hermes").Env {
+		proxyEnv[env.Name] = env
+	}
+	if proxyEnv["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || proxyEnv["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Key != "bot-token-key" {
+		t.Errorf("expected proxy SLACK_BOT_TOKEN custom-slack-secret/bot-token-key, got %v", proxyEnv["SLACK_BOT_TOKEN"].ValueFrom)
+	}
+	if proxyEnv["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || proxyEnv["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Key != "app-token-key" {
+		t.Errorf("expected proxy SLACK_APP_TOKEN custom-slack-secret/app-token-key, got %v", proxyEnv["SLACK_APP_TOKEN"].ValueFrom)
 	}
 }
 
@@ -623,7 +796,7 @@ func TestBuildDeploymentSlackAllowAllUsers(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -59,7 +59,7 @@ func TestBuildDeploymentHasOTelEnv(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	container := dep.Spec.Template.Spec.Containers[0]
 
 	seen := make(map[string]bool)
@@ -97,7 +97,7 @@ func TestBuildDeploymentAllowsOTelEnvOverrides(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	m := envMapOf(dep.Spec.Template.Spec.Containers[0].Env)
 
 	if got := m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value; got != "http://custom-collector:4318" {

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ func init() {
 	_ = agentv1alpha1.AddToScheme(testScheme)
 	_ = corev1.AddToScheme(testScheme)
 	_ = appsv1.AddToScheme(testScheme)
+	_ = networkingv1.AddToScheme(testScheme)
 	_ = rbacv1.AddToScheme(testScheme)
 }
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -275,12 +275,43 @@ metadata:
       name: platformagent
       uid: ""
 ---
+apiVersion: v1
+data:
+  policy.json: |-
+    {
+      "apiVersion": "cli.proxy.kubeagents.io/v1alpha1",
+      "blockedMessage": "Command blocked for security reasons.",
+      "rules": [
+        {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\s+auth\\s+(?:application-default\\s+)?print-(?:access|identity)-token\\b"},
+        {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\s+config\\s+config-helper\\b"},
+        {"id":"github.token-disclosure","pattern":"\\bgh\\s+auth\\s+token\\b|\\bgh\\s+auth\\s+status\\b[^;&|\\n]*--show-token\\b"},
+        {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\s+create\\s+token\\b|\\bkubectl\\s+config\\s+view\\b[^;&|\\n]*--raw\\b"},
+        {"id":"git.credential-disclosure","pattern":"\\bgit\\s+credential\\s+fill\\b"},
+        {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\s+auth\\s+(?:login|activate-service-account)\\b|\\bgcloud\\s+auth\\s+application-default\\s+login\\b"},
+        {"id":"github.credential-replacement","pattern":"\\bgh\\s+auth\\s+(?:login|refresh|switch|logout)\\b"},
+        {"id":"tool.self-modification","pattern":"\\bgcloud\\s+components\\s+(?:install|update|remove)\\b|\\bgh\\s+extension\\s+(?:install|upgrade|remove)\\b"}
+      ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-credential-proxy-policy
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
     app: platformagent-gateway
+    kubeagents.x-k8s.io/has-credential-proxy: "true"
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
@@ -302,11 +333,14 @@ spec:
       annotations:
         kubeagents.x-k8s.io/config-hash: 268343ffef4f80b81b57e301ed60eff3d7f738da032b97d0644d60b15d88d3ad
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
+        kubeagents.x-k8s.io/proxy-policy-hash: ed79bb55a08861c97ed1169dce81c68352f3dbbdceb1506df9b438c4f7bc5d75
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null
       labels:
         app: platformagent-gateway
+        kubeagents.x-k8s.io/has-credential-proxy: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
         - env:
             - name: PLATFORM_AGENT_HOME
@@ -320,7 +354,9 @@ spec:
             - name: API_SERVER_ENABLED
               value: "true"
             - name: API_SERVER_HOST
-              value: 0.0.0.0
+              value: 127.0.0.1
+            - name: API_SERVER_KEY
+              value: cluster-internal-trusted
             - name: SESSION_KV_DB_PATH
               value: /var/lib/kube-agents/session/session_kv.db
             - name: OTEL_SERVICE_NAME
@@ -335,11 +371,10 @@ spec:
               value: cluster-a
             - name: GKE_LOCATION
               value: us-central1-a
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
+            - name: KUBE_DEFAULT_NAMESPACE
+              value: kubeagents-system
+            - name: GOOGLE_CHAT_RELAY_URL
+              value: http://127.0.0.1:8765
             - name: GOOGLE_CHAT_PROJECT_ID
               value: kube-agents-gkedemos
             - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
@@ -348,8 +383,12 @@ spec:
             - name: GOOGLE_CHAT_HOME_CHANNEL
             - name: GOOGLE_CHAT_ALLOW_ALL_USERS
               value: "true"
-            - name: TOKEN_BROKER_URL
-              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+            - name: CREDENTIAL_PROXY_URL
+              value: http://127.0.0.1:8765
+            - name: PATH
+              value: /opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: PYTHONPATH
+              value: /opt/defaults/scripts
           image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
           imagePullPolicy: IfNotPresent
           name: platform-agent
@@ -357,7 +396,7 @@ spec:
             - containerPort: 9119
               name: dashboard
             - containerPort: 8642
-              name: api
+              name: agent-api
           resources:
             limits:
               cpu: "2"
@@ -416,6 +455,119 @@ spec:
               subPath: parsers.conf
             - mountPath: /fluent-bit/state
               name: fluent-bit-state
+        - command:
+            - /usr/local/bin/envoy-credential-sidecar
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /tmp/credential-proxy
+            - name: HOME
+              value: /tmp/credential-proxy/home
+            - name: CREDENTIAL_PROXY_POLICY
+              value: /etc/credential-proxy/policy.json
+            - name: CREDENTIAL_PROXY_STATE_DIR
+              value: /var/lib/credential-proxy
+            - name: CREDENTIAL_PROXY_UNIX_SOCKET
+              value: /var/run/credential-proxy/backend.sock
+            - name: KSA_TOKEN_FILE
+              value: /var/run/secrets/kubeagents/serviceaccount/token
+            - name: TOKEN_BROKER_URL
+              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+            - name: AGENT_API_PROXY_PORT
+              value: "8643"
+            - name: AGENT_API_UPSTREAM_KEY
+              value: cluster-internal-trusted
+            - name: API_SERVER_EXTERNAL_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: CREDENTIAL_PROXY_WORKSPACE_ROOT
+              value: /opt/data
+          image: ghcr.io/gke-labs/kube-agents/credential-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: envoy-credential-proxy
+          ports:
+            - containerPort: 8765
+              name: cred-proxy
+            - containerPort: 8643
+              name: api
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - --fail
+                - --silent
+                - --show-error
+                - http://127.0.0.1:8765/healthz
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            limits:
+              cpu: "2"
+              ephemeral-storage: 2Gi
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/credential-proxy/policy.json
+              name: credential-proxy-policy
+              readOnly: true
+              subPath: policy.json
+            - mountPath: /tmp
+              name: credential-proxy-tmp
+            - mountPath: /var/lib/credential-proxy
+              name: credential-proxy-state
+            - mountPath: /var/run/credential-proxy
+              name: credential-proxy-runtime
+            - mountPath: /var/run/secrets/kubeagents/serviceaccount
+              name: credential-proxy-ksa-token
+              readOnly: true
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+      initContainers:
+        - args:
+            - |-
+              rm -rf -- \
+                /workspace/home/.config/gcloud \
+                /workspace/home/.config/gh \
+                /workspace/home/.aws/credentials \
+                /workspace/home/.aws/cli/cache \
+                /workspace/home/.aws/sso/cache \
+                /workspace/home/.azure \
+                /workspace/home/.docker/config.json \
+                /workspace/home/.git-credentials \
+                /workspace/home/.hermes/.env \
+                /workspace/home/.kube/config \
+                /workspace/home/.netrc \
+                /workspace/home/.npmrc \
+                /workspace/home/.pypirc
+          command:
+            - sh
+            - -ec
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: sandbox-credential-cleanup
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /workspace
+              name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -444,6 +596,27 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - configMap:
+            name: platformagent-credential-proxy-policy
+          name: credential-proxy-policy
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: credential-proxy-tmp
+        - emptyDir:
+            sizeLimit: 5Gi
+          name: credential-proxy-state
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: credential-proxy-runtime
+        - name: credential-proxy-ksa-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  audience: kubeagents-credential-proxy
+                  expirationSeconds: 3600
+                  path: token
 status: {}
 ---
 apiVersion: v1

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -187,6 +187,7 @@ load_state() {
   fi
   export NAMESPACE="kubeagents-system"
   export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+  export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
   export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
   export CONTROLLER_KSA_NAME="kubeagents-controller"
   export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
@@ -201,6 +202,7 @@ ensure_teardown_state() {
     export DEV_ARTIFACT_REGISTRY_CREATED="${DEV_ARTIFACT_REGISTRY_CREATED:-false}"
     export NAMESPACE="kubeagents-system"
     export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+    export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
     export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
@@ -243,6 +245,7 @@ ensure_teardown_state() {
       export CHAT_SUB_NAME="${CHAT_SUB_NAME:-}"
     fi
     export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+    export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
     export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"

--- a/k8s-operator/scripts/dev/dev_rebuild_agent.sh
+++ b/k8s-operator/scripts/dev/dev_rebuild_agent.sh
@@ -97,6 +97,9 @@ DEV_TAG="dev-$(date +%Y%m%d-%H%M%S)"
 IMAGE_BASE="$REGION-docker.pkg.dev/$PROJECT_ID/$GCP_ARTIFACT_REGISTRY_REPO_NAME/$IMAGE_NAME"
 IMAGE_URI="$IMAGE_BASE:$DEV_TAG"
 IMAGE_URI_LATEST="$IMAGE_BASE:latest"
+PROXY_IMAGE_BASE="$REGION-docker.pkg.dev/$PROJECT_ID/$GCP_ARTIFACT_REGISTRY_REPO_NAME/credential-proxy"
+PROXY_IMAGE_URI="$PROXY_IMAGE_BASE:$DEV_TAG"
+PROXY_IMAGE_URI_LATEST="$PROXY_IMAGE_BASE:latest"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -126,6 +129,9 @@ execute_image_build() {
     print_info "Pushing images to Artifact Registry ($IMAGE_BASE)..."
     docker push "$IMAGE_URI" || return 1
     docker push "$IMAGE_URI_LATEST" || return 1
+    DOCKER_BUILDKIT=1 docker build --cache-from "$PROXY_IMAGE_URI_LATEST" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg HERMES_AGENT_TAG="$HERMES_AGENT_TAG" --target credential-proxy -t "$PROXY_IMAGE_URI" -t "$PROXY_IMAGE_URI_LATEST" -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" || return 1
+    docker push "$PROXY_IMAGE_URI" || return 1
+    docker push "$PROXY_IMAGE_URI_LATEST" || return 1
   else
     print_info "Submitting build for '$AGENT_TARGET' agent to Google Cloud Build..."
     print_info "Target Images: $IMAGE_URI and $IMAGE_URI_LATEST"
@@ -134,6 +140,14 @@ execute_image_build() {
       gcloud builds submit \
           --config="deploy/docker/cloudbuild.yaml" \
           --substitutions="_IMAGE_URI=${IMAGE_URI},_IMAGE_URI_LATEST=${IMAGE_URI_LATEST},_TARGET=${AGENT_TARGET},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
+          --project="${PROJECT_ID}" \
+          .
+    ) || return 1
+    (
+      cd "${REPO_ROOT}"
+      gcloud builds submit \
+          --config="deploy/docker/cloudbuild.yaml" \
+          --substitutions="_IMAGE_URI=${PROXY_IMAGE_URI},_IMAGE_URI_LATEST=${PROXY_IMAGE_URI_LATEST},_TARGET=credential-proxy,_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
           --project="${PROJECT_ID}" \
           .
     ) || return 1
@@ -184,7 +198,7 @@ execute_redeploy() {
     for dep_entry in $deployments; do
       local ns="${dep_entry%%:*}"
       local dep="${dep_entry#*:}"
-      if [[ "$dep" == *"${AGENT_TARGET}"* ]]; then
+      if [[ "$dep" == *"${AGENT_TARGET}"* && "$dep" != *"credential-proxy"* ]]; then
         print_info "Triggering rolling update for Deployment '${dep}' in namespace '${ns}'..."
         # Set image in case it's a standalone deployment not managed by a CR
         local container_name

--- a/k8s-operator/scripts/platform-agent.yaml.template
+++ b/k8s-operator/scripts/platform-agent.yaml.template
@@ -7,6 +7,7 @@ spec:
   harness:
     clusterName: "${CLUSTER_NAME}"
     location: "${REGION}"
+    projectId: "${PROJECT_ID}"
     hermes:
       dashboardEnabled: true
       pluginsDebug: false

--- a/k8s-operator/scripts/provision_03_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_03_gcp_iam.sh
@@ -196,10 +196,24 @@ get_platform_agent_roles() {
 verify_platform_agent() {
   local -a roles=($(get_platform_agent_roles))
   verify_agent_iam "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" "${roles[@]}"
+
+  local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  local sandbox_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${PLATFORM_AGENT_SANDBOX_KSA_NAME}]"
+  ! gcloud iam service-accounts get-iam-policy "${gsa_email}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -F -q "${sandbox_member}"
 }
 execute_platform_agent() {
   local -a roles=($(get_platform_agent_roles))
   execute_agent_iam "Platform Agent" "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" "${roles[@]}"
+
+  local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  local sandbox_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${PLATFORM_AGENT_SANDBOX_KSA_NAME}]"
+  print_info "Removing legacy sandbox Workload Identity binding from ${PLATFORM_AGENT_SANDBOX_KSA_NAME}..."
+  gcloud iam service-accounts remove-iam-policy-binding "${gsa_email}" \
+      --role="roles/iam.workloadIdentityUser" \
+      --member="${sandbox_member}" \
+      --project="${PROJECT_ID}" \
+      --condition=None \
+      --quiet >/dev/null 2>&1 || true
 }
 
 

--- a/k8s-operator/scripts/provision_06_gcp_k8s_secrets.sh
+++ b/k8s-operator/scripts/provision_06_gcp_k8s_secrets.sh
@@ -41,7 +41,7 @@ if [ "$MODEL_PROVIDER" = "gemini" ]; then
     if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
       save_var "GEMINI_API_KEY" "${GEMINI_API_KEY:-placeholder}"
     else
-      echo -ne "  ${C_CYAN}Enter your GEMINI_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
+      echo -ne "  ${C_CYAN}Enter your GEMINI_API_KEY (required): ${C_RESET}"
       read -s -r INPUT_KEY
       echo ""
       save_var "GEMINI_API_KEY" "${INPUT_KEY:-placeholder}"
@@ -57,7 +57,7 @@ if [ "$MODEL_PROVIDER" = "openai" ]; then
     if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
       save_var "OPENAI_API_KEY" "${OPENAI_API_KEY:-placeholder}"
     else
-      echo -ne "  ${C_CYAN}Enter your OPENAI_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
+      echo -ne "  ${C_CYAN}Enter your OPENAI_API_KEY (required): ${C_RESET}"
       read -s -r INPUT_KEY
       echo ""
       save_var "OPENAI_API_KEY" "${INPUT_KEY:-placeholder}"
@@ -73,7 +73,7 @@ if [ "$MODEL_PROVIDER" = "anthropic" ]; then
     if [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline; then
       save_var "ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY:-placeholder}"
     else
-      echo -ne "  ${C_CYAN}Enter your ANTHROPIC_API_KEY (press ENTER to default to empty placeholder): ${C_RESET}"
+      echo -ne "  ${C_CYAN}Enter your ANTHROPIC_API_KEY (required): ${C_RESET}"
       read -s -r INPUT_KEY
       echo ""
       save_var "ANTHROPIC_API_KEY" "${INPUT_KEY:-placeholder}"
@@ -108,11 +108,14 @@ verify_k8s_secrets() {
 }
 execute_k8s_secrets() {
   if [ "$MODEL_PROVIDER" = "gemini" ] && [ "$GEMINI_API_KEY" = "placeholder" ]; then
-    print_warning "GEMINI_API_KEY is currently a placeholder. The platform agent will run but cannot authenticate with Gemini until updated."
+    print_error "GEMINI_API_KEY is required when MODEL_PROVIDER=gemini."
+    return 1
   elif [ "$MODEL_PROVIDER" = "openai" ] && [ "$OPENAI_API_KEY" = "placeholder" ]; then
-    print_warning "OPENAI_API_KEY is currently a placeholder. The platform agent will run but cannot authenticate with OpenAI until updated."
+    print_error "OPENAI_API_KEY is required when MODEL_PROVIDER=openai."
+    return 1
   elif [ "$MODEL_PROVIDER" = "anthropic" ] && [ "$ANTHROPIC_API_KEY" = "placeholder" ]; then
-    print_warning "ANTHROPIC_API_KEY is currently a placeholder. The platform agent will run but cannot authenticate with Anthropic until updated."
+    print_error "ANTHROPIC_API_KEY is required when MODEL_PROVIDER=anthropic."
+    return 1
   fi
 
   print_info "Writing Kubernetes Secret 'platform-agent-secrets' into '$NAMESPACE'..."

--- a/k8s-operator/scripts/provision_07_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_07_deploy_platform_agent.sh
@@ -25,7 +25,15 @@ check_prereqs "gcloud" "kubectl" "envsubst"
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
 print_step "Setting up Configuration State for Agent Deployment"
+AGENT_IMAGE_OVERRIDE="${AGENT_IMAGE:-}"
+AGENT_TAG_OVERRIDE="${AGENT_TAG:-}"
 load_state
+if [ -n "$AGENT_IMAGE_OVERRIDE" ]; then
+  export AGENT_IMAGE="$AGENT_IMAGE_OVERRIDE"
+fi
+if [ -n "$AGENT_TAG_OVERRIDE" ]; then
+  export AGENT_TAG="$AGENT_TAG_OVERRIDE"
+fi
 
 ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"
 DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"

--- a/k8s-operator/scripts/provision_08_deploy_litellm.sh
+++ b/k8s-operator/scripts/provision_08_deploy_litellm.sh
@@ -20,7 +20,7 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 
 # ─── Prerequisites Check ──────────────────────────────────────────────────────
 print_step "Checking Local Prerequisites"
-check_prereqs "gcloud" "kubectl" "envsubst"
+check_prereqs "gcloud" "kubectl" "envsubst" "base64"
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
 print_step "Setting up Configuration State for Agent Deployment"
@@ -48,12 +48,34 @@ execute_kubeconfig() {
   connect_cluster
 }
 
+# Fail before rollout if the selected provider's credential is absent or still
+# a provisioning placeholder. The value is checked locally and never printed.
+verify_model_api_key() {
+  local key_name encoded value
+  case "$MODEL_PROVIDER" in
+    gemini) key_name="GEMINI_API_KEY" ;;
+    openai) key_name="OPENAI_API_KEY" ;;
+    anthropic) key_name="ANTHROPIC_API_KEY" ;;
+    chatgpt) return 0 ;;
+  esac
+
+  encoded="$(kubectl get secret platform-agent-secrets \
+    --namespace="$NAMESPACE" \
+    -o "jsonpath={.data.${key_name}}" 2>/dev/null || true)"
+  value="$(printf '%s' "$encoded" | base64 --decode 2>/dev/null || true)"
+  if [ -z "$value" ] || [ "$value" = "placeholder" ]; then
+    print_error "${key_name} is required when MODEL_PROVIDER=${MODEL_PROVIDER}. Run the secrets provisioning step first."
+    return 1
+  fi
+}
+
 # Step 2: Deploy LiteLLM Gateway
 verify_litellm() {
   # Always return false to ensure that Kustomize builds and configs are applied idempotently on every run
   return 1
 }
 execute_litellm() {
+  verify_model_api_key || return 1
   print_info "Deploying LiteLLM Gateway into GKE..."
   export NAMESPACE MODEL_PROVIDER MODEL_DEFAULT_NAME
   make -C "${OPERATOR_DIR}" deploy-litellm || return 1


### PR DESCRIPTION
# Pull Request

## Why This Change

PlatformAgent currently needs cloud, Kubernetes, GitHub, Google Chat, and Slack capabilities, but placing their API keys, access tokens, refresh tokens, or Kubernetes ServiceAccount tokens in the agent container would make them directly readable by the model through its environment or filesystem.

This change makes the agent container an untrusted sandbox and moves credentialed execution into an Envoy-fronted sidecar in the same Pod. The security boundary is enforced by Kubernetes container environment and volume mounts rather than prompt instructions.

## What Changed

**Files:**

- `agents/platform/scripts/credential_proxy*.py`, `google_chat_relay_patch.py`, and `slack_relay_patch.py`
- `deploy/docker/Dockerfile` and `deploy/shared/envoy-credential-*`
- `k8s-operator/internal/controller/platformagent_*`
- `k8s-operator/scripts/` deployment and provisioning helpers
- `.github/workflows/docker-publish-*.yml`
- `docs/credential-isolation-design.md`

**Added/Changed/Fixed:**

- Runs the PlatformAgent sandbox and Envoy credential proxy as containers with a shared Pod lifecycle while mounting the projected KSA token only in the credential sidecar.
- Removes credential-aware `gcloud`, `kubectl`, `gh`, and `git` binaries from the sandbox image and replaces them with wrappers that send restricted command strings to the proxy.
- Moves arbitrary `spec.deployment.env` values to the credential sidecar; only an explicit literal-value OpenTelemetry allowlist remains configurable in the sandbox; `valueFrom` sources are rejected.
- Routes Google Chat and Slack transports through credentialed relays so their tokens remain outside the sandbox environment and filesystem.
- Keeps GitHub installation tokens and Git credential state in the sidecar, using the existing Minty broker for short-lived repository-scoped tokens.
- Moves external PlatformAgent API authentication into the sidecar and forwards a fixed non-secret loopback sentinel to the sandbox API.
- Adds a managed init container that removes credential files left on retained PVCs by older deployments before the sandbox starts.
- Publishes a dedicated credential-proxy image and migrates operator-owned resources from the abandoned two-Pod prototype.
- Hardens the proxy after review: Slack initialization retries without blocking other services, upload reads are bounded, timeout process races return cleanly, and the gVisor exec probe runs less frequently.

## Why This Matters

- Prevents API keys, access tokens, refresh tokens, and KSA tokens from being delivered to the PlatformAgent sandbox through its environment or mounted filesystem.
- Preserves existing CLI and chat integration surfaces while centralizing credential handling and command policy in one component.
- Upgrades existing installations in place without retaining legacy credentials on the agent PVC.

## Context

The scoped guarantee is credential isolation from the sandbox environment and filesystem. Credential-like values returned as approved tool output are an accepted risk and are not filtered by this change. Containers in the same Pod also share a network namespace; the design does not claim that a compromised sandbox is isolated from the sidecar's loopback API.

The branch is rebased on current upstream `main` and contains one squashed Conventional Commit.

## Testing

- `go test ./...`, `go vet ./...`, and `go build ./...` in `k8s-operator/`.
- `PYTHONPATH=agents/platform/scripts python3 -m unittest agents/platform/scripts/test_credential_proxy.py agents/platform/scripts/test_github_token_refresh.py` — 20 tests passed.
- `bash -n` across all changed shell scripts.
- Prettier checks passed for changed Markdown, YAML, workflow, and template files.
- Cloud Build platform image: `013680a7-9f83-4916-8345-00ab0006051a` — succeeded.
- Cloud Build credential-proxy image: `c6da04bb-7b12-41f0-a30f-193b36864ad3` — succeeded.
- Live GKE audit verified the sandbox had no KSA token at either projected path, no managed credential files after migration, and no secret-backed environment variables; the KSA token was present only in the credential sidecar.
- Live Pub/Sub → Google Chat E2E used message ID `20772700060239200`; the persisted session recorded the exact assistant response `E2E_OK_chatgpt-clean-e2e-20260720T173144Z`, and the Google Chat relay send returned HTTP 200.

---

This changes the PlatformAgent credential boundary while retaining the existing user-facing command and messaging workflows.
