### PR TITLE
feat(gchat): set typing status text to "Kage is thinking…"

### DIFF
--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -296,9 +296,6 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	// human turn — chat ingress lands here, not on the platform specialist.
 	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge", "tool_call_audit", "incident_context", "bootstrap_onboarding"}
 	cfg.Display.Platforms = map[string]map[string]any{}
-	// Rebrand the Google Chat "thinking" marker card from the upstream default
-	// ("Hermes is thinking…") to our product name.
-	cfg.Platforms.GoogleChat.TypingStatusText = "Kage is thinking…"
 	// Per-user memory. The built-in MEMORY.md/USER.md store stays off; the
 	// multiuser_memory provider replaces it and keys each user's notes off the
 	// gateway identity (agent._user_id), writing to memories/users/<user>.md with a
@@ -341,6 +338,11 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 		if gchat := agent.Spec.Integration.GoogleChat; gchat != nil {
 			if gchat.Enabled != nil {
 				cfg.Platforms.GoogleChat.Enabled = *gchat.Enabled
+				if *gchat.Enabled {
+					// Rebrand the Google Chat "thinking" marker card from the
+					// upstream default ("Hermes is thinking…") to our product name.
+					cfg.Platforms.GoogleChat.TypingStatusText = "Kage is thinking…"
+				}
 			}
 			cfg.Display.Platforms["google_chat"] = resolveGoogleChatDisplayConfig(gchat.Mode)
 		}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -173,6 +173,9 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 		Platforms struct {
 			GoogleChat struct {
 				Enabled bool `json:"enabled"`
+				// Overrides the adapter's default "Hermes is thinking…" marker
+				// card text with our product name.
+				TypingStatusText string `json:"typing_status_text,omitempty"`
 			} `json:"google_chat"`
 			Slack struct {
 				Enabled bool `json:"enabled"`
@@ -293,6 +296,9 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent) string {
 	// human turn — chat ingress lands here, not on the platform specialist.
 	cfg.Plugins.Enabled = []string{"hermes_otel", "session_store", "session_otel_bridge", "tool_call_audit", "incident_context", "bootstrap_onboarding"}
 	cfg.Display.Platforms = map[string]map[string]any{}
+	// Rebrand the Google Chat "thinking" marker card from the upstream default
+	// ("Hermes is thinking…") to our product name.
+	cfg.Platforms.GoogleChat.TypingStatusText = "Kage is thinking…"
 	// Per-user memory. The built-in MEMORY.md/USER.md store stays off; the
 	// multiuser_memory provider replaces it and keys each user's notes off the
 	// gateway identity (agent._user_id), writing to memories/users/<user>.md with a

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -226,6 +226,7 @@ data:
     platforms:
       google_chat:
         enabled: true
+        typing_status_text: Kage is thinking…
       slack:
         enabled: false
     plugins:
@@ -388,7 +389,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 15c8133bf2d3d05b9319482669827f9891e7956c74e5b8f96f4416310755b341
+        kubeagents.x-k8s.io/config-hash: 1088ea5ecf4bb6f1f9c1c0a6262d6c83f22e717a5a655ea8d232dccbccd8b115
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9


### PR DESCRIPTION
## What

The Google Chat adapter posts a "thinking" marker card while a response is being
generated. Upstream it defaults to **"Hermes is thinking…"** (the underlying
framework name). This sets the platform's `typing_status_text` so the card shows
the product name — **"Kage is thinking…"** — instead.

## How

`typing_status_text` is a first-class field on Hermes' `PlatformConfig` (the
adapter reads `getattr(self.config, "typing_status_text", None) or "Hermes is thinking…"`).
This adds the field to the operator's rendered `platforms.google_chat` config in
`renderConfigYAML`.

## Changes

- `platformagent_manifests.go`: add `TypingStatusText` to the rendered
  `google_chat` platform config and set it.
- Golden fixture updated (the new key + the config-hash annotation it shifts).

## Testing

- `go build ./...`
- `go test ./internal/...` (all pass, incl. `TestAgentsGolden`, `TestBuildConfigMap`)
- `go vet ./internal/...`
