### PR TITLE
docs: verify docs site against code and remove inaccuracies

### DIFF
--- a/docs/site/src/content/docs/concepts/autonomous-watchdogs.md
+++ b/docs/site/src/content/docs/concepts/autonomous-watchdogs.md
@@ -7,6 +7,8 @@ sidebar:
 
 `agents/platform/cron/jobs.json` defines the scheduled jobs. Each one fires a pre-authored prompt at the Platform Agent on a cron schedule. The prompts typically point at a [governance SOP](/kube-agents/concepts/governance-sops/); the agent reads the SOP, executes the procedure, and either files a PR (via `submit-suggestion`) or posts a proactive Chat alert.
 
+Watchdog runs execute autonomously: the agent config sets `approvals.cron_mode: approve` (see `deploy/shared/defaults/config.yaml`), so commands that would otherwise require human approval run without prompting when triggered by a scheduled job.
+
 Full JSON is annotated on [Reference → Cron jobs](/kube-agents/reference/cron-jobs/).
 
 ## The shipping jobs
@@ -54,11 +56,7 @@ Each job in `jobs.json` follows this schema:
 
 ## Recent changes
 
-- [PR #354 — `fix(cron): reduce github issue resolver execution frequency`](https://github.com/gke-labs/kube-agents/pull/354) — reduced from a more aggressive schedule to every 30 minutes to lower LLM cost and Chat noise.
-- [PR #356 — daily fleet health digest at 13:00 UTC](https://github.com/gke-labs/kube-agents/pull/356) — adds a new job that emits a daily digest of the day's findings.
-- [PR #347 — `gke-node-problem-detector` skill + 15m watchdog](https://github.com/gke-labs/kube-agents/pull/347) — adds a 15-minute node-health watchdog.
-
-Both PR #356 and PR #347 are unmerged as of this writing. When they land, the table above will need updating.
+- [PR #354 — `fix(cron): reduce github issue resolver execution frequency`](https://github.com/gke-labs/kube-agents/pull/354) — reduced the `github-issue-resolver` cadence to every 30 minutes (`*/30 * * * *`) to lower LLM cost and Chat noise.
 
 ## Disabling a watchdog
 

--- a/docs/site/src/content/docs/concepts/chatops.md
+++ b/docs/site/src/content/docs/concepts/chatops.md
@@ -5,18 +5,22 @@ sidebar:
   order: 2
 ---
 
-Chat is the Platform Agent's primary interface — for both requests from humans and proactive alerts from cron watchdogs. The channels shipping today are **Google Chat** (default, fully wired, E2E tested) and **Slack** (opt-in via `SLACK_ENABLED=true` during provisioning). Both terminate at the same Platform Agent Deployment, so a user only sees one agent regardless of channel.
+Chat is the Platform Agent's primary interface — for both requests from humans and proactive alerts from cron watchdogs. The channels shipping today are **Google Chat** (the reference channel, fully wired and E2E tested; enable with `GOOGLE_CHAT_ENABLED=true` during provisioning) and **Slack** (enable with `SLACK_ENABLED=true` during provisioning). Both are opt-in and default to disabled, and both terminate at the same Platform Agent Deployment, so a user only sees one agent regardless of channel.
 
 ## Google Chat
 
-Google Chat is the default channel. Setup is automated by the provisioner (`provision_05_gcp_gchat.sh`).
+Google Chat is the reference channel. Setup is automated by the provisioner (`provision_05_gcp_gchat.sh`), which runs when `GOOGLE_CHAT_ENABLED=true`.
 
 ### How it's wired
 
 - A **Pub/Sub topic** and **subscription** are created in the target GCP project.
 - Your Google Chat app (configured separately in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com)) publishes events to the topic.
 - The Platform Agent pod runs the `platform_control` MCP server, which consumes the subscription.
-- Environment variables `GOOGLE_CHAT_PROJECT_ID` and `GOOGLE_CHAT_SUBSCRIPTION_NAME` are wired into `config.yaml`.
+- Environment variables `GOOGLE_CHAT_PROJECT_ID` and `GOOGLE_CHAT_SUBSCRIPTION_NAME` are wired into `config.yaml` (on the `platform_control` MCP server).
+
+### Allowed users
+
+Google Chat ingress can be gated by `GOOGLE_CHAT_ALLOWED_USERS` (a comma-separated list of user emails, collected by the provisioner as `ALLOWED_USERS`). Leaving it empty allows all users — the operator sets `GOOGLE_CHAT_ALLOW_ALL_USERS=true` in that case.
 
 ### What it looks like end to end
 
@@ -46,7 +50,7 @@ Slack is opt-in. Configure with `SLACK_ENABLED=true` during provisioning; the pr
 
 ### Allowed users
 
-Slack ingress is gated by `SLACK_ALLOWED_USERS` (a comma-separated list of Slack user IDs). Messages from users not on the list are silently ignored — a per-channel allowlist for the harness.
+Slack ingress is gated by `SLACK_ALLOWED_USERS` (a comma-separated list of Slack user IDs). Messages from users not on the list are silently ignored — a per-channel allowlist for the harness. Leaving it empty allows all users (the operator sets `SLACK_ALLOW_ALL_USERS=true` in that case).
 
 ### Home channel
 
@@ -56,7 +60,7 @@ Slack ingress is gated by `SLACK_ALLOWED_USERS` (a comma-separated list of Slack
 
 The Platform Agent doesn't only reply to messages. When a cron watchdog finds something worth surfacing (a security patch is available, a PR was opened, a cluster is drifting from blueprint), it posts to the configured Chat channel unprompted:
 
-- **Google Chat**: to the space that owns the interaction, or a configured monitoring space.
+- **Google Chat**: to the space that owns the interaction, or the space set via `GOOGLE_CHAT_HOME_CHANNEL`.
 - **Slack**: to `SLACK_HOME_CHANNEL`.
 
 See [Proactive autonomy](/kube-agents/overview/proactive-autonomy/) for what triggers these alerts and [Autonomous watchdogs](/kube-agents/concepts/autonomous-watchdogs/) for the schedules.

--- a/docs/site/src/content/docs/concepts/declarative-workflow.md
+++ b/docs/site/src/content/docs/concepts/declarative-workflow.md
@@ -18,16 +18,15 @@ The Platform Agent's `SOUL.md` forbids direct infrastructure mutations. When the
 
 Source: [`agents/platform/skills/submit-suggestion/`](https://github.com/gke-labs/kube-agents/tree/main/agents/platform/skills/submit-suggestion).
 
-The agent invokes this skill whenever an SOP or on-request task decides "propose a change". The skill:
+The agent invokes this skill whenever an SOP or on-request task decides "propose a change". The agent works inside the GitOps repo checkout (whose URL it resolves on startup from `/opt/data/SETTINGS.md`, per `SOUL.md §1`). The flow:
 
-1. Reads the target GitOps repo URL from `/opt/data/SETTINGS.md` (the dynamic per-install setting).
-2. Clones the repo (or uses a cached checkout) into a working directory.
-3. Applies the change (file writes, YAML patches).
-4. Creates a topic branch, commits, and pushes.
-5. Opens a PR against the repo's default branch using the GitHub App identity minted by Minty.
-6. Returns the PR URL to the agent, which posts it to Chat.
+1. Starts from an up-to-date default branch (`git checkout main && git pull origin main`).
+2. Creates a topic branch named `platform-agent/<change_type>-<target_id>` (e.g. `platform-agent/upgrade-policy-baseline`).
+3. Applies the change (file writes, YAML patches), then stages **only** the specific files it edited — `git add .` / `git add -A` are explicitly forbidden — and commits using Conventional Commit messages.
+4. Runs the packaged helper `./skills/submit-suggestion/scripts/submit_suggestion.py --branch … --title … --body …`, which mints a fresh GitHub App token (via `github_token_refresh.py`), pushes the branch, and opens a PR against `main` with `gh pr create`.
+5. The script prints the PR URL to stdout; the agent posts it to Chat.
 
-The skill body also defines commit-message conventions, PR-body structure, and safety red lines (e.g. no changes outside the declared scope of the invoking SOP).
+Safety red lines enforced by the skill: direct/manual cluster mutations are forbidden, blanket staging (`git add .`) is refused, and `submit_suggestion.py` hard-blocks force-pushes to the protected branches `main`, `master`, and `production`.
 
 ## Minty (GitHub Token Minter)
 
@@ -38,21 +37,24 @@ Minty is a small in-cluster service that brokers GitHub App installation tokens 
 ### How it works
 
 1. A GitHub App is created (once, by you) with the needed permissions (`contents:write`, `pull_requests:write`) and installed on the target repo.
-2. The App's private key is wrapped in a **GCP KMS key** (created by `provision_10_deploy_github_minter.sh`) — the raw key material never lives outside KMS.
-3. When `submit-suggestion` needs a token, it calls Minty via the agent's Workload Identity.
-4. Minty asks KMS to sign a JWT with the wrapped private key.
-5. Minty exchanges the JWT with GitHub for a **1-hour installation token**.
+2. The App's private key is imported into a **GCP KMS asymmetric signing key** (keyring `github-token-minter-keyring`, key `github-token-minter-key`, created by `provision_10_deploy_github_minter.sh`) — the raw key material never lives outside KMS.
+3. When `submit-suggestion` needs a token, the credential broker calls Minty (default endpoint `http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token`) using the agent's Workload Identity.
+4. Minty asks KMS to sign a JWT with the imported private key.
+5. Minty exchanges the JWT with GitHub for a **short-lived installation token scoped to the target repository**.
 6. Minty returns the token to the caller.
 
 ### Recovery
 
-If a git operation fails with an auth error (expired token, revoked installation), `SOUL.md §4` requires the agent to run:
+If a git operation fails with an auth error (e.g. `fatal: Authentication failed`, `could not read Username`), `SOUL.md §4` requires the agent to run the packaged token refresher:
 
 ```bash
+# outside a git repo
 ./scripts/github_token_refresh.py <owner>/<repo>
+# inside a git repo (repo inferred from remote.origin.url)
+./scripts/github_token_refresh.py
 ```
 
-which triggers a fresh mint from Minty and caches it. The recovery ladder (§5) retries the failed op up to 5 times before escalating.
+which triggers a fresh mint from Minty and caches it, then retries the command. The recovery ladder (`§5`) caps retries at **5 iterations or ~10 minutes per distinct blocker** before escalating.
 
 ## Complementary integrations
 

--- a/docs/site/src/content/docs/concepts/governance-sops.md
+++ b/docs/site/src/content/docs/concepts/governance-sops.md
@@ -19,19 +19,19 @@ Invoked by the [`blueprint-sync`](/kube-agents/concepts/autonomous-watchdogs/) w
 
 ### `compliance_audit_sop.md`
 
-Fleet-wide security and architectural policy sweep. Verifies namespaces have `NetworkPolicy`, `ResourceQuota`, and workload-identity bindings; checks pods for privileged escalation, disallowed capabilities, and unpatched CVEs.
+Fleet-wide security and architectural policy sweep. Verifies every namespace (outside `kube-system` and `cnrm-system`) has an active `NetworkPolicy`, flags any container running `privileged: true`, and audits RBAC for over-privileged bindings (non-system service accounts granted `cluster-admin` or wildcard `*` grants).
 
 Invoked by the [`compliance-audit`](/kube-agents/concepts/autonomous-watchdogs/) watchdog weekly on Sunday 09:00.
 
 ### `fleet_wide_cost_analysis_sop.md`
 
-Aggregate cost data across clusters (via BigQuery cost export). Surface right-sizing candidates, idle allocations, and expensive Spot fallback events. The `gke-cost-analysis` skill provides the query surface.
+Aggregates node instance types, pricing models (Spot vs. on-demand), and resource requests across the fleet. Surfaces right-sizing candidates, idle capacity (nodes whose aggregate Pod requests are below 40% of node capacity), and stateless workloads that could move to Spot VMs, and publishes a daily cost-delta report.
 
 Invoked by the [`fleet-wide-cost-analysis`](/kube-agents/concepts/autonomous-watchdogs/) watchdog daily at 10:00.
 
 ### `global_capacity_orchestrator_sop.md`
 
-Hourly cross-cluster utilization audit. Identifies hot regions and cold regions; proposes rebalancing (moving workloads, adjusting HPA, changing compute classes) via the declarative workflow.
+Hourly cross-cluster utilization audit. Flags clusters above 85% aggregate CPU/memory utilization (exhaustion risk) and below 30% (waste), then recommends `ComputeClass` adjustments and cross-region workload shifts, delivered as a fleet resource-map report.
 
 Invoked by the [`global-capacity-orchestrator`](/kube-agents/concepts/autonomous-watchdogs/) watchdog hourly.
 
@@ -43,35 +43,35 @@ Invoked by the [`lifecycle-deprecation-manager`](/kube-agents/concepts/autonomou
 
 ### `obtainability_audit_sop.md`
 
-Daily audit for rigid capacity allocations — pods that pin to a specific machine type when a `ComputeClass` would give them flexibility. Auto-generates YAML patches to migrate workloads onto flexible capacity pools.
+Daily audit for rigid capacity allocations — workloads that pin to a specific node hostname or zone via `nodeSelector`, and deployments with more than three replicas that lack a `HorizontalPodAutoscaler`. Auto-generates YAML patches that swap static selectors for `ComputeClass` tolerations and add the missing HPAs.
 
 Invoked by the [`obtainability-audit`](/kube-agents/concepts/autonomous-watchdogs/) watchdog daily at 12:00.
 
 ### `policy_propagation_sop.md`
 
-Hourly push of updated platform default policies (`NetworkPolicy`, `PodSecurityStandards`, `ResourceQuota`) across clusters and namespaces. Reconciles any drift where a namespace lost a required default.
+Hourly propagation of platform default policies. Reads the baseline `NetworkPolicy` and `ResourceQuota` templates from `/opt/defaults/templates/` and verifies they are active across clusters and namespaces, reconciling any drift where a namespace lost a required default.
 
 Invoked by the [`policy-propagation`](/kube-agents/concepts/autonomous-watchdogs/) watchdog hourly.
 
 ### `security_patch_orchestrator_sop.md`
 
-Daily CVE scan against node OS and workload images. Coordinates staggered emergency GKE upgrade rollouts (canary, then rolling) when critical CVEs land. Escalates for human confirmation before triggering any upgrade.
+Daily audit of GKE control plane and node versions against the latest available security patches (queried via `gcloud container get-server-config`). When a critical upgrade is required it proposes a staggered rollout — dev/staging cluster first, then production once the dev change is merged and healthy — as GitHub PRs via `submit-suggestion`, never applying upgrades directly.
 
 Invoked by the [`security-patch-orchestrator`](/kube-agents/concepts/autonomous-watchdogs/) watchdog daily at 11:00.
 
 ### `standardization_validator_sop.md`
 
-Weekly deep-diff of live cluster configuration against corporate architectural patterns. Beyond compliance (which is pass/fail on discrete rules), this looks at higher-order shape: are workloads structured consistently, are namespaces named per convention, are IAM patterns uniform.
+Weekly deep-diff of live cluster configuration against corporate architectural patterns. Verifies that deployments and services carry the standard metadata labels (`app.kubernetes.io/name`, `owner`, `environment`), and flags any dev-namespace Service exposing a public external LoadBalancer IP without the `platform.harness.io/public-exposition-approved: "true"` annotation.
 
 Invoked by the [`standardization-validator`](/kube-agents/concepts/autonomous-watchdogs/) watchdog weekly on Sunday 10:00.
 
 ## How SOPs work
 
-Each SOP is a Markdown file with a small number of sections (loose convention, not enforced):
+Each SOP is a Markdown file that opens with a `**Purpose:**` line and then a single `## Execution Checklist` broken into numbered steps (loose convention, not enforced). The steps typically cover:
 
-1. **Scope** — which clusters, namespaces, or resource kinds the SOP covers.
-2. **Procedure** — the exact diagnostic queries the agent should run and what to look for.
-3. **Remediation policy** — what to do with findings (open a PR, post to Chat, both).
+1. **Target selection** — which clusters, namespaces, or resource kinds the SOP audits (usually "retrieve the active GKE clusters list directly using native GKE monitoring and read-only tools").
+2. **Audit rules** — the exact diagnostic queries the agent runs and the policy thresholds that constitute a violation.
+3. **Remediation / reporting** — what to do with findings: file a PR via `submit-suggestion`, or emit a report or Chat alert.
 
 The cron watchdog invokes the SOP by prompting the agent to "read `/opt/defaults/governance/<sop>.md` and execute". The SOP is loaded once, executed, and the run terminates when the SOP's completion criteria are met.
 
@@ -80,7 +80,7 @@ The cron watchdog invokes the SOP by prompting the agent to "read `/opt/defaults
 - A **skill** is a reusable capability (how to onboard an app, how to submit a PR, how to query costs).
 - An **SOP** composes skills into a fleet-wide procedure with a policy for when to act.
 
-`fleet_wide_cost_analysis_sop.md` uses the `gke-cost-analysis` skill; `security_patch_orchestrator_sop.md` uses `gke-cluster-lifecycle`; `blueprint_sync_sop.md` uses `submit-suggestion` for its remediation step.
+`blueprint_sync_sop.md` and `security_patch_orchestrator_sop.md` both call `submit-suggestion` to turn their findings into GitHub PRs. The remaining SOPs deliver their findings as reports or Chat alerts rather than invoking a named skill, and none preload skills via the cron job entry (every governance job ships with `"skills": []`).
 
 ## Where to go next
 

--- a/docs/site/src/content/docs/concepts/inference-gateway.md
+++ b/docs/site/src/content/docs/concepts/inference-gateway.md
@@ -62,7 +62,7 @@ This rewrites the LiteLLM `ConfigMap` and rolls the gateway; the agent picks up 
 
 ## vLLM (local models)
 
-[vLLM](https://vllm.ai) serves open models with server-side batching and speculative decoding for high throughput on GPU node pools.
+[vLLM](https://vllm.ai) serves open models with continuous batching, chunked prefill, and prefix caching for high throughput on GPU node pools.
 
 ### What ships
 
@@ -72,7 +72,7 @@ vLLM speaks OpenAI-compatible Completions, so LiteLLM can be layered on top (or 
 
 ## Inference replay
 
-[`examples/inference-replay/`](https://github.com/gke-labs/kube-agents/tree/main/examples/inference-replay) is a small proxy that sits between the Platform Agent and LiteLLM. Requests are keyed by prompt hash; hits return the cached response, misses forward to LiteLLM and cache the reply.
+[`examples/inference-replay/`](https://github.com/gke-labs/kube-agents/tree/main/examples/inference-replay) is a small proxy that sits between the Platform Agent and LiteLLM. Requests are keyed by a SHA-256 hash of the canonicalized request body (messages plus params); hits return the cached response, misses forward to LiteLLM and cache the reply.
 
 ### Modes
 
@@ -97,7 +97,7 @@ Deploy it as part of the provisioner by setting `INFERENCE_REPLAY_ENABLED=true`.
 
 ## What the agent doesn't care about
 
-The Platform Agent's config (`agents/platform/config.yaml`) doesn't mention the LLM provider. Provider selection is entirely at the LiteLLM / vLLM layer — the agent talks to whatever the `litellm` (or `litellm-gateway`, when the replay proxy is present) Service resolves to. That means:
+The Platform Agent's config (`agents/platform/config.yaml`) doesn't mention the LLM provider. Provider selection is entirely at the LiteLLM / vLLM layer — the agent always talks to the `litellm` Service, and provisioning decides what that Service resolves to. When the replay proxy is deployed, the `litellm` Service is repointed at the replay proxy and the original LiteLLM pods are re-exposed through a new `litellm-gateway` Service that the proxy forwards cache misses to. That means:
 
 - Swapping Gemini for Anthropic is a LiteLLM `ConfigMap` change.
 - Turning on replay is a `INFERENCE_REPLAY_ENABLED=true` reprovision.

--- a/docs/site/src/content/docs/concepts/observability.md
+++ b/docs/site/src/content/docs/concepts/observability.md
@@ -5,15 +5,16 @@ sidebar:
   order: 8
 ---
 
-The Platform Agent Deployment, LiteLLM, and vLLM all export OpenTelemetry traces and Prometheus metrics to GKE Managed telemetry. Container logs go to Cloud Logging. The Platform Agent's persona also generates Cloud Console links inline in Chat replies whenever it's discussing telemetry.
+The Platform Agent (Hermes) Deployment exports OpenTelemetry traces, and LiteLLM and vLLM export both OpenTelemetry traces and Prometheus metrics to GKE Managed telemetry. Container logs go to Cloud Logging. The Platform Agent's persona also generates Cloud Console links inline in Chat replies whenever it's discussing telemetry.
 
 ## What gets exported
 
 ### Prometheus metrics
 
-- **LiteLLM** — request latency, per-model token counts, error rates. Scraped by GKE Managed Prometheus.
-- **vLLM** — GPU utilization, KV cache hit rate, per-request latency histograms. Scraped by GKE Managed Prometheus.
-- **Hermes runtime** — session count, tool-call rate, LLM turn latency. Exposed via the `hermes_otel` plugin.
+- **LiteLLM** — request latency, per-model token counts, error rates on its `/metrics` endpoint (port 4000). Scraped by GKE Managed Prometheus via the `litellm-monitoring` `PodMonitoring` shipped in the LiteLLM integration base (`k8s-operator/config/integrations/litellm/base/podmonitoring.yaml`).
+- **vLLM** — per-request latency histograms, queue depth, and GPU/KV-cache stats when running local models on GPU node pools. Exposed on its own `/metrics` endpoint and scraped by GKE Managed Prometheus.
+
+The Platform Agent (Hermes) Deployment does **not** expose a Prometheus `/metrics` endpoint — it serves only the API (`8642`) and Dashboard (`9119`) ports. Its runtime signals surface as OpenTelemetry traces (below) and `tool_call_audit` log records; pod-level CPU/memory is available through the Kubernetes metrics API (`kubectl top`). The `event-watcher` sidecar can expose watcher metrics (`k8s_event_watcher_*`) via a `--metrics-addr` flag, but this is disabled by default in the shipping deploy.
 
 ### OpenTelemetry traces
 
@@ -23,7 +24,7 @@ The Platform Agent Deployment, LiteLLM, and vLLM all export OpenTelemetry traces
 
 ### Cloud Logging
 
-All container `stdout`/`stderr` is ingested by Cloud Logging. Cluster and pod labels flow through automatically.
+All container `stdout`/`stderr` is ingested by Cloud Logging by the GKE log agent. Cluster and pod labels flow through automatically. The Platform Agent writes its own logs to files under `/opt/data/logs/*.log`; a `fluent-bit` sidecar tails that shared volume and streams the lines to stdout so they reach Cloud Logging alongside every other container.
 
 ## Session metadata plumbing
 

--- a/docs/site/src/content/docs/concepts/platform-agent.md
+++ b/docs/site/src/content/docs/concepts/platform-agent.md
@@ -15,7 +15,7 @@ The Platform Agent is a single autonomous agent with a defined role — **Platfo
 - **Security through strict separation.** Tenant isolation is non-negotiable — namespaces, RBAC, `NetworkPolicy`, `ResourceQuota`. A workload is physically constrained to its allocated namespace.
 - **Least privilege.** The agent's identity has fleet-wide read via the Kubernetes MCP server plus narrow write scoped to its own agent-identity Custom Resources. No general infrastructure write.
 - **Autonomous recovery.** Retries transient auth/IAM/identity failures via a bounded ladder (5 iterations or ~10 minutes per distinct blocker) before escalating to a human.
-- **User intent priority.** "Fix it for me", "just do it", "loop until done" are permission-granting phrases — the agent proceeds without confirmation. Destructive or irreversible operations (cluster deletion, tenant offboarding, broad IAM revocation) still require explicit human sign-off no matter what phrasing is used.
+- **User intent priority.** "Fix it for me", "directly", "do it", "loop until done" are permission-granting phrases — the agent proceeds without confirmation. Destructive or irreversible operations (cluster deletion, tenant offboarding, broad IAM revocation) still require explicit human sign-off no matter what phrasing is used.
 - **Proactive stance.** The agent doesn't wait to be asked. It surfaces drift, version skew, security baseline violations, IaC/live divergence, and policy gaps — and proposes fixes through the declarative workflow.
 
 ## Runtime wiring
@@ -43,9 +43,10 @@ Both include `hermes-cli`/`hermes-api-server` plus `mcp-agent_common`, `mcp-plat
 ### Plugins
 
 - `hermes_otel` — OpenTelemetry export to the GKE Managed OTel collector.
-- `session_store` — durable session state.
-- `session_otel_bridge` — annotates spans with session context.
-- `tool_call_audit` — writes tool-call telemetry for audit and debug.
+- `session_store` — persists gateway session metadata for cross-agent attribution.
+- `session_otel_bridge` — annotates Hermes OTel spans with session metadata from `session_kv.db`.
+- `tool_call_audit` — logs every tool call and approval decision to stdout as a structured audit trail.
+- `incident_context` — injects Kubernetes incident context into known chat threads on reply.
 
 ## Behavioral shape
 

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -27,38 +27,45 @@ This project follows [Google's Open Source Community Guidelines](https://opensou
 
 Before pushing, run the checks CI enforces:
 
-- **Prettier** on changed Markdown, JSON, YAML:
+- **Prettier** on changed Markdown and YAML (what the `Prettier Check` CI job enforces — it checks changed `.md`/`.yaml`/`.yml` files):
 
   ```bash
-  npx prettier --write <files>
-  # or, from k8s-operator/:
+  # format all Markdown/YAML in the repo (root Makefile target)
   make prettier-write
+  # or target specific files
+  npx prettier --write <files>
   ```
 
   Check without modifying:
 
   ```bash
-  npx prettier --check .
+  make prettier-check
+  ```
+
+- **Repo structure validation** (the `Validate Repo Structure` CI job runs this on every PR):
+
+  ```bash
+  make validate   # fails if skills live under agents/*/defaults/skills/ instead of agents/*/skills/
   ```
 
 - **Docker build** (if you touched the platform-agent image):
 
   ```bash
-  docker build -f deploy/docker/Dockerfile --target platform .
+  # from the repo root; supplies the required HERMES_AGENT_TAG (from tags.env) and builds --target platform, matching the Docker Build CI job
+  make docker-build-platform
   ```
 
 - **Operator compile + test** (if you touched `k8s-operator/`):
 
   ```bash
-  cd k8s-operator
-  make       # runs generate, manifests, fmt, vet, test, build
+  make -C k8s-operator test   # runs manifests, generate, fmt, vet, then go test — this is what the Operator Tests CI job runs
   ```
 
 - **Docs build** (if you touched `docs/site/`):
 
   ```bash
   cd docs/site
-  npm install
+  npm ci
   npm run build
   ```
 

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -13,7 +13,7 @@ Published on push to `main` via GitHub Actions workflows.
 
 ### `platform-agent`
 
-The Platform Agent Deployment image. Built from [`deploy/docker/Dockerfile`](https://github.com/gke-labs/kube-agents/blob/main/deploy/docker/Dockerfile) on top of `nousresearch/hermes-agent` with the Platform Agent workspace, GCP tools, and `kubectl` layered in.
+The Platform Agent Deployment image. Built from the `platform` target of [`deploy/docker/Dockerfile`](https://github.com/gke-labs/kube-agents/blob/main/deploy/docker/Dockerfile) on top of `nousresearch/hermes-agent` with the Platform Agent workspace, GCP tools, and `kubectl` layered in.
 
 - **Registry**: `ghcr.io/gke-labs/kube-agents/platform-agent`
 - **Published by**: [`.github/workflows/docker-publish-ghcr.yml`](https://github.com/gke-labs/kube-agents/blob/main/.github/workflows/docker-publish-ghcr.yml)
@@ -23,7 +23,24 @@ The Dockerfile installs system tooling the Platform Agent needs to inspect and r
 
 - `google-cloud-cli` + `google-cloud-cli-gke-gcloud-auth-plugin`
 - `kubectl`
-- Standard debugging tools: `curl`, `jq`, `dnsutils`, `iputils-ping`, `patch`, `git`
+- `gh` (GitHub CLI), `yq`, `k9s`, `helm`
+- Standard debugging tools: `curl`, `jq`, `dnsutils`, `iputils-ping`, `patch`, `git`, `wget`, `nano`, `vim`
+
+It also builds the `k8s-event-watcher` binary from `k8s-operator/cmd/k8s-event-watcher/` in a Go builder stage and copies it into the image.
+
+### `credential-proxy`
+
+The Platform Agent image plus the Envoy-based credential proxy sidecar runtime. Built from the `credential-proxy` target of the same [`deploy/docker/Dockerfile`](https://github.com/gke-labs/kube-agents/blob/main/deploy/docker/Dockerfile) (it extends the `platform` target with the `envoy` binary and credential-proxy scripts).
+
+- **Registry**: `ghcr.io/gke-labs/kube-agents/credential-proxy`
+- **Published by**: [`docker-publish-ghcr.yml`](https://github.com/gke-labs/kube-agents/blob/main/.github/workflows/docker-publish-ghcr.yml) and [`docker-publish-gcp.yml`](https://github.com/gke-labs/kube-agents/blob/main/.github/workflows/docker-publish-gcp.yml)
+
+### `replay-proxy`
+
+The inference replay proxy used for record/replay of model traffic. Built from [`examples/inference-replay/replay-proxy/Dockerfile`](https://github.com/gke-labs/kube-agents/blob/main/examples/inference-replay/replay-proxy/Dockerfile).
+
+- **Registry**: `ghcr.io/gke-labs/kube-agents/replay-proxy`
+- **Published by**: [`docker-publish-ghcr.yml`](https://github.com/gke-labs/kube-agents/blob/main/.github/workflows/docker-publish-ghcr.yml) and [`docker-publish-gcp.yml`](https://github.com/gke-labs/kube-agents/blob/main/.github/workflows/docker-publish-gcp.yml)
 
 ### `k8s-operator`
 
@@ -38,7 +55,7 @@ The Kubebuilder-generated operator manager image.
 The Hermes base image tag is pinned in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) at the repo root:
 
 ```bash
-HERMES_AGENT_TAG=v2026.7.7.2@sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973
+HERMES_AGENT_TAG=v2026.7.20@sha256:a6ce64e2038867885c2c90f6602425e6e70293d5e6d952a0e603a99265e01c40
 ```
 
 Docker builds source `tags.env` via the `HERMES_AGENT_TAG` build arg:

--- a/docs/site/src/content/docs/deploy/kustomize.md
+++ b/docs/site/src/content/docs/deploy/kustomize.md
@@ -20,6 +20,8 @@ deploy/
 │       └── service.yaml        # ClusterIP Service for the Platform Agent
 └── shared/
     ├── docker-entrypoint.sh
+    ├── envoy-credential-proxy.yaml
+    ├── envoy-credential-sidecar.sh
     └── defaults/config.yaml
 ```
 
@@ -60,8 +62,8 @@ The exposed ports:
 - `config/webhook/` — admission webhook config (validating + mutating).
 - `config/manager/` — Deployment for the controller manager.
 - `config/integrations/github/` — Minty deployment.
-- `config/integrations/litellm/` — LiteLLM Deployment + Service.
-- `config/integrations/inference-replay/` — replay proxy Deployment + PVC.
+- `config/integrations/litellm/` — LiteLLM Deployment + Service (plus `NetworkPolicy`, `PodMonitoring`, and a `chatgpt` overlay).
+- `config/integrations/inference-replay/` — replay proxy Deployment, Service, and PVC.
 
 Deploy these via `make deploy-*` from `k8s-operator/`:
 
@@ -74,4 +76,4 @@ make deploy-inference-replay    # replay proxy
 
 ## What's coming (not merged)
 
-[PR #353](https://github.com/gke-labs/kube-agents/pull/353) proposes a Helm chart at `deploy/helm/platform-agent/` as a higher-level packaging option. When it lands, this page will document both surfaces.
+[PR #230](https://github.com/gke-labs/kube-agents/pull/230) proposes Infrastructure-as-Code deployment for the operator: a Terraform stack under `k8s-operator/deploy/terraform/` plus a Helm chart at `k8s-operator/deploy/helm/kube-agents/` that packages the operator, agents, LiteLLM, and secrets. When it lands, this page will document both surfaces.

--- a/docs/site/src/content/docs/deploy/telemetry.md
+++ b/docs/site/src/content/docs/deploy/telemetry.md
@@ -13,20 +13,20 @@ For what's exported and how the agent surfaces it in Chat replies, see [Concepts
 
 | Signal          | Producer                        | Collector                               | Destination      |
 | --------------- | ------------------------------- | --------------------------------------- | ---------------- |
-| Metrics         | LiteLLM, vLLM, Hermes           | GKE Managed Prometheus                  | Cloud Monitoring |
+| Metrics         | LiteLLM, vLLM                   | GKE Managed Prometheus                  | Cloud Monitoring |
 | Traces          | LiteLLM, vLLM, Hermes           | GKE OTel collector (`gke-managed-otel`) | Cloud Trace      |
 | Container logs  | All containers                  | GKE built-in log agent                  | Cloud Logging    |
-| Tool-call audit | Hermes `tool_call_audit` plugin | Cloud Logging                           | Cloud Logging    |
+| Tool-call audit | Hermes `tool_call_audit` plugin | GKE built-in log agent (via `stdout`)   | Cloud Logging    |
 
 ## GKE Managed Prometheus
 
-Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints; managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration's Kustomize base.
+Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints (LiteLLM on port 4000, vLLM on port 8000); managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration (the LiteLLM operator base at `k8s-operator/config/integrations/litellm/base/podmonitoring.yaml` and the vLLM example manifests under `examples/`).
 
 ## OpenTelemetry
 
-The Hermes runtime enables the `hermes_otel` plugin (`agents/platform/config.yaml`). It exports spans to the OTel collector Service in the `gke-managed-otel` namespace, which forwards to Cloud Trace.
+The Hermes runtime enables the `hermes_otel` plugin (`agents/platform/config.yaml`). Its trace backend is baked into the image, pointing spans at `http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces` (`deploy/docker/Dockerfile`), which forwards to Cloud Trace.
 
-LiteLLM and vLLM are configured (in their respective Kustomize bases) to export directly to the same collector — no per-component collector deploy.
+LiteLLM (via the `otel` callback and `OTEL_EXPORTER_OTLP_ENDPOINT`) and vLLM (via `--otlp-traces-endpoint`) are configured in their deployment manifests to export directly to the same collector — no per-component collector deploy.
 
 ## Cloud Logging
 

--- a/docs/site/src/content/docs/deploy/token-minter.md
+++ b/docs/site/src/content/docs/deploy/token-minter.md
@@ -13,7 +13,7 @@ Full README: [`k8s-operator/config/integrations/github/README.md`](https://githu
 ## How it works
 
 1. **Request.** The agent calls Minty via HTTP, specifying the target org and repo. The request is authenticated with the agent's Google Service Account OIDC token (via Workload Identity).
-2. **Verification.** Minty checks the request against local rules ([`configmap.yaml`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator/config/integrations/github)). It extracts the `email` claim from the OIDC token and verifies against `assertion.email`.
+2. **Verification.** Minty checks the request against local rules ([`configmap.yaml.template`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator/config/integrations/github)). It extracts the `email` claim from the OIDC token and verifies against `assertion.email`.
 3. **KMS signing.** Minty asks GCP KMS to sign a JWT with the GitHub App's private key. The raw key material never touches Minty.
 4. **Token exchange.** Minty exchanges the signed JWT with GitHub for a 1-hour installation access token.
 5. **Delivery.** Minty returns the token to the agent, which uses it for `git push` and PR-open operations.
@@ -30,7 +30,7 @@ Full README: [`k8s-operator/config/integrations/github/README.md`](https://githu
 
 ### Provisioning variables
 
-Add to `k8s-operator/scripts/vars.sh` (or answer the prompts when `provision_10_*` runs):
+Add to `k8s-operator/scripts/vars.sh` (or answer the prompts when `provision_04_gcp_iam.sh` runs):
 
 - `GITHUB_APP_ID` — numeric App ID.
 - `GITHUB_ORG` — org or user hosting the repo.
@@ -43,13 +43,23 @@ Add to `k8s-operator/scripts/vars.sh` (or answer the prompts when `provision_10_
 - **Auditable.** Every sign operation logs to Cloud Audit Logs.
 - **Rotatable without redeploy.** Import a new key version to KMS; Minty picks it up.
 
-The Minty CLI (`minty tools import-pk`) handles the KMS import — it deals with PKCS#1 to PKCS#8 conversion and RSA-OAEP wrapping automatically. Manual import via `gcloud kms keys versions import` would require you to do that yourself.
+The Minty CLI handles the KMS import — it deals with PKCS#1 to PKCS#8 conversion, provisions the KMS Import Job, and does RSA-OAEP wrapping automatically. The provisioner clones [`abcxyz/github-token-minter`](https://github.com/abcxyz/github-token-minter) at tag `v2.7.1` and runs `go run ./cmd/minty tools import-pk` (requires `go` on the provisioning host). Manual import via `gcloud kms keys versions import` would require you to do all of that yourself.
 
 ## GSA-only auth
 
 Native Kubernetes SA tokens don't carry the `repository` claim Minty's default validator expects, so Minty routes through **Google Service Account (GSA)** tokens instead. When the token issuer is `https://accounts.google.com`, Minty bypasses the `repository` claim check and validates on `assertion.email`, deriving the target repo from the POST body.
 
 That's why the provisioner (`provision_04_gcp_iam.sh`) pre-provisions GSAs and Workload Identity bindings — Minty won't accept KSA tokens.
+
+## Deployment details
+
+Names and values baked into the deployment templates ([`k8s-operator/config/integrations/github/`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator/config/integrations/github)):
+
+- **Kubernetes Service / Deployment:** `github-token-minter` (namespace `kubeagents-system`), listening on port `8080` with a `/version` health endpoint.
+- **Image:** `us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server:v2.7.1-amd64`, run as `/minty server run`.
+- **Kubernetes SA:** `kubeagents-github-minter`, Workload-Identity-bound to GSA `kubeagents-github-minter-gsa` (which holds `roles/cloudkms.signerVerifier` on the KMS key).
+- **Scope:** the ConfigMap rule exposes a `platform-agent-scope` scope granting `contents: write` and `pull_requests: write`; requests must pass this in the `scope` field.
+- The App ID is injected from the `github-app-credentials` Secret, and the KMS key reference (`projects/.../cryptoKeyVersions/<n>`) is resolved dynamically to the latest enabled version at provision time.
 
 ## Manual testing
 
@@ -58,21 +68,26 @@ kubectl run debug-box --rm -it \
   --image=curlimages/curl \
   --namespace=kubeagents-system \
   --serviceaccount=kubeagents-platform-agent \
+  --labels="app=platform-agent" \
   -- sh
 ```
 
-From inside the pod:
+The `app=platform-agent` label is required: Minty's `NetworkPolicy` only accepts ingress from pods carrying it.
+
+From inside the pod (the OIDC `audience` must match the Minty service URL, and the token is passed in the `X-OIDC-Token` header — not `Authorization`):
 
 ```sh
-TOKEN=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=minty" \
-  -H "Metadata-Flavor: Google")
-curl -X POST http://minty.kubeagents-system:8080/token \
-  -H "Authorization: Bearer $TOKEN" \
+AUDIENCE="http://github-token-minter.kubeagents-system.svc.cluster.local:8080"
+OIDC_TOKEN=$(curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=${AUDIENCE}&format=full")
+
+curl -i -X POST http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token \
   -H "Content-Type: application/json" \
-  -d '{"org":"<org>","repo":"<repo>"}'
+  -H "X-OIDC-Token: $OIDC_TOKEN" \
+  -d '{"org_name":"<org>","repositories":["<repo>"],"scope":"platform-agent-scope"}'
 ```
 
-A 200 response with a `token` field means the pipeline works end-to-end.
+A 200 response whose body is the short-lived GitHub installation token means the pipeline works end-to-end.
 
 ## Where to go next
 

--- a/docs/site/src/content/docs/install/helm-and-kind.md
+++ b/docs/site/src/content/docs/install/helm-and-kind.md
@@ -1,20 +1,30 @@
 ---
 title: Helm and Kind
-description: A Helm chart for the Platform Agent and a Kind-based local install are proposed but not yet merged.
+description: A Helm chart for kube-agents is proposed but not yet merged; a Kind-based local install does not exist yet.
 ---
 
-A Helm chart at `deploy/helm/platform-agent/` and a local development flow at `local-dev/setup-kind.sh` are proposed in [PR #353](https://github.com/gke-labs/kube-agents/pull/353) but not yet merged.
+A Helm chart for kube-agents is proposed in [PR #230](https://github.com/gke-labs/kube-agents/pull/230) ("k8s-operator IaC deployment with Terraform and Helm") but not yet merged. There is **no** Kind (or other local, non-GKE) install path in the repo or any open PR today.
+
+## Helm (proposed)
+
+- Chart path in the PR: `k8s-operator/deploy/helm/kube-agents/` (`Chart.yaml`, `values.yaml`, and templates for the operator, platform agent, LiteLLM, GitHub minter, RBAC, and secrets).
+- The chart is GKE/GCP-oriented: `values.yaml` expects `projectId`, `clusterName`, `clusterLocation`, and Workload Identity GSA emails, and it ships alongside a Terraform module (`k8s-operator/deploy/terraform/`) that populates those values. It is not a local/offline chart.
+- Operator and agent images default to `ghcr.io/gke-labs/kube-agents/k8s-operator` and `ghcr.io/gke-labs/kube-agents/platform-agent`.
+
+## Kind / local clusters
+
+No Kind script or local-cluster flow exists in the codebase yet. A scripted installer, [`scripts/quick-install.sh`](https://github.com/gke-labs/kube-agents/pull/353) (proposed in [PR #353](https://github.com/gke-labs/kube-agents/pull/353)), targets GKE Autopilot only — it can create or reuse a GKE cluster but does not support Kind.
 
 ## Track progress
 
-- [PR #353 — README overhaul + Helm + Kind](https://github.com/gke-labs/kube-agents/pull/353) — the umbrella change adding the chart and the Kind script.
-- Watch [`deploy/`](https://github.com/gke-labs/kube-agents/tree/main/deploy) and [`local-dev/`](https://github.com/gke-labs/kube-agents/tree/main/local-dev) for the artifacts once they land.
+- [PR #230 — k8s-operator IaC deployment with Terraform and Helm](https://github.com/gke-labs/kube-agents/pull/230) — adds the Helm chart and Terraform module.
+- Watch [`k8s-operator/deploy/`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator/deploy) for the chart once it lands.
 
 ## Install today
 
-Until those merge, use:
+Until the chart merges, use:
 
 - [Quick start (GKE)](/kube-agents/install/quickstart-gke/) — `./provision.sh` bootstraps GKE + operator + agent.
 - [Manual install](/kube-agents/install/manual/) — for other Hermes-compatible harnesses.
 
-This page will be rewritten when the chart and Kind flow are in `main`.
+This page will be rewritten when the Helm chart is in `main`.

--- a/docs/site/src/content/docs/install/manual.md
+++ b/docs/site/src/content/docs/install/manual.md
@@ -31,7 +31,8 @@ platform/
 ├── cron/jobs.json           # scheduled autonomous jobs
 ├── plugins/                 # in-tree Hermes plugins
 ├── defaults/                # hooks + plugin defaults
-└── scripts/                 # in-pod Python MCP server
+├── docs/                    # workspace docs (glossary, etc.)
+└── scripts/                 # in-pod Python MCP servers
 ```
 
 ## Step 2: Register the agent
@@ -44,22 +45,14 @@ Configure your harness to register a new agent named `platform`:
 - **Skills**: point the harness at `skills/` (the runtime discovers `SKILL.md` files automatically).
 - **Registration**: perform the platform-specific agent registration and reload/restart the harness if required.
 
-## Step 3: Configure the heartbeat
+## Step 3: Enable the scheduled watchdogs
 
-The Platform Agent expects a scheduled heartbeat for routine maintenance and drift detection. Configure a recurring task:
+The Platform Agent runs its routine maintenance and drift detection as autonomous governance jobs on cron schedules. These are defined in `cron/jobs.json`; each job fires a pre-authored prompt that points the agent at a [governance SOP](/kube-agents/concepts/governance-sops/) under `governance/`.
 
-- **Schedule**: every 1 minute (`* * * * *`)
-- **Target agent**: `platform`
-- **Message**:
+- If your harness has native cron support (Hermes does), the jobs in `cron/jobs.json` register automatically once the workspace is loaded — no extra configuration is needed.
+- Otherwise, wire each job into your scheduler by hand: for every entry in `cron/jobs.json`, create a recurring task that targets the `platform` agent using the job's `schedule.expr` (a standard 5-field cron expression) and sends its `prompt` verbatim.
 
-  ```text
-  [Scheduled Heartbeat]
-  Read HEARTBEAT.md and execute due checks.
-  Update memory/heartbeat-state.json with fresh timestamps/results.
-  If healthy and no anomalies, respond exactly NO_REPLY; otherwise return concise blockers.
-  ```
-
-If your harness has native cron support (Hermes does, via `cron/jobs.json`), the governance watchdogs will register automatically once the workspace is loaded. Otherwise wire them by hand from `cron/jobs.json`.
+See [Autonomous watchdogs](/kube-agents/concepts/autonomous-watchdogs/) and [Reference → Cron jobs](/kube-agents/reference/cron-jobs/) for the full, annotated job list.
 
 ## Step 4: Wire the surrounding infrastructure
 
@@ -72,7 +65,7 @@ The manual install covers only the agent workspace. To reach parity with a `./pr
 
 ## Verify
 
-Interact with the agent through your harness's chat surface. It should respond with a status update and, on the next heartbeat tick, begin running the governance SOPs on schedule.
+Interact with the agent through your harness's chat surface. It should respond with a status update, and it will begin running the governance SOPs autonomously as their cron schedules fire.
 
 ## Post-install
 

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -15,7 +15,7 @@ The shipping install path targets GKE. You'll need one working GCP project plus 
 
 ## GCP project
 
-- A GCP project you can enable APIs on and where you can create GKE clusters, Artifact Registry repositories, Pub/Sub topics, KMS keyrings, and IAM service accounts.
+- A GCP project you can enable APIs on and where you can create GKE clusters, Pub/Sub topics, KMS keyrings, and IAM service accounts.
 - Billing enabled on that project.
 - The `Editor` or `Owner` role for the user running `./provision.sh` (or a scoped set covering the resources above).
 
@@ -74,7 +74,7 @@ Pick one at least:
 - `ANTHROPIC_API_KEY`.
 - `OPENAI_API_KEY`.
 
-Or configure Vertex AI credentials (Gemini or Claude via Vertex) at the LiteLLM layer — see [`examples/litellm-gemini/`](https://github.com/gke-labs/kube-agents/tree/main/examples/litellm-gemini) for a template.
+Or route one of these keys through a self-hosted LiteLLM gateway — see [`examples/litellm-gemini/`](https://github.com/gke-labs/kube-agents/tree/main/examples/litellm-gemini) for a Gemini API-key template.
 
 ## GitOps repo (for `submit-suggestion`)
 

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -8,11 +8,11 @@ import { Aside, Steps } from "@astrojs/starlight/components";
 The `./provision.sh` script bootstraps everything you need for a running Platform Agent on GKE: cluster, CRDs, IAM, secrets, Chat integration, inference gateway, and the token minter.
 
 <Aside type="note">
-  Prerequisites: a GCP project with billing enabled, `gcloud` authenticated, and
-  [cert-manager](/kube-agents/install/prerequisites/#cert-manager-on-the-target-cluster)
-  installed on the target cluster. If you're starting from a fresh project, the
-  provisioner will create the cluster for you — install cert-manager immediately
-  after step 1 completes.
+  Prerequisites: a GCP project with billing enabled and `gcloud` authenticated.
+  If you're starting from a fresh project, the provisioner creates the GKE
+  cluster for you. You do **not** need to pre-install
+  [cert-manager](/kube-agents/install/prerequisites/#cert-manager-on-the-target-cluster) —
+  the operator step installs it automatically if it isn't already present.
 </Aside>
 
 ## Run the provisioner
@@ -26,9 +26,10 @@ The `./provision.sh` script bootstraps everything you need for a running Platfor
    cd kube-agents
    ```
 
-2. **Run the provisioner.**
+2. **Run the provisioner.** The `gcp-provision` target lives in the operator's Makefile:
 
    ```bash
+   cd k8s-operator
    make gcp-provision
    ```
 
@@ -39,20 +40,18 @@ The `./provision.sh` script bootstraps everything you need for a running Platfor
    ./provision.sh
    ```
 
-   The first run is interactive: it prompts for the values it needs (project ID, region, cluster name, model provider, API key, GitOps repo). Answers are cached in `k8s-operator/scripts/vars.sh` (git-ignored) so re-runs are non-interactive.
+   The first run is interactive: it prompts for the values it needs (project ID, region, cluster name, model provider and API key, agent permission set, and opt-in integrations such as Google Chat, Slack, and GitHub). Answers are cached in `k8s-operator/scripts/vars.sh` (git-ignored) so re-runs are non-interactive. Every sub-step is idempotent, so you can safely Ctrl-C and re-run.
 
-3. **Install cert-manager after step 1 finishes** if you haven't already. See [Prerequisites → cert-manager](/kube-agents/install/prerequisites/#cert-manager-on-the-target-cluster). You can Ctrl-C `provision.sh` after step 1 emits the "GKE cluster ready" message, install cert-manager, then re-run — it's idempotent.
+3. **Configure Google Chat** (only if you enabled the Google Chat integration). In the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com), point the bot's Pub/Sub connection at the topic created in step 5 (`projects/<PROJECT_ID>/topics/<CHAT_TOPIC_NAME>`). The provisioner prints the exact topic name and step-by-step instructions when it finishes.
 
-4. **Configure Google Chat** in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com) to publish events to the Pub/Sub topic created in step 4. The provisioner prints the topic name when it finishes.
-
-5. **Verify.**
+4. **Verify.**
 
    ```bash
    kubectl get platformagents -n kubeagents-system
    kubectl get pods -n kubeagents-system
    ```
 
-   You should see one `PlatformAgent` resource and pods for the operator, Platform Agent, LiteLLM, and Minty. When the Platform Agent pod is `Running`, DM your Chat app and it should reply.
+   You should see one `PlatformAgent` resource plus pods for the operator (`kubeagents-controller-manager`), the Platform Agent gateway (`platform-agent-gateway`), and LiteLLM (`litellm`). The GitHub token minter (`github-token-minter`) also appears if you enabled the GitHub integration. When the Platform Agent gateway pod is `Running` and Google Chat is configured, DM your Chat app and it should reply.
 
 </Steps>
 
@@ -63,16 +62,16 @@ The `./provision.sh` script bootstraps everything you need for a running Platfor
 ```mermaid
 flowchart TB
     A[provision.sh] --> B["01: GKE cluster<br/>Workload Identity"]
-    A --> C["01a: gVisor node pool (opt-in)"]
-    A --> D["02: Operator CRDs + manager"]
-    A --> E["03: IAM + Workload Identity bindings"]
-    A --> F["04: Google Chat Pub/Sub"]
-    A --> G["05: Slack (opt-in)"]
-    A --> H["06: LLM API key Secret"]
-    A --> I["07: PlatformAgent CR"]
-    A --> J["08: LiteLLM Deployment"]
-    A --> K["09: Minty + GCP KMS"]
-    A --> L["10: inference-replay (opt-in)"]
+    A --> C["02: gVisor node pool (opt-in)"]
+    A --> D["03: Operator CRDs + manager<br/>(+ cert-manager)"]
+    A --> E["04: IAM + Workload Identity bindings"]
+    A --> F["05: Google Chat Pub/Sub (opt-in)"]
+    A --> G["06: Slack (opt-in)"]
+    A --> H["07: LLM API key Secret"]
+    A --> I["08: PlatformAgent CR"]
+    A --> J["09: LiteLLM Deployment"]
+    A --> K["10: GitHub token minter + Cloud KMS (opt-in)"]
+    A --> L["11: inference-replay (opt-in)"]
 ```
 
 See [Provisioning scripts](/kube-agents/operator/provisioning-scripts/) for the per-script breakdown.
@@ -80,15 +79,16 @@ See [Provisioning scripts](/kube-agents/operator/provisioning-scripts/) for the 
 ## Common flags and toggles
 
 - `--dry-run` — prints what would be done without applying anything.
-- `ENABLE_GVISOR=true` — provisions the gVisor sandbox node pool in step 1a.
-- `SLACK_ENABLED=true` — configures Slack tokens in step 5 (otherwise step 5 no-ops).
-- `INFERENCE_REPLAY_ENABLED=true` — deploys the inference-replay proxy in step 10.
+- `ENABLE_GVISOR=true` — provisions the gVisor sandbox node pool in step 2.
+- `GOOGLE_CHAT_ENABLED=true` — configures the Google Chat Pub/Sub integration in step 5 (otherwise step 5 no-ops).
+- `SLACK_ENABLED=true` — configures Slack tokens in step 6 (otherwise step 6 no-ops).
+- `INFERENCE_REPLAY_ENABLED=true` — deploys the inference-replay proxy in step 11.
 
 Set these as environment variables before running, or accept the interactive defaults.
 
 ## Uninstall
 
-`./teardown.sh` runs the sub-scripts in reverse order. See [Uninstall](/kube-agents/install/uninstall/) for the full procedure.
+Run `make gcp-teardown` from `k8s-operator` (or `./teardown.sh` directly from `k8s-operator/scripts`) to run the sub-scripts in reverse order. See [Uninstall](/kube-agents/install/uninstall/) for the full procedure.
 
 ## Next steps
 

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -11,8 +11,8 @@ The `./provision.sh` script bootstraps everything you need for a running Platfor
   Prerequisites: a GCP project with billing enabled and `gcloud` authenticated.
   If you're starting from a fresh project, the provisioner creates the GKE
   cluster for you. You do **not** need to pre-install
-  [cert-manager](/kube-agents/install/prerequisites/#cert-manager-on-the-target-cluster) —
-  the operator step installs it automatically if it isn't already present.
+  [cert-manager](/kube-agents/install/prerequisites/#cert-manager-on-the-target-cluster)
+  — the operator step installs it automatically if it isn't already present.
 </Aside>
 
 ## Run the provisioner

--- a/docs/site/src/content/docs/install/uninstall.md
+++ b/docs/site/src/content/docs/install/uninstall.md
@@ -23,6 +23,16 @@ Use this to remove the agent while leaving the GKE cluster and operator in place
      --type=merge -p '{"metadata":{"finalizers":null}}'
    ```
 
+   **Note:** the `kubeagents.x-k8s.io/finalizer` finalizer is what deletes the agent's **cluster-scoped** RBAC — a ClusterRole and two ClusterRoleBindings that Kubernetes cannot garbage-collect via owner references. Bypassing it leaves these behind, so delete them manually (names are derived from the CR's namespace and name):
+
+   ```bash
+   kubectl delete clusterrolebinding \
+     kubeagents:viewer:kubeagents-system:platform-agent \
+     kubeagents:explorer:kubeagents-system:platform-agent --ignore-not-found=true
+   kubectl delete clusterrole \
+     kubeagents:explorer:kubeagents-system:platform-agent --ignore-not-found=true
+   ```
+
 3. **Delete the agent secrets.**
 
    ```bash
@@ -34,7 +44,7 @@ Use this to remove the agent while leaving the GKE cluster and operator in place
 
 4. **Remove the workspace** — delete the `agents/platform` directory from your harness workspace if you installed it there.
 
-The operator garbage-collects the agent's Deployment, Service, ServiceAccount, RBAC bindings, and ConfigMaps once the CR is gone.
+Once the CR is gone, the operator's finalizer first removes the cluster-scoped RBAC (the ClusterRole and ClusterRoleBindings above), then Kubernetes garbage-collects the namespaced resources it owns — the agent's Deployment, Service, ServiceAccount, PersistentVolumeClaims, and ConfigMaps.
 
 ## Full teardown
 

--- a/docs/site/src/content/docs/operator/development.md
+++ b/docs/site/src/content/docs/operator/development.md
@@ -11,7 +11,7 @@ Everything below runs from `k8s-operator/`.
 
 ## Prerequisites
 
-- Go 1.24+.
+- Go 1.25+ (the module's `go.mod` requires 1.25).
 - `docker` (or `podman`) for image builds.
 - `kubectl` pointed at a target cluster for `make install` / `make deploy`.
 - `make` — the entire workflow is Makefile-driven.
@@ -25,6 +25,8 @@ make build         # build the manager binary
 ```
 
 Generated CRDs land in `config/crd/bases/`; RBAC in `config/rbac/`; webhook config in `config/webhook/`.
+
+`make build`, `make run`, and `make test` all run `manifests`, `generate`, `fmt`, and `vet` first, so generated code and manifests stay in sync automatically.
 
 ## Test
 
@@ -61,7 +63,7 @@ For local Platform Agent development you don't want to run the full provisioner 
 make dev-rebuild-agent ARGS="platform"
 ```
 
-This builds the agent workspace image, pushes to Artifact Registry, and restarts the Deployment. First run creates a dev Artifact Registry repo; clean it up later with `make gcp-teardown-dev-artifact-registry`.
+This builds the Platform Agent image, pushes to Artifact Registry, and restarts the Deployment. First run creates a dev Artifact Registry repo; clean it up later with `make gcp-teardown-dev-artifact-registry`.
 
 ## Integrations (Kustomize)
 
@@ -78,7 +80,7 @@ Each has a matching `undeploy-*` target. These are the same kustomize bases the 
 ## Formatting
 
 ```bash
-make prettier-check    # verify Markdown/YAML/JSON formatting
+make prettier-check    # verify Markdown/YAML formatting (**/*.{md,yaml,yml})
 make prettier-write    # apply formatting
 ```
 

--- a/docs/site/src/content/docs/operator/development.md
+++ b/docs/site/src/content/docs/operator/development.md
@@ -11,7 +11,7 @@ Everything below runs from `k8s-operator/`.
 
 ## Prerequisites
 
-- Go 1.25+ (the module's `go.mod` requires 1.25).
+- Go 1.25+.
 - `docker` (or `podman`) for image builds.
 - `kubectl` pointed at a target cluster for `make install` / `make deploy`.
 - `make` — the entire workflow is Makefile-driven.

--- a/docs/site/src/content/docs/operator/index.md
+++ b/docs/site/src/content/docs/operator/index.md
@@ -5,7 +5,7 @@ sidebar:
   order: 0
 ---
 
-The `k8s-operator` is a Kubernetes controller that turns a `PlatformAgent` custom resource into a running Platform Agent Deployment plus everything it needs — Service, ServiceAccount, RBAC, ConfigMaps for persona and skills, and the container image reference.
+The `k8s-operator` is a Kubernetes controller that turns a `PlatformAgent` custom resource into a running Platform Agent Deployment plus everything it needs — Service, ServiceAccount, RBAC, PersistentVolumeClaims, and ConfigMaps for the agent config and logging. It also runs mutating (defaulting) and validating admission webhooks for the `PlatformAgent` type.
 
 Source: [`k8s-operator/`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator). Full README: [`k8s-operator/README.md`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/README.md).
 
@@ -16,7 +16,7 @@ k8s-operator/
 ├── api/v1alpha1/           # PlatformAgent type definitions (Kubebuilder)
 ├── cmd/                    # manager entrypoint
 ├── config/                 # Kustomize base for the operator + integrations
-├── internal/               # controller reconciler logic
+├── internal/               # controller reconciler + admission webhook logic
 ├── examples/               # sample PlatformAgent CR
 ├── scripts/                # provision + teardown scripts
 ├── testing/staging_workloads/  # multi-cluster staging PoC
@@ -32,11 +32,12 @@ A single custom resource today:
 
 The controller reconciles a `PlatformAgent` into:
 
-- A `Deployment` for the Platform Agent (running the Hermes runtime).
-- A `Service` fronting the Deployment.
-- A `ServiceAccount` (annotated for Workload Identity) plus RBAC.
-- `ConfigMap`s mounting the persona (`SOUL.md`), skills, governance SOPs, and cron jobs into `/opt/data/` inside the pod.
-- Optional integrations: Google Chat Pub/Sub subscription config, Slack tokens, Minty client config.
+- A `Deployment` (named `<name>-gateway`) for the Platform Agent, running the Hermes runtime with a Fluent Bit log-forwarding sidecar.
+- A `Service` fronting the Deployment (API port `8642`, plus dashboard port `9119` when the dashboard is enabled).
+- A `ServiceAccount` (annotated for Workload Identity) plus RBAC — a viewer `ClusterRoleBinding` and an "explorer" `ClusterRole` with its own `ClusterRoleBinding`.
+- `PersistentVolumeClaim`s for the agent's data and system metadata.
+- `ConfigMap`s mounted into `/opt/data/` inside the pod: the agent `config.yaml`, a `SETTINGS.md` (GKE scope / GitOps repo), and a Fluent Bit config for the logging sidecar.
+- Optional integrations wired through the CR `spec.integration` block: Google Chat (Pub/Sub topic/subscription), Slack (bot/app token secret refs), and GitHub (GitOps repo, with the GitHub Token Minter endpoint injected as an env var).
 
 ## Custom resource shape
 

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -22,28 +22,47 @@ metadata:
   namespace: kubeagents-system
 spec:
   harness: { ... } # execution environment + framework
-  deployment: { ... } # container image, pull policy, resources
+  deployment: { ... } # container image, pull policy, containers, volumes
   security: { ... } # service account + Workload Identity
   integration: { ... } # Google Chat, Slack, GitHub
 ```
 
+`spec.deployment` and `spec.security` are inlined from the shared `AgentSpec`, so they are common to every agent type. `spec.harness` is required; `spec.integration` is optional.
+
 ## `spec.harness`
 
-Framework-level settings passed to Hermes.
+Framework-level settings passed to Hermes. `clusterName` and `location` are required.
 
 | Field                                    | Type   | Purpose                                                                              |
 | ---------------------------------------- | ------ | ------------------------------------------------------------------------------------ |
 | `clusterName`                            | string | Logical cluster name (e.g. `cluster-a`). Surfaces in observability and chat replies. |
 | `location`                               | string | Cloud region (e.g. `us-central1-a`).                                                 |
+| `projectId`                              | string | GCP Project ID of the cluster. Optional.                                             |
 | `hermes.dashboardEnabled`                | bool   | Toggle the Hermes dashboard endpoint. Default `true`.                                |
 | `hermes.pluginsDebug`                    | bool   | Enable plugin-level debug logging. Default `false`.                                  |
-| `hermes.apiServerSecretRef.name` + `key` | string | `Secret` holding the Hermes API server key.                                          |
+| `hermes.agentHome`                       | string | Path to the `AGENT_HOME` directory. Default `/opt/data`.                             |
+| `hermes.apiServerSecretRef.name` + `key` | string | `Secret` holding the Hermes API server key (`API_SERVER_KEY`).                       |
+| `memory.memoryEnabled`                   | bool   | Toggle framework memory persistence. Default `false`.                               |
+| `memory.provider`                        | string | Memory provider implementation. Default `multiuser_memory`.                          |
+| `memory.userProfileEnabled`             | bool   | Toggle per-user memory profiling. Default `false`.                                   |
 
 ## `spec.deployment`
 
-Standard container spec: `image`, `imagePullPolicy`, `resources`, node selectors, tolerations. The controller synthesises a `Deployment` from these plus the workspace ConfigMaps.
+Abstracts the pod/deployment configuration. The controller synthesises a `Deployment` from these plus the workspace ConfigMaps. Available fields:
 
-Default image: `ghcr.io/gke-labs/kube-agents/platform-agent`. Rebuild with `make dev-rebuild-agent ARGS="platform"` for local iteration.
+- `image` — container image repository.
+- `tag` — image tag. Default `latest`.
+- `imagePullPolicy` — one of `Always`, `Never`, `IfNotPresent`. Default `IfNotPresent`.
+- `browserArgs` — extra command-line args for the agent's browser (e.g. `--no-sandbox`).
+- `runtimeClassName` — pod runtime class (e.g. `gvisor`).
+- `env` — additional container environment variables.
+- `initContainers` / `sidecars` — standard init and sidecar containers.
+- `extraVolumes` / `extraVolumeMounts` — custom volumes and mounts for the main container.
+- `sidecarVolumes` — custom volumes for the sidecar containers.
+- `podAnnotations` — annotations applied to the generated pod template.
+- `scaleToZero` — when `true`, scales the deployment to 0 replicas (idle cost saving).
+
+Default image: `ghcr.io/gke-labs/kube-agents/platform-agent:latest`. Rebuild with `make dev-rebuild-agent ARGS="platform"` for local iteration.
 
 ## `spec.security`
 
@@ -52,25 +71,40 @@ Default image: `ghcr.io/gke-labs/kube-agents/platform-agent`. Rebuild with `make
 
 The Workload Identity target GSA (`kubeagents-platform-gsa@<project>.iam.gserviceaccount.com`) is created and bound by `provision_04_gcp_iam.sh` with one of these permission sets:
 
-- `read-only` (default)
-- `gke-admin`
-- `custom`
+- `read-only`
+- `gke-admin` (default)
+- `custom` (roles supplied via `PLATFORM_AGENT_CUSTOM_ROLES`)
 
 ## `spec.integration`
 
 Enables external integrations. Only the enabled ones need to be present.
 
-- **`googleChat`** — Pub/Sub subscription name, project ID, allowed users. Populated by `provision_05_gcp_gchat.sh`.
-- **`slack`** — token Secret refs, home channel, allowed users. Populated by `provision_06_slack.sh` when `SLACK_ENABLED=true`.
-- **`github`** — Minty endpoint, GitOps repo URL. Populated by `provision_10_deploy_github_minter.sh`.
+- **`googleChat`** — `enabled` (default `false`), `projectId`, `topicName`, `subscriptionName`, `allowedUsers`, `homeChannel`, and `mode` (`default` or `debug`, default `default`). When `enabled`, `projectId`, `topicName`, and `subscriptionName` are required (enforced by a CEL validation rule). Populated by `provision_05_gcp_gchat.sh`.
+- **`slack`** — `enabled` (default `false`), `botTokenSecretRef` and `appTokenSecretRef` (Secret refs, required when enabled), `allowedUsers`, `homeChannel`, and `homeChannelName`. Populated by `provision_06_slack.sh` when `SLACK_ENABLED=true`.
+- **`github`** — `gitRepo`, the target GitOps repository URL for the agent environment. Populated by `provision_10_deploy_github_minter.sh`.
 
 See [`k8s-operator/api/v1alpha1/platformagent_types.go`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/api/v1alpha1/platformagent_types.go) for the exact struct definitions.
+
+## `status`
+
+The operator writes observed state to the `status` subresource:
+
+| Field                            | Type   | Purpose                                                            |
+| -------------------------------- | ------ | ----------------------------------------------------------------- |
+| `phase`                          | string | Overall state (`Pending`, `Provisioning`, `Ready`, `Failed`).     |
+| `address`                        | string | Fully qualified domain name (FQDN) of the agent service.          |
+| `lastReconcileTime`              | time   | Timestamp of the last status update.                              |
+| `conditions`                     | list   | Standard `metav1.Condition` observations, keyed by `type`.        |
+| `deploymentStatus.name`          | string | Name of the underlying Deployment.                                |
+| `deploymentStatus.readyReplicas` | int32  | Number of fully ready replicas.                                   |
+| `serviceStatus.endpoint`         | string | Primary URL/IP (with protocol and port) to reach the agent.       |
+| `storageStatus.bound`            | bool   | Whether the primary PVC has been provisioned.                     |
 
 ## Reconcile behavior
 
 - On create/update, the controller ensures the Deployment, Service, ServiceAccount, and ConfigMaps match the spec.
 - On delete, it garbage-collects owned resources.
-- The admission webhook (behind cert-manager) validates the spec before it's persisted.
+- The admission webhook (behind cert-manager) validates the spec before it's persisted; it enforces at most one `PlatformAgent` per project.
 - `provision_08_deploy_platform_agent.sh` renders and applies the CR; you can also edit it directly with `kubectl edit`.
 
 ## Where to go next

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -42,9 +42,9 @@ Framework-level settings passed to Hermes. `clusterName` and `location` are requ
 | `hermes.pluginsDebug`                    | bool   | Enable plugin-level debug logging. Default `false`.                                  |
 | `hermes.agentHome`                       | string | Path to the `AGENT_HOME` directory. Default `/opt/data`.                             |
 | `hermes.apiServerSecretRef.name` + `key` | string | `Secret` holding the Hermes API server key (`API_SERVER_KEY`).                       |
-| `memory.memoryEnabled`                   | bool   | Toggle framework memory persistence. Default `false`.                               |
+| `memory.memoryEnabled`                   | bool   | Toggle framework memory persistence. Default `false`.                                |
 | `memory.provider`                        | string | Memory provider implementation. Default `multiuser_memory`.                          |
-| `memory.userProfileEnabled`             | bool   | Toggle per-user memory profiling. Default `false`.                                   |
+| `memory.userProfileEnabled`              | bool   | Toggle per-user memory profiling. Default `false`.                                   |
 
 ## `spec.deployment`
 
@@ -89,16 +89,16 @@ See [`k8s-operator/api/v1alpha1/platformagent_types.go`](https://github.com/gke-
 
 The operator writes observed state to the `status` subresource:
 
-| Field                            | Type   | Purpose                                                            |
-| -------------------------------- | ------ | ----------------------------------------------------------------- |
-| `phase`                          | string | Overall state (`Pending`, `Provisioning`, `Ready`, `Failed`).     |
-| `address`                        | string | Fully qualified domain name (FQDN) of the agent service.          |
-| `lastReconcileTime`              | time   | Timestamp of the last status update.                              |
-| `conditions`                     | list   | Standard `metav1.Condition` observations, keyed by `type`.        |
-| `deploymentStatus.name`          | string | Name of the underlying Deployment.                                |
-| `deploymentStatus.readyReplicas` | int32  | Number of fully ready replicas.                                   |
-| `serviceStatus.endpoint`         | string | Primary URL/IP (with protocol and port) to reach the agent.       |
-| `storageStatus.bound`            | bool   | Whether the primary PVC has been provisioned.                     |
+| Field                            | Type   | Purpose                                                       |
+| -------------------------------- | ------ | ------------------------------------------------------------- |
+| `phase`                          | string | Overall state (`Pending`, `Provisioning`, `Ready`, `Failed`). |
+| `address`                        | string | Fully qualified domain name (FQDN) of the agent service.      |
+| `lastReconcileTime`              | time   | Timestamp of the last status update.                          |
+| `conditions`                     | list   | Standard `metav1.Condition` observations, keyed by `type`.    |
+| `deploymentStatus.name`          | string | Name of the underlying Deployment.                            |
+| `deploymentStatus.readyReplicas` | int32  | Number of fully ready replicas.                               |
+| `serviceStatus.endpoint`         | string | Primary URL/IP (with protocol and port) to reach the agent.   |
+| `storageStatus.bound`            | bool   | Whether the primary PVC has been provisioned.                 |
 
 ## Reconcile behavior
 

--- a/docs/site/src/content/docs/operator/provisioning-scripts.md
+++ b/docs/site/src/content/docs/operator/provisioning-scripts.md
@@ -7,7 +7,7 @@ sidebar:
 
 The provisioner in [`k8s-operator/scripts/`](https://github.com/gke-labs/kube-agents/tree/main/k8s-operator/scripts) is composed of one orchestrator (`provision.sh`) and a set of idempotent step scripts (plus their teardown mirrors and an optional gVisor step). This page catalogs each step; the [quick start](/kube-agents/install/quickstart-gke/) shows the operator's-eye view.
 
-Shared state — cluster name, region, project ID, model provider, GitOps repo — lives in `k8s-operator/scripts/vars.sh` (git-ignored). Each script sources it; missing values prompt the user and get appended to `vars.sh`.
+Shared state — cluster name, region, project ID, model provider, GitOps repo — lives in `k8s-operator/scripts/vars.sh` (git-ignored). Each script sources `common.sh`, which loads that state and provides the shared helpers (prompting, retries, step runner); missing values prompt the user and get appended to `vars.sh`.
 
 ## Orchestrators
 
@@ -20,7 +20,7 @@ Both accept `--dry-run` to print planned actions without applying them.
 
 ### 01. GKE cluster
 
-`provision_01_gcp_cluster.sh` — Enables the required GCP APIs, provisions a GKE Standard cluster with Workload Identity, sets `kubectl` credentials, and creates the target namespace (`kubeagents-system`).
+`provision_01_gcp_cluster.sh` — Enables the required GCP APIs (`container.googleapis.com`), provisions a GKE Standard cluster with Workload Identity, and fetches `kubectl` credentials. The `kubeagents-system` namespace is created later by the operator deploy in step 03.
 
 ### 02. gVisor node pool (opt-in)
 
@@ -28,23 +28,23 @@ Both accept `--dry-run` to print planned actions without applying them.
 
 ### 03. Operator CRDs + controller
 
-`provision_03_gcp_gke_operator.sh` — Installs the `PlatformAgent` CRD and deploys the operator controller manager into the cluster.
+`provision_03_gcp_gke_operator.sh` — Ensures cert-manager is present (auto-installing it, with leader election disabled on Autopilot, if the `certificates.cert-manager.io` CRD is missing), then installs the `PlatformAgent` CRD (`make install`) and deploys the operator controller manager (`make deploy`) into the cluster.
 
 ### 04. IAM + Workload Identity
 
-`provision_04_gcp_iam.sh` — Creates GSAs for the controller and Platform Agent, binds Kubernetes SAs to them via Workload Identity, and grants the appropriate GKE permissions (`read-only`, `gke-admin`, or `custom`).
+`provision_04_gcp_iam.sh` — Creates the Platform Agent GSA (and, when GitHub integration is configured, the GitHub Token Minter GSA), binds their Kubernetes SAs via Workload Identity, and grants the Platform Agent the roles matching its `PLATFORM_AGENT_PERMISSION_SET` (`read-only`, `gke-admin`, or `custom`).
 
-### 05. Google Chat Pub/Sub
+### 05. Google Chat Pub/Sub (opt-in)
 
-`provision_05_gcp_gchat.sh` — Creates the Pub/Sub topic and subscription that the Google Chat app publishes events into. Prints the topic name for you to configure in the Chat API console.
+`provision_05_gcp_gchat.sh` — Only runs if `GOOGLE_CHAT_ENABLED=true`. Enables the Chat/Pub/Sub APIs, provisions the Workspace Add-ons service identity, creates the Pub/Sub topic and subscription that the Google Chat app publishes events into, and grants the Platform Agent GSA subscriber access. Prints setup instructions for the Chat API console.
 
 ### 06. Slack (opt-in)
 
-`provision_06_slack.sh` — Only configures Slack if `SLACK_ENABLED=true`. Collects bot token, app token, allowed users, and home channel, and stores them as Kubernetes secrets.
+`provision_06_slack.sh` — Only configures Slack if `SLACK_ENABLED=true`. Collects bot token(s), app token, allowed users, and home channel, and saves them to `vars.sh`. The tokens are synced into the `platform-agent-secrets` Secret later, by step 07.
 
 ### 07. LLM API key Secret
 
-`provision_07_gcp_k8s_secrets.sh` — Prompts for the model provider (`gemini` / `anthropic` / `openai`) and API key, and creates the `platform-agent-secrets` Secret in the target namespace.
+`provision_07_gcp_k8s_secrets.sh` — Prompts for the model provider (`gemini` / `anthropic` / `chatgpt` / `openai`) and its API key, generates a random `API_SERVER_KEY`, and creates the `platform-agent-secrets` Secret (also carrying the Slack tokens from step 06) in the target namespace.
 
 ### 08. PlatformAgent CR
 
@@ -56,7 +56,7 @@ Both accept `--dry-run` to print planned actions without applying them.
 
 ### 10. Minty (GitHub Token Minter)
 
-`provision_10_deploy_github_minter.sh` — Sets up a GCP KMS keyring + key for token signing, then deploys Minty. See the [Token minter](/kube-agents/deploy/token-minter/) deploy page for details.
+`provision_10_deploy_github_minter.sh` — Only runs when GitHub integration is configured (`GITHUB_ORG`, `GITHUB_REPO`, and `GITHUB_APP_ID` set). Enables the Cloud KMS API, sets up a KMS keyring + key for token signing (importing the GitHub App PEM via the Minty CLI when a path is provided), then deploys Minty (`make deploy-github`). See the [Token minter](/kube-agents/deploy/token-minter/) deploy page for details.
 
 ### 11. Inference replay (opt-in)
 
@@ -66,13 +66,18 @@ Both accept `--dry-run` to print planned actions without applying them.
 
 Mirror the provisioning steps in reverse. Full table on [Uninstall](/kube-agents/install/uninstall/).
 
+## Utilities
+
+- **[`update_cluster_name.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/update_cluster_name.sh)** — Patches the target GKE cluster name into the deployed `platform-agent` `PlatformAgent` spec (`spec.harness.clusterName`), triggering the operator to reconcile.
+
 ## Development helpers (`dev/`)
 
 - **[`dev/dev_rebuild_agent.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/dev_rebuild_agent.sh)** — Fast local iteration on the Platform Agent workspace image.
+- **[`dev/setup-gcp-github-wif.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/setup-gcp-github-wif.sh)** — Sets up GCP Workload Identity Federation (pool + OIDC provider + service account) so GitHub Actions can deploy to the project keylessly. Requires `PROJECT_ID`, `SA_NAME`, and `GITHUB_REPO` env vars.
 - **[`dev/teardown_dev_01_gcp_artifact_registry.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/teardown_dev_01_gcp_artifact_registry.sh)** — Deletes the dev-only Artifact Registry created by `dev_rebuild_agent.sh`.
 
 ## Common gotchas
 
-- **cert-manager missing.** Step 02 will fail if cert-manager isn't installed. Install it once per cluster; the provisioner is idempotent so you can re-run.
+- **cert-manager.** Step 03 auto-installs cert-manager (v1.14.4) if the `certificates.cert-manager.io` CRD isn't present, so you normally don't need to install it yourself. All steps are idempotent, so you can safely re-run.
 - **`vars.sh` collision.** If you rerun the provisioner against a different project without wiping `vars.sh`, you'll target the previous project. Delete `vars.sh` to reset.
-- **Autopilot leader election.** cert-manager on Autopilot needs leader election disabled — see [Prerequisites](/kube-agents/install/prerequisites/#gke-autopilot-install).
+- **Autopilot leader election.** On GKE Autopilot, step 03 installs cert-manager with leader election disabled automatically (kube-system restrictions) — see [Prerequisites](/kube-agents/install/prerequisites/#gke-autopilot-install).

--- a/docs/site/src/content/docs/overview/architecture.mdx
+++ b/docs/site/src/content/docs/overview/architecture.mdx
@@ -70,7 +70,7 @@ flowchart TB
 
 1. A user posts in a Google Chat space (or DMs the Slack app).
 2. Google Chat publishes the event to a Pub/Sub topic; Slack routes via Socket Mode. `provision_05_gcp_gchat.sh` sets up the topic and subscription.
-3. The Platform Agent pod consumes the event via its `platform_control` MCP server.
+3. The Platform Agent pod (running the Hermes runtime, image `nousresearch/hermes-agent`) consumes the event through Hermes' bundled Google Chat adapter, patched for credential-free operation by `google_chat_relay_patch.py` (Slack uses `slack_relay_patch.py` in Socket Mode).
 4. Hermes runs a tool-calling loop: system prompt (`SOUL.md`) + user message + available tools. It picks skills to load and MCP tools to call.
 5. Cluster reads go through the `gke` MCP server; mutations that touch infra route through the `submit-suggestion` skill (see flow 3) rather than direct `kubectl`.
 6. The reply is posted back to the same Chat thread. Long operations return a summary; console links use the templates in `SOUL.md §6`.

--- a/docs/site/src/content/docs/overview/what-is-kube-agents.md
+++ b/docs/site/src/content/docs/overview/what-is-kube-agents.md
@@ -13,7 +13,7 @@ A Go controller built with [Kubebuilder](https://kubebuilder.io) that defines th
 
 ### 2. Platform Agent (k8s-deployment)
 
-The `PlatformAgent` CR reconciles into a Deployment running the [Hermes runtime](https://github.com/NousResearch/hermes-agent) (`nousresearch/hermes-agent`). Inside the pod:
+The `PlatformAgent` CR reconciles into a Deployment running the [Hermes runtime](https://github.com/NousResearch/hermes-agent). The default image is `ghcr.io/gke-labs/kube-agents/platform-agent`, built on top of `nousresearch/hermes-agent`. Inside the pod:
 
 - **Persona (`SOUL.md`)** — the system prompt. Describes the Platform Agent's role, safety rails, autonomous recovery ladder, and reporting style.
 - **Skills** (`agents/platform/skills/*/SKILL.md`) — Claude-style skill bundles the agent loads on demand.
@@ -48,8 +48,8 @@ Once the [provisioning script](/kube-agents/install/quickstart-gke/) finishes, y
 
 ## What is _not_ included
 
-- **No Helm chart yet** — [PR #353](https://github.com/gke-labs/kube-agents/pull/353) is proposing one. Today, install is via `./provision.sh` + Kustomize.
-- **No local Kind path yet** — same PR proposes `local-dev/setup-kind.sh`. Today you need a real cluster.
+- **No Helm chart yet** — [PR #230](https://github.com/gke-labs/kube-agents/pull/230) proposes a GKE-oriented chart (plus Terraform) at `k8s-operator/deploy/helm/kube-agents/`. Today, install is via `./provision.sh` + Kustomize.
+- **No local Kind path** — there is no `kind` workflow in the repo. Today you need a real GKE cluster; the only scripted installer (`scripts/quick-install.sh`) targets GKE Autopilot.
 - **No web UI or CLI beyond `kubectl` port-forward + the Hermes API** — chat is the primary user interface.
 - **No cross-cloud abstractions** — the shipping MCP toolset, IAM assumptions, and provisioning scripts all target GKE. The runtime and persona are cluster-agnostic; the skill catalog is not.
 

--- a/docs/site/src/content/docs/reference/attribution.md
+++ b/docs/site/src/content/docs/reference/attribution.md
@@ -19,7 +19,7 @@ Every agent action can be traced back to a requester. The full design rationale 
 ## What ships today
 
 - **OTel defaults on the Platform Agent Deployment.** Managed collector endpoint, OTLP protocol, service name, namespace, and agent identity. Overridable via `spec.deployment.env`.
-- **Session-to-user span enrichment.** The `session_store` and `session_otel_bridge` plugins attach requester context to spans. See [Google Chat session metadata data flow](https://github.com/gke-labs/kube-agents/blob/main/docs/gchat-session-metadata-data-flow.md).
+- **Session-to-user span enrichment.** The `session_store` plugin persists requester metadata (platform and user id/email) keyed by session, and the `session_otel_bridge` plugin reads it to stamp `session.id`, `user.id`, and `hermes.sender.id` onto spans. See [Google Chat session metadata data flow](https://github.com/gke-labs/kube-agents/blob/main/docs/gchat-session-metadata-data-flow.md).
 - **Structured chat and tool audit records on stdout.** Collected by GKE's log agent without giving the workload direct write access to Cloud Logging.
 - **Reference API-server audit policy for self-managed clusters:** [`k8s-operator/config/audit/audit-policy.yaml`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/config/audit/audit-policy.yaml).
 

--- a/docs/site/src/content/docs/reference/config.md
+++ b/docs/site/src/content/docs/reference/config.md
@@ -57,6 +57,7 @@ plugins:
     - session_store
     - session_otel_bridge
     - tool_call_audit
+    - incident_context
 ```
 
 ## Sections
@@ -77,7 +78,7 @@ Toolsets group MCP servers into named bundles for different Hermes surfaces:
 - **`cli`** — Exposed to the Hermes CLI (interactive terminal usage inside the pod).
 - **`api_server`** — Exposed to the Hermes REST API (Chat integrations, external callers).
 
-Both include the same MCP servers plus their respective Hermes-native tools (`hermes-cli` / `hermes-api-server`). `mcp-developer_knowledge` is a documentation MCP shipped by Hermes; `mcp-agent_common` is shared agent utilities.
+Both include the same MCP servers plus their respective Hermes-native tools (`hermes-cli` / `hermes-api-server`). `mcp-agent_common` (a local Python server, `agent_common_server.py`) and `mcp-developer_knowledge` (a remote proxy to `developerknowledge.googleapis.com/mcp`) are declared in the shared defaults config ([`deploy/shared/defaults/config.yaml`](https://github.com/gke-labs/kube-agents/blob/main/deploy/shared/defaults/config.yaml)) and merged in at runtime.
 
 ### `memory`
 
@@ -91,6 +92,7 @@ Hermes plugins enabled:
 - **`session_store`** — durable session state (writes to the pod's persistent volume if configured).
 - **`session_otel_bridge`** — enriches OTel spans with session context (see [Session metadata](/kube-agents/concepts/observability/#session-metadata-plumbing)).
 - **`tool_call_audit`** — writes per-tool-call records for audit and debug.
+- **`incident_context`** — injects Kubernetes incident context into known chat threads on reply (`pre_gateway_dispatch` hook).
 
 ## Related files
 

--- a/docs/site/src/content/docs/reference/examples.md
+++ b/docs/site/src/content/docs/reference/examples.md
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-Self-contained example stacks live in [`examples/`](https://github.com/gke-labs/kube-agents/tree/main/examples). Each is a Kubernetes manifest bundle you can deploy directly with `kubectl apply -k` — no framework, no rendering.
+Self-contained example stacks live in [`examples/`](https://github.com/gke-labs/kube-agents/tree/main/examples). Each is a plain Kubernetes manifest bundle you deploy with `kubectl apply -f` (see the `README.md` in each directory) — no framework, no rendering.
 
 ## `inference-replay`
 
@@ -23,7 +23,7 @@ A proxy that sits between the Platform Agent and LiteLLM. Requests are keyed by 
 
 [`examples/litellm-gemini/`](https://github.com/gke-labs/kube-agents/tree/main/examples/litellm-gemini)
 
-LiteLLM Deployment + Service + `ConfigMap` fronting Gemini. Reads `GEMINI_API_KEY` from a Secret. This is what `provision_09_deploy_litellm.sh` uses by default.
+LiteLLM Deployment + Service + `ConfigMap` fronting Gemini, plus a `Secret`, `NetworkPolicy`, and `PodMonitoring`. Reads `GEMINI_API_KEY` from the Secret. The default install path (`provision_09_deploy_litellm.sh`) deploys an equivalent LiteLLM + Gemini config from `k8s-operator/config/integrations/litellm/base` rather than this example directory.
 
 **When to use:** the default install path; anything except explicit local-inference or subscription-based demos.
 
@@ -39,7 +39,7 @@ LiteLLM configured to proxy a personal ChatGPT subscription via OAuth device flo
 
 [`examples/vllm-gemma/`](https://github.com/gke-labs/kube-agents/tree/main/examples/vllm-gemma)
 
-vLLM serving Gemma on a GKE GPU node pool. Based on GKE's official inference tutorial. Includes the node pool spec, GPU driver installer, and vLLM Deployment.
+vLLM serving Gemma (`gemma-4-e2b-it`) on GKE GPU nodes, based on GKE's official inference tutorial. Ships the vLLM Deployment, Service, `NetworkPolicy`, and `PodMonitoring`. It does not include a node pool spec or GPU driver installer — a cluster with GPU nodes is a prerequisite.
 
 **When to use:** data-locality, air-gapped, or open-model requirements. Provision a GPU node pool first (or use the `gke-compute-classes` skill to spec one).
 

--- a/docs/site/src/content/docs/reference/glossary.md
+++ b/docs/site/src/content/docs/reference/glossary.md
@@ -13,6 +13,10 @@ Terms used throughout the `kube-agents` docs and the wider agentic-Kubernetes ec
 
 The single autonomous agent shipped in `agents/platform/`. Configured with the `SOUL.md` persona, a library of skills, governance SOPs, and cron watchdogs. Deployed as a Kubernetes Deployment running the [Hermes runtime](https://github.com/NousResearch/hermes-agent).
 
+### `SOUL.md`
+
+The persona and operating charter for the Platform Agent at `agents/platform/SOUL.md`. Defines the agent's role, guardrails, and the declarative GitOps workflow it must follow.
+
 ### Governance SOP
 
 A standard operating procedure in `agents/platform/governance/`. Codifies how a fleet-wide audit or reconciliation is performed. Invoked by cron watchdogs or on request.
@@ -28,6 +32,14 @@ A cron-scheduled job in `agents/platform/cron/jobs.json` that fires a pre-author
 ### Declarative workflow
 
 The GitOps PR path all infrastructure changes take. Enforced by `SOUL.md` and implemented via the `submit-suggestion` skill + Minty.
+
+### `kubeagents-system`
+
+The Kubernetes namespace that hosts the kube-agents control plane: the operator, the Platform Agent gateway Deployment, the LiteLLM gateway, Minty, and related integration workloads.
+
+### Toolset
+
+A named set of tools and MCP servers exposed to the agent, declared under `platform_toolsets` in `agents/platform/config.yaml`. Separate `cli` and `api_server` toolsets select which capabilities (e.g. `mcp-platform_control`, `mcp-gke`, `mcp-agent_common`) are available in each mode. `platform_toolsets` is a reserved framework key in Hermes.
 
 ## Runtime and framework
 
@@ -49,7 +61,15 @@ Open-source inference server for local model serving. Alternative to LiteLLM whe
 
 ### Minty (GitHub Token Minter)
 
-In-cluster broker that mints short-lived GitHub App installation tokens via GCP KMS. Lets `submit-suggestion` open PRs without a long-lived credential.
+In-cluster broker that mints short-lived GitHub App installation tokens via GCP KMS. Deployed as the `github-token-minter` workload (upstream [`abcxyz/github-token-minter`](https://github.com/abcxyz/github-token-minter)) and queried by `github_token_refresh.py`. Lets `submit-suggestion` open PRs without a long-lived credential.
+
+### Credential proxy
+
+An in-pod sidecar (Envoy plus `credential_proxy.py`) that mediates credentialed CLI execution. The agent runs `gcloud`, `kubectl`, `gh`, and `git` through the proxy against an executable allowlist, so it never holds the raw credentials directly. Started by `deploy/shared/envoy-credential-sidecar.sh`.
+
+### Inference Replay Proxy
+
+An optional caching proxy that sits in front of the `litellm` gateway. It hashes each request (prompt + available skills + target model), serves cache hits from a Persistent Disk, and forwards misses upstream. Used for deterministic, low-cost replay of agent trajectories. Provisioned by `make gcp-provision-11-inference-replay`; example in `examples/inference-replay/`.
 
 ## Related Kubernetes-native agent projects
 

--- a/docs/site/src/content/docs/reference/security-and-iam.md
+++ b/docs/site/src/content/docs/reference/security-and-iam.md
@@ -27,7 +27,7 @@ flowchart LR
     end
 ```
 
-The binding is pre-provisioned by [`provision_04_gcp_iam.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/provision_04_gcp_iam.sh), which annotates the KSA with `iam.gke.io/gcp-service-account: kubeagents-platform-gsa@<project>.iam.gserviceaccount.com`. The operator applies the same annotation from `spec.security` on the [`PlatformAgent` CR](/kube-agents/operator/platformagent-crd/).
+The IAM side of the binding is pre-provisioned by [`provision_04_gcp_iam.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/provision_04_gcp_iam.sh), which grants `roles/iam.workloadIdentityUser` on the GSA to the KSA member `<project>.svc.id.goog[kubeagents-system/kubeagents-platform-agent]`. The KSA-side annotation `iam.gke.io/gcp-service-account: kubeagents-platform-gsa@<project>.iam.gserviceaccount.com` is applied by the operator from `spec.security.serviceAccountAnnotations` on the [`PlatformAgent` CR](/kube-agents/operator/platformagent-crd/).
 
 ## GCP IAM permission sets
 
@@ -37,7 +37,7 @@ The binding is pre-provisioned by [`provision_04_gcp_iam.sh`](https://github.com
 | -------------- | ------------------------------- | -------------------------------------------------------------- |
 | **gke-admin**  | `gke-admin` (default)           | The agent should manage GKE lifecycle and node pools directly. |
 | **read-only**  | `read-only`                     | Auditing / monitoring only — no GCP write capability.          |
-| **custom**     | `custom`                        | You bind roles yourself and skip the built-in grants.          |
+| **custom**     | `custom`                        | You supply the exact roles via `PLATFORM_AGENT_CUSTOM_ROLES`.   |
 
 ### Roles per set
 
@@ -56,7 +56,7 @@ The **read-only** set swaps the admin roles for viewers:
 - `roles/monitoring.viewer`, `roles/logging.viewer` — read-only telemetry.
 - `roles/iam.serviceAccountUser`, `roles/iam.securityReviewer`, `roles/mcp.toolUser` — unchanged.
 
-The **custom** set binds nothing automatically; grant roles to the GSA yourself.
+The **custom** set binds exactly the roles listed in `PLATFORM_AGENT_CUSTOM_ROLES` (space- or comma-separated; the provisioner prompts for it and requires a non-empty value when this set is selected) — none of the built-in role bundles are added.
 
 ## Kubernetes RBAC
 
@@ -129,7 +129,7 @@ The agent never has direct write access to running infrastructure — see [Decla
 - **One agent per project.** The admission webhook rejects a second `PlatformAgent` CR, so a cluster can't accumulate agents with overlapping scope. See [PlatformAgent CRD](/kube-agents/operator/platformagent-crd/).
 - **Human sign-off for destructive ops.** Cluster deletion, tenant offboarding, and broad IAM revocation always require explicit human approval, regardless of any "just do it" phrasing.
 - **Bounded recovery.** The agent retries a blocker through its recovery ladder (roughly five iterations or ~10 minutes) before escalating to a human instead of looping indefinitely.
-- **Read-only log access by default.** Provisioning grants the agent `roles/logging.viewer`, not admin — it cannot tamper with the audit-log sink. Stronger environments should route an immutable log copy to a separate security project (see [User attribution](/kube-agents/reference/attribution/#trust-boundary)).
+- **Read-only log access by default.** Provisioning grants the agent `roles/logging.viewer`, not admin — it cannot tamper with the audit-log sink. `provision_04_gcp_iam.sh` also actively reconciles away any legacy `roles/logging.admin` grant on the GSA unless a custom role set explicitly requests it. Stronger environments should route an immutable log copy to a separate security project (see [User attribution](/kube-agents/reference/attribution/#trust-boundary)).
 
 ## Where to go next
 

--- a/docs/site/src/content/docs/reference/security-and-iam.md
+++ b/docs/site/src/content/docs/reference/security-and-iam.md
@@ -37,7 +37,7 @@ The IAM side of the binding is pre-provisioned by [`provision_04_gcp_iam.sh`](ht
 | -------------- | ------------------------------- | -------------------------------------------------------------- |
 | **gke-admin**  | `gke-admin` (default)           | The agent should manage GKE lifecycle and node pools directly. |
 | **read-only**  | `read-only`                     | Auditing / monitoring only — no GCP write capability.          |
-| **custom**     | `custom`                        | You supply the exact roles via `PLATFORM_AGENT_CUSTOM_ROLES`.   |
+| **custom**     | `custom`                        | You supply the exact roles via `PLATFORM_AGENT_CUSTOM_ROLES`.  |
 
 ### Roles per set
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The documentation site (`docs/site/src/content/docs/`) had drifted from the
codebase and contained several inaccuracies and hallucinated features that would
mislead operators and contributors. This PR audits every page against the actual
source (operator, agent, deploy manifests, and provisioning scripts) and brings
the docs back in line with what the code actually does.

## What Changed

Every `.md`/`.mdx` page under `docs/site/src/content/docs/` was verified against
code. 28 pages were corrected; 9 were confirmed accurate and left unchanged. The
docs site builds cleanly after the changes.

**Files:**

- `docs/site/src/content/docs/overview/what-is-kube-agents.md`, `overview/architecture.mdx`
- `docs/site/src/content/docs/concepts/*` (platform-agent, chatops, declarative-workflow, governance-sops, inference-gateway, observability, autonomous-watchdogs)
- `docs/site/src/content/docs/install/*` (helm-and-kind, manual, prerequisites, quickstart-gke, uninstall)
- `docs/site/src/content/docs/operator/*` (index, development, platformagent-crd, provisioning-scripts)
- `docs/site/src/content/docs/deploy/*` (docker-images, kustomize, telemetry, token-minter)
- `docs/site/src/content/docs/reference/*` (config, examples, glossary, security-and-iam, attribution)
- `docs/site/src/content/docs/contributing.md`

**Added/Changed/Fixed:**

- Removed hallucinated features: the "heartbeat" protocol / `HEARTBEAT.md`, the `local-dev/setup-kind.sh` Kind path, Vertex AI support, Hermes Prometheus metrics, and non-existent `PlatformAgent` CRD fields (`resources`/nodeSelector/tolerations).
- Fixed the token-minter page to the real API contract (service name `github-token-minter`, `X-OIDC-Token` header, request/response body, audience).
- Corrected the IAM permission-set default (`gke-admin`, not `read-only`) and the custom-set behavior.
- Fixed wrong PR attributions (Helm chart is PR #230 at `k8s-operator/deploy/helm/kube-agents/`, not #353) and stale image/command references.
- Added missing coverage: `PlatformAgent` `status` subresource and integration fields, the `incident_context` plugin, PVCs, cluster-scoped RBAC finalizer cleanup, the `credential-proxy`/`replay-proxy` images, and 5 glossary terms.
- Corrected contributor commands to real make targets and `npm ci`; documented `make validate`.

## Why This Matters

Inaccurate docs erode trust and cause failed installs (e.g. the token-minter
curl example and the fabricated cert-manager Ctrl-C step would not work as
written). Aligning the docs with code makes quickstart, operator, and reference
pages reliable.

## Context

- Documentation-only change; no source code touched.
- Follows the docs consolidation in prior PRs (#290/#341/#343/#345).

## Testing

- `npm run build` in `docs/site` completes successfully (exit 0); all 37 pages render.

---

Documentation-only; no runtime or API impact and no rollout risk.
