### PR TITLE
docs: stop hard-coding the provisioning step count in prose

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,8 +64,8 @@ For full end-to-end setups on Google Cloud Platform (GCP) with GKE Standard, Wor
 
 ### Modular Pipeline Stages
 
-The automated installer executes eleven idempotent stages sequentially, from GKE cluster creation
-through to the optional inference-replay proxy. Each stage has its own `make` target and can be
+The automated installer executes a sequence of numbered, idempotent stages, from GKE cluster
+creation through to the optional inference-replay proxy. Each stage has its own `make` target and can be
 re-run on its own.
 
 - **What each stage does:** [`k8s-operator/scripts/README.md`](k8s-operator/scripts/README.md)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd k8s-operator
 make gcp-provision
 ```
 
-This runs eleven staged, idempotent scripts — GKE cluster, gVisor sandbox pool, operator + CRDs, IAM & Workload Identity, Google Chat, Slack, secrets, the Platform Agent CR, the LiteLLM gateway, the GitHub token minter, and inference replay. `make gcp-teardown` reverses it. See the [quick start](https://gke-labs.github.io/kube-agents/install/quickstart-gke/) for the walkthrough, or [INSTALL.md](INSTALL.md) for manual and local-development paths.
+This runs the staged, idempotent provisioning scripts end to end — from GKE cluster creation through IAM and chat integration to the optional inference stack. `make gcp-teardown` reverses it. See the [quick start](https://gke-labs.github.io/kube-agents/install/quickstart-gke/) for the walkthrough, or [INSTALL.md](INSTALL.md) for manual and local-development paths.
 
 ---
 

--- a/docs/site/src/content/docs/operator/provisioning-scripts.md
+++ b/docs/site/src/content/docs/operator/provisioning-scripts.md
@@ -18,7 +18,7 @@ Both accept `--dry-run` to print planned actions without applying them.
 
 ## Provisioning steps
 
-Eleven numbered steps run in order; opt-in steps no-op unless their flag is set. Rather than
+The numbered steps run in order; opt-in steps no-op unless their flag is set. Rather than
 restate them here, the catalogue lives next to the code so it cannot drift from it:
 
 **[`k8s-operator/scripts/README.md`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/README.md)**


### PR DESCRIPTION
## Why This Change

Hand-written prose still stated the provisioning step count ("eleven staged scripts") in three places, and the README additionally enumerated every stage inline. The number and the list both live in the scripts and in the generated catalogue; every prose restatement goes stale the moment a step is added, and no CI check can catch a wrong number inside a sentence.

## What Changed

**Files:**

- `README.md`
- `INSTALL.md`
- `docs/site/src/content/docs/operator/provisioning-scripts.md`

**Added/Changed/Fixed:**

- Describe the pipeline without counting it ("the staged, idempotent provisioning scripts", "a sequence of numbered, idempotent stages", "the numbered steps").
- Drop the README's inline enumeration of all stages — the generated catalogue in `k8s-operator/scripts/README.md` owns that list.

Deliberately kept: the quickstart's Mermaid pipeline diagram (a visual walkthrough earns its maintenance cost in a way a prose count does not), and counts inside generated regions (they regenerate from source).

## Why This Matters

- Adding a 12th provisioning script now requires zero prose edits — the generated table updates via `make docs-generate` and nothing else mentions a number.

## Context

Part 6, stacked on #435 — the incremental diff is the last commit. These were the only hardcoded cardinalities left in tracked, in-scope docs after the refactor series (verified by sweep).

## Testing

- `make docs-check` green; the three files pass `prettier --check`.

---

Three-sentence docs change; no functional impact. Happy to squash this into #435 instead if a sixth PR is too granular. This PR was generated with the help of Claude.
