### PR TITLE
refactor(owners): rename alias to waw-leads and add root approver permissions

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -10,7 +10,7 @@ reviewers:
       - jayantid
       - toshiowang
       - dshnayder
-    k8s-operator-owners:
+    waw-leads:
       - fatoshoti
       - mateuszklinowski
       - mplakhtiy
@@ -21,11 +21,11 @@ files:
   "**":
     - repository-owners # group
   "k8s-operator/**":
-    - k8s-operator-owners
+    - waw-leads
   ".github/workflows/k8s-operator-test.yml":
-    - k8s-operator-owners
+    - waw-leads
   ".github/workflows/staging-redeploy-*.yml":
-    - k8s-operator-owners
+    - waw-leads
 
 options:
   ignore_draft: true

--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,7 +1,7 @@
 filters:
   "staging-redeploy-.*\\.yml$":
     approvers:
-      - k8s-operator-owners
+      - waw-leads
   "k8s-operator-test\\.yml$":
     approvers:
-      - k8s-operator-owners
+      - waw-leads

--- a/.github/workflows/OWNERS
+++ b/.github/workflows/OWNERS
@@ -1,7 +1,0 @@
-filters:
-  "staging-redeploy-.*\\.yml$":
-    approvers:
-      - waw-leads
-  "k8s-operator-test\\.yml$":
-    approvers:
-      - waw-leads

--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,4 @@ approvers:
 - haoxuw
 - jayantid
 - toshiowang
-- k8s-operator-owners
+- waw-leads

--- a/OWNERS
+++ b/OWNERS
@@ -4,4 +4,4 @@ approvers:
 - haoxuw
 - jayantid
 - toshiowang
-
+- k8s-operator-owners

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,5 @@
 aliases:
-  k8s-operator-owners:
+  waw-leads:
     - fatoshoti
     - mateuszklinowski
     - mplakhtiy


### PR DESCRIPTION
# Pull Request

## Why This Change

Previously, the Warsaw-based leads (`fatoshoti`, `mateuszklinowski`, `mplakhtiy`) were grouped under the `k8s-operator-owners` alias and only had approval permissions scoped to specific subdirectories. This PR renames the alias to `waw-leads` to reflect the team more accurately and elevates the group to root-level approvers across the repository.

## What Changed

Renamed the `k8s-operator-owners` alias to `waw-leads` across GitHub review automation configurations, promoted `waw-leads` to root-level `approvers` in the repository `OWNERS` file, and removed redundant subdirectory `OWNERS` overrides.

**Files:**

- `OWNERS_ALIASES`
- `OWNERS`
- `.github/auto_request_review.yml`
- `.github/workflows/OWNERS`

**Added/Changed/Fixed:**

- Renamed the alias `k8s-operator-owners` to `waw-leads` in `OWNERS_ALIASES` (`fatoshoti`, `mateuszklinowski`, `mplakhtiy`).
- Added `- waw-leads` to `approvers` in the root `OWNERS` file so members can approve PRs repository-wide (`/approve`).
- Updated `.github/auto_request_review.yml` reviewer group definitions and file match patterns to use `waw-leads`.
- Removed `.github/workflows/OWNERS` as it is now redundant with root `OWNERS` approver inheritance.

## Why This Matters

- Ensures the Warsaw leads have `/approve` permissions across all repository files and documentation, reducing review bottlenecks.
- Decouples team identity (`waw-leads`) from a single subdirectory (`k8s-operator`), clarifying ownership and PR assignment rules.
- Cleans up redundant `OWNERS` files in subdirectories.

## Context

- Follows standard Kubernetes/Prow `OWNERS` file inheritance where subdirectories inherit approvers from parent directories unless overridden.

## Testing

- Verified that `git grep k8s-operator-owners` returns zero references across the repository.
- Verified YAML syntax formatting across all modified configuration files.

---

Low-risk configuration update affecting PR approval (`/approve`) and auto-assignment permissions; no runtime or workflow execution changes.
