### PR TITLE
fix(scripts): correct Google Chat bot avatar URL

### DIFF
--- a/k8s-operator/scripts/print_instructions_gchat.sh
+++ b/k8s-operator/scripts/print_instructions_gchat.sh
@@ -18,7 +18,7 @@ if [ "${GOOGLE_CHAT_ENABLED:-false}" = "true" ]; then
   echo -e "[ ] 1. Configure GChat bot connection in GCP Console:"
   echo -e "       ${C_WHITE}https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat?project=${PROJECT_ID}${C_RESET}"
   echo -e "       - Name: ${C_GREEN}GKE Platform Agent Bot${C_RESET}"
-  echo -e "       - Avatar: ${C_GREEN}https://platform-agent.nousresearch.com/docs/img/logo.png${C_RESET}"
+  echo -e "       - Avatar: ${C_GREEN}https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/icon/color/kubernetes-icon-color.png${C_RESET}"
   echo -e "       - Connection Settings: Select ${C_BOLD}Cloud Pub/Sub${C_RESET}"
   echo -e "       - Pub/Sub Topic Name: ${C_GREEN}projects/${PROJECT_ID}/topics/${CHAT_TOPIC_NAME}${C_RESET}"
   echo -e "       - Under Visibility, check: ${C_GREEN}Only specific people (add your email/emails: ${ALLOWED_USERS:-your-email})${C_RESET}"

--- a/k8s-operator/scripts/provision_05_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_05_gcp_gchat.sh
@@ -117,6 +117,7 @@ execute_pubsub_setup() {
   gcloud pubsub topics add-iam-policy-binding "${CHAT_TOPIC_NAME}" \
       --member="serviceAccount:chat-api-push@system.gserviceaccount.com" \
       --role="roles/pubsub.publisher" \
+      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 
@@ -124,6 +125,7 @@ execute_pubsub_setup() {
   gcloud pubsub topics add-iam-policy-binding "${CHAT_TOPIC_NAME}" \
       --member="serviceAccount:${gsuite_sa}" \
       --role="roles/pubsub.publisher" \
+      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 }
@@ -143,12 +145,14 @@ execute_agent_gcp() {
   gcloud pubsub subscriptions add-iam-policy-binding "${CHAT_SUB_NAME}" \
       --member="serviceAccount:${gsa_email}" \
       --role="roles/pubsub.subscriber" \
+      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 
   gcloud pubsub subscriptions add-iam-policy-binding "${CHAT_SUB_NAME}" \
       --member="serviceAccount:${gsa_email}" \
       --role="roles/pubsub.viewer" \
+      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 }

--- a/k8s-operator/scripts/provision_05_gcp_gchat.sh
+++ b/k8s-operator/scripts/provision_05_gcp_gchat.sh
@@ -117,7 +117,6 @@ execute_pubsub_setup() {
   gcloud pubsub topics add-iam-policy-binding "${CHAT_TOPIC_NAME}" \
       --member="serviceAccount:chat-api-push@system.gserviceaccount.com" \
       --role="roles/pubsub.publisher" \
-      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 
@@ -125,7 +124,6 @@ execute_pubsub_setup() {
   gcloud pubsub topics add-iam-policy-binding "${CHAT_TOPIC_NAME}" \
       --member="serviceAccount:${gsuite_sa}" \
       --role="roles/pubsub.publisher" \
-      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 }
@@ -145,14 +143,12 @@ execute_agent_gcp() {
   gcloud pubsub subscriptions add-iam-policy-binding "${CHAT_SUB_NAME}" \
       --member="serviceAccount:${gsa_email}" \
       --role="roles/pubsub.subscriber" \
-      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 
   gcloud pubsub subscriptions add-iam-policy-binding "${CHAT_SUB_NAME}" \
       --member="serviceAccount:${gsa_email}" \
       --role="roles/pubsub.viewer" \
-      --condition=None \
       --project="${PROJECT_ID}" \
       --quiet >/dev/null || return 1
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

The Google Chat setup instructions pointed the bot avatar at an unrelated
fork's domain (`platform-agent.nousresearch.com/docs/img/logo.png`), which
is off-project and likely broken. Extracted from the functional portion of
#290 (the documentation portion was already consolidated in #390).

> Note: this PR originally also added `--condition=None` to the Pub/Sub IAM
> bindings, but that change was reverted because it introduced a bug. The PR
> now carries only the avatar URL correction.

## What Changed

**Files:**

- `k8s-operator/scripts/print_instructions_gchat.sh`

**Added/Changed/Fixed:**

- Replaced the stale, off-project bot avatar URL with the official
  Kubernetes icon.

## Why This Matters

- The old avatar URL points at an unrelated fork's domain and is likely
  broken; the Kubernetes icon is on-project and stable.

## Context

- Extracted from the functional changes in #290 (closed).
- Documentation content of #290 was already consolidated by #390.

## Testing

- `bash -n` syntax check passes.
- Avatar URL verified to return HTTP 200.

---

Low risk: a documentation-string URL correction in the printed setup
instructions. No operator/controller code or provisioning logic affected.

_This PR was generated with the help of Claude._
