### PR TITLE
docs: consolidate PR #290/#341/#343/#345 content into the docs site

### DIFF
--- a/docs/site/src/content/docs/concepts/inference-gateway.md
+++ b/docs/site/src/content/docs/concepts/inference-gateway.md
@@ -28,6 +28,38 @@ The Platform Agent talks to an LLM through a **Completions API** proxy so provid
 
 To switch providers, edit the LiteLLM `config.yaml` (mounted from a `ConfigMap`) and set the corresponding API key secret. The Platform Agent config doesn't change — it always talks to a Service named `litellm`.
 
+### Setting the default model
+
+The agent always requests a single logical model, `model-default`. LiteLLM maps that alias to a real provider model in its [`config.yaml`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/config/integrations/litellm/base/config.yaml):
+
+```yaml
+model_list:
+  - model_name: model-default
+    litellm_params:
+      model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
+```
+
+The two substituted values come from provisioning (`MODEL_PROVIDER` and `MODEL_DEFAULT_NAME`, cached in `vars.sh`). Supported providers and their shipping defaults:
+
+| `MODEL_PROVIDER`   | Default `MODEL_DEFAULT_NAME` | Notes                                  |
+| ------------------ | ---------------------------- | -------------------------------------- |
+| `gemini` (default) | `gemini-3.5-flash`           | Uses `GEMINI_API_KEY`.                 |
+| `anthropic`        | `claude-sonnet-4-5-20250929` | Uses `ANTHROPIC_API_KEY`.              |
+| `openai`           | `gpt-5.4`                    | Uses `OPENAI_API_KEY`.                 |
+| `chatgpt`          | `gpt-5.4`                    | Personal ChatGPT subscription (OAuth). |
+
+Any model string the chosen provider accepts is valid — there is no allow-list in the harness. For example, [`examples/litellm-gemini/`](https://github.com/gke-labs/kube-agents/tree/main/examples/litellm-gemini) pins `gemini-3.1-flash-lite`.
+
+To change the default, set the variables and re-run the LiteLLM step (or `make deploy-litellm`):
+
+```bash
+export MODEL_PROVIDER=gemini
+export MODEL_DEFAULT_NAME=gemini-3.5-flash
+cd k8s-operator/scripts && ./provision_09_deploy_litellm.sh
+```
+
+This rewrites the LiteLLM `ConfigMap` and rolls the gateway; the agent picks up the new model on its next request without any change to its own config.
+
 ## vLLM (local models)
 
 [vLLM](https://vllm.ai) serves open models with server-side batching and speculative decoding for high throughput on GPU node pools.

--- a/docs/site/src/content/docs/concepts/skills.md
+++ b/docs/site/src/content/docs/concepts/skills.md
@@ -74,6 +74,66 @@ The `gke-compute-classes` skill is a good example — it explicitly delineates w
 5. Test locally: DM the agent in Chat with a prompt that should trigger the skill, and verify it loads and follows the procedure.
 6. If the skill should also run on schedule, add an entry to `agents/platform/cron/jobs.json`.
 
+## Importing external skills
+
+The agent discovers skills from **two** locations at startup:
+
+- **Baked into the image** at `/opt/hermes/skills/` — everything under `agents/platform/skills/` is copied here by [`deploy/docker/Dockerfile`](https://github.com/gke-labs/kube-agents/blob/main/deploy/docker/Dockerfile).
+- **The runtime workspace** at `$HERMES_HOME/skills` — `HERMES_HOME` defaults to `/opt/data`, so `/opt/data/skills`. This path is backed by the agent's persistent volume.
+
+That gives you two ways to bring in additional skills — for example from the upstream [`google/skills`](https://github.com/google/skills/tree/main/skills/cloud) catalog.
+
+### Method 1 — bake into a custom image (production)
+
+Reproducible and immutable: the skill ships inside the container.
+
+1. Copy the skill directory into `agents/platform/skills/<skill>/` (it must contain `SKILL.md` plus any `references/`).
+2. Build and push the `platform` image stage:
+
+   ```bash
+   docker build -f deploy/docker/Dockerfile --target platform \
+     -t my-registry/kube-agents/platform-agent:v1.1.0 .
+   docker push my-registry/kube-agents/platform-agent:v1.1.0
+   ```
+
+3. Point the `PlatformAgent` CR at the new image and apply it:
+
+   ```yaml
+   apiVersion: kubeagents.x-k8s.io/v1alpha1
+   kind: PlatformAgent
+   metadata:
+     name: platform-agent
+     namespace: kubeagents-system
+   spec:
+     deployment:
+       image: my-registry/kube-agents/platform-agent
+       tag: v1.1.0
+   ```
+
+The operator rolls the Deployment and the new skill loads on boot.
+
+### Method 2 — inject into the running pod (development)
+
+Faster for iterating: drop the skill into the persistent workspace without rebuilding.
+
+```bash
+# The agent pod carries the label app=platform-agent-gateway; the container is `platform-agent`.
+AGENT_POD=$(kubectl get pods -n kubeagents-system \
+  -l app=platform-agent-gateway -o jsonpath='{.items[0].metadata.name}')
+
+kubectl cp <skill-dir>/ \
+  kubeagents-system/$AGENT_POD:/opt/data/skills/<skill-dir> -c platform-agent
+```
+
+Verify it landed:
+
+```bash
+kubectl exec -n kubeagents-system -it $AGENT_POD -c platform-agent -- \
+  ls -la /opt/data/skills/<skill-dir>
+```
+
+The runtime discovers the skill on its next relevant turn. Because this writes to the persistent volume, it survives pod restarts — but it is **not** captured in the image, so bake it in (Method 1) before relying on it in production.
+
 ## Skill vs. governance SOP vs. cron job
 
 A few related concepts that are easy to confuse:

--- a/docs/site/src/content/docs/install/uninstall.md
+++ b/docs/site/src/content/docs/install/uninstall.md
@@ -3,7 +3,38 @@ title: Uninstall
 description: Remove the Platform Agent, operator, and provisioned GCP resources.
 ---
 
-The shipping teardown mirrors `./provision.sh` in reverse.
+There are two levels of cleanup: removing just the Platform Agent (keeping the cluster and operator), or a full teardown of everything the provisioner created.
+
+## Uninstall the Platform Agent only
+
+Use this to remove the agent while leaving the GKE cluster and operator in place.
+
+1. **Stop the heartbeat.** Delete or disable the recurring 1-minute cron in your agent harness so no new runs fire.
+2. **Delete the `PlatformAgent` CR.**
+
+   ```bash
+   kubectl delete platformagent platform-agent -n kubeagents-system --ignore-not-found=true
+   ```
+
+   If deletion hangs on a controller finalizer (e.g. the operator or its webhook is offline), clear the finalizer and retry:
+
+   ```bash
+   kubectl patch platformagent platform-agent -n kubeagents-system \
+     --type=merge -p '{"metadata":{"finalizers":null}}'
+   ```
+
+3. **Delete the agent secrets.**
+
+   ```bash
+   kubectl delete secret platform-agent-secrets github-app-credentials \
+     -n kubeagents-system --ignore-not-found=true
+   ```
+
+   (`github-app-credentials` only exists if you configured the GitHub integration.)
+
+4. **Remove the workspace** — delete the `agents/platform` directory from your harness workspace if you installed it there.
+
+The operator garbage-collects the agent's Deployment, Service, ServiceAccount, RBAC bindings, and ConfigMaps once the CR is gone.
 
 ## Full teardown
 
@@ -34,6 +65,7 @@ You can also run individual `teardown_NN_*.sh` scripts to remove one layer at a 
 
 Each script is idempotent — safe to re-run if it fails partway through.
 
-## Related work
+## Where to go next
 
-An expanded uninstall + teardown guide is proposed in [PR #345](https://github.com/gke-labs/kube-agents/pull/345) with more detail on the cleanup steps for each integration.
+- [Provisioning scripts](/kube-agents/operator/provisioning-scripts/) — what each `provision_NN_*` / `teardown_NN_*` step does.
+- [Security & IAM](/kube-agents/reference/security-and-iam/) — the GCP service accounts and bindings removed by `teardown_04_gcp_iam.sh`.

--- a/docs/site/src/content/docs/overview/architecture.mdx
+++ b/docs/site/src/content/docs/overview/architecture.mdx
@@ -97,7 +97,16 @@ Everything except the LLM (and, for hosted providers, the LLM API endpoint) runs
 - **Namespace**: `kubeagents-system` (renamed from earlier `platform-agent-system` in PR #336).
 - **Node pools**: default node pool is enough for the operator, Platform Agent, LiteLLM, and Minty. If you use vLLM, provision a GPU node pool separately.
 - **Optional gVisor node pool** for sandboxed skill execution (`provision_02_gvisor_nodepool.sh`, opt-in via `ENABLE_GVISOR=true`).
-- **Workload Identity** bindings are pre-provisioned in `provision_04_gcp_iam.sh` — the operator gets cluster management scope, the Platform Agent gets a configurable permission set (`read-only`, `gke-admin`, or `custom`).
+- **Workload Identity** bindings are pre-provisioned in `provision_04_gcp_iam.sh` — the operator gets cluster management scope, the Platform Agent gets a configurable permission set (`read-only`, `gke-admin`, or `custom`). See [Security & IAM](/kube-agents/reference/security-and-iam/).
+
+### Capacity and isolation
+
+The hub footprint (operator, Platform Agent, LiteLLM, Minty) is small and roughly fixed — it doesn't grow with the number of clusters the agent manages, since those are read remotely through the GKE MCP server. What actually drives node capacity:
+
+- **vLLM.** Local inference needs a GPU node pool; hosted LiteLLM does not.
+- **gVisor.** Sandboxed skill execution runs the agent pod on the optional `gvisor-pool` (`ENABLE_GVISOR=true`).
+
+For production, prefer a **dedicated cluster** for the harness. The agent GSA can hold broad GKE permissions in the default `gke-admin` set, so a hard cluster boundary limits blast radius if the execution sandbox is ever compromised. A shared cluster (with the `kubeagents-system` namespace for logical isolation) is fine for development.
 
 ## Failure modes worth knowing
 

--- a/docs/site/src/content/docs/reference/index.mdx
+++ b/docs/site/src/content/docs/reference/index.mdx
@@ -33,4 +33,9 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
     description="How to connect an agent action back to the authenticated human who requested it."
     href="/kube-agents/reference/attribution/"
   />
+  <LinkCard
+    title="Security & IAM"
+    description="Workload Identity, the GCP permission sets, the read-only Kubernetes RBAC, and auditing mode."
+    href="/kube-agents/reference/security-and-iam/"
+  />
 </CardGrid>

--- a/docs/site/src/content/docs/reference/security-and-iam.md
+++ b/docs/site/src/content/docs/reference/security-and-iam.md
@@ -1,0 +1,139 @@
+---
+title: Security & IAM
+description: The Workload Identity model, the GCP IAM permission sets, the read-only Kubernetes RBAC the operator grants, and how to run the agent in a strict auditing posture.
+sidebar:
+  order: 6
+---
+
+`kube-agents` separates two access planes that are easy to conflate:
+
+- **GCP IAM** — what the agent's Google Service Account (GSA) can do at the Google Cloud control-plane level (create clusters, read monitoring, etc.). Selectable at provisioning time.
+- **Kubernetes RBAC** — what the agent's Kubernetes ServiceAccount (KSA) can do against the cluster API. Always read-only, regardless of the GCP permission set.
+
+Writes to running infrastructure never happen through the agent's own credentials — they route through the [declarative GitOps path](#secure-write-path-gitops).
+
+## Identity model
+
+The agent uses [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) to bind its in-cluster KSA to a GSA, so no static GCP key ever lands in the cluster.
+
+```mermaid
+flowchart LR
+    subgraph K8s["GKE cluster"]
+        Pod["Platform Agent pod"] --> KSA["KSA<br/>kubeagents-platform-agent"]
+    end
+    subgraph IAM["GCP IAM"]
+        KSA -->|Workload Identity| GSA["GSA<br/>kubeagents-platform-gsa@PROJECT.iam.gserviceaccount.com"]
+        GSA -->|IAM roles| Res["GCP / GKE resources"]
+    end
+```
+
+The binding is pre-provisioned by [`provision_04_gcp_iam.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/provision_04_gcp_iam.sh), which annotates the KSA with `iam.gke.io/gcp-service-account: kubeagents-platform-gsa@<project>.iam.gserviceaccount.com`. The operator applies the same annotation from `spec.security` on the [`PlatformAgent` CR](/kube-agents/operator/platformagent-crd/).
+
+## GCP IAM permission sets
+
+`provision_04_gcp_iam.sh` grants the agent GSA one of three permission sets, chosen with the `PLATFORM_AGENT_PERMISSION_SET` variable (prompted during provisioning, cached in `vars.sh`):
+
+| Permission set | `PLATFORM_AGENT_PERMISSION_SET` | Use it when                                                    |
+| -------------- | ------------------------------- | -------------------------------------------------------------- |
+| **gke-admin**  | `gke-admin` (default)           | The agent should manage GKE lifecycle and node pools directly. |
+| **read-only**  | `read-only`                     | Auditing / monitoring only — no GCP write capability.          |
+| **custom**     | `custom`                        | You bind roles yourself and skip the built-in grants.          |
+
+### Roles per set
+
+The default **gke-admin** set binds:
+
+- `roles/container.clusterAdmin`, `roles/container.admin` — full GKE control.
+- `roles/monitoring.admin` — manage monitoring configuration.
+- `roles/logging.viewer` — read logs only (the agent must **not** administer the audit-log sink).
+- `roles/iam.serviceAccountUser` — act as service accounts when running jobs.
+- `roles/iam.securityReviewer` — read IAM policy for review.
+- `roles/mcp.toolUser` — call the GKE MCP server.
+
+The **read-only** set swaps the admin roles for viewers:
+
+- `roles/container.clusterViewer`, `roles/container.viewer` — read-only GKE.
+- `roles/monitoring.viewer`, `roles/logging.viewer` — read-only telemetry.
+- `roles/iam.serviceAccountUser`, `roles/iam.securityReviewer`, `roles/mcp.toolUser` — unchanged.
+
+The **custom** set binds nothing automatically; grant roles to the GSA yourself.
+
+## Kubernetes RBAC
+
+Independently of the GCP permission set, the operator grants the agent KSA a **read-only** footprint on the Kubernetes API. It creates two bindings (see [`platformagent_manifests.go`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/internal/controller/platformagent_manifests.go)):
+
+| Binding                                  | Role                         | Grants                                                            |
+| ---------------------------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| `kubeagents:viewer:<namespace>:<name>`   | standard `view` ClusterRole  | Read access to most namespaced resources — **excluding Secrets**. |
+| `kubeagents:explorer:<namespace>:<name>` | custom `kubeagents:explorer` | `get`/`list` on `nodes`, `pods`, `namespaces`, and CRDs.          |
+
+For the default CR (`platform-agent` in `kubeagents-system`) the bindings resolve to `kubeagents:viewer:kubeagents-system:platform-agent` and `kubeagents:explorer:kubeagents-system:platform-agent`.
+
+Neither role carries any write verb (`create`, `update`, `patch`, `delete`), and neither can read Secrets. The agent cannot modify Deployments, Services, or namespaces directly, and it cannot read Secret values — if a resource it proposes needs a Secret, it references the Secret by name rather than reading its contents.
+
+Verify the bindings on a running cluster:
+
+```bash
+kubectl describe clusterrolebinding kubeagents:viewer:kubeagents-system:platform-agent
+kubectl describe clusterrolebinding kubeagents:explorer:kubeagents-system:platform-agent
+```
+
+## Configuring read-only (auditing) mode
+
+To run the agent purely for auditing, monitoring, and trend analysis:
+
+**With the provisioner (recommended)** — select the `read-only` permission set when `provision_04_gcp_iam.sh` prompts, or set it up front:
+
+```bash
+cd k8s-operator/scripts
+PLATFORM_AGENT_PERMISSION_SET=read-only ./provision_04_gcp_iam.sh
+```
+
+**On an existing GSA** — swap the admin roles for viewers by hand:
+
+```bash
+PROJECT_ID="your-gcp-project-id"
+GSA_EMAIL="kubeagents-platform-gsa@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# Remove the admin roles
+for role in roles/container.clusterAdmin roles/container.admin roles/monitoring.admin; do
+  gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${GSA_EMAIL}" --role="${role}"
+done
+
+# Add the read-only roles
+for role in roles/container.clusterViewer roles/container.viewer roles/monitoring.viewer; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${GSA_EMAIL}" --role="${role}"
+done
+```
+
+Leave `roles/logging.viewer`, `roles/iam.serviceAccountUser`, `roles/iam.securityReviewer`, and `roles/mcp.toolUser` in place — they are shared by both sets.
+
+The Kubernetes RBAC above is already read-only in every mode, so no cluster-side change is needed.
+
+## Secure write path: GitOps
+
+Because the agent's Kubernetes RBAC is read-only, remediations are proposed rather than applied:
+
+1. The agent invokes the [`submit-suggestion`](/kube-agents/concepts/declarative-workflow/) skill with a proposed diff (usually a YAML patch from a governance SOP).
+2. `submit-suggestion` commits to a topic branch and calls [Minty](/kube-agents/deploy/token-minter/) for a short-lived GitHub App token.
+3. It opens a Pull Request against your GitOps repository.
+4. A human reviews and merges; a GitOps controller (Argo CD, Flux) reconciles the change into the cluster.
+
+The agent never has direct write access to running infrastructure — see [Declarative workflow](/kube-agents/concepts/declarative-workflow/).
+
+## Change control & safety
+
+- **No direct cluster writes.** Enforced by RBAC (above) and by the persona's automation-first stance — the agent does not `kubectl apply`; it opens PRs. See [Platform Agent](/kube-agents/concepts/platform-agent/).
+- **One agent per project.** The admission webhook rejects a second `PlatformAgent` CR, so a cluster can't accumulate agents with overlapping scope. See [PlatformAgent CRD](/kube-agents/operator/platformagent-crd/).
+- **Human sign-off for destructive ops.** Cluster deletion, tenant offboarding, and broad IAM revocation always require explicit human approval, regardless of any "just do it" phrasing.
+- **Bounded recovery.** The agent retries a blocker through its recovery ladder (roughly five iterations or ~10 minutes) before escalating to a human instead of looping indefinitely.
+- **Read-only log access by default.** Provisioning grants the agent `roles/logging.viewer`, not admin — it cannot tamper with the audit-log sink. Stronger environments should route an immutable log copy to a separate security project (see [User attribution](/kube-agents/reference/attribution/#trust-boundary)).
+
+## Where to go next
+
+- [Platform Agent](/kube-agents/concepts/platform-agent/) — the persona and least-privilege stance.
+- [PlatformAgent CRD](/kube-agents/operator/platformagent-crd/) — `spec.security` and the permission set field.
+- [User attribution](/kube-agents/reference/attribution/) — tracing an action back to the human who requested it.
+- [Provisioning scripts](/kube-agents/operator/provisioning-scripts/) — where the IAM and RBAC are laid down.


### PR DESCRIPTION
# Pull Request

## Why This Change

Four documentation PRs (#290, #341, #343, #345) were authored against the **pre-reorg** doc layout (root `INSTALL.md`, `GKE_SETUP.md`, `docs/*.md`) and never merged. Since then, the docs were restructured into the Astro Starlight site under `docs/site/src/content/docs/`, which is now the source of truth. This PR reviews all four, verifies their technical claims against `main`, and migrates the genuinely net-new, accurate content into the site — dropping anything hallucinated or already superseded.

## What Changed

Every fact was checked against the actual code on `main` (scripts, `k8s-operator/` Go source, Kustomize, `cron/jobs.json`, Dockerfile) before merging. Content was re-targeted to the correct site pages and corrected where the source PRs were wrong.

**Files:**

- `docs/site/src/content/docs/reference/security-and-iam.md` (new)
- `docs/site/src/content/docs/concepts/inference-gateway.md`
- `docs/site/src/content/docs/concepts/skills.md`
- `docs/site/src/content/docs/install/uninstall.md`
- `docs/site/src/content/docs/overview/architecture.mdx`
- `docs/site/src/content/docs/reference/index.mdx`

**Added/Changed/Fixed:**

- **Added `reference/security-and-iam.md`** (from #290): Workload Identity model; the three GCP permission sets (`gke-admin`/`read-only`/`custom`) with verified role lists; the read-only Kubernetes RBAC the operator grants (standard `view` + custom `kubeagents:explorer`, Secrets excluded); read-only auditing-mode setup; and the GitOps secure-write path. Registered in the Reference nav.
- **Extended `concepts/inference-gateway.md`** (from #290): a "Setting the default model" section with the real default model IDs, a sample `model_list`, and how to change it via `MODEL_PROVIDER`/`MODEL_DEFAULT_NAME`.
- **Extended `concepts/skills.md`** (from #290): importing external skills two ways — bake-into-image vs. runtime injection — with verified paths (`/opt/hermes/skills`, `/opt/data/skills`) and correct pod/container names.
- **Extended `install/uninstall.md`** (from #345): an "Uninstall the Platform Agent only" path (CR delete, finalizer force-removal, secret cleanup).
- **Extended `overview/architecture.mdx`** (from #290): a "Capacity and isolation" note (honest scale drivers + dedicated-cluster guidance).

**Corrected vs. the source PRs:**

- GSA is `kubeagents-platform-gsa` (PR used three wrong variants); KSA `kubeagents-platform-agent`; deployment `platform-agent-gateway`.
- Default `gke-admin` roles include `roles/logging.viewer` (not `logging.admin`) and `roles/mcp.toolUser`; read-only adds `container.clusterViewer`.
- RBAC bindings end in `:platform-agent`; default model is `gemini-3.5-flash`.

**Rejected as inaccurate / redundant:**

- PR #290's provisioning step **renumbering** (`01a/02/03…`) — the site's `operator/provisioning-scripts.md` numbering (gvisor=02, operator=03, iam=04 … replay=11) is canonical.
- The webhook "GCS lock bucket / 10s timeout" Autopilot-EOF story — the webhook only enforces a **singleton** (one `PlatformAgent` per project); no GCS lookup or timeout exists.
- Nonexistent `make gcp-provision` / `gcp-teardown` aggregate targets, and the fabricated "Gemini-only / gemini-3.5-pro" model allow-list.
- **PR #341** — no migration: the single-Platform-Agent framing is already the site's premise, and its cron table is both redundant with `reference/cron-jobs.md` and wrong (claims `github-issue-resolver` runs "every 1 min"; actual is `*/30 * * * *`).
- **PR #343** — no migration: it's a CI workflow (`docs-freshness-check.yml`), not user-facing docs.

## Why This Matters

- Fills real gaps the site had no coverage for: Kubernetes RBAC + Secrets exclusion, per-mode GCP IAM roles, concrete model IDs, and skill-import mechanics.
- Keeps the source of truth accurate by rejecting hallucinated claims rather than propagating them.
- Consolidates scattered/duplicated PR content into cohesive, cross-linked pages that match the Starlight house style.

## Context

Supersedes the documentation portions of #290, #341, #343, and #345 by re-targeting them onto the restructured site. `install/uninstall.md` no longer references #345 as "proposed" — it now ships that content.

## Testing

- `npm run build` (Astro) — clean, exit 0; all 35 pages render, including the new `/reference/security-and-iam/`.
- `npx prettier --check` on all changed files — passes.
- Verified every internal Starlight link resolves and all code fences are balanced.

---

Documentation-only change. No code or runtime impact; risk is limited to doc content. All migrated claims were verified against `main` before inclusion.
