### PR TITLE
docs: modernize README and surface credential isolation in the docs site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,20 +8,22 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
 
 - `agents/`: Source of truth for agent blueprints (personas and skills).
   - `platform/`: Configuration for the Platform Agent.
-- `deploy/`: Deployment infrastructure code (Dockerfile, Helm charts, manifests).
-- `docs/`: Documentation, guides, and walkthroughs.
-- `local-dev/`: Tooling for local offline testing (Kind setup).
+- `.agents/skills/`: Repository-level security review skills.
+- `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
+- `docs/`: Design docs and the documentation site (`docs/site/`).
+- `k8s-operator/`: Go/Kubebuilder operator reconciling `PlatformAgent` Custom Resources, plus provisioning scripts.
+- `examples/`: Example integrations (LiteLLM provider configs, vLLM serving, inference replay).
 - `INSTALL.md`: Installation guide.
 - `README.md`: Project overview.
 
 ## Agent Setup & Integration
 
-This repository is primarily a configuration and documentation repository for AI agents. It does not contain code that requires compilation or traditional building.
+This repository is primarily a configuration and documentation repository for AI agents. The main exception is the Go-based Kubernetes operator in `k8s-operator/`, which requires compilation (see Local Validation Checks below).
 
 To use these agents:
 
 1. Follow the instructions in [INSTALL.md](INSTALL.md) to set up and register the Platform Agent in your agent harness.
-2. Refer to SRE walkthroughs in [docs/m1-demos.md](docs/m1-demos.md) for details on how to interact with the cooperative agent layout and run demo scenarios.
+2. Refer to the documentation site content in [docs/site/src/content/docs/](docs/site/src/content/docs/) for architecture, concepts, and operational guides.
 
 ## Skills Guidelines
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
-# kube-agents: The Kubernetes Agentic Harness
+# 🧭 kube-agents — The Kubernetes Agentic Harness
 
-The k8s agentic harness will fundamentally redefine the DevOps presentation layer by replacing traditional interfaces like kubectl, gcloud, and the Google Cloud console with intelligent, autonomous agents. By replacing the static, imperative nature of the traditional Kubernetes presentation layer with an autonomous agentic harness, we transition from reactive manual management to proactive, intent-driven operations.
+**Stop driving your clusters. Start delegating them.**
 
-## Key Components
+`kube-agents` replaces the traditional imperative DevOps presentation layer — `kubectl`, `gcloud`, the Google Cloud Console — with autonomous, proactive AI agents that manage your Kubernetes/GKE infrastructure, enforce multi-tenant governance, and continuously audit security posture. Instead of you reacting to pages and typing commands, a **Platform Agent** watches your fleet around the clock, opens pull requests with fixes, and reports to you in chat.
 
-### 1. Platform Agent (`platform`)
+| Traditional Ops                              | With `kube-agents`                                                                                           |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| Reactive, manual toil (`kubectl` + runbooks) | Proactive, intent-driven operations                                                                          |
+| Drift discovered during incidents            | Scheduled compliance & blueprint audits ([10 autonomous watchdogs](agents/platform/cron/jobs.json))          |
+| Hand-rolled RBAC and tenancy reviews         | Automated RBAC & boundary enforcement, [credential isolation by design](docs/credential-isolation-design.md) |
+| Patch Tuesdays and CVE spreadsheets          | Continuous vulnerability scanning & staggered patch orchestration                                            |
+| One human, one terminal                      | Seamless multi-agent collaboration over Google Chat & Slack                                                  |
 
-The master custodian and agent architect configured with an architectural persona (`SOUL.md`). It manages multi-tenancy governance, RBAC boundaries, and GKE infrastructure lifecycle.
+### ⚡ Try it now
 
----
+The fastest way in: clone this repository into the workspace of your multi-agent platform's default agent (CrewAI, LangGraph, Microsoft AutoGen, or any Hermes-compatible harness) and delegate the setup itself to an agent:
 
-## Harness Integration & Setup
+```text
+"Using kube-agents/INSTALL.md provision k8s agentic harness and create platform agent"
+```
 
-This workspace contains agent configurations, personas, and skills that can be imported into various pattern gateways or multi-agent platforms (such as CrewAI, Microsoft AutoGen, or LangGraph).
+Or register the Platform Agent yourself:
 
-Multi-agent platforms and orchestrators can use the [INSTALL.md](INSTALL.md) guide to set up the Platform Agent. To delegate this task to your platform, clone this repository to the workspace of the default agent of multi-agent platform and ask it:
-
-> "Using `kube-agents/INSTALL.md` provision k8s agentic harness and create platform agent"
-
-### 1. Declarative Registration (YAML/JSON)
-
-For platforms or gateways that load agents declaratively, add the Platform Agent workspace path to your profile or orchestrator configuration:
+**Declarative (YAML/JSON)** — for platforms and gateways that load agents from configuration:
 
 ```yaml
 agents:
@@ -28,16 +30,157 @@ agents:
     workspace: ./agents/platform
 ```
 
-### 2. Imperative CLI Registration
-
-For hosts supporting CLI-driven imports, register the Platform Agent directory from the repository root. For example (using a generic gateway CLI or reference host):
+**Imperative (CLI)** — for hosts supporting CLI-driven imports:
 
 ```bash
-# Register platform agent
+# Register the Platform Agent from the repository root
 gateway-cli agents add platform --workspace ./agents/platform --non-interactive
 ```
 
-For more details on routing policies, proof gates, and showcasing scenarios, see the [Kubernetes Multi-Agent Integration Guide](docs/m1-demos.md).
+Full setup options — from a one-command GKE provisioning pipeline to local Kind development — are in [INSTALL.md](INSTALL.md) and covered in [Installation & Quickstart](#-installation--quickstart) below.
+
+---
+
+## 📖 Overview
+
+At the heart of the harness is the **Platform Agent (`platform`)** — the master custodian and agent architect. It serves as the primary chat entrypoint into the entire harness, manages the GKE infrastructure lifecycle, establishes multi-tenancy boundaries, and enforces fleet-wide compliance.
+
+The Platform Agent is driven by:
+
+- 🧬 **An architectural persona** — [`agents/platform/SOUL.md`](agents/platform/SOUL.md) defines its identity, its _Automation First_ rule (no manual cluster mutations; all changes flow through declarative, PR-based workflows), and its _Least Privilege_ constraint (read-only fleet visibility, with narrowly scoped write access only to its own Custom Resources).
+- 📚 **Operational playbooks** — nine governance SOPs in [`agents/platform/governance/`](agents/platform/governance/) covering blueprint sync, compliance audits, cost analysis, capacity orchestration, security patch orchestration, lifecycle/deprecation management, and more.
+- 🛠️ **Specialized Skills** — 20 task-focused skills under [`agents/platform/skills/`](agents/platform/skills/), each a documented `SKILL.md` bundle: cluster creation from templates, app onboarding, workload troubleshooting, cost analysis via BigQuery, observability setup, autoscaling, backup & DR, and manifest generation, among others.
+- 🔍 **Security review skills** — a dedicated suite under [`.agents/skills/`](.agents/skills/) for continuous security auditing: admission control (webhooks, VAP/MAP), NetworkPolicy isolation, Pod security contexts, Gateway API configurations, RBAC, service accounts, and agent-specific reviews including **prompt injection defense**, **credential isolation**, **execution sandbox hardening**, and **data exfiltration prevention**.
+
+The agent runtime is built on the Hermes agent framework and wires in MCP servers for platform control and GKE's hosted MCP endpoint, so the agent speaks to your clusters through structured tools rather than raw shell access.
+
+📗 **Full documentation** lives in the docs site under [`docs/site/src/content/docs/`](docs/site/src/content/docs/), including [architecture](docs/site/src/content/docs/overview/architecture.mdx), [concepts](docs/site/src/content/docs/concepts/), and a [complete skill catalog](docs/site/src/content/docs/skills/index.mdx).
+
+---
+
+## 🚀 Installation & Quickstart
+
+Three paths, depending on where you want to run. [INSTALL.md](INSTALL.md) is the deep-dive reference for all of them.
+
+### Method 1: Automated GCP & GKE Provisioning (Recommended)
+
+A modular, idempotent pipeline that takes you from an empty GCP project to a production-grade deployment:
+
+```bash
+cd k8s-operator
+make gcp-provision
+```
+
+The pipeline runs 11 staged scripts (each re-runnable and supporting `--dry-run`): GKE cluster creation, a gVisor-sandboxed node pool, operator + CRD installation, IAM & Workload Identity, Google Chat Pub/Sub wiring, Slack integration, secrets, the Platform Agent Custom Resource, the LiteLLM gateway, the GitHub token minter, and inference replay. A matching `make gcp-teardown` reverses everything.
+
+### Method 2: Manual Kubernetes Deployment
+
+For existing clusters, deploy the pieces yourself:
+
+1. Install **cert-manager** (required for the operator's admission webhooks).
+2. Create the `kubeagents-system` namespace and a `platform-agent-secrets` Secret (API keys for your model providers).
+3. Build and deploy the Kubebuilder-powered Go operator from [`k8s-operator/`](k8s-operator/): `make install && make deploy IMG=<your-image>`.
+4. Optionally deploy the LiteLLM gateway (`make deploy-litellm`) and GitHub integration (`make deploy-github`).
+5. Create your agent: `kubectl apply -f examples/platformagent.yaml` — the operator reconciles the `PlatformAgent` Custom Resource into a fully wired workload.
+
+### Method 3: Local Development
+
+Fast offline iteration against a local [Kind](https://kind.sigs.k8s.io/) cluster (or a remote GKE cluster):
+
+```bash
+cd k8s-operator
+make install                      # install CRDs
+ENABLE_WEBHOOKS=false make run    # run the operator locally, outside the cluster
+make dev-rebuild-agent ARGS="platform"   # fast agent-image rebuild loop
+```
+
+---
+
+## 🛡️ Governance & Multi-Tenancy
+
+`kube-agents` is designed for enterprise fleets where agents must be powerful _and_ provably contained.
+
+### Isolation by construction
+
+- **Least-privilege RBAC boundaries** — the operator provisions each agent with read-only (`view` + a scoped custom `explorer` ClusterRole) fleet visibility; write access is confined to the agent's own Custom Resources. NetworkPolicies are owned and reconciled by the operator.
+- **Credential isolation** — the agent sandbox container _never_ receives API keys or tokens. An Envoy credential-proxy sidecar injects credentials at the network boundary, and the sandbox image ships only non-functional CLI wrappers — the real credential-aware CLIs live in a separate, inaccessible image. See the full design in [docs/credential-isolation-design.md](docs/credential-isolation-design.md).
+- **Kernel-level sandboxing** — agent workloads run under a gVisor RuntimeClass (GKE Sandbox), validated by the operator at reconcile time.
+- **GitOps-only mutations** — the agent proposes changes as pull requests (via the `submit-suggestion` skill and short-lived GitHub App tokens minted through KMS) for human SRE review; it does not apply mutations directly.
+
+### Continuous security auditing
+
+The [`.agents/skills/`](.agents/skills/) suite gives the harness automated Kubernetes security reviews across: admission control, network policies, Pod security contexts, Gateway API configs, RBAC, service accounts, namespaces, nodes, storage, audit logs — plus agent-threat-model reviews for prompt injection, execution sandbox escape, credential exposure, and data exfiltration.
+
+### Scheduled governance watchdogs
+
+Ten cron-driven jobs in [`agents/platform/cron/jobs.json`](agents/platform/cron/jobs.json) keep the fleet honest without human prompting:
+
+| Watchdog                        | Cadence      | What it does                                             |
+| ------------------------------- | ------------ | -------------------------------------------------------- |
+| Blueprint Sync                  | Daily        | Checks cluster state against master blueprints           |
+| Compliance Audit                | Weekly       | Fleet-wide scan for security/network policy deviations   |
+| Policy Propagation              | Hourly       | Verifies latest policies are applied across clusters     |
+| Global Capacity Orchestrator    | Hourly       | Cross-cluster capacity optimization                      |
+| Fleet-wide Cost Analysis        | Daily        | Aggregates spend, flags savings                          |
+| Security Patch Orchestrator     | Daily        | CVE scanning, staggered rolling updates                  |
+| Lifecycle / Deprecation Manager | Monthly      | Tracks Kubernetes version deprecations                   |
+| Standardization Validator       | Weekly       | Deep-diffs live state vs. global standards               |
+| Obtainability Audit             | Daily        | Finds rigid allocations, proposes capacity patches       |
+| GitHub Issue Resolver           | Every 30 min | Triages and resolves open issues within authorized scope |
+
+---
+
+## 🏗️ End State Architecture
+
+What a fully provisioned harness looks like, across three layers:
+
+```mermaid
+flowchart TB
+    subgraph agent["🧠 Control Plane — Agent Layer"]
+        SOUL["SOUL.md persona<br/>+ governance SOPs"]
+        SKILLS["Skills<br/>(agents/platform/skills)"]
+        CRON["Scheduled watchdogs<br/>(cron/jobs.json)"]
+        PA["Platform Agent workspace<br/>(agents/platform)"]
+        SOUL --> PA
+        SKILLS --> PA
+        CRON --> PA
+    end
+
+    subgraph cluster["☸️ Cluster Plane — Kubernetes Layer"]
+        OP["k8s-operator<br/>(Go / Kubebuilder)"]
+        CRD["PlatformAgent CRD<br/>kubeagents.x-k8s.io/v1alpha1"]
+        POD["Agent pod: gVisor sandbox<br/>+ Envoy credential proxy<br/>+ Fluent Bit + event watcher"]
+        RBAC["RBAC isolation boundaries<br/>+ NetworkPolicies"]
+        OP -->|reconciles| CRD
+        CRD --> POD
+        OP --> RBAC
+    end
+
+    subgraph integration["🔀 Integration & Routing Layer"]
+        LLM["LiteLLM Gateway<br/>Gemini · OpenAI · Anthropic"]
+        CHAT["Messaging bridges<br/>Google Chat (Pub/Sub) · Slack (Socket Mode)"]
+        GH["Minty — GitHub App<br/>token minter (KMS)"]
+    end
+
+    PA -.runs inside.-> POD
+    POD --> LLM
+    CHAT <--> POD
+    POD -->|PR-based changes| GH
+```
+
+**1. Control Plane (Agent Layer)** — the Platform Agent workspace at [`agents/platform/`](agents/platform/): its persona ([`SOUL.md`](agents/platform/SOUL.md)), operational playbooks ([`governance/`](agents/platform/governance/)), skills, and scheduled governance tasks ([`cron/jobs.json`](agents/platform/cron/jobs.json)).
+
+**2. Cluster Plane (Kubernetes Layer)** — the Go-based operator at [`k8s-operator/`](k8s-operator/) reconciles `PlatformAgent` Custom Resources (`kubeagents.x-k8s.io/v1alpha1`) into complete workloads: the sandboxed agent container, an Envoy credential-proxy sidecar, log and cluster-event-watcher sidecars, per-agent ServiceAccounts with Workload Identity, RBAC bindings, PVCs, Services, and NetworkPolicies — with admission webhooks enforcing spec validity.
+
+**3. Integration & Routing Layer** — a [LiteLLM gateway](k8s-operator/config/integrations/litellm/) routes inference between Gemini (default), OpenAI, and Anthropic (see [`examples/`](examples/) for provider configs and local vLLM serving); messaging bridges connect the agent to **Google Chat** (via GCP Pub/Sub) and **Slack** (via Socket Mode); and the **Minty** GitHub token minter brokers short-lived, KMS-backed GitHub App tokens for the agent's PR workflow. Observability flows through OpenTelemetry and Prometheus into Cloud Trace and GKE Managed Prometheus.
+
+---
+
+## 🤝 Contributing
+
+Contributions are welcome! See [docs/contributing.md](docs/contributing.md) for CLA requirements, community guidelines, and the review process. Follow the [PR hygiene guidelines](AGENTS.md#pull-request-hygiene) — Conventional Commits, scoped changes, and the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
+
+---
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | Reactive, manual toil (`kubectl` + runbooks) | Proactive, intent-driven operations                                                                          |
 | Drift discovered during incidents            | Scheduled compliance & blueprint audits ([10 autonomous watchdogs](agents/platform/cron/jobs.json))          |
 | Hand-rolled RBAC and tenancy reviews         | Automated RBAC & boundary enforcement, [credential isolation by design](docs/credential-isolation-design.md) |
-| Patch Tuesdays and CVE spreadsheets          | Continuous vulnerability scanning & staggered patch orchestration                                            |
+| Patch Tuesdays and CVE spreadsheets          | Daily vulnerability & patch scans with staggered rollout orchestration                                       |
 | One human, one terminal                      | Seamless multi-agent collaboration over Google Chat & Slack                                                  |
 
 ### ⚡ Try it now
@@ -54,7 +54,7 @@ The Platform Agent is driven by:
 
 The agent runtime is built on the Hermes agent framework and wires in MCP servers for platform control and GKE's hosted MCP endpoint, so the agent speaks to your clusters through structured tools rather than raw shell access.
 
-📗 **Full documentation** lives in the docs site under [`docs/site/src/content/docs/`](docs/site/src/content/docs/), including [architecture](docs/site/src/content/docs/overview/architecture.mdx), [concepts](docs/site/src/content/docs/concepts/), and a [complete skill catalog](docs/site/src/content/docs/skills/index.mdx).
+📗 **Full documentation** lives at [gke-labs.github.io/kube-agents](https://gke-labs.github.io/kube-agents/), including the [architecture](https://gke-labs.github.io/kube-agents/overview/architecture/), [concepts](https://gke-labs.github.io/kube-agents/concepts/), and a [complete skill catalog](https://gke-labs.github.io/kube-agents/skills/).
 
 ---
 
@@ -81,7 +81,7 @@ For existing clusters, deploy the pieces yourself:
 2. Create the `kubeagents-system` namespace and a `platform-agent-secrets` Secret (API keys for your model providers).
 3. Build and deploy the Kubebuilder-powered Go operator from [`k8s-operator/`](k8s-operator/): `make install && make deploy IMG=<your-image>`.
 4. Optionally deploy the LiteLLM gateway (`make deploy-litellm`) and GitHub integration (`make deploy-github`).
-5. Create your agent: `kubectl apply -f examples/platformagent.yaml` — the operator reconciles the `PlatformAgent` Custom Resource into a fully wired workload.
+5. Create your agent: `kubectl apply -f k8s-operator/examples/platformagent.yaml` — the operator reconciles the `PlatformAgent` Custom Resource into a fully wired workload.
 
 ### Method 3: Local Development
 
@@ -102,14 +102,14 @@ make dev-rebuild-agent ARGS="platform"   # fast agent-image rebuild loop
 
 ### Isolation by construction
 
-- **Least-privilege RBAC boundaries** — the operator provisions each agent with read-only (`view` + a scoped custom `explorer` ClusterRole) fleet visibility; write access is confined to the agent's own Custom Resources. NetworkPolicies are owned and reconciled by the operator.
+- **Least-privilege RBAC boundaries** — the operator provisions each agent with read-only (`view` + a scoped custom `explorer` ClusterRole) fleet visibility; the only write grant is a namespaced leader-election Role. Infrastructure changes happen exclusively through the GitOps path below.
 - **Credential isolation** — the agent sandbox container _never_ receives API keys or tokens. An Envoy credential-proxy sidecar injects credentials at the network boundary, and the sandbox image ships only non-functional CLI wrappers — the real credential-aware CLIs live in a separate, inaccessible image. See the full design in [docs/credential-isolation-design.md](docs/credential-isolation-design.md).
 - **Kernel-level sandboxing** — agent workloads run under a gVisor RuntimeClass (GKE Sandbox), validated by the operator at reconcile time.
 - **GitOps-only mutations** — the agent proposes changes as pull requests (via the `submit-suggestion` skill and short-lived GitHub App tokens minted through KMS) for human SRE review; it does not apply mutations directly.
 
 ### Continuous security auditing
 
-The [`.agents/skills/`](.agents/skills/) suite gives the harness automated Kubernetes security reviews across: admission control, network policies, Pod security contexts, Gateway API configs, RBAC, service accounts, namespaces, nodes, storage, audit logs — plus agent-threat-model reviews for prompt injection, execution sandbox escape, credential exposure, and data exfiltration.
+The [`.agents/skills/`](.agents/skills/) suite gives the harness automated Kubernetes security reviews across: admission control, network policies, Pod security contexts, Gateway API configs, RBAC, service accounts, namespaces, nodes, storage — plus agent-threat-model reviews for prompt injection, execution sandbox escape, credential exposure, audit logging, and data exfiltration.
 
 ### Scheduled governance watchdogs
 
@@ -150,7 +150,7 @@ flowchart TB
         OP["k8s-operator<br/>(Go / Kubebuilder)"]
         CRD["PlatformAgent CRD<br/>kubeagents.x-k8s.io/v1alpha1"]
         POD["Agent pod: gVisor sandbox<br/>+ Envoy credential proxy<br/>+ Fluent Bit + event watcher"]
-        RBAC["RBAC isolation boundaries<br/>+ NetworkPolicies"]
+        RBAC["RBAC isolation boundaries<br/>(read-only view + explorer)"]
         OP -->|reconciles| CRD
         CRD --> POD
         OP --> RBAC
@@ -170,9 +170,9 @@ flowchart TB
 
 **1. Control Plane (Agent Layer)** — the Platform Agent workspace at [`agents/platform/`](agents/platform/): its persona ([`SOUL.md`](agents/platform/SOUL.md)), operational playbooks ([`governance/`](agents/platform/governance/)), skills, and scheduled governance tasks ([`cron/jobs.json`](agents/platform/cron/jobs.json)).
 
-**2. Cluster Plane (Kubernetes Layer)** — the Go-based operator at [`k8s-operator/`](k8s-operator/) reconciles `PlatformAgent` Custom Resources (`kubeagents.x-k8s.io/v1alpha1`) into complete workloads: the sandboxed agent container, an Envoy credential-proxy sidecar, log and cluster-event-watcher sidecars, per-agent ServiceAccounts with Workload Identity, RBAC bindings, PVCs, Services, and NetworkPolicies — with admission webhooks enforcing spec validity.
+**2. Cluster Plane (Kubernetes Layer)** — the Go-based operator at [`k8s-operator/`](k8s-operator/) reconciles `PlatformAgent` Custom Resources (`kubeagents.x-k8s.io/v1alpha1`) into complete workloads: the sandboxed agent container, an Envoy credential-proxy sidecar, log and cluster-event-watcher sidecars, per-agent ServiceAccounts with Workload Identity annotations, read-only RBAC bindings, PVCs, and Services — with admission webhooks enforcing spec validity.
 
-**3. Integration & Routing Layer** — a [LiteLLM gateway](k8s-operator/config/integrations/litellm/) routes inference between Gemini (default), OpenAI, and Anthropic (see [`examples/`](examples/) for provider configs and local vLLM serving); messaging bridges connect the agent to **Google Chat** (via GCP Pub/Sub) and **Slack** (via Socket Mode); and the **Minty** GitHub token minter brokers short-lived, KMS-backed GitHub App tokens for the agent's PR workflow. Observability flows through OpenTelemetry and Prometheus into Cloud Trace and GKE Managed Prometheus.
+**3. Integration & Routing Layer** — a [LiteLLM gateway](k8s-operator/config/integrations/litellm/) routes inference to your configured model provider — Gemini (default), OpenAI, or Anthropic (see [`examples/`](examples/) for provider configs and local vLLM serving); messaging bridges connect the agent to **Google Chat** (via GCP Pub/Sub) and **Slack** (via Socket Mode); and the **Minty** GitHub token minter brokers short-lived, KMS-backed GitHub App tokens for the agent's PR workflow. Observability flows through OpenTelemetry and Prometheus into Cloud Trace and GKE Managed Prometheus.
 
 ---
 

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -1,0 +1,71 @@
+---
+title: Credential isolation
+description: How the operator keeps API keys, tokens, and ServiceAccount credentials out of the agent sandbox container using an Envoy credential-proxy sidecar.
+sidebar:
+  order: 7
+---
+
+The PlatformAgent sandbox container never receives API keys, access tokens, refresh tokens, or Kubernetes ServiceAccount tokens through its environment or filesystem. Credentials live exclusively in a trusted **Envoy credential-proxy sidecar** inside the same Pod, and the sandbox reaches credentialed capabilities only through a policy-enforced local proxy.
+
+This page summarizes the architecture. The canonical design — including scope, deny-policy details, migration steps, and CI verification assertions — is [`docs/credential-isolation-design.md`](https://github.com/gke-labs/kube-agents/blob/main/docs/credential-isolation-design.md).
+
+## Pod anatomy
+
+Each PlatformAgent runs as one long-lived Pod with these managed containers:
+
+| Container                  | Trust level | Role                                                                 |
+| -------------------------- | ----------- | -------------------------------------------------------------------- |
+| `platform-agent`           | Untrusted   | The agent sandbox — credential-free env and mounts, CLI wrappers.    |
+| `envoy-credential-proxy`   | Trusted     | Envoy plus the credentialed command and chat runtime.                |
+| `event-watcher`            | Trusted     | Cluster-event forwarding with its own separate Kubernetes-API token. |
+| `fluent-bit`               | Trusted     | Log forwarding.                                                      |
+| `platform-agent-dashboard` | Untrusted   | Optional local dashboard (also credential-free).                     |
+
+```mermaid
+flowchart TB
+    subgraph Pod["PlatformAgent Pod"]
+        SANDBOX["platform-agent (sandbox)<br/>CLI wrappers / chat adapters<br/>no credentials"]
+        subgraph SIDECAR["envoy-credential-proxy"]
+            ENVOY["Envoy listener<br/>127.0.0.1:8765"]
+            RUNTIME["Credential runtime<br/>real CLIs, Slack/Chat clients, Minty client<br/>secret env + projected KSA token"]
+        end
+        SANDBOX -->|"HTTP (structured argv)"| ENVOY
+        ENVOY -->|private Unix socket| RUNTIME
+    end
+```
+
+The sandbox image contains only **wrapper binaries** for `gcloud`, `kubectl`, `gh`, and `git`. A wrapper sends the executable name and argument array to Envoy at `127.0.0.1:8765`; the credential runtime executes the corresponding real CLI and returns output and exit status. It never evaluates an agent-supplied shell command, and the runtime's Unix socket is mounted only in the sidecar, so the sandbox cannot bypass Envoy. The real credential-aware CLIs ship in a separate `credential-proxy` image that the sandbox never runs.
+
+## Credential placement
+
+| Data                            | Sandbox     | Credential sidecar        |
+| ------------------------------- | ----------- | ------------------------- |
+| `spec.deployment.env`           | No          | Yes                       |
+| Slack tokens                    | No          | Yes, Secret-backed env    |
+| PlatformAgent external API key  | No          | Yes, Secret-backed env    |
+| Automatic KSA token mount       | Disabled    | Disabled                  |
+| Explicit projected KSA token    | Not mounted | Read-only, one-hour token |
+| gcloud/kubectl configuration    | No          | Private `emptyDir`        |
+| GitHub installation token/cache | No          | Private `emptyDir`        |
+| Agent workspace                 | Yes         | Yes, for proxied commands |
+
+Pod-wide `automountServiceAccountToken` is `false`. The sidecar's projected token uses the audience `kubeagents-credential-proxy` and expires after one hour; the event watcher gets a separate one-hour Kubernetes-API token projection. Neither token is mounted in the agent or dashboard containers.
+
+## Request paths
+
+- **CLI commands** — only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy rejects known credential-disclosure, credential-replacement, and self-modification operations; interactive TTY programs, unbounded streaming, sandbox-only file paths, and background processes fail closed.
+- **Chat** — Slack and Google Chat adapters send credential-free payloads to Envoy; the credential runtime owns the platform tokens and performs the external API calls, enforcing user allowlists and payload limits.
+- **PlatformAgent API** — the Service targets port 8643 on the sidecar, which validates the external bearer key and forwards to the sandbox API on loopback (port 8642) with a non-secret sentinel. The real key never enters the sandbox.
+- **GitHub** — the sidecar obtains a Google OIDC identity token and calls [Minty](/kube-agents/deploy/token-minter/), which brokers a repository-scoped GitHub App installation token with a maximum one-hour lifetime. The App's private key stays in Cloud KMS.
+
+## Guarantee and limitation
+
+**Guarantee:** the operator does not place managed credentials in the sandbox container's environment, root filesystem, persistent agent volume, or mounted ServiceAccount token path. `spec.deployment.env` is applied to the credential sidecar because it may contain credentials (only four allowlisted OpenTelemetry settings are copied to the sandbox, as literal values only).
+
+**Limitation:** containers in one Pod share a network namespace and one Pod identity. The sandbox has no KSA token file, but it can technically reach the GKE metadata server used by the sidecar — a Pod-level NetworkPolicy cannot block metadata for one container while allowing it for another. The design meets the scoped filesystem-and-environment goal but does not provide the stronger identity boundary of separate Pods.
+
+## Where to go next
+
+- [Security & IAM](/kube-agents/reference/security-and-iam/) — Workload Identity, the GCP permission sets, and the read-only Kubernetes RBAC.
+- [Token minter (Minty)](/kube-agents/deploy/token-minter/) — short-lived GitHub App tokens via KMS.
+- [Full design doc](https://github.com/gke-labs/kube-agents/blob/main/docs/credential-isolation-design.md) — scope, deny policy, migration, and CI verification assertions.

--- a/docs/site/src/content/docs/reference/index.mdx
+++ b/docs/site/src/content/docs/reference/index.mdx
@@ -38,4 +38,9 @@ import { CardGrid, LinkCard } from "@astrojs/starlight/components";
     description="Workload Identity, the GCP permission sets, the read-only Kubernetes RBAC, and auditing mode."
     href="/kube-agents/reference/security-and-iam/"
   />
+  <LinkCard
+    title="Credential isolation"
+    description="How the Envoy credential-proxy sidecar keeps API keys and tokens out of the agent sandbox."
+    href="/kube-agents/reference/credential-isolation/"
+  />
 </CardGrid>

--- a/docs/site/src/content/docs/reference/security-and-iam.md
+++ b/docs/site/src/content/docs/reference/security-and-iam.md
@@ -126,6 +126,7 @@ The agent never has direct write access to running infrastructure — see [Decla
 ## Change control & safety
 
 - **No direct cluster writes.** Enforced by RBAC (above) and by the persona's automation-first stance — the agent does not `kubectl apply`; it opens PRs. See [Platform Agent](/kube-agents/concepts/platform-agent/).
+- **No credentials in the sandbox.** API keys, chat tokens, and ServiceAccount tokens live only in the Envoy credential-proxy sidecar; the agent container gets wrapper CLIs that forward through a policy-enforced local proxy. See [Credential isolation](/kube-agents/reference/credential-isolation/).
 - **One agent per project.** The admission webhook rejects a second `PlatformAgent` CR, so a cluster can't accumulate agents with overlapping scope. See [PlatformAgent CRD](/kube-agents/operator/platformagent-crd/).
 - **Human sign-off for destructive ops.** Cluster deletion, tenant offboarding, and broad IAM revocation always require explicit human approval, regardless of any "just do it" phrasing.
 - **Bounded recovery.** The agent retries a blocker through its recovery ladder (roughly five iterations or ~10 minutes) before escalating to a human instead of looping indefinitely.
@@ -133,6 +134,7 @@ The agent never has direct write access to running infrastructure — see [Decla
 
 ## Where to go next
 
+- [Credential isolation](/kube-agents/reference/credential-isolation/) — how credentials are kept out of the agent sandbox container.
 - [Platform Agent](/kube-agents/concepts/platform-agent/) — the persona and least-privilege stance.
 - [PlatformAgent CRD](/kube-agents/operator/platformagent-crd/) — `spec.security` and the permission set field.
 - [User attribution](/kube-agents/reference/attribution/) — tracing an action back to the human who requested it.


### PR DESCRIPTION
# Pull Request

## Why This Change

The root `README.md` was a short technical summary that undersold the project and contained a broken link (`docs/m1-demos.md` does not exist). `AGENTS.md` described repository layout that no longer matches reality (`local-dev/`, Helm charts in `deploy/`, "no code requiring compilation"). Additionally, the credential-isolation architecture — one of the strongest security properties of the harness — was documented only in a root design doc and not surfaced anywhere on the documentation site.

## What Changed

**Files:**

- `README.md`
- `AGENTS.md`
- `docs/site/src/content/docs/reference/credential-isolation.md` (new)
- `docs/site/src/content/docs/reference/index.mdx`
- `docs/site/src/content/docs/reference/security-and-iam.md`

**Added/Changed/Fixed:**

- Rewrote `README.md` as a landing page: value proposition with a before/after comparison, quickstart snippets, the three install methods from `INSTALL.md`, a governance section with the 10 scheduled watchdogs, and a Mermaid end-state architecture diagram across the agent, cluster, and integration layers. Documentation links now point at the published site (https://gke-labs.github.io/kube-agents/).
- Removed the broken `docs/m1-demos.md` reference and corrected inaccurate claims: deployment uses Kustomize + `make deploy` (no Helm charts in `deploy/`), local dev uses Kind via `make run` (no `local-dev/`), the example CR lives at `k8s-operator/examples/platformagent.yaml`, the agent's only RBAC write grant is the namespaced leader-election Role, NetworkPolicies ship as static integration manifests (not operator-reconciled), and LiteLLM routes to one configured provider at a time.
- Fixed stale `AGENTS.md` entries and added `k8s-operator/`, `.agents/skills/`, and `examples/` to the repository layout.
- Added a `reference/credential-isolation` page to the docs site summarizing `docs/credential-isolation-design.md` (pod anatomy, credential placement, request paths, guarantee and limitation), cross-linked from the Reference index and the Security & IAM page.

## Why This Matters

- The README is the project's front door; it now communicates value quickly and every claim in it was verified against the code (skill/SOP/cron counts, Makefile targets, CRD group/version, container names, provisioning stages).
- Contributors following `AGENTS.md` no longer get pointed at files and directories that do not exist.
- The credential-isolation design is now discoverable on the docs site instead of only in the repo tree.

## Context

Documentation-only change; no code or manifests are modified. The standalone docs audit also found `docs/attribution.md`, `docs/contributing.md`, and `docs/glossary.md` are fully superseded by their site counterparts — potential follow-up cleanup.

This PR was generated with the help of Claude.

## Testing

- `npm run build` in `docs/site/` passes; the new page renders at `/reference/credential-isolation/`.
- `prettier --check` passes on all changed files (matching the `prettier.yml` CI check).
- All relative links in `README.md` verified to resolve to existing files; the three published-site URLs verified against the live site.

---

No functional impact — documentation only. Low risk; worst case is copy that needs wording tweaks in review.