### PR TITLE
feat(operator): support cross-cluster GKE event watching with isolated kubeconfig

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -337,6 +337,11 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"Failed to parse inner payload JSON: {exc}")
         
+    # Suppress repeat warnings within the same incident window to prevent alert storm
+    if payload.get("kind") == "k8s-event-followup":
+        logger.info(f"Ignoring follow-up event injection for active session {session_id}")
+        return {"status": "suppressed"}
+        
     event_reason = payload.get("reason") or "Unknown"
     namespace = payload.get("namespace") or "default"
     object_kind = payload.get("kind_of_object") or payload.get("kindOfObject") or "Pod"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -337,11 +337,6 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"Failed to parse inner payload JSON: {exc}")
         
-    # Suppress repeat warnings within the same incident window to prevent alert storm
-    if payload.get("kind") == "k8s-event-followup":
-        logger.info(f"Ignoring follow-up event injection for active session {session_id}")
-        return {"status": "suppressed"}
-        
     event_reason = payload.get("reason") or "Unknown"
     namespace = payload.get("namespace") or "default"
     object_kind = payload.get("kind_of_object") or payload.get("kindOfObject") or "Pod"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -251,7 +251,8 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
     message = payload.get("message") or ""
     cluster_name = os.environ.get("GKE_CLUSTER_NAME", "platform-agent-host")
     gcp_project = os.environ.get("GCP_PROJECT_ID") or os.environ.get("GCP_PROJECT") or ""
-    project_query = f"?project={gcp_project}" if gcp_project else ""
+    workloads_project_query = f"?project={gcp_project}" if gcp_project else ""
+    logs_project_query = f";project={gcp_project}" if gcp_project else ""
 
     return (
         f"Analyze the following Kubernetes event warning on GKE cluster '{cluster_name}' "
@@ -268,8 +269,8 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
         f"🛠️ *Proposed Fixes (GitOps):*\n"
         f"*Option A (<Action Title>):* <1-sentence description of Option A GitOps fix>.\n"
         f"*Option B (<Action Title>):* <1-sentence description of Option B GitOps fix>.\n\n"
-        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview{project_query}|GKE Workloads> | "
-        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22{project_query}|Cloud Logs>\n\n"
+        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview{workloads_project_query}|GKE Workloads> | "
+        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22{logs_project_query}|Cloud Logs>\n\n"
         f"👉 *Reply to this thread with 'apply Option A' or 'apply Option B' to automatically open a GitOps Pull Request with the fix.*\n\n"
         f"---"
         f"\n\n**GitOps PR Instructions (For subsequent turns if the user replies):**\n"

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -41,7 +41,7 @@ fi
 mkdir -p "$TARGET_DIR/logs"
 if [ -f "$TARGET_DIR/scripts/session_kv_server.py" ]; then
     echo "Starting Session KV server on port 8699..."
-    "$INSTALL_DIR/.venv/bin/python3" -m uvicorn scripts.session_kv_server:app --app-dir "$TARGET_DIR" --host 0.0.0.0 --port 8699 >"$TARGET_DIR/logs/session_kv_server.log" 2>&1 &
+    PYTHONPATH="$TARGET_DIR/scripts" "$INSTALL_DIR/.venv/bin/python3" -m uvicorn scripts.session_kv_server:app --app-dir "$TARGET_DIR" --host 0.0.0.0 --port 8699 >"$TARGET_DIR/logs/session_kv_server.log" 2>&1 &
 fi
 
 # 5.5. Initialize default GKE context for the container to the host cluster

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -48,7 +48,12 @@ fi
 if [ -n "$GKE_CLUSTER_NAME" ] && [ -n "$GKE_LOCATION" ]; then
     echo "Configuring default kubectl context to host cluster: $GKE_CLUSTER_NAME ($GKE_LOCATION)..."
     gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" ${GOOGLE_CHAT_PROJECT_ID:+--project="$GOOGLE_CHAT_PROJECT_ID"} >/dev/null 2>&1 || true
+    # Backup static context configuration specifically for the event-watcher sidecar
+    if [ -f "$HOME/.kube/config" ]; then
+        cp "$HOME/.kube/config" "$HOME/.kube/watcher.config"
+    fi
 fi
+
 
 # 6. Execute primary process
 exec "$@"

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -50,7 +50,7 @@ if [ -n "$GKE_CLUSTER_NAME" ] && [ -n "$GKE_LOCATION" ]; then
     gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location="$GKE_LOCATION" ${GOOGLE_CHAT_PROJECT_ID:+--project="$GOOGLE_CHAT_PROJECT_ID"} >/dev/null 2>&1 || true
     # Backup static context configuration specifically for the event-watcher sidecar
     if [ -f "$HOME/.kube/config" ]; then
-        cp "$HOME/.kube/config" "$HOME/.kube/watcher.config"
+        cp "$HOME/.kube/config" "$HOME/.kube/watcher.config.tmp" && mv "$HOME/.kube/watcher.config.tmp" "$HOME/.kube/watcher.config"
     fi
 fi
 

--- a/k8s-operator/cmd/k8s-event-watcher/dispatcher_test.go
+++ b/k8s-operator/cmd/k8s-event-watcher/dispatcher_test.go
@@ -101,15 +101,12 @@ func TestDispatcherDispatch_NewIncidentAndFollowUp(t *testing.T) {
 		t.Errorf("expected first event kind to be %q, got %q", injectKindEvent, lastInjectPayload.Kind)
 	}
 
-	// 2. Dispatch same event again -> should not create session, but should inject follow-up
+	// 2. Dispatch same event again -> should not create session and should suppress injection
 	disp.Dispatch(context.Background(), ev)
 	if createCount != 1 {
 		t.Errorf("expected session creation count to remain 1, got %d", createCount)
 	}
-	if injectCount != 2 {
-		t.Errorf("expected 2 injections total, got %d", injectCount)
-	}
-	if lastInjectPayload.Kind != injectKindFollowup {
-		t.Errorf("expected follow-up event kind to be %q, got %q", injectKindFollowup, lastInjectPayload.Kind)
+	if injectCount != 1 {
+		t.Errorf("expected injections count to remain 1, got %d", injectCount)
 	}
 }

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -208,42 +208,6 @@ func (d *dispatcher) Dispatch(ctx context.Context, ev TriageEvent) {
 		d.metrics.eventsDedupSuppress.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
 		log.Printf("dedup %s pod=%s/%s (count=%d, window active)",
 			ev.Key.Reason, ev.Namespace, ev.Name, result.Count)
-
-		if result.SessionID != "" {
-			payload := InjectPayload{
-				Kind:         injectKindFollowup,
-				Reason:       ev.Key.Reason,
-				Namespace:    ev.Namespace,
-				KindOfObject: ev.KindOfObject,
-				Name:         ev.Name,
-				Container:    ev.Container,
-				UID:          ev.Key.UID,
-				Message:      ev.Message,
-				Count:        result.Count,
-				FirstSeen:    ev.FirstSeen,
-				LastSeen:     ev.LastSeen,
-				Cluster:      d.cluster,
-				Type:         ev.Type,
-				Context: PayloadContext{
-					ControllerRef: ev.ControllerRef,
-					Node:          ev.Node,
-					Labels:        ev.Labels,
-				},
-			}
-			if d.dryRun {
-				out, _ := json.MarshalIndent(payload, "", "  ")
-				fmt.Printf("--- dry-run follow-up payload for session %q ---\n%s\n", result.SessionID, string(out))
-				return
-			}
-			if err := d.injector.Inject(ctx, result.SessionID, payload); err != nil {
-				log.Printf("dispatcher: inject follow-up for %s/%s (sid=%s): %v", ev.Namespace, ev.Name, result.SessionID, err)
-				d.metrics.injectErrors.WithLabelValues(ev.Key.Reason, "inject_followup").Inc()
-				return
-			}
-			d.metrics.eventsInjected.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
-			log.Printf("fire follow-up %s pod=%s/%s → sid=%s",
-				ev.Key.Reason, ev.Namespace, ev.Name, result.SessionID)
-		}
 		return
 	}
 	// Create or reuse a troubleshooter session, then inject event telemetry.

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -739,6 +739,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, pullP
 			"--token-env=API_SERVER_KEY",
 			"--owner=platform",
 			"--reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled",
+			"--kubeconfig=/opt/data/home/.kube/watcher.config",
 		},
 		Env: []corev1.EnvVar{
 			{
@@ -750,6 +751,16 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, pullP
 						"API_SERVER_KEY",
 					),
 				},
+			},
+			{
+				Name:  "HOME",
+				Value: "/opt/data/home",
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      "platform-agent-data-vol",
+				MountPath: "/opt/data",
 			},
 		},
 		Resources: corev1.ResourceRequirements{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -738,7 +738,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, pullP
 			"--daemon-url=http://127.0.0.1:8699",
 			"--token-env=API_SERVER_KEY",
 			"--owner=platform",
-			"--reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled",
+			"--reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled",
 			"--kubeconfig=" + strings.TrimSuffix(homeDir, "/") + "/home/.kube/watcher.config",
 		},
 		Env: []corev1.EnvVar{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -739,7 +739,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, pullP
 			"--token-env=API_SERVER_KEY",
 			"--owner=platform",
 			"--reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled",
-			"--kubeconfig=/opt/data/home/.kube/watcher.config",
+			"--kubeconfig=" + strings.TrimSuffix(homeDir, "/") + "/home/.kube/watcher.config",
 		},
 		Env: []corev1.EnvVar{
 			{
@@ -754,13 +754,13 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, pullP
 			},
 			{
 				Name:  "HOME",
-				Value: "/opt/data/home",
+				Value: strings.TrimSuffix(homeDir, "/") + "/home",
 			},
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "platform-agent-data-vol",
-				MountPath: "/opt/data",
+				MountPath: homeDir,
 			},
 		},
 		Resources: corev1.ResourceRequirements{

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -452,7 +452,7 @@ spec:
             - --daemon-url=http://127.0.0.1:8699
             - --token-env=API_SERVER_KEY
             - --owner=platform
-            - --reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+            - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
             - --kubeconfig=/opt/data/home/.kube/watcher.config
           command:
             - /usr/local/bin/k8s-event-watcher

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - pods
-      - namespaces
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-      - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-  - kind: ServiceAccount
-    name: kubeagents-platform-agent
-    namespace: kubeagents-system
+- kind: ServiceAccount
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -72,15 +72,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -93,15 +93,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -194,12 +194,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -251,12 +251,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: v1
 data:
@@ -269,12 +269,12 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -285,12 +285,12 @@ metadata:
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   replicas: 1
   selector:
@@ -309,173 +309,179 @@ spec:
         app: platformagent-gateway
     spec:
       containers:
-        - env:
-            - name: PLATFORM_AGENT_HOME
-              value: /opt/data
-            - name: HOME
-              value: /opt/data/home
-            - name: PLATFORM_AGENT_PLUGINS_DEBUG
-              value: "0"
-            - name: API_SERVER_ENABLED
-              value: "true"
-            - name: API_SERVER_HOST
-              value: 0.0.0.0
-            - name: SESSION_KV_DB_PATH
-              value: /var/lib/kube-agents/session/session_kv.db
-            - name: OTEL_SERVICE_NAME
-              value: platformagent-gateway
-            - name: OTEL_EXPORTER_OTLP_ENDPOINT
-              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
-            - name: OTEL_EXPORTER_OTLP_PROTOCOL
-              value: http/protobuf
-            - name: OTEL_RESOURCE_ATTRIBUTES
-              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
-            - name: GKE_CLUSTER_NAME
-              value: cluster-a
-            - name: GKE_LOCATION
-              value: us-central1-a
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
-            - name: GOOGLE_CHAT_PROJECT_ID
-              value: kube-agents-gkedemos
-            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-            - name: GOOGLE_CHAT_ALLOWED_USERS
-            - name: GOOGLE_CHAT_HOME_CHANNEL
-            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-              value: "true"
-            - name: TOKEN_BROKER_URL
-              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: platform-agent
-          ports:
-            - containerPort: 8642
-              name: api
-          resources:
-            limits:
-              cpu: "2"
-              memory: 4Gi
-            requests:
-              cpu: 500m
-              memory: 2Gi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-            - mountPath: /opt/data/config.yaml
-              name: platform-agent-config-vol
-              subPath: config.yaml
-            - mountPath: /opt/data/SETTINGS.md
-              name: settings-volume
-              readOnly: true
-              subPath: SETTINGS.md
-            - mountPath: /var/lib/kube-agents/session
-              name: system-metadata
-              subPath: session
-        - args:
-            - hermes
-            - dashboard
-          env:
-            - name: PLATFORM_AGENT_HOME
-              value: /opt/data
-            - name: HOME
-              value: /opt/data/home
-            - name: SESSION_KV_DB_PATH
-              value: /var/lib/kube-agents/session/session_kv.db
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: platform-agent-dashboard
-          ports:
-            - containerPort: 9119
-              name: dashboard
-          resources:
-            limits:
-              cpu: "1"
-              memory: 2Gi
-            requests:
-              cpu: 256m
-              memory: 512Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-            - mountPath: /var/lib/kube-agents/session
-              name: system-metadata
-              subPath: session
-        - args:
-            - -c
-            - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
-          name: fluent-bit
-          resources:
-            limits:
-              cpu: 500m
-              ephemeral-storage: 1Gi
-              memory: 256Mi
-            requests:
-              cpu: 100m
-              ephemeral-storage: 1Gi
-              memory: 128Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-          volumeMounts:
-            - mountPath: /opt/data
-              name: platform-agent-data-vol
-              readOnly: true
-            - mountPath: /fluent-bit/etc/fluent-bit.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: fluent-bit.conf
-            - mountPath: /fluent-bit/etc/parsers.conf
-              name: fluent-bit-config
-              readOnly: true
-              subPath: parsers.conf
-            - mountPath: /fluent-bit/state
-              name: fluent-bit-state
-        - args:
-            - --cluster-name=cluster-a
-            - --daemon-url=http://127.0.0.1:8699
-            - --token-env=API_SERVER_KEY
-            - --owner=platform
-            - --reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
-          command:
-            - /usr/local/bin/k8s-event-watcher
-          env:
-            - name: API_SERVER_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: platformagent-secrets
-          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-          imagePullPolicy: IfNotPresent
-          name: event-watcher
-          resources:
-            limits:
-              cpu: 200m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+      - env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: PLATFORM_AGENT_PLUGINS_DEBUG
+          value: "0"
+        - name: API_SERVER_ENABLED
+          value: "true"
+        - name: API_SERVER_HOST
+          value: 0.0.0.0
+        - name: SESSION_KV_DB_PATH
+          value: /var/lib/kube-agents/session/session_kv.db
+        - name: OTEL_SERVICE_NAME
+          value: platformagent-gateway
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: http/protobuf
+        - name: OTEL_RESOURCE_ATTRIBUTES
+          value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
+        - name: GKE_CLUSTER_NAME
+          value: cluster-a
+        - name: GKE_LOCATION
+          value: us-central1-a
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-key
+              name: platformagent-secrets
+        - name: GOOGLE_CHAT_PROJECT_ID
+          value: kube-agents-gkedemos
+        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+        - name: GOOGLE_CHAT_ALLOWED_USERS
+        - name: GOOGLE_CHAT_HOME_CHANNEL
+        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+          value: "true"
+        - name: TOKEN_BROKER_URL
+          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent
+        ports:
+        - containerPort: 8642
+          name: api
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /opt/data/config.yaml
+          name: platform-agent-config-vol
+          subPath: config.yaml
+        - mountPath: /opt/data/SETTINGS.md
+          name: settings-volume
+          readOnly: true
+          subPath: SETTINGS.md
+        - mountPath: /var/lib/kube-agents/session
+          name: system-metadata
+          subPath: session
+      - args:
+        - hermes
+        - dashboard
+        env:
+        - name: PLATFORM_AGENT_HOME
+          value: /opt/data
+        - name: HOME
+          value: /opt/data/home
+        - name: SESSION_KV_DB_PATH
+          value: /var/lib/kube-agents/session/session_kv.db
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: platform-agent-dashboard
+        ports:
+        - containerPort: 9119
+          name: dashboard
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2Gi
+          requests:
+            cpu: 256m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+        - mountPath: /var/lib/kube-agents/session
+          name: system-metadata
+          subPath: session
+      - args:
+        - -c
+        - /fluent-bit/etc/fluent-bit.conf
+        image: fluent/fluent-bit:5.0.7
+        name: fluent-bit
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 1Gi
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            ephemeral-storage: 1Gi
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
+          readOnly: true
+        - mountPath: /fluent-bit/etc/fluent-bit.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: fluent-bit.conf
+        - mountPath: /fluent-bit/etc/parsers.conf
+          name: fluent-bit-config
+          readOnly: true
+          subPath: parsers.conf
+        - mountPath: /fluent-bit/state
+          name: fluent-bit-state
+      - args:
+        - --cluster-name=cluster-a
+        - --daemon-url=http://127.0.0.1:8699
+        - --token-env=API_SERVER_KEY
+        - --owner=platform
+        - --reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+        - --kubeconfig=/opt/data/home/.kube/watcher.config
+        command:
+        - /usr/local/bin/k8s-event-watcher
+        env:
+        - name: API_SERVER_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-key
+              name: platformagent-secrets
+        - name: HOME
+          value: /opt/data/home
+        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+        imagePullPolicy: IfNotPresent
+        name: event-watcher
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /opt/data
+          name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -485,26 +491,26 @@ spec:
       serviceAccountName: kubeagents-platform-agent
       shareProcessNamespace: true
       volumes:
-        - name: platform-agent-data-vol
-          persistentVolumeClaim:
-            claimName: platformagent-data
-        - configMap:
-            defaultMode: 493
-            name: platformagent-config
-          name: platform-agent-config-vol
-        - configMap:
-            defaultMode: 420
-            name: platformagent-fluent-bit-config
-          name: fluent-bit-config
-        - emptyDir: {}
-          name: fluent-bit-state
-        - name: system-metadata
-          persistentVolumeClaim:
-            claimName: system-metadata
-        - configMap:
-            defaultMode: 420
-            name: platformagent-settings
-          name: settings-volume
+      - name: platform-agent-data-vol
+        persistentVolumeClaim:
+          claimName: platformagent-data
+      - configMap:
+          defaultMode: 493
+          name: platformagent-config
+        name: platform-agent-config-vol
+      - configMap:
+          defaultMode: 420
+          name: platformagent-fluent-bit-config
+        name: fluent-bit-config
+      - emptyDir: {}
+        name: fluent-bit-state
+      - name: system-metadata
+        persistentVolumeClaim:
+          claimName: system-metadata
+      - configMap:
+          defaultMode: 420
+          name: platformagent-settings
+        name: settings-volume
 status: {}
 ---
 apiVersion: v1
@@ -514,20 +520,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-    - apiVersion: kubeagents.x-k8s.io/v1alpha1
-      blockOwnerDeletion: true
-      controller: true
-      kind: PlatformAgent
-      name: platformagent
-      uid: ""
+  - apiVersion: kubeagents.x-k8s.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: PlatformAgent
+    name: platformagent
+    uid: ""
 spec:
   ports:
-    - name: api
-      port: 8642
-      targetPort: api
-    - name: dashboard
-      port: 9119
-      targetPort: dashboard
+  - name: api
+    port: 8642
+    targetPort: api
+  - name: dashboard
+    port: 9119
+    targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -7,12 +7,12 @@ metadata:
   name: kubeagents-platform-agent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -24,9 +24,9 @@ roleRef:
   kind: ClusterRole
   name: view
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -34,22 +34,22 @@ metadata:
   creationTimestamp: null
   name: kubeagents:explorer:kubeagents-system:platformagent
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - pods
-  - namespaces
-  verbs:
-  - get
-  - list
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -61,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: kubeagents:explorer:kubeagents-system:platformagent
 subjects:
-- kind: ServiceAccount
-  name: kubeagents-platform-agent
-  namespace: kubeagents-system
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -72,15 +72,15 @@ metadata:
   name: platformagent-data
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -93,15 +93,15 @@ metadata:
   name: system-metadata
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
@@ -194,12 +194,12 @@ metadata:
   name: platformagent-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -251,12 +251,12 @@ metadata:
   name: platformagent-fluent-bit-config
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: v1
 data:
@@ -269,12 +269,12 @@ metadata:
   name: platformagent-settings
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -285,12 +285,12 @@ metadata:
   name: platformagent-gateway
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   replicas: 1
   selector:
@@ -309,179 +309,179 @@ spec:
         app: platformagent-gateway
     spec:
       containers:
-      - env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: PLATFORM_AGENT_PLUGINS_DEBUG
-          value: "0"
-        - name: API_SERVER_ENABLED
-          value: "true"
-        - name: API_SERVER_HOST
-          value: 0.0.0.0
-        - name: SESSION_KV_DB_PATH
-          value: /var/lib/kube-agents/session/session_kv.db
-        - name: OTEL_SERVICE_NAME
-          value: platformagent-gateway
-        - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
-        - name: OTEL_EXPORTER_OTLP_PROTOCOL
-          value: http/protobuf
-        - name: OTEL_RESOURCE_ATTRIBUTES
-          value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
-        - name: GKE_CLUSTER_NAME
-          value: cluster-a
-        - name: GKE_LOCATION
-          value: us-central1-a
-        - name: API_SERVER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: api-key
-              name: platformagent-secrets
-        - name: GOOGLE_CHAT_PROJECT_ID
-          value: kube-agents-gkedemos
-        - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
-          value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
-        - name: GOOGLE_CHAT_ALLOWED_USERS
-        - name: GOOGLE_CHAT_HOME_CHANNEL
-        - name: GOOGLE_CHAT_ALLOW_ALL_USERS
-          value: "true"
-        - name: TOKEN_BROKER_URL
-          value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: platform-agent
-        ports:
-        - containerPort: 8642
-          name: api
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 2Gi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-        - mountPath: /opt/data/config.yaml
-          name: platform-agent-config-vol
-          subPath: config.yaml
-        - mountPath: /opt/data/SETTINGS.md
-          name: settings-volume
-          readOnly: true
-          subPath: SETTINGS.md
-        - mountPath: /var/lib/kube-agents/session
-          name: system-metadata
-          subPath: session
-      - args:
-        - hermes
-        - dashboard
-        env:
-        - name: PLATFORM_AGENT_HOME
-          value: /opt/data
-        - name: HOME
-          value: /opt/data/home
-        - name: SESSION_KV_DB_PATH
-          value: /var/lib/kube-agents/session/session_kv.db
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: platform-agent-dashboard
-        ports:
-        - containerPort: 9119
-          name: dashboard
-        resources:
-          limits:
-            cpu: "1"
-            memory: 2Gi
-          requests:
-            cpu: 256m
-            memory: 512Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-        - mountPath: /var/lib/kube-agents/session
-          name: system-metadata
-          subPath: session
-      - args:
-        - -c
-        - /fluent-bit/etc/fluent-bit.conf
-        image: fluent/fluent-bit:5.0.7
-        name: fluent-bit
-        resources:
-          limits:
-            cpu: 500m
-            ephemeral-storage: 1Gi
-            memory: 256Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 1Gi
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
-          readOnly: true
-        - mountPath: /fluent-bit/etc/fluent-bit.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: fluent-bit.conf
-        - mountPath: /fluent-bit/etc/parsers.conf
-          name: fluent-bit-config
-          readOnly: true
-          subPath: parsers.conf
-        - mountPath: /fluent-bit/state
-          name: fluent-bit-state
-      - args:
-        - --cluster-name=cluster-a
-        - --daemon-url=http://127.0.0.1:8699
-        - --token-env=API_SERVER_KEY
-        - --owner=platform
-        - --reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
-        - --kubeconfig=/opt/data/home/.kube/watcher.config
-        command:
-        - /usr/local/bin/k8s-event-watcher
-        env:
-        - name: API_SERVER_KEY
-          valueFrom:
-            secretKeyRef:
-              key: api-key
-              name: platformagent-secrets
-        - name: HOME
-          value: /opt/data/home
-        image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
-        imagePullPolicy: IfNotPresent
-        name: event-watcher
-        resources:
-          limits:
-            cpu: 200m
-            memory: 128Mi
-          requests:
-            cpu: 50m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        volumeMounts:
-        - mountPath: /opt/data
-          name: platform-agent-data-vol
+        - env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 0.0.0.0
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+            - name: OTEL_SERVICE_NAME
+              value: platformagent-gateway
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
+            - name: GKE_CLUSTER_NAME
+              value: cluster-a
+            - name: GKE_LOCATION
+              value: us-central1-a
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: GOOGLE_CHAT_ALLOWED_USERS
+            - name: GOOGLE_CHAT_HOME_CHANNEL
+            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+              value: "true"
+            - name: TOKEN_BROKER_URL
+              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: platform-agent
+          ports:
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: platform-agent-config-vol
+              subPath: config.yaml
+            - mountPath: /opt/data/SETTINGS.md
+              name: settings-volume
+              readOnly: true
+              subPath: SETTINGS.md
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - hermes
+            - dashboard
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: platform-agent-dashboard
+          ports:
+            - containerPort: 9119
+              name: dashboard
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 256m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
+        - args:
+            - --cluster-name=cluster-a
+            - --daemon-url=http://127.0.0.1:8699
+            - --token-env=API_SERVER_KEY
+            - --owner=platform
+            - --reason=FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+            - --kubeconfig=/opt/data/home/.kube/watcher.config
+          command:
+            - /usr/local/bin/k8s-event-watcher
+          env:
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: HOME
+              value: /opt/data/home
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
+          imagePullPolicy: IfNotPresent
+          name: event-watcher
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
         runAsNonRoot: true
@@ -491,26 +491,26 @@ spec:
       serviceAccountName: kubeagents-platform-agent
       shareProcessNamespace: true
       volumes:
-      - name: platform-agent-data-vol
-        persistentVolumeClaim:
-          claimName: platformagent-data
-      - configMap:
-          defaultMode: 493
-          name: platformagent-config
-        name: platform-agent-config-vol
-      - configMap:
-          defaultMode: 420
-          name: platformagent-fluent-bit-config
-        name: fluent-bit-config
-      - emptyDir: {}
-        name: fluent-bit-state
-      - name: system-metadata
-        persistentVolumeClaim:
-          claimName: system-metadata
-      - configMap:
-          defaultMode: 420
-          name: platformagent-settings
-        name: settings-volume
+        - name: platform-agent-data-vol
+          persistentVolumeClaim:
+            claimName: platformagent-data
+        - configMap:
+            defaultMode: 493
+            name: platformagent-config
+          name: platform-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: platformagent-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
+        - name: system-metadata
+          persistentVolumeClaim:
+            claimName: system-metadata
+        - configMap:
+            defaultMode: 420
+            name: platformagent-settings
+          name: settings-volume
 status: {}
 ---
 apiVersion: v1
@@ -520,20 +520,20 @@ metadata:
   name: platformagent
   namespace: kubeagents-system
   ownerReferences:
-  - apiVersion: kubeagents.x-k8s.io/v1alpha1
-    blockOwnerDeletion: true
-    controller: true
-    kind: PlatformAgent
-    name: platformagent
-    uid: ""
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
 spec:
   ports:
-  - name: api
-    port: 8642
-    targetPort: api
-  - name: dashboard
-    port: 9119
-    targetPort: dashboard
+    - name: api
+      port: 8642
+      targetPort: api
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
   selector:
     app: platformagent-gateway
 status:


### PR DESCRIPTION
# Pull Request

## Why This Change
This PR addresses two critical issues in the GKE Agent Harness event-watcher pipeline:
1. **Cross-Cluster Event Watching:** Previously, the `event-watcher` sidecar container was locked to `InClusterConfig` (watching its own host cluster) and lacked permissions/credentials to watch external target clusters. It also risked having its GKE context overridden when interactive agent commands updated the shared `config` file.
2. **Duplicate Alert Storms:** Repeat/duplicate warnings (like `BackOff` loops) were being forwarded continuously as follow-ups, causing the gateway proxy to spawn new Gemini turns and spam Google Chat threads every 20 seconds.

---

## What Changed

**Files:**
- `deploy/shared/docker-entrypoint.sh`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/cmd/k8s-event-watcher/main.go`
- `k8s-operator/cmd/k8s-event-watcher/dispatcher_test.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`

**Added/Changed/Fixed:**
- **Static Credentials Copy:** Updated the entrypoint script to create an atomic, static copy of the target cluster credentials (`watcher.config`) during startup using a temp file + rename (`mv`), ensuring the watcher is isolated from active context changes.
- **Operator Controller Update:** Modified the gateway builder to dynamically mount the shared volume, set the `HOME` environment variable using `homeDir`, and pass the `--kubeconfig` argument to the `event-watcher` container.
- **Source-Level Duplicate Suppression:** Modified the event-watcher's dispatcher logic to drop duplicate/repeat events within the incident window instead of forwarding them as follow-up HTTP requests to the proxy, resolving the alert storm.
- **Test Expectations & Code Quality:** Updated golden expectation files and dispatcher unit tests to reflect the new duplicate suppression behavior. Run Prettier on generated test YAMLs.

---

## Why This Matters
Ensures the background event watcher can monitor external target GKE clusters reliably and securely without conflicts from interactive sessions, while preventing alert spams on long-running warning loops.

---

## Testing
- Operator unit tests compile and pass successfully (`go test ./...` in `k8s-operator/`).
