### PR TITLE
Add force-conflicts to the serversidde apply

### DIFF
--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -81,7 +81,7 @@ endif
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	@out="$$( $(KUSTOMIZE) build config/crd 2>/dev/null || true )"; \
-	if [ -n "$$out" ]; then echo "$$out" | kubectl apply --server-side -f -; else echo "No CRDs to install; skipping."; fi
+	if [ -n "$$out" ]; then echo "$$out" | kubectl apply --server-side --force-conflicts -f -; else echo "No CRDs to install; skipping."; fi
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -91,7 +91,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply --server-side -f -
+	$(KUSTOMIZE) build config/default | kubectl apply --server-side --force-conflicts -f -
 
 .PHONY: undeploy
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.


### PR DESCRIPTION
# Pull Request

## Why This Change
When deploying the operator using `kubectl apply --server-side` during CI/CD or local provisioning, the operation occasionally fails with a Server-Side Apply (SSA) conflict. This happens if fields in the target cluster are already managed by another manager (e.g., `kubectl-client-side-apply` or an older controller version), causing the pipeline to crash.

## What Changed
Appended the `--force-conflicts` flag to the `kubectl apply --server-side` commands to forcefully take ownership of conflicting fields.

**Files:**
- `k8s-operator/Makefile`

**Added/Changed/Fixed:**
- Fixed the `install` and `deploy` Makefile targets by adding `--force-conflicts` to resolve field ownership disputes during Server-Side Apply.

## Why This Matters
- **Stability**: Prevents the operator deployment and GitHub Actions pipelines from randomly failing due to SSA field manager conflicts.
- **Idempotency**: Ensures the `make deploy` and `make install` commands are fully idempotent and can cleanly overwrite older configurations.

## Context
- Addresses the Kubernetes API error: `If you intend to manage all of these fields, please re-run the apply command with the --force-conflicts flag.`
- Resolves the failing `gcp-provision-03-operator` CI pipeline step.

## Testing
- Verified that running `make deploy` locally successfully applies the operator manifests and forcefully resolves any existing field ownership conflicts without exiting with `Error 1`.

---
