### PR TITLE
docs(watcher): expand "Running the Binary Directly" with local verification options

### DIFF
--- a/k8s-operator/cmd/k8s-event-watcher/README.md
+++ b/k8s-operator/cmd/k8s-event-watcher/README.md
@@ -67,14 +67,45 @@ When executing the `k8s-event-watcher` service binary directly, the following co
 
 ### Running the Binary Directly
 
-For local testing or standalone executions, run the compiled binary:
+Before running any of the verification options below, navigate to the watcher directory from the repository root and compile the Go binary:
+
+```bash
+cd k8s-operator/cmd/k8s-event-watcher
+go build -o k8s-event-watcher .
+```
+
+You can then run the compiled binary locally on your workstation against any Kubernetes cluster configured in your `~/.kube/config`.
+
+#### Option A: Standalone Verification (`--dry-run`)
+
+To verify event streaming, filtering, and JSON payload formatting without connecting to a backend server:
 
 ```bash
 ./k8s-event-watcher \
-  --cluster-name="local-kind-cluster" \
-  --daemon-url="http://localhost:8699" \
-  --metrics-addr=":8080"
+  --cluster-name="local-test-cluster" \
+  --dry-run
 ```
+
+#### Option B: Live Verification via Port-Forwarding (Recommended)
+
+To test the full autonomous triage loop against a live Platform Agent in Kubernetes without running Python servers locally:
+
+1. Port-forward the session bridge from your platform agent host cluster:
+
+   ```bash
+   kubectl -n kubeagents-system port-forward deployment/platform-agent-gateway 8699:8699
+   ```
+
+2. Run the watcher with live-mode flags (`--token-env` and `--owner` are required in per-incident mode when not using `--dry-run`):
+
+   ```bash
+   export DUMMY_TOKEN="test-token"
+   ./k8s-event-watcher \
+     --cluster-name="local-test-cluster" \
+     --daemon-url="http://127.0.0.1:8699" \
+     --token-env="DUMMY_TOKEN" \
+     --owner="k8s-watcher"
+   ```
 
 ---
 


### PR DESCRIPTION
# Pull Request

## Why This Change

- The existing "Running the Binary Directly" section in `k8s-operator/cmd/k8s-event-watcher/README.md` gave one generic invocation that doesn't work end-to-end (no build step, no explanation of when `--token-env`/`--owner` are required, no mention of `--dry-run`). 
- Replace it with a step-by-step recipe covering the two useful local-verification paths: 
- **Option A (`--dry-run`)**: exercises the informer, filter, dedup, and JSON payload formatting against a live cluster without needing the daemon-side stack running. Assumes the `--dry-run` fix from the companion PR (`fix/event-watcher-dry-run-early-exit`) has landed. 
- **Option B (port-forward)**: drives the full autonomous triage loop against a real Platform Agent deployment via `kubectl port-forward`, without needing to run the Python servers locally. - Documents the build step from repo root and calls out the per-incident-mode requirements for `--token-env` and `--owner` when not running in `--dry-run`.

## Testing

Ran the steps in the new readme. Once event watcher was running, I simulated an error and the platform agent automatically triaged it. 

<!-- Close with a short note on functional impact, risk, or rollout. -->
