### PR TITLE
fix(credential-proxy): strip CR/LF from forwarded upstream headers

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -117,7 +117,10 @@ class AgentAPIProxyHandler(BaseHTTPRequestHandler):
                     "transfer-encoding",
                     "upgrade",
                 }:
-                    self.send_header(name, value)
+                    self.send_header(
+                        self._sanitize_header(name),
+                        self._sanitize_header(value),
+                    )
             self.send_header("Connection", "close")
             self.end_headers()
             response_started = True
@@ -131,6 +134,11 @@ class AgentAPIProxyHandler(BaseHTTPRequestHandler):
             self.close_connection = True
         finally:
             upstream.close()
+
+    @staticmethod
+    def _sanitize_header(value: str) -> str:
+        """Strip CR/LF so upstream headers cannot split the response (CWE-113)."""
+        return value.replace("\r", "").replace("\n", "")
 
     def log_message(self, message: str, *args: Any) -> None:
         LOGGER.info("agent-api " + message, *args)

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -108,7 +108,7 @@ class AgentAPIProxyHandler(BaseHTTPRequestHandler):
         try:
             upstream.request(self.command, self.path, body=body, headers=headers)
             response = upstream.getresponse()
-            self.send_response(response.status, response.reason)
+            self.send_response(response.status, self._sanitize_header(response.reason))
             for name, value in response.getheaders():
                 if name.lower() not in {
                     "connection",

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -1,5 +1,6 @@
 import json
 import queue
+import socket
 import subprocess
 import sys
 import tempfile
@@ -79,6 +80,64 @@ class AgentAPIProxyTest(unittest.TestCase):
             AgentAPIProxyHandler._sanitize_header(dirty),
         )
         self.assertEqual("clean", AgentAPIProxyHandler._sanitize_header("clean"))
+
+    def test_proxy_strips_crlf_from_forwarded_response_headers(self):
+        body = b"proxied"
+
+        class FakeResponse:
+            status = 200
+            reason = "OK\r\nX-Status-Injected: evil"
+
+            def __init__(self):
+                self._pending = body
+
+            def getheaders(self):
+                return [
+                    ("Content-Length", str(len(body))),
+                    ("X-Test", "value\r\nX-Injected: evil"),
+                ]
+
+            def read(self, _amount=-1):
+                chunk, self._pending = self._pending, b""
+                return chunk
+
+        class FakeConnection:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def request(self, *_args, **_kwargs):
+                pass
+
+            def getresponse(self):
+                return FakeResponse()
+
+            def close(self):
+                pass
+
+# Patching http.client.HTTPConnection is global, so read the raw response
+        # over a socket instead of urllib (which would use the fake too).
+        with mock.patch(
+            "credential_proxy.http.client.HTTPConnection", FakeConnection
+        ):
+            with socket.create_connection(
+                ("127.0.0.1", self.proxy.server_port), timeout=10
+            ) as sock:
+                sock.sendall(
+                    b"GET /health HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Authorization: Bearer external-secret\r\n"
+                    b"Connection: close\r\n\r\n"
+                )
+                raw = b""
+                while chunk := sock.recv(4096):
+                    raw += chunk
+
+        self.assertTrue(raw.endswith(body))
+        # The CRLF-carrying value is folded onto a single header line...
+        self.assertIn(b"X-Test: valueX-Injected: evil\r\n", raw)
+        # ...so nothing injected appears as its own header or in the status line.
+        self.assertNotIn(b"\r\nX-Injected:", raw)
+        self.assertNotIn(b"\r\nX-Status-Injected:", raw)
 
 
 class PolicyTest(unittest.TestCase):

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -72,6 +72,14 @@ class AgentAPIProxyTest(unittest.TestCase):
         self.assertEqual(401, raised.exception.code)
         self.assertEqual("", self.received_authorization)
 
+    def test_sanitizes_crlf_in_forwarded_headers(self):
+        dirty = "value\r\nX-Injected: evil"
+        self.assertEqual(
+            "valueX-Injected: evil",
+            AgentAPIProxyHandler._sanitize_header(dirty),
+        )
+        self.assertEqual("clean", AgentAPIProxyHandler._sanitize_header("clean"))
+
 
 class PolicyTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning [alert #9](https://github.com/gke-labs/kube-agents/security/code-scanning/9) (`py/http-response-splitting`, CWE-113/79, severity: error/medium).

`AgentAPIProxyHandler._proxy` copied every upstream response header to the downstream client via `send_header(name, value)` with no CR/LF filtering. Since `BaseHTTPRequestHandler.send_header` neither strips nor rejects `\r`/`\n`, a header name or value containing CRLF could inject extra headers or split the response body (header injection / cache poisoning / XSS).

## Changes

- Add `AgentAPIProxyHandler._sanitize_header` that strips `\r`/`\n`, matching CodeQL's recommended pattern.
- Route both header name and value through it in the response-forwarding loop.
- Add `test_sanitizes_crlf_in_forwarded_headers` covering the helper.

## Verification

- `python3 -m py_compile agents/platform/scripts/credential_proxy.py` — clean.
- `python3 -m unittest test_credential_proxy` — 22 tests pass.

The alert should auto-resolve once the CodeQL Python analysis re-runs after merge.