### PR TITLE
ci: add advisory documentation freshness check workflow

### DIFF
--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -1,0 +1,68 @@
+name: Documentation Freshness Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-docs-freshness:
+    name: Check Documentation Freshness
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Verify Code and Documentation Coverage
+        run: |
+          git fetch origin ${{ github.base_ref }}
+
+          # Identify modified code files (excluding documentation and metadata)
+          mapfile -t CODE_FILES < <(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep -E '^(k8s-operator/|agents/|deploy/|scripts/|examples/|tests/)' | grep -v -E '\.md$' || true)
+
+          # Identify modified documentation files
+          mapfile -t DOC_FILES < <(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep -E '(\.md$|^docs/)' || true)
+
+          echo "## Documentation Freshness Assessment" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${#CODE_FILES[@]}" -eq 0 ]; then
+            echo "✅ **No core code changes detected.** This PR contains documentation or configuration updates only." >> $GITHUB_STEP_SUMMARY
+            echo "No code changes detected."
+            exit 0
+          fi
+
+          echo "### 📦 Code Files Modified (${#CODE_FILES[@]} files)" >> $GITHUB_STEP_SUMMARY
+          printf '- `%s`\n' "${CODE_FILES[@]}" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${#DOC_FILES[@]}" -gt 0 ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### 📝 Documentation Files Updated (${#DOC_FILES[@]} files)" >> $GITHUB_STEP_SUMMARY
+            printf '- `%s`\n' "${DOC_FILES[@]}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Documentation updated alongside code changes.** Good job maintaining repository documentation!" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### ⚠️ Notice: No Documentation Updates Included" >> $GITHUB_STEP_SUMMARY
+            echo "This Pull Request modifies code files but does not include updates to documentation (\`*.md\`)." >> $GITHUB_STEP_SUMMARY
+            echo "Please verify whether any of the following documentation should be updated:" >> $GITHUB_STEP_SUMMARY
+
+            HAS_OPERATOR=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^k8s-operator/' || true)
+            HAS_SKILLS=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^agents/platform/skills/' || true)
+            HAS_SCRIPTS=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^k8s-operator/scripts/' || true)
+
+            if [ "$HAS_SCRIPTS" -gt 0 ]; then
+              echo "- 💡 \`k8s-operator/scripts/\` modified: Consider updating \`k8s-operator/scripts/README.md\` or \`INSTALL.md\`." >> $GITHUB_STEP_SUMMARY
+            elif [ "$HAS_OPERATOR" -gt 0 ]; then
+              echo "- 💡 \`k8s-operator/\` modified: Consider updating \`k8s-operator/README.md\` or \`docs/\`." >> $GITHUB_STEP_SUMMARY
+            fi
+            if [ "$HAS_SKILLS" -gt 0 ]; then
+              echo "- 💡 \`agents/platform/skills/\` modified: Consider updating the corresponding \`SKILL.md\`." >> $GITHUB_STEP_SUMMARY
+            fi
+
+            echo "::notice title=Documentation Freshness Check::Code changes detected without corresponding documentation updates. Please review if READMEs, INSTALL.md, or docs/ require updates."
+          fi

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -20,48 +20,54 @@ jobs:
 
       - name: Verify Code and Documentation Coverage
         run: |
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin "${{ github.base_ref }}"
 
           # Identify modified code files (excluding documentation and metadata)
-          mapfile -t CODE_FILES < <(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep -E '^(k8s-operator/|agents/|deploy/|scripts/|examples/|tests/)' | grep -v -E '\.md$' || true)
+          mapfile -t CODE_FILES < <(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" | grep -E '^(k8s-operator/|agents/|deploy/|scripts/|examples/|tests/)' | grep -v -E '\.md$' || true)
 
           # Identify modified documentation files
-          mapfile -t DOC_FILES < <(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep -E '(\.md$|^docs/)' || true)
+          mapfile -t DOC_FILES < <(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" | grep -E '(\.md$|^docs/)' || true)
 
-          echo "## Documentation Freshness Assessment" >> $GITHUB_STEP_SUMMARY
+          echo "## Documentation Freshness Assessment" >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${#CODE_FILES[@]}" -eq 0 ]; then
-            echo "✅ **No core code changes detected.** This PR contains documentation or configuration updates only." >> $GITHUB_STEP_SUMMARY
+            echo "✅ **No core code changes detected.** This PR contains documentation or configuration updates only." >> "$GITHUB_STEP_SUMMARY"
             echo "No code changes detected."
             exit 0
           fi
 
-          echo "### 📦 Code Files Modified (${#CODE_FILES[@]} files)" >> $GITHUB_STEP_SUMMARY
-          printf '- `%s`\n' "${CODE_FILES[@]}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### 📦 Code Files Modified (${#CODE_FILES[@]} files)"
+            printf -- "- \`%s\`\n" "${CODE_FILES[@]}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ "${#DOC_FILES[@]}" -gt 0 ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### 📝 Documentation Files Updated (${#DOC_FILES[@]} files)" >> $GITHUB_STEP_SUMMARY
-            printf '- `%s`\n' "${DOC_FILES[@]}" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "✅ **Documentation updated alongside code changes.** Good job maintaining repository documentation!" >> $GITHUB_STEP_SUMMARY
+            {
+              echo ""
+              echo "### 📝 Documentation Files Updated (${#DOC_FILES[@]} files)"
+              printf -- "- \`%s\`\n" "${DOC_FILES[@]}"
+              echo ""
+              echo "✅ **Documentation updated alongside code changes.** Good job maintaining repository documentation!"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### ⚠️ Notice: No Documentation Updates Included" >> $GITHUB_STEP_SUMMARY
-            echo "This Pull Request modifies code files but does not include updates to documentation (\`*.md\`)." >> $GITHUB_STEP_SUMMARY
-            echo "Please verify whether any of the following documentation should be updated:" >> $GITHUB_STEP_SUMMARY
+            {
+              echo ""
+              echo "### ⚠️ Notice: No Documentation Updates Included"
+              echo "This Pull Request modifies code files but does not include updates to documentation (\`*.md\`)."
+              echo "Please verify whether any of the following documentation should be updated:"
+            } >> "$GITHUB_STEP_SUMMARY"
 
             HAS_OPERATOR=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^k8s-operator/' || true)
             HAS_SKILLS=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^agents/platform/skills/' || true)
             HAS_SCRIPTS=$(printf '%s\n' "${CODE_FILES[@]}" | grep -c '^k8s-operator/scripts/' || true)
 
             if [ "$HAS_SCRIPTS" -gt 0 ]; then
-              echo "- 💡 \`k8s-operator/scripts/\` modified: Consider updating \`k8s-operator/scripts/README.md\` or \`INSTALL.md\`." >> $GITHUB_STEP_SUMMARY
+              echo "- 💡 \`k8s-operator/scripts/\` modified: Consider updating \`k8s-operator/scripts/README.md\` or \`INSTALL.md\`." >> "$GITHUB_STEP_SUMMARY"
             elif [ "$HAS_OPERATOR" -gt 0 ]; then
-              echo "- 💡 \`k8s-operator/\` modified: Consider updating \`k8s-operator/README.md\` or \`docs/\`." >> $GITHUB_STEP_SUMMARY
+              echo "- 💡 \`k8s-operator/\` modified: Consider updating \`k8s-operator/README.md\` or \`docs/\`." >> "$GITHUB_STEP_SUMMARY"
             fi
             if [ "$HAS_SKILLS" -gt 0 ]; then
-              echo "- 💡 \`agents/platform/skills/\` modified: Consider updating the corresponding \`SKILL.md\`." >> $GITHUB_STEP_SUMMARY
+              echo "- 💡 \`agents/platform/skills/\` modified: Consider updating the corresponding \`SKILL.md\`." >> "$GITHUB_STEP_SUMMARY"
             fi
 
             echo "::notice title=Documentation Freshness Check::Code changes detected without corresponding documentation updates. Please review if READMEs, INSTALL.md, or docs/ require updates."


### PR DESCRIPTION
# Pull Request

## Why This Change

We want a lightweight, automatic reminder to keep documentation in sync
with code. Today it is easy to merge code changes and forget to update the
corresponding READMEs, `INSTALL.md`, or `docs/`. This is the functional
extraction of #343 (a docs-CI change that #390 did not consolidate).

## What Changed

**Files:**

- `.github/workflows/docs-freshness-check.yml`

**Added/Changed/Fixed:**

- New **advisory** (non-blocking) PR workflow. It diffs the branch against
  the base and, if code files changed with no accompanying `*.md` / `docs/`
  update, posts a job step-summary plus a `::notice` nudging the author to
  review documentation. It never fails the build.
- Reuses the existing `prettier.yml` diffing conventions: `git fetch` of the
  base ref, `--diff-filter=d`, three-dot merge-base diff, and `grep`
  pipelines guarded with `|| true` for `pipefail`.

**Polish over the original #343 proposal:**

- Trimmed redundant DOC-regex anchors already covered by `\.md$`.
- Made the `k8s-operator/scripts/` hint and the generic `k8s-operator/`
  hint mutually exclusive so they don't both fire for a scripts-only change.

## Why This Matters

- Reduces documentation drift with zero enforcement risk — it is a soft
  nudge, so it will not block legitimate code-only or test-only PRs.

## Context

- Extracted from the CI portion of #343.
- Intentionally kept advisory to avoid notice-fatigue / false-positive
  failures on refactors, bug fixes, and test-only PRs.

## Testing

- Workflow YAML validated locally.
- Logic mirrors the already-working `prettier.yml`; CI `actionlint` will
  lint it on this PR.

---

Low risk: advisory-only CI addition. No existing workflows, code, or gates
are modified.

_This PR was generated with the help of Claude._
