### PR TITLE
feat(platform): enforce and roll out sandbox credential isolation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,4 @@ venv/
 .env
 .env.*
 !agents/shared/defaults/.env
+**/vars.sh

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -24,3 +24,4 @@ k8s-operator/bin/
 .env
 .env.*
 !agents/shared/defaults/.env
+**/vars.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -31,6 +31,17 @@ jobs:
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
+      - name: Build Credential Sidecar
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/docker/Dockerfile
+          target: credential-proxy
+          push: false
+          tags: credential-proxy:latest
+          build-args: |
+            HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
       - name: Build Replay Proxy
         uses: docker/build-push-action@v7
         with:

--- a/agents/platform/SOUL.md
+++ b/agents/platform/SOUL.md
@@ -135,6 +135,6 @@ Whenever you triage an incident, alert the user to system failures, or synthesiz
 The `kube-agents` harness deployment architecture consists of:
 
 - **Kubernetes Operator (`k8s-operator`)**: Written in Go (Kubebuilder), running in the GKE cluster. It defines and manages the lifecycle of the agent custom resource (`PlatformAgent`).
-- **PlatformAgent**: Deployed by the operator as a gateway pod (running `nousresearch/hermes-agent`). Handles fleet-wide multi-tenancy configurations and global RBAC.
+- **PlatformAgent**: Deployed by the operator as a Pod containing a credential-free sandbox container (running `nousresearch/hermes-agent`) and an Envoy credential-proxy sidecar. Handles fleet-wide multi-tenancy configurations and global RBAC.
 - **Inference Service**: An LLM provider proxy exposing a unified Completions API endpoint to the agents. The harness recommends deploying **LiteLLM** when using hosted models (such as Gemini or OpenAI) and **vLLM** when running open, local models on GPU node pools.
 - **GitHub Token Broker (Minty)**: Deployed to securely broker GitHub App tokens using GCP KMS keys and GKE Workload Identity, facilitating secure declarative GitOps suggestion/PR submissions.

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -86,11 +86,15 @@ class PolicyTest(unittest.TestCase):
                     "rules": [
                         {
                             "id": "gcp.access-token-disclosure",
-                            "pattern": r"\bgcloud\s+auth\s+print-access-token\b",
+                            "pattern": r"\bgcloud\b(?:\s+\S+)*?\s+auth\b(?:\s+\S+)*?\s+print-(?:access|identity)-token\b",
                         },
                         {
                             "id": "github.token-disclosure",
-                            "pattern": r"\bgh\s+auth\s+token\b",
+                            "pattern": r"\bgh\b(?:\s+\S+)*?\s+auth\b(?:\s+\S+)*?\s+token\b",
+                        },
+                        {
+                            "id": "kubernetes.token-disclosure",
+                            "pattern": r"\bkubectl\b(?:\s+\S+)*?\s+config\b(?:\s+\S+)*?\s+view\b(?:\s+\S+)*?\s+--raw\b",
                         },
                     ],
                 }
@@ -106,6 +110,19 @@ class PolicyTest(unittest.TestCase):
         rule = self.policy.blocked_by(["gcloud", "auth", "print-access-token"])
         self.assertIsNotNone(rule)
         self.assertEqual("gcp.access-token-disclosure", rule.rule_id)
+
+    def test_blocks_disclosure_commands_with_global_flags(self):
+        cases = (
+            (["gcloud", "--quiet", "auth", "print-access-token"], "gcp.access-token-disclosure"),
+            (["gcloud", "--project", "example", "auth", "--quiet", "print-identity-token"], "gcp.access-token-disclosure"),
+            (["gh", "--help", "auth", "token"], "github.token-disclosure"),
+            (["kubectl", "--namespace=default", "config", "view", "--raw"], "kubernetes.token-disclosure"),
+        )
+        for argv, rule_id in cases:
+            with self.subTest(argv=argv):
+                rule = self.policy.blocked_by(argv)
+                self.assertIsNotNone(rule)
+                self.assertEqual(rule_id, rule.rule_id)
 
     def test_allows_supported_command(self):
         self.assertIsNone(self.policy.blocked_by(["kubectl", "get", "pods"]))

--- a/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
+++ b/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
@@ -25,7 +25,7 @@ def push_branch(branch_name: str):
     log(f"Pushing active branch '{branch_name}' securely to origin...")
     subprocess.run(["git", "push", "-f", "origin", branch_name], check=True)
 
-def create_pull_request(token: str, branch: str, title: str, body: str) -> str:
+def create_pull_request(branch: str, title: str, body: str) -> str:
     """Submit the Pull Request securely using the GitHub CLI (gh)."""
     log(f"Submitting GitOps Pull Request for branch '{branch}'...")
     
@@ -51,13 +51,13 @@ def main():
     
     try:
         # Secure dynamic token exchange & Git/gh credentials configuration
-        token = refresh_git_credentials()
+        refresh_git_credentials()
         
         # Git branch pushing
         push_branch(args.branch)
         
         # Submit Pull Request
-        pr_url = create_pull_request(token, args.branch, args.title, args.body)
+        pr_url = create_pull_request(args.branch, args.title, args.body)
         log(f"PR SUBMITTED SUCCESSFULLY! 🏆 URL: {pr_url}")
         
         # Print raw URL to stdout for the MCP tool to parse

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     dnsutils \
-    git \
     gnupg \
     iputils-ping \
     jq \
@@ -29,20 +28,8 @@ RUN apt-get update && apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Install google-cloud-cli and kubectl natively using the Google Cloud apt repository
-RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get update && apt-get install -y \
-    google-cloud-cli \
-    google-cloud-cli-gke-gcloud-auth-plugin \
-    kubectl \
-    && rm -rf /var/lib/apt/lists/*
-
-# 3. Install GitHub CLI (gh), yq, k9s, and helm
+# 2. Install credential-free utility CLIs used by the sandbox.
 RUN ARCH=$(dpkg --print-architecture) && \
-    curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" \
-    && dpkg -i /tmp/gh.deb \
-    && rm /tmp/gh.deb && \
     curl -sSLf -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_linux_${ARCH}" && \
     chmod +x /usr/local/bin/yq && \
     curl -sSLf -o /tmp/k9s.tar.gz "https://github.com/derailed/k9s/releases/download/v0.51.0/k9s_Linux_${ARCH}.tar.gz" && \
@@ -75,8 +62,10 @@ RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed
 RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/hermes/tools/send_message_tool.py'); c = p.read_text(); t = 'def _parse_target_ref(platform_name: str, target_ref: str):\n    \"\"\"Parse a tool target into chat_id/thread_id and whether it is explicit.\"\"\"'; r = t + '\n    if platform_name == \"google_chat\":\n        parts = target_ref.split(\":\", 1)\n        if len(parts) == 2 and parts[0].startswith(\"spaces/\"):\n            return parts[0].strip(), parts[1].strip(), True\n        elif target_ref.startswith(\"spaces/\"):\n            return target_ref.strip(), None, True'; p.write_text(c.replace(t, r)) if t in c else exit(1)"
 
 
-# 4. Clone and build mcp-remote proxy
-RUN git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \
+# 3. Clone and build mcp-remote proxy. Git is a build-only dependency here;
+# the sandbox runtime exposes only the credential-proxy Git wrapper.
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \
     cd /opt/mcp-remote && \
     git checkout 2ff8f16753d8c744e6982b99e6ed5ab62f44f311 && \
     npm install && \
@@ -96,11 +85,26 @@ RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes pl
     HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins enable hermes_otel && \
     /opt/hermes/.venv/bin/python3 -c "import yaml, pathlib; p = pathlib.Path('/opt/defaults/plugins/hermes_otel/config.yaml'); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; c['backends'] = [{'name': 'gke-managed-otel', 'type': 'otlp', 'endpoint': 'http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces'}]; p.write_text(yaml.safe_dump(c))"
 
-
+# Remove the build-only clone dependency after all plugin installation is done.
+RUN apt-get purge -y git && apt-get autoremove -y && \
+	rm -rf /var/lib/apt/lists/* && \
+	for binary in gcloud kubectl gh git; do \
+		if command -v "${binary}" >/dev/null 2>&1; then \
+			echo "unexpected credential-aware CLI in sandbox image: ${binary}" >&2; \
+			exit 1; \
+		fi; \
+	done
 
 # 5.8. Copy custom agent startup script
 COPY deploy/shared/docker-entrypoint.sh /usr/local/bin/agent-entrypoint
-RUN chmod 755 /usr/local/bin/agent-entrypoint
+COPY deploy/shared/credential-proxy-path.sh /etc/profile.d/credential-proxy-path.sh
+COPY agents/platform/scripts/credential_proxy_client.py /usr/local/bin/credential-proxy-exec
+RUN chmod 755 /usr/local/bin/agent-entrypoint /usr/local/bin/credential-proxy-exec /etc/profile.d/credential-proxy-path.sh && \
+    mkdir -p /opt/credential-proxy/bin && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/kubectl && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/gcloud && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/gh && \
+    ln -s /usr/local/bin/credential-proxy-exec /opt/credential-proxy/bin/git
 
 # Copy event-watcher binary from builder stage
 COPY --from=watcher-builder /workspace/k8s-event-watcher /usr/local/bin/k8s-event-watcher
@@ -158,8 +162,8 @@ RUN chown -R hermes:hermes /opt/defaults /opt/hermes/skills /opt/hermes/plugins 
 
 
 # --- CREDENTIAL PROXY TARGET ---
-# This additive target packages Envoy with the credential runtime. Existing
-# platform images remain unchanged until the operator enables the sidecar.
+# Only this image contains the real credential-aware CLIs. The platform target
+# above contains wrappers with the same names and cannot execute locally.
 FROM platform AS credential-proxy
 
 USER root
@@ -168,4 +172,16 @@ COPY --from=envoy-bin /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --chmod=0644 deploy/shared/envoy-credential-proxy.yaml /etc/envoy/envoy-credential-proxy.yaml
 COPY deploy/shared/envoy-credential-sidecar.sh /usr/local/bin/envoy-credential-sidecar
 
-RUN chmod 755 /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar
+RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    apt-get update && apt-get install -y \
+      git \
+      google-cloud-cli \
+      google-cloud-cli-gke-gcloud-auth-plugin \
+      kubectl && \
+    ARCH=$(dpkg --print-architecture) && \
+    curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" && \
+    dpkg -i /tmp/gh.deb && \
+    rm -f /tmp/gh.deb && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod 755 /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar

--- a/deploy/shared/credential-proxy-path.sh
+++ b/deploy/shared/credential-proxy-path.sh
@@ -1,0 +1,3 @@
+# Login shells are used by the agent terminal executor. Keep credential-aware
+# CLI names ahead of the native binaries that exist only for the paired proxy.
+export PATH="/opt/credential-proxy/bin:${PATH}"

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -223,6 +223,7 @@ credentials forward from an older deployment. It deletes operator-owned
 resources from the abandoned two-Pod design:
 
 - `<agent>-credential-proxy` Deployment;
+- `<agent>-sandbox` Deployment;
 - `<agent>-credential-proxy` Service;
 - `<agent>-sandbox` ServiceAccount; and
 - `<agent>-sandbox-metadata-deny` NetworkPolicy.

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -28,11 +28,13 @@ send a structured argument vector to Envoy at `127.0.0.1:8765`. Envoy forwards
 requests over a private Unix socket to the credential runtime. Slack and Google
 Chat use the same local relay.
 
-Only the credential sidecar receives secret environment variables, credential
-state volumes, and the explicitly projected Kubernetes ServiceAccount (KSA)
-token. It also authenticates callers of the PlatformAgent API before forwarding
-requests with a non-secret internal sentinel. Pod-wide automatic KSA token
-mounting is disabled.
+Only trusted sidecars receive projected Kubernetes ServiceAccount (KSA) tokens.
+The credential sidecar receives secret environment variables, credential state,
+and its identity token. The event watcher receives a separate Kubernetes-API
+token, CA, and namespace projection. Neither token is mounted in the agent or
+dashboard containers. The credential sidecar also authenticates callers of the
+PlatformAgent API before forwarding requests with a non-secret internal
+sentinel. Pod-wide automatic KSA token mounting is disabled.
 
 ### Guarantee
 
@@ -132,6 +134,9 @@ it.
 The projected token uses the audience `kubeagents-credential-proxy`, expires
 after one hour, and is mounted only at
 `/var/run/secrets/kubeagents/serviceaccount/token` in the credential sidecar.
+The event watcher has a separate one-hour token with the Kubernetes API's
+default audience, plus the cluster CA and Pod namespace, at the conventional
+in-cluster path. It is not shared with the sandbox or dashboard.
 Deleting a default token during startup is intentionally not used: projected
 tokens rotate, and mount-time exclusion is reliable.
 
@@ -200,8 +205,9 @@ only command output, never a mounted Git credential file.
 - The Pod uses the configured PlatformAgent KSA for the credential sidecar's
   Workload Identity.
 - `automountServiceAccountToken: false` applies to the Pod.
-- A projected ServiceAccount token volume is mounted only by the credential
-  sidecar.
+- Separate projected ServiceAccount token volumes are mounted only by the
+  credential sidecar and event watcher; neither is mounted by the agent or
+  dashboard containers.
 - Secret and credential-state volumes are mounted only by the credential
   sidecar.
 - The sandbox and sidecar run non-root, drop all Linux capabilities, disallow
@@ -261,7 +267,8 @@ CI and deployment tests should assert that:
 
 1. the sandbox has no Secret-backed env, `spec.deployment.env`, secret volume,
    credential-state volume, or ServiceAccount token mount;
-2. only the credential sidecar mounts the projected KSA token and proxy state;
+2. only the credential sidecar mounts proxy identity/state, and only the event
+   watcher mounts its Kubernetes-API token projection;
 3. only the credential sidecar receives Slack tokens and deployment env;
 4. wrapper URLs resolve to `127.0.0.1:8765`;
 5. Envoy can reach the Unix-socket backend and `/healthz` reflects both;

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -1,0 +1,272 @@
+# PlatformAgent Credential Isolation
+
+## Summary
+
+### Goal
+
+The PlatformAgent sandbox container must not receive API keys, access tokens,
+refresh tokens, or Kubernetes ServiceAccount tokens through its environment or
+filesystem.
+
+Credential values returned by an approved tool call are an accepted risk. For
+example, an approved `gcloud auth print-access-token` response may expose a
+token to the agent. Preventing that disclosure is not part of this design.
+
+### Design
+
+Each PlatformAgent runs as one long-lived Pod with these managed containers:
+
+1. `platform-agent`: the untrusted agent sandbox.
+2. `platform-agent-dashboard`: the optional local dashboard.
+3. `fluent-bit`: log forwarding.
+4. `event-watcher`: cluster-event forwarding using a non-secret internal key.
+5. `envoy-credential-proxy`: Envoy plus the credentialed command and chat
+   runtime.
+
+The sandbox calls wrappers for `gcloud`, `kubectl`, `gh`, and `git`. Wrappers
+send a structured argument vector to Envoy at `127.0.0.1:8765`. Envoy forwards
+requests over a private Unix socket to the credential runtime. Slack and Google
+Chat use the same local relay.
+
+Only the credential sidecar receives secret environment variables, credential
+state volumes, and the explicitly projected Kubernetes ServiceAccount (KSA)
+token. It also authenticates callers of the PlatformAgent API before forwarding
+requests with a non-secret internal sentinel. Pod-wide automatic KSA token
+mounting is disabled.
+
+### Guarantee
+
+The operator does not place managed credentials in the sandbox container's:
+
+- environment;
+- root filesystem;
+- persistent agent volume; or
+- mounted ServiceAccount token path.
+
+`spec.deployment.env` is applied to the credential sidecar because it may
+contain credentials. Four allowlisted OpenTelemetry settings may also be copied
+to the sandbox, but only as literal values; all `valueFrom` sources are rejected.
+Reserved proxy, runtime-loader, and shell-startup variables cannot override the
+operator's managed values.
+
+### Limitation
+
+Containers in one Pod share a network namespace and one Pod identity. The
+sandbox does not have the KSA token file, but it can technically reach the GKE
+metadata server used by the credential sidecar. A Pod-level NetworkPolicy
+cannot block metadata for one container while allowing it for another.
+
+This design therefore meets the scoped filesystem-and-environment goal, but it
+does not provide the stronger identity boundary of separate Pods. It assumes
+the agent does not deliberately request credentials from the metadata server.
+
+## Scope
+
+### In scope
+
+- PlatformAgent only.
+- Credentials managed by the operator.
+- CLI forwarding for `gcloud`, `kubectl`, `gh`, and `git`.
+- Slack and Google Chat credentialed relays.
+- PlatformAgent API bearer-key termination in the credential sidecar.
+- GitHub installation tokens minted through Minty.
+- Sidecar health, lifecycle, rollout, and migration from the former proxy Pod.
+
+### Out of scope
+
+- Preventing credentials from appearing in approved command or tool output.
+- Preventing an approved credentialed command from deliberately copying a
+  credential into the shared workspace. Such credential disclosure and tool
+  side effects require a separate approval/policy design.
+- Preventing deliberate access to the shared Pod identity or metadata server.
+- Arbitrary user-supplied init containers, sidecars, volumes, and mounts. These
+  are trusted configuration and may intentionally weaken isolation.
+- OperatorAgent and DevTeamAgent.
+- General data-exfiltration prevention.
+
+## Architecture
+
+```text
+PlatformAgent Pod
+
+  platform-agent
+    credential-free env and mounts
+    CLI wrappers / chat adapters
+              |
+              | HTTP on 127.0.0.1:8765
+              v
+  envoy-credential-proxy
+    Envoy listener
+              |
+              | private Unix socket
+              v
+    credential runtime
+    real CLIs, Slack/Chat clients, Minty client
+    secret env, KSA token, private temporary state
+```
+
+Envoy is the only listener for credentialed tool and chat requests. The
+credential runtime listens on a Unix socket mounted only in the sidecar, so the
+sandbox cannot bypass Envoy by calling the runtime directly. A separate sidecar
+listener authenticates the existing PlatformAgent API on port 8643 and forwards
+to the sandbox API on loopback using a non-secret sentinel.
+
+The containers have the same lifecycle because they are part of the same
+Deployment and Pod. If the sidecar is not ready, the Pod is not ready. If either
+Envoy or the credential runtime exits, the sidecar exits and Kubernetes restarts
+it.
+
+## Credential Placement
+
+| Data                            | Sandbox     | Credential sidecar        |
+| ------------------------------- | ----------- | ------------------------- |
+| `spec.deployment.env`           | No          | Yes                       |
+| Slack tokens                    | No          | Yes, Secret-backed env    |
+| PlatformAgent external API key  | No          | Yes, Secret-backed env    |
+| Automatic KSA token mount       | Disabled    | Disabled                  |
+| Explicit projected KSA token    | Not mounted | Read-only, one-hour token |
+| gcloud/kubectl configuration    | No          | Private `emptyDir`        |
+| GitHub installation token/cache | No          | Private `emptyDir`        |
+| Agent workspace                 | Yes         | Yes, for proxied commands |
+
+The projected token uses the audience `kubeagents-credential-proxy`, expires
+after one hour, and is mounted only at
+`/var/run/secrets/kubeagents/serviceaccount/token` in the credential sidecar.
+Deleting a default token during startup is intentionally not used: projected
+tokens rotate, and mount-time exclusion is reliable.
+
+## Request Paths
+
+### CLI commands
+
+The sandbox image contains wrapper binaries instead of credential-aware CLI
+binaries. A wrapper sends the executable name and argument array to the local
+proxy. The credential runtime directly executes the corresponding real CLI and
+returns output and exit status. It never evaluates an agent-supplied shell
+command.
+
+Only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy also rejects
+known credential-disclosure, credential-replacement, and self-modification
+operations. Pipelines and redirections are interpreted by the sandbox shell
+around an individual wrapper invocation, so they cannot execute inside the
+credential sidecar. Requests that cannot be represented safely fail closed,
+including:
+
+- interactive TTY programs and password prompts;
+- arbitrary binary or unbounded streaming input/output;
+- file paths that refer to sandbox-only files;
+- background processes or commands that outlive the request; and
+- commands exceeding request, output, or timeout limits.
+
+Standard input and full-duplex streaming require a future bounded protocol; the
+wrapper does not silently consume an inherited protocol stream.
+
+The current deny policy applies regular expressions to a shell-escaped rendering
+of the argument vector and permits flags before or between subcommands. This is
+an interim policy mechanism, not a general shell parser. If the policy grows
+beyond these narrowly defined commands, it should use tool-specific argument
+parsers over the structured argument vector.
+
+### Chat
+
+Slack and Google Chat adapters send credential-free request payloads to Envoy.
+The credential runtime owns platform tokens and performs the external API call.
+Allowlisted users, payload size limits, and file size limits are enforced by the
+relay.
+
+### PlatformAgent API
+
+The Kubernetes Service sends API traffic to port 8643 on the credential
+sidecar. The sidecar validates the configured external bearer key and replaces
+it with the sandbox's fixed, non-secret sentinel before forwarding to port 8642.
+Existing API clients retain bearer-key authentication without placing the real
+key in the sandbox.
+
+### GitHub and Minty
+
+The credential sidecar obtains a Google OIDC identity token and calls Minty.
+Minty validates CEL authorization rules for the authenticated agent identity and
+requested repository, then brokers a repository-scoped GitHub installation
+token with a maximum one-hour lifetime. The GitHub App private key remains in
+Cloud KMS and signing uses `AsymmetricSign`.
+
+The workspace is mounted at the same path in both containers so proxied Git
+commands operate on the agent's repository. Git authentication, CLI config, and
+token caches remain on a separate sidecar-only volume. The sandbox receives
+only command output, never a mounted Git credential file.
+
+## Kubernetes Details
+
+- The Pod uses the configured PlatformAgent KSA for the credential sidecar's
+  Workload Identity.
+- `automountServiceAccountToken: false` applies to the Pod.
+- A projected ServiceAccount token volume is mounted only by the credential
+  sidecar.
+- Secret and credential-state volumes are mounted only by the credential
+  sidecar.
+- The sandbox and sidecar run non-root, drop all Linux capabilities, disallow
+  privilege escalation, and use the runtime-default seccomp profile.
+- The credential sidecar root filesystem is read-only; writable state uses
+  bounded `emptyDir` volumes.
+- A policy ConfigMap hash is placed on the Pod template to trigger rollout when
+  command policy changes.
+- The operator reports Ready only when the combined Pod is ready.
+
+## Deployment and Migration
+
+The operator always creates the sandbox and Envoy credential sidecar together
+in the existing `<agent>-gateway` Deployment and retains the existing
+`<agent>-data` PVC. Before the sandbox starts, a managed init container removes
+legacy gcloud, GitHub, Git, Kubernetes, AWS, Azure, Docker, npm, and Python
+credential files from that PVC. This preserves agent state without carrying
+credentials forward from an older deployment. It deletes operator-owned
+resources from the abandoned two-Pod design:
+
+- `<agent>-credential-proxy` Deployment;
+- `<agent>-credential-proxy` Service;
+- `<agent>-sandbox` ServiceAccount; and
+- `<agent>-sandbox-metadata-deny` NetworkPolicy.
+
+Deletion refuses to remove resources not owned by the PlatformAgent.
+
+The credential-sidecar image contains Envoy, the real credential-aware CLIs,
+and the credential runtime. The sandbox image contains only the wrappers for
+those CLI names.
+
+## Tradeoffs
+
+Benefits:
+
+- one Deployment and one Pod lifecycle;
+- no managed credential env or files in the sandbox container;
+- no separate proxy Service or cross-Pod availability coordination;
+- a single local surface for CLI and chat policy; and
+- credentials remain usable without adding real cloud CLIs to the sandbox.
+
+Costs:
+
+- no hard network or identity boundary between the sandbox and sidecar;
+- a custom command-forwarding protocol must be maintained;
+- interactive, streaming, and file-based CLI behavior is limited; and
+- each new service needs an explicit proxy integration and policy.
+
+If deliberate metadata or Pod-identity access becomes in scope, this design
+must return to separate Pods or use a node/runtime mechanism that enforces
+per-container network identity.
+
+## Verification
+
+CI and deployment tests should assert that:
+
+1. the sandbox has no Secret-backed env, `spec.deployment.env`, secret volume,
+   credential-state volume, or ServiceAccount token mount;
+2. only the credential sidecar mounts the projected KSA token and proxy state;
+3. only the credential sidecar receives Slack tokens and deployment env;
+4. wrapper URLs resolve to `127.0.0.1:8765`;
+5. Envoy can reach the Unix-socket backend and `/healthz` reflects both;
+6. unsupported executables, raw shell requests, and blocked disclosure commands
+   fail closed;
+7. the old proxy Deployment and Service are absent after reconciliation; and
+8. the external PlatformAgent API key is accepted by the sidecar and replaced
+   before forwarding to the loopback-only sandbox API; and
+9. Pod readiness fails when either Envoy or the credential runtime fails.

--- a/k8s-operator/.dockerignore
+++ b/k8s-operator/.dockerignore
@@ -1,0 +1,4 @@
+.git
+bin/
+cover.out
+*.test

--- a/k8s-operator/.dockerignore
+++ b/k8s-operator/.dockerignore
@@ -2,3 +2,4 @@
 bin/
 cover.out
 *.test
+**/vars.sh

--- a/k8s-operator/.gcloudignore
+++ b/k8s-operator/.gcloudignore
@@ -3,3 +3,4 @@
 bin/
 cover.out
 *.test
+**/vars.sh

--- a/k8s-operator/.gcloudignore
+++ b/k8s-operator/.gcloudignore
@@ -1,0 +1,5 @@
+.gcloudignore
+.git
+bin/
+cover.out
+*.test

--- a/k8s-operator/config/integrations/github/deployment.yaml.template
+++ b/k8s-operator/config/integrations/github/deployment.yaml.template
@@ -113,7 +113,7 @@ spec:
     - from:
         - podSelector:
             matchLabels:
-              app: platform-agent
+              kubeagents.x-k8s.io/has-credential-proxy: "true"
       ports:
         - protocol: TCP
           port: 8080

--- a/k8s-operator/config/rbac/role.yaml
+++ b/k8s-operator/config/rbac/role.yaml
@@ -90,6 +90,18 @@ rules:
       - patch
       - update
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - node.k8s.io
     resources:
       - runtimeclasses

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -147,7 +147,7 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.reconcileService(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.deleteLegacyCredentialProxyResources(ctx, instance); err != nil {
+	if err := r.deleteLegacyCredentialIsolationResources(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -346,8 +346,9 @@ func (r *PlatformAgentReconciler) reconcileWorkload(ctx context.Context, agent *
 	return r.Patch(ctx, dep, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
 }
 
-func (r *PlatformAgentReconciler) deleteLegacyCredentialProxyResources(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+func (r *PlatformAgentReconciler) deleteLegacyCredentialIsolationResources(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
 	resources := []client.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox", Namespace: agent.Namespace}},
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox", Namespace: agent.Namespace}},

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	nodev1 "k8s.io/api/node/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,6 +58,7 @@ type PlatformAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=namespaces;nodes;events;persistentvolumes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete;bind
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list
 
@@ -89,7 +91,6 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.reconcileServiceAccount(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
-
 	// 3b. Reconcile RBAC (ClusterRole and ClusterRoleBindings)
 	if err := r.reconcileRBAC(ctx, instance); err != nil {
 		return ctrl.Result{}, err
@@ -118,6 +119,11 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
+	proxyPolicyHash, err := r.reconcileCredentialProxyPolicyConfigMap(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	// 6. Validate RuntimeClass if specified
 	if err := r.validateRuntimeClass(ctx, instance); err != nil {
 		if errors.IsNotFound(err) {
@@ -132,8 +138,8 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, fmt.Errorf("failed to validate RuntimeClass: %w", err)
 	}
 
-	// 7. Reconcile Workload (Deployment or StatefulSet)
-	if err := r.reconcileWorkload(ctx, instance, configMapHash, fluentBitHash, settingsHash); err != nil {
+	// 7. Reconcile the Agent Sandbox Pod with its Envoy credential sidecar.
+	if err := r.reconcileWorkload(ctx, instance, configMapHash, fluentBitHash, settingsHash, proxyPolicyHash); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -141,8 +147,11 @@ func (r *PlatformAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if err := r.reconcileService(ctx, instance); err != nil {
 		return ctrl.Result{}, err
 	}
+	if err := r.deleteLegacyCredentialProxyResources(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
-	// 7. Update status phase to Ready
+	// 9. Update status phase to Ready
 	return ctrl.Result{}, r.updateStatusReady(ctx, instance)
 }
 
@@ -297,7 +306,18 @@ func (r *PlatformAgentReconciler) reconcileSettingsConfigMap(ctx context.Context
 	return hash, nil
 }
 
-func (r *PlatformAgentReconciler) reconcileWorkload(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsHash string) error {
+func (r *PlatformAgentReconciler) reconcileCredentialProxyPolicyConfigMap(ctx context.Context, agent *agentv1alpha1.PlatformAgent) (string, error) {
+	cm := buildCredentialProxyPolicyConfigMap(agent)
+	if err := ctrl.SetControllerReference(agent, cm, r.Scheme); err != nil {
+		return "", err
+	}
+	if err := r.Patch(ctx, cm, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller")); err != nil {
+		return "", err
+	}
+	return getConfigMapHash(cm)
+}
+
+func (r *PlatformAgentReconciler) reconcileWorkload(ctx context.Context, agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsHash, policyHash string) error {
 	// Note: Switching between Deployment and StatefulSet causes a full delete+recreate of the workload.
 	// This will incur downtime and potentially stuck pods if RWO volumes take time to unbind.
 	// This is an acceptable tradeoff since switching replicas/storage requires an explicit CRD update.
@@ -307,7 +327,7 @@ func (r *PlatformAgentReconciler) reconcileWorkload(ctx context.Context, agent *
 			return fmt.Errorf("failed to cleanup legacy Deployment: %w", err)
 		}
 
-		sts := buildStatefulSet(agent, configHash, fluentBitHash, settingsHash)
+		sts := buildStatefulSet(agent, configHash, fluentBitHash, settingsHash, policyHash)
 		if err := ctrl.SetControllerReference(agent, sts, r.Scheme); err != nil {
 			return err
 		}
@@ -319,11 +339,35 @@ func (r *PlatformAgentReconciler) reconcileWorkload(ctx context.Context, agent *
 		return fmt.Errorf("failed to cleanup legacy StatefulSet: %w", err)
 	}
 
-	dep := buildDeployment(agent, configHash, fluentBitHash, settingsHash)
+	dep := buildDeployment(agent, configHash, fluentBitHash, settingsHash, policyHash)
 	if err := ctrl.SetControllerReference(agent, dep, r.Scheme); err != nil {
 		return err
 	}
 	return r.Patch(ctx, dep, client.Apply, client.ForceOwnership, client.FieldOwner("platformagent-controller"))
+}
+
+func (r *PlatformAgentReconciler) deleteLegacyCredentialProxyResources(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
+	resources := []client.Object{
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-credential-proxy", Namespace: agent.Namespace}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox", Namespace: agent.Namespace}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: agent.Name + "-sandbox-metadata-deny", Namespace: agent.Namespace}},
+	}
+	for _, resource := range resources {
+		if err := r.Get(ctx, client.ObjectKeyFromObject(resource), resource); err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			continue
+		}
+		if !metav1.IsControlledBy(resource, agent) {
+			return fmt.Errorf("refusing to delete unowned legacy %T %s/%s", resource, resource.GetNamespace(), resource.GetName())
+		}
+		if err := client.IgnoreNotFound(r.Delete(ctx, resource)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *PlatformAgentReconciler) reconcileService(ctx context.Context, agent *agentv1alpha1.PlatformAgent) error {
@@ -431,7 +475,7 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 		newPhase = "Ready"
 		condStatus = metav1.ConditionTrue
 		condReason = "Reconciled"
-		condMsg = "Agent deployment and resources are fully reconciled"
+		condMsg = "Agent sandbox and Envoy credential sidecar are fully reconciled"
 	} else if errWorkload == nil {
 		if phaseOverride, reasonOverride, msgOverride := r.getDeploymentStatusDetails(ctx, agent); reasonOverride != "Provisioning" {
 			newPhase = phaseOverride
@@ -557,6 +601,7 @@ func (r *PlatformAgentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Service{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Watches(
 			&rbacv1.ClusterRoleBinding{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/k8s-operator/internal/controller/platformagent_controller_test.go
+++ b/k8s-operator/internal/controller/platformagent_controller_test.go
@@ -224,7 +224,7 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 	}
 }
 
-func TestDeleteLegacyCredentialProxyResources(t *testing.T) {
+func TestDeleteLegacyCredentialIsolationResources(t *testing.T) {
 	scheme := setupScheme()
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns", UID: types.UID("agent-uid")},
@@ -238,6 +238,7 @@ func TestDeleteLegacyCredentialProxyResources(t *testing.T) {
 	}
 	objects := []client.Object{
 		agent,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
 		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
@@ -246,8 +247,8 @@ func TestDeleteLegacyCredentialProxyResources(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	r := &PlatformAgentReconciler{Client: cl, Scheme: scheme}
 
-	if err := r.deleteLegacyCredentialProxyResources(context.Background(), agent); err != nil {
-		t.Fatalf("deleteLegacyCredentialProxyResources failed: %v", err)
+	if err := r.deleteLegacyCredentialIsolationResources(context.Background(), agent); err != nil {
+		t.Fatalf("deleteLegacyCredentialIsolationResources failed: %v", err)
 	}
 	for _, object := range objects[1:] {
 		err := cl.Get(context.Background(), client.ObjectKeyFromObject(object), object)

--- a/k8s-operator/internal/controller/platformagent_controller_test.go
+++ b/k8s-operator/internal/controller/platformagent_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	nodev1 "k8s.io/api/node/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -168,6 +169,9 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 			t.Errorf("expected Deployment to have container named 'platform-agent'")
 		}
 	}
+	if len(dep.Spec.Template.Spec.Containers) < 5 || dep.Spec.Template.Spec.Containers[4].Name != "envoy-credential-proxy" {
+		t.Errorf("expected Deployment to contain Envoy credential sidecar")
+	}
 
 	// Service
 	svc := &corev1.Service{}
@@ -217,6 +221,39 @@ func TestPlatformAgentReconciler_Reconcile(t *testing.T) {
 	err = cl.Get(ctx, types.NamespacedName{Name: "kubeagents:explorer:test-ns:test-agent"}, explorerRole)
 	if err == nil {
 		t.Errorf("expected ClusterRole to be deleted")
+	}
+}
+
+func TestDeleteLegacyCredentialProxyResources(t *testing.T) {
+	scheme := setupScheme()
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns", UID: types.UID("agent-uid")},
+	}
+	ownerReference := metav1.OwnerReference{
+		APIVersion: agentv1alpha1.GroupVersion.String(),
+		Kind:       "PlatformAgent",
+		Name:       agent.Name,
+		UID:        agent.UID,
+		Controller: ptr.To(true),
+	}
+	objects := []client.Object{
+		agent,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-credential-proxy", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "test-agent-sandbox-metadata-deny", Namespace: "test-ns", OwnerReferences: []metav1.OwnerReference{ownerReference}}},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	r := &PlatformAgentReconciler{Client: cl, Scheme: scheme}
+
+	if err := r.deleteLegacyCredentialProxyResources(context.Background(), agent); err != nil {
+		t.Fatalf("deleteLegacyCredentialProxyResources failed: %v", err)
+	}
+	for _, object := range objects[1:] {
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(object), object)
+		if !errors.IsNotFound(err) {
+			t.Errorf("expected legacy %T to be deleted, got %v", object, err)
+		}
 	}
 }
 
@@ -442,7 +479,7 @@ func TestPlatformAgentReconciler_Reconcile_PodUnschedulable(t *testing.T) {
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-agent-unschedulable-gateway-pod",
+			Name:      "test-agent-unschedulable-sandbox-pod",
 			Namespace: "test-ns",
 			Labels: map[string]string{
 				"app": "test-agent-unschedulable-gateway",
@@ -526,7 +563,7 @@ func TestPlatformAgentReconciler_Reconcile_PodUnschedulable(t *testing.T) {
 		t.Fatalf("expected Ready condition False with reason PodUnschedulable, got %v", cond)
 	}
 
-	expectedMsg := "Pod test-agent-unschedulable-gateway-pod is waiting to be scheduled because no nodes in the cluster match the requested RuntimeClass 'gvisor'. For GKE Standard, enable GKE Sandbox by provisioning a gVisor node pool."
+	expectedMsg := "Pod test-agent-unschedulable-sandbox-pod is waiting to be scheduled because no nodes in the cluster match the requested RuntimeClass 'gvisor'. For GKE Standard, enable GKE Sandbox by provisioning a gVisor node pool."
 	if cond.Message != expectedMsg {
 		t.Errorf("expected polished condition message:\n%q\ngot:\n%q", expectedMsg, cond.Message)
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -41,6 +41,7 @@ const (
 	sessionKVDBPath             = "/var/lib/kube-agents/session/session_kv.db"
 	defaultAgentHome            = "/opt/data"
 	defaultStorageSize          = "5Gi"
+	credentialProxyPort         = 8765
 )
 
 // getDefaultStorageConfig returns the access modes and storage class name based on the replica count and user configuration.
@@ -63,6 +64,24 @@ func getDefaultStorageConfig(agent *agentv1alpha1.PlatformAgent) ([]corev1.Persi
 }
 
 var defaultAccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+
+// The broker currently receives a shell command string, so these rules allow
+// flags between command components. If the protocol is extended to carry argv,
+// replace this regex matching with tool-specific argument parsing.
+const credentialProxyPolicyJSON = `{
+  "apiVersion": "cli.proxy.kubeagents.io/v1alpha1",
+  "blockedMessage": "Command blocked for security reasons.",
+  "rules": [
+    {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+print-(?:access|identity)-token\\b"},
+    {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+config-helper\\b"},
+    {"id":"github.token-disclosure","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+token\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+status\\b(?:\\s+\\S+)*?\\s+--show-token\\b"},
+    {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\b(?:\\s+\\S+)*?\\s+create\\b(?:\\s+\\S+)*?\\s+token\\b|\\bkubectl\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+view\\b(?:\\s+\\S+)*?\\s+--raw\\b"},
+    {"id":"git.credential-disclosure","pattern":"\\bgit\\b(?:\\s+\\S+)*?\\s+credential\\b(?:\\s+\\S+)*?\\s+fill\\b"},
+    {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|activate-service-account)\\b"},
+    {"id":"github.credential-replacement","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|refresh|switch|logout)\\b"},
+    {"id":"tool.self-modification","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+components\\b(?:\\s+\\S+)*?\\s+(?:install|update|remove)\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+extension\\b(?:\\s+\\S+)*?\\s+(?:install|upgrade|remove)\\b"}
+  ]
+}`
 
 // buildConfigMap generates the ConfigMap manifest containing config.yaml
 func buildConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
@@ -499,7 +518,7 @@ func buildCustomStorageVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volu
 }
 
 // buildPodTemplateSpec generates the shared PodTemplateSpec for Deployment and StatefulSet
-func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash string) corev1.PodTemplateSpec {
+func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string) corev1.PodTemplateSpec {
 	replicas, _ := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
 	// UID/GID 10000 matches the canonical unprivileged 'hermes' runtime user created in NousResearch/hermes-agent upstream Dockerfile
 	fsGroup := int64(10000)
@@ -510,6 +529,10 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 
 	image := resolveAgentImage(agent.Spec.Deployment, defaultPlatformAgentImage)
+	pullPolicy := corev1.PullAlways
+	if agent.Spec.Deployment != nil && agent.Spec.Deployment.ImagePullPolicy != nil {
+		pullPolicy = *agent.Spec.Deployment.ImagePullPolicy
+	}
 
 	var initContainers []corev1.Container
 	var sidecars []corev1.Container
@@ -528,6 +551,9 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.AgentHome != "" {
 		homeDir = agent.Spec.Harness.Hermes.AgentHome
 	}
+	// The data PVC survives upgrades. Remove credential files written by older,
+	// credentialed deployments before the agent sandbox can mount the PVC.
+	initContainers = append([]corev1.Container{buildSandboxCredentialCleanup(image, pullPolicy)}, initContainers...)
 
 	pluginsDebugVal := "0"
 	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.PluginsDebug != nil {
@@ -555,7 +581,13 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 		},
 		{
 			Name:  "API_SERVER_HOST",
-			Value: "0.0.0.0",
+			Value: "127.0.0.1",
+		},
+		{
+			// The sidecar authenticates external callers and replaces their bearer
+			// key with this non-secret loopback sentinel.
+			Name:  "API_SERVER_KEY",
+			Value: "cluster-internal-trusted",
 		},
 		{
 			Name:  "SESSION_KV_DB_PATH",
@@ -564,6 +596,9 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 
 	envVars = append(envVars, otelTelemetryEnvVars("platform", agent.Name, agent.Namespace)...)
+	if agent.Spec.Deployment != nil {
+		envVars = mergeEnvVars(envVars, safeSandboxEnvOverrides(agent.Spec.Deployment.Env))
+	}
 
 	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.BrowserArgs) > 0 {
 		envVars = append(envVars, corev1.EnvVar{
@@ -573,6 +608,12 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 
 	if agent.Spec.Harness != nil {
+		if agent.Spec.Harness.ProjectID != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "GKE_PROJECT_ID",
+				Value: agent.Spec.Harness.ProjectID,
+			})
+		}
 		if agent.Spec.Harness.ClusterName != "" {
 			envVars = append(envVars, corev1.EnvVar{
 				Name:  "GKE_CLUSTER_NAME",
@@ -591,19 +632,30 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 				Value: agent.Spec.Harness.ProjectID,
 			})
 		}
-		var apiServerSecretRef *corev1.SecretKeySelector
-		if agent.Spec.Harness.Hermes != nil {
-			apiServerSecretRef = agent.Spec.Harness.Hermes.ApiServerSecretRef
+		if agent.Spec.Harness.ProjectID != "" && agent.Spec.Harness.Location != "" && agent.Spec.Harness.ClusterName != "" {
+			envVars = append(envVars, corev1.EnvVar{
+				Name: "KUBE_CONTEXT_NAME",
+				Value: fmt.Sprintf(
+					"gke_%s_%s_%s",
+					agent.Spec.Harness.ProjectID,
+					agent.Spec.Harness.Location,
+					agent.Spec.Harness.ClusterName,
+				),
+			})
 		}
 		envVars = append(envVars, corev1.EnvVar{
-			Name:      "API_SERVER_KEY",
-			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(apiServerSecretRef, defaultPlatformAgentSecrets, "API_SERVER_KEY")},
+			Name:  "KUBE_DEFAULT_NAMESPACE",
+			Value: agent.Namespace,
 		})
 	}
 
 	if integration := agent.Spec.Integration; integration != nil {
 		if gchat := integration.GoogleChat; gchat != nil && gchat.Enabled != nil && *gchat.Enabled {
 			envVars = append(envVars, []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_CHAT_RELAY_URL",
+					Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
+				},
 				{
 					Name:  "GOOGLE_CHAT_PROJECT_ID",
 					Value: gchat.ProjectID,
@@ -633,16 +685,10 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 			}
 		}
 		if slack := integration.Slack; slack != nil && slack.Enabled != nil && *slack.Enabled {
-			envVars = append(envVars,
-				corev1.EnvVar{
-					Name:      "SLACK_BOT_TOKEN",
-					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.BotTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_BOT_TOKEN")},
-				},
-				corev1.EnvVar{
-					Name:      "SLACK_APP_TOKEN",
-					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.AppTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_APP_TOKEN")},
-				},
-			)
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  "SLACK_RELAY_URL",
+				Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
+			})
 			allowAllSlack := len(slack.AllowedUsers) == 0 || (len(slack.AllowedUsers) == 1 && slack.AllowedUsers[0] == "")
 			if allowAllSlack {
 				envVars = append(envVars, corev1.EnvVar{
@@ -688,13 +734,17 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 
 	envVars = append(envVars, corev1.EnvVar{
-		Name:  "TOKEN_BROKER_URL",
-		Value: fmt.Sprintf("http://github-token-minter.%s.svc.cluster.local:8080/token", agent.Namespace),
+		Name:  "CREDENTIAL_PROXY_URL",
+		Value: fmt.Sprintf("http://127.0.0.1:%d", credentialProxyPort),
 	})
-
-	if agent.Spec.Deployment != nil && len(agent.Spec.Deployment.Env) > 0 {
-		envVars = mergeEnvVars(envVars, agent.Spec.Deployment.Env)
-	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PATH",
+		Value: "/opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+	})
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  "PYTHONPATH",
+		Value: "/opt/defaults/scripts",
+	})
 
 	dashboardEnabled := isDashboardEnabled(agent)
 
@@ -709,18 +759,20 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 
 	containers := buildBaseContainers(agent, image, envVars)
+	containers = append(containers, buildCredentialProxySidecar(agent, homeDir))
 	defaultAnnotations := map[string]string{
 		"kubeagents.x-k8s.io/config-hash":            configHash,
 		"kubeagents.x-k8s.io/fluent-bit-config-hash": fluentBitHash,
 		"kubeagents.x-k8s.io/settings-config-hash":   settingsConfigHash,
+		"kubeagents.x-k8s.io/proxy-policy-hash":      policyHash,
 	}
-
 	if len(sidecars) > 0 {
 		containers = append(containers, sidecars...)
 	}
 
 	volumes := buildDefaultVolumes(agent)
 	volumes = append(volumes, buildCustomStorageVolumes(agent)...)
+	volumes = append(volumes, buildCredentialProxyVolumes(agent)...)
 	if len(sidecarVolumes) > 0 {
 		volumes = append(volumes, sidecarVolumes...)
 	}
@@ -742,14 +794,16 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				"app": agent.Name + "-gateway",
+				"kubeagents.x-k8s.io/has-credential-proxy": "true",
 			},
 			Annotations: mergeAnnotations(defaultAnnotations, podAnnotations),
 		},
 		Spec: corev1.PodSpec{
-			ShareProcessNamespace: shareProcessNamespace,
-			RuntimeClassName:      runtimeClassName,
-			InitContainers:        initContainers,
-			ServiceAccountName:    saName,
+			ShareProcessNamespace:        shareProcessNamespace,
+			RuntimeClassName:             runtimeClassName,
+			InitContainers:               initContainers,
+			ServiceAccountName:           saName,
+			AutomountServiceAccountToken: ptr.To(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				FSGroup: &fsGroup,
 				// UID 10000 matches canonical 'hermes' runtime user in upstream image (NousResearch/hermes-agent Dockerfile line 92)
@@ -767,9 +821,9 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 }
 
 // buildDeployment generates the Deployment manifest for the agent payload
-func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash string) *appsv1.Deployment {
+func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string) *appsv1.Deployment {
 	replicas, strategy := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
-	podTemplate := buildPodTemplateSpec(agent, configHash, fluentBitHash, settingsConfigHash)
+	podTemplate := buildPodTemplateSpec(agent, configHash, fluentBitHash, settingsConfigHash, policyHash)
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -781,6 +835,7 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			Namespace: agent.Namespace,
 			Labels: map[string]string{
 				"app": agent.Name + "-gateway",
+				"kubeagents.x-k8s.io/has-credential-proxy": "true",
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -797,9 +852,9 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 }
 
 // buildStatefulSet generates the StatefulSet manifest for PlatformAgent when RWO custom storage is used with multiple replicas
-func buildStatefulSet(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash string) *appsv1.StatefulSet {
+func buildStatefulSet(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string) *appsv1.StatefulSet {
 	replicas, _ := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
-	podTemplate := buildPodTemplateSpec(agent, configHash, fluentBitHash, settingsConfigHash)
+	podTemplate := buildPodTemplateSpec(agent, configHash, fluentBitHash, settingsConfigHash, policyHash)
 	vcts := buildRWOVolumeClaimTemplates(agent)
 
 	return &appsv1.StatefulSet{
@@ -859,7 +914,243 @@ func buildDefaultVolumeMounts(homeDir string) []corev1.VolumeMount {
 	}
 }
 
-// buildBaseContainers generates the base containers for PlatformAgent
+func buildSandboxCredentialCleanup(image string, pullPolicy corev1.PullPolicy) corev1.Container {
+	return corev1.Container{
+		Name:            "sandbox-credential-cleanup",
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"sh", "-ec"},
+		Args: []string{`rm -rf -- \
+  /workspace/home/.config/gcloud \
+  /workspace/home/.config/gh \
+  /workspace/home/.aws/credentials \
+  /workspace/home/.aws/cli/cache \
+  /workspace/home/.aws/sso/cache \
+  /workspace/home/.azure \
+  /workspace/home/.docker/config.json \
+  /workspace/home/.git-credentials \
+  /workspace/home/.hermes/.env \
+  /workspace/home/.kube/config \
+  /workspace/home/.netrc \
+  /workspace/home/.npmrc \
+  /workspace/home/.pypirc`},
+		VolumeMounts: []corev1.VolumeMount{{Name: "platform-agent-data-vol", MountPath: "/workspace"}},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+func buildCredentialProxyPolicyConfigMap(agent *agentv1alpha1.PlatformAgent) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agent.Name + "-credential-proxy-policy",
+			Namespace: agent.Namespace,
+		},
+		Data: map[string]string{"policy.json": credentialProxyPolicyJSON},
+	}
+}
+
+// buildCredentialProxySidecar returns the Envoy-fronted credential runtime.
+// Its environment and volume mounts are intentionally disjoint from the agent
+// container even though both containers share a Pod network namespace.
+func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir string) corev1.Container {
+	image := resolveCredentialProxyImage(agent.Spec.Deployment)
+	pullPolicy := corev1.PullAlways
+	if agent.Spec.Deployment != nil && agent.Spec.Deployment.ImagePullPolicy != nil {
+		pullPolicy = *agent.Spec.Deployment.ImagePullPolicy
+	}
+	envVars := buildCredentialProxyEnv(agent)
+	envVars = append(envVars, corev1.EnvVar{Name: "CREDENTIAL_PROXY_WORKSPACE_ROOT", Value: homeDir})
+	return corev1.Container{
+		Name:            "envoy-credential-proxy",
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Command:         []string{"/usr/local/bin/envoy-credential-sidecar"},
+		Env:             envVars,
+		Ports: []corev1.ContainerPort{
+			{Name: "cred-proxy", ContainerPort: credentialProxyPort},
+			{Name: "api", ContainerPort: 8643},
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: []string{
+				"curl", "--fail", "--silent", "--show-error", "http://127.0.0.1:8765/healthz",
+			}}},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"), corev1.ResourceMemory: resource.MustParse("2Gi"), corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "credential-proxy-policy", MountPath: "/etc/credential-proxy/policy.json", SubPath: "policy.json", ReadOnly: true},
+			{Name: "credential-proxy-tmp", MountPath: "/tmp"},
+			{Name: "credential-proxy-state", MountPath: "/var/lib/credential-proxy"},
+			{Name: "credential-proxy-runtime", MountPath: "/var/run/credential-proxy"},
+			{Name: "credential-proxy-ksa-token", MountPath: "/var/run/secrets/kubeagents/serviceaccount", ReadOnly: true},
+			{Name: "platform-agent-data-vol", MountPath: homeDir},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false), ReadOnlyRootFilesystem: ptr.To(true), Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+	}
+}
+
+func buildCredentialProxyEnv(agent *agentv1alpha1.PlatformAgent) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{
+		{Name: "PLATFORM_AGENT_HOME", Value: "/tmp/credential-proxy"},
+		{Name: "HOME", Value: "/tmp/credential-proxy/home"},
+		{Name: "CREDENTIAL_PROXY_POLICY", Value: "/etc/credential-proxy/policy.json"},
+		{Name: "CREDENTIAL_PROXY_STATE_DIR", Value: "/var/lib/credential-proxy"},
+		{Name: "CREDENTIAL_PROXY_UNIX_SOCKET", Value: "/var/run/credential-proxy/backend.sock"},
+		{Name: "KSA_TOKEN_FILE", Value: "/var/run/secrets/kubeagents/serviceaccount/token"},
+		{Name: "TOKEN_BROKER_URL", Value: fmt.Sprintf("http://github-token-minter.%s.svc.cluster.local:8080/token", agent.Namespace)},
+		{Name: "AGENT_API_PROXY_PORT", Value: "8643"},
+		{Name: "AGENT_API_UPSTREAM_KEY", Value: "cluster-internal-trusted"},
+	}
+	apiServerSecretRef := defaultSecretRef(nil, defaultPlatformAgentSecrets, "API_SERVER_KEY")
+	if harness := agent.Spec.Harness; harness != nil && harness.Hermes != nil && harness.Hermes.ApiServerSecretRef != nil {
+		apiServerSecretRef = harness.Hermes.ApiServerSecretRef
+	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name: "API_SERVER_EXTERNAL_KEY",
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: apiServerSecretRef,
+		},
+	})
+	if harness := agent.Spec.Harness; harness != nil && harness.ProjectID != "" && harness.Location != "" && harness.ClusterName != "" {
+		envVars = append(envVars,
+			corev1.EnvVar{Name: "GKE_PROJECT_ID", Value: harness.ProjectID}, corev1.EnvVar{Name: "GKE_CLUSTER_NAME", Value: harness.ClusterName}, corev1.EnvVar{Name: "GKE_LOCATION", Value: harness.Location},
+			corev1.EnvVar{Name: "KUBE_CONTEXT_NAME", Value: fmt.Sprintf("gke_%s_%s_%s", harness.ProjectID, harness.Location, harness.ClusterName)}, corev1.EnvVar{Name: "KUBE_DEFAULT_NAMESPACE", Value: agent.Namespace},
+			corev1.EnvVar{Name: "CREDENTIAL_PROXY_BOOTSTRAP_COMMAND", Value: `gcloud config set project "$GKE_PROJECT_ID" >/dev/null &&
+gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location "$GKE_LOCATION" --project "$GKE_PROJECT_ID" &&
+kubectl config use-context "$KUBE_CONTEXT_NAME" >/dev/null &&
+kubectl config set-context "$KUBE_CONTEXT_NAME" --namespace="$KUBE_DEFAULT_NAMESPACE" >/dev/null`},
+		)
+	}
+	if integration := agent.Spec.Integration; integration != nil {
+		if gchat := integration.GoogleChat; gchat != nil && gchat.Enabled != nil && *gchat.Enabled {
+			envVars = append(envVars, corev1.EnvVar{Name: "GOOGLE_CHAT_PROJECT_ID", Value: gchat.ProjectID}, corev1.EnvVar{Name: "GOOGLE_CHAT_SUBSCRIPTION_NAME", Value: fmt.Sprintf("projects/%s/subscriptions/%s", gchat.ProjectID, gchat.SubscriptionName)})
+		}
+		if slack := integration.Slack; slack != nil && slack.Enabled != nil && *slack.Enabled {
+			envVars = append(envVars,
+				corev1.EnvVar{Name: "SLACK_BOT_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.BotTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_BOT_TOKEN")}},
+				corev1.EnvVar{Name: "SLACK_APP_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: defaultSecretRef(slack.AppTokenSecretRef, defaultPlatformAgentSecrets, "SLACK_APP_TOKEN")}},
+			)
+		}
+	}
+	if agent.Spec.Deployment != nil {
+		envVars = mergeCredentialProxyEnv(envVars, agent.Spec.Deployment.Env)
+	}
+	return envVars
+}
+
+func mergeCredentialProxyEnv(managed, custom []corev1.EnvVar) []corev1.EnvVar {
+	reserved := map[string]struct{}{
+		"PATH": {}, "PYTHONPATH": {}, "ENV": {}, "BASH_ENV": {},
+		"LD_PRELOAD": {}, "LD_LIBRARY_PATH": {},
+		"KUBERNETES_SERVICE_HOST": {}, "KUBERNETES_SERVICE_PORT": {},
+	}
+	for _, env := range managed {
+		reserved[env.Name] = struct{}{}
+	}
+	for _, name := range []string{
+		"CREDENTIAL_PROXY_BOOTSTRAP_COMMAND",
+		"CREDENTIAL_PROXY_MAX_OUTPUT_BYTES",
+		"CREDENTIAL_PROXY_MAX_REQUEST_BYTES",
+		"CREDENTIAL_PROXY_POLICY",
+		"CREDENTIAL_PROXY_PORT",
+		"CREDENTIAL_PROXY_STATE_DIR",
+		"CREDENTIAL_PROXY_TIMEOUT_SECONDS",
+		"CREDENTIAL_PROXY_UNIX_SOCKET",
+		"CREDENTIAL_PROXY_WORKSPACE_ROOT",
+		"KSA_TOKEN_FILE",
+		"TOKEN_BROKER_URL",
+	} {
+		reserved[name] = struct{}{}
+	}
+
+	result := append([]corev1.EnvVar{}, managed...)
+	for _, env := range custom {
+		if _, found := reserved[env.Name]; !found {
+			result = append(result, env)
+		}
+	}
+	return result
+}
+
+// safeSandboxEnvOverrides preserves non-secret telemetry customization without
+// copying arbitrary deployment environment variables into the agent sandbox.
+func safeSandboxEnvOverrides(custom []corev1.EnvVar) []corev1.EnvVar {
+	allowed := map[string]struct{}{
+		"OTEL_EXPORTER_OTLP_ENDPOINT": {},
+		"OTEL_EXPORTER_OTLP_PROTOCOL": {},
+		"OTEL_RESOURCE_ATTRIBUTES":    {},
+		"OTEL_SERVICE_NAME":           {},
+	}
+	var result []corev1.EnvVar
+	for _, env := range custom {
+		// Only literal telemetry settings are safe to copy. A ValueFrom source can
+		// reference a Secret even when its environment variable name is allowlisted.
+		if _, ok := allowed[env.Name]; ok && env.ValueFrom == nil {
+			result = append(result, env)
+		}
+	}
+	return result
+}
+
+func buildCredentialProxyVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volume {
+	return []corev1.Volume{
+		{Name: "credential-proxy-policy", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{LocalObjectReference: corev1.LocalObjectReference{Name: agent.Name + "-credential-proxy-policy"}}}},
+		{Name: "credential-proxy-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("2Gi"))}}},
+		{Name: "credential-proxy-state", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("5Gi"))}}},
+		{Name: "credential-proxy-runtime", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory, SizeLimit: ptr.To(resource.MustParse("16Mi"))}}},
+		{Name: "credential-proxy-ksa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+			DefaultMode: ptr.To(int32(0400)),
+			Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+				Audience: "kubeagents-credential-proxy", ExpirationSeconds: ptr.To(int64(3600)), Path: "token",
+			}}},
+		}}},
+	}
+}
+
+func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) string {
+	image := defaultPlatformAgentImage
+	if deployment != nil && deployment.Image != "" {
+		image = deployment.Image
+	}
+	lastSlash := strings.LastIndex(image, "/")
+	prefix, name := "", image
+	if lastSlash >= 0 {
+		prefix, name = image[:lastSlash+1], image[lastSlash+1:]
+	}
+	suffix := ""
+	if digest := strings.Index(name, "@"); digest >= 0 {
+		suffix, name = name[digest:], name[:digest]
+	} else if tag := strings.LastIndex(name, ":"); tag >= 0 {
+		suffix, name = name[tag:], name[:tag]
+	}
+	if name == "platform-agent" {
+		name = "credential-proxy"
+	} else {
+		name += "-credential-proxy"
+	}
+	if deployment != nil && deployment.Tag != nil && *deployment.Tag != "" {
+		return prefix + name + ":" + *deployment.Tag
+	}
+	if suffix == "" {
+		suffix = ":latest"
+	}
+	return prefix + name + suffix
+}
+
+// buildBaseContainers generates the base containers for PlatformAgent.
 func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVars []corev1.EnvVar) []corev1.Container {
 	homeDir := defaultAgentHome
 	if agent.Spec.Harness != nil && agent.Spec.Harness.Hermes != nil && agent.Spec.Harness.Hermes.AgentHome != "" {
@@ -896,12 +1187,8 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 		args = []string{fmt.Sprintf("%s/leader_elect.py", homeDir)}
 	}
 
-	var apiServerSecretRef *corev1.SecretKeySelector
 	clusterName := "platform-agent-host"
 	if agent.Spec.Harness != nil {
-		if agent.Spec.Harness.Hermes != nil {
-			apiServerSecretRef = agent.Spec.Harness.Hermes.ApiServerSecretRef
-		}
 		if agent.Spec.Harness.ClusterName != "" {
 			clusterName = agent.Spec.Harness.ClusterName
 		}
@@ -1060,14 +1347,8 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 		},
 		Env: []corev1.EnvVar{
 			{
-				Name: "API_SERVER_KEY",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: defaultSecretRef(
-						apiServerSecretRef,
-						defaultPlatformAgentSecrets,
-						"API_SERVER_KEY",
-					),
-				},
+				Name:  "API_SERVER_KEY",
+				Value: "cluster-internal-trusted",
 			},
 			{
 				Name:  "HOME",
@@ -1304,7 +1585,7 @@ func buildPlatformService(agent *agentv1alpha1.PlatformAgent) *corev1.Service {
 		{
 			Name:       "api",
 			Port:       8642,
-			TargetPort: intstr.FromString("api"),
+			TargetPort: intstr.FromInt32(8643),
 		},
 	}
 

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -973,7 +973,7 @@ func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir str
 		Env:             envVars,
 		Ports: []corev1.ContainerPort{
 			{Name: "cred-proxy", ContainerPort: credentialProxyPort},
-			{Name: "api", ContainerPort: 8643},
+			{Name: "proxy-api", ContainerPort: 8643},
 		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: []string{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -993,6 +993,7 @@ func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir str
 			{Name: "credential-proxy-tmp", MountPath: "/tmp"},
 			{Name: "credential-proxy-state", MountPath: "/var/lib/credential-proxy"},
 			{Name: "credential-proxy-runtime", MountPath: "/var/run/credential-proxy"},
+			{Name: "event-watcher-kubeconfig", MountPath: "/var/run/event-watcher"},
 			{Name: "credential-proxy-ksa-token", MountPath: "/var/run/secrets/kubeagents/serviceaccount", ReadOnly: true},
 			{Name: "platform-agent-data-vol", MountPath: homeDir},
 		},
@@ -1009,6 +1010,7 @@ func buildCredentialProxyEnv(agent *agentv1alpha1.PlatformAgent) []corev1.EnvVar
 		{Name: "CREDENTIAL_PROXY_POLICY", Value: "/etc/credential-proxy/policy.json"},
 		{Name: "CREDENTIAL_PROXY_STATE_DIR", Value: "/var/lib/credential-proxy"},
 		{Name: "CREDENTIAL_PROXY_UNIX_SOCKET", Value: "/var/run/credential-proxy/backend.sock"},
+		{Name: "KUBECONFIG", Value: "/var/run/event-watcher/watcher.config"},
 		{Name: "KSA_TOKEN_FILE", Value: "/var/run/secrets/kubeagents/serviceaccount/token"},
 		{Name: "TOKEN_BROKER_URL", Value: fmt.Sprintf("http://github-token-minter.%s.svc.cluster.local:8080/token", agent.Namespace)},
 		{Name: "AGENT_API_PROXY_PORT", Value: "8643"},
@@ -1111,11 +1113,25 @@ func buildCredentialProxyVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Vo
 		{Name: "credential-proxy-tmp", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("2Gi"))}}},
 		{Name: "credential-proxy-state", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{SizeLimit: ptr.To(resource.MustParse("5Gi"))}}},
 		{Name: "credential-proxy-runtime", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory, SizeLimit: ptr.To(resource.MustParse("16Mi"))}}},
+		{Name: "event-watcher-kubeconfig", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory, SizeLimit: ptr.To(resource.MustParse("1Mi"))}}},
 		{Name: "credential-proxy-ksa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
 			DefaultMode: ptr.To(int32(0400)),
 			Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
 				Audience: "kubeagents-credential-proxy", ExpirationSeconds: ptr.To(int64(3600)), Path: "token",
 			}}},
+		}}},
+		{Name: "event-watcher-ksa-token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+			DefaultMode: ptr.To(int32(0400)),
+			Sources: []corev1.VolumeProjection{
+				{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{ExpirationSeconds: ptr.To(int64(3600)), Path: "token"}},
+				{ConfigMap: &corev1.ConfigMapProjection{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "kube-root-ca.crt"},
+					Items:                []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+				}},
+				{DownwardAPI: &corev1.DownwardAPIProjection{Items: []corev1.DownwardAPIVolumeFile{{
+					Path: "namespace", FieldRef: &corev1.ObjectFieldSelector{APIVersion: "v1", FieldPath: "metadata.namespace"},
+				}}}},
+			},
 		}}},
 	}
 }
@@ -1343,7 +1359,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			"--token-env=API_SERVER_KEY",
 			"--owner=platform",
 			"--reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled",
-			"--kubeconfig=" + strings.TrimSuffix(homeDir, "/") + "/home/.kube/watcher.config",
+			"--kubeconfig=/var/run/event-watcher/watcher.config",
 		},
 		Env: []corev1.EnvVar{
 			{
@@ -1356,10 +1372,8 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
-			{
-				Name:      "platform-agent-data-vol",
-				MountPath: homeDir,
-			},
+			{Name: "event-watcher-kubeconfig", MountPath: "/var/run/event-watcher", ReadOnly: true},
+			{Name: "event-watcher-ksa-token", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true},
 		},
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -403,6 +403,10 @@ func TestBuildDeployment(t *testing.T) {
 		if watcherEnv["API_SERVER_KEY"].Value != "cluster-internal-trusted" || watcherEnv["API_SERVER_KEY"].ValueFrom != nil {
 			t.Errorf("expected watcher to receive the non-secret API sentinel, got %#v", watcherC.Env)
 		}
+		if len(watcherC.VolumeMounts) != 2 || watcherC.VolumeMounts[0].Name != "event-watcher-kubeconfig" || !watcherC.VolumeMounts[0].ReadOnly ||
+			watcherC.VolumeMounts[1].Name != "event-watcher-ksa-token" || !watcherC.VolumeMounts[1].ReadOnly {
+			t.Errorf("expected watcher to receive only its isolated kubeconfig and projected Kubernetes token, got %#v", watcherC.VolumeMounts)
+		}
 
 		if dep.Spec.Template.Spec.Containers[4].Name != "envoy-credential-proxy" {
 			t.Errorf("expected managed Envoy sidecar, got %s", dep.Spec.Template.Spec.Containers[4].Name)

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -214,6 +214,22 @@ func TestBuildDeployment(t *testing.T) {
 							Name:  "CUSTOM_VAR", // Duplicate custom var, should override previous
 							Value: "new-custom-value",
 						},
+						{
+							Name:  "CREDENTIAL_PROXY_STATE_DIR",
+							Value: "/var/agent/exposed-proxy-state",
+						},
+						{
+							Name:  "BASH_ENV",
+							Value: "/var/agent/untrusted-shell-profile",
+						},
+						{
+							Name:  "KUBERNETES_SERVICE_HOST",
+							Value: "attacker.example",
+						},
+						{
+							Name:  "KUBERNETES_SERVICE_PORT",
+							Value: "443",
+						},
 					},
 					InitContainers: []corev1.Container{
 						{
@@ -289,7 +305,7 @@ func TestBuildDeployment(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 
 	if dep.Name != "my-agent-gateway" {
 		t.Errorf("expected deployment name my-agent-gateway, got %s", dep.Name)
@@ -314,9 +330,15 @@ func TestBuildDeployment(t *testing.T) {
 	if dep.Spec.Template.Spec.RuntimeClassName == nil || *dep.Spec.Template.Spec.RuntimeClassName != "gvisor" {
 		t.Errorf("expected RuntimeClassName gvisor, got %v", dep.Spec.Template.Spec.RuntimeClassName)
 	}
+	if dep.Spec.Template.Spec.ServiceAccountName != "custom-sa" {
+		t.Errorf("expected shared pod service account custom-sa, got %s", dep.Spec.Template.Spec.ServiceAccountName)
+	}
+	if dep.Spec.Template.Spec.AutomountServiceAccountToken == nil || *dep.Spec.Template.Spec.AutomountServiceAccountToken {
+		t.Errorf("expected sandbox service account token automount to be disabled")
+	}
 
-	if len(dep.Spec.Template.Spec.Containers) != 5 {
-		t.Errorf("expected 5 containers, got %d", len(dep.Spec.Template.Spec.Containers))
+	if len(dep.Spec.Template.Spec.Containers) != 6 {
+		t.Errorf("expected 6 containers, got %d", len(dep.Spec.Template.Spec.Containers))
 	} else {
 		dashboardC := dep.Spec.Template.Spec.Containers[1]
 		if dashboardC.Name != "platform-agent-dashboard" {
@@ -374,8 +396,18 @@ func TestBuildDeployment(t *testing.T) {
 		if watcherC.Command[0] != "/usr/local/bin/k8s-event-watcher" {
 			t.Errorf("expected watcher command /usr/local/bin/k8s-event-watcher, got %s", watcherC.Command[0])
 		}
+		watcherEnv := make(map[string]corev1.EnvVar)
+		for _, env := range watcherC.Env {
+			watcherEnv[env.Name] = env
+		}
+		if watcherEnv["API_SERVER_KEY"].Value != "cluster-internal-trusted" || watcherEnv["API_SERVER_KEY"].ValueFrom != nil {
+			t.Errorf("expected watcher to receive the non-secret API sentinel, got %#v", watcherC.Env)
+		}
 
-		sidecarC := dep.Spec.Template.Spec.Containers[4]
+		if dep.Spec.Template.Spec.Containers[4].Name != "envoy-credential-proxy" {
+			t.Errorf("expected managed Envoy sidecar, got %s", dep.Spec.Template.Spec.Containers[4].Name)
+		}
+		sidecarC := dep.Spec.Template.Spec.Containers[5]
 		if sidecarC.Name != "my-sidecar" {
 			t.Errorf("expected sidecar name my-sidecar, got %s", sidecarC.Name)
 		}
@@ -384,10 +416,18 @@ func TestBuildDeployment(t *testing.T) {
 		}
 	}
 
-	if len(dep.Spec.Template.Spec.InitContainers) != 2 {
-		t.Errorf("expected 2 init containers, got %d", len(dep.Spec.Template.Spec.InitContainers))
+	if len(dep.Spec.Template.Spec.InitContainers) != 3 {
+		t.Errorf("expected managed cleanup plus 2 configured init containers, got %d", len(dep.Spec.Template.Spec.InitContainers))
 	} else {
-		initC1 := dep.Spec.Template.Spec.InitContainers[0]
+		cleanup := dep.Spec.Template.Spec.InitContainers[0]
+		if cleanup.Name != "sandbox-credential-cleanup" {
+			t.Errorf("expected managed credential cleanup first, got %s", cleanup.Name)
+		}
+		if len(cleanup.VolumeMounts) != 1 || cleanup.VolumeMounts[0].Name != "platform-agent-data-vol" {
+			t.Errorf("expected cleanup to mount the agent data PVC")
+		}
+
+		initC1 := dep.Spec.Template.Spec.InitContainers[1]
 		if initC1.Name != "init-git" {
 			t.Errorf("expected first init container name init-git, got %s", initC1.Name)
 		}
@@ -395,7 +435,7 @@ func TestBuildDeployment(t *testing.T) {
 			t.Errorf("expected first init container image git-image:latest, got %s", initC1.Image)
 		}
 
-		initC2 := dep.Spec.Template.Spec.InitContainers[1]
+		initC2 := dep.Spec.Template.Spec.InitContainers[2]
 		if initC2.Name != "init-bootstrap" {
 			t.Errorf("expected second init container name init-bootstrap, got %s", initC2.Name)
 		}
@@ -416,6 +456,9 @@ func TestBuildDeployment(t *testing.T) {
 		if seen[env.Name] {
 			t.Errorf("duplicate env var found: %s", env.Name)
 		}
+		if env.ValueFrom != nil && env.ValueFrom.SecretKeyRef != nil {
+			t.Errorf("sandbox must not receive Secret-backed environment variable %s", env.Name)
+		}
 		seen[env.Name] = true
 		envMap[env.Name] = env
 	}
@@ -429,14 +472,53 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value != "0" {
 		t.Errorf("expected PLATFORM_AGENT_PLUGINS_DEBUG 0, got %s", envMap["PLATFORM_AGENT_PLUGINS_DEBUG"].Value)
 	}
-	if envMap["CUSTOM_VAR"].Value != "new-custom-value" {
-		t.Errorf("expected CUSTOM_VAR new-custom-value, got %s", envMap["CUSTOM_VAR"].Value)
+	if _, ok := envMap["CUSTOM_VAR"]; ok {
+		t.Error("expected spec.deployment.env CUSTOM_VAR to be absent from sandbox")
 	}
 	if envMap["AGENT_BROWSER_ARGS"].Value != "--no-sandbox --disable-gpu" {
 		t.Errorf("expected AGENT_BROWSER_ARGS --no-sandbox --disable-gpu, got %s", envMap["AGENT_BROWSER_ARGS"].Value)
 	}
-	if envMap["TOKEN_BROKER_URL"].Value != "http://github-token-minter.my-ns.svc.cluster.local:8080/token" {
-		t.Errorf("expected TOKEN_BROKER_URL http://github-token-minter.my-ns.svc.cluster.local:8080/token, got %s", envMap["TOKEN_BROKER_URL"].Value)
+	if envMap["CREDENTIAL_PROXY_URL"].Value != "http://127.0.0.1:8765" {
+		t.Errorf("expected localhost Envoy CREDENTIAL_PROXY_URL, got %s", envMap["CREDENTIAL_PROXY_URL"].Value)
+	}
+	proxyEnv := make(map[string]corev1.EnvVar)
+	for _, env := range dep.Spec.Template.Spec.Containers[4].Env {
+		proxyEnv[env.Name] = env
+	}
+	if proxyEnv["CUSTOM_VAR"].Value != "new-custom-value" {
+		t.Errorf("expected spec.deployment.env only on credential sidecar, got %#v", proxyEnv)
+	}
+	if proxyEnv["CREDENTIAL_PROXY_STATE_DIR"].Value != "/var/lib/credential-proxy" {
+		t.Errorf("reserved proxy state directory was overridden: %#v", proxyEnv["CREDENTIAL_PROXY_STATE_DIR"])
+	}
+	if _, found := proxyEnv["BASH_ENV"]; found {
+		t.Errorf("expected unsafe shell environment override to be rejected")
+	}
+	for _, name := range []string{"KUBERNETES_SERVICE_HOST", "KUBERNETES_SERVICE_PORT"} {
+		if _, found := proxyEnv[name]; found {
+			t.Errorf("expected reserved Kubernetes service environment %s to be rejected", name)
+		}
+	}
+	apiKeyRef := proxyEnv["API_SERVER_EXTERNAL_KEY"].ValueFrom.SecretKeyRef
+	if apiKeyRef.Name != "secrets" || apiKeyRef.Key != "api-key" {
+		t.Errorf("expected external API key only in credential sidecar, got %#v", apiKeyRef)
+	}
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == "credential-proxy-ksa-token" || strings.Contains(mount.MountPath, "serviceaccount") {
+			t.Errorf("sandbox must not mount a ServiceAccount token: %#v", mount)
+		}
+	}
+	proxyHasTokenMount := false
+	for _, mount := range dep.Spec.Template.Spec.Containers[4].VolumeMounts {
+		if mount.Name == "credential-proxy-ksa-token" && mount.ReadOnly {
+			proxyHasTokenMount = true
+		}
+	}
+	if !proxyHasTokenMount {
+		t.Error("expected projected KSA token to be mounted only by credential sidecar")
+	}
+	if !strings.HasPrefix(envMap["PATH"].Value, "/opt/credential-proxy/bin:") {
+		t.Errorf("expected sandbox PATH to prefer credential proxy shims, got %s", envMap["PATH"].Value)
 	}
 	if envMap["GKE_CLUSTER_NAME"].Value != "gke-cluster" {
 		t.Errorf("expected GKE_CLUSTER_NAME gke-cluster, got %s", envMap["GKE_CLUSTER_NAME"].Value)
@@ -447,8 +529,8 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["GCP_PROJECT_ID"].Value != "my-gcp-project" {
 		t.Errorf("expected GCP_PROJECT_ID my-gcp-project, got %s", envMap["GCP_PROJECT_ID"].Value)
 	}
-	if envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name != "secrets" {
-		t.Errorf("expected API_SERVER_KEY SecretRef secrets, got %s", envMap["API_SERVER_KEY"].ValueFrom.SecretKeyRef.Name)
+	if envMap["API_SERVER_KEY"].Value != "cluster-internal-trusted" || envMap["API_SERVER_KEY"].ValueFrom != nil {
+		t.Errorf("expected non-secret cluster trust sentinel, got %#v", envMap["API_SERVER_KEY"])
 	}
 	if _, ok := envMap["GEMINI_API_KEY"]; ok {
 		t.Errorf("expected GEMINI_API_KEY to not be set on platform agent container")
@@ -468,8 +550,8 @@ func TestBuildDeployment(t *testing.T) {
 	if envMap["API_SERVER_ENABLED"].Value != "true" {
 		t.Errorf("expected API_SERVER_ENABLED true, got %s", envMap["API_SERVER_ENABLED"].Value)
 	}
-	if envMap["API_SERVER_HOST"].Value != "0.0.0.0" {
-		t.Errorf("expected API_SERVER_HOST 0.0.0.0, got %s", envMap["API_SERVER_HOST"].Value)
+	if envMap["API_SERVER_HOST"].Value != "127.0.0.1" {
+		t.Errorf("expected API_SERVER_HOST 127.0.0.1, got %s", envMap["API_SERVER_HOST"].Value)
 	}
 	if envMap["SESSION_KV_DB_PATH"].Value != "/var/lib/kube-agents/session/session_kv.db" {
 		t.Errorf("expected SESSION_KV_DB_PATH /var/lib/kube-agents/session/session_kv.db, got %s", envMap["SESSION_KV_DB_PATH"].Value)
@@ -479,6 +561,11 @@ func TestBuildDeployment(t *testing.T) {
 	mountsMap := make(map[string]corev1.VolumeMount)
 	for _, m := range container.VolumeMounts {
 		mountsMap[m.Name] = m
+	}
+	for _, volume := range dep.Spec.Template.Spec.Volumes {
+		if _, mounted := mountsMap[volume.Name]; mounted && volume.Secret != nil {
+			t.Errorf("sandbox must not mount Secret volume %s", volume.Name)
+		}
 	}
 	if _, ok := mountsMap["settings-volume"]; !ok {
 		t.Errorf("expected settings-volume mount, not found")
@@ -620,12 +707,12 @@ func TestBuildDeployment_DashboardEnabled(t *testing.T) {
 				t.Errorf("expected isDashboardEnabled to be true")
 			}
 
-			dep := buildDeployment(agent, "hash1", "hash2", "hash3")
+			dep := buildDeployment(agent, "hash1", "hash2", "hash3", "hash4")
 			if dep.Spec.Template.Spec.ShareProcessNamespace == nil || !*dep.Spec.Template.Spec.ShareProcessNamespace {
 				t.Errorf("expected ShareProcessNamespace to be true, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
 			}
-			if len(dep.Spec.Template.Spec.Containers) != 4 {
-				t.Fatalf("expected 4 base containers, got %d", len(dep.Spec.Template.Spec.Containers))
+			if len(dep.Spec.Template.Spec.Containers) != 5 {
+				t.Fatalf("expected dashboard deployment plus credential sidecar to have 5 containers, got %d", len(dep.Spec.Template.Spec.Containers))
 			}
 			if dep.Spec.Template.Spec.Containers[0].Name != "platform-agent" {
 				t.Errorf("expected container 0 to be platform-agent, got %s", dep.Spec.Template.Spec.Containers[0].Name)
@@ -638,6 +725,9 @@ func TestBuildDeployment_DashboardEnabled(t *testing.T) {
 			}
 			if dep.Spec.Template.Spec.Containers[3].Name != "event-watcher" {
 				t.Errorf("expected container 3 to be event-watcher, got %s", dep.Spec.Template.Spec.Containers[3].Name)
+			}
+			if dep.Spec.Template.Spec.Containers[4].Name != "envoy-credential-proxy" {
+				t.Errorf("expected container 4 to be envoy-credential-proxy, got %s", dep.Spec.Template.Spec.Containers[4].Name)
 			}
 
 			svc := buildPlatformService(agent)
@@ -674,12 +764,12 @@ func TestBuildDeployment_DashboardDisabled(t *testing.T) {
 		t.Errorf("expected isDashboardEnabled to be false")
 	}
 
-	dep := buildDeployment(agent, "hash1", "hash2", "hash3")
+	dep := buildDeployment(agent, "hash1", "hash2", "hash3", "hash4")
 	if dep.Spec.Template.Spec.ShareProcessNamespace != nil {
 		t.Errorf("expected ShareProcessNamespace to be nil, got %v", *dep.Spec.Template.Spec.ShareProcessNamespace)
 	}
-	if len(dep.Spec.Template.Spec.Containers) != 3 {
-		t.Fatalf("expected 3 base containers, got %d", len(dep.Spec.Template.Spec.Containers))
+	if len(dep.Spec.Template.Spec.Containers) != 4 {
+		t.Fatalf("expected dashboard-disabled deployment plus credential sidecar to have 4 containers, got %d", len(dep.Spec.Template.Spec.Containers))
 	}
 	if dep.Spec.Template.Spec.Containers[0].Name != "platform-agent" {
 		t.Errorf("expected container 0 to be platform-agent, got %s", dep.Spec.Template.Spec.Containers[0].Name)
@@ -690,12 +780,106 @@ func TestBuildDeployment_DashboardDisabled(t *testing.T) {
 	if dep.Spec.Template.Spec.Containers[2].Name != "event-watcher" {
 		t.Errorf("expected container 2 to be event-watcher, got %s", dep.Spec.Template.Spec.Containers[2].Name)
 	}
+	if dep.Spec.Template.Spec.Containers[3].Name != "envoy-credential-proxy" {
+		t.Errorf("expected container 3 to be envoy-credential-proxy, got %s", dep.Spec.Template.Spec.Containers[3].Name)
+	}
 
 	svc := buildPlatformService(agent)
 	for _, port := range svc.Spec.Ports {
 		if port.Name == "dashboard" || port.Port == 9119 {
 			t.Errorf("expected dashboard port 9119 to be omitted when dashboard disabled")
 		}
+	}
+}
+
+func TestSafeSandboxEnvOverridesRejectsValueFrom(t *testing.T) {
+	custom := []corev1.EnvVar{
+		{Name: "OTEL_SERVICE_NAME", Value: "platform-agent"},
+		{
+			Name: "OTEL_EXPORTER_OTLP_ENDPOINT",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "telemetry-secret"},
+				Key:                  "endpoint",
+			}},
+		},
+		{
+			Name: "OTEL_RESOURCE_ATTRIBUTES",
+			ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: "metadata.annotations['telemetry']",
+			}},
+		},
+	}
+
+	got := safeSandboxEnvOverrides(custom)
+	if len(got) != 1 || got[0].Name != "OTEL_SERVICE_NAME" || got[0].Value != "platform-agent" {
+		t.Fatalf("expected only literal allowlisted telemetry env, got %#v", got)
+	}
+}
+
+func TestBuildCredentialProxySidecar(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Harness: &agentv1alpha1.HarnessSpec{
+				ProjectID:   "example-project",
+				ClusterName: "example-cluster",
+				Location:    "us-central1",
+			},
+			AgentSpec: agentv1alpha1.AgentSpec{
+				Deployment: &agentv1alpha1.DeploymentSpec{Image: "example/platform-agent", Tag: ptr.To("v1")},
+				Security:   &agentv1alpha1.SecuritySpec{ServiceAccountName: "credential-sa"},
+			},
+		},
+	}
+
+	policy := buildCredentialProxyPolicyConfigMap(agent)
+	if policy.Name != "test-agent-credential-proxy-policy" || !strings.Contains(policy.Data["policy.json"], "github.token-disclosure") {
+		t.Fatalf("unexpected credential proxy policy: %#v", policy)
+	}
+
+	container := buildCredentialProxySidecar(agent, "/opt/hermes")
+	if container.Name != "envoy-credential-proxy" || container.Image != "example/credential-proxy:v1" {
+		t.Errorf("unexpected proxy container: %#v", container)
+	}
+	if len(container.Command) != 1 || container.Command[0] != "/usr/local/bin/envoy-credential-sidecar" {
+		t.Errorf("unexpected proxy command: %v", container.Command)
+	}
+	env := make(map[string]corev1.EnvVar)
+	for _, item := range container.Env {
+		env[item.Name] = item
+	}
+	if env["CREDENTIAL_PROXY_STATE_DIR"].Value != "/var/lib/credential-proxy" {
+		t.Errorf("expected private proxy state directory, got %#v", env["CREDENTIAL_PROXY_STATE_DIR"])
+	}
+	if env["KUBE_CONTEXT_NAME"].Value != "gke_example-project_us-central1_example-cluster" {
+		t.Errorf("expected proxy Kubernetes context, got %#v", env["KUBE_CONTEXT_NAME"])
+	}
+	if env["KUBE_DEFAULT_NAMESPACE"].Value != "test-ns" {
+		t.Errorf("expected proxy default namespace, got %#v", env["KUBE_DEFAULT_NAMESPACE"])
+	}
+	bootstrap := env["CREDENTIAL_PROXY_BOOTSTRAP_COMMAND"].Value
+	for _, expected := range []string{"gcloud config set project", "gcloud container clusters get-credentials", "kubectl config use-context", "kubectl config set-context"} {
+		if !strings.Contains(bootstrap, expected) {
+			t.Errorf("expected generic shell bootstrap to contain %q, got %q", expected, bootstrap)
+		}
+	}
+	stateMounted := false
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == "credential-proxy-state" && mount.MountPath == "/var/lib/credential-proxy" {
+			stateMounted = true
+		}
+	}
+	if !stateMounted {
+		t.Errorf("expected private proxy state volume mount, got %#v", container.VolumeMounts)
+	}
+}
+
+func TestResolveCredentialProxyImagePreservesTag(t *testing.T) {
+	if got := resolveCredentialProxyImage(nil); got != "ghcr.io/gke-labs/kube-agents/credential-proxy:latest" {
+		t.Fatalf("unexpected default credential sidecar image: %s", got)
+	}
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: "example/platform-agent"}); got != "example/credential-proxy:latest" {
+		t.Fatalf("expected explicit latest tag for untagged sidecar image: %s", got)
 	}
 }
 
@@ -723,7 +907,7 @@ func TestBuildDeploymentGoogleChatAllowedUsersEmpty(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {
@@ -764,18 +948,21 @@ func TestBuildDeploymentSlackIntegration(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {
 		envMap[env.Name] = env
 	}
 
-	if envMap["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || envMap["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Key != "bot-token-key" {
-		t.Errorf("expected SLACK_BOT_TOKEN custom-slack-secret/bot-token-key, got %v", envMap["SLACK_BOT_TOKEN"].ValueFrom)
+	if _, ok := envMap["SLACK_BOT_TOKEN"]; ok {
+		t.Error("expected SLACK_BOT_TOKEN to be absent from sandbox")
 	}
-	if envMap["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || envMap["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Key != "app-token-key" {
-		t.Errorf("expected SLACK_APP_TOKEN custom-slack-secret/app-token-key, got %v", envMap["SLACK_APP_TOKEN"].ValueFrom)
+	if _, ok := envMap["SLACK_APP_TOKEN"]; ok {
+		t.Error("expected SLACK_APP_TOKEN to be absent from sandbox")
+	}
+	if envMap["SLACK_RELAY_URL"].Value != "http://127.0.0.1:8765" {
+		t.Errorf("expected credential-free Slack relay URL, got %v", envMap["SLACK_RELAY_URL"])
 	}
 	if envMap["SLACK_ALLOWED_USERS"].Value != "U123,U456" {
 		t.Errorf("expected SLACK_ALLOWED_USERS U123,U456, got %s", envMap["SLACK_ALLOWED_USERS"].Value)
@@ -785,6 +972,17 @@ func TestBuildDeploymentSlackIntegration(t *testing.T) {
 	}
 	if envMap["SLACK_HOME_CHANNEL_NAME"].Value != "general" {
 		t.Errorf("expected SLACK_HOME_CHANNEL_NAME general, got %s", envMap["SLACK_HOME_CHANNEL_NAME"].Value)
+	}
+
+	proxyEnv := make(map[string]corev1.EnvVar)
+	for _, env := range buildCredentialProxySidecar(agent, "/opt/hermes").Env {
+		proxyEnv[env.Name] = env
+	}
+	if proxyEnv["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || proxyEnv["SLACK_BOT_TOKEN"].ValueFrom.SecretKeyRef.Key != "bot-token-key" {
+		t.Errorf("expected proxy SLACK_BOT_TOKEN custom-slack-secret/bot-token-key, got %v", proxyEnv["SLACK_BOT_TOKEN"].ValueFrom)
+	}
+	if proxyEnv["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Name != "custom-slack-secret" || proxyEnv["SLACK_APP_TOKEN"].ValueFrom.SecretKeyRef.Key != "app-token-key" {
+		t.Errorf("expected proxy SLACK_APP_TOKEN custom-slack-secret/app-token-key, got %v", proxyEnv["SLACK_APP_TOKEN"].ValueFrom)
 	}
 }
 
@@ -804,7 +1002,7 @@ func TestBuildDeploymentSlackAllowAllUsers(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
 	container := dep.Spec.Template.Spec.Containers[0]
 	envMap := make(map[string]corev1.EnvVar)
 	for _, env := range container.Env {
@@ -895,6 +1093,9 @@ func TestBuildPlatformService(t *testing.T) {
 		}
 		if portsMap["dashboard"] != 9119 {
 			t.Errorf("expected dashboard port 9119, got %d", portsMap["dashboard"])
+		}
+		if svc.Spec.Ports[0].TargetPort.IntVal != 8643 {
+			t.Errorf("expected api service to terminate at credential proxy port 8643, got %s", svc.Spec.Ports[0].TargetPort.String())
 		}
 
 		if svc.Spec.Selector["app"] != "test-platform-agent-gateway" {
@@ -1226,7 +1427,7 @@ func TestBuildDeploymentHA(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	if *dep.Spec.Replicas != 2 {
 		t.Errorf("expected 2 replicas for HA deployment, got %d", *dep.Spec.Replicas)
 	}
@@ -1326,7 +1527,7 @@ func TestBuildDeploymentReplicasConfig(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	if *dep.Spec.Replicas != 3 {
 		t.Errorf("expected 3 replicas when explicitly set, got %d", *dep.Spec.Replicas)
 	}
@@ -1393,7 +1594,7 @@ func TestRWOStoragePerReplica(t *testing.T) {
 		t.Errorf("expected 0 custom storage volumes in pod spec when using StatefulSet RWO, got %d", len(vols))
 	}
 
-	sts := buildStatefulSet(agent, "h1", "h2", "h3")
+	sts := buildStatefulSet(agent, "h1", "h2", "h3", "h4")
 	if *sts.Spec.Replicas != 2 {
 		t.Errorf("expected 2 replicas in StatefulSet, got %d", *sts.Spec.Replicas)
 	}

--- a/k8s-operator/internal/controller/telemetry_test.go
+++ b/k8s-operator/internal/controller/telemetry_test.go
@@ -59,7 +59,7 @@ func TestBuildDeploymentHasOTelEnv(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	container := dep.Spec.Template.Spec.Containers[0]
 
 	seen := make(map[string]bool)
@@ -97,7 +97,7 @@ func TestBuildDeploymentAllowsOTelEnvOverrides(t *testing.T) {
 		},
 	}
 
-	dep := buildDeployment(agent, "h1", "h2", "h3")
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4")
 	m := envMapOf(dep.Spec.Template.Spec.Containers[0].Env)
 
 	if got := m["OTEL_EXPORTER_OTLP_ENDPOINT"].Value; got != "http://custom-collector:4318" {

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -7,6 +7,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -26,6 +27,7 @@ func init() {
 	_ = agentv1alpha1.AddToScheme(testScheme)
 	_ = corev1.AddToScheme(testScheme)
 	_ = appsv1.AddToScheme(testScheme)
+	_ = networkingv1.AddToScheme(testScheme)
 	_ = rbacv1.AddToScheme(testScheme)
 }
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - pods
-  - namespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -72,25 +72,25 @@ metadata:
   name: kubeagents:leader:kubeagents-system:platformagent
   namespace: kubeagents-system
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -103,9 +103,9 @@ roleRef:
   kind: Role
   name: kubeagents:leader:kubeagents-system:platformagent
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -114,15 +114,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -135,15 +135,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -239,12 +239,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -296,12 +296,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -314,12 +314,12 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -344,12 +344,12 @@ metadata:
   name: platformagent-credential-proxy-policy
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -361,12 +361,12 @@ metadata:
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   replicas: 1
   selector:
@@ -388,305 +388,305 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: PLATFORM_AGENT_PLUGINS_DEBUG
-          value: "0"
-        - name: API_SERVER_ENABLED
-          value: "true"
-        - name: API_SERVER_HOST
-          value: 127.0.0.1
-        - name: API_SERVER_KEY
-          value: cluster-internal-trusted
-        - name: SESSION_KV_DB_PATH
-          value: /var/lib/kube-agents/session/session_kv.db
-        - name: OTEL_SERVICE_NAME
-          value: platformagent-gateway
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
-        - name: OTEL_EXPORTER_OTLP_PROTOCOL
-          value: http/protobuf
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
-        - name: GKE_CLUSTER_NAME
-          value: cluster-a
-        - name: GKE_LOCATION
-          value: us-central1-a
-        - name: KUBE_DEFAULT_NAMESPACE
-          value: kubeagents-system
-        - name: GOOGLE_CHAT_RELAY_URL
-          value: http://127.0.0.1:8765
-        - name: GOOGLE_CHAT_PROJECT_ID
-          value: kube-agents-gkedemos
-        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-        - name: GOOGLE_CHAT_ALLOWED_USERS
-        - name: GOOGLE_CHAT_HOME_CHANNEL
-        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-          value: "true"
-        - name: CREDENTIAL_PROXY_URL
-          value: http://127.0.0.1:8765
-        - name: PATH
-          value: /opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        - name: PYTHONPATH
-          value: /opt/defaults/scripts
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: platform-agent
-        ports:
-        - containerPort: 8642
-          name: api
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 2Gi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-        - mountPath: /opt/data/config.yaml
-          name: platform-agent-config-vol
-          subPath: config.yaml
-        - mountPath: /opt/data/leader_elect.py
-          name: platform-agent-config-vol
-          subPath: leader_elect.py
-        - mountPath: /opt/data/SETTINGS.md
-          name: settings-volume
-          readOnly: true
-          subPath: SETTINGS.md
-        - mountPath: /var/lib/kube-agents/session
-          name: system-metadata
-          subPath: session
-      - args:
-        - hermes
-        - dashboard
-        env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: SESSION_KV_DB_PATH
-          value: /var/lib/kube-agents/session/session_kv.db
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: platform-agent-dashboard
-        ports:
-        - containerPort: 9119
-          name: dashboard
-        resources:
-          limits:
-            cpu: "1"
-            memory: 2Gi
-          requests:
-            cpu: 256m
-            memory: 512Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-        - mountPath: /var/lib/kube-agents/session
-          name: system-metadata
-          subPath: session
-      - args:
-        - -c
-        - /fluent-bit/etc/fluent-bit.conf
-        image: fluent/fluent-bit:5.0.7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 500m
-            ephemeral-storage: 1Gi
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 1Gi
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-          readOnly: true
-        - mountPath: /fluent-bit/etc/fluent-bit.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: fluent-bit.conf
-        - mountPath: /fluent-bit/etc/parsers.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: parsers.conf
-        - mountPath: /fluent-bit/state
-          name: fluent-bit-state
-      - args:
-        - --cluster-name=cluster-a
-        - --daemon-url=http://127.0.0.1:8699
-        - --token-env=API_SERVER_KEY
-        - --owner=platform
-        - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
-        - --kubeconfig=/var/run/event-watcher/watcher.config
-        command:
-        - /usr/local/bin/k8s-event-watcher
-        env:
-        - name: API_SERVER_KEY
-          value: cluster-internal-trusted
-        - name: HOME
-          value: /opt/data/home
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: event-watcher
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /var/run/event-watcher
-          name: event-watcher-kubeconfig
-          readOnly: true
-        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-          name: event-watcher-ksa-token
-          readOnly: true
-      - command:
-        - /usr/local/bin/envoy-credential-sidecar
-        env:
-        - name: PLATFORM_AGENT_HOME
-          value: /tmp/credential-proxy
-        - name: HOME
-          value: /tmp/credential-proxy/home
-        - name: CREDENTIAL_PROXY_POLICY
-          value: /etc/credential-proxy/policy.json
-        - name: CREDENTIAL_PROXY_STATE_DIR
-          value: /var/lib/credential-proxy
-        - name: CREDENTIAL_PROXY_UNIX_SOCKET
-          value: /var/run/credential-proxy/backend.sock
-        - name: KUBECONFIG
-          value: /var/run/event-watcher/watcher.config
-        - name: KSA_TOKEN_FILE
-          value: /var/run/secrets/kubeagents/serviceaccount/token
-        - name: TOKEN_BROKER_URL
-          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-        - name: AGENT_API_PROXY_PORT
-          value: "8643"
-        - name: AGENT_API_UPSTREAM_KEY
-          value: cluster-internal-trusted
-        - name: API_SERVER_EXTERNAL_KEY
-          valueFrom:
-            secretKeyRef:
-              key: api-key
-              name: platformagent-secrets
-        - name: GOOGLE_CHAT_PROJECT_ID
-          value: kube-agents-gkedemos
-        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-        - name: CREDENTIAL_PROXY_WORKSPACE_ROOT
-          value: /opt/data
-        image: ghcr.io/gke-labs/kube-agents/credential-proxy:latest
-        imagePullPolicy: IfNotPresent
-        name: envoy-credential-proxy
-        ports:
-        - containerPort: 8765
-          name: cred-proxy
-        - containerPort: 8643
-          name: proxy-api
-        readinessProbe:
-          exec:
-            command:
-            - curl
-            - --fail
-            - --silent
-            - --show-error
-            - http://127.0.0.1:8765/healthz
-          initialDelaySeconds: 5
-          periodSeconds: 15
-        resources:
-          limits:
-            cpu: "2"
-            ephemeral-storage: 2Gi
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 256Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-        volumeMounts:
-        - mountPath: /etc/credential-proxy/policy.json
-          name: credential-proxy-policy
-          readOnly: true
-          subPath: policy.json
-        - mountPath: /tmp
-          name: credential-proxy-tmp
-        - mountPath: /var/lib/credential-proxy
-          name: credential-proxy-state
-        - mountPath: /var/run/credential-proxy
-          name: credential-proxy-runtime
-        - mountPath: /var/run/event-watcher
-          name: event-watcher-kubeconfig
-        - mountPath: /var/run/secrets/kubeagents/serviceaccount
-          name: credential-proxy-ksa-token
-          readOnly: true
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
+        - env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 127.0.0.1
+            - name: API_SERVER_KEY
+              value: cluster-internal-trusted
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+            - name: OTEL_SERVICE_NAME
+              value: platformagent-gateway
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
+            - name: GKE_CLUSTER_NAME
+              value: cluster-a
+            - name: GKE_LOCATION
+              value: us-central1-a
+            - name: KUBE_DEFAULT_NAMESPACE
+              value: kubeagents-system
+            - name: GOOGLE_CHAT_RELAY_URL
+              value: http://127.0.0.1:8765
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: GOOGLE_CHAT_ALLOWED_USERS
+            - name: GOOGLE_CHAT_HOME_CHANNEL
+            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+              value: "true"
+            - name: CREDENTIAL_PROXY_URL
+              value: http://127.0.0.1:8765
+            - name: PATH
+              value: /opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: PYTHONPATH
+              value: /opt/defaults/scripts
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: platform-agent
+          ports:
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: platform-agent-config-vol
+              subPath: config.yaml
+            - mountPath: /opt/data/leader_elect.py
+              name: platform-agent-config-vol
+              subPath: leader_elect.py
+            - mountPath: /opt/data/SETTINGS.md
+              name: settings-volume
+              readOnly: true
+              subPath: SETTINGS.md
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - hermes
+            - dashboard
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: platform-agent-dashboard
+          ports:
+            - containerPort: 9119
+              name: dashboard
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 256m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
+        - args:
+            - --cluster-name=cluster-a
+            - --daemon-url=http://127.0.0.1:8699
+            - --token-env=API_SERVER_KEY
+            - --owner=platform
+            - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+            - --kubeconfig=/var/run/event-watcher/watcher.config
+          command:
+            - /usr/local/bin/k8s-event-watcher
+          env:
+            - name: API_SERVER_KEY
+              value: cluster-internal-trusted
+            - name: HOME
+              value: /opt/data/home
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: event-watcher
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /var/run/event-watcher
+              name: event-watcher-kubeconfig
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: event-watcher-ksa-token
+              readOnly: true
+        - command:
+            - /usr/local/bin/envoy-credential-sidecar
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /tmp/credential-proxy
+            - name: HOME
+              value: /tmp/credential-proxy/home
+            - name: CREDENTIAL_PROXY_POLICY
+              value: /etc/credential-proxy/policy.json
+            - name: CREDENTIAL_PROXY_STATE_DIR
+              value: /var/lib/credential-proxy
+            - name: CREDENTIAL_PROXY_UNIX_SOCKET
+              value: /var/run/credential-proxy/backend.sock
+            - name: KUBECONFIG
+              value: /var/run/event-watcher/watcher.config
+            - name: KSA_TOKEN_FILE
+              value: /var/run/secrets/kubeagents/serviceaccount/token
+            - name: TOKEN_BROKER_URL
+              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+            - name: AGENT_API_PROXY_PORT
+              value: "8643"
+            - name: AGENT_API_UPSTREAM_KEY
+              value: cluster-internal-trusted
+            - name: API_SERVER_EXTERNAL_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: CREDENTIAL_PROXY_WORKSPACE_ROOT
+              value: /opt/data
+          image: ghcr.io/gke-labs/kube-agents/credential-proxy:latest
+          imagePullPolicy: IfNotPresent
+          name: envoy-credential-proxy
+          ports:
+            - containerPort: 8765
+              name: cred-proxy
+            - containerPort: 8643
+              name: proxy-api
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - --fail
+                - --silent
+                - --show-error
+                - http://127.0.0.1:8765/healthz
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            limits:
+              cpu: "2"
+              ephemeral-storage: 2Gi
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/credential-proxy/policy.json
+              name: credential-proxy-policy
+              readOnly: true
+              subPath: policy.json
+            - mountPath: /tmp
+              name: credential-proxy-tmp
+            - mountPath: /var/lib/credential-proxy
+              name: credential-proxy-state
+            - mountPath: /var/run/credential-proxy
+              name: credential-proxy-runtime
+            - mountPath: /var/run/event-watcher
+              name: event-watcher-kubeconfig
+            - mountPath: /var/run/secrets/kubeagents/serviceaccount
+              name: credential-proxy-ksa-token
+              readOnly: true
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
       initContainers:
-      - args:
-        - |-
-          rm -rf -- \
-            /workspace/home/.config/gcloud \
-            /workspace/home/.config/gh \
-            /workspace/home/.aws/credentials \
-            /workspace/home/.aws/cli/cache \
-            /workspace/home/.aws/sso/cache \
-            /workspace/home/.azure \
-            /workspace/home/.docker/config.json \
-            /workspace/home/.git-credentials \
-            /workspace/home/.hermes/.env \
-            /workspace/home/.kube/config \
-            /workspace/home/.netrc \
-            /workspace/home/.npmrc \
-            /workspace/home/.pypirc
-        command:
-        - sh
-        - -ec
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: sandbox-credential-cleanup
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-        volumeMounts:
-        - mountPath: /workspace
-          name: platform-agent-data-vol
+        - args:
+            - |-
+              rm -rf -- \
+                /workspace/home/.config/gcloud \
+                /workspace/home/.config/gh \
+                /workspace/home/.aws/credentials \
+                /workspace/home/.aws/cli/cache \
+                /workspace/home/.aws/sso/cache \
+                /workspace/home/.azure \
+                /workspace/home/.docker/config.json \
+                /workspace/home/.git-credentials \
+                /workspace/home/.hermes/.env \
+                /workspace/home/.kube/config \
+                /workspace/home/.netrc \
+                /workspace/home/.npmrc \
+                /workspace/home/.pypirc
+          command:
+            - sh
+            - -ec
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: sandbox-credential-cleanup
+          resources: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /workspace
+              name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -696,69 +696,69 @@ spec:
       serviceAccountName: kubeagents-platform-agent
       shareProcessNamespace: true
       volumes:
-      - name: platform-agent-data-vol
-        persistentVolumeClaim:
-          claimName: platformagent-data
-      - configMap:
-          defaultMode: 493
-          name: platformagent-config
-        name: platform-agent-config-vol
-      - configMap:
-          defaultMode: 420
-          name: platformagent-fluent-bit-config
-        name: fluent-bit-config
-      - emptyDir: {}
-        name: fluent-bit-state
-      - name: system-metadata
-        persistentVolumeClaim:
-          claimName: system-metadata
-      - configMap:
-          defaultMode: 420
-          name: platformagent-settings
-        name: settings-volume
-      - configMap:
-          name: platformagent-credential-proxy-policy
-        name: credential-proxy-policy
-      - emptyDir:
-          sizeLimit: 2Gi
-        name: credential-proxy-tmp
-      - emptyDir:
-          sizeLimit: 5Gi
-        name: credential-proxy-state
-      - emptyDir:
-          medium: Memory
-          sizeLimit: 16Mi
-        name: credential-proxy-runtime
-      - emptyDir:
-          medium: Memory
-          sizeLimit: 1Mi
-        name: event-watcher-kubeconfig
-      - name: credential-proxy-ksa-token
-        projected:
-          defaultMode: 256
-          sources:
-          - serviceAccountToken:
-              audience: kubeagents-credential-proxy
-              expirationSeconds: 3600
-              path: token
-      - name: event-watcher-ksa-token
-        projected:
-          defaultMode: 256
-          sources:
-          - serviceAccountToken:
-              expirationSeconds: 3600
-              path: token
-          - configMap:
-              items:
-              - key: ca.crt
-                path: ca.crt
-              name: kube-root-ca.crt
-          - downwardAPI:
-              items:
-              - fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-                path: namespace
+        - name: platform-agent-data-vol
+          persistentVolumeClaim:
+            claimName: platformagent-data
+        - configMap:
+            defaultMode: 493
+            name: platformagent-config
+          name: platform-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: platformagent-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
+        - name: system-metadata
+          persistentVolumeClaim:
+            claimName: system-metadata
+        - configMap:
+            defaultMode: 420
+            name: platformagent-settings
+          name: settings-volume
+        - configMap:
+            name: platformagent-credential-proxy-policy
+          name: credential-proxy-policy
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: credential-proxy-tmp
+        - emptyDir:
+            sizeLimit: 5Gi
+          name: credential-proxy-state
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: credential-proxy-runtime
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+          name: event-watcher-kubeconfig
+        - name: credential-proxy-ksa-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  audience: kubeagents-credential-proxy
+                  expirationSeconds: 3600
+                  path: token
+        - name: event-watcher-ksa-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3600
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
 status: {}
 ---
 apiVersion: v1
@@ -768,20 +768,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   ports:
-  - name: api
-    port: 8642
-    targetPort: 8643
-  - name: dashboard
-    port: 9119
-    targetPort: dashboard
+    - name: api
+      port: 8642
+      targetPort: 8643
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - pods
-      - namespaces
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -72,25 +72,25 @@ metadata:
   name: kubeagents:leader:kubeagents-system:platformagent
   namespace: kubeagents-system
 rules:
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -103,9 +103,9 @@ roleRef:
   kind: Role
   name: kubeagents:leader:kubeagents-system:platformagent
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -114,15 +114,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -135,15 +135,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -239,12 +239,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -296,12 +296,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -314,12 +314,42 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
+---
+apiVersion: v1
+data:
+  policy.json: |-
+    {
+      "apiVersion": "cli.proxy.kubeagents.io/v1alpha1",
+      "blockedMessage": "Command blocked for security reasons.",
+      "rules": [
+        {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+print-(?:access|identity)-token\\b"},
+        {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+config-helper\\b"},
+        {"id":"github.token-disclosure","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+token\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+status\\b(?:\\s+\\S+)*?\\s+--show-token\\b"},
+        {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\b(?:\\s+\\S+)*?\\s+create\\b(?:\\s+\\S+)*?\\s+token\\b|\\bkubectl\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+view\\b(?:\\s+\\S+)*?\\s+--raw\\b"},
+        {"id":"git.credential-disclosure","pattern":"\\bgit\\b(?:\\s+\\S+)*?\\s+credential\\b(?:\\s+\\S+)*?\\s+fill\\b"},
+        {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|activate-service-account)\\b"},
+        {"id":"github.credential-replacement","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|refresh|switch|logout)\\b"},
+        {"id":"tool.self-modification","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+components\\b(?:\\s+\\S+)*?\\s+(?:install|update|remove)\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+extension\\b(?:\\s+\\S+)*?\\s+(?:install|upgrade|remove)\\b"}
+      ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-credential-proxy-policy
+  namespace: kubeagents-system
+  ownerReferences:
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -327,15 +357,16 @@ metadata:
   creationTimestamp: null
   labels:
     app: platformagent-gateway
+    kubeagents.x-k8s.io/has-credential-proxy: "true"
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   replicas: 1
   selector:
@@ -348,188 +379,306 @@ spec:
       annotations:
         kubeagents.x-k8s.io/config-hash: 3aba3634aa7759b8b4822d8d6ebcd6515c03838559352e3d71b2a17a36622047
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
+        kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
       creationTimestamp: null
       labels:
         app: platformagent-gateway
+        kubeagents.x-k8s.io/has-credential-proxy: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
-        - env:
-            - name: PLATFORM_AGENT_HOME
-              value: /opt/data
-            - name: HOME
-              value: /opt/data/home
-            - name: PLATFORM_AGENT_PLUGINS_DEBUG
-              value: "0"
-            - name: API_SERVER_ENABLED
-              value: "true"
-            - name: API_SERVER_HOST
-              value: 0.0.0.0
-            - name: SESSION_KV_DB_PATH
-              value: /var/lib/kube-agents/session/session_kv.db
-            - name: OTEL_SERVICE_NAME
-              value: platformagent-gateway
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
-            - name: GKE_CLUSTER_NAME
-              value: cluster-a
-            - name: GKE_LOCATION
-              value: us-central1-a
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
-            - name: GOOGLE_CHAT_PROJECT_ID
-              value: kube-agents-gkedemos
-            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-            - name: GOOGLE_CHAT_ALLOWED_USERS
-            - name: GOOGLE_CHAT_HOME_CHANNEL
-            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-              value: "true"
-            - name: TOKEN_BROKER_URL
-              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: platform-agent
-          ports:
-            - containerPort: 8642
-              name: api
-          resources:
-            limits:
-              cpu: "2"
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 2Gi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-            - mountPath: /opt/data/config.yaml
-              name: platform-agent-config-vol
-              subPath: config.yaml
-            - mountPath: /opt/data/leader_elect.py
-              name: platform-agent-config-vol
-              subPath: leader_elect.py
-            - mountPath: /opt/data/SETTINGS.md
-              name: settings-volume
-              readOnly: true
-              subPath: SETTINGS.md
-            - mountPath: /var/lib/kube-agents/session
-              name: system-metadata
-              subPath: session
-        - args:
-            - hermes
-            - dashboard
-          env:
-            - name: PLATFORM_AGENT_HOME
-              value: /opt/data
-            - name: HOME
-              value: /opt/data/home
-            - name: SESSION_KV_DB_PATH
-              value: /var/lib/kube-agents/session/session_kv.db
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: platform-agent-dashboard
-          ports:
-            - containerPort: 9119
-              name: dashboard
-          resources:
-            limits:
-              cpu: "1"
-              memory: 2Gi
-            requests:
-              cpu: 256m
-              memory: 512Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-            - mountPath: /var/lib/kube-agents/session
-              name: system-metadata
-              subPath: session
-        - args:
-            - -c
-            - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
-          name: fluent-bit
-          resources:
-            limits:
-              cpu: 500m
-              ephemeral-storage: 1Gi
-              memory: 256Mi
-            requests:
-              cpu: 100m
-              ephemeral-storage: 1Gi
-              memory: 128Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-              readOnly: true
-            - mountPath: /fluent-bit/etc/fluent-bit.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: fluent-bit.conf
-            - mountPath: /fluent-bit/etc/parsers.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: parsers.conf
-            - mountPath: /fluent-bit/state
-              name: fluent-bit-state
-        - args:
-            - --cluster-name=cluster-a
-            - --daemon-url=http://127.0.0.1:8699
-            - --token-env=API_SERVER_KEY
-            - --owner=platform
-            - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
-            - --kubeconfig=/opt/data/home/.kube/watcher.config
-          command:
-            - /usr/local/bin/k8s-event-watcher
-          env:
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
-            - name: HOME
-              value: /opt/data/home
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: event-watcher
-          resources:
-            limits:
-              cpu: 200m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
+      - env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: API_SERVER_HOST
+          value: 127.0.0.1
+        - name: API_SERVER_KEY
+          value: cluster-internal-trusted
+        - name: SESSION_KV_DB_PATH
+          value: /var/lib/kube-agents/session/session_kv.db
+        - name: OTEL_SERVICE_NAME
+          value: platformagent-gateway
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
+        - name: GKE_CLUSTER_NAME
+          value: cluster-a
+        - name: GKE_LOCATION
+          value: us-central1-a
+        - name: KUBE_DEFAULT_NAMESPACE
+          value: kubeagents-system
+        - name: GOOGLE_CHAT_RELAY_URL
+          value: http://127.0.0.1:8765
+        - name: GOOGLE_CHAT_PROJECT_ID
+          value: kube-agents-gkedemos
+        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+        - name: GOOGLE_CHAT_ALLOWED_USERS
+        - name: GOOGLE_CHAT_HOME_CHANNEL
+        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+          value: "true"
+        - name: CREDENTIAL_PROXY_URL
+          value: http://127.0.0.1:8765
+        - name: PATH
+          value: /opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - name: PYTHONPATH
+          value: /opt/defaults/scripts
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent
+        ports:
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: platform-agent-config-vol
+          subPath: config.yaml
+        - mountPath: /opt/data/leader_elect.py
+          name: platform-agent-config-vol
+          subPath: leader_elect.py
+        - mountPath: /opt/data/SETTINGS.md
+          name: settings-volume
+          readOnly: true
+          subPath: SETTINGS.md
+        - mountPath: /var/lib/kube-agents/session
+          name: system-metadata
+          subPath: session
+      - args:
+        - hermes
+        - dashboard
+        env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: SESSION_KV_DB_PATH
+          value: /var/lib/kube-agents/session/session_kv.db
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent-dashboard
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 256m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /var/lib/kube-agents/session
+          name: system-metadata
+          subPath: session
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/etc/parsers.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: parsers.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
+      - args:
+        - --cluster-name=cluster-a
+        - --daemon-url=http://127.0.0.1:8699
+        - --token-env=API_SERVER_KEY
+        - --owner=platform
+        - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+        - --kubeconfig=/opt/data/home/.kube/watcher.config
+        command:
+        - /usr/local/bin/k8s-event-watcher
+        env:
+        - name: API_SERVER_KEY
+          value: cluster-internal-trusted
+        - name: HOME
+          value: /opt/data/home
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: event-watcher
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+      - command:
+        - /usr/local/bin/envoy-credential-sidecar
+        env:
+        - name: PLATFORM_AGENT_HOME
+          value: /tmp/credential-proxy
+        - name: HOME
+          value: /tmp/credential-proxy/home
+        - name: CREDENTIAL_PROXY_POLICY
+          value: /etc/credential-proxy/policy.json
+        - name: CREDENTIAL_PROXY_STATE_DIR
+          value: /var/lib/credential-proxy
+        - name: CREDENTIAL_PROXY_UNIX_SOCKET
+          value: /var/run/credential-proxy/backend.sock
+        - name: KSA_TOKEN_FILE
+          value: /var/run/secrets/kubeagents/serviceaccount/token
+        - name: TOKEN_BROKER_URL
+          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+        - name: AGENT_API_PROXY_PORT
+          value: "8643"
+        - name: AGENT_API_UPSTREAM_KEY
+          value: cluster-internal-trusted
+        - name: API_SERVER_EXTERNAL_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-key
+              name: platformagent-secrets
+        - name: GOOGLE_CHAT_PROJECT_ID
+          value: kube-agents-gkedemos
+        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+        - name: CREDENTIAL_PROXY_WORKSPACE_ROOT
+          value: /opt/data
+        image: ghcr.io/gke-labs/kube-agents/credential-proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: envoy-credential-proxy
+        ports:
+        - containerPort: 8765
+          name: cred-proxy
+        - containerPort: 8643
+          name: api
+        readinessProbe:
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - --show-error
+            - http://127.0.0.1:8765/healthz
+          initialDelaySeconds: 5
+          periodSeconds: 15
+        resources:
+          limits:
+            cpu: "2"
+            ephemeral-storage: 2Gi
+            memory: 2Gi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /etc/credential-proxy/policy.json
+          name: credential-proxy-policy
+          readOnly: true
+          subPath: policy.json
+        - mountPath: /tmp
+          name: credential-proxy-tmp
+        - mountPath: /var/lib/credential-proxy
+          name: credential-proxy-state
+        - mountPath: /var/run/credential-proxy
+          name: credential-proxy-runtime
+        - mountPath: /var/run/secrets/kubeagents/serviceaccount
+          name: credential-proxy-ksa-token
+          readOnly: true
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+      initContainers:
+      - args:
+        - |-
+          rm -rf -- \
+            /workspace/home/.config/gcloud \
+            /workspace/home/.config/gh \
+            /workspace/home/.aws/credentials \
+            /workspace/home/.aws/cli/cache \
+            /workspace/home/.aws/sso/cache \
+            /workspace/home/.azure \
+            /workspace/home/.docker/config.json \
+            /workspace/home/.git-credentials \
+            /workspace/home/.hermes/.env \
+            /workspace/home/.kube/config \
+            /workspace/home/.netrc \
+            /workspace/home/.npmrc \
+            /workspace/home/.pypirc
+        command:
+        - sh
+        - -ec
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: sandbox-credential-cleanup
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+        volumeMounts:
+        - mountPath: /workspace
+          name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -539,26 +688,47 @@ spec:
       serviceAccountName: kubeagents-platform-agent
       shareProcessNamespace: true
       volumes:
-        - name: platform-agent-data-vol
-          persistentVolumeClaim:
-            claimName: platformagent-data
-        - configMap:
-            defaultMode: 493
-            name: platformagent-config
-          name: platform-agent-config-vol
-        - configMap:
-            defaultMode: 420
-            name: platformagent-fluent-bit-config
-          name: fluent-bit-config
-        - emptyDir: {}
-          name: fluent-bit-state
-        - name: system-metadata
-          persistentVolumeClaim:
-            claimName: system-metadata
-        - configMap:
-            defaultMode: 420
-            name: platformagent-settings
-          name: settings-volume
+      - name: platform-agent-data-vol
+        persistentVolumeClaim:
+          claimName: platformagent-data
+      - configMap:
+          defaultMode: 493
+          name: platformagent-config
+        name: platform-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: platformagent-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+      - name: system-metadata
+        persistentVolumeClaim:
+          claimName: system-metadata
+      - configMap:
+          defaultMode: 420
+          name: platformagent-settings
+        name: settings-volume
+      - configMap:
+          name: platformagent-credential-proxy-policy
+        name: credential-proxy-policy
+      - emptyDir:
+          sizeLimit: 2Gi
+        name: credential-proxy-tmp
+      - emptyDir:
+          sizeLimit: 5Gi
+        name: credential-proxy-state
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 16Mi
+        name: credential-proxy-runtime
+      - name: credential-proxy-ksa-token
+        projected:
+          defaultMode: 256
+          sources:
+          - serviceAccountToken:
+              audience: kubeagents-credential-proxy
+              expirationSeconds: 3600
+              path: token
 status: {}
 ---
 apiVersion: v1
@@ -568,20 +738,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   ports:
-    - name: api
-      port: 8642
-      targetPort: api
-    - name: dashboard
-      port: 9119
-      targetPort: dashboard
+  - name: api
+    port: 8642
+    targetPort: 8643
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -611,7 +611,7 @@ spec:
         - containerPort: 8765
           name: cred-proxy
         - containerPort: 8643
-          name: api
+          name: proxy-api
         readinessProbe:
           exec:
             command:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -540,7 +540,7 @@ spec:
         - --token-env=API_SERVER_KEY
         - --owner=platform
         - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
-        - --kubeconfig=/opt/data/home/.kube/watcher.config
+        - --kubeconfig=/var/run/event-watcher/watcher.config
         command:
         - /usr/local/bin/k8s-event-watcher
         env:
@@ -564,8 +564,12 @@ spec:
             drop:
             - ALL
         volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
+        - mountPath: /var/run/event-watcher
+          name: event-watcher-kubeconfig
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: event-watcher-ksa-token
+          readOnly: true
       - command:
         - /usr/local/bin/envoy-credential-sidecar
         env:
@@ -579,6 +583,8 @@ spec:
           value: /var/lib/credential-proxy
         - name: CREDENTIAL_PROXY_UNIX_SOCKET
           value: /var/run/credential-proxy/backend.sock
+        - name: KUBECONFIG
+          value: /var/run/event-watcher/watcher.config
         - name: KSA_TOKEN_FILE
           value: /var/run/secrets/kubeagents/serviceaccount/token
         - name: TOKEN_BROKER_URL
@@ -641,6 +647,8 @@ spec:
           name: credential-proxy-state
         - mountPath: /var/run/credential-proxy
           name: credential-proxy-runtime
+        - mountPath: /var/run/event-watcher
+          name: event-watcher-kubeconfig
         - mountPath: /var/run/secrets/kubeagents/serviceaccount
           name: credential-proxy-ksa-token
           readOnly: true
@@ -721,6 +729,10 @@ spec:
           medium: Memory
           sizeLimit: 16Mi
         name: credential-proxy-runtime
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 1Mi
+        name: event-watcher-kubeconfig
       - name: credential-proxy-ksa-token
         projected:
           defaultMode: 256
@@ -729,6 +741,24 @@ spec:
               audience: kubeagents-credential-proxy
               expirationSeconds: 3600
               path: token
+      - name: event-watcher-ksa-token
+        projected:
+          defaultMode: 256
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 3600
+              path: token
+          - configMap:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+              - fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+                path: namespace
 status: {}
 ---
 apiVersion: v1

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -187,6 +187,7 @@ load_state() {
   fi
   export NAMESPACE="kubeagents-system"
   export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+  export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
   export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
   export CONTROLLER_KSA_NAME="kubeagents-controller"
   export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
@@ -201,6 +202,7 @@ ensure_teardown_state() {
     export DEV_ARTIFACT_REGISTRY_CREATED="${DEV_ARTIFACT_REGISTRY_CREATED:-false}"
     export NAMESPACE="kubeagents-system"
     export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+    export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
     export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"
@@ -243,6 +245,7 @@ ensure_teardown_state() {
       export CHAT_SUB_NAME="${CHAT_SUB_NAME:-}"
     fi
     export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
+    export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"
     export PLATFORM_AGENT_GSA_NAME="kubeagents-platform-gsa"
     export CONTROLLER_KSA_NAME="kubeagents-controller"
     export CONTROLLER_GSA_NAME="kubeagents-controller-gsa"

--- a/k8s-operator/scripts/dev/dev_rebuild_agent.sh
+++ b/k8s-operator/scripts/dev/dev_rebuild_agent.sh
@@ -97,6 +97,9 @@ DEV_TAG="dev-$(date +%Y%m%d-%H%M%S)"
 IMAGE_BASE="$REGION-docker.pkg.dev/$PROJECT_ID/$GCP_ARTIFACT_REGISTRY_REPO_NAME/$IMAGE_NAME"
 IMAGE_URI="$IMAGE_BASE:$DEV_TAG"
 IMAGE_URI_LATEST="$IMAGE_BASE:latest"
+PROXY_IMAGE_BASE="$REGION-docker.pkg.dev/$PROJECT_ID/$GCP_ARTIFACT_REGISTRY_REPO_NAME/credential-proxy"
+PROXY_IMAGE_URI="$PROXY_IMAGE_BASE:$DEV_TAG"
+PROXY_IMAGE_URI_LATEST="$PROXY_IMAGE_BASE:latest"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -126,6 +129,9 @@ execute_image_build() {
     print_info "Pushing images to Artifact Registry ($IMAGE_BASE)..."
     docker push "$IMAGE_URI" || return 1
     docker push "$IMAGE_URI_LATEST" || return 1
+    DOCKER_BUILDKIT=1 docker build --cache-from "$PROXY_IMAGE_URI_LATEST" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg HERMES_AGENT_TAG="$HERMES_AGENT_TAG" --target credential-proxy -t "$PROXY_IMAGE_URI" -t "$PROXY_IMAGE_URI_LATEST" -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" || return 1
+    docker push "$PROXY_IMAGE_URI" || return 1
+    docker push "$PROXY_IMAGE_URI_LATEST" || return 1
   else
     print_info "Submitting build for '$AGENT_TARGET' agent to Google Cloud Build..."
     print_info "Target Images: $IMAGE_URI and $IMAGE_URI_LATEST"
@@ -134,6 +140,14 @@ execute_image_build() {
       gcloud builds submit \
           --config="deploy/docker/cloudbuild.yaml" \
           --substitutions="_IMAGE_URI=${IMAGE_URI},_IMAGE_URI_LATEST=${IMAGE_URI_LATEST},_TARGET=${AGENT_TARGET},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
+          --project="${PROJECT_ID}" \
+          .
+    ) || return 1
+    (
+      cd "${REPO_ROOT}"
+      gcloud builds submit \
+          --config="deploy/docker/cloudbuild.yaml" \
+          --substitutions="_IMAGE_URI=${PROXY_IMAGE_URI},_IMAGE_URI_LATEST=${PROXY_IMAGE_URI_LATEST},_TARGET=credential-proxy,_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
           --project="${PROJECT_ID}" \
           .
     ) || return 1
@@ -184,13 +198,19 @@ execute_redeploy() {
     for dep_entry in $deployments; do
       local ns="${dep_entry%%:*}"
       local dep="${dep_entry#*:}"
-      if [[ "$dep" == *"${AGENT_TARGET}"* ]]; then
+      if [[ "$dep" == *"${AGENT_TARGET}"* && "$dep" != *"credential-proxy"* ]]; then
         print_info "Triggering rolling update for Deployment '${dep}' in namespace '${ns}'..."
         # Set image in case it's a standalone deployment not managed by a CR
         local container_name
-        container_name=$(kubectl get deployment "${dep}" -n "${ns}" -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' 2>/dev/null | grep -E "agent|${AGENT_TARGET}" | head -n 1)
+        local container_names
+        container_names=$(kubectl get deployment "${dep}" -n "${ns}" -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' 2>/dev/null || true)
+        container_name=$(echo "$container_names" | grep -E "agent|${AGENT_TARGET}" | head -n 1)
         if [ -n "$container_name" ]; then
-          kubectl set image "deployment/${dep}" -n "${ns}" "${container_name}=${IMAGE_URI}" 2>/dev/null || true
+          local image_updates=("${container_name}=${IMAGE_URI}")
+          if echo "$container_names" | grep -Fxq "envoy-credential-proxy"; then
+            image_updates+=("envoy-credential-proxy=${PROXY_IMAGE_URI}")
+          fi
+          kubectl set image "deployment/${dep}" -n "${ns}" "${image_updates[@]}" 2>/dev/null || true
         else
           kubectl set image "deployment/${dep}" -n "${ns}" "${AGENT_TARGET}=${IMAGE_URI}" 2>/dev/null || true
         fi
@@ -214,5 +234,6 @@ run_step "3. Connect to Host GKE Cluster" verify_kubeconfig execute_kubeconfig 0
 run_step "4. Trigger Redeployment in GKE" verify_redeploy execute_redeploy 0
 
 echo -e "\n${C_GREEN}${C_BOLD}🚀 Fast iteration update complete for ${SELECTED_AGENT}!${C_RESET}"
-echo -e "  ${C_CYAN}New Image deployed:${C_RESET} ${IMAGE_URI}"
+echo -e "  ${C_CYAN}New sandbox image deployed:${C_RESET} ${IMAGE_URI}"
+echo -e "  ${C_CYAN}New credential proxy image deployed:${C_RESET} ${PROXY_IMAGE_URI}"
 echo ""

--- a/k8s-operator/scripts/platform-agent.yaml.template
+++ b/k8s-operator/scripts/platform-agent.yaml.template
@@ -7,6 +7,7 @@ spec:
   harness:
     clusterName: "${CLUSTER_NAME}"
     location: "${REGION}"
+    projectId: "${PROJECT_ID}"
     hermes:
       dashboardEnabled: true
       pluginsDebug: false

--- a/k8s-operator/scripts/provision_04_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_04_gcp_iam.sh
@@ -196,10 +196,24 @@ get_platform_agent_roles() {
 verify_platform_agent() {
   local -a roles=($(get_platform_agent_roles))
   verify_agent_iam "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" "${roles[@]}"
+
+  local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  local sandbox_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${PLATFORM_AGENT_SANDBOX_KSA_NAME}]"
+  ! gcloud iam service-accounts get-iam-policy "${gsa_email}" --project="${PROJECT_ID}" --format="json" 2>/dev/null | grep -F -q "${sandbox_member}"
 }
 execute_platform_agent() {
   local -a roles=($(get_platform_agent_roles))
   execute_agent_iam "Platform Agent" "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" "${roles[@]}"
+
+  local gsa_email="${PLATFORM_AGENT_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+  local sandbox_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${PLATFORM_AGENT_SANDBOX_KSA_NAME}]"
+  print_info "Removing legacy sandbox Workload Identity binding from ${PLATFORM_AGENT_SANDBOX_KSA_NAME}..."
+  gcloud iam service-accounts remove-iam-policy-binding "${gsa_email}" \
+      --role="roles/iam.workloadIdentityUser" \
+      --member="${sandbox_member}" \
+      --project="${PROJECT_ID}" \
+      --condition=None \
+      --quiet >/dev/null 2>&1 || true
 }
 
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The PlatformAgent sandbox must not receive API keys, access tokens, refresh tokens, or Kubernetes ServiceAccount tokens through its environment or filesystem. The enforcement, image rollout, migration, and operator behavior need to ship together so the sandbox and credential proxy cannot be deployed at mismatched revisions.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_*`
- `k8s-operator/config/rbac/role.yaml`
- `k8s-operator/scripts/`
- `deploy/docker/Dockerfile` and `deploy/shared/`
- `agents/platform/` integration helpers
- `docs/credential-isolation-design.md`

**Added/Changed/Fixed:**

- Adds an Envoy credential-proxy sidecar to every PlatformAgent Pod and ties its readiness and lifecycle to the existing Deployment.
- Disables automatic KSA token mounting and mounts an explicit one-hour projected token only in the credential sidecar.
- Moves Secret-backed integration variables and `spec.deployment.env` to the sidecar; the sandbox accepts only literal allowlisted OpenTelemetry settings.
- Removes native credential-aware CLIs from the sandbox image and installs wrappers for `gcloud`, `kubectl`, `gh`, and `git`.
- Relays Slack, Google Chat, GitHub/Minty, and credentialed CLI operations through the sidecar while keeping credential state private to it.
- Terminates external PlatformAgent API authentication on sidecar port 8643, then forwards a non-secret loopback sentinel to the sandbox. The Kubernetes Service now explicitly targets 8643.
- Blocks known credential disclosure/replacement commands even when supported CLI global flags precede or separate subcommands. Regex matching is documented as interim pending tool-specific argv parsers.
- Rejects deployment attempts to override Kubernetes service endpoint and other runtime-loader/shell variables in the credential sidecar.
- Adds retained-PVC credential cleanup and removes resources and Workload Identity bindings from the abandoned two-Pod prototype.
- Builds, pushes, and rolls out the sandbox and credential-proxy images together.
- Documents the scoped guarantee, same-Pod identity limitation, architecture, migration, and verification criteria.

## Why This Matters

- Enforces the requested credential boundary through container environment and mount configuration rather than model instructions.
- Avoids a partial rollout where the sandbox wrappers and credential runtime use different revisions.
- Preserves existing CLI, API, GitHub, and chat workflows through a local, policy-controlled proxy surface.

## Context

This combines the former isolation and rollout/documentation changes into one mergeable PR. It builds on the runtime and chat-relay foundations merged in #359 and #364.

## Testing

- `go test ./...`, `go vet ./...`, and `go build ./...` in `k8s-operator/`.
- Python compilation and credential-proxy unit suite: 22 tests passed.
- Golden manifest regeneration and comparison passed.
- Shell syntax checks passed for changed deployment/runtime scripts.
- Prettier and `git diff --check` passed.
- PR Docker Build passed for the Platform Agent, credential sidecar, and replay proxy targets.

---

This PR contains both the enforcement code and the deployment/documentation work required to roll it out safely.

## Live E2E Verification

Deployed PR head `54832ef` to the `platform-agent-host` test cluster using Artifact Registry tag `pr368-54832ef`.

- Operator: 1/1 Ready.
- PlatformAgent Pod: 5/5 Ready, zero restarts.
- `automountServiceAccountToken: false` observed on the live Pod.
- Sandbox: zero Secret-backed env references, zero ServiceAccount token mounts, and known credential paths absent.
- Legacy `platform-agent-sandbox` Deployment absent after reconciliation.
- Service port 8642 targets authenticated proxy port 8643.
- Sandbox `kubectl` resolved to `/usr/local/bin/credential-proxy-exec`; `kubectl get namespace kubeagents-system` returned `namespace/kubeagents-system` through the proxy.
- Proxied `git --version` succeeded.
- `gcloud --quiet auth print-access-token` was rejected by `gcp.access-token-disclosure`; proxy logs recorded HTTP 200 for approved execution and HTTP 403 for the blocked request.
