### PR TITLE
fix(watcher): let --dry-run actually watch events

### DIFF
--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -384,14 +384,6 @@ func realMain(argv []string) error {
 	}
 
 	// Build the kube client.
-	if f.dryRun {
-		log.Printf("k8s-event-watcher: --dry-run: skipping kube client; would watch cluster %q", f.clusterName)
-		<-ctx.Done()
-		if err := dedup.Snapshot(); err != nil {
-			log.Printf("dedup snapshot on shutdown: %v", err)
-		}
-		return nil
-	}
 	client, err := buildKubeClient(f)
 	if err != nil {
 		return err

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -383,6 +383,9 @@ func realMain(argv []string) error {
 		go runSnapshotLoop(ctx, dedup, f.snapshotInterval)
 	}
 
+	if f.dryRun {
+		log.Printf("k8s-event-watcher: running in --dry-run mode; watching cluster %q without calling the daemon", f.clusterName)
+	}
 	// Build the kube client.
 	client, err := buildKubeClient(f)
 	if err != nil {


### PR DESCRIPTION
# Pull Request

## Why This Change

`realMain` in `k8s-operator/cmd/k8s-event-watcher/main.go` short-circuited whenever `--dry-run` was set: it logged one line and blocked on `ctx.Done()` before ever calling `buildKubeClient` / `newWatcher`, so no informer was created and `dispatcher.Dispatch` was never invoked. The payload-printing branches at `main.go:233` and `main.go:285` — documented behavior of `--dry-run`: _"Print inject payloads to stdout without calling the daemon."_ — were therefore dead code. Observed symptom: `--dry-run` prints a single log line and then does nothing.
  ### Reproducer
  
  ```console
  $ cd ~/kube-agents/k8s-operator/cmd/k8s-event-watcher
  $ go build -o k8s-event-watcher .
  $ ./k8s-event-watcher \
      --cluster-name="test-cluster" \
      --dry-run
  2026/07/22 17:09:45 k8s-event-watcher: --dry-run: skipping kube client; would
  watch cluster "test-cluster"
```
That single line is the entirety of the output. The process then blocks on ctx.Done() until you Ctrl+C, without ever connecting to a cluster, starting an informer, or exercising the filter/dedup/print pipeline the flag is supposed to demonstrate.


## Testing

  1. Re ran the reproducer above and it succeeded. 
  2. Simulated an error and event watcher successfully logged it.

<!-- Close with a short note on functional impact, risk, or rollout. -->
