### PR TITLE
docs(agents): fix stale repository layout and setup references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,20 +8,22 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
 
 - `agents/`: Source of truth for agent blueprints (personas and skills).
   - `platform/`: Configuration for the Platform Agent.
-- `deploy/`: Deployment infrastructure code (Dockerfile, Helm charts, manifests).
-- `docs/`: Documentation, guides, and walkthroughs.
-- `local-dev/`: Tooling for local offline testing (Kind setup).
+- `.agents/skills/`: Repository-level security review skills.
+- `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
+- `docs/`: Design docs and the documentation site (`docs/site/`).
+- `k8s-operator/`: Go/Kubebuilder operator reconciling `PlatformAgent` Custom Resources, plus provisioning scripts.
+- `examples/`: Example integrations (LiteLLM provider configs, vLLM serving, inference replay).
 - `INSTALL.md`: Installation guide.
 - `README.md`: Project overview.
 
 ## Agent Setup & Integration
 
-This repository is primarily a configuration and documentation repository for AI agents. It does not contain code that requires compilation or traditional building.
+This repository is primarily a configuration and documentation repository for AI agents. The main exception is the Go-based Kubernetes operator in `k8s-operator/`, which requires compilation (see Local Validation Checks below).
 
 To use these agents:
 
 1. Follow the instructions in [INSTALL.md](INSTALL.md) to set up and register the Platform Agent in your agent harness.
-2. Refer to SRE walkthroughs in [docs/m1-demos.md](docs/m1-demos.md) for details on how to interact with the cooperative agent layout and run demo scenarios.
+2. Refer to the documentation site content in [docs/site/src/content/docs/](docs/site/src/content/docs/) for architecture, concepts, and operational guides.
 
 ## Skills Guidelines
 


### PR DESCRIPTION
# Pull Request

## Why This Change

`AGENTS.md` is the contributor- and agent-facing map of the repository, but several entries no longer match reality: it references a `local-dev/` directory and a `docs/m1-demos.md` walkthrough that do not exist, claims `deploy/` contains Helm charts (it contains `docker/`, `kustomize/`, and `shared/`), and states the repo has "no code that requires compilation" while its own Local Validation Checks section instructs running `go build` in `k8s-operator/`.

## What Changed

**Files:**

- `AGENTS.md`

**Added/Changed/Fixed:**

- Removed the nonexistent `local-dev/` entry and the broken `docs/m1-demos.md` link.
- Corrected the `deploy/` description to Dockerfile, Kustomize bases, and shared runtime assets.
- Added missing top-level entries to the repository layout: `k8s-operator/` (Go/Kubebuilder operator and provisioning scripts), `.agents/skills/` (security review skills), and `examples/`.
- Reworded the compilation note to acknowledge the Go operator, consistent with the Local Validation Checks section.
- Pointed setup guidance at `docs/site/src/content/docs/` instead of the removed walkthrough doc.

## Why This Matters

- Agents and contributors following `AGENTS.md` no longer get pointed at files and directories that do not exist.
- The layout section now covers the largest code component of the repository (the operator), which was previously omitted entirely.

## Context

Part of a documentation refresh split into three scoped PRs (docs site, AGENTS.md, README). This PR was generated with the help of Claude.

## Testing

- Every path referenced in the updated file verified to exist in the repository.
- `prettier --check` passes on the changed file.

---

Documentation-only; no functional impact.