### PR TITLE
fix(security): sanitize http headers to prevent response splitting

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -117,7 +117,9 @@ class AgentAPIProxyHandler(BaseHTTPRequestHandler):
                     "transfer-encoding",
                     "upgrade",
                 }:
-                    self.send_header(name, value)
+                    safe_name = name.replace("\n", "").replace("\r", "").replace(":", "")
+                    safe_value = value.replace("\n", "").replace("\r", "")
+                    self.send_header(safe_name, safe_value)
             self.send_header("Connection", "close")
             self.end_headers()
             response_started = True


### PR DESCRIPTION

# Pull Request

## Why This Change

Addresses the HTTP Response Splitting vulnerability (CodeQL Alert #9) in the credential proxy. Unsanitized headers returned from an upstream were being reflected directly to the client.

## What Changed

**Files:**
- `agents/platform/scripts/credential_proxy.py`

**Added/Changed/Fixed:**
- Removed CRLF (`\r`, `\n`) and colon (`:`) characters from HTTP response headers before transmitting them to the client. 

## Why This Matters

- Prevents malicious entities from manipulating HTTP headers to inject arbitrary ones or affect the HTTP response body (mitigating XSS or Cache Poisoning risks).

## Context

Addresses Code Scanning Alert #9.

## Testing

- Verified that all unit tests (`pytest agents/platform/scripts/test_credential_proxy.py`) still pass.
- Verified logic properly scrubs problematic characters.

---

Mitigates a medium severity vulnerability with no expected impact on benign proxy operations.
