### PR TITLE
docs: add CLAUDE.md with commit authorship guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+@AGENTS.md
+
+## Commit Authorship
+
+- Do not add Claude as a co-author on commits.
+- Do not include "Co-Authored-By: Claude" trailers or "Generated with Claude Code" attribution in commit messages.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,7 @@
 
 - Do not add Claude as a co-author on commits.
 - Do not include "Co-Authored-By: Claude" trailers or "Generated with Claude Code" attribution in commit messages.
+
+## Pull Request Descriptions
+
+- Mention in the PR description that the PR was generated with the help of Claude.


### PR DESCRIPTION
# Pull Request

## Why This Change

The repository relies on `AGENTS.md` for agent guidance, but there was no
`CLAUDE.md` to configure Claude-based agents directly. Without it, Claude does
not automatically inherit the project's agent instructions and lacks explicit
commit authorship and PR description conventions.

## What Changed

**Files:**

- `CLAUDE.md`

**Added/Changed/Fixed:**

- Added a project-level `CLAUDE.md` that imports `AGENTS.md` via `@AGENTS.md`.
- Documented commit authorship rules: no Claude co-author trailers and no
  "Generated with Claude Code" attribution in commit messages.
- Documented that PR descriptions should mention when a PR was generated with
  the help of Claude.

## Why This Matters

Ensures Claude-based agents pick up the existing project guidance and follow the
repository's commit hygiene and PR description conventions consistently.

## Context

Complements the existing `AGENTS.md` guidance.

## Testing

- `npx prettier --check CLAUDE.md` passes.

---

Documentation-only change; no functional impact or rollout risk.

_This PR was generated with the help of Claude._
