### PR TITLE
fix(credential-proxy): validate repository segments to remove ReDoS pattern

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -33,20 +33,26 @@ from typing import Any
 LOGGER = logging.getLogger("credential-proxy")
 SLACK_EVENT_QUEUE_MAXSIZE = 1000
 
-# GitHub "owner/name" slug validation. The length guard bounds untrusted input
-# before the regex runs, as defense-in-depth against regex denial-of-service and
-# to satisfy CodeQL py/polynomial-redos; 256 is far above real GitHub
-# owner/name limits, so valid input is never rejected.
+# GitHub "owner/name" slug validation. Each segment is matched with a single,
+# unambiguous character class rather than two adjacent "+" groups around the
+# "/" separator, so the match is linear-time and cannot be forced into
+# polynomial backtracking (ReDoS). The length guard bounds untrusted input as
+# defense-in-depth; 256 is far above real GitHub owner/name limits, so valid
+# input is never rejected.
 MAX_REPOSITORY_LENGTH = 256
-_REPOSITORY_PATTERN = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+_REPOSITORY_SEGMENT = re.compile(r"[A-Za-z0-9_.-]+")
 
 
 def is_valid_repository(repository: Any) -> bool:
     """Return True if ``repository`` is a well-formed ``owner/name`` slug."""
+    if not isinstance(repository, str) or len(repository) > MAX_REPOSITORY_LENGTH:
+        return False
+    owner, slash, name = repository.partition("/")
+    if not slash:
+        return False
     return (
-        isinstance(repository, str)
-        and len(repository) <= MAX_REPOSITORY_LENGTH
-        and _REPOSITORY_PATTERN.fullmatch(repository) is not None
+        _REPOSITORY_SEGMENT.fullmatch(owner) is not None
+        and _REPOSITORY_SEGMENT.fullmatch(name) is not None
     )
 
 

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -211,6 +211,11 @@ class RepositoryValidationTest(unittest.TestCase):
     def test_rejects_missing_slash(self):
         self.assertFalse(is_valid_repository("owner-name"))
 
+    def test_rejects_extra_slash_and_empty_segments(self):
+        self.assertFalse(is_valid_repository("owner/name/extra"))
+        self.assertFalse(is_valid_repository("/name"))
+        self.assertFalse(is_valid_repository("owner/"))
+
     def test_rejects_oversized_input(self):
         # The length guard rejects unbounded untrusted input before the regex
         # runs (defense-in-depth against regex denial-of-service).


### PR DESCRIPTION
# Pull Request

## Why This Change

CodeQL alert [#12](https://github.com/gke-labs/kube-agents/security/code-scanning/12) (`py/polynomial-redos`, severity **high**) re-flagged the GitHub `owner/name` validation in the credential proxy after #395 merged. #395 added a length guard but kept the pattern `[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+`; CodeQL still flags it because the two adjacent unbounded `+` groups around the `/` remain and the short-circuit `and len(...)` guard is not recognized as a sanitizing barrier.

## What Changed

`is_valid_repository` no longer matches the whole slug with two adjacent quantifier groups. It splits on `/` (`str.partition`) and matches each segment with a single, unambiguous character class, removing the ambiguity CodeQL flags.

**Files:**

- `agents/platform/scripts/credential_proxy.py`
- `agents/platform/scripts/test_credential_proxy.py`

**Added/Changed/Fixed:**

- Fixed: replaced `[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+` fullmatch with a `partition("/")` + per-segment `[A-Za-z0-9_.-]+` match.
- Changed: kept `MAX_REPOSITORY_LENGTH` (256) as defense-in-depth.
- Added: tests for extra-slash and empty-segment inputs to lock behavioral equivalence.

## Why This Matters

- A lone `[class]+` matches in linear time and cannot be forced into polynomial backtracking, eliminating the ReDoS exposure on an untrusted POST field (`/v1/github/refresh`) rather than just bounding it.

## Context

- Supersedes the length-guard approach in #395 (merged), which CodeQL re-flagged as #12.
- Behavior is unchanged for valid `owner/name` input.

## Testing

`python3 -m pytest test_credential_proxy.py -q` -> **26 passed**.

---

Low risk: validation-only change, equivalent to prior behavior for valid input; no functional change for callers.
