### PR TITLE
feat(ci): add step timestamps and timer metrics to prow pipeline

### DIFF
--- a/hack/ci-connection-test.sh
+++ b/hack/ci-connection-test.sh
@@ -5,15 +5,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/ci-env.sh"
 trap dump_prow_artifacts_on_failure EXIT
 
+START_TIME=$SECONDS
+echo "=== [$(date -u)] Running GKE Cluster Connectivity Verification ==="
 TIMEOUT="30s"
 
-echo "=== Sourcing GKE Cluster Credentials ==="
+echo "=== [$(date -u)] Sourcing GKE Cluster Credentials ==="
 gcloud container clusters get-credentials "$HOST_CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
 
-echo "=== Verifying GKE Cluster Connectivity ==="
+echo "=== [$(date -u)] Verifying GKE Cluster Connectivity ==="
 kubectl cluster-info --request-timeout="${TIMEOUT}"
 
-echo "=== Verifying Namespace Access ==="
+echo "=== [$(date -u)] Verifying Namespace Access ==="
 kubectl get namespaces --request-timeout="${TIMEOUT}"
 
-echo "=== Connectivity Smoke Test Passed ==="
+TOTAL_DURATION=$((SECONDS - START_TIME))
+echo "=== [$(date -u)] Connectivity Smoke Test Passed (Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-connection-test.sh
+++ b/hack/ci-connection-test.sh
@@ -6,17 +6,17 @@ source "${SCRIPT_DIR}/ci-env.sh"
 trap dump_prow_artifacts_on_failure EXIT
 
 START_TIME=$SECONDS
-echo "=== [$(date -u)] Running GKE Cluster Connectivity Verification ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running GKE Cluster Connectivity Verification ==="
 TIMEOUT="30s"
 
-echo "=== [$(date -u)] Sourcing GKE Cluster Credentials ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Sourcing GKE Cluster Credentials ==="
 gcloud container clusters get-credentials "$HOST_CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
 
-echo "=== [$(date -u)] Verifying GKE Cluster Connectivity ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Verifying GKE Cluster Connectivity ==="
 kubectl cluster-info --request-timeout="${TIMEOUT}"
 
-echo "=== [$(date -u)] Verifying Namespace Access ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Verifying Namespace Access ==="
 kubectl get namespaces --request-timeout="${TIMEOUT}"
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
-echo "=== [$(date -u)] Connectivity Smoke Test Passed (Duration: ${TOTAL_DURATION}s) ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Connectivity Smoke Test Passed (Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -43,12 +43,18 @@ export USER_PROFILE_ENABLED="false"
 export GOOGLE_CHAT_ENABLED="false"
 export SLACK_ENABLED="false"
 
-echo "=== Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
+START_TIME=$SECONDS
+echo "=== [$(date -u)] Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
 
 # ─── 3. Cluster Auth ──────────────────────────────────────────────────────────
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Authenticating to GKE Cluster ==="
 gcloud container clusters get-credentials "$CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
+echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 
 # ─── 4. Build Container Images ────────────────────────────────────────────────
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Building Container Images (platform, credential-proxy, operator) ==="
 gcloud builds submit --config="deploy/docker/cloudbuild.yaml" \
   --substitutions="_IMAGE_URI=${AR_REPO}/platform-agent:${TAG},_IMAGE_URI_LATEST=${AR_REPO}/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=latest" \
   --project="${PROJECT_ID}" --quiet .
@@ -58,15 +64,20 @@ gcloud builds submit --config="deploy/docker/cloudbuild.yaml" \
   --project="${PROJECT_ID}" --quiet .
 
 gcloud builds submit --tag="${AR_REPO}/kube-agents-operator:${TAG}" --project="${PROJECT_ID}" --quiet k8s-operator
+echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 
 # ─── 5. Provisioning Pipeline Execution ───────────────────────────────────────
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Executing Provisioning Pipeline Scripts ==="
 ./k8s-operator/scripts/provision_03_gcp_gke_operator.sh --non-interactive
 ./k8s-operator/scripts/provision_07_gcp_k8s_secrets.sh --non-interactive
 ./k8s-operator/scripts/provision_08_deploy_platform_agent.sh --non-interactive
 ./k8s-operator/scripts/provision_09_deploy_litellm.sh --non-interactive
+echo "✓ Provisioning scripts finished in $((SECONDS - STEP_START))s"
 
 # ─── 6. Readiness Verification ────────────────────────────────────────────────
-echo "Waiting for deployment/platform-agent-gateway to be created by operator..."
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Waiting for deployment/platform-agent-gateway to be created by operator ==="
 MAX_WAIT_SECONDS=300
 ELAPSED=0
 FOUND=0
@@ -86,9 +97,11 @@ if [ "$FOUND" -ne 1 ]; then
 fi
 
 kubectl rollout status deployment/platform-agent-gateway -n "${NAMESPACE}" --timeout=600s
+echo "✓ Rollout verification finished in $((SECONDS - STEP_START))s"
 
 # ─── 7. Agent API Connectivity Verification ──────────────────────────────────
-echo "=== Verifying Platform Agent API Connectivity ==="
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Verifying Platform Agent API Connectivity ==="
 API_KEY="$(kubectl get secret platform-agent-secrets -n "${NAMESPACE}" -o jsonpath='{.data.API_SERVER_KEY}' | base64 --decode)"
 
 kubectl port-forward svc/platform-agent -n "${NAMESPACE}" 8642:8642 >/tmp/pf-8642.log 2>&1 &
@@ -116,7 +129,7 @@ kill $PF_PID 2>/dev/null || true
 trap dump_prow_artifacts_on_failure EXIT
 
 if [[ "$HEALTH_RESP" == *"output"* || "$HEALTH_RESP" == *"assistant"* || "$HEALTH_RESP" == *"pong"* ]]; then
-  echo "✓ Agent API Server responded successfully!"
+  echo "✓ Agent API Server responded successfully in $((SECONDS - STEP_START))s!"
 else
   echo "ERROR: Platform Agent API server connectivity check failed!"
   echo "Response received: ${HEALTH_RESP}"
@@ -127,4 +140,5 @@ else
   exit 1
 fi
 
-echo "=== Deployment Ready in Namespace: ${NAMESPACE} ==="
+TOTAL_DURATION=$((SECONDS - START_TIME))
+echo "=== [$(date -u)] Deployment Ready in Namespace: ${NAMESPACE} (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -44,17 +44,17 @@ export GOOGLE_CHAT_ENABLED="false"
 export SLACK_ENABLED="false"
 
 START_TIME=$SECONDS
-echo "=== [$(date -u)] Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
 
 # ─── 3. Cluster Auth ──────────────────────────────────────────────────────────
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Authenticating to GKE Cluster ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Authenticating to GKE Cluster ==="
 gcloud container clusters get-credentials "$CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
 echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 
 # ─── 4. Build Container Images ────────────────────────────────────────────────
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Building Container Images (platform, credential-proxy, operator) ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Building Container Images (platform, credential-proxy, operator) ==="
 gcloud builds submit --config="deploy/docker/cloudbuild.yaml" \
   --substitutions="_IMAGE_URI=${AR_REPO}/platform-agent:${TAG},_IMAGE_URI_LATEST=${AR_REPO}/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=latest" \
   --project="${PROJECT_ID}" --quiet .
@@ -68,7 +68,7 @@ echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 
 # ─── 5. Provisioning Pipeline Execution ───────────────────────────────────────
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Executing Provisioning Pipeline Scripts ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Executing Provisioning Pipeline Scripts ==="
 ./k8s-operator/scripts/provision_03_gcp_gke_operator.sh --non-interactive
 ./k8s-operator/scripts/provision_07_gcp_k8s_secrets.sh --non-interactive
 ./k8s-operator/scripts/provision_08_deploy_platform_agent.sh --non-interactive
@@ -77,7 +77,7 @@ echo "✓ Provisioning scripts finished in $((SECONDS - STEP_START))s"
 
 # ─── 6. Readiness Verification ────────────────────────────────────────────────
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Waiting for deployment/platform-agent-gateway to be created by operator ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Waiting for deployment/platform-agent-gateway to be created by operator ==="
 MAX_WAIT_SECONDS=300
 ELAPSED=0
 FOUND=0
@@ -101,7 +101,7 @@ echo "✓ Rollout verification finished in $((SECONDS - STEP_START))s"
 
 # ─── 7. Agent API Connectivity Verification ──────────────────────────────────
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Verifying Platform Agent API Connectivity ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Verifying Platform Agent API Connectivity ==="
 API_KEY="$(kubectl get secret platform-agent-secrets -n "${NAMESPACE}" -o jsonpath='{.data.API_SERVER_KEY}' | base64 --decode)"
 
 kubectl port-forward svc/platform-agent -n "${NAMESPACE}" 8642:8642 >/tmp/pf-8642.log 2>&1 &
@@ -141,4 +141,4 @@ else
 fi
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
-echo "=== [$(date -u)] Deployment Ready in Namespace: ${NAMESPACE} (Total Duration: ${TOTAL_DURATION}s) ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deployment Ready in Namespace: ${NAMESPACE} (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -29,7 +29,7 @@ dump_prow_artifacts_on_failure() {
     # 1. Pipeline Summary & Cloud Build / Port-Forward Diagnostics (works even if kubectl fails)
     {
       echo "=== EXIT CODE: ${exit_code} ==="
-      echo "=== TIMESTAMP: $(date -u) ==="
+      echo "=== TIMESTAMP: $(date -u +'%Y-%m-%dT%H:%M:%SZ') ==="
       echo "=== ACTIVE KUBECTL CONTEXT ==="
       kubectl config current-context 2>&1 || true
       echo "=== RECENT CLOUD BUILDS ==="

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -34,6 +34,9 @@ export AGENT_NAMESPACE="${TARGET_NAMESPACE}"
 # For opentofu provider
 export CLOUD_PROVIDER="gcp"
 export TF_VAR_infra_provider="gcp"
+export GKE_CLUSTER_NAME="test-cluster"
+export CLUSTER_NAME="test-cluster"
+export TF_VAR_cluster_name="test-cluster"
 
 # 4. Token & Model Configuration
 # Dynamically fetches API_SERVER_KEY from GKE secret and locks down Gemini 3.1

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -13,10 +13,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/ci-env.sh"
 trap dump_prow_artifacts_on_failure EXIT
 
-echo "=== Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
+START_TIME=$SECONDS
+echo "=== [$(date -u)] Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
 
 # 2. Cluster Auth
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Authenticating to GKE Cluster ==="
 gcloud container clusters get-credentials "$HOST_CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
+echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 
 # 3. Agent & Harness Configuration
 # Configures devops-bench runner to target deployed platform-agent service
@@ -50,7 +54,8 @@ FAILED_TASKS=()
 
 for TASK in "${TASKS[@]}"; do
   TASK_NAME="$(basename "$(dirname "${TASK}")")"
-  echo ">>> Running Task: ${TASK_NAME} (${TASK}) <<<"
+  TASK_START=$SECONDS
+  echo ">>> [$(date -u)] Running Task: ${TASK_NAME} (${TASK}) <<<"
 
   # Enable BENCH_NO_INFRA=true for noop tasks (skip OpenTofu); set false for real infra evaluation tasks
   if [[ "${TASK}" == *"noop"* ]]; then
@@ -82,19 +87,21 @@ for TASK in "${TASKS[@]}"; do
     cp "${LATEST_RESULT}" "results_${TASK_NAME}.json" || true
   fi
 
+  TASK_DURATION=$((SECONDS - TASK_START))
   # 6. Validate Score Threshold
   IS_PASS=$(python3 -c "print(1 if float('${SCORE}') >= 0.7 else 0)" 2>/dev/null || echo "0")
   if [ "${IS_PASS}" -eq 1 ]; then
-    echo "Task ${TASK_NAME} Result: [PASSED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7)"
+    echo "Task ${TASK_NAME} Result: [PASSED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
   else
-    echo "Task ${TASK_NAME} Result: [FAILED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7)"
+    echo "Task ${TASK_NAME} Result: [FAILED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
     FAILED_TASKS+=("${TASK_NAME}")
   fi
 done
 
+TOTAL_DURATION=$((SECONDS - START_TIME))
 if [ "${#FAILED_TASKS[@]}" -gt 0 ]; then
-  echo "❌ PR Smoke Test Evaluation Failed for tasks: ${FAILED_TASKS[*]}"
+  echo "❌ [$(date -u)] PR Smoke Test Evaluation Failed for tasks: ${FAILED_TASKS[*]} (Total Duration: ${TOTAL_DURATION}s)"
   exit 1
 fi
 
-echo "=== PR Smoke Test Evaluation Succeeded ==="
+echo "=== [$(date -u)] PR Smoke Test Evaluation Succeeded (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -14,11 +14,11 @@ source "${SCRIPT_DIR}/ci-env.sh"
 trap dump_prow_artifacts_on_failure EXIT
 
 START_TIME=$SECONDS
-echo "=== [$(date -u)] Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
 
 # 2. Cluster Auth
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Authenticating to GKE Cluster ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Authenticating to GKE Cluster ==="
 gcloud container clusters get-credentials "$HOST_CLUSTER_NAME" --region "$REGION" --project "$PROJECT_ID" --quiet
 echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 
@@ -59,7 +59,7 @@ FAILED_TASKS=()
 for TASK in "${TASKS[@]}"; do
   TASK_NAME="$(basename "$(dirname "${TASK}")")"
   TASK_START=$SECONDS
-  echo ">>> [$(date -u)] Running Task: ${TASK_NAME} (${TASK}) <<<"
+  echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running Task: ${TASK_NAME} (${TASK}) <<<"
 
   # Enable BENCH_NO_INFRA=true for noop tasks (skip OpenTofu); set false for real infra evaluation tasks
   if [[ "${TASK}" == *"noop"* ]]; then
@@ -124,8 +124,8 @@ done
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
 if [ "${#FAILED_TASKS[@]}" -gt 0 ]; then
-  echo "❌ [$(date -u)] PR Smoke Test Evaluation Failed for tasks: ${FAILED_TASKS[*]} (Total Duration: ${TOTAL_DURATION}s)"
+  echo "❌ [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] PR Smoke Test Evaluation Failed for tasks: ${FAILED_TASKS[*]} (Total Duration: ${TOTAL_DURATION}s)"
   exit 1
 fi
 
-echo "=== [$(date -u)] PR Smoke Test Evaluation Succeeded (Total Duration: ${TOTAL_DURATION}s) ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] PR Smoke Test Evaluation Succeeded (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -37,6 +37,7 @@ export TF_VAR_infra_provider="gcp"
 export GKE_CLUSTER_NAME="test-cluster"
 export CLUSTER_NAME="test-cluster"
 export TF_VAR_cluster_name="test-cluster"
+export GCP_LOCATION="us-west4-a" # set to different zone due to resource availability stockouts in us-central1
 
 # 4. Token & Model Configuration
 # Dynamically fetches API_SERVER_KEY from GKE secret and locks down Gemini 3.1
@@ -70,8 +71,9 @@ for TASK in "${TASKS[@]}"; do
 
   # Snapshot existing result directories before running evaluate.py to prevent stale score leakage
   PRE_RUNS="$(ls -d /app/results/run_* 2>/dev/null | sort || true)"
+  EVAL_LOG="/tmp/eval_${TASK_NAME}.log"
 
-  (cd /app && python3 /app/pkg/evaluator/evaluate.py "${TASK}") || true
+  (cd /app && python3 /app/pkg/evaluator/evaluate.py "${TASK}" 2>&1 | tee "${EVAL_LOG}") || true
 
   # Use set difference (comm -13) to isolate the brand new directory created strictly by THIS task run.
   # If evaluate.py crashed before or during execution without completing results.json, NEW_RUN_DIR will be empty.
@@ -80,24 +82,43 @@ for TASK in "${TASKS[@]}"; do
   LATEST_RESULT=""
   [ -n "${NEW_RUN_DIR}" ] && LATEST_RESULT="${NEW_RUN_DIR}/results.json"
 
-  # Assert that results.json exists for this specific run; if the task crashed or failed to output results,
-  # fail closed with SCORE=0 instead of reading a previous task's results file.
-  if [ -z "${LATEST_RESULT}" ] || [ ! -f "${LATEST_RESULT}" ]; then
-    echo "ERROR: Evaluation task ${TASK_NAME} did not produce a results.json file!"
-    SCORE="0"
+  # Check if results.json is missing or empty [] due to OpenTofu / resource creation or deletion failure
+  IS_RESOURCE_PREP_FAILURE=$(python3 -c "
+import json, os
+path = '${LATEST_RESULT}'
+if not path or not os.path.exists(path):
+    print('1')
+else:
+    try:
+        data = json.load(open(path))
+        print('1' if not data or len(data) == 0 else '0')
+    except Exception:
+        print('1')
+" 2>/dev/null || echo "1")
+
+  TASK_DURATION=$((SECONDS - TASK_START))
+
+  if [ "${IS_RESOURCE_PREP_FAILURE}" -eq 1 ]; then
+    echo "⚠️ [RESOURCE_PREPARATION_FAILED] Evaluation task ${TASK_NAME} resource creation or teardown failed! (The evaluation is skipped)"
+    ARTIFACT_DIR="${ARTIFACTS:-/tmp/artifacts}"
+    mkdir -p "${ARTIFACT_DIR}"
+    cp "${EVAL_LOG}" "${ARTIFACT_DIR}/resource_prep_failure_${TASK_NAME}.log" 2>/dev/null || true
+    [ -n "${NEW_RUN_DIR}" ] && cp "${EVAL_LOG}" "${NEW_RUN_DIR}/resource_prep_failure.log" 2>/dev/null || true
+    echo "Saved resource preparation log to artifact: ${ARTIFACT_DIR}/resource_prep_failure_${TASK_NAME}.log"
+    echo "Task ${TASK_NAME} Result: [RESOURCE_PREPARATION_FAILED] Infrastructure setup/teardown error (Duration: ${TASK_DURATION}s)"
+    FAILED_TASKS+=("${TASK_NAME} (Resource Preparation Failed)")
   else
     SCORE=$(python3 -c "import json; d=json.load(open('${LATEST_RESULT}'))[0] if '${LATEST_RESULT}' else {}; s=d.get('scores', d.get('metrics', {})); v=s.get('OutcomeValidity [GEval]', s.get('OutcomeValidity', 0)); print(v.get('score', v) if isinstance(v, dict) else v)" 2>/dev/null || echo "0")
     cp "${LATEST_RESULT}" "results_${TASK_NAME}.json" || true
-  fi
 
-  TASK_DURATION=$((SECONDS - TASK_START))
-  # 6. Validate Score Threshold
-  IS_PASS=$(python3 -c "print(1 if float('${SCORE}') >= 0.7 else 0)" 2>/dev/null || echo "0")
-  if [ "${IS_PASS}" -eq 1 ]; then
-    echo "Task ${TASK_NAME} Result: [PASSED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
-  else
-    echo "Task ${TASK_NAME} Result: [FAILED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
-    FAILED_TASKS+=("${TASK_NAME}")
+    # 6. Validate Score Threshold
+    IS_PASS=$(python3 -c "print(1 if float('${SCORE}') >= 0.7 else 0)" 2>/dev/null || echo "0")
+    if [ "${IS_PASS}" -eq 1 ]; then
+      echo "Task ${TASK_NAME} Result: [PASSED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
+    else
+      echo "Task ${TASK_NAME} Result: [FAILED] OutcomeValidity Score: ${SCORE} (Threshold: >= 0.7) (Duration: ${TASK_DURATION}s)"
+      FAILED_TASKS+=("${TASK_NAME}")
+    fi
   fi
 done
 

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -39,18 +39,28 @@ if [[ "$CURRENT_CTX" != *"${CLUSTER_NAME}"* && "$CURRENT_CTX" != *"${PROJECT_ID}
   exit 1
 fi
 
-echo "=== Cleaning Up GKE Resources ==="
+START_TIME=$SECONDS
+echo "=== [$(date -u)] Cleaning Up GKE Resources ==="
 
-# [Step 1] Undeploy LiteLLM Gateway
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Step 1: Undeploying LiteLLM Gateway ==="
 ./k8s-operator/scripts/teardown_09_deploy_litellm.sh --no-confirm || true
+echo "✓ LiteLLM Gateway teardown finished in $((SECONDS - STEP_START))s"
 
-# [Step 2] Delete PlatformAgent Custom Resource
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Step 2: Deleting PlatformAgent Custom Resource ==="
 ./k8s-operator/scripts/teardown_08_deploy_platform_agent.sh --no-confirm || true
+echo "✓ PlatformAgent CR teardown finished in $((SECONDS - STEP_START))s"
 
-# [Step 3] Delete Secrets
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Step 3: Deleting Secrets ==="
 ./k8s-operator/scripts/teardown_07_gcp_k8s_secrets.sh --no-confirm || true
+echo "✓ Secrets deletion finished in $((SECONDS - STEP_START))s"
 
-# [Step 4] Undeploy Operator Controller Manager & CRDs
+STEP_START=$SECONDS
+echo "=== [$(date -u)] Step 4: Undeploying Operator Controller Manager & CRDs ==="
 ./k8s-operator/scripts/teardown_03_gcp_gke_operator.sh --no-confirm || true
+echo "✓ Operator & CRD teardown finished in $((SECONDS - STEP_START))s"
 
-echo "=== Cleanup Complete ==="
+TOTAL_DURATION=$((SECONDS - START_TIME))
+echo "=== [$(date -u)] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -40,27 +40,27 @@ if [[ "$CURRENT_CTX" != *"${CLUSTER_NAME}"* && "$CURRENT_CTX" != *"${PROJECT_ID}
 fi
 
 START_TIME=$SECONDS
-echo "=== [$(date -u)] Cleaning Up GKE Resources ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleaning Up GKE Resources ==="
 
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Step 1: Undeploying LiteLLM Gateway ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Undeploying LiteLLM Gateway ==="
 ./k8s-operator/scripts/teardown_09_deploy_litellm.sh --no-confirm || true
 echo "✓ LiteLLM Gateway teardown finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Step 2: Deleting PlatformAgent Custom Resource ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 2: Deleting PlatformAgent Custom Resource ==="
 ./k8s-operator/scripts/teardown_08_deploy_platform_agent.sh --no-confirm || true
 echo "✓ PlatformAgent CR teardown finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Step 3: Deleting Secrets ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Deleting Secrets ==="
 ./k8s-operator/scripts/teardown_07_gcp_k8s_secrets.sh --no-confirm || true
 echo "✓ Secrets deletion finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
-echo "=== [$(date -u)] Step 4: Undeploying Operator Controller Manager & CRDs ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 4: Undeploying Operator Controller Manager & CRDs ==="
 ./k8s-operator/scripts/teardown_03_gcp_gke_operator.sh --no-confirm || true
 echo "✓ Operator & CRD teardown finished in $((SECONDS - STEP_START))s"
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
-echo "=== [$(date -u)] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -156,6 +156,15 @@ func buildKubeClient(f *flags) (kubernetes.Interface, error) {
 	)
 	switch {
 	case f.kubeconfig != "":
+		for i := 0; i < 120; i++ {
+			if _, statErr := os.Stat(f.kubeconfig); statErr == nil {
+				break
+			}
+			if i == 0 {
+				log.Printf("k8s-event-watcher: waiting up to 120s for kubeconfig file %s to be created by credential-proxy sidecar...", f.kubeconfig)
+			}
+			time.Sleep(1 * time.Second)
+		}
 		cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
 		if err != nil {
 			return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -156,15 +156,6 @@ func buildKubeClient(f *flags) (kubernetes.Interface, error) {
 	)
 	switch {
 	case f.kubeconfig != "":
-		for i := 0; i < 120; i++ {
-			if _, statErr := os.Stat(f.kubeconfig); statErr == nil {
-				break
-			}
-			if i == 0 {
-				log.Printf("k8s-event-watcher: waiting up to 120s for kubeconfig file %s to be created by credential-proxy sidecar...", f.kubeconfig)
-			}
-			time.Sleep(1 * time.Second)
-		}
 		cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
 		if err != nil {
 			return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)


### PR DESCRIPTION
# Pull Request

## Why This Change
Prow CI runs for PR evaluation currently lack detailed wall-clock timing metrics and synchronized UTC timestamps, making it difficult to pinpoint bottlenecks or timeouts across container builds,  cluster provisioning, and devops-bench execution. 

## What Changed

Files:
- hack/ci-connection-test.sh
- hack/ci-deploy.sh
- hack/ci-env.sh
- hack/ci-eval-pr.sh
- hack/ci-teardown.sh

Added/Changed/Fixed:
- Added: Stage execution timer instrumentation (`$SECONDS`) and UTC timestamps (`[$(date -u)]`) across all script milestones in ci-deploy.sh, ci-eval-pr.sh, and ci-teardown.sh.
- Added Required env var for devops-bench to deploy the resources for evaluation.
- Changed behaviour of the test when the devops-bench fails to run evaluation, now it now logs an explicit infrastructure error instead of reporting a 0.0 model score.


## Why This Matters
- Faster CI Triage: Precise timing metrics pinpoint exactly which pipeline stage is slow or timing out in Prow presubmits without guesswork.
- Reliable Failure Diagnostics: Preserves pod logs, crash history, and describe snapshots on failure, eliminating silent job drops when port-forwarding fails.

## Context

Extends and hardens the presubmit automated Prow CI deployment

## Testing

Verified syntax locally with bash -n across all modified shell scripts under hack/ (0 syntax errors).

Functional Impact & Risk: This PR modifies Prow CI test scripts under hack/ only. It does not change agent runtime behavior, operator CRDs, or production Go code.
