### PR TITLE
fix: address review comments from dshnayder on PR 370

### DIFF
--- a/agents/platform/scripts/agent_common_server.py
+++ b/agents/platform/scripts/agent_common_server.py
@@ -25,7 +25,6 @@ SESSION_MANAGER = SessionManager()
 # Shared Configuration Defaults
 CONFIG_PATH = os.environ.get("PLATFORM_AGENT_CONFIG_PATH", "/opt/data/config.yaml")
 DOTENV_PATH = os.environ.get("PLATFORM_AGENT_DOTENV_PATH", "/opt/data/.env")
-STATE_DB_PATH = os.environ.get("PLATFORM_AGENT_STATE_DB_PATH", "/opt/data/state.db")
 
 def load_slack_token():
     """Load SLACK_BOT_TOKEN dynamically from Kubernetes secret if missing from environment."""

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -38,6 +38,7 @@ except Exception:
 app = FastAPI()
 
 SESSION_KV_DB_PATH = os.getenv("SESSION_KV_DB_PATH", "/var/lib/kube-agents/session/session_kv.db")
+CLEANUP_TTL_DAYS = int(os.getenv("SESSION_KV_CLEANUP_TTL_DAYS", "14"))
 
 
 def init_db() -> None:
@@ -75,10 +76,10 @@ def init_db() -> None:
 
 def cleanup_old_records(conn: sqlite3.Connection) -> None:
     try:
-        # Delete incident reports older than 14 days
-        conn.execute("DELETE FROM incidents WHERE created_at < datetime('now', '-14 days')")
-        # Delete session metadata older than 14 days
-        conn.execute("DELETE FROM session_metadata WHERE updated_at < datetime('now', '-14 days')")
+        # Delete incident reports and session metadata older than CLEANUP_TTL_DAYS
+        param = f"-{CLEANUP_TTL_DAYS} days"
+        conn.execute("DELETE FROM incidents WHERE created_at < datetime('now', ?)", (param,))
+        conn.execute("DELETE FROM session_metadata WHERE updated_at < datetime('now', ?)", (param,))
     except Exception as exc:
         logger.error(f"Failed to clean up old DB records: {exc}")
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -19,7 +19,7 @@ from contextlib import closing
 import logging
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException
-from agent_common_server import _run_env, CONFIG_PATH, DOTENV_PATH, STATE_DB_PATH
+from agent_common_server import _run_env, CONFIG_PATH, DOTENV_PATH
 
 # Configure logging
 logging.basicConfig(

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -73,6 +73,16 @@ def init_db() -> None:
 
 
 
+def cleanup_old_records(conn: sqlite3.Connection) -> None:
+    try:
+        # Delete incident reports older than 14 days
+        conn.execute("DELETE FROM incidents WHERE created_at < datetime('now', '-14 days')")
+        # Delete session metadata older than 14 days
+        conn.execute("DELETE FROM session_metadata WHERE updated_at < datetime('now', '-14 days')")
+    except Exception as exc:
+        logger.error(f"Failed to clean up old DB records: {exc}")
+
+
 @app.get("/healthz")
 def healthz() -> Dict[str, str]:
     return {"status": "ok"}
@@ -90,7 +100,9 @@ def create_session() -> Dict[str, str]:
                 "INSERT INTO session_metadata (session_id, metadata) VALUES (?, ?)",
                 (session_id, json.dumps({"platform": "k8s-watcher", "created_at": datetime.now(timezone.utc).isoformat()}))
             )
+            cleanup_old_records(conn)
     return {"sessionID": session_id}
+
 
 def clean_workload_name(kind: str, name: str) -> str:
     if kind.lower() == "pod":
@@ -409,6 +421,7 @@ def store_incident(body: Dict[str, Any]) -> Dict[str, str]:
                 "INSERT OR IGNORE INTO incidents (chat_id, thread_id, report) VALUES (?, ?, ?)",
                 (chat_id, thread_id, report),
             )
+            cleanup_old_records(conn)
     return {"status": "stored"}
 
 

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -113,6 +113,51 @@ class TestSessionKvServerApi(unittest.TestCase):
         get_resp = self.client.get("/v1/incidents/by-thread?chat_id=missing&thread_id=missing")
         self.assertEqual(get_resp.status_code, 404)
 
+    def test_database_cleanup_ttl(self):
+        import sqlite3
+        from datetime import datetime, timedelta
+        
+        # 1. Insert stale records manually (older than 14 days)
+        old_time = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d %H:%M:%S")
+        with sqlite3.connect(temp_db_path) as conn:
+            with conn:
+                # Insert old session metadata
+                conn.execute(
+                    "INSERT INTO session_metadata (session_id, metadata, updated_at) VALUES (?, ?, ?)",
+                    ("old-session", '{"platform": "k8s-watcher"}', old_time)
+                )
+                # Insert old incident
+                conn.execute(
+                    "INSERT INTO incidents (chat_id, thread_id, report, created_at) VALUES (?, ?, ?, ?)",
+                    ("old-chat", "old-thread", "old-report", old_time)
+                )
+                
+                # Insert fresh incident manually so we verify it is NOT deleted
+                conn.execute(
+                    "INSERT INTO incidents (chat_id, thread_id, report) VALUES (?, ?, ?)",
+                    ("fresh-chat", "fresh-thread", "fresh-report")
+                )
+
+        # 2. Trigger endpoint write which calls cleanup_old_records
+        resp = self.client.post("/sessions")
+        self.assertEqual(resp.status_code, 201)
+
+        # 3. Assert old records are deleted and fresh records are kept
+        with sqlite3.connect(temp_db_path) as conn:
+            # Check old session metadata
+            res = conn.execute("SELECT session_id FROM session_metadata WHERE session_id = ?", ("old-session",)).fetchone()
+            self.assertIsNone(res)
+            
+            # Check old incident
+            res = conn.execute("SELECT report FROM incidents WHERE chat_id = ? AND thread_id = ?", ("old-chat", "old-thread")).fetchone()
+            self.assertIsNone(res)
+
+            # Check fresh incident
+            res = conn.execute("SELECT report FROM incidents WHERE chat_id = ? AND thread_id = ?", ("fresh-chat", "fresh-thread")).fetchone()
+            self.assertIsNotNone(res)
+            self.assertEqual(res[0], "fresh-report")
+
+
 
 
 

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -47,7 +47,7 @@ fi
 # 5.5. Initialize default GKE context for the container to the host cluster
 if [ -n "$GKE_CLUSTER_NAME" ] && [ -n "$GKE_LOCATION" ]; then
     echo "Configuring default kubectl context to host cluster: $GKE_CLUSTER_NAME ($GKE_LOCATION)..."
-    gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" --project="${GOOGLE_CHAT_PROJECT_ID}" >/dev/null 2>&1 || true
+    gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" ${GOOGLE_CHAT_PROJECT_ID:+--project="$GOOGLE_CHAT_PROJECT_ID"} >/dev/null 2>&1 || true
 fi
 
 # 6. Execute primary process

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -47,7 +47,7 @@ fi
 # 5.5. Initialize default GKE context for the container to the host cluster
 if [ -n "$GKE_CLUSTER_NAME" ] && [ -n "$GKE_LOCATION" ]; then
     echo "Configuring default kubectl context to host cluster: $GKE_CLUSTER_NAME ($GKE_LOCATION)..."
-    gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" --project="${GOOGLE_CHAT_PROJECT_ID:-jayantid-gkedemos}" >/dev/null 2>&1 || true
+    gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" --project="${GOOGLE_CHAT_PROJECT_ID}" >/dev/null 2>&1 || true
 fi
 
 # 6. Execute primary process


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses review comments from `dshnayder` on PR #370:
1. Removes the unused `STATE_DB_PATH` constant from `agent_common_server.py` and `session_kv_server.py`.
2. Removes the hardcoded personal GCP Project ID fallback `jayantid-gkedemos` from the container entrypoint initialization context.
3. Implements automatic database cleanup (TTL) for `incidents` and `session_metadata` tables.

## What Changed

**Files:**

- `agents/platform/scripts/agent_common_server.py`
- `agents/platform/scripts/session_kv_server.py`
- `agents/platform/scripts/test_session_kv_server.py`
- `deploy/shared/docker-entrypoint.sh`

**Added/Changed/Fixed:**

- Removed `STATE_DB_PATH` definition and imports.
- Removed hardcoded project fallback in `gcloud container get-credentials` call.
- Added `cleanup_old_records` method in `session_kv_server.py` deleting rows older than 14 days on every session write transaction.

## Why This Matters

- Cleans up dead code.
- Ensures the docker container has no hardcoded references to developer personal projects.
- Prevents unbounded growth of SQLite database files on the container filesystem volume.

## Context

PR #370 comments:
- https://github.com/gke-labs/kube-agents/pull/370#discussion_r3630756197
- https://github.com/gke-labs/kube-agents/pull/370#discussion_r3630767849
- Reviewer general comment: "incidents table grows unbounded, need TTL or max size..."

## Testing

- Added `test_database_cleanup_ttl` to `test_session_kv_server.py` verifying that records older than 14 days are automatically pruned while fresh records are preserved.
- Executed unit tests inside the running gateway container; all 10 tests passed successfully.

