### PR TITLE
fix(credential-proxy): bound repository length to prevent ReDoS

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -33,6 +33,21 @@ from typing import Any
 LOGGER = logging.getLogger("credential-proxy")
 SLACK_EVENT_QUEUE_MAXSIZE = 1000
 
+# GitHub "owner/name" slug validation. The length guard bounds untrusted input
+# before the regex runs so adversarial strings cannot trigger polynomial-time
+# backtracking (ReDoS); 256 is far above real GitHub owner/name limits.
+MAX_REPOSITORY_LENGTH = 256
+_REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def is_valid_repository(repository: Any) -> bool:
+    """Return True if ``repository`` is a well-formed ``owner/name`` slug."""
+    return (
+        isinstance(repository, str)
+        and len(repository) <= MAX_REPOSITORY_LENGTH
+        and _REPOSITORY_PATTERN.fullmatch(repository) is not None
+    )
+
 
 class ThreadingUnixHTTPServer(socketserver.ThreadingMixIn, socketserver.UnixStreamServer):
     """HTTP server over a private Unix socket used behind Envoy."""
@@ -762,9 +777,7 @@ class CredentialProxyHandler(BaseHTTPRequestHandler):
                 raise ValueError("invalid request size")
             payload = json.loads(self.rfile.read(content_length))
             repository = payload["repository"]
-            if not isinstance(repository, str) or not re.fullmatch(
-                r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
-            ):
+            if not is_valid_repository(repository):
                 raise ValueError("repository must be owner/name")
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -34,8 +34,9 @@ LOGGER = logging.getLogger("credential-proxy")
 SLACK_EVENT_QUEUE_MAXSIZE = 1000
 
 # GitHub "owner/name" slug validation. The length guard bounds untrusted input
-# before the regex runs so adversarial strings cannot trigger polynomial-time
-# backtracking (ReDoS); 256 is far above real GitHub owner/name limits.
+# before the regex runs, as defense-in-depth against regex denial-of-service and
+# to satisfy CodeQL py/polynomial-redos; 256 is far above real GitHub
+# owner/name limits, so valid input is never rejected.
 MAX_REPOSITORY_LENGTH = 256
 _REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -13,11 +13,13 @@ from pathlib import Path
 from unittest import mock
 
 from credential_proxy import (
+    MAX_REPOSITORY_LENGTH,
     AgentAPIProxyHandler,
     CommandExecutor,
     GoogleChatRelay,
     Policy,
     SlackRelay,
+    is_valid_repository,
 )
 from slack_relay_patch import read_upload
 
@@ -195,6 +197,24 @@ class CommandExecutorTest(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "exit code 9") as raised:
             self.executor().bootstrap("printf secret >&2; exit 9")
         self.assertNotIn("secret", str(raised.exception))
+
+
+class RepositoryValidationTest(unittest.TestCase):
+    def test_accepts_valid_owner_name(self):
+        self.assertTrue(is_valid_repository("gke-labs/kube-agents"))
+        self.assertTrue(is_valid_repository("Owner_1/repo.name-2"))
+
+    def test_rejects_non_string(self):
+        self.assertFalse(is_valid_repository(None))
+        self.assertFalse(is_valid_repository(["owner/name"]))
+
+    def test_rejects_missing_slash(self):
+        self.assertFalse(is_valid_repository("owner-name"))
+
+    def test_rejects_oversized_input_without_regex_backtracking(self):
+        # A long run of dashes with no slash is the ReDoS payload; the length
+        # guard must reject it before the regex ever runs.
+        self.assertFalse(is_valid_repository("-" * (MAX_REPOSITORY_LENGTH + 1)))
 
 
 class GoogleChatRelayTest(unittest.TestCase):

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -211,9 +211,9 @@ class RepositoryValidationTest(unittest.TestCase):
     def test_rejects_missing_slash(self):
         self.assertFalse(is_valid_repository("owner-name"))
 
-    def test_rejects_oversized_input_without_regex_backtracking(self):
-        # A long run of dashes with no slash is the ReDoS payload; the length
-        # guard must reject it before the regex ever runs.
+    def test_rejects_oversized_input(self):
+        # The length guard rejects unbounded untrusted input before the regex
+        # runs (defense-in-depth against regex denial-of-service).
         self.assertFalse(is_valid_repository("-" * (MAX_REPOSITORY_LENGTH + 1)))
 
 


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#8](https://github.com/gke-labs/kube-agents/security/code-scanning/8) (`py/polynomial-redos`, severity **high**).

The `/v1/github/refresh` handler validated the untrusted `repository` slug with two adjacent unbounded character-class groups (`re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository)`). `repository` comes straight from the POST body, so adversarial input (e.g. a long run of `-` with no `/`) can force super-linear backtracking — a denial-of-service vector.

## Changes

- Extract validation into a module-level `is_valid_repository()` helper that applies a **256-char length guard before the regex runs**. This is CodeQL's documented remediation for this pattern and is comfortably above real GitHub owner/name limits, so valid input is unaffected.
- Add `RepositoryValidationTest` covering valid slugs, non-strings, missing-slash, and the oversized ReDoS payload.

## Testing

`python3 -m pytest test_credential_proxy.py -q` → **25 passed**.