### PR TITLE
chore: remove stale references to deleted operator and devteam agents

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,25 +21,3 @@ updates:
       - "docker"
     commit-message:
       prefix: "ci"
-
-  - package-ecosystem: "docker"
-    directory: "/agents/operator"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "docker"
-    commit-message:
-      prefix: "ci"
-
-  - package-ecosystem: "docker"
-    directory: "/agents/devteam"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "docker"
-    commit-message:
-      prefix: "ci"

--- a/agents/platform/skills/gke-manifest-generation/SKILL.md
+++ b/agents/platform/skills/gke-manifest-generation/SKILL.md
@@ -14,7 +14,7 @@ When generating or updating YAML manifests, you **must** strictly adhere to the 
 ### 1. Namespace & Resource Isolation
 
 - **Explicit Namespace**: Always declare `namespace: <NAMESPACE>` explicitly in the metadata of every resource (Deployments, Services, ConfigMaps, Secrets, PVCs, Roles, bindings). Map it to the namespace configured in your active `SETTINGS.md`. Never omit the namespace.
-- **Dedicated ServiceAccount**: Avoid using the namespace's `default` ServiceAccount. Always create and reference a dedicated `ServiceAccount` (e.g., `devteam-agent-sa`) for each microservice.
+- **Dedicated ServiceAccount**: Avoid using the namespace's `default` ServiceAccount. Always create and reference a dedicated `ServiceAccount` (e.g., `app-sa`) for each microservice.
 
 ### 2. GKE Resource Tuning (Autopilot & Standard)
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The migration to the single Platform Agent architecture removed the
`agents/operator` and `agents/devteam` directories, but a couple of
references to those deleted agents were left behind in configuration and
skill files. This is follow-up cleanup extracted from the functional
portion of #341 (the documentation portion was already consolidated in #390).

## What Changed

**Files:**

- `.github/dependabot.yml`
- `agents/platform/skills/gke-manifest-generation/SKILL.md`

**Added/Changed/Fixed:**

- Removed the two `package-ecosystem: docker` entries pointing at
  `/agents/operator` and `/agents/devteam`, which no longer exist.
  Dependabot was scanning non-existent paths.
- Updated the `ServiceAccount` naming example in the GKE manifest
  generation skill from `devteam-agent-sa` to `app-sa`, removing a
  reference to a removed agent.

## Why This Matters

- Stops Dependabot from erroring/scanning deleted directories, reducing CI noise.
- Keeps the skill guidance consistent with the single-agent architecture.

## Context

- Extracted from the functional changes in #341.
- Documentation content of #341 was already consolidated by #390.

## Testing

- No runtime behavior changes. `dependabot.yml` remains valid YAML
  (only whole ecosystem blocks removed); the skill change is a docstring
  example only.

---

Low risk: configuration/documentation-example cleanup only, no code paths affected.

_This PR was generated with the help of Claude._
