### PR TITLE
fix(dev scripts): grant Service Usage Consumer role to WIF principal

### DIFF
--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -15,7 +15,8 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account.
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
-6. **Outputs Variables**: Generates the exact variables you need to configure in GitHub.
+6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.
+7. **Outputs Variables**: Generates the exact variables you need to configure in GitHub.
 
 ### Usage
 

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -105,6 +105,13 @@ gcloud iam service-accounts add-iam-policy-binding "${SA_NAME}@${PROJECT_ID}.iam
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_NAME}/attribute.repository/${GITHUB_REPO}" \
   --project="${PROJECT_ID}" >/dev/null
 
+# 7. Grant the WIF principal Service Usage Consumer role on the project
+echo "Granting Service Usage Consumer role to the WIF Principal..."
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --role="roles/serviceusage.serviceUsageConsumer" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${POOL_NAME}/attribute.repository/${GITHUB_REPO}" \
+  >/dev/null
+
 echo ""
 echo "✅ GCP Setup Completed Successfully!"
 echo ""


### PR DESCRIPTION
# Pull Request

## Why This Change

GitHub Actions deployment workflows (redploying integrations like Cloud KMS API and Token Minter) were failing during executions of `gcloud` commands with the following error:
`There was a problem refreshing your current auth tokens: ('Unable to acquire impersonated credentials' ... 'Caller does not have required permission to use project')`.

This occurred because `gcloud` attaches the quota project to its token requests. As a result, the originating caller—the actual Workload Identity Federation (WIF) principal derived from GitHub Actions, rather than the service account it tries to impersonate—is checked for the `Service Usage Consumer` IAM role on the quota project, which it previously lacked.

## What Changed

Added a step to automatically grant the `roles/serviceusage.serviceUsageConsumer` IAM role directly to the GitHub WIF Principal on the GCP project.

**Files:**

- `k8s-operator/scripts/dev/setup-gcp-github-wif.sh`

**Added/Changed/Fixed:**

- Fixed `setup-gcp-github-wif.sh` to bind `roles/serviceusage.serviceUsageConsumer` to the federated `principalSet://.../attribute.repository/$GITHUB_REPO` identity during initial GCP setup.

## Why This Matters

- Fixes immediate blockers preventing GitHub Actions CI/CD from generating valid impersonated user tokens when the Quota Project context is implicitly passed.

## Context

- Resolves deployment failures where GCP rejected impersonation token (`iamcredentials.googleapis.com`) fetch requests from the GitHub WIF principal.

## Testing

- **Manually Tested:** Bound the IAM policy manually and successfully triggered the failing action execution. Confirmed workflows operate smoothly post-binding.

---

**Functional Impact & Risk:** Low risk. We are granting a necessary identity role exclusively to the scoped WIF repository principal on the project level solely for service utilization purposes.