### PR TITLE
feat: customize Gemini Code Assist bot code review behavior

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,9 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -3,7 +3,7 @@ code_review:
   disable: false
   comment_severity_threshold: MEDIUM
   pull_request_opened:
-    help: false
+    help: true
     summary: true
     code_review: true
     include_drafts: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -4,7 +4,7 @@
 
 When reviewing code for this repository, please ensure the following hygiene rules are followed:
 
-- **Scope:** Keep changes scoped to the request. Flag PRs that include unrelated changes or features.
+- **Scope:** Keep changes scoped to the request. Flag PRs that include unrelated changes or features, and suggest if you think a single large PR could be split into smaller, more focused PRs.
 - **Formatting:** Do not commit unrelated formatting changes.
 - **Agent Configuration:** Maintain the structure and intent of the agent configuration files.
 - **Commit Messages:** Check if the PR summary or commits follow the Conventional Commits specification.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,18 @@
+# kube-agents Code Review Style Guide
+
+## Pull Request Hygiene
+
+When reviewing code for this repository, please ensure the following hygiene rules are followed:
+
+- **Scope:** Keep changes scoped to the request. Flag PRs that include unrelated changes or features.
+- **Formatting:** Do not commit unrelated formatting changes.
+- **Agent Configuration:** Maintain the structure and intent of the agent configuration files.
+- **Commit Messages:** Check if the PR summary or commits follow the Conventional Commits specification.
+
+## Skills Guidelines
+
+When reviewing new or modified skills, please enforce the following rules:
+
+- Skills must be located under the `agents/platform/skills/` directory.
+- Each skill directory must contain a `SKILL.md` file that provides the instructions for that specific skill.
+- Ensure that skill instructions are clearly documented and structured to be understood by AI agents.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -8,6 +8,7 @@ When reviewing code for this repository, please ensure the following hygiene rul
 - **Formatting:** Do not commit unrelated formatting changes.
 - **Agent Configuration:** Maintain the structure and intent of the agent configuration files.
 - **Commit Messages:** Check if the PR summary or commits follow the Conventional Commits specification.
+- **PR Template:** Verify that the PR description adheres to the structure and format defined in `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ## Skills Guidelines
 


### PR DESCRIPTION
## Why This Change

We want to enforce PR hygiene rules and specific guidelines for the agent skill definitions within this repository using Gemini Code Assist.

## What Changed

Added `.gemini/` configurations to customize the Gemini PR code review bot.

**Files:**

- `.gemini/config.yaml`
- `.gemini/styleguide.md`

**Added/Changed/Fixed:**

- Customized minimum comment severity threshold to MEDIUM
- Enabled PR summary and code review generation
- Created repository specific code review style guide enforcing PR hygiene

## Why This Matters

Reduces manual review time checking PR hygiene and ensures all PRs get an automatic AI-generated summary and initial review before a human steps in.

## Context

N/A

## Testing

Will be tested against this PR after creation automatically.
