### PR TITLE
fix(platform): suppress duplicate alerts on k8s-event-watcher follow-up injects

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -336,7 +336,17 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
         payload = json.loads(raw_message)
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"Failed to parse inner payload JSON: {exc}")
-        
+
+    # Follow-up telemetry from k8s-event-watcher (payload.kind = "k8s-event-followup")
+    # updates an already-triggered incident's count/LastSeen. Suppress the chat notification
+    # and skip spawning another agent turn; the initial POST already did both for this session.
+    if payload.get("kind") == "k8s-event-followup":
+        logger.info(
+            f"Session {session_id}: suppressing follow-up inject "
+            f"(count={payload.get('count')}, reason={payload.get('reason')})."
+        )
+        return {"status": "injected_followup"}
+
     event_reason = payload.get("reason") or "Unknown"
     namespace = payload.get("namespace") or "default"
     object_kind = payload.get("kind_of_object") or payload.get("kindOfObject") or "Pod"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -337,6 +337,9 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
     except Exception as exc:
         raise HTTPException(status_code=400, detail=f"Failed to parse inner payload JSON: {exc}")
 
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="Inner payload must be a JSON object")
+
     # Follow-up telemetry from k8s-event-watcher (payload.kind = "k8s-event-followup")
     # updates an already-triggered incident's count/LastSeen. Suppress the chat notification
     # and skip spawning another agent turn; the initial POST already did both for this session.


### PR DESCRIPTION

# Pull Request

## Why This Change

`k8s-event-watcher` POSTs both **initial** event injects and **follow-up telemetry updates** to the same URL (`POST /sessions/{id}/inject`). The two are distinguished only by the `kind` field in the payload:

- `kind: "k8s-event"` — first sighting of an incident. Session was just bound. 
- `kind: "k8s-event-followup"` — a repeat, sent so the backend sees updated `count` / `LastSeen`.


any repeating failure (OOMKill, ImagePullBackOff, FailedScheduling) produced a barrage of duplicate chat messages and redundant LLM turns competing on the same incident.

## Fix
Honor `payload.kind == "k8s-event-followup"`: log the update at INFO level and return `{"status": "injected_followup"}` without invoking the chat/agent path. The initial POST for the session already did both.

Stateless (no SQLite writes, no SELECT-then-UPDATE race), uses the semantic signal the watcher already stamps on follow-ups, and keeps the "why" close to the Go code that produces the kind field.


## Testing

Manually. Ran the event watcher, and simulated a repeating error. The triage report by the platform agent no longer produced redundant messages for the same incident.



<!-- Close with a short note on functional impact, risk, or rollout. -->
