### PR TITLE
feat(platform): relay chat integrations through credential proxy

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -31,6 +31,7 @@ from typing import Any
 
 
 LOGGER = logging.getLogger("credential-proxy")
+SLACK_EVENT_QUEUE_MAXSIZE = 1000
 
 
 class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
@@ -260,7 +261,9 @@ class SlackRelay:
             )
         if self.primary_client is None:
             raise RuntimeError("no Slack bot token could be authenticated")
-        self._events: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._events: queue.Queue[dict[str, Any]] = queue.Queue(
+            maxsize=SLACK_EVENT_QUEUE_MAXSIZE
+        )
         self._receipts: dict[str, dict[str, Any]] = {}
         self._lock = threading.Lock()
         self.socket_client = SocketModeClient(
@@ -275,12 +278,14 @@ class SlackRelay:
         client.send_socket_mode_response(
             SocketModeResponse(envelope_id=request.envelope_id)
         )
-        self._events.put(
-            {
-                "type": str(request.type),
-                "payload": request.payload,
-            }
-        )
+        event = {
+            "type": str(request.type),
+            "payload": request.payload,
+        }
+        try:
+            self._events.put_nowait(event)
+        except queue.Full:
+            LOGGER.warning("Slack event queue is full; dropping event")
 
     def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
         try:
@@ -294,12 +299,17 @@ class SlackRelay:
 
     def settle(self, receipt: str, acknowledge: bool) -> bool:
         with self._lock:
-            event = self._receipts.pop(receipt, None)
-        if event is None:
-            return False
-        if not acknowledge:
-            self._events.put(event)
-        return True
+            event = self._receipts.get(receipt)
+            if event is None:
+                return False
+            if not acknowledge:
+                try:
+                    self._events.put_nowait(event)
+                except queue.Full:
+                    LOGGER.warning("Slack event queue is full; cannot requeue event")
+                    return False
+            del self._receipts[receipt]
+            return True
 
     def bootstrap(self) -> list[dict[str, str]]:
         return self.workspaces

--- a/agents/platform/scripts/google_chat_relay_patch.py
+++ b/agents/platform/scripts/google_chat_relay_patch.py
@@ -1,0 +1,177 @@
+"""Credential-free Google Chat transport for Hermes' bundled adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import urllib.request
+from typing import Any
+
+
+LOGGER = logging.getLogger("google-chat-relay-patch")
+
+
+def install() -> None:
+    relay_url = os.getenv("GOOGLE_CHAT_RELAY_URL", "").rstrip("/")
+    if not relay_url:
+        return
+
+    def request(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            relay_url + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="GET" if body is None else "POST",
+        )
+        with urllib.request.urlopen(req, timeout=35) as response:
+            return json.load(response)
+
+    class RelayMessage:
+        """Pub/Sub-shaped message that settles an opaque proxy receipt."""
+
+        def __init__(self, event: dict[str, Any]) -> None:
+            self.data = base64.b64decode(event["data"], validate=True)
+            self.attributes = event.get("attributes") or {}
+            self.message_id = str(event.get("messageId", ""))
+            self._receipt = str(event["receipt"])
+            self._settled = False
+
+        def _settle(self, acknowledge: bool) -> None:
+            if self._settled:
+                return
+            path = "/v1/chat/events/ack" if acknowledge else "/v1/chat/events/nack"
+            request(path, {"receipt": self._receipt})
+            self._settled = True
+
+        def ack(self) -> None:
+            self._settle(True)
+
+        def nack(self) -> None:
+            self._settle(False)
+
+    class RemoteRequest:
+        def __init__(
+            self, resource: list[str], method: str, arguments: dict[str, Any]
+        ) -> None:
+            self.resource = resource
+            self.method = method
+            self.arguments = arguments
+
+        def execute(self, **_kwargs: Any) -> Any:
+            response = request(
+                "/v1/chat/api",
+                {
+                    "resource": self.resource,
+                    "method": self.method,
+                    "arguments": self.arguments,
+                },
+            )
+            return response.get("response")
+
+    class RemoteResource:
+        """googleapiclient discovery-resource-shaped remote facade."""
+
+        def __init__(self, resource: list[str] | None = None) -> None:
+            self.resource = resource or []
+
+        def __getattr__(self, name: str) -> Any:
+            if name.startswith("_"):
+                raise AttributeError(name)
+
+            def invoke(**arguments: Any) -> Any:
+                if arguments:
+                    return RemoteRequest(self.resource, name, arguments)
+                return RemoteResource([*self.resource, name])
+
+            return invoke
+
+    async def relay_loop(self: Any) -> None:
+        while not self._shutting_down:
+            message: RelayMessage | None = None
+            try:
+                response = await asyncio.to_thread(request, "/v1/chat/events")
+                event = response.get("event")
+                if not event:
+                    continue
+                message = RelayMessage(event)
+                await asyncio.to_thread(self._on_pubsub_message, message)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.warning("Google Chat relay receive failed", exc_info=True)
+                if message is not None:
+                    try:
+                        await asyncio.to_thread(message.nack)
+                    except Exception:
+                        pass
+                await asyncio.sleep(2)
+
+    def patch_adapter_class(adapter_class: type[Any]) -> None:
+        if getattr(adapter_class, "_credential_proxy_relay_patched", False):
+            return
+        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
+            self._loop = asyncio.get_running_loop()
+            self._shutting_down = False
+            self._chat_api = RemoteResource()
+            try:
+                await asyncio.to_thread(self._thread_count_store.load)
+            except Exception:
+                LOGGER.warning("Google Chat thread state load failed", exc_info=True)
+            self._bot_user_id = self._load_cached_bot_id()
+            self._relay_task = asyncio.create_task(relay_loop(self))
+            self._mark_connected()
+            LOGGER.info("Google Chat connected through credential proxy relay")
+            return True
+
+        async def disconnect(self: Any) -> None:
+            self._shutting_down = True
+            task = getattr(self, "_relay_task", None)
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            self._chat_api = None
+            self._mark_disconnected()
+
+        def new_authed_http(self: Any) -> Any:
+            return None
+
+        async def setup_files(
+            self: Any,
+            chat_id: str,
+            thread_id: str | None,
+            raw_text: str,
+            sender_email: str | None = None,
+        ) -> bool:
+            await self.send(
+                chat_id,
+                "File attachment setup is unavailable through the credential proxy.",
+                metadata={"thread_id": thread_id} if thread_id else None,
+            )
+            return True
+
+        adapter_class.connect = connect
+        adapter_class.disconnect = disconnect
+        adapter_class._new_authed_http = new_authed_http
+        adapter_class._handle_setup_files_command = setup_files
+        adapter_class._credential_proxy_relay_patched = True
+
+    from gateway.platform_registry import PlatformRegistry
+
+    original_registry_create = PlatformRegistry.create_adapter
+    if not getattr(PlatformRegistry, "_credential_proxy_relay_patched", False):
+
+        def create_adapter(self: Any, name: str, config: Any) -> Any:
+            adapter = original_registry_create(self, name, config)
+            if name == "google_chat" and adapter is not None:
+                patch_adapter_class(type(adapter))
+            return adapter
+
+        PlatformRegistry.create_adapter = create_adapter
+        PlatformRegistry._credential_proxy_relay_patched = True

--- a/agents/platform/scripts/sitecustomize.py
+++ b/agents/platform/scripts/sitecustomize.py
@@ -1,0 +1,24 @@
+"""Runtime patches for the platform agent image."""
+
+import os
+
+if os.getenv("GOOGLE_CHAT_RELAY_URL"):
+    try:
+        from google_chat_relay_patch import install
+
+        install()
+    except ModuleNotFoundError as exc:
+        # Credential-free wrapper scripts use the system Python, which can see
+        # this directory through PYTHONPATH but not Hermes' gateway packages.
+        # The long-lived Hermes process uses its venv and applies the patch.
+        if exc.name not in {"gateway", "plugins"}:
+            raise
+
+if os.getenv("SLACK_RELAY_URL"):
+    try:
+        from slack_relay_patch import install
+
+        install()
+    except ModuleNotFoundError as exc:
+        if exc.name not in {"gateway", "plugins"}:
+            raise

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -1,0 +1,316 @@
+"""Credential-free Slack SDK transport for Hermes' bundled adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+LOGGER = logging.getLogger("slack-relay-patch")
+DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+
+
+def read_upload(path: Path, max_file_bytes: int) -> bytes:
+    """Read an upload without allowing it to grow past the relay limit."""
+    if path.stat().st_size > max_file_bytes:
+        raise ValueError("Slack upload exceeds relay size limit")
+    with path.open("rb") as upload:
+        content = upload.read(max_file_bytes + 1)
+    if len(content) > max_file_bytes:
+        raise ValueError("Slack upload exceeds relay size limit")
+    return content
+
+
+def install() -> None:
+    relay_url = os.getenv("SLACK_RELAY_URL", "").rstrip("/")
+    if not relay_url:
+        return
+    try:
+        max_file_bytes = int(
+            os.getenv("SLACK_RELAY_MAX_FILE_BYTES", str(DEFAULT_MAX_FILE_BYTES))
+        )
+    except ValueError:
+        LOGGER.warning("Invalid Slack relay file limit; using the default")
+        max_file_bytes = DEFAULT_MAX_FILE_BYTES
+
+    def request(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+        body = None if payload is None else json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            relay_url + path,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="GET" if body is None else "POST",
+        )
+        with urllib.request.urlopen(req, timeout=35) as response:
+            return json.load(response)
+
+    def json_value(value: Any, *, file_value: bool = False) -> Any:
+        if isinstance(value, bytes):
+            if len(value) > max_file_bytes:
+                raise ValueError("Slack upload exceeds relay size limit")
+            return {"__bytesBase64": base64.b64encode(value).decode("ascii")}
+        if hasattr(value, "read"):
+            content = value.read(max_file_bytes + 1)
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            if len(content) > max_file_bytes:
+                raise ValueError("Slack upload exceeds relay size limit")
+            return {
+                "__fileBase64": base64.b64encode(content).decode("ascii"),
+                "filename": Path(getattr(value, "name", "upload")).name,
+            }
+        if file_value and isinstance(value, (str, Path)):
+            path = Path(value)
+            return {
+                "__fileBase64": base64.b64encode(
+                    read_upload(path, max_file_bytes)
+                ).decode("ascii"),
+                "filename": path.name,
+            }
+        if isinstance(value, Path):
+            return str(value)
+        if isinstance(value, dict):
+            return {
+                key: json_value(item, file_value=file_value)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [json_value(item, file_value=file_value) for item in value]
+        return value
+
+    async def relay_loop(self: Any) -> None:
+        from slack_bolt.adapter.socket_mode.async_internals import run_async_bolt_app
+        from slack_sdk.socket_mode.request import SocketModeRequest
+
+        while self._running:
+            receipt = ""
+            try:
+                response = await asyncio.to_thread(request, "/v1/chat/slack/events")
+                event = response.get("event")
+                if not event:
+                    continue
+                receipt = str(event["receipt"])
+                socket_request = SocketModeRequest(
+                    type=str(event.get("type", "")),
+                    envelope_id=receipt,
+                    payload=event.get("payload") or {},
+                )
+                await run_async_bolt_app(self._app, socket_request)
+                await asyncio.to_thread(
+                    request, "/v1/chat/slack/events/ack", {"receipt": receipt}
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.warning("Slack relay receive failed", exc_info=True)
+                if receipt:
+                    try:
+                        await asyncio.to_thread(
+                            request,
+                            "/v1/chat/slack/events/nack",
+                            {"receipt": receipt},
+                        )
+                    except Exception:
+                        pass
+                await asyncio.sleep(2)
+
+    def patch_adapter_class(adapter_class: type[Any]) -> None:
+        if getattr(adapter_class, "_credential_proxy_relay_patched", False):
+            return
+
+        module = sys.modules[adapter_class.__module__]
+        real_async_app = module.AsyncApp
+        real_async_client = module.AsyncWebClient
+        original_connect = adapter_class.connect
+        original_disconnect = adapter_class.disconnect
+
+        class RemoteSlackClient(real_async_client):
+            """Slack SDK client whose generic API calls execute in the proxy."""
+
+            def __init__(self, token: str | None = None, **_kwargs: Any) -> None:
+                placeholder = token or "relay:"
+                super().__init__(token=placeholder)
+                self.team_id = (
+                    placeholder.split(":", 1)[1]
+                    if placeholder.startswith("relay:")
+                    else ""
+                )
+
+            async def api_call(
+                self,
+                api_method: str,
+                *,
+                http_verb: str = "POST",
+                files: dict[str, Any] | None = None,
+                data: Any = None,
+                params: dict[str, Any] | None = None,
+                json: dict[str, Any] | None = None,
+                headers: dict[str, Any] | None = None,
+                auth: dict[str, Any] | None = None,
+            ) -> Any:
+                arguments = {
+                    "http_verb": http_verb,
+                    "files": json_value(files, file_value=True) if files else None,
+                    "data": json_value(data) if data is not None else None,
+                    "params": json_value(params) if params else None,
+                    "json": json_value(json) if json else None,
+                    "headers": json_value(headers) if headers else None,
+                    "auth": json_value(auth) if auth else None,
+                }
+                response = await asyncio.to_thread(
+                    request,
+                    "/v1/chat/slack/api",
+                    {
+                        "teamId": self.team_id,
+                        "method": api_method,
+                        "arguments": {
+                            key: value
+                            for key, value in arguments.items()
+                            if value is not None
+                        },
+                    },
+                )
+                return response.get("response") or {}
+
+        def remote_client_factory(
+            token: str | None = None, **kwargs: Any
+        ) -> RemoteSlackClient:
+            return RemoteSlackClient(token=token, **kwargs)
+
+        def remote_app_factory(
+            *_args: Any, token: str | None = None, **kwargs: Any
+        ) -> Any:
+            kwargs.pop("client", None)
+            kwargs["request_verification_enabled"] = False
+            return real_async_app(
+                client=RemoteSlackClient(token=token),
+                **kwargs,
+            )
+
+        module.AsyncWebClient = remote_client_factory
+        module.AsyncApp = remote_app_factory
+
+        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
+            bootstrap = await asyncio.to_thread(
+                request, "/v1/chat/slack/bootstrap", {}
+            )
+            workspaces = bootstrap.get("workspaces") or []
+            if not workspaces:
+                LOGGER.error("Slack credential proxy has no authenticated workspace")
+                return False
+            first_connect = not hasattr(
+                self, "_credential_proxy_original_slack_token"
+            )
+            if first_connect:
+                self._credential_proxy_original_slack_token = self.config.token
+                self._credential_proxy_original_slack_app_token = os.environ.get(
+                    "SLACK_APP_TOKEN"
+                )
+            self.config.token = ",".join(
+                "relay:" + str(workspace.get("teamId", ""))
+                for workspace in workspaces
+            )
+            os.environ["SLACK_APP_TOKEN"] = "relay"
+            self._shutting_down = False
+            try:
+                connected = await original_connect(self, is_reconnect=is_reconnect)
+            except Exception:
+                if first_connect:
+                    restore_slack_placeholders(self)
+                raise
+            if not connected and first_connect:
+                restore_slack_placeholders(self)
+            return connected
+
+        async def disconnect(self: Any) -> None:
+            self._shutting_down = True
+            try:
+                await original_disconnect(self)
+            finally:
+                restore_slack_placeholders(self)
+
+        def restore_slack_placeholders(self: Any) -> None:
+            if not hasattr(self, "_credential_proxy_original_slack_token"):
+                return
+            self.config.token = self._credential_proxy_original_slack_token
+            original_app_token = self._credential_proxy_original_slack_app_token
+            if original_app_token is None:
+                os.environ.pop("SLACK_APP_TOKEN", None)
+            else:
+                os.environ["SLACK_APP_TOKEN"] = original_app_token
+            del self._credential_proxy_original_slack_token
+            del self._credential_proxy_original_slack_app_token
+
+        def start_transport(self: Any) -> None:
+            task = asyncio.create_task(relay_loop(self))
+            self._socket_mode_task = task
+            self._relay_task = task
+
+        async def stop_transport(self: Any) -> None:
+            task = getattr(self, "_relay_task", None)
+            self._relay_task = None
+            self._socket_mode_task = None
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        def no_watchdog(self: Any) -> None:
+            return None
+
+        async def download(
+            self: Any, url: str, ext: str, audio: bool = False, team_id: str = ""
+        ) -> str:
+            response = await asyncio.to_thread(
+                request,
+                "/v1/chat/slack/files/download",
+                {"url": url, "teamId": team_id},
+            )
+            content = base64.b64decode(response["data"])
+            if audio:
+                from gateway.platforms.base import cache_audio_from_bytes
+
+                return cache_audio_from_bytes(content, ext)
+            from gateway.platforms.base import cache_image_from_bytes
+
+            return cache_image_from_bytes(content, ext)
+
+        async def download_bytes(self: Any, url: str, team_id: str = "") -> bytes:
+            response = await asyncio.to_thread(
+                request,
+                "/v1/chat/slack/files/download",
+                {"url": url, "teamId": team_id},
+            )
+            return base64.b64decode(response["data"])
+
+        adapter_class.connect = connect
+        adapter_class.disconnect = disconnect
+        adapter_class._start_socket_mode_handler = start_transport
+        adapter_class._stop_socket_mode_handler = stop_transport
+        adapter_class._ensure_socket_watchdog = no_watchdog
+        adapter_class._download_slack_file = download
+        adapter_class._download_slack_file_bytes = download_bytes
+        adapter_class._credential_proxy_relay_patched = True
+
+    from gateway.platform_registry import PlatformRegistry
+
+    original_registry_create = PlatformRegistry.create_adapter
+    if not getattr(PlatformRegistry, "_slack_credential_proxy_relay_patched", False):
+
+        def create_adapter(self: Any, name: str, config: Any) -> Any:
+            adapter = original_registry_create(self, name, config)
+            if name == "slack" and adapter is not None:
+                patch_adapter_class(type(adapter))
+            return adapter
+
+        PlatformRegistry.create_adapter = create_adapter
+        PlatformRegistry._slack_credential_proxy_relay_patched = True

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -19,6 +19,9 @@ from credential_proxy import (
     Policy,
     SlackRelay,
 )
+from slack_relay_patch import read_upload
+
+
 class AgentAPIProxyTest(unittest.TestCase):
     def setUp(self):
         self.received_authorization = ""
@@ -279,17 +282,28 @@ class SlackRelayTest(unittest.TestCase):
             def connect(self):
                 return None
 
+        class FakeSocketModeResponse:
+            def __init__(self, envelope_id):
+                self.envelope_id = envelope_id
+
         slack_sdk = types.ModuleType("slack_sdk")
         slack_sdk.WebClient = FakeWebClient
         socket_mode = types.ModuleType("slack_sdk.socket_mode")
         socket_mode.SocketModeClient = FakeSocketModeClient
-        return {"slack_sdk": slack_sdk, "slack_sdk.socket_mode": socket_mode}
+        response = types.ModuleType("slack_sdk.socket_mode.response")
+        response.SocketModeResponse = FakeSocketModeResponse
+        return {
+            "slack_sdk": slack_sdk,
+            "slack_sdk.socket_mode": socket_mode,
+            "slack_sdk.socket_mode.response": response,
+        }
 
     def test_initialization_skips_invalid_token_when_another_is_valid(self):
         with mock.patch.dict(sys.modules, self.slack_modules()):
             relay = SlackRelay("invalid,valid", "app-token")
         self.assertEqual("valid", relay.primary_client.token)
         self.assertEqual("T123", relay.bootstrap()[0]["teamId"])
+        self.assertEqual(1000, relay._events.maxsize)
 
     def test_initialization_rejects_all_invalid_tokens(self):
         with mock.patch.dict(sys.modules, self.slack_modules()):
@@ -313,6 +327,51 @@ class SlackRelayTest(unittest.TestCase):
         self.assertTrue(relay.settle(event["receipt"], acknowledge=False))
         retried = relay.pull(timeout_seconds=1)
         self.assertEqual("events_api", retried["type"])
+
+    def test_nack_does_not_block_or_lose_receipt_when_queue_is_full(self):
+        relay = self.relay()
+        relay._events = queue.Queue(maxsize=1)
+        relay._receipts["receipt"] = {
+            "type": "events_api",
+            "payload": {"event": {"type": "message"}},
+        }
+        relay._events.put_nowait({"type": "existing", "payload": {}})
+
+        with self.assertLogs("credential-proxy", level="WARNING"):
+            self.assertFalse(relay.settle("receipt", acknowledge=False))
+
+        self.assertIn("receipt", relay._receipts)
+        self.assertEqual("existing", relay._events.get_nowait()["type"])
+
+    def test_incoming_event_is_acknowledged_and_dropped_when_queue_is_full(self):
+        relay = self.relay()
+        relay._events = queue.Queue(maxsize=1)
+        relay._events.put_nowait({"type": "existing", "payload": {}})
+
+        client = mock.Mock()
+        request = types.SimpleNamespace(
+            envelope_id="envelope", type="events_api", payload={"event": {}}
+        )
+        with mock.patch.dict(sys.modules, self.slack_modules()):
+            with self.assertLogs("credential-proxy", level="WARNING"):
+                relay._on_event(client, request)
+
+        client.send_socket_mode_response.assert_called_once()
+        self.assertEqual("existing", relay._events.get_nowait()["type"])
+
+    def test_upload_reader_rejects_oversized_file(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "upload"
+            path.write_bytes(b"12345")
+            with self.assertRaisesRegex(ValueError, "size limit"):
+                read_upload(path, 4)
+
+    def test_upload_reader_accepts_file_at_limit(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "upload"
+            path.write_bytes(b"1234")
+            self.assertEqual(b"1234", read_upload(path, 4))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -53,6 +53,7 @@ RUN /usr/local/bin/uv pip install --python /opt/hermes/.venv/bin/python \
     google-auth \
     google-cloud-pubsub \
     "hermes-agent[google_chat]" \
+    "hermes-agent[slack]" \
     opentelemetry-api \
     opentelemetry-sdk \
     opentelemetry-exporter-otlp-proto-http


### PR DESCRIPTION
# Pull Request

## Why This Change

Google Chat and Slack adapters currently expect credentialed SDK clients in the agent process. They need transparent transports that preserve Hermes behavior while moving external API access to the credential proxy runtime introduced by #359.

## What Changed

**Files:**

- `agents/platform/scripts/credential_proxy.py`
- `agents/platform/scripts/google_chat_relay_patch.py`
- `agents/platform/scripts/slack_relay_patch.py`
- `agents/platform/scripts/sitecustomize.py`
- `agents/platform/scripts/test_credential_proxy.py`
- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Routes Google Chat event delivery and API calls through credential-free relay payloads.
- Routes Slack Socket Mode events, Web API calls, and bounded file transfers through the proxy.
- Bounds pending Slack events and drops excess events without blocking when the agent falls behind.
- Preserves Slack relay placeholders for automatic reconnect and restores them only after disconnect or failed initial connection.
- Enables patches only when relay URLs are configured, leaving existing deployments unchanged.
- Adds the Hermes Slack runtime dependency and relay regression tests.

## Why This Matters

- Removes the need for Slack and Google credentials in the agent process while preserving their existing integration surfaces.
- Keeps the adapters dormant and backward compatible until the operator supplies relay configuration.

## Context

Part 2 of the credential-isolation rollout. Depends on the credential proxy runtime merged in #359. The PlatformAgent deployment and sandbox-isolation changes will follow separately.

## Testing

- Python compilation passed for the credential proxy, both relay patches, and `sitecustomize.py`.
- `python3 -m unittest -v test_credential_proxy.py test_github_token_refresh.py` — 22 tests passed.
- `git diff --check upstream/main...HEAD` passed.
- Docker build was not run locally because Docker is unavailable in the current environment.

---

This PR adds transparent chat transports; credential placement changes arrive in the next rollout layer.
