### PR TITLE
fix(operator): implement message-aware reason deduplication for image pull warning events

### DIFF
--- a/k8s-operator/cmd/k8s-event-watcher/dedup.go
+++ b/k8s-operator/cmd/k8s-event-watcher/dedup.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -98,23 +99,29 @@ func (c *dedupCache) clock() time.Time {
 	return time.Now()
 }
 
-// reasonCanonical maps transient or secondary failure reasons to their canonical
-// primary reasons (e.g. ErrImagePull and ImagePullBackOff collapse to a single entry).
-// This prevents multiple redundant troubleshooting sessions from triggering for the same root cause.
-var reasonCanonical = map[string]string{
-	"ErrImagePull": "ImagePullBackOff",
-	"BackOff":      "CrashLoopBackOff",
-}
-
-// canonicalizeReason returns the canonical reason name.
-func canonicalizeReason(reason string) string {
-	if canonical, ok := reasonCanonical[reason]; ok {
-		return canonical
+// canonicalizeReason returns the canonical reason name, checking the event message for
+// generic reasons (like Failed or BackOff) to group them into their specific failure families.
+func canonicalizeReason(reason, message string) string {
+	if reason == "BackOff" {
+		if strings.Contains(message, "pulling image") {
+			return "ImagePullBackOff"
+		}
+		return "CrashLoopBackOff"
+	}
+	if reason == "Failed" {
+		if strings.Contains(message, "Failed to pull image") ||
+			strings.Contains(message, "ErrImagePull") ||
+			strings.Contains(message, "ImagePullBackOff") {
+			return "ImagePullBackOff"
+		}
+	}
+	if reason == "ErrImagePull" {
+		return "ImagePullBackOff"
 	}
 	return reason
 }
 
-// Observe evaluates an incoming event target key and timestamp against cached state.
+// Observe evaluates an incoming event target key, message, and timestamp against cached state.
 // It returns a dedupResult indicating whether to create a new session or suppress the event.
 //
 // Evaluates the following three cases:
@@ -124,8 +131,8 @@ func canonicalizeReason(reason string) string {
 //    Result: classified as a new incident to trigger a retry session.
 // 3. Ongoing Incidents: New EventLastTS observed within the rolling window.
 //    Result: suppressed as a duplicate. LastSeen is advanced.
-func (c *dedupCache) Observe(key EventKey, eventLastTS time.Time) dedupResult {
-	key.Reason = canonicalizeReason(key.Reason)
+func (c *dedupCache) Observe(key EventKey, message string, eventLastTS time.Time) dedupResult {
+	key.Reason = canonicalizeReason(key.Reason, message)
 	now := c.clock()
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -173,8 +180,8 @@ func (c *dedupCache) Observe(key EventKey, eventLastTS time.Time) dedupResult {
 // that saw a `dedupNewIncident` result on one reason variant can
 // bind the session using the wire-level reason without having to
 // know about the family mapping.
-func (c *dedupCache) BindSession(key EventKey, sessionID string) {
-	key.Reason = canonicalizeReason(key.Reason)
+func (c *dedupCache) BindSession(key EventKey, message string, sessionID string) {
+	key.Reason = canonicalizeReason(key.Reason, message)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if entry, ok := c.entries[key]; ok {

--- a/k8s-operator/cmd/k8s-event-watcher/dedup_test.go
+++ b/k8s-operator/cmd/k8s-event-watcher/dedup_test.go
@@ -34,7 +34,7 @@ func TestDedupObserve(t *testing.T) {
 	eventTime := now
 
 	// 1. First event should be a new incident
-	res := c.Observe(key, eventTime)
+	res := c.Observe(key, "", eventTime)
 	if res.Kind != dedupNewIncident {
 		t.Errorf("Observe (first) got kind %v; want dedupNewIncident", res.Kind)
 	}
@@ -43,10 +43,10 @@ func TestDedupObserve(t *testing.T) {
 	}
 
 	// Bind a mock session to it
-	c.BindSession(key, "session-abc")
+	c.BindSession(key, "", "session-abc")
 
 	// 2. Immediate repeat should be a duplicate
-	res = c.Observe(key, eventTime)
+	res = c.Observe(key, "", eventTime)
 	if res.Kind != dedupDuplicate {
 		t.Errorf("Observe (immediate repeat) got kind %v; want dedupDuplicate", res.Kind)
 	}
@@ -59,7 +59,7 @@ func TestDedupObserve(t *testing.T) {
 
 	// 3. Advancing time past window should result in a new incident
 	now = now.Add(6 * time.Minute)
-	res = c.Observe(key, now)
+	res = c.Observe(key, "", now)
 	if res.Kind != dedupNewIncident {
 		t.Errorf("Observe (expired window) got kind %v; want dedupNewIncident", res.Kind)
 	}
@@ -83,18 +83,83 @@ func TestCanonicalReasonMatching(t *testing.T) {
 	key2 := EventKey{Reason: "ImagePullBackOff", UID: "pod-image-pull"}
 
 	// First event: ErrImagePull
-	res1 := c.Observe(key1, now)
+	res1 := c.Observe(key1, "", now)
 	if res1.Kind != dedupNewIncident {
 		t.Errorf("Observe key1 got kind %v; want dedupNewIncident", res1.Kind)
 	}
-	c.BindSession(key1, "session-image-pull")
+	c.BindSession(key1, "", "session-image-pull")
 
 	// Second event: ImagePullBackOff for same pod should be duplicate
-	res2 := c.Observe(key2, now)
+	res2 := c.Observe(key2, "", now)
 	if res2.Kind != dedupDuplicate {
 		t.Errorf("Observe key2 got kind %v; want dedupDuplicate", res2.Kind)
 	}
 	if res2.SessionID != "session-image-pull" {
 		t.Errorf("Observe key2 got session %q; want 'session-image-pull'", res2.SessionID)
+	}
+}
+
+func TestMessageAwareReasonMatching(t *testing.T) {
+	window := 5 * time.Minute
+	c, err := newDedupCache(window, "")
+	if err != nil {
+		t.Fatalf("Failed to create dedup cache: %v", err)
+	}
+
+	now := time.Now()
+	c.now = func() time.Time { return now }
+
+	podUID := "pod-pull-failure"
+
+	// All these events should canonicalize to ImagePullBackOff:
+	// 1. Failed (msg: Failed to pull image...)
+	// 2. Failed (msg: Error: ErrImagePull)
+	// 3. BackOff (msg: Back-off pulling image...)
+	// 4. Failed (msg: Error: ImagePullBackOff)
+
+	e1Key := EventKey{Reason: "Failed", UID: podUID}
+	e1Msg := `Failed to pull image "nginx:invalid-tag-for-testing": rpc error: code = NotFound ...`
+
+	e2Key := EventKey{Reason: "Failed", UID: podUID}
+	e2Msg := "Error: ErrImagePull"
+
+	e3Key := EventKey{Reason: "BackOff", UID: podUID}
+	e3Msg := `Back-off pulling image "nginx:invalid-tag-for-testing"`
+
+	e4Key := EventKey{Reason: "Failed", UID: podUID}
+	e4Msg := "Error: ImagePullBackOff"
+
+	// 1st: Failed (Failed to pull image)
+	res1 := c.Observe(e1Key, e1Msg, now)
+	if res1.Kind != dedupNewIncident {
+		t.Errorf("1st event got %v; want dedupNewIncident", res1.Kind)
+	}
+	c.BindSession(e1Key, e1Msg, "session-shared")
+
+	// 2nd: Failed (ErrImagePull)
+	res2 := c.Observe(e2Key, e2Msg, now)
+	if res2.Kind != dedupDuplicate {
+		t.Errorf("2nd event got %v; want dedupDuplicate", res2.Kind)
+	}
+	if res2.SessionID != "session-shared" {
+		t.Errorf("2nd event got session %q; want 'session-shared'", res2.SessionID)
+	}
+
+	// 3rd: BackOff (Back-off pulling image)
+	res3 := c.Observe(e3Key, e3Msg, now)
+	if res3.Kind != dedupDuplicate {
+		t.Errorf("3rd event got %v; want dedupDuplicate", res3.Kind)
+	}
+	if res3.SessionID != "session-shared" {
+		t.Errorf("3rd event got session %q; want 'session-shared'", res3.SessionID)
+	}
+
+	// 4th: Failed (ImagePullBackOff)
+	res4 := c.Observe(e4Key, e4Msg, now)
+	if res4.Kind != dedupDuplicate {
+		t.Errorf("4th event got %v; want dedupDuplicate", res4.Kind)
+	}
+	if res4.SessionID != "session-shared" {
+		t.Errorf("4th event got session %q; want 'session-shared'", res4.SessionID)
 	}
 }

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -202,7 +202,7 @@ func (d *dispatcher) Dispatch(ctx context.Context, ev TriageEvent) {
 	if !d.filter.Accept(ev) {
 		return
 	}
-	result := d.dedup.Observe(ev.Key, ev.LastSeen)
+	result := d.dedup.Observe(ev.Key, ev.Message, ev.LastSeen)
 	d.metrics.activeIncidents.Set(float64(d.dedup.Len()))
 	if result.Kind == dedupDuplicate {
 		d.metrics.eventsDedupSuppress.WithLabelValues(ev.Key.Reason, ev.Namespace).Inc()
@@ -224,7 +224,7 @@ func (d *dispatcher) Dispatch(ctx context.Context, ev TriageEvent) {
 		}
 		sid = newSid
 		d.metrics.sessionCreates.WithLabelValues("ok").Inc()
-		d.dedup.BindSession(ev.Key, sid)
+		d.dedup.BindSession(ev.Key, ev.Message, sid)
 	}
 	payload := InjectPayload{
 		Kind:         injectKindEvent,


### PR DESCRIPTION
# Pull Request

## Why This Change

When simulating an image pull failure on GKE (e.g. `nginx:invalid-tag-for-testing`), the event watcher triggers two duplicate autonomous troubleshooting sessions in chat:
1. One for the `Failed` warning event (`Failed to pull image...`).
2. One for the `BackOff` normal event (`Back-off pulling image...`), which maps to `CrashLoopBackOff` in canonical reason mapping.

Because the watcher's deduplication logic grouped events by reason name without checking messages:
- `Failed` reason was not canonicalized and stayed as `Failed`.
- `BackOff` reason was canonicalized to `CrashLoopBackOff`.
These generated two different event keys (`{UID, Failed}` and `{UID, CrashLoopBackOff}`), leading to parallel investigations.

## What Changed

Implemented message-aware reason canonicalization in `dedupCache`:
- `BackOff` events with a message containing `"pulling image"` are now mapped to `ImagePullBackOff`.
- `Failed` events with messages containing `"Failed to pull image"`, `"ErrImagePull"`, or `"ImagePullBackOff"` are now mapped to `ImagePullBackOff`.
- This ensures all 4 sequential GKE events for an image pull failure (`Failed` -> `Failed` -> `BackOff` -> `Failed`) canonicalize to `ImagePullBackOff` for the same Pod UID, resolving them to a single incident key and preventing duplicate alerts.

**Files:**

- `k8s-operator/cmd/k8s-event-watcher/dedup.go`
- `k8s-operator/cmd/k8s-event-watcher/dedup_test.go`
- `k8s-operator/cmd/k8s-event-watcher/main.go`

**Added/Changed/Fixed:**

- Added message-based reason routing to `canonicalizeReason`.
- Updated `Observe` and `BindSession` methods to take the event `Message` field.
- Added `TestMessageAwareReasonMatching` to test coverage.

## Why This Matters

Reduces noise and prevents duplicate troubleshooting agent sessions from triggering for the same root cause (image pull failures) in production.

## Context

Reported duplicate alerts:
1. `🔵 Info: Back off autopush-workloads/simulate-image-pull-error — Back-off pulling image ...`
2. `🟡 Warning: Failed autopush-workloads/simulate-image-pull-error — Failed to pull image ...`

## Testing

- Added unit tests in `dedup_test.go` confirming that sequential `Failed` (pull failed), `Failed` (ErrImagePull), `BackOff` (image pull backoff), and `Failed` (ImagePullBackOff) events collapse into a single active deduplication window incident for the pod.
- Verified all Go tests pass: `go test -v ./...` in `k8s-operator/` completed successfully.
