### PR TITLE
fix(operator): filter deleted tombstone GSAs when checking PubSub subscription IAM policy

### DIFF
--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -132,7 +132,7 @@ execute_pubsub_setup() {
 verify_agent_gcp() {
   local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
   gcloud iam service-accounts describe "${gsa_email}" --project="${PROJECT_ID}" >/dev/null 2>&1 && \
-  gcloud pubsub subscriptions get-iam-policy "${CHAT_SUB_NAME}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -v "deleted:" | grep -F -q "${gsa_email}"
+  gcloud pubsub subscriptions get-iam-policy "${CHAT_SUB_NAME}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -F -q "\"serviceAccount:${gsa_email}\""
 }
 execute_agent_gcp() {
   local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"

--- a/k8s-operator/scripts/provision_04_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_04_gcp_gchat.sh
@@ -132,7 +132,7 @@ execute_pubsub_setup() {
 verify_agent_gcp() {
   local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
   gcloud iam service-accounts describe "${gsa_email}" --project="${PROJECT_ID}" >/dev/null 2>&1 && \
-  gcloud pubsub subscriptions get-iam-policy "${CHAT_SUB_NAME}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -F -q "${gsa_email}"
+  gcloud pubsub subscriptions get-iam-policy "${CHAT_SUB_NAME}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -v "deleted:" | grep -F -q "${gsa_email}"
 }
 execute_agent_gcp() {
   local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"


### PR DESCRIPTION
# Pull Request

## Why This Change

When a Google Service Account (GSA) is recreated with the same name, GCP Pub/Sub IAM policies retain orphaned tombstone entries formatted as `deleted:serviceAccount:<gsa_email>?uid=...`.

In `k8s-operator/scripts/provision_04_gcp_gchat.sh`, the `verify_agent_gcp()` function checked for subscriber access using `grep -F -q "${gsa_email}"`. This matched the deleted tombstone entry, producing a false positive that caused the script to skip executing `gcloud pubsub subscriptions add-iam-policy-binding`. As a result, the active GSA was left without subscriber permissions, leading to `403 Permission Denied` errors at runtime when the Platform Agent attempted to read Google Chat messages.

## What Changed

**Files:**

- `k8s-operator/scripts/provision_04_gcp_gchat.sh`

**Fixed:**

- Updated `verify_agent_gcp()` in `provision_04_gcp_gchat.sh` to use an exact string match for `"serviceAccount:${gsa_email}"` (enclosed in double quotes).

## Why This Matters

- **Exact Principal Match**: Avoids negative filtering (`grep -v "deleted:"`). The leading quote `"` rejects `deleted:serviceAccount:...` and the trailing quote `"` rejects `...iam.gserviceaccount.com?uid=...`.
- Ensures idempotent setup scripts correctly detect missing IAM role bindings on recreated GSAs.
- Fixes `403 Permission Denied` errors on Pub/Sub subscriptions during platform agent initialization.

## Context

- Fixes Pub/Sub permission verification bypass in operator deployment pipeline.

## Testing

- Tested against JSON policy output from GCP cluster `toshiowang-gkedemos`:
  - Active GSA string `"serviceAccount:kubeagents-platform-gsa@..."` correctly matches (returns `0`).
  - Tombstoned entry `"deleted:serviceAccount:kubeagents-platform-gsa@...?uid=..."` does not match.

TAG=agy
CONV=e4742920-4e88-4410-a584-c8ecfe93483f