### PR TITLE
feat(platform): add credential proxy runtime and image

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,6 +18,7 @@ __pycache__/
 node_modules/
 .venv/
 venv/
+k8s-operator/bin/
 
 # Local configuration files (except tracked default .env)
 .env

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -59,6 +59,16 @@ jobs:
           DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
+      - name: Build and Push Credential Sidecar (GCP Cloud Build)
+        id: gcp-credential-proxy
+        run: |
+          gcloud builds submit \
+            --config=deploy/docker/cloudbuild.yaml \
+            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/credential-proxy:latest,_TARGET=credential-proxy,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            .
+          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
@@ -66,3 +76,4 @@ jobs:
         run: |
           cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"
           cosign sign --yes "${{ env.GCP_REGISTRY }}/replay-proxy@${{ steps.gcp-replay-proxy.outputs.digest }}"
+          cosign sign --yes "${{ env.GCP_REGISTRY }}/credential-proxy@${{ steps.gcp-credential-proxy.outputs.digest }}"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -59,6 +59,20 @@ jobs:
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:${{ github.sha }}
 
+      - name: Build and Push Credential Sidecar (GHCR)
+        uses: docker/build-push-action@v7
+        id: build-credential-proxy
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          target: credential-proxy
+          push: true
+          tags: |
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy:latest
+            ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy:${{ github.sha }}
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.2
 
@@ -66,3 +80,4 @@ jobs:
         run: |
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
           cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy@${{ steps.build-replay-proxy.outputs.digest }}"
+          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy@${{ steps.build-credential-proxy.outputs.digest }}"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO ?= $(eval REPO := $(LOCATION)-docker.pkg.dev/$(shell gcloud config get core
 
 BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
 
-.PHONY: default docker-build docker-build-agents docker-push docker-push-agents dev-rebuild-agent status prettier-check prettier-write validate
+.PHONY: default docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write validate
 
 AGENTS := $(notdir $(patsubst %/,%,$(wildcard agents/*/)))
 
@@ -13,20 +13,26 @@ AGENTS := $(notdir $(patsubst %/,%,$(wildcard agents/*/)))
 default: docker-build
 
 # Docker builds
-docker-build: docker-build-agents
+docker-build: docker-build-agents docker-build-credential-proxy
 docker-build-agents: $(foreach agent,$(AGENTS),docker-build-$(agent))
 
 .PHONY: $(foreach agent,$(AGENTS),docker-build-$(agent))
 $(foreach agent,$(AGENTS),docker-build-$(agent)): docker-build-%:
 	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target $* -t $(REPO)/$*-agent:latest -f deploy/docker/Dockerfile .
 
+docker-build-credential-proxy:
+	docker build --build-arg HERMES_AGENT_TAG=$(HERMES_AGENT_TAG) --target credential-proxy -t $(REPO)/credential-proxy:latest -f deploy/docker/Dockerfile .
+
 # Docker pushes
-docker-push: docker-push-agents
+docker-push: docker-push-agents docker-push-credential-proxy
 docker-push-agents: $(foreach agent,$(AGENTS),docker-push-$(agent))
 
 .PHONY: $(foreach agent,$(AGENTS),docker-push-$(agent))
 $(foreach agent,$(AGENTS),docker-push-$(agent)): docker-push-%: docker-build-%
 	docker push $(REPO)/$*-agent:latest
+
+docker-push-credential-proxy: docker-build-credential-proxy
+	docker push $(REPO)/credential-proxy:latest
 
 dev-rebuild-agent: ## Fast local iteration: rebuild and redeploy an agent image (e.g. make dev-rebuild-agent ARGS="platform").
 	@$(MAKE) -C k8s-operator dev-rebuild-agent ARGS="$(ARGS)"
@@ -50,7 +56,6 @@ validate:
 	else \
 		echo "Validation passed: No skills found in invalid paths."; \
 	fi
-
 
 
 

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -1,0 +1,1009 @@
+#!/usr/bin/env python3
+"""Credential proxy for restricted credentialed CLI execution."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hmac
+import http.client
+import io
+import json
+import logging
+import os
+import queue
+import re
+import shlex
+import signal
+import shutil
+import socketserver
+import subprocess
+import threading
+import time
+import urllib.parse
+import urllib.request
+import uuid
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+LOGGER = logging.getLogger("credential-proxy")
+
+
+class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
+    """HTTP server over a private Unix socket used behind Envoy."""
+
+    daemon_threads = True
+
+
+class AgentAPIProxyHandler(BaseHTTPRequestHandler):
+    """Authenticate the external PlatformAgent API without sharing its key."""
+
+    external_key: str
+    upstream_key: str
+    upstream_host = "127.0.0.1"
+    upstream_port = 8642
+    max_request_bytes = 10 * 1024 * 1024
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_PATCH(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def do_DELETE(self) -> None:  # noqa: N802
+        self._proxy()
+
+    def _proxy(self) -> None:
+        supplied = self.headers.get("Authorization", "")
+        expected = f"Bearer {self.external_key}"
+        if not hmac.compare_digest(supplied, expected):
+            self.send_error(HTTPStatus.UNAUTHORIZED)
+            return
+        if self.headers.get("Transfer-Encoding"):
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self.send_error(HTTPStatus.BAD_REQUEST)
+            return
+        if content_length < 0 or content_length > self.max_request_bytes:
+            self.send_error(HTTPStatus.REQUEST_ENTITY_TOO_LARGE)
+            return
+        body = self.rfile.read(content_length) if content_length else None
+        headers = {
+            name: value
+            for name, value in self.headers.items()
+            if name.lower()
+            not in {
+                "authorization",
+                "connection",
+                "content-length",
+                "host",
+                "proxy-authorization",
+                "transfer-encoding",
+                "upgrade",
+            }
+        }
+        headers["Authorization"] = f"Bearer {self.upstream_key}"
+        if body is not None:
+            headers["Content-Length"] = str(len(body))
+
+        upstream = http.client.HTTPConnection(
+            self.upstream_host, self.upstream_port, timeout=300
+        )
+        response_started = False
+        try:
+            upstream.request(self.command, self.path, body=body, headers=headers)
+            response = upstream.getresponse()
+            self.send_response(response.status, response.reason)
+            for name, value in response.getheaders():
+                if name.lower() not in {
+                    "connection",
+                    "keep-alive",
+                    "proxy-authenticate",
+                    "transfer-encoding",
+                    "upgrade",
+                }:
+                    self.send_header(name, value)
+            self.send_header("Connection", "close")
+            self.end_headers()
+            response_started = True
+            while chunk := response.read(64 * 1024):
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except (ConnectionError, TimeoutError, OSError, http.client.HTTPException):
+            LOGGER.warning("PlatformAgent API upstream request failed", exc_info=True)
+            if not response_started:
+                self.send_error(HTTPStatus.BAD_GATEWAY)
+            self.close_connection = True
+        finally:
+            upstream.close()
+
+    def log_message(self, message: str, *args: Any) -> None:
+        LOGGER.info("agent-api " + message, *args)
+
+
+class GoogleChatRelay:
+    """Credentialed Google Chat/Pub/Sub transport for a credential-free agent."""
+
+    SCOPES = (
+        "https://www.googleapis.com/auth/chat.bot",
+        "https://www.googleapis.com/auth/pubsub",
+    )
+
+    def __init__(self, project_id: str, subscription_name: str) -> None:
+        import google.auth
+        from google.cloud import pubsub_v1
+        from googleapiclient.discovery import build
+
+        credentials, _ = google.auth.default(scopes=self.SCOPES)
+        self.subscriber = pubsub_v1.SubscriberClient(credentials=credentials)
+        self.subscription_path = (
+            subscription_name
+            if subscription_name.startswith("projects/")
+            else self.subscriber.subscription_path(project_id, subscription_name)
+        )
+        self.chat = build("chat", "v1", credentials=credentials, cache_discovery=False)
+        self._receipts: dict[str, Any] = {}
+        self._lock = threading.Lock()
+
+    def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
+        from google.api_core import retry
+        from google.api_core.exceptions import DeadlineExceeded
+
+        try:
+            response = self.subscriber.pull(
+                request={"subscription": self.subscription_path, "max_messages": 1},
+                retry=retry.Retry(deadline=max(timeout_seconds, 1)),
+                timeout=max(timeout_seconds, 1),
+            )
+        except DeadlineExceeded:
+            return None
+        if not response.received_messages:
+            return None
+        received = response.received_messages[0]
+        receipt = str(uuid.uuid4())
+        with self._lock:
+            self._receipts[receipt] = received.ack_id
+        return {
+            "receipt": receipt,
+            "data": base64.b64encode(received.message.data).decode("ascii"),
+            "attributes": dict(received.message.attributes),
+            "messageId": received.message.message_id,
+        }
+
+    def settle(self, receipt: str, acknowledge: bool) -> bool:
+        with self._lock:
+            ack_id = self._receipts.pop(receipt, None)
+        if ack_id is None:
+            return False
+        if acknowledge:
+            self.subscriber.acknowledge(
+                request={"subscription": self.subscription_path, "ack_ids": [ack_id]}
+            )
+        else:
+            self.subscriber.modify_ack_deadline(
+                request={
+                    "subscription": self.subscription_path,
+                    "ack_ids": [ack_id],
+                    "ack_deadline_seconds": 0,
+                }
+            )
+        return True
+
+    def api_call(
+        self, resource: list[str], method: str, arguments: dict[str, Any]
+    ) -> Any:
+        target = self.chat
+        for name in resource:
+            if not isinstance(name, str) or not name or name.startswith("_"):
+                raise ValueError("invalid Google Chat API resource")
+            target = getattr(target, name)()
+        if not method or method.startswith("_"):
+            raise ValueError("invalid Google Chat API method")
+        operation = getattr(target, method)(**arguments)
+        return operation.execute()
+
+
+class SlackRelay:
+    """Credentialed Slack Socket Mode and Web API transport."""
+
+    def __init__(
+        self, bot_tokens: str, app_token: str, max_file_bytes: int = 20 * 1024 * 1024
+    ) -> None:
+        from slack_sdk import WebClient
+        from slack_sdk.socket_mode import SocketModeClient
+
+        tokens = [token.strip() for token in bot_tokens.split(",") if token.strip()]
+        if not tokens or not app_token:
+            raise ValueError("Slack bot and app tokens are required")
+        self.max_file_bytes = max_file_bytes
+        self.clients: dict[str, Any] = {}
+        self.workspaces: list[dict[str, str]] = []
+        self.primary_client = None
+        for token in tokens:
+            client = WebClient(token=token)
+            try:
+                identity = client.auth_test()
+            except Exception as exc:
+                LOGGER.error(
+                    "Slack bot token authentication failed type=%s",
+                    type(exc).__name__,
+                )
+                continue
+            team_id = str(identity.get("team_id", ""))
+            if not team_id:
+                LOGGER.error("Slack bot token authentication returned no team ID")
+                continue
+            if self.primary_client is None:
+                self.primary_client = client
+            self.clients[team_id] = client
+            self.workspaces.append(
+                {
+                    "teamId": team_id,
+                    "teamName": str(identity.get("team", "")),
+                    "botUserId": str(identity.get("user_id", "")),
+                    "botName": str(identity.get("user", "")),
+                }
+            )
+        if self.primary_client is None:
+            raise RuntimeError("no Slack bot token could be authenticated")
+        self._events: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._receipts: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self.socket_client = SocketModeClient(
+            app_token=app_token, web_client=self.primary_client
+        )
+        self.socket_client.socket_mode_request_listeners.append(self._on_event)
+        self.socket_client.connect()
+
+    def _on_event(self, client: Any, request: Any) -> None:
+        from slack_sdk.socket_mode.response import SocketModeResponse
+
+        client.send_socket_mode_response(
+            SocketModeResponse(envelope_id=request.envelope_id)
+        )
+        self._events.put(
+            {
+                "type": str(request.type),
+                "payload": request.payload,
+            }
+        )
+
+    def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
+        try:
+            event = self._events.get(timeout=max(timeout_seconds, 1))
+        except queue.Empty:
+            return None
+        receipt = str(uuid.uuid4())
+        with self._lock:
+            self._receipts[receipt] = event
+        return {"receipt": receipt, **event}
+
+    def settle(self, receipt: str, acknowledge: bool) -> bool:
+        with self._lock:
+            event = self._receipts.pop(receipt, None)
+        if event is None:
+            return False
+        if not acknowledge:
+            self._events.put(event)
+        return True
+
+    def bootstrap(self) -> list[dict[str, str]]:
+        return self.workspaces
+
+    def _client(self, team_id: str) -> Any:
+        return self.clients.get(team_id) or self.primary_client
+
+    def _decode_argument(self, value: Any) -> Any:
+        if isinstance(value, list):
+            return [self._decode_argument(item) for item in value]
+        if isinstance(value, dict):
+            if set(value).issubset({"__bytesBase64"}) and "__bytesBase64" in value:
+                content = base64.b64decode(value["__bytesBase64"], validate=True)
+                if len(content) > self.max_file_bytes:
+                    raise ValueError("Slack upload exceeds relay size limit")
+                return content
+            if "__fileBase64" in value:
+                content = base64.b64decode(value["__fileBase64"], validate=True)
+                if len(content) > self.max_file_bytes:
+                    raise ValueError("Slack upload exceeds relay size limit")
+                stream = io.BytesIO(content)
+                stream.name = str(value.get("filename", "upload"))
+                return stream
+            return {key: self._decode_argument(item) for key, item in value.items()}
+        return value
+
+    def api_call(
+        self, team_id: str, method: str, arguments: dict[str, Any]
+    ) -> dict[str, Any]:
+        if not method or method.startswith("_"):
+            raise ValueError("Slack API method is not available through the relay")
+        response = self._client(team_id).api_call(
+            method, **self._decode_argument(arguments)
+        )
+        return dict(response)
+
+    def download(self, team_id: str, url: str) -> bytes:
+        def is_slack_url(value: str) -> bool:
+            parsed = urllib.parse.urlparse(value)
+            hostname = (parsed.hostname or "").lower()
+            return parsed.scheme == "https" and (
+                hostname == "slack.com" or hostname.endswith(".slack.com")
+            )
+
+        if not is_slack_url(url):
+            raise ValueError("Slack file URL must use HTTPS on a slack.com host")
+
+        class SlackRedirectHandler(urllib.request.HTTPRedirectHandler):
+            def redirect_request(
+                self,
+                request: Any,
+                file_pointer: Any,
+                code: int,
+                message: str,
+                headers: Any,
+                new_url: str,
+            ) -> Any:
+                if not is_slack_url(new_url):
+                    raise ValueError("Slack file redirect left slack.com")
+                return super().redirect_request(
+                    request, file_pointer, code, message, headers, new_url
+                )
+
+        token = self._client(team_id).token
+        request = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {token}"}
+        )
+        opener = urllib.request.build_opener(SlackRedirectHandler())
+        with opener.open(request, timeout=30) as response:
+            content_type = response.headers.get("Content-Type", "")
+            if "text/html" in content_type.lower():
+                raise ValueError("Slack returned HTML instead of file content")
+            content = response.read(self.max_file_bytes + 1)
+        if len(content) > self.max_file_bytes:
+            raise ValueError("Slack file exceeds relay size limit")
+        return content
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+class Policy:
+    def __init__(self, rules: list[Rule], blocked_message: str) -> None:
+        self.rules = rules
+        self.blocked_message = blocked_message
+
+    @classmethod
+    def load(cls, path: str) -> "Policy":
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        blocked_message = payload.get(
+            "blockedMessage", "Command blocked for security reasons."
+        )
+        rules = []
+        for item in payload.get("rules", []):
+            rules.append(
+                Rule(
+                    rule_id=item["id"],
+                    pattern=re.compile(item["pattern"], re.IGNORECASE | re.MULTILINE),
+                    message=item.get("message", blocked_message),
+                )
+            )
+        return cls(rules=rules, blocked_message=blocked_message)
+
+    def blocked_by(self, argv: list[str]) -> Rule | None:
+        command = shlex.join(argv)
+        return next((rule for rule in self.rules if rule.pattern.search(command)), None)
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+    truncated: bool
+    timed_out: bool
+
+
+class CommandExecutor:
+    ALLOWED_EXECUTABLES = ("gcloud", "kubectl", "gh", "git")
+
+    def __init__(
+        self, timeout_seconds: int, max_output_bytes: int, state_dir: str
+    ) -> None:
+        self.timeout_seconds = timeout_seconds
+        self.max_output_bytes = max_output_bytes
+        self.state_dir = Path(state_dir)
+        self.home_dir = self.state_dir / "home"
+        self.workspace_dir = Path(
+            os.getenv("CREDENTIAL_PROXY_WORKSPACE_ROOT", str(self.state_dir / "workspace"))
+        ).resolve()
+        self.tmp_dir = self.state_dir / "tmp"
+        self.config_dir = self.home_dir / ".config"
+        self.cache_dir = self.home_dir / ".cache"
+        self.local_state_dir = self.home_dir / ".local" / "state"
+        self.kube_dir = self.home_dir / ".kube"
+        for path in (
+            self.home_dir,
+            self.workspace_dir,
+            self.tmp_dir,
+            self.config_dir,
+            self.cache_dir,
+            self.local_state_dir,
+            self.kube_dir,
+        ):
+            path.mkdir(parents=True, exist_ok=True)
+        trusted_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        self.executables = {
+            name: shutil.which(name, path=trusted_path)
+            for name in self.ALLOWED_EXECUTABLES
+        }
+        self.environment = {
+            "PATH": trusted_path,
+            "HOME": str(self.home_dir),
+            "TMPDIR": str(self.tmp_dir),
+            "XDG_CONFIG_HOME": str(self.config_dir),
+            "XDG_CACHE_HOME": str(self.cache_dir),
+            "XDG_STATE_HOME": str(self.local_state_dir),
+            "CLOUDSDK_CONFIG": str(self.config_dir / "gcloud"),
+            "GH_CONFIG_DIR": str(self.config_dir / "gh"),
+            "KUBECONFIG": str(self.home_dir / ".kube" / "config"),
+            "CLOUDSDK_CORE_DISABLE_PROMPTS": "1",
+        }
+        # Forward only variables required by supported credential clients. Chat
+        # tokens and proxy control variables must never enter an agent-selected
+        # subprocess, even though that subprocess runs in the sidecar.
+        for name in (
+            "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "NO_PROXY",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
+            "REQUESTS_CA_BUNDLE",
+            "LANG",
+            "LC_ALL",
+            "TOKEN_BROKER_URL",
+            "KSA_TOKEN_FILE",
+        ):
+            if name in os.environ:
+                self.environment[name] = os.environ[name]
+
+    def bootstrap(self, command: str) -> None:
+        """Prepare the trusted shell profile without interpreting later commands."""
+        if not command.strip():
+            return
+        bootstrap_environment = self.environment.copy()
+        for name in (
+            "GKE_PROJECT_ID",
+            "GKE_CLUSTER_NAME",
+            "GKE_LOCATION",
+            "KUBE_CONTEXT_NAME",
+            "KUBE_DEFAULT_NAMESPACE",
+        ):
+            if name in os.environ:
+                bootstrap_environment[name] = os.environ[name]
+        result = subprocess.run(
+            ["/bin/bash", "--noprofile", "--norc", "-c", command],
+            cwd=self.workspace_dir,
+            env=bootstrap_environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=max(self.timeout_seconds, 120),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"credential proxy shell bootstrap failed with exit code {result.returncode}"
+            )
+
+    def execute(
+        self,
+        argv: list[str],
+        stdin: str | None = None,
+        cwd: str | None = None,
+    ) -> ExecutionResult:
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(argument, str) for argument in argv)
+        ):
+            raise ValueError("argv must be a non-empty list of strings")
+        executable = argv[0]
+        if executable not in self.ALLOWED_EXECUTABLES:
+            raise ValueError("executable is not supported by the credential proxy")
+        executable_path = self.executables.get(executable)
+        if not executable_path:
+            raise RuntimeError(f"supported executable is unavailable: {executable}")
+        return self._execute([executable_path, *argv[1:]], stdin=stdin, cwd=cwd)
+
+    def execute_internal(
+        self, argv: list[str], cwd: str | None = None
+    ) -> ExecutionResult:
+        """Run a trusted, operator-defined helper that is not agent selectable."""
+        return self._execute(argv, cwd=cwd)
+
+    def _execute(
+        self,
+        argv: list[str],
+        stdin: str | None = None,
+        cwd: str | None = None,
+    ) -> ExecutionResult:
+        started = time.monotonic()
+        timed_out = False
+        command_cwd = self.workspace_dir
+        if cwd:
+            requested_cwd = Path(cwd).resolve()
+            if requested_cwd != self.workspace_dir and self.workspace_dir not in requested_cwd.parents:
+                raise ValueError("working directory is outside the shared workspace")
+            command_cwd = requested_cwd
+        process = subprocess.Popen(
+            argv,
+            cwd=command_cwd,
+            env=self.environment.copy(),
+            stdin=subprocess.PIPE if stdin is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        try:
+            stdout_bytes, stderr_bytes = process.communicate(
+                input=stdin.encode("utf-8") if stdin is not None else None,
+                timeout=self.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            stdout_bytes, stderr_bytes = process.communicate()
+
+        stdout_bytes, stdout_truncated = self._truncate(stdout_bytes)
+        stderr_bytes, stderr_truncated = self._truncate(stderr_bytes)
+        duration_ms = int((time.monotonic() - started) * 1000)
+        return ExecutionResult(
+            exit_code=124 if timed_out else process.returncode,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            duration_ms=duration_ms,
+            truncated=stdout_truncated or stderr_truncated,
+            timed_out=timed_out,
+        )
+
+    def _truncate(self, value: bytes) -> tuple[bytes, bool]:
+        if len(value) <= self.max_output_bytes:
+            return value, False
+        return value[: self.max_output_bytes], True
+
+
+class CredentialProxyHandler(BaseHTTPRequestHandler):
+    policy: Policy
+    executor: CommandExecutor
+    max_request_bytes: int
+    slack_max_request_bytes: int
+    chat_relay: GoogleChatRelay | None = None
+    slack_relay: SlackRelay | None = None
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path.startswith("/v1/chat/slack/events"):
+            if self.slack_relay is None:
+                self._json(
+                    HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack relay disabled"}
+                )
+                return
+            try:
+                self._json(HTTPStatus.OK, {"event": self.slack_relay.pull()})
+            except Exception as exc:
+                LOGGER.warning("Slack event pull failed: %s", type(exc).__name__)
+                self._json(
+                    HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack event pull failed"}
+                )
+            return
+        if self.path.startswith("/v1/chat/events"):
+            if self.chat_relay is None:
+                self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat relay disabled"})
+                return
+            try:
+                event = self.chat_relay.pull()
+                self._json(HTTPStatus.OK, {"event": event})
+            except Exception as exc:
+                LOGGER.warning("chat event pull failed: %s", type(exc).__name__)
+                self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat event pull failed"})
+            return
+        if self.path != "/healthz":
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+            return
+        self._json(HTTPStatus.OK, {"status": "ok"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path.startswith("/v1/chat/slack/"):
+            self._handle_slack_post()
+            return
+        if self.path.startswith("/v1/chat/"):
+            self._handle_chat_post()
+            return
+        if self.path == "/v1/github/refresh":
+            self._handle_github_refresh()
+            return
+        if self.path != "/v1/exec":
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+            return
+
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": "invalid content length"})
+            return
+        if content_length <= 0 or content_length > self.max_request_bytes:
+            self._json(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                {"error": "command request exceeds configured size limit"},
+            )
+            return
+
+        try:
+            payload = json.loads(self.rfile.read(content_length))
+            argv = payload["argv"]
+            if (
+                not isinstance(argv, list)
+                or not argv
+                or not all(isinstance(argument, str) for argument in argv)
+            ):
+                raise ValueError("argv must be a non-empty list of strings")
+            stdin = payload.get("stdin")
+            if stdin is not None and not isinstance(stdin, str):
+                raise ValueError("stdin must be a string")
+            cwd = payload.get("cwd")
+            if cwd is not None and not isinstance(cwd, str):
+                raise ValueError("cwd must be a string")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        request_id = str(payload.get("requestId", ""))
+        if argv[0] not in CommandExecutor.ALLOWED_EXECUTABLES:
+            LOGGER.warning(
+                "executable blocked request_id=%s executable=%s",
+                request_id,
+                argv[0],
+            )
+            self._json(
+                HTTPStatus.FORBIDDEN,
+                {
+                    "status": "blocked",
+                    "code": "SECURITY_POLICY_BLOCKED",
+                    "rule": "executable.allowlist",
+                    "message": "Executable is not supported by the credential proxy.",
+                },
+            )
+            return
+        rule = self.policy.blocked_by(argv)
+        if rule is not None:
+            LOGGER.warning(
+                "command blocked request_id=%s rule=%s", request_id, rule.rule_id
+            )
+            self._json(
+                HTTPStatus.FORBIDDEN,
+                {
+                    "status": "blocked",
+                    "code": "SECURITY_POLICY_BLOCKED",
+                    "rule": rule.rule_id,
+                    "message": rule.message,
+                },
+            )
+            return
+
+        try:
+            result = self.executor.execute(argv, stdin=stdin, cwd=cwd)
+        except Exception as exc:
+            LOGGER.exception(
+                "command failed request_id=%s type=%s",
+                request_id,
+                type(exc).__name__,
+            )
+            self._json(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": "credential proxy command execution failed"},
+            )
+            return
+        LOGGER.info(
+            "command complete request_id=%s exit_code=%d duration_ms=%d truncated=%s",
+            request_id,
+            result.exit_code,
+            result.duration_ms,
+            result.truncated,
+        )
+        self._json(
+            HTTPStatus.OK,
+            {
+                "status": "completed",
+                "exitCode": result.exit_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "durationMs": result.duration_ms,
+                "truncated": result.truncated,
+                "timedOut": result.timed_out,
+            },
+        )
+
+    def _handle_github_refresh(self) -> None:
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+            if content_length <= 0 or content_length > self.max_request_bytes:
+                raise ValueError("invalid request size")
+            payload = json.loads(self.rfile.read(content_length))
+            repository = payload["repository"]
+            if not isinstance(repository, str) or not re.fullmatch(
+                r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+            ):
+                raise ValueError("repository must be owner/name")
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+
+        try:
+            result = self.executor.execute_internal(
+                ["/opt/defaults/scripts/github_token_refresh.py", repository]
+            )
+        except Exception as exc:
+            LOGGER.warning("GitHub credential refresh failed: %s", type(exc).__name__)
+            self._json(
+                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
+            )
+            return
+        if result.exit_code != 0:
+            LOGGER.warning("GitHub credential refresh exited %d", result.exit_code)
+            self._json(
+                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
+            )
+            return
+        self._json(HTTPStatus.OK, {"status": "refreshed"})
+
+    def _read_json_body(self, max_bytes: int | None = None) -> dict[str, Any]:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        if content_length <= 0 or content_length > (
+            max_bytes or self.max_request_bytes
+        ):
+            raise ValueError("request exceeds configured size limit")
+        payload = json.loads(self.rfile.read(content_length))
+        if not isinstance(payload, dict):
+            raise ValueError("request body must be an object")
+        return payload
+
+    def _handle_chat_post(self) -> None:
+        if self.chat_relay is None:
+            self._json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "chat relay disabled"})
+            return
+        try:
+            payload = self._read_json_body()
+            if self.path == "/v1/chat/events/ack":
+                ok = self.chat_relay.settle(str(payload.get("receipt", "")), True)
+                self._json(HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok})
+                return
+            if self.path == "/v1/chat/events/nack":
+                ok = self.chat_relay.settle(str(payload.get("receipt", "")), False)
+                self._json(HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok})
+                return
+            if self.path == "/v1/chat/api":
+                resource = payload.get("resource", [])
+                arguments = payload.get("arguments", {})
+                if not isinstance(resource, list) or not isinstance(arguments, dict):
+                    raise ValueError("resource must be a list and arguments an object")
+                result = self.chat_relay.api_call(
+                    resource,
+                    str(payload.get("method", "")),
+                    arguments,
+                )
+                self._json(HTTPStatus.OK, {"response": result})
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception as exc:
+            LOGGER.warning("chat relay operation failed path=%s type=%s", self.path, type(exc).__name__)
+            self._json(HTTPStatus.BAD_GATEWAY, {"error": "Google Chat operation failed"})
+
+    def _handle_slack_post(self) -> None:
+        if self.slack_relay is None:
+            self._json(
+                HTTPStatus.SERVICE_UNAVAILABLE, {"error": "Slack relay disabled"}
+            )
+            return
+        try:
+            payload = self._read_json_body(self.slack_max_request_bytes)
+            if self.path == "/v1/chat/slack/bootstrap":
+                self._json(
+                    HTTPStatus.OK,
+                    {"workspaces": self.slack_relay.bootstrap()},
+                )
+                return
+            if self.path == "/v1/chat/slack/events/ack":
+                ok = self.slack_relay.settle(str(payload.get("receipt", "")), True)
+                self._json(
+                    HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok}
+                )
+                return
+            if self.path == "/v1/chat/slack/events/nack":
+                ok = self.slack_relay.settle(str(payload.get("receipt", "")), False)
+                self._json(
+                    HTTPStatus.OK if ok else HTTPStatus.NOT_FOUND, {"settled": ok}
+                )
+                return
+            if self.path == "/v1/chat/slack/api":
+                arguments = payload.get("arguments", {})
+                if not isinstance(arguments, dict):
+                    raise ValueError("arguments must be an object")
+                result = self.slack_relay.api_call(
+                    str(payload.get("teamId", "")),
+                    str(payload.get("method", "")),
+                    arguments,
+                )
+                self._json(HTTPStatus.OK, {"response": result})
+                return
+            if self.path == "/v1/chat/slack/files/download":
+                content = self.slack_relay.download(
+                    str(payload.get("teamId", "")), str(payload["url"])
+                )
+                self._json(
+                    HTTPStatus.OK,
+                    {"data": base64.b64encode(content).decode("ascii")},
+                )
+                return
+            self._json(HTTPStatus.NOT_FOUND, {"status": "not_found"})
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except Exception as exc:
+            LOGGER.warning(
+                "Slack relay operation failed path=%s type=%s",
+                self.path,
+                type(exc).__name__,
+            )
+            self._json(HTTPStatus.BAD_GATEWAY, {"error": "Slack operation failed"})
+
+    def log_message(self, message: str, *args: Any) -> None:
+        LOGGER.info("http " + message, *args)
+
+    def _json(self, status: HTTPStatus, payload: dict[str, Any]) -> None:
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def serve(args: argparse.Namespace) -> None:
+    CredentialProxyHandler.policy = Policy.load(args.policy)
+    executor = CommandExecutor(
+        timeout_seconds=args.timeout_seconds,
+        max_output_bytes=args.max_output_bytes,
+        state_dir=args.state_dir,
+    )
+    executor.bootstrap(os.getenv("CREDENTIAL_PROXY_BOOTSTRAP_COMMAND", ""))
+    CredentialProxyHandler.executor = executor
+    CredentialProxyHandler.max_request_bytes = args.max_request_bytes
+    CredentialProxyHandler.slack_max_request_bytes = int(
+        os.getenv("SLACK_RELAY_MAX_REQUEST_BYTES", str(28 * 1024 * 1024))
+    )
+    chat_project = os.getenv("GOOGLE_CHAT_PROJECT_ID", "").strip()
+    chat_subscription = os.getenv("GOOGLE_CHAT_SUBSCRIPTION_NAME", "").strip()
+    if chat_project and chat_subscription:
+        CredentialProxyHandler.chat_relay = GoogleChatRelay(
+            chat_project, chat_subscription
+        )
+        LOGGER.info("Google Chat relay enabled project=%s subscription=<redacted>", chat_project)
+    slack_bot_tokens = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    slack_app_token = os.getenv("SLACK_APP_TOKEN", "").strip()
+    if slack_bot_tokens and slack_app_token:
+        def initialize_slack_relay() -> None:
+            while CredentialProxyHandler.slack_relay is None:
+                try:
+                    relay = SlackRelay(
+                        slack_bot_tokens,
+                        slack_app_token,
+                        max_file_bytes=int(
+                            os.getenv(
+                                "SLACK_RELAY_MAX_FILE_BYTES", str(20 * 1024 * 1024)
+                            )
+                        ),
+                    )
+                except Exception as exc:
+                    LOGGER.error(
+                        "Slack relay initialization failed; retrying type=%s",
+                        type(exc).__name__,
+                    )
+                    time.sleep(30)
+                else:
+                    CredentialProxyHandler.slack_relay = relay
+                    LOGGER.info(
+                        "Slack relay enabled workspaces=%d",
+                        len(relay.bootstrap()),
+                    )
+
+        threading.Thread(target=initialize_slack_relay, daemon=True).start()
+    AgentAPIProxyHandler.external_key = os.getenv("API_SERVER_EXTERNAL_KEY", "").strip()
+    if not AgentAPIProxyHandler.external_key:
+        raise RuntimeError("API_SERVER_EXTERNAL_KEY must be configured")
+    AgentAPIProxyHandler.upstream_key = os.getenv(
+        "AGENT_API_UPSTREAM_KEY", "cluster-internal-trusted"
+    )
+    api_server = ThreadingHTTPServer(
+        ("0.0.0.0", int(os.getenv("AGENT_API_PROXY_PORT", "8643"))),
+        AgentAPIProxyHandler,
+    )
+    threading.Thread(target=api_server.serve_forever, daemon=True).start()
+    LOGGER.info("authenticated PlatformAgent API proxy listening on port 8643")
+    if args.unix_socket:
+        socket_path = Path(args.unix_socket)
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+        socket_path.unlink(missing_ok=True)
+        server = ThreadingUnixHTTPServer(str(socket_path), CredentialProxyHandler)
+        LOGGER.info("credential proxy listening on unix socket %s", socket_path)
+    else:
+        server = ThreadingHTTPServer((args.host, args.port), CredentialProxyHandler)
+        LOGGER.info("credential proxy listening on %s:%d", args.host, args.port)
+    server.serve_forever()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--policy",
+        default=os.getenv(
+            "CREDENTIAL_PROXY_POLICY", "/etc/credential-proxy/policy.json"
+        ),
+    )
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument(
+        "--port", type=int, default=int(os.getenv("CREDENTIAL_PROXY_PORT", "8765"))
+    )
+    parser.add_argument(
+        "--unix-socket", default=os.getenv("CREDENTIAL_PROXY_UNIX_SOCKET", "")
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_TIMEOUT_SECONDS", "300")),
+    )
+    parser.add_argument(
+        "--max-request-bytes",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_MAX_REQUEST_BYTES", "1048576")),
+    )
+    parser.add_argument(
+        "--max-output-bytes",
+        type=int,
+        default=int(os.getenv("CREDENTIAL_PROXY_MAX_OUTPUT_BYTES", "4194304")),
+    )
+    parser.add_argument(
+        "--state-dir",
+        default=os.getenv("CREDENTIAL_PROXY_STATE_DIR", "/var/lib/credential-proxy"),
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=os.getenv("LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    serve(parse_args())

--- a/agents/platform/scripts/credential_proxy_client.py
+++ b/agents/platform/scripts/credential_proxy_client.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Submit a supported CLI argv vector to the paired credential proxy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+
+def execute(
+    endpoint: str,
+    argv: list[str],
+    stdin: str | None = None,
+) -> int:
+    request_payload = {
+        "requestId": str(uuid.uuid4()),
+        "argv": argv,
+        "cwd": os.getcwd(),
+    }
+    if stdin is not None:
+        request_payload["stdin"] = stdin
+    body = json.dumps(
+        request_payload,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint.rstrip("/") + "/v1/exec",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        payload = json.load(exc)
+        if payload.get("code") == "SECURITY_POLICY_BLOCKED":
+            print(
+                payload.get("message", "Command blocked for security reasons."),
+                file=sys.stderr,
+            )
+            print(f"policy rule: {payload.get('rule', 'unknown')}", file=sys.stderr)
+            return 126
+        print(payload.get("error", str(exc)), file=sys.stderr)
+        return 1
+    except urllib.error.URLError as exc:
+        print(f"credential proxy unavailable: {exc.reason}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(payload.get("stdout", ""))
+    sys.stderr.write(payload.get("stderr", ""))
+    if payload.get("truncated"):
+        print("credential proxy output truncated", file=sys.stderr)
+    return int(payload.get("exitCode", 1))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--endpoint",
+        default=os.getenv("CREDENTIAL_PROXY_URL"),
+        required=os.getenv("CREDENTIAL_PROXY_URL") is None,
+    )
+    parser.add_argument(
+        "executable",
+        choices=("kubectl", "gcloud", "gh", "git"),
+    )
+    parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    invoked_as = os.path.basename(sys.argv[0])
+    if invoked_as in {"kubectl", "gcloud", "gh", "git"}:
+        endpoint = os.getenv("CREDENTIAL_PROXY_URL")
+        if endpoint is None:
+            print("CREDENTIAL_PROXY_URL is not configured", file=sys.stderr)
+            raise SystemExit(1)
+        argv = [invoked_as, *sys.argv[1:]]
+        # Do not consume inherited stdin here. MCP and other stdio-based parent
+        # processes may have a protocol stream on fd 0. Pipelines and
+        # redirections remain local to the sandbox shell around this wrapper.
+        stdin = None
+    else:
+        args = parse_args()
+        endpoint = args.endpoint
+        argv = [args.executable, *args.arguments]
+        stdin = None
+    raise SystemExit(
+        execute(
+            endpoint,
+            argv,
+            stdin=stdin,
+        )
+    )

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -2,9 +2,8 @@
 """
 GKE Platform Agent — Secure GitHub Token Refresher (Broker Client)
 
-This script queries the internal cluster-local Token Broker to retrieve
-a short-lived (1-hour), repository-scoped installation token, and securely
-caches it inside the git credentials store and GitHub CLI.
+In the agent sandbox this script asks the credential sidecar to refresh. Only
+the sidecar queries Minty and caches the short-lived repository-scoped token.
 """
 
 import json
@@ -48,6 +47,27 @@ def get_current_git_repo() -> str:
 
 def refresh_git_credentials(target_repo: str = None) -> str:
     """Query local Minty, retrieve token, and cache inside git credentials."""
+    repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
+    if not repository or "/" not in repository:
+        raise RuntimeError("Could not identify target repository as owner/name")
+
+    proxy_url = os.getenv("CREDENTIAL_PROXY_URL", "").strip()
+    if proxy_url:
+        request = urllib.request.Request(
+            proxy_url.rstrip("/") + "/v1/github/refresh",
+            data=json.dumps({"repository": repository}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                if response.status != 200:
+                    raise RuntimeError("credential sidecar rejected refresh")
+        except Exception as exc:
+            raise RuntimeError("Credential sidecar failed to refresh GitHub auth") from exc
+        log(f"GitHub credentials refreshed in credential sidecar for {repository}.")
+        return ""
+
     # 1. Retrieve Google OIDC identity token via gcloud external command
     oidc_token = None
     try:
@@ -71,12 +91,6 @@ def refresh_git_credentials(target_repo: str = None) -> str:
         raise RuntimeError("Retrieved Google OIDC token via gcloud is empty")
 
     # 2. Dynamically identify target repository from workspace git remote or parameter
-    repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
-    if not repository:
-        raise RuntimeError("Could not identify target repository (no argument passed and no local git config found)")
-    if "/" not in repository:
-        raise RuntimeError(f"Invalid repository format: {repository}")
-
     org_name, repo_name = repository.split("/", 1)
 
     headers = {

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -1,0 +1,318 @@
+import json
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import types
+import unittest
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+from credential_proxy import (
+    AgentAPIProxyHandler,
+    CommandExecutor,
+    GoogleChatRelay,
+    Policy,
+    SlackRelay,
+)
+class AgentAPIProxyTest(unittest.TestCase):
+    def setUp(self):
+        self.received_authorization = ""
+        owner = self
+
+        class UpstreamHandler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                owner.received_authorization = self.headers.get("Authorization", "")
+                body = b"proxied"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, _message, *_args):
+                return
+
+        self.upstream = ThreadingHTTPServer(("127.0.0.1", 0), UpstreamHandler)
+        AgentAPIProxyHandler.external_key = "external-secret"
+        AgentAPIProxyHandler.upstream_key = "internal-sentinel"
+        AgentAPIProxyHandler.upstream_port = self.upstream.server_port
+        self.proxy = ThreadingHTTPServer(("127.0.0.1", 0), AgentAPIProxyHandler)
+        for server in (self.upstream, self.proxy):
+            threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    def tearDown(self):
+        self.proxy.shutdown()
+        self.upstream.shutdown()
+        self.proxy.server_close()
+        self.upstream.server_close()
+
+    def test_replaces_external_api_key_before_forwarding(self):
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.proxy.server_port}/health",
+            headers={"Authorization": "Bearer external-secret"},
+        )
+        with urllib.request.urlopen(request) as response:
+            self.assertEqual(b"proxied", response.read())
+        self.assertEqual("Bearer internal-sentinel", self.received_authorization)
+
+    def test_rejects_invalid_external_api_key(self):
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.proxy.server_port}/health",
+            headers={"Authorization": "Bearer wrong"},
+        )
+        with self.assertRaises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request)
+        self.assertEqual(401, raised.exception.code)
+        self.assertEqual("", self.received_authorization)
+
+
+class PolicyTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.policy_path = Path(self.temp_dir.name) / "policy.json"
+        self.policy_path.write_text(
+            json.dumps(
+                {
+                    "blockedMessage": "Command blocked for security reasons.",
+                    "rules": [
+                        {
+                            "id": "gcp.access-token-disclosure",
+                            "pattern": r"\bgcloud\s+auth\s+print-access-token\b",
+                        },
+                        {
+                            "id": "github.token-disclosure",
+                            "pattern": r"\bgh\s+auth\s+token\b",
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.policy = Policy.load(str(self.policy_path))
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_blocks_configured_command(self):
+        rule = self.policy.blocked_by(["gcloud", "auth", "print-access-token"])
+        self.assertIsNotNone(rule)
+        self.assertEqual("gcp.access-token-disclosure", rule.rule_id)
+
+    def test_allows_supported_command(self):
+        self.assertIsNone(self.policy.blocked_by(["kubectl", "get", "pods"]))
+
+
+class CommandExecutorTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def executor(self, timeout_seconds=5):
+        return CommandExecutor(
+            timeout_seconds=timeout_seconds,
+            max_output_bytes=1024,
+            state_dir=self.temp_dir.name,
+        )
+
+    def test_rejects_unsupported_executable(self):
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            self.executor().execute(["env"])
+
+    def test_rejects_shell_command_string(self):
+        with self.assertRaisesRegex(ValueError, "list of strings"):
+            self.executor().execute("gcloud auth list")
+
+    def test_rejects_working_directory_outside_shared_workspace(self):
+        with self.assertRaisesRegex(ValueError, "outside the shared workspace"):
+            self.executor().execute(["git", "status"], cwd="/")
+
+    def test_timeout_kills_command(self):
+        result = self.executor(timeout_seconds=1).execute_internal(["/bin/sleep", "10"])
+        self.assertTrue(result.timed_out)
+        self.assertEqual(124, result.exit_code)
+
+    def test_timeout_handles_process_group_exit_race(self):
+        process = mock.Mock(pid=123, returncode=0)
+        process.communicate.side_effect = [
+            subprocess.TimeoutExpired(["command"], 1),
+            (b"", b""),
+        ]
+        with (
+            mock.patch("credential_proxy.subprocess.Popen", return_value=process),
+            mock.patch("credential_proxy.os.killpg", side_effect=ProcessLookupError),
+        ):
+            result = self.executor(timeout_seconds=1).execute_internal(["command"])
+        self.assertTrue(result.timed_out)
+        self.assertEqual(124, result.exit_code)
+
+    def test_command_environment_excludes_sidecar_tokens(self):
+        import os
+
+        previous = os.environ.get("SLACK_BOT_TOKEN")
+        os.environ["SLACK_BOT_TOKEN"] = "must-not-be-forwarded"
+        try:
+            executor = self.executor()
+        finally:
+            if previous is None:
+                del os.environ["SLACK_BOT_TOKEN"]
+            else:
+                os.environ["SLACK_BOT_TOKEN"] = previous
+        self.assertNotIn("SLACK_BOT_TOKEN", executor.environment)
+        self.assertEqual(str(Path(self.temp_dir.name) / "home"), executor.environment["HOME"])
+
+    def test_bootstrap_prepares_profile_for_later_commands(self):
+        import os
+
+        previous = os.environ.get("GKE_PROJECT_ID")
+        os.environ["GKE_PROJECT_ID"] = "bootstrap-project"
+        try:
+            executor = self.executor()
+            executor.bootstrap(
+                'printf "%s" "$GKE_PROJECT_ID" > "$HOME/bootstrap-state"'
+            )
+        finally:
+            if previous is None:
+                del os.environ["GKE_PROJECT_ID"]
+            else:
+                os.environ["GKE_PROJECT_ID"] = previous
+        self.assertTrue((Path(self.temp_dir.name) / "home" / "bootstrap-state").exists())
+        self.assertEqual(
+            "bootstrap-project",
+            (Path(self.temp_dir.name) / "home" / "bootstrap-state").read_text(),
+        )
+        self.assertNotIn("GKE_PROJECT_ID", executor.environment)
+
+    def test_bootstrap_failure_does_not_return_command_output(self):
+        with self.assertRaisesRegex(RuntimeError, "exit code 9") as raised:
+            self.executor().bootstrap("printf secret >&2; exit 9")
+        self.assertNotIn("secret", str(raised.exception))
+
+
+class GoogleChatRelayTest(unittest.TestCase):
+    class FakeRequest:
+        def __init__(self, response):
+            self.response = response
+
+        def execute(self):
+            return self.response
+
+    class FakeResource:
+        def __init__(self, calls, path=()):
+            self.calls = calls
+            self.path = path
+
+        def __getattr__(self, name):
+            def invoke(**arguments):
+                if not arguments:
+                    return GoogleChatRelayTest.FakeResource(
+                        self.calls, (*self.path, name)
+                    )
+                self.calls.append((self.path, name, arguments))
+                return GoogleChatRelayTest.FakeRequest(
+                    {"path": self.path, "method": name, "arguments": arguments}
+                )
+
+            return invoke
+
+    def test_forwards_unknown_resource_method_and_body_unchanged(self):
+        calls = []
+        relay = GoogleChatRelay.__new__(GoogleChatRelay)
+        relay.chat = self.FakeResource(calls)
+        arguments = {"body": {"futureSchema": {"nested": [1, 2, 3]}}}
+
+        result = relay.api_call(
+            ["futureResource", "messages"], "futureMethod", arguments
+        )
+
+        self.assertEqual(
+            [(("futureResource", "messages"), "futureMethod", arguments)], calls
+        )
+        self.assertEqual(arguments, result["arguments"])
+
+
+class SlackRelayTest(unittest.TestCase):
+    class FakeClient:
+        token = "xoxb-not-returned"
+
+        def api_call(self, method, **arguments):
+            return {"ok": True, "method": method, "arguments": arguments}
+
+    def relay(self):
+        relay = SlackRelay.__new__(SlackRelay)
+        relay.primary_client = self.FakeClient()
+        relay.clients = {"T123": relay.primary_client}
+        relay.workspaces = [{"teamId": "T123", "botUserId": "U123", "botName": "agent"}]
+        relay._events = queue.Queue()
+        relay._receipts = {}
+        import threading
+
+        relay._lock = threading.Lock()
+        return relay
+
+    def slack_modules(self):
+        class FakeWebClient:
+            def __init__(self, token):
+                self.token = token
+
+            def auth_test(self):
+                if self.token == "invalid":
+                    raise RuntimeError("authentication failed")
+                return {
+                    "team_id": "T123",
+                    "team": "workspace",
+                    "user_id": "U123",
+                    "user": "agent",
+                }
+
+        class FakeSocketModeClient:
+            def __init__(self, app_token, web_client):
+                self.app_token = app_token
+                self.web_client = web_client
+                self.socket_mode_request_listeners = []
+
+            def connect(self):
+                return None
+
+        slack_sdk = types.ModuleType("slack_sdk")
+        slack_sdk.WebClient = FakeWebClient
+        socket_mode = types.ModuleType("slack_sdk.socket_mode")
+        socket_mode.SocketModeClient = FakeSocketModeClient
+        return {"slack_sdk": slack_sdk, "slack_sdk.socket_mode": socket_mode}
+
+    def test_initialization_skips_invalid_token_when_another_is_valid(self):
+        with mock.patch.dict(sys.modules, self.slack_modules()):
+            relay = SlackRelay("invalid,valid", "app-token")
+        self.assertEqual("valid", relay.primary_client.token)
+        self.assertEqual("T123", relay.bootstrap()[0]["teamId"])
+
+    def test_initialization_rejects_all_invalid_tokens(self):
+        with mock.patch.dict(sys.modules, self.slack_modules()):
+            with self.assertRaisesRegex(RuntimeError, "no Slack bot token"):
+                SlackRelay("invalid", "app-token")
+
+    def test_forwards_unknown_web_api_method_and_arguments_unchanged(self):
+        arguments = {"json": {"futureSchema": {"nested": [1, 2, 3]}}}
+        result = self.relay().api_call(
+            "T123", "future.method", arguments
+        )
+        self.assertTrue(result["ok"])
+        self.assertEqual("future.method", result["method"])
+        self.assertEqual(arguments, result["arguments"])
+        self.assertNotIn("token", json.dumps(result))
+
+    def test_nack_requeues_event(self):
+        relay = self.relay()
+        relay._events.put({"type": "events_api", "payload": {"event": {}}})
+        event = relay.pull(timeout_seconds=1)
+        self.assertTrue(relay.settle(event["receipt"], acknowledge=False))
+        retried = relay.pull(timeout_seconds=1)
+        self.assertEqual("events_api", retried["type"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -1,0 +1,32 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from github_token_refresh import refresh_git_credentials
+
+
+class GitHubTokenRefreshTest(unittest.TestCase):
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_delegates_without_receiving_token(self, urlopen, run):
+        response = MagicMock()
+        response.__enter__.return_value.status = 200
+        urlopen.return_value = response
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            token = refresh_git_credentials("owner/repository")
+
+        self.assertEqual("", token)
+        run.assert_not_called()
+        request = urlopen.call_args.args[0]
+        self.assertEqual(
+            "http://127.0.0.1:8765/v1/github/refresh", request.full_url
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,8 @@
 # check=skip=InvalidDefaultArgInFrom
 ARG HERMES_AGENT_TAG
+ARG ENVOY_VERSION=v1.38.0
+FROM envoyproxy/envoy:${ENVOY_VERSION} AS envoy-bin
+
 FROM nousresearch/hermes-agent:${HERMES_AGENT_TAG} AS agent-base
 
 USER root
@@ -133,3 +136,17 @@ RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills /opt/hermes/plugins 
     find /opt/hermes/plugins -type f -exec chmod 644 {} + && \
     find /opt/defaults/scripts -type f -exec chmod 755 {} + 2>/dev/null && \
     find /opt/hermes/skills -path '*/scripts/*' -type f -exec chmod 755 {} + 2>/dev/null || true
+
+
+# --- CREDENTIAL PROXY TARGET ---
+# This additive target packages Envoy with the credential runtime. Existing
+# platform images remain unchanged until the operator enables the sidecar.
+FROM platform AS credential-proxy
+
+USER root
+
+COPY --from=envoy-bin /usr/local/bin/envoy /usr/local/bin/envoy
+COPY --chmod=0644 deploy/shared/envoy-credential-proxy.yaml /etc/envoy/envoy-credential-proxy.yaml
+COPY deploy/shared/envoy-credential-sidecar.sh /usr/local/bin/envoy-credential-sidecar
+
+RUN chmod 755 /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar

--- a/deploy/shared/envoy-credential-proxy.yaml
+++ b/deploy/shared/envoy-credential-proxy.yaml
@@ -1,0 +1,44 @@
+static_resources:
+  listeners:
+    - name: credential_proxy
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 8765
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: credential_proxy
+                route_config:
+                  name: credential_proxy
+                  virtual_hosts:
+                    - name: credential_proxy
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: credential_runtime
+                            timeout: 0s
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: credential_runtime
+      connect_timeout: 1s
+      type: STATIC
+      load_assignment:
+        cluster_name: credential_runtime
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /var/run/credential-proxy/backend.sock
+
+admin:
+  address:
+    pipe:
+      path: /var/run/credential-proxy/envoy-admin.sock

--- a/deploy/shared/envoy-credential-sidecar.sh
+++ b/deploy/shared/envoy-credential-sidecar.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime_pid=""
+envoy_pid=""
+
+terminate() {
+  [[ -z "${runtime_pid}" ]] || kill "${runtime_pid}" 2>/dev/null || true
+  [[ -z "${envoy_pid}" ]] || kill "${envoy_pid}" 2>/dev/null || true
+}
+trap terminate EXIT INT TERM
+
+/opt/hermes/.venv/bin/python3 /opt/defaults/scripts/credential_proxy.py &
+runtime_pid=$!
+
+/usr/local/bin/envoy --config-path /etc/envoy/envoy-credential-proxy.yaml --log-level info &
+envoy_pid=$!
+
+wait -n "${runtime_pid}" "${envoy_pid}"


### PR DESCRIPTION
# Pull Request

## Why This Change

PlatformAgent needs a credentialed runtime that can execute approved cloud, Kubernetes, GitHub, and API operations without returning credential files or environment variables to the agent container.

## What Changed

**Files:**

- `agents/platform/scripts/credential_proxy*.py`
- `agents/platform/scripts/github_token_refresh.py`
- `deploy/shared/envoy-credential-*`
- `deploy/docker/Dockerfile`
- image publishing workflows and `Makefile`

**Added/Changed/Fixed:**

- Adds the restricted `gcloud`, `kubectl`, `gh`, and `git` command broker with argument-vector execution, policy checks, bounded I/O, and timeouts.
- Adds GitHub/Minty refresh and external PlatformAgent API authentication inside the credential runtime.
- Places Envoy in front of the runtime over a private Unix socket.
- Adds an additive `credential-proxy` image target and publishes/signs that image without changing the existing PlatformAgent deployment.
- Covers command policy, environment filtering, timeout races, Slack credential initialization, Google Chat forwarding, API-key replacement, and sandbox GitHub delegation.

## Why This Matters

- Establishes the credential-handling boundary before the operator starts depending on it.
- Keeps this first layer backward compatible: existing PlatformAgent Pods are unchanged.

## Context

Part 1 of 4 replacing #355. Later PRs add transparent chat adapters, enforce the sidecar in PlatformAgent, and complete rollout/migration documentation.

## Testing

- `python3 -m py_compile` for the runtime, client, and GitHub refresher.
- `python3 -m unittest test_credential_proxy.py test_github_token_refresh.py` — 18 tests passed.
- `bash -n deploy/shared/envoy-credential-sidecar.sh`.
- Prettier and `git diff --check` passed.

---

This PR adds the credential-proxy foundation without switching production agent Pods to it yet.
