### PR TITLE
feat(github-minter): add issues: write permission to allow platform agent to list issues

### DIFF
--- a/k8s-operator/config/integrations/github/README.md
+++ b/k8s-operator/config/integrations/github/README.md
@@ -21,7 +21,7 @@ By installing the GitHub App into a target repository, explicit authorization is
 ### Setting up the GitHub App
 
 1. Navigate to your GitHub Organization (or personal settings) -> **Developer Settings** -> **GitHub Apps** -> **New GitHub App**.
-2. Assign a name and configure the required repository permissions (e.g., `Contents: Read & write`, `Pull requests: Read & write`).
+2. Assign a name and configure the required repository permissions (e.g., `Contents: Read & write`, `Pull requests: Read & write`, `Issues: Read & write`).
 3. Once created, note the **App ID**.
 4. Scroll down and click **Generate a private key**. This will download a `.pem` file to your local machine.
 5. Navigate to the target repository the agent is intended to manage, go to **Settings** -> **GitHub Apps**, and install the newly created App.

--- a/k8s-operator/config/integrations/github/configmap.yaml.template
+++ b/k8s-operator/config/integrations/github/configmap.yaml.template
@@ -16,3 +16,5 @@ data:
         permissions:
           contents: 'write'
           pull_requests: 'write'
+          issues: 'write'
+

--- a/k8s-operator/config/integrations/github/configmap.yaml.template
+++ b/k8s-operator/config/integrations/github/configmap.yaml.template
@@ -17,4 +17,3 @@ data:
           contents: 'write'
           pull_requests: 'write'
           issues: 'write'
-


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform Agent requires access to GitHub Issues to autonomously poll, triage, investigate, and resolve open issues (e.g., via the `github-issue-resolver` skill). Previously, the `github-token-minter` scope configuration template only requested `contents: 'write'` and `pull_requests: 'write'`. Consequently, tokens minted by Minty lacked permissions to list or interact with GitHub Issues (`gh issue list`, `gh issue comment`, `gh issue edit`).

This PR adds `issues: 'write'` to the Token Minter's default configuration template and updates documentation accordingly.

## What Changed

**Files:**

- `k8s-operator/config/integrations/github/configmap.yaml.template`
- `k8s-operator/config/integrations/github/README.md`

**Added/Changed/Fixed:**

- Added `issues: 'write'` to `platform-agent-scope` permissions in `configmap.yaml.template`.
- Updated GitHub App setup guidelines in `README.md` to specify `Issues: Read & write` permissions.

## Why This Matters

- Allows the Platform Agent to mint GitHub installation tokens with permissions to list, inspect, and update issues directly via the GitHub API and `gh` CLI.

## Context

- Supports automated issue resolution workflows (`github-issue-resolver` skill).

## Testing

- Validated template YAML formatting and alignment with GitHub App setup documentation.
