### PR TITLE
build: generate the reference tables that mirror machine-readable sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO ?= $(eval REPO := $(LOCATION)-docker.pkg.dev/$(shell gcloud config get core
 
 BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
 
-.PHONY: default docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write validate
+.PHONY: default docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write validate docs-generate docs-check
 
 AGENTS := $(notdir $(patsubst %/,%,$(wildcard agents/*/)))
 
@@ -46,6 +46,14 @@ prettier-check:
 
 prettier-write:
 	npx prettier --write "**/*.md" "**/*.yaml" "**/*.yml"
+
+# Documentation tables that mirror a machine-readable source (cron jobs, the
+# skill catalogue, the provisioning steps) are generated rather than hand-kept.
+docs-generate:
+	@python3 scripts/generate_docs.py
+
+docs-check:
+	@python3 scripts/generate_docs.py --check
 
 validate:
 	@if [ -n "$(BAD_SKILLS)" ]; then \

--- a/docs/site/src/content/docs/reference/cron-jobs.md
+++ b/docs/site/src/content/docs/reference/cron-jobs.md
@@ -13,6 +13,7 @@ Generated from [`agents/platform/cron/jobs.json`](https://github.com/gke-labs/ku
 
 <!-- BEGIN GENERATED: cron-jobs -->
 <!-- Regenerate with: make docs-generate -- do not edit by hand. -->
+<!-- prettier-ignore-start -->
 
 | ID | Schedule | Cadence | Enabled | Prompt |
 | -- | -------- | ------- | :-----: | ------ |
@@ -27,6 +28,7 @@ Generated from [`agents/platform/cron/jobs.json`](https://github.com/gke-labs/ku
 | `obtainability-audit` | `0 12 * * *` | Daily 12:00 | yes | Execute dynamic capacity pool alignment audit. Read '/opt/defaults/governance/obtainability_audit_sop.md' t... |
 | `github-issue-resolver` | `*/30 * * * *` | Every 30 minutes | yes | Run the github-issue-resolver skill to poll, triage, investigate, and resolve unaddressed open issues on ou... |
 
+<!-- prettier-ignore-end -->
 <!-- END GENERATED: cron-jobs -->
 
 ## Job schema

--- a/docs/site/src/content/docs/reference/cron-jobs.md
+++ b/docs/site/src/content/docs/reference/cron-jobs.md
@@ -9,20 +9,25 @@ sidebar:
 
 ## The shipping jobs
 
-| ID                              | Schedule       | Prompt (abbreviated)                                                                         |
-| ------------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
-| `blueprint-sync`                | `0 9 * * *`    | Execute GKE blueprint alignment audit; read `blueprint_sync_sop.md`.                         |
-| `compliance-audit`              | `0 9 * * 0`    | Execute fleet-wide security compliance audit; read `compliance_audit_sop.md`.                |
-| `policy-propagation`            | `0 * * * *`    | Propagate updated operational policies; read `policy_propagation_sop.md`.                    |
-| `global-capacity-orchestrator`  | `0 * * * *`    | Execute cross-cluster capacity optimization; read `global_capacity_orchestrator_sop.md`.     |
-| `fleet-wide-cost-analysis`      | `0 10 * * *`   | Execute daily cost delta audit; read `fleet_wide_cost_analysis_sop.md`.                      |
-| `security-patch-orchestrator`   | `0 11 * * *`   | Run vulnerability and patch compliance scan; read `security_patch_orchestrator_sop.md`.      |
-| `lifecycle-deprecation-manager` | `0 9 1 * *`    | Execute monthly toolchain lifecycle audit; read `lifecycle_deprecation_manager_sop.md`.      |
-| `standardization-validator`     | `0 10 * * 0`   | Run weekly structural GKE alignment audit; read `standardization_validator_sop.md`.          |
-| `obtainability-audit`           | `0 12 * * *`   | Execute dynamic capacity pool alignment audit; read `obtainability_audit_sop.md`.            |
-| `github-issue-resolver`         | `*/30 * * * *` | Run the `github-issue-resolver` skill to poll, triage, investigate, and resolve open issues. |
+Generated from [`agents/platform/cron/jobs.json`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/cron/jobs.json).
 
-All are `"enabled": true` in the shipping config.
+<!-- BEGIN GENERATED: cron-jobs -->
+<!-- Regenerate with: make docs-generate -- do not edit by hand. -->
+
+| ID | Schedule | Cadence | Enabled | Prompt |
+| -- | -------- | ------- | :-----: | ------ |
+| `blueprint-sync` | `0 9 * * *` | Daily 09:00 | yes | Execute GKE blueprint alignment audit. Read '/opt/defaults/governance/blueprint_sync_sop.md' and perform th... |
+| `compliance-audit` | `0 9 * * 0` | Weekly, Sunday 09:00 | yes | Execute fleet-wide security compliance audit. Read '/opt/defaults/governance/compliance_audit_sop.md' and s... |
+| `policy-propagation` | `0 * * * *` | Hourly | yes | Propagate updated operational policies. Read '/opt/defaults/governance/policy_propagation_sop.md' and inspe... |
+| `global-capacity-orchestrator` | `0 * * * *` | Hourly | yes | Execute cross-cluster capacity optimization. Read '/opt/defaults/governance/global_capacity_orchestrator_so... |
+| `fleet-wide-cost-analysis` | `0 10 * * *` | Daily 10:00 | yes | Execute daily cost delta audit. Read '/opt/defaults/governance/fleet_wide_cost_analysis_sop.md' to aggregat... |
+| `security-patch-orchestrator` | `0 11 * * *` | Daily 11:00 | yes | Run vulnerability and patch compliance scan. Read '/opt/defaults/governance/security_patch_orchestrator_sop... |
+| `lifecycle-deprecation-manager` | `0 9 1 * *` | Monthly, 1st 09:00 | yes | Execute monthly toolchain lifecycle audit. Read '/opt/defaults/governance/lifecycle_deprecation_manager_sop... |
+| `standardization-validator` | `0 10 * * 0` | Weekly, Sunday 10:00 | yes | Run weekly structural GKE alignment audit. Read '/opt/defaults/governance/standardization_validator_sop.md'... |
+| `obtainability-audit` | `0 12 * * *` | Daily 12:00 | yes | Execute dynamic capacity pool alignment audit. Read '/opt/defaults/governance/obtainability_audit_sop.md' t... |
+| `github-issue-resolver` | `*/30 * * * *` | Every 30 minutes | yes | Run the github-issue-resolver skill to poll, triage, investigate, and resolve unaddressed open issues on ou... |
+
+<!-- END GENERATED: cron-jobs -->
 
 ## Job schema
 

--- a/docs/site/src/content/docs/skills/index.mdx
+++ b/docs/site/src/content/docs/skills/index.mdx
@@ -11,8 +11,8 @@ For how skills are structured and invoked, see [Concepts → Skills](/kube-agent
 
 Generated from the `name` and `description` frontmatter of every `agents/platform/skills/*/SKILL.md`.
 
-<!-- BEGIN GENERATED: skill-catalog -->
-<!-- Regenerate with: make docs-generate -- do not edit by hand. -->
+{/* BEGIN GENERATED: skill-catalog */}
+{/* Regenerate with: make docs-generate -- do not edit by hand. */}
 
 ### Cluster lifecycle
 
@@ -34,7 +34,7 @@ Generated from the `name` and `description` frontmatter of every `agents/platfor
 
 | Skill | Description |
 | ----- | ----------- |
-| [`gke-compute-classes`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-compute-classes/SKILL.md) | >- |
+| [`gke-compute-classes`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-compute-classes/SKILL.md) | Configures, optimizes, and troubleshoots GKE ComputeClasses. Use when configuring Spot VMs with on-demand fallback, targeting specific accelerators (GPUs/TPUs) or machine families, restricting ComputeClass access, or debugging pending pods related to node pool auto-creation. Do not use for cluster-level Node Auto Provisioning configuration or general GKE cluster creation. |
 | [`gke-cost-analysis`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cost-analysis/SKILL.md) | Answer natural language questions about GKE-related costs by leveraging BigQuery export and cost allocation data. |
 | [`gke-productionize`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-productionize/SKILL.md) | Assists in preparing applications and clusters on GKE for production. |
 | [`gke-reliability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-reliability/SKILL.md) | Workflows for ensuring high availability and reliability of GKE workloads. |
@@ -77,9 +77,9 @@ Generated from the `name` and `description` frontmatter of every `agents/platfor
 
 | Skill | Description |
 | ----- | ----------- |
-| [`github-issue-resolver`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/github-issue-resolver/SKILL.md) |  |
+| [`github-issue-resolver`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/github-issue-resolver/SKILL.md) | Autonomously poll, triage, investigate, and resolve unaddressed open issues on our target GitHub repository strictly within authorized scope. |
 
-<!-- END GENERATED: skill-catalog -->
+{/* END GENERATED: skill-catalog */}
 
 ## Adding a new skill
 

--- a/docs/site/src/content/docs/skills/index.mdx
+++ b/docs/site/src/content/docs/skills/index.mdx
@@ -7,70 +7,79 @@ Every skill is a `SKILL.md` bundle in [`agents/platform/skills/`](https://github
 
 For how skills are structured and invoked, see [Concepts → Skills](/kube-agents/concepts/skills/).
 
-## Cluster lifecycle
+## The catalogue
 
-| Skill                                                                                                                              | Description                                                                                              |
-| ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [`gke-cluster-creator`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cluster-creator/SKILL.md)     | Guides the user through creating GKE clusters using pre-defined templates (Standard, Autopilot, GPU/AI). |
-| [`gke-cluster-lifecycle`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cluster-lifecycle/SKILL.md) | Guidance on managing the lifecycle and upgrades of Google Kubernetes Engine (GKE) clusters.              |
-| [`gke-multi-tenancy`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-multi-tenancy/SKILL.md)         | Guidance on implementing multi-tenancy and governance in Google Kubernetes Engine (GKE) clusters.        |
+Generated from the `name` and `description` frontmatter of every `agents/platform/skills/*/SKILL.md`.
 
-## Workloads
+<!-- BEGIN GENERATED: skill-catalog -->
+<!-- Regenerate with: make docs-generate -- do not edit by hand. -->
 
-| Skill                                                                                                                                            | Description                                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| [`gke-app-onboarding`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-app-onboarding/SKILL.md)                     | Workflows for containerizing and deploying applications to GKE for the first time.                                           |
-| [`gke-workload-scaling`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-workload-scaling/SKILL.md)                 | Specific workflows for scaling GKE workloads using HPA and VPA, as well as best practices for autoscaling configuration.     |
-| [`gke-workload-troubleshooting`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-workload-troubleshooting/SKILL.md) | Systematic SOP for diagnosing GKE workload failures, crash loops, resource OOMs, mounting errors, and connectivity timeouts. |
+### Cluster lifecycle
 
-## Cost and capacity
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-cluster-creator`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cluster-creator/SKILL.md) | Guides the user through creating GKE clusters using pre-defined templates (Standard, Autopilot, GPU/AI). |
+| [`gke-cluster-lifecycle`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cluster-lifecycle/SKILL.md) | Guidance on managing the lifecycle and upgrades of Google Kubernetes Engine (GKE) clusters. |
+| [`gke-multi-tenancy`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-multi-tenancy/SKILL.md) | Guidance on implementing multi-tenancy and governance in Google Kubernetes Engine (GKE) clusters. |
 
-| Skill                                                                                                                          | Description                                                                                                                                                                             |
-| ------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`gke-cost-analysis`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cost-analysis/SKILL.md)     | Answer natural language questions about GKE-related costs by leveraging BigQuery export and cost allocation data.                                                                       |
-| [`gke-compute-classes`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-compute-classes/SKILL.md) | Configure, optimize, and troubleshoot GKE ComputeClasses — Spot with on-demand fallback, accelerator targeting, ComputeClass access restrictions, pending pods from node auto-creation. |
-| [`gke-productionize`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-productionize/SKILL.md)     | Assists in preparing applications and clusters on GKE for production.                                                                                                                   |
-| [`gke-reliability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-reliability/SKILL.md)         | Workflows for ensuring high availability and reliability of GKE workloads.                                                                                                              |
+### Workloads
 
-## Security and compliance
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-app-onboarding`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-app-onboarding/SKILL.md) | Workflows for containerizing and deploying applications to GKE for the first time. |
+| [`gke-workload-scaling`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-workload-scaling/SKILL.md) | Specific workflows for scaling GKE workloads using HPA and VPA, as well as best practices for autoscaling configuration. |
+| [`gke-workload-troubleshooting`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-workload-troubleshooting/SKILL.md) | Systematic Standard Operating Procedure (SOP) for diagnosing GKE workload failures, crash loops, resource OOMs, mounting errors, and connectivity timeouts. |
 
-| Skill                                                                                                                              | Description                                                         |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+### Cost and capacity
+
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-compute-classes`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-compute-classes/SKILL.md) | >- |
+| [`gke-cost-analysis`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-cost-analysis/SKILL.md) | Answer natural language questions about GKE-related costs by leveraging BigQuery export and cost allocation data. |
+| [`gke-productionize`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-productionize/SKILL.md) | Assists in preparing applications and clusters on GKE for production. |
+| [`gke-reliability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-reliability/SKILL.md) | Workflows for ensuring high availability and reliability of GKE workloads. |
+
+### Security and compliance
+
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-backup-dr`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-backup-dr/SKILL.md) | Workflows for configuring Backup for GKE and disaster recovery. |
 | [`gke-workload-security`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-workload-security/SKILL.md) | Workflows for auditing and hardening the security of GKE workloads. |
-| [`gke-backup-dr`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-backup-dr/SKILL.md)                 | Workflows for configuring Backup for GKE and disaster recovery.     |
 
-## Networking and storage
+### Networking and storage
 
-| Skill                                                                                                                          | Description                                                              |
-| ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Skill | Description |
+| ----- | ----------- |
 | [`gke-networking-edge`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-networking-edge/SKILL.md) | Workflows for configuring edge networking, ingress, and security on GKE. |
-| [`gke-storage`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-storage/SKILL.md)                 | Guidance on managing storage in Google Kubernetes Engine (GKE) clusters. |
+| [`gke-storage`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-storage/SKILL.md) | Guidance on managing storage in Google Kubernetes Engine (GKE) clusters. |
 
-## AI and inference
+### AI and inference
 
-| Skill                                                                                                                                    | Description                                                                                                                                                          |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`gke-inference-quickstart`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-inference-quickstart/SKILL.md) | Deploy optimized AI/ML inference workloads on GKE using Google's Inference Quickstart (GIQ). Model discovery, manifest generation, deployment via MCP tools and CLI. |
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-inference-quickstart`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-inference-quickstart/SKILL.md) | Deploy optimized AI/ML inference workloads on GKE using Google's Inference Quickstart (GIQ). Covers model discovery, manifest generation, and deployment using native MCP tools and CLI. |
 
-## Observability
+### Observability
 
-| Skill                                                                                                                                      | Description                                                                                                            |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| [`gke-observability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-observability/SKILL.md)                 | Workflows for setting up and auditing observability (logging, monitoring, tracing) on GKE.                             |
-| [`kube-agents-observability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/kube-agents-observability/SKILL.md) | Audit, monitor, and debug the logging, tracing, metrics, and API/dashboard observability of the Platform Agent itself. |
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-observability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-observability/SKILL.md) | Workflows for setting up and auditing observability (logging, monitoring, tracing) on GKE. |
+| [`kube-agents-observability`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/kube-agents-observability/SKILL.md) | Audit, monitor, and debug the logging, tracing, metrics, and API/dashboard observability of the Platform Agent. |
 
-## Manifests and remediation
+### Manifests and remediation
 
-| Skill                                                                                                                                  | Description                                                                                                                       |
-| -------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| [`gke-manifest-generation`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-manifest-generation/SKILL.md) | SOP for generating and updating secure, compliant, and cost-effective GKE manifests.                                              |
-| [`submit-suggestion`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/submit-suggestion/SKILL.md)             | Propose declarative configuration updates securely by committing file changes and submitting GitHub Pull Requests for SRE review. |
+| Skill | Description |
+| ----- | ----------- |
+| [`gke-manifest-generation`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/gke-manifest-generation/SKILL.md) | Standard Operating Procedure (SOP) for generating and updating secure, compliant, and cost-effective GKE manifests. |
+| [`submit-suggestion`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/submit-suggestion/SKILL.md) | Propose declarative configuration updates securely by committing file changes and submitting GitHub Pull Requests (PRs) for SRE review. |
 
-## Meta
+### Meta
 
-| Skill                                                                                                                              | Description                                                                                                                          |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`github-issue-resolver`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/github-issue-resolver/SKILL.md) | Autonomously poll, triage, investigate, and resolve unaddressed open issues on the target GitHub repository within authorized scope. |
+| Skill | Description |
+| ----- | ----------- |
+| [`github-issue-resolver`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/github-issue-resolver/SKILL.md) |  |
+
+<!-- END GENERATED: skill-catalog -->
 
 ## Adding a new skill
 

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -34,21 +34,22 @@ Generated from each script's own comment banner.
 
 <!-- BEGIN GENERATED: provisioning-steps -->
 <!-- Regenerate with: make docs-generate -- do not edit by hand. -->
+<!-- prettier-ignore-start -->
 
 ### Provisioning steps
 
 | # | Script | What it does |
 | :-: | ------ | ------------ |
-| 1 | [`provision_01_gcp_cluster.sh`](provision_01_gcp_cluster.sh) | **GCP APIs & GKE Cluster Initialization** — Idempotent setup script to bootstrap the bare GKE cluster and namespace. |
+| 1 | [`provision_01_gcp_cluster.sh`](provision_01_gcp_cluster.sh) | **GCP APIs & GKE Cluster Initialization** — Idempotent setup script that enables the GCP APIs and bootstraps the bare GKE cluster. The target namespace is created later, by the operator deploy in step 03. |
 | 2 | [`provision_02_gvisor_nodepool.sh`](provision_02_gvisor_nodepool.sh) | **Optional Dedicated gVisor Node Pool Initialization** — Idempotent script to bootstrap a dedicated GKE Sandbox (gVisor) node pool on an existing GKE Standard cluster. Can be run independently for migration. |
 | 3 | [`provision_03_gcp_gke_operator.sh`](provision_03_gcp_gke_operator.sh) | **Deploy Kubernetes Operator (CRDs & Controller Manager)** — Idempotent script that installs the CRDs and deploys the operator to the cluster. |
 | 4 | [`provision_04_gcp_iam.sh`](provision_04_gcp_iam.sh) | **Controller & Agent GCP Workload Identity & GCP IAM Permissions** — Idempotent script for granting GKE cluster management and Workload Identity permissions to the Operator Controller Manager and Agent GSAs. |
-| 5 | [`provision_05_gcp_gchat.sh`](provision_05_gcp_gchat.sh) | **Google Chat & Pub/Sub Setup** — Configures the Google Chat backend: Pub/Sub routing, the Agent's Service Account, and grants the Service Account permission to read incoming chat messages. |
+| 5 | [`provision_05_gcp_gchat.sh`](provision_05_gcp_gchat.sh) | **Google Chat & Pub/Sub Setup** — Configures the Google Chat backend: Pub/Sub routing, the Agent's Service Account, and grants the Service Account permission to read incoming chat messages. Also enables the Workspace Add-ons and Chat APIs and provisions their service identities — without the Chat API identity, Google Chat fails silently. |
 | 6 | [`provision_06_slack.sh`](provision_06_slack.sh) | **Slack Integration Setup** — Configures Slack bot tokens, app tokens, and home channel settings. |
 | 7 | [`provision_07_gcp_k8s_secrets.sh`](provision_07_gcp_k8s_secrets.sh) | **GKE Kubernetes Secrets Setup** — Idempotent setup script to configure local Kubernetes secrets directly. |
 | 8 | [`provision_08_deploy_platform_agent.sh`](provision_08_deploy_platform_agent.sh) | **Deploy PlatformAgent Custom Resource Manifest** — Idempotent script that connects to GKE, renders the platform-agent.yaml template, and deploys it to the cluster. |
 | 9 | [`provision_09_deploy_litellm.sh`](provision_09_deploy_litellm.sh) | **Deploy LiteLLM Gateway** — Idempotent script that connects to GKE and deploys the LiteLLM Gateway. |
-| 10 | [`provision_10_deploy_github_minter.sh`](provision_10_deploy_github_minter.sh) | **Deploy GitHub Token Minter** — Idempotent script that deploys the GitHub Token Minter. |
+| 10 | [`provision_10_deploy_github_minter.sh`](provision_10_deploy_github_minter.sh) | **Deploy GitHub Token Minter** — Idempotent script that deploys the GitHub Token Minter. Runs only when GITHUB_ORG, GITHUB_REPO, and GITHUB_APP_ID are all set; skipped otherwise. |
 | 11 | [`provision_11_deploy_inference_replay.sh`](provision_11_deploy_inference_replay.sh) | **Deploy Inference Replay Proxy (optional)** — Idempotent script that deploys the Inference Replay proxy in front of the LiteLLM gateway. Skipped unless INFERENCE_REPLAY_ENABLED=true. The proxy intercepts the `litellm` Service so agents need no configuration changes. With REPLAY_MODE=off (default) it is a pure pass-through; flip the `inference-replay-config` ConfigMap to `on` to start recording/replaying. |
 
 ### Teardown steps
@@ -67,6 +68,7 @@ Generated from each script's own comment banner.
 | 10 | [`teardown_10_deploy_github_minter.sh`](teardown_10_deploy_github_minter.sh) | **Teardown GitHub Token Minter** — Idempotent script to clean up the GitHub Token Minter. |
 | 11 | [`teardown_11_deploy_inference_replay.sh`](teardown_11_deploy_inference_replay.sh) | **Teardown Inference Replay Proxy** — Idempotent script to undeploy the Inference Replay proxy and restore the original LiteLLM Service. Safe to run even when the proxy was never deployed. |
 
+<!-- prettier-ignore-end -->
 <!-- END GENERATED: provisioning-steps -->
 
 ### Auxiliary & Development Scripts

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -28,54 +28,46 @@ When any script is run:
 - **[provision.sh](provision.sh)**: Master script that coordinates the sequential execution of all core provisioning steps.
 - **[teardown.sh](teardown.sh)**: Master script that coordinates the teardown steps in reverse order (conditionally including auxiliary scripts).
 
-#### Provisioning Steps
+### Pipeline steps
 
-1. **[provision_01_gcp_cluster.sh](provision_01_gcp_cluster.sh)**
-   - Sets up initial project configs.
-   - Enables GKE Service API (`container.googleapis.com`).
-   - Provisions a GKE Standard Cluster with Workload Identity enabled.
-   - Points `kubectl` credentials to the new cluster. (The target namespace is created later, by the operator deploy in step 03.)
-2. **[provision_02_gvisor_nodepool.sh](provision_02_gvisor_nodepool.sh)**
-   - Provisions a dedicated GKE Sandbox (gVisor) node pool (defaults to `gvisor-pool`, configurable via `GVISOR_POOL_NAME`). Executed automatically if `ENABLE_GVISOR=true`.
-3. **[provision_03_gcp_gke_operator.sh](provision_03_gcp_gke_operator.sh)**
-   - Installs `cert-manager` (`v1.14.4`) if not present (including leader-election compatibility patching for GKE Autopilot clusters).
-   - Installs Custom Resource Definitions (CRDs) for `PlatformAgent`.
-   - Deploys the Operator controller manager into the GKE cluster.
-4. **[provision_04_gcp_iam.sh](provision_04_gcp_iam.sh)**
-   - Enables GCP Service APIs (`container.googleapis.com` and `cloudresourcemanager.googleapis.com`).
-   - Pre-provisions GCP Service Accounts (GSAs) for the Platform Agent and conditionally for the GitHub Token Minter.
-   - Configures Workload Identity policy bindings mapping the Kubernetes SAs to the GCP GSAs.
-   - Grants GKE cluster management and monitoring permissions to the Platform Agent GSA based on the selected permission set (`read-only`, `gke-admin`, or `custom`, default: `read-only`).
-   - Configures Workload Identity policy bindings and annotations for the GitHub Token Minter GSA/KSA if GitHub integration is configured.
-5. **[provision_05_gcp_gchat.sh](provision_05_gcp_gchat.sh)**
-   - Enables GCP Service APIs (`pubsub.googleapis.com` and `chat.googleapis.com`).
-   - Sets up the Pub/Sub Topic and Subscription for Google Chat events (skipped if `GOOGLE_CHAT_ENABLED=false`).
-   - Configures IAM policy bindings allowing the Platform Agent GSA to read incoming messages from the Pub/Sub subscription.
-   - Note: Access can be restricted to specific users by configuring `GOOGLE_CHAT_ALLOWED_USERS`.
-6. **[provision_06_slack.sh](provision_06_slack.sh)**
-   - Configures Slack integration parameters, bot tokens, app tokens, and home channel settings (skipped if `SLACK_ENABLED=false`).
-   - **Note:** You must create a Slack App and obtain tokens before running this. [See the Slack App Setup Guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack).
-   - Note: Access can be restricted to specific users by configuring `SLACK_ALLOWED_USERS`.
-7. **[provision_07_gcp_k8s_secrets.sh](provision_07_gcp_k8s_secrets.sh)**
-   - Prompts for/reads the `MODEL_PROVIDER` and corresponding `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`.
-   - Generates a secure random `API_SERVER_KEY` if not already set.
-   - Creates the Kubernetes Secret (`platform-agent-secrets`) containing model API keys, the server key, and Slack tokens directly in the target GKE namespace.
-   - Creates the Kubernetes Secret (`github-app-credentials`) if `GITHUB_APP_ID` is configured.
-8. **[provision_08_deploy_platform_agent.sh](provision_08_deploy_platform_agent.sh)**
-   - Uses `envsubst` to render `platform-agent.yaml` from its template.
-   - Automatically enables the `gvisor` runtime class in the rendered manifest if `ENABLE_GVISOR=true`.
-   - Applies the resulting `PlatformAgent` Custom Resource (CR) to deploy the platform agent instance.
-9. **[provision_09_deploy_litellm.sh](provision_09_deploy_litellm.sh)**
-   - Deploys the LiteLLM Gateway to the GKE cluster.
-10. **[provision_10_deploy_github_minter.sh](provision_10_deploy_github_minter.sh)**
-    - Enables Cloud KMS API (`cloudkms.googleapis.com`).
-    - Sets up Google Cloud KMS keyrings and keys for token signing and grants signer/verifier roles to the Minter GSA.
-    - Imports GitHub App private keys (`GITHUB_PEM_PATH`) into Cloud KMS when configured.
-    - Deploys the GitHub Token Minter into the cluster.
-11. **[provision_11_deploy_inference_replay.sh](provision_11_deploy_inference_replay.sh)**
-    - Opt-in via `INFERENCE_REPLAY_ENABLED=true`; otherwise skipped.
-    - Prompts for `REPLAY_IMAGE` (the proxy container image).
-    - Deploys the Inference Replay proxy: PVC + ConfigMap (mode=off pass-through), Deployment, a `litellm-gateway` Service pointing at the original LiteLLM pods, and a replacement `litellm` Service routing traffic through the proxy. Toggle caching on at runtime via `kubectl patch configmap inference-replay-config -n <ns> --type merge -p '{"data":{"mode":"on"}}'`.
+Generated from each script's own comment banner.
+
+<!-- BEGIN GENERATED: provisioning-steps -->
+<!-- Regenerate with: make docs-generate -- do not edit by hand. -->
+
+### Provisioning steps
+
+| # | Script | What it does |
+| :-: | ------ | ------------ |
+| 1 | [`provision_01_gcp_cluster.sh`](provision_01_gcp_cluster.sh) | **GCP APIs & GKE Cluster Initialization** — Idempotent setup script to bootstrap the bare GKE cluster and namespace. |
+| 2 | [`provision_02_gvisor_nodepool.sh`](provision_02_gvisor_nodepool.sh) | **Optional Dedicated gVisor Node Pool Initialization** — Idempotent script to bootstrap a dedicated GKE Sandbox (gVisor) node pool on an existing GKE Standard cluster. Can be run independently for migration. |
+| 3 | [`provision_03_gcp_gke_operator.sh`](provision_03_gcp_gke_operator.sh) | **Deploy Kubernetes Operator (CRDs & Controller Manager)** — Idempotent script that installs the CRDs and deploys the operator to the cluster. |
+| 4 | [`provision_04_gcp_iam.sh`](provision_04_gcp_iam.sh) | **Controller & Agent GCP Workload Identity & GCP IAM Permissions** — Idempotent script for granting GKE cluster management and Workload Identity permissions to the Operator Controller Manager and Agent GSAs. |
+| 5 | [`provision_05_gcp_gchat.sh`](provision_05_gcp_gchat.sh) | **Google Chat & Pub/Sub Setup** — Configures the Google Chat backend: Pub/Sub routing, the Agent's Service Account, and grants the Service Account permission to read incoming chat messages. |
+| 6 | [`provision_06_slack.sh`](provision_06_slack.sh) | **Slack Integration Setup** — Configures Slack bot tokens, app tokens, and home channel settings. |
+| 7 | [`provision_07_gcp_k8s_secrets.sh`](provision_07_gcp_k8s_secrets.sh) | **GKE Kubernetes Secrets Setup** — Idempotent setup script to configure local Kubernetes secrets directly. |
+| 8 | [`provision_08_deploy_platform_agent.sh`](provision_08_deploy_platform_agent.sh) | **Deploy PlatformAgent Custom Resource Manifest** — Idempotent script that connects to GKE, renders the platform-agent.yaml template, and deploys it to the cluster. |
+| 9 | [`provision_09_deploy_litellm.sh`](provision_09_deploy_litellm.sh) | **Deploy LiteLLM Gateway** — Idempotent script that connects to GKE and deploys the LiteLLM Gateway. |
+| 10 | [`provision_10_deploy_github_minter.sh`](provision_10_deploy_github_minter.sh) | **Deploy GitHub Token Minter** — Idempotent script that deploys the GitHub Token Minter. |
+| 11 | [`provision_11_deploy_inference_replay.sh`](provision_11_deploy_inference_replay.sh) | **Deploy Inference Replay Proxy (optional)** — Idempotent script that deploys the Inference Replay proxy in front of the LiteLLM gateway. Skipped unless INFERENCE_REPLAY_ENABLED=true. The proxy intercepts the `litellm` Service so agents need no configuration changes. With REPLAY_MODE=off (default) it is a pure pass-through; flip the `inference-replay-config` ConfigMap to `on` to start recording/replaying. |
+
+### Teardown steps
+
+| # | Script | What it does |
+| :-: | ------ | ------------ |
+| 1 | [`teardown_01_gcp_cluster.sh`](teardown_01_gcp_cluster.sh) | **Teardown GKE Cluster & Local State** — Idempotent script to clean up the GKE Standard Cluster and local state files. |
+| 2 | [`teardown_02_gvisor_nodepool.sh`](teardown_02_gvisor_nodepool.sh) | **Optional Teardown of Dedicated gVisor Node Pool** — Idempotent script to clean up the dedicated GKE Sandbox (gVisor) node pool and RuntimeClass. Can be run independently to test disabling gVisor. |
+| 3 | [`teardown_03_gcp_gke_operator.sh`](teardown_03_gcp_gke_operator.sh) | **Teardown Kubernetes Operator (CRDs & Controller Manager)** — Idempotent script to clean up the deployed operator and CRDs. |
+| 4 | [`teardown_04_gcp_iam.sh`](teardown_04_gcp_iam.sh) | **Teardown Controller & Agent GCP Workload Identity & GCP IAM** — Idempotent script to remove cluster management and Workload Identity bindings from the Controller manager and all Agent GSAs, and delete the GSAs. |
+| 5 | [`teardown_05_gcp_gchat.sh`](teardown_05_gcp_gchat.sh) | **Teardown Google Chat & Pub/Sub Setup** — Idempotent script to clean up GChat Pub/Sub Topic/Subscription and the Bot GSA. |
+| 6 | [`teardown_06_slack.sh`](teardown_06_slack.sh) | **Teardown Slack Integration Setup** — Idempotent script to clean up Slack integration state and tokens. |
+| 7 | [`teardown_07_gcp_k8s_secrets.sh`](teardown_07_gcp_k8s_secrets.sh) | **Teardown GKE Secrets** — Idempotent script to clean up Kubernetes secrets. |
+| 8 | [`teardown_08_deploy_platform_agent.sh`](teardown_08_deploy_platform_agent.sh) | **Teardown PlatformAgent Custom Resource** — Idempotent script to clean up the applied PlatformAgent Custom Resource (CR) and delete the local generated manifest file. |
+| 9 | [`teardown_09_deploy_litellm.sh`](teardown_09_deploy_litellm.sh) | **Teardown LiteLLM Gateway** — Idempotent script to undeploy the LiteLLM gateway. |
+| 10 | [`teardown_10_deploy_github_minter.sh`](teardown_10_deploy_github_minter.sh) | **Teardown GitHub Token Minter** — Idempotent script to clean up the GitHub Token Minter. |
+| 11 | [`teardown_11_deploy_inference_replay.sh`](teardown_11_deploy_inference_replay.sh) | **Teardown Inference Replay Proxy** — Idempotent script to undeploy the Inference Replay proxy and restore the original LiteLLM Service. Safe to run even when the proxy was never deployed. |
+
+<!-- END GENERATED: provisioning-steps -->
 
 ### Auxiliary & Development Scripts
 
@@ -84,23 +76,6 @@ When any script is run:
 - **[print_instructions_gchat.sh](print_instructions_gchat.sh)**: Helper script that prints Google Chat integration post-provisioning instructions.
 - **[print_instructions_slack.sh](print_instructions_slack.sh)**: Helper script that prints Slack integration post-provisioning instructions.
 - **[dev/dev_rebuild_agent.sh](dev/dev_rebuild_agent.sh)**: Fast local development utility that builds, pushes, and redeploys agent container images.
-
-### Teardown Steps
-
-- **[teardown_11_deploy_inference_replay.sh](teardown_11_deploy_inference_replay.sh)**: Always executed by master teardown; undeploys the proxy (including the cache PVC) if present and re-applies the LiteLLM Service manifest to restore the original selector. Idempotent no-op if the proxy was never deployed.
-- **[teardown_10_deploy_github_minter.sh](teardown_10_deploy_github_minter.sh)**: Cleans up the GitHub Token Minter deployment and disables/schedules Cloud KMS key versions for destruction.
-- **[teardown_09_deploy_litellm.sh](teardown_09_deploy_litellm.sh)**: Undeploys the LiteLLM Gateway from the cluster.
-- **[teardown_08_deploy_platform_agent.sh](teardown_08_deploy_platform_agent.sh)**: Safely deletes the `PlatformAgent` Custom Resource and cleans up local manifests.
-- **[teardown_07_gcp_k8s_secrets.sh](teardown_07_gcp_k8s_secrets.sh)**: Deletes the Kubernetes secrets in GKE.
-- **[teardown_06_slack.sh](teardown_06_slack.sh)**: Resets Slack integration configuration state and tokens.
-- **[teardown_05_gcp_gchat.sh](teardown_05_gcp_gchat.sh)**: Deletes the Google Chat Pub/Sub topic and subscription.
-- **[teardown_04_gcp_iam.sh](teardown_04_gcp_iam.sh)**: Removes all GCP IAM policy bindings, Workload Identity mappings, and deletes the GSAs for the Platform Agent and GitHub Token Minter.
-- **[teardown_03_gcp_gke_operator.sh](teardown_03_gcp_gke_operator.sh)**: Removes the Operator manager deployment and unregisters CRDs.
-- **[teardown_02_gvisor_nodepool.sh](teardown_02_gvisor_nodepool.sh)**: Deletes the dedicated gVisor node pool without destroying the cluster.
-- **[dev/teardown_dev_01_gcp_artifact_registry.sh](dev/teardown_dev_01_gcp_artifact_registry.sh)**: Conditionally executed by master teardown if local dev artifact registry was created.
-- **[teardown_01_gcp_cluster.sh](teardown_01_gcp_cluster.sh)**: Deletes the GKE Standard cluster and removes the local state file `vars.sh`.
-
----
 
 ## Direct Usage Examples
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Generate the documentation tables that mirror machine-readable sources.
+
+Several reference tables in this repository restate information that already
+exists in a file the code reads: the cron schedule lives in ``jobs.json``, the
+skill catalogue lives in each skill's frontmatter, and the provisioning steps
+live in the scripts themselves. Maintaining those tables by hand guarantees they
+drift. This script regenerates them from the source of truth instead.
+
+Each generated region is delimited in its target file by::
+
+    <!-- BEGIN GENERATED: <block-id> -->
+    <!-- END GENERATED: <block-id> -->
+
+Everything outside those markers is hand-written and is never touched.
+
+Usage::
+
+    python3 scripts/generate_docs.py            # rewrite the generated regions
+    python3 scripts/generate_docs.py --check    # exit 1 if anything is stale
+
+``--check`` is what CI runs: if regenerating would change a file, the committed
+documentation no longer matches its source.
+
+Standard library only, deliberately -- this must run in CI and in a bare clone
+without installing anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+CRON_JOBS = REPO / "agents/platform/cron/jobs.json"
+SKILLS_DIR = REPO / "agents/platform/skills"
+SCRIPTS_DIR = REPO / "k8s-operator/scripts"
+
+CRON_PAGE = REPO / "docs/site/src/content/docs/reference/cron-jobs.md"
+SKILLS_PAGE = REPO / "docs/site/src/content/docs/skills/index.mdx"
+SCRIPTS_PAGE = SCRIPTS_DIR / "README.md"
+
+GITHUB_BLOB = "https://github.com/gke-labs/kube-agents/blob/main"
+
+# Editorial grouping for the skill catalogue. Skills missing from this map are
+# emitted under "Other" rather than dropped, so a new skill shows up as a diff
+# in `--check` instead of silently vanishing from the catalogue.
+SKILL_GROUPS: dict[str, list[str]] = {
+    "Cluster lifecycle": [
+        "gke-cluster-creator",
+        "gke-cluster-lifecycle",
+        "gke-multi-tenancy",
+    ],
+    "Workloads": [
+        "gke-app-onboarding",
+        "gke-workload-scaling",
+        "gke-workload-troubleshooting",
+    ],
+    "Cost and capacity": [
+        "gke-cost-analysis",
+        "gke-compute-classes",
+        "gke-productionize",
+        "gke-reliability",
+    ],
+    "Security and compliance": ["gke-workload-security", "gke-backup-dr"],
+    "Networking and storage": ["gke-networking-edge", "gke-storage"],
+    "AI and inference": ["gke-inference-quickstart"],
+    "Observability": ["gke-observability", "kube-agents-observability"],
+    "Manifests and remediation": ["gke-manifest-generation", "submit-suggestion"],
+    "Meta": ["github-issue-resolver"],
+}
+
+CRON_CADENCE = {
+    "0 9 * * *": "Daily 09:00",
+    "0 10 * * *": "Daily 10:00",
+    "0 11 * * *": "Daily 11:00",
+    "0 12 * * *": "Daily 12:00",
+    "0 * * * *": "Hourly",
+    "*/30 * * * *": "Every 30 minutes",
+    "0 9 * * 0": "Weekly, Sunday 09:00",
+    "0 10 * * 0": "Weekly, Sunday 10:00",
+    "0 9 1 * *": "Monthly, 1st 09:00",
+}
+
+
+def md_escape(text: str) -> str:
+    """Make a string safe to drop into a Markdown table cell."""
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+# --------------------------------------------------------------------------- #
+# Generators
+# --------------------------------------------------------------------------- #
+
+
+def gen_cron_jobs() -> str:
+    data = json.loads(CRON_JOBS.read_text())
+    jobs = data["jobs"] if isinstance(data, dict) and "jobs" in data else data
+
+    rows = [
+        "| ID | Schedule | Cadence | Enabled | Prompt |",
+        "| -- | -------- | ------- | :-----: | ------ |",
+    ]
+    for job in jobs:
+        expr = job.get("schedule", {}).get("expr", "")
+        prompt = md_escape(job.get("prompt", ""))
+        if len(prompt) > 110:
+            prompt = prompt[:107].rstrip() + "..."
+        rows.append(
+            "| `{id}` | `{expr}` | {cadence} | {enabled} | {prompt} |".format(
+                id=job.get("id", ""),
+                expr=expr,
+                cadence=CRON_CADENCE.get(expr, "—"),
+                enabled="yes" if job.get("enabled") else "no",
+                prompt=prompt,
+            )
+        )
+    return "\n".join(rows)
+
+
+def read_frontmatter(path: Path) -> dict[str, str]:
+    text = path.read_text()
+    m = re.match(r"^---\n(.*?)\n---", text, re.S)
+    if not m:
+        return {}
+    fields: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        km = re.match(r"^([A-Za-z_-]+):\s*(.*)$", line)
+        if km:
+            fields[km.group(1)] = km.group(2).strip().strip("\"'")
+    return fields
+
+
+def gen_skill_catalog() -> str:
+    skills: dict[str, str] = {}
+    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        fm = read_frontmatter(skill_md)
+        name = fm.get("name") or skill_md.parent.name
+        skills[name] = fm.get("description", "")
+
+    grouped = {g: [] for g in SKILL_GROUPS}
+    grouped["Other"] = []
+    for name in sorted(skills):
+        group = next((g for g, members in SKILL_GROUPS.items() if name in members), "Other")
+        grouped[group].append(name)
+
+    out: list[str] = []
+    for group, names in grouped.items():
+        if not names:
+            continue
+        out.append(f"### {group}\n")
+        out.append("| Skill | Description |")
+        out.append("| ----- | ----------- |")
+        for name in names:
+            link = f"{GITHUB_BLOB}/agents/platform/skills/{name}/SKILL.md"
+            out.append(f"| [`{name}`]({link}) | {md_escape(skills[name])} |")
+        out.append("")
+    return "\n".join(out).rstrip()
+
+
+def parse_script_banner(path: Path) -> tuple[str, str]:
+    """Return (title, description) from a script's comment banner."""
+    lines = path.read_text().splitlines()
+    title, desc = "", []
+    rules = [i for i, line in enumerate(lines[:12]) if set(line.strip("# ")) == {"="}]
+    if len(rules) >= 2:
+        between = lines[rules[0] + 1 : rules[1]]
+        if between:
+            title = between[0].lstrip("# ").strip()
+            title = re.sub(r"^[^\w]*Step \d+:\s*", "", title).strip()
+    if len(rules) >= 3:
+        for line in lines[rules[1] + 1 : rules[2]]:
+            desc.append(line.lstrip("#").strip())
+    return title, " ".join(d for d in desc if d)
+
+
+def gen_provisioning_steps() -> str:
+    out: list[str] = []
+    for kind, heading in (("provision", "Provisioning"), ("teardown", "Teardown")):
+        out.append(f"### {heading} steps\n")
+        out.append("| # | Script | What it does |")
+        out.append("| :-: | ------ | ------------ |")
+        for path in sorted(SCRIPTS_DIR.glob(f"{kind}_[0-9][0-9]_*.sh")):
+            num = int(re.search(r"_(\d{2})_", path.name).group(1))
+            title, desc = parse_script_banner(path)
+            summary = md_escape(desc or title)
+            out.append(f"| {num} | [`{path.name}`]({path.name}) | **{md_escape(title)}** — {summary} |")
+        out.append("")
+    return "\n".join(out).rstrip()
+
+
+BLOCKS = {
+    "cron-jobs": (CRON_PAGE, gen_cron_jobs),
+    "skill-catalog": (SKILLS_PAGE, gen_skill_catalog),
+    "provisioning-steps": (SCRIPTS_PAGE, gen_provisioning_steps),
+}
+
+
+# --------------------------------------------------------------------------- #
+# Marker handling
+# --------------------------------------------------------------------------- #
+
+
+def splice(path: Path, block_id: str, body: str) -> tuple[bool, str]:
+    """Return (changed, new_text) with the generated region replaced."""
+    text = path.read_text()
+    begin = f"<!-- BEGIN GENERATED: {block_id} -->"
+    end = f"<!-- END GENERATED: {block_id} -->"
+    pattern = re.compile(
+        re.escape(begin) + r".*?" + re.escape(end),
+        re.S,
+    )
+    if not pattern.search(text):
+        raise SystemExit(
+            f"{path.relative_to(REPO)}: missing markers for block '{block_id}'.\n"
+            f"  Add:\n    {begin}\n    {end}"
+        )
+    replacement = (
+        f"{begin}\n"
+        f"<!-- Regenerate with: make docs-generate -- do not edit by hand. -->\n\n"
+        f"{body}\n\n"
+        f"{end}"
+    )
+    new_text = pattern.sub(lambda _: replacement, text, count=1)
+    return new_text != text, new_text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="do not write; exit non-zero if any generated region is out of date",
+    )
+    args = ap.parse_args()
+
+    stale: list[str] = []
+    for block_id, (path, generator) in BLOCKS.items():
+        changed, new_text = splice(path, block_id, generator())
+        rel = path.relative_to(REPO)
+        if not changed:
+            print(f"  ok       {rel} [{block_id}]")
+            continue
+        if args.check:
+            stale.append(f"{rel} [{block_id}]")
+            print(f"  STALE    {rel} [{block_id}]")
+        else:
+            path.write_text(new_text)
+            print(f"  updated  {rel} [{block_id}]")
+
+    if stale:
+        print(
+            "\nGenerated documentation is out of date with its source.\n"
+            "Run `make docs-generate` and commit the result.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -142,11 +142,13 @@ def read_frontmatter(path: Path) -> dict[str, str]:
             # Block scalar indicators start a multi-line value on the next line.
             if value in (">", ">-", ">+", "|", "|-", "|+"):
                 value = ""
-            fields[key] = value.strip("\"'")
+            fields[key] = value
         elif key and line[:1] in (" ", "\t") and line.strip():
             # Continuation line of a multi-line value.
             fields[key] = f"{fields[key]} {line.strip()}".strip()
-    return fields
+    # Strip quotes only once values are fully assembled: a quoted value that
+    # wraps across lines carries its closing quote on the last line.
+    return {k: v.strip("\"'") for k, v in fields.items()}
 
 
 def gen_skill_catalog() -> str:

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -12,6 +12,11 @@ Each generated region is delimited in its target file by::
     <!-- BEGIN GENERATED: <block-id> -->
     <!-- END GENERATED: <block-id> -->
 
+or, in ``.mdx`` files (where MDX rejects HTML comments), by::
+
+    {/* BEGIN GENERATED: <block-id> */}
+    {/* END GENERATED: <block-id> */}
+
 Everything outside those markers is hand-written and is never touched.
 
 Usage::
@@ -128,10 +133,19 @@ def read_frontmatter(path: Path) -> dict[str, str]:
     if not m:
         return {}
     fields: dict[str, str] = {}
+    key: str | None = None
     for line in m.group(1).splitlines():
         km = re.match(r"^([A-Za-z_-]+):\s*(.*)$", line)
         if km:
-            fields[km.group(1)] = km.group(2).strip().strip("\"'")
+            key = km.group(1)
+            value = km.group(2).strip()
+            # Block scalar indicators start a multi-line value on the next line.
+            if value in (">", ">-", ">+", "|", "|-", "|+"):
+                value = ""
+            fields[key] = value.strip("\"'")
+        elif key and line[:1] in (" ", "\t") and line.strip():
+            # Continuation line of a multi-line value.
+            fields[key] = f"{fields[key]} {line.strip()}".strip()
     return fields
 
 
@@ -205,11 +219,28 @@ BLOCKS = {
 # --------------------------------------------------------------------------- #
 
 
+def region_markers(path: Path, block_id: str) -> tuple[str, str, str]:
+    """Return (begin, end, notice) markers in the comment syntax the file allows.
+
+    MDX rejects HTML comments, so ``.mdx`` files use JSX-style comments.
+    """
+    if path.suffix == ".mdx":
+        return (
+            f"{{/* BEGIN GENERATED: {block_id} */}}",
+            f"{{/* END GENERATED: {block_id} */}}",
+            "{/* Regenerate with: make docs-generate -- do not edit by hand. */}",
+        )
+    return (
+        f"<!-- BEGIN GENERATED: {block_id} -->",
+        f"<!-- END GENERATED: {block_id} -->",
+        "<!-- Regenerate with: make docs-generate -- do not edit by hand. -->",
+    )
+
+
 def splice(path: Path, block_id: str, body: str) -> tuple[bool, str]:
     """Return (changed, new_text) with the generated region replaced."""
     text = path.read_text()
-    begin = f"<!-- BEGIN GENERATED: {block_id} -->"
-    end = f"<!-- END GENERATED: {block_id} -->"
+    begin, end, notice = region_markers(path, block_id)
     pattern = re.compile(
         re.escape(begin) + r".*?" + re.escape(end),
         re.S,
@@ -221,7 +252,7 @@ def splice(path: Path, block_id: str, body: str) -> tuple[bool, str]:
         )
     replacement = (
         f"{begin}\n"
-        f"<!-- Regenerate with: make docs-generate -- do not edit by hand. -->\n\n"
+        f"{notice}\n\n"
         f"{body}\n\n"
         f"{end}"
     )

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -180,7 +180,7 @@ def parse_script_banner(path: Path) -> tuple[str, str]:
     """Return (title, description) from a script's comment banner."""
     lines = path.read_text().splitlines()
     title, desc = "", []
-    rules = [i for i, line in enumerate(lines[:12]) if set(line.strip("# ")) == {"="}]
+    rules = [i for i, line in enumerate(lines[:24]) if set(line.strip("# ")) == {"="}]
     if len(rules) >= 2:
         between = lines[rules[0] + 1 : rules[1]]
         if between:
@@ -250,10 +250,20 @@ def splice(path: Path, block_id: str, body: str) -> tuple[bool, str]:
             f"{path.relative_to(REPO)}: missing markers for block '{block_id}'.\n"
             f"  Add:\n    {begin}\n    {end}"
         )
+    # Prettier would reflow the compact generated tables, which then fail
+    # --check; fence the region off for .md files (the Prettier CI job does
+    # not cover .mdx, and MDX rejects HTML comments anyway).
+    if path.suffix == ".mdx":
+        guard_open = guard_close = ""
+    else:
+        guard_open = "<!-- prettier-ignore-start -->\n"
+        guard_close = "<!-- prettier-ignore-end -->\n"
     replacement = (
         f"{begin}\n"
-        f"{notice}\n\n"
+        f"{notice}\n"
+        f"{guard_open}\n"
         f"{body}\n\n"
+        f"{guard_close}"
         f"{end}"
     )
     new_text = pattern.sub(lambda _: replacement, text, count=1)

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -103,7 +103,7 @@ def md_escape(text: str) -> str:
 
 
 def gen_cron_jobs() -> str:
-    data = json.loads(CRON_JOBS.read_text())
+    data = json.loads(CRON_JOBS.read_text(encoding="utf-8"))
     jobs = data["jobs"] if isinstance(data, dict) and "jobs" in data else data
 
     rows = [
@@ -128,7 +128,7 @@ def gen_cron_jobs() -> str:
 
 
 def read_frontmatter(path: Path) -> dict[str, str]:
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     m = re.match(r"^---\n(.*?)\n---", text, re.S)
     if not m:
         return {}
@@ -180,7 +180,7 @@ def gen_skill_catalog() -> str:
 
 def parse_script_banner(path: Path) -> tuple[str, str]:
     """Return (title, description) from a script's comment banner."""
-    lines = path.read_text().splitlines()
+    lines = path.read_text(encoding="utf-8").splitlines()
     title, desc = "", []
     rules = [i for i, line in enumerate(lines[:24]) if set(line.strip("# ")) == {"="}]
     if len(rules) >= 2:
@@ -241,7 +241,7 @@ def region_markers(path: Path, block_id: str) -> tuple[str, str, str]:
 
 def splice(path: Path, block_id: str, body: str) -> tuple[bool, str]:
     """Return (changed, new_text) with the generated region replaced."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     begin, end, notice = region_markers(path, block_id)
     pattern = re.compile(
         re.escape(begin) + r".*?" + re.escape(end),
@@ -292,7 +292,7 @@ def main() -> int:
             stale.append(f"{rel} [{block_id}]")
             print(f"  STALE    {rel} [{block_id}]")
         else:
-            path.write_text(new_text)
+            path.write_text(new_text, encoding="utf-8")
             print(f"  updated  {rel} [{block_id}]")
 
     if stale:


### PR DESCRIPTION
## Why This Change

Three reference tables mirror machine-readable sources and were maintained by hand: the cron schedule (`agents/platform/cron/jobs.json`), the skill catalogue (`SKILL.md` frontmatter), and the provisioning-step list (the scripts themselves). Hand-maintained mirrors of machine-readable files are guaranteed to drift.

## What Changed

**Files:**

- `scripts/generate_docs.py` — new; regenerates three marker-delimited regions from their sources (stdlib-only)
- `docs/site/src/content/docs/reference/cron-jobs.md`, `docs/site/src/content/docs/skills/index.mdx`, `k8s-operator/scripts/README.md` — tables now generated
- 18 `provision_*/teardown_*` scripts — banner step numbers aligned with their filenames (the generator reads the banners)
- Root `Makefile` — `docs-generate` / `docs-check` targets

**Added/Changed/Fixed:**

- `make docs-generate` rewrites the regions; `--check` fails CI-style if a committed table no longer matches its source.
- `.mdx` regions use JSX-style comment markers (MDX rejects HTML comments and the Astro build fails otherwise) and the frontmatter reader folds YAML block scalars — without this, two skills rendered a literal `>-` or an empty description.
- Generated `.md` regions are fenced with `prettier-ignore` markers so the Prettier CI job and the staleness check cannot fight over table formatting.

## Why This Matters

- Editing `jobs.json`, a skill's frontmatter, or a script banner now updates the docs with one command; drift becomes detectable instead of silent.

## Context

Part 4/6, stacked on #433 — the incremental diff is the last 5 commits (the newest two are review fixes: frontmatter quote handling, explicit utf-8 encoding). Part 5 adds the CI workflow that runs the staleness check on every PR. The PlatformAgent CRD reference is deliberately not generated here (needs `crd-ref-docs` + a Go toolchain) and remains a follow-up.

## Testing

- Generator is idempotent (regenerating produces no diff) and `--check` verified to fail on a hand-edited table.
- Generated counts match sources: 20 skills, 10 cron jobs, 11+11 scripts; all 22 banner step numbers match their filenames.
- `docs/site` builds (`astro build` exit 0) — this is what the MDX-safe markers fix.

---

Build tooling and generated docs only; script banner comments changed, script behaviour did not. This PR was generated with the help of Claude.



