### PR TITLE
fix(operator): increase resource limits for platform-agent-dashboard to prevent OOM

### DIFF
--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -639,12 +639,12 @@ func buildBaseContainers(image string, pullPolicy corev1.PullPolicy, envVars []c
 			Env: dashboardEnvVars,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("256Mi"),
+					corev1.ResourceCPU:    resource.MustParse("256m"),
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
-					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
 				},
 			},
 			VolumeMounts: append(dashboardVolumeMounts, extraVolumeMounts...),

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -336,11 +336,11 @@ func TestBuildDeployment(t *testing.T) {
 		if dashboardC.SecurityContext == nil || dashboardC.SecurityContext.AllowPrivilegeEscalation == nil || *dashboardC.SecurityContext.AllowPrivilegeEscalation {
 			t.Errorf("expected SecurityContext.AllowPrivilegeEscalation false on dashboard container")
 		}
-		if dashboardC.Resources.Requests.Cpu().String() != "100m" || dashboardC.Resources.Requests.Memory().String() != "256Mi" {
-			t.Errorf("expected CPU 100m and Mem 256Mi requests on dashboard container, got %v", dashboardC.Resources.Requests)
+		if dashboardC.Resources.Requests.Cpu().String() != "256m" || dashboardC.Resources.Requests.Memory().String() != "512Mi" {
+			t.Errorf("expected CPU 256m and Mem 512Mi requests on dashboard container, got %v", dashboardC.Resources.Requests)
 		}
-		if dashboardC.Resources.Limits.Cpu().String() != "500m" || dashboardC.Resources.Limits.Memory().String() != "1Gi" {
-			t.Errorf("expected CPU 500m and Mem 1Gi limits on dashboard container, got %v", dashboardC.Resources.Limits)
+		if dashboardC.Resources.Limits.Cpu().String() != "1" || dashboardC.Resources.Limits.Memory().String() != "2Gi" {
+			t.Errorf("expected CPU 1 and Mem 2Gi limits on dashboard container, got %v", dashboardC.Resources.Limits)
 		}
 		if len(dashboardC.Env) != 3 {
 			t.Errorf("expected 3 env vars on dashboard container, got %d", len(dashboardC.Env))

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -397,11 +397,11 @@ spec:
               name: dashboard
           resources:
             limits:
-              cpu: 500m
-              memory: 1Gi
+              cpu: "1"
+              memory: 2Gi
             requests:
-              cpu: 100m
-              memory: 256Mi
+              cpu: 256m
+              memory: 512Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
# Pull Request

## Why This Change

The `platform-agent-dashboard` sidecar container was experiencing Out Of Memory (OOM) kills under dashboard workloads with the previous resource limit allocation.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**

- Increased `platform-agent-dashboard` resource requests: CPU `100m` → `256m`, Memory `256Mi` → `512Mi`.
- Increased `platform-agent-dashboard` resource limits: CPU `500m` → `1`, Memory `1Gi` → `2Gi`.
- Updated unit test assertions and golden test fixtures.

## Why This Matters

Ensures sufficient CPU and memory headroom for the dashboard container to prevent OOM termination and performance degradation.

## Context

- Resolves dashboard container OOM crashes under active UI load.

## Testing

- Ran `go test ./...` in `k8s-operator` (all controller, webhook, and golden tests passed).