### PR TITLE
fix(platform): drop hardcoded project fallback in incident triage links

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -250,6 +250,12 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
     object_name = payload.get("name") or ""
     message = payload.get("message") or ""
     cluster_name = os.environ.get("GKE_CLUSTER_NAME", "platform-agent-host")
+    gcp_project = (
+        os.environ.get("GCP_PROJECT")
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("GOOGLE_CHAT_PROJECT_ID")
+        or ""
+    )
 
     return (
         f"Analyze the following Kubernetes event warning on GKE cluster '{cluster_name}' "
@@ -266,8 +272,8 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
         f"🛠️ *Proposed Fixes (GitOps):*\n"
         f"*Option A (<Action Title>):* <1-sentence description of Option A GitOps fix>.\n"
         f"*Option B (<Action Title>):* <1-sentence description of Option B GitOps fix>.\n\n"
-        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview?project={os.environ.get('GCP_PROJECT', 'jayantid-gkedemos')}|GKE Workloads> | "
-        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22?project={os.environ.get('GCP_PROJECT', 'jayantid-gkedemos')}|Cloud Logs>\n\n"
+        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview?project={gcp_project}|GKE Workloads> | "
+        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22?project={gcp_project}|Cloud Logs>\n\n"
         f"👉 *Reply to this thread with 'apply Option A' or 'apply Option B' to automatically open a GitOps Pull Request with the fix.*\n\n"
         f"---"
         f"\n\n**GitOps PR Instructions (For subsequent turns if the user replies):**\n"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -256,6 +256,7 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
         or os.environ.get("GOOGLE_CHAT_PROJECT_ID")
         or ""
     )
+    project_suffix = f"?project={gcp_project}" if gcp_project else ""
 
     return (
         f"Analyze the following Kubernetes event warning on GKE cluster '{cluster_name}' "
@@ -272,8 +273,8 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
         f"🛠️ *Proposed Fixes (GitOps):*\n"
         f"*Option A (<Action Title>):* <1-sentence description of Option A GitOps fix>.\n"
         f"*Option B (<Action Title>):* <1-sentence description of Option B GitOps fix>.\n\n"
-        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview?project={gcp_project}|GKE Workloads> | "
-        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22?project={gcp_project}|Cloud Logs>\n\n"
+        f"🔗 <https://console.cloud.google.com/kubernetes/workload/overview{project_suffix}|GKE Workloads> | "
+        f"<https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22{project_suffix}|Cloud Logs>\n\n"
         f"👉 *Reply to this thread with 'apply Option A' or 'apply Option B' to automatically open a GitOps Pull Request with the fix.*\n\n"
         f"---"
         f"\n\n**GitOps PR Instructions (For subsequent turns if the user replies):**\n"


### PR DESCRIPTION
# Pull Request

## Why This Change

The Google Chat incident triage message built by `_build_agent_query` hardcoded a personal test project (`jayantid-gkedemos`) as the fallback when `GCP_PROJECT` was unset, so links pointed at the wrong project in any install that did not export `GCP_PROJECT`.

Resolve `gcp_project` once per call from a fallback chain (`GCP_PROJECT` -> `GOOGLE_CLOUD_PROJECT` -> `GOOGLE_CHAT_PROJECT_ID` -> "") and reuse it in both console link expansions. `GOOGLE_CHAT_PROJECT_ID` is already injected by the operator (platformagent_manifests.go:151).

## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  - agents/platform/scripts/session_kv_server.py

**Added/Changed/Fixed:**

  - Fixed: Removed the hardcoded jayantid-gkedemos fallback from the two
  os.environ.get('GCP_PROJECT', 'jayantid-gkedemos') expansions inside
  _build_agent_query (formerly lines 269-270).
  - Added: A gcp_project fallback chain resolved once per call — GCP_PROJECT →
  GOOGLE_CLOUD_PROJECT → GOOGLE_CHAT_PROJECT_ID → "" — reused in both the GKE 
  Workloads and Cloud Logs console link expansions.

## Why This Matters

-

## Context

<!-- Include related issues, PRs, follow-up work, or other background. -->

## Testing

Manually. Ran the event watcher, and simulated an error. The triage report by the platform agent no longer had a hard coded link for jayantis project. 

<!-- Close with a short note on functional impact, risk, or rollout. -->
