### PR TITLE
fix(platform): make envoy config directory traversable

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -184,4 +184,4 @@ RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dear
     dpkg -i /tmp/gh.deb && \
     rm -f /tmp/gh.deb && \
     rm -rf /var/lib/apt/lists/* && \
-    chmod 755 /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar
+    chmod 755 /etc/envoy /usr/local/bin/envoy /usr/local/bin/envoy-credential-sidecar


### PR DESCRIPTION
# Pull Request

## Why This Change

The credential-proxy image created `/etc/envoy` with mode `0644`. The PlatformAgent Pod runs the sidecar as UID 10000, which could not traverse that directory to read `envoy-credential-proxy.yaml`. Envoy exited with `Invalid path`, causing the credential runtime and event watcher to enter `CrashLoopBackOff`.

## What Changed

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Set `/etc/envoy` to mode `0755` alongside the existing executable permission normalization.
- Preserve the read-only root filesystem and the immutable Envoy configuration path.

## Why This Matters

- Allows Envoy to start under the production non-root security context.
- Restores the credential proxy, Google Chat relay, and event-watcher kubeconfig bootstrap.
- Avoids copying security-sensitive configuration into `/tmp` or another runtime location.

## Context

The autopush deployment failed with:

```text
Invalid path: /etc/envoy/envoy-credential-proxy.yaml
k8s-event-watcher: kubeconfig /var/run/event-watcher/watcher.config: no such file or directory
```

The image contained a readable `0644` YAML file, but its parent directory was `drw-r--r--`, preventing UID 10000 from traversing it.

## Testing

- Cloud Build completed successfully:
  - Build: `e4e00970-387a-4779-b679-f267eb1eb754`
  - Image digest: `sha256:94acd44f8fd54a38d744ed8947ffaff55c6b1930e0493420bcca85a3f3f944c6`
- Deployed the test image into the real five-container PlatformAgent Deployment with:
  - UID/GID `10000:10000`
  - `readOnlyRootFilesystem: true`
  - Production volumes, bootstrap command, and readiness probes
- Verified:
  - Deployment reached `5/5 Ready`
  - All containers had zero restarts
  - `/etc/envoy` was `0755` and the YAML was `0644`
  - Envoy initialized its listener and admin socket
  - Credential proxy started its API and Unix socket
  - Health check returned HTTP 200
  - Event watcher started successfully
- Restored the original test-cluster image and confirmed both the PlatformAgent and controller Deployments were healthy.

---

This is a minimal image-permission fix with no change to the runtime security context or configuration location.
