### PR TITLE
docs(designs): add the agent communication design

### DIFF
--- a/docs/designs/agent-communication.md
+++ b/docs/designs/agent-communication.md
@@ -1,0 +1,388 @@
+# Agent Communication Design — kube-agents
+
+> **STATUS — design of record; not yet implemented.** The file-based handover channel described as the "primary channel" below is a proposal: no code in this repository implements it today. The **kanban delegation** design (optional task delegation) builds on the Hermes kanban board, which does exist. Treat this document as the reference design for both, not as a description of shipped behaviour.
+
+**Status:** Draft for review
+**Scope:** How the Platform Agent and per-cluster subagents exchange information.
+**Primary topic:** structured, file-based handover. **Secondary:** optional task delegation via the Hermes kanban board.
+
+---
+
+## 1. Summary
+
+The platform is a **decoupled, persona-based** system:
+
+- **Platform Agent** — one Hermes profile (the `default` profile). User-facing (chat), fleet-wide synthesis.
+- **Cluster subagent** — one Hermes profile **per managed cluster**, co-located in the same pod for the MVP. Runs its own cron for periodic local scans, processes delegated tasks, and keeps its own `multiuser_memory`.
+
+Two communication channels, with different shapes and different reliability requirements:
+
+| Channel                           | Direction          | Shape                                   | Mechanism                                                            |
+| --------------------------------- | ------------------ | --------------------------------------- | -------------------------------------------------------------------- |
+| **Structured handover (primary)** | cluster → platform | continuous status (latest-wins, typed)  | files under `/opt/data/fleet/…`, written via a `write_handover` tool |
+| **Task delegation (optional)**    | platform → cluster | discrete work items (lifecycle, fan-in) | Hermes kanban board                                                  |
+
+**Guiding principles**
+
+1. **No agent-to-agent prompting.** Agents never call each other. They coordinate through shared state (files) and, when delegating, through the kanban board. This avoids the delegation/loop antipatterns.
+2. **Constrain writes, free reads.** Writers use a schema-enforcing tool; readers use ordinary file tools. LLMs are reliable at reading files and less reliable at bespoke interfaces, so only the _write_ path is a tool.
+3. **Co-located now, migrateable later.** For the MVP all profiles share one pod and one PVC. The design keeps a single seam (the write helper) where a future cross-pod transport would slot in without changing the reader contract.
+
+---
+
+## 2. Structured file-based handover (primary channel)
+
+### 2.1 Model
+
+Cluster subagents continuously produce structured **status records** (health, utilization, upgrade-readiness, …). The platform agent consumes them to reason about the fleet. This is a classic producer/consumer blackboard:
+
+- **Producers** (cluster subagents) write one file per `(cluster, record-type)`, latest-wins.
+- **Consumer** (platform agent) reads those files whenever it needs fleet state — no request/response, no prompting.
+
+### 2.2 Location
+
+```
+/opt/data/fleet/clusters/<cluster>/<location>/<type>.json
+```
+
+`/opt/data/fleet` is a **fixed absolute path**, shared by every agent in the pod.
+
+### 2.3 Record envelope
+
+Every file is a single JSON object with a common envelope and a typed `payload`:
+
+```json
+{
+  "schema_version": 1,
+  "cluster": "prod",
+  "location": "us-central1",
+  "type": "health",
+  "generated_at": "2026-07-21T14:03:11Z",
+  "expires_at": "2026-07-21T14:18:11Z",
+  "payload": {}
+}
+```
+
+| Field            | Meaning                                                                                                                                    |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `schema_version` | Envelope/schema version for forward compatibility.                                                                                         |
+| `cluster`        | The cluster this record describes. Set from the writer's **profile identity**, never a caller argument.                                    |
+| `location`       | The cluster location (zonal/regional). Set from the writer's **profile identity**, never a caller argument.                                |
+| `type`           | Record type (`health`, `utilization`, `upgrade_readiness`, `drift`, `inventory`, …). Determines the `payload` schema.                      |
+| `generated_at`   | Write timestamp (UTC ISO-8601).                                                                                                            |
+| `expires_at`     | Staleness horizon. A reader treats a record past `expires_at` as **stale** — this is how a dead subagent's data is detectably out of date. |
+| `payload`        | Typed body (see §2.6).                                                                                                                     |
+
+### 2.4 The `write_handover` tool
+
+All writes funnel through a single tool (registered only for cluster-subagent profiles):
+
+- **Name:** `write_handover`
+- **Toolset:** `handover` (gated via `enabled_toolsets`).
+- **Arguments:**
+  - `type` (enum: `health | utilization | upgrade_readiness | drift | inventory`)
+  - `payload` (object — the typed body)
+  - `ttl_seconds` (optional int; default per-type, used to compute `expires_at`)
+- **Handler behavior:**
+  1. Derive `cluster` and `location` from the **profile identity** (bound once at `register()` via `ctx.profile_name` / config), so they are **not** an argument. A subagent therefore _cannot_ write another cluster's record.
+  2. Build the envelope (`generated_at = now`, `expires_at = now + ttl`).
+  3. **Atomic write** (temp file + `fsync` + `os.replace`) to `/opt/data/fleet/clusters/<cluster>/<location>/<type>.json`. Atomicity is load-bearing: it guarantees the platform's plain reads never observe a torn/half-written file.
+  4. Return a short JSON result string.
+
+**One shared write helper.** The tool handler and any deterministic `no_agent` cron scripts call the **same** small helper:
+
+```python
+handover.write(cluster, location, type, payload, ttl_seconds=None)
+```
+
+This single-sources the envelope, path resolution, and atomicity, so the tool path and the script path can never drift. It is a concrete helper — **not** a generic pluggable interface (that abstraction is intentionally omitted while co-located; see §2.8).
+
+**Writer rule:** cluster subagents write status **only** via `write_handover` (or the helper). They must not `write_file` these paths directly — that would bypass the envelope and break the reader contract. State this rule in the cluster `SOUL.md`.
+
+### 2.5 Reading (platform side)
+
+The platform agent reads with **ordinary file tools** (`list_files`, `read_file`). No custom read tool is needed. Its `SOUL.md` / skill documents three facts:
+
+1. The path: `/opt/data/fleet/clusters/<cluster>/<location>/<type>.json`.
+2. The envelope shape (so it parses `payload` and reads `generated_at`).
+3. The staleness rule: **treat any record whose `expires_at` is in the past as stale** and do not act on it as current truth.
+
+Because writes are atomic, concurrent reads are always of a complete file.
+
+### 2.6 Record types and example payloads
+
+The MVP starts with `health` and `utilization`; the others are added as their CUJs land. All examples show only the `payload` (the envelope wraps them).
+
+**`health`** — SRE health snapshot.
+
+```json
+{
+  "overall": "degraded",
+  "node_ready_ratio": "11/12",
+  "pods_crashlooping": 3,
+  "pods_oomkilled_1h": 2,
+  "pods_pending": 0,
+  "apiserver_p99_ms": 180,
+  "failing_workloads": [
+    {
+      "namespace": "payments",
+      "kind": "Deployment",
+      "name": "ledger",
+      "reason": "CrashLoopBackOff"
+    },
+    {
+      "namespace": "search",
+      "kind": "StatefulSet",
+      "name": "indexer",
+      "reason": "OOMKilled"
+    }
+  ],
+  "notes": "ledger crashlooping since 13:40 after chart bump 4.2.0"
+}
+```
+
+**`utilization`** — capacity / rightsizing input.
+
+```json
+{
+  "window": "15m",
+  "node_count": 12,
+  "cpu": {
+    "allocatable_vcpu": 96,
+    "requested_vcpu": 34,
+    "used_vcpu": 21,
+    "utilization_pct": 22
+  },
+  "memory": {
+    "allocatable_gib": 384,
+    "requested_gib": 150,
+    "used_gib": 96,
+    "utilization_pct": 25
+  },
+  "headroom": { "cpu_vcpu": 62, "memory_gib": 234 },
+  "pressure": false,
+  "top_consumers": [
+    { "namespace": "search", "name": "indexer", "cpu_vcpu": 8, "mem_gib": 40 },
+    { "namespace": "payments", "name": "ledger", "cpu_vcpu": 5, "mem_gib": 18 }
+  ]
+}
+```
+
+**`upgrade_readiness`** — readiness for a target K8s version.
+
+```json
+{
+  "current_version": "1.30.5-gke.1000",
+  "target_version": "1.32",
+  "ready": false,
+  "readiness_score": 62,
+  "blockers": [
+    {
+      "severity": "high",
+      "kind": "deprecated_api",
+      "detail": "policy/v1beta1 PodSecurityPolicy in use (removed in 1.25+ path check)"
+    },
+    {
+      "severity": "medium",
+      "kind": "pdb_risk",
+      "detail": "search/indexer PDB minAvailable=100% blocks node drain"
+    }
+  ],
+  "deprecated_apis_in_use": [
+    { "api": "batch/v1beta1 CronJob", "used_by": ["ops/reporting"] }
+  ],
+  "addon_compat": [
+    { "addon": "ingress-nginx", "version": "1.9.0", "compatible": true }
+  ],
+  "recommended_window": "weekend maintenance; drain search last"
+}
+```
+
+**`drift`** — live state vs GitOps baseline.
+
+```json
+{
+  "baseline_ref": "git@github.com:org/fleet-config@a1b2c3d",
+  "clean": false,
+  "summary": { "added": 1, "removed": 0, "modified": 2 },
+  "drift_items": [
+    {
+      "namespace": "payments",
+      "kind": "Deployment",
+      "name": "ledger",
+      "field": "spec.replicas",
+      "desired": 3,
+      "live": 6,
+      "drift_type": "modified"
+    },
+    {
+      "namespace": "kube-system",
+      "kind": "ConfigMap",
+      "name": "manual-hotfix",
+      "drift_type": "added"
+    }
+  ]
+}
+```
+
+**`inventory`** — obtainability / topology snapshot.
+
+```json
+{
+  "k8s_version": "1.30.5-gke.1000",
+  "region": "us-central1",
+  "node_pools": [
+    {
+      "name": "default",
+      "machine_type": "e2-standard-4",
+      "count": 3,
+      "autoscaling": "3-8"
+    }
+  ],
+  "namespaces": 24,
+  "workloads": { "deployments": 61, "statefulsets": 7, "daemonsets": 9 },
+  "features": {
+    "workload_identity": true,
+    "dataplane_v2": true,
+    "managed_prometheus": false
+  },
+  "addons": ["gke-gateway", "cert-manager", "gke-managed-otel"]
+}
+```
+
+### 2.7 Concurrency, atomicity, retention
+
+- **Atomic writes** (temp + `fsync` + `os.replace`) — no torn reads, crash-safe (matches the `multiuser_memory` / `save_job_output` recipe).
+- **Latest-wins** — each `(cluster, location, type)` is a single file, overwritten each cycle. No history in the handover layer (history lives in cron output / logs if needed).
+- **Staleness** — readers honor `expires_at`; producers set a `ttl_seconds` sized to their scan cadence (e.g. a 5-minute health scan → `ttl ≈ 15m`).
+- **Concurrent writers within a profile** — the persistent cron context and any transient worker share the profile; if both could write the same handover file, wrap the helper's write in an `flock` (the `_jobs_lock` pattern). Low risk (distinct types, low cadence) but cheap to harden.
+
+### 2.8 No generic interface now; the write helper is the migration seam
+
+We deliberately do **not** introduce a pluggable `FleetStore` backend interface while agents are co-located — it's unnecessary abstraction. Instead, _all writes funnel through `write_handover` and its one helper_, which gives the swappability where it matters without the ceremony:
+
+- **Today (co-located):** the helper does an atomic local write to `/opt/data/fleet/…`.
+- **Future (separate pods):** the _same_ helper instead **SCPs or HTTP-POSTs** the record into the **platform pod's** `/opt/data/fleet/clusters/<self>/…`. Only that one function changes.
+- **The reader contract never changes.** The platform always just reads local files under `/opt/data/fleet/`. In the co-located world those files arrive by local write; in the split world they arrive by push. The platform (and its `SOUL.md`) cannot tell the difference, so nothing on the read side changes across the migration.
+
+For the MVP we stay co-located; this section is the documented forward path.
+
+---
+
+## 3. Optional task delegation via the existing kanban board (secondary channel)
+
+### 3.1 Delegation is optional — the platform decides
+
+The platform agent can accomplish fleet operations **by itself**: it reads handover files, reasons, and emits GitOps PRs. Delegation to cluster subagents via the kanban board is an **optimization the platform chooses**, not a requirement. **With or without delegation, the functionality works.** This is the main difference between the initial three-agent implementation and the current design.
+
+The platform delegates when it benefits from one of:
+
+- **Context preservation.** Deep per-cluster investigation (RCA, upgrade analysis) would bloat the platform's context window. Delegating gives each cluster subagent a **fresh context** plus its **own cluster memory** (`multiuser_memory`), and returns only a compact structured result to the platform.
+- **Deterministic planning.** The kanban board provides structured orchestration the platform would otherwise hand-roll: parent/child **DAG dependencies**, **fan-in** aggregation, lifecycle states, **claim/lease** semantics (no double-execution) and retries. When a job has real structure or ordering, delegating makes the plan deterministic and inspectable rather than something the platform juggles in a single turn.
+
+If neither applies (a quick, single-cluster action), the platform just does it directly and skips kanban.
+
+### 3.2 Mechanism
+
+- The kanban board is a **shared** store at the Hermes root (`<root>/kanban.db`) — the intended cross-profile coordination primitive. Co-located profiles share it directly.
+- The platform (orchestrator) creates cards with `kanban_create(assignee=<cluster-profile>, body=<spec>, …)`.
+- The Hermes **dispatcher** (running in the platform gateway) automatically spawns the assigned cluster subagent as a local worker (`hermes -p <cluster> chat -q "work kanban task <id>"`). No polling; the worker reads its pre-built context.
+- The worker does the local work and returns a **structured result** via `kanban_complete(summary=…, metadata={…})`. `block_kind=needs_input` escalates to a human.
+- **Fan-out / fan-in:** per-cluster cards are **parents**; a platform **aggregation card** is their **child**, gated until all parents finish. The child runs as a new platform turn whose context contains every parent's structured `metadata` — that's where the platform synthesizes and acts.
+
+### 3.3 Read-only / declarative posture in delegated tasks
+
+Delegated cards **do not imperatively mutate clusters**. They either (a) **validate** something locally and return findings, or (b) **generate declarative artifacts** (KCC/GitOps YAML). The platform opens the PR; Config Connector reconciles. This keeps cluster subagents read-only and puts all mutation in the GitOps path (with free rollback via PR revert).
+
+### 3.4 Delegated tasks are visible in chat (thoughts emitted to the user)
+
+Delegation is **transparent to the user**, not hidden plumbing:
+
+- On `kanban_create`, the originating chat session is **auto-subscribed** to the task.
+- The gateway's kanban notifier surfaces task **lifecycle events** (claimed / completed / blocked) back into that chat, and workers can post progress via `kanban_comment`.
+- The orchestrator (platform) narrates its plan when it decides to delegate ("delegating readiness checks to 3 clusters…") and reports the synthesized result when the fan-in completes.
+
+Net effect: delegated cluster subagents **emit their thoughts and results to the chat**, so the platform admin can watch the orchestration unfold and intervene (e.g. answer a `needs_input` block) without digging into internal state.
+
+---
+
+## 4. Worked CUJ — cross-cluster workload rebalancing (validation-then-declare)
+
+**Trigger (handover channel):** the platform reads `utilization.json` for all clusters and detects **clusterA underutilized** and **clusterB overutilized / under pressure**. It decides some workloads should move from B to A.
+
+**Decision (delegate or not):** the platform _chooses_ to orchestrate rather than do everything itself — to preserve its context and to make the plan deterministic. It uses the **validation-then-declare** pattern: cluster subagents **validate feasibility** (read-only); the platform **declares** the change (a single GitOps PR); KCC reconciles the actual move.
+
+**Card graph (fan-out validation → fan-in declare):**
+
+```
+Card A  (assignee = clusterA):  "Can you host workload W?"      ─┐  parents
+Card B  (assignee = clusterB):  "Is it safe to evacuate W?"     ─┤  (parallel — independent checks)
+                                                                 ▼
+Card C  (assignee = platform, parents = [A, B]):  "Decide & declare"   fan-in child
+```
+
+The two validation cards are **parallel** (no ordering dependency — they're read-only checks). The make-before-break _execution_ ordering is handled later by KCC when it reconciles the PR, not by the agents.
+
+**Card A result — clusterA feasibility (`kanban_complete` metadata):**
+
+```json
+{
+  "can_host": true,
+  "workload": {
+    "namespace": "search",
+    "name": "indexer",
+    "cpu_vcpu": 8,
+    "mem_gib": 40
+  },
+  "headroom_after": { "cpu_vcpu": 54, "memory_gib": 194 },
+  "constraints": [],
+  "confidence": "high"
+}
+```
+
+**Card B result — clusterB evacuation safety:**
+
+```json
+{
+  "safe_to_evacuate": true,
+  "workload": { "namespace": "search", "name": "indexer" },
+  "blockers": [],
+  "pdb_ok": true,
+  "stateful": false,
+  "in_flight_work": false,
+  "notes": "no local PVs; safe to relocate"
+}
+```
+
+**Card C — platform decision & declaration:**
+
+- If both green → generate the **relocation PR** (move the workload's manifest from clusterB's overlay to clusterA's overlay, or flip its target-cluster field) and open it. KCC/Config Sync performs the actual make-before-break move.
+- If either red → do not declare; report blockers to the user, or `block_kind=needs_input` for a human decision.
+
+```json
+{
+  "decision": "proceed",
+  "workload": "search/indexer",
+  "from": "clusterB",
+  "to": "clusterA",
+  "pr_url": "https://github.com/org/fleet-config/pull/482",
+  "rationale": "clusterB CPU 88% / clusterA 22%; A has headroom; W stateless, no PDB block"
+}
+```
+
+**Failure / compensation:** because the change is a **PR**, rollback is a revert. If a validation fails mid-flight, the fan-in aborts the declaration (no partial move). Human-in-the-loop happens via `needs_input`.
+
+**Why this is a good kanban CUJ:** genuine cross-cluster coordination (not just parallel independent tasks), a real orchestrator/executor split, an autonomous _decide-to-delegate_, both channels working together (FleetStore trigger → kanban orchestration), and a declarative, reversible outcome. It's the "global capacity orchestrator" concern graduating from a single do-it-all bot to platform-orchestrates / clusters-validate / KCC-executes.
+
+---
+
+## 5. Guardrails (summary)
+
+1. **No agent-to-agent prompting.** Coordinate via handover files and the kanban board only.
+2. **Constrain writes, free reads.** `write_handover` tool for status writes; plain file reads for consumption.
+3. **Ownership by identity.** `cluster` and `location` come from the writer's profile, never a caller argument.
+4. **Atomic writes.** Temp + rename on every handover write; readers honor `expires_at`.
+5. **Write only via the tool/helper.** Never `write_file` handover paths directly.
+6. **Read-only / declarative.** No imperative cluster mutation; emit KCC/GitOps PRs and let Config Connector reconcile.
+7. **Delegation is optional and transparent.** The platform decides when to delegate; delegated work is visible in chat.
+8. **Co-located MVP, one migration seam.** The write helper is the only place a future cross-pod transport changes; the reader contract is stable.

--- a/docs/designs/agent-communication.md
+++ b/docs/designs/agent-communication.md
@@ -86,14 +86,16 @@ All writes funnel through a single tool (registered only for cluster-subagent pr
 - **Handler behavior:**
   1. Derive `cluster` and `location` from the **profile identity** (bound once at `register()` via `ctx.profile_name` / config), so they are **not** an argument. A subagent therefore _cannot_ write another cluster's record.
   2. Build the envelope (`generated_at = now`, `expires_at = now + ttl`).
-  3. **Atomic write** (temp file + `fsync` + `os.replace`) to `/opt/data/fleet/clusters/<cluster>/<location>/<type>.json`. Atomicity is load-bearing: it guarantees the platform's plain reads never observe a torn/half-written file.
+  3. **Atomic write** (temp file + `fsync` + `os.replace`) to `/opt/data/fleet/clusters/<cluster>/<location>/<type>.json`. Atomicity is load-bearing: it guarantees the platform's plain reads never observe a torn/half-written file. The temp file **must be created in the destination directory**, not in `/tmp`: `os.replace` is only atomic within a single filesystem, and `/opt/data` is a PVC while `/tmp` is usually a separate `tmpfs` — renaming across that boundary fails with `EXDEV` (invalid cross-device link).
   4. Return a short JSON result string.
 
 **One shared write helper.** The tool handler and any deterministic `no_agent` cron scripts call the **same** small helper:
 
 ```python
-handover.write(cluster, location, type, payload, ttl_seconds=None)
+handover.write(cluster, location, record_type, payload, ttl_seconds=None)
 ```
+
+The parameter is `record_type`, not `type`, so the helper does not shadow the Python built-in. The tool argument and the envelope field stay named `type` — those are the agent-facing and on-disk contracts; only the Python signature is renamed.
 
 This single-sources the envelope, path resolution, and atomicity, so the tool path and the script path can never drift. It is a concrete helper — **not** a generic pluggable interface (that abstraction is intentionally omitted while co-located; see §2.8).
 
@@ -252,7 +254,7 @@ The MVP starts with `health` and `utilization`; the others are added as their CU
 
 ### 2.7 Concurrency, atomicity, retention
 
-- **Atomic writes** (temp + `fsync` + `os.replace`) — no torn reads, crash-safe (matches the `multiuser_memory` / `save_job_output` recipe).
+- **Atomic writes** (same-directory temp + `fsync` + `os.replace`) — no torn reads, crash-safe (matches the `multiuser_memory` / `save_job_output` recipe).
 - **Latest-wins** — each `(cluster, location, type)` is a single file, overwritten each cycle. No history in the handover layer (history lives in cron output / logs if needed).
 - **Staleness** — readers honor `expires_at`; producers set a `ttl_seconds` sized to their scan cadence (e.g. a 5-minute health scan → `ttl ≈ 15m`).
 - **Concurrent writers within a profile** — the persistent cron context and any transient worker share the profile; if both could write the same handover file, wrap the helper's write in an `flock` (the `_jobs_lock` pattern). Low risk (distinct types, low cadence) but cheap to harden.


### PR DESCRIPTION
# Pull Request

## Why This Change

The Platform Agent and any per-cluster subagents need a defined way to exchange
information. Today there is no written protocol, so any implementation would be
inventing one ad hoc and the next one would invent a different one.

This adds the design of record so the protocol can be reviewed on its merits
before code depends on it.

## What Changed

**Files:**

- `docs/designs/agent-communication.md`

**Added/Changed/Fixed:**

- Documents a structured, **file-based handover channel** as the primary
  mechanism: on-disk layout, write and read protocols, staleness handling, and
  failure modes.
- Documents **optional task delegation over the Hermes kanban board** as the
  secondary channel, for work that should be queued and picked up
  asynchronously rather than handed over in-line.

## Why This Matters

- Agent-to-agent communication is the seam where context gets lost or silently
  duplicated. Pinning the protocol before implementation is cheaper than
  reconciling two half-built channels later.
- The doc is explicit that **neither channel is implemented in this repository
  today**. The kanban board it builds on is provided by the Hermes runtime; the
  handover channel is a proposal. The status banner says so, so nobody reads it
  as a description of shipped behaviour.

## Context

**Stack position: 1 of 5.** This series splits a long-running feature branch
into reviewable pieces. The intended merge order is:

1. **this PR** — agent communication design doc
2. `pr/02-readonly-permission-default` — default the Platform Agent permission set to read-only
3. `pr/03-chat-agent-front-door` — Chat Agent front door + multi-profile pod
4. `pr/04-kanban-progress-propagation` — child-card chat subscription propagation
5. `pr/05-cluster-agent-profiles` — per-cluster Cluster Agents

GitHub requires a PR's base branch to live in the target repo, and these
branches are on a fork, so all five are opened against `main`. **PRs 2–5 will
therefore show cumulative diffs until their predecessors merge.** Each branch
will be rebased as the one before it lands. This PR is the base of the stack and
its diff is already clean.

Review only commit `ccd607c`.

## Testing

- `npx prettier --check docs/designs/agent-communication.md` — passes.
- Checked the document for links to repo paths or sibling docs: there are none,
  so it is self-contained and adds no dangling references.

---

Documentation only — no code, no behavioral change, nothing to roll back.
