### PR TITLE
feat(security)!: default the Platform Agent permission set to read-only

### DIFF
--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -71,8 +71,8 @@ Default image: `ghcr.io/gke-labs/kube-agents/platform-agent:latest`. Rebuild wit
 
 The Workload Identity target GSA (`kubeagents-platform-gsa@<project>.iam.gserviceaccount.com`) is created and bound by `provision_04_gcp_iam.sh` with one of these permission sets:
 
-- `read-only`
-- `gke-admin` (default)
+- `read-only` (default)
+- `gke-admin`
 - `custom` (roles supplied via `PLATFORM_AGENT_CUSTOM_ROLES`)
 
 ## `spec.integration`

--- a/docs/site/src/content/docs/overview/architecture.mdx
+++ b/docs/site/src/content/docs/overview/architecture.mdx
@@ -106,7 +106,7 @@ The hub footprint (operator, Platform Agent, LiteLLM, Minty) is small and roughl
 - **vLLM.** Local inference needs a GPU node pool; hosted LiteLLM does not.
 - **gVisor.** Sandboxed skill execution runs the agent pod on the optional `gvisor-pool` (`ENABLE_GVISOR=true`).
 
-For production, prefer a **dedicated cluster** for the harness. The agent GSA can hold broad GKE permissions in the default `gke-admin` set, so a hard cluster boundary limits blast radius if the execution sandbox is ever compromised. A shared cluster (with the `kubeagents-system` namespace for logical isolation) is fine for development.
+For production, prefer a **dedicated cluster** for the harness. The agent GSA can hold broad GKE permissions in the `gke-admin` set, so a hard cluster boundary limits blast radius if the execution sandbox is ever compromised. A shared cluster (with the `kubeagents-system` namespace for logical isolation) is fine for development.
 
 ## Failure modes worth knowing
 

--- a/docs/site/src/content/docs/reference/security-and-iam.md
+++ b/docs/site/src/content/docs/reference/security-and-iam.md
@@ -35,13 +35,13 @@ The IAM side of the binding is pre-provisioned by [`provision_04_gcp_iam.sh`](ht
 
 | Permission set | `PLATFORM_AGENT_PERMISSION_SET` | Use it when                                                    |
 | -------------- | ------------------------------- | -------------------------------------------------------------- |
-| **gke-admin**  | `gke-admin` (default)           | The agent should manage GKE lifecycle and node pools directly. |
-| **read-only**  | `read-only`                     | Auditing / monitoring only — no GCP write capability.          |
+| **gke-admin**  | `gke-admin`                     | The agent should manage GKE lifecycle and node pools directly. |
+| **read-only**  | `read-only` (default)           | Auditing / monitoring only — no GCP write capability.          |
 | **custom**     | `custom`                        | You supply the exact roles via `PLATFORM_AGENT_CUSTOM_ROLES`.  |
 
 ### Roles per set
 
-The default **gke-admin** set binds:
+The **gke-admin** set binds:
 
 - `roles/container.clusterAdmin`, `roles/container.admin` — full GKE control.
 - `roles/monitoring.admin` — manage monitoring configuration.
@@ -50,7 +50,7 @@ The default **gke-admin** set binds:
 - `roles/iam.securityReviewer` — read IAM policy for review.
 - `roles/mcp.toolUser` — call the GKE MCP server.
 
-The **read-only** set swaps the admin roles for viewers:
+The default **read-only** set swaps the admin roles for viewers:
 
 - `roles/container.clusterViewer`, `roles/container.viewer` — read-only GKE.
 - `roles/monitoring.viewer`, `roles/logging.viewer` — read-only telemetry.

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -77,7 +77,7 @@ graph TD
 4. **[provision_04_gcp_iam.sh](scripts/provision_04_gcp_iam.sh)**:
    - Enables GCP Service APIs (`container.googleapis.com` and `cloudresourcemanager.googleapis.com`).
    - Pre-provisions GCP Service Accounts (GSAs) and Workload Identity bindings for the Platform Agent and conditionally for the GitHub Token Minter.
-   - Grants GKE cluster management and monitoring permissions to the Platform Agent GSA based on the selected permission set (`read-only`, `gke-admin`, or `custom`, default: `gke-admin`).
+   - Grants GKE cluster management and monitoring permissions to the Platform Agent GSA based on the selected permission set (`read-only`, `gke-admin`, or `custom`, default: `read-only`).
    - Configures Workload Identity policy bindings and annotations for the GitHub Token Minter GSA/KSA if GitHub integration is configured.
 
 5. **[provision_05_gcp_gchat.sh](scripts/provision_05_gcp_gchat.sh)**:

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -41,7 +41,7 @@ When any script is run:
    - Enables GCP Service APIs (`container.googleapis.com` and `cloudresourcemanager.googleapis.com`).
    - Pre-provisions GCP Service Accounts (GSAs) for the Platform Agent and conditionally for the GitHub Token Minter.
    - Configures Workload Identity policy bindings mapping the Kubernetes SAs to the GCP GSAs.
-   - Grants GKE cluster management and monitoring permissions to the Platform Agent GSA based on the selected permission set (`read-only`, `gke-admin`, or `custom`, default: `gke-admin`).
+   - Grants GKE cluster management and monitoring permissions to the Platform Agent GSA based on the selected permission set (`read-only`, `gke-admin`, or `custom`, default: `read-only`).
    - Configures Workload Identity policy bindings and annotations for the GitHub Token Minter GSA/KSA if GitHub integration is configured.
 5. **[provision_05_gcp_gchat.sh](provision_05_gcp_gchat.sh)**
    - Enables GCP Service APIs (`pubsub.googleapis.com` and `chat.googleapis.com`).

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -172,7 +172,7 @@ init_var_model_provider() {
 }
 
 init_var_platform_agent_permission_set() {
-  init_var "PLATFORM_AGENT_PERMISSION_SET" "gke-admin" "Enter Platform Agent Permission Set (read-only, gke-admin, custom)"
+  init_var "PLATFORM_AGENT_PERMISSION_SET" "read-only" "Enter Platform Agent Permission Set (read-only, gke-admin, custom)"
 
   PLATFORM_AGENT_PERMISSION_SET=$(echo "$PLATFORM_AGENT_PERMISSION_SET" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
   if [[ ! "$PLATFORM_AGENT_PERMISSION_SET" =~ ^(read-only|gke-admin|custom)$ ]]; then

--- a/k8s-operator/scripts/provision_04_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_04_gcp_iam.sh
@@ -175,7 +175,7 @@ get_platform_agent_roles() {
     "roles/mcp.toolUser"
   )
 
-  case "${PLATFORM_AGENT_PERMISSION_SET:-gke-admin}" in
+  case "${PLATFORM_AGENT_PERMISSION_SET:-read-only}" in
     read-only)
       echo "${read_only_roles[*]}"
       ;;

--- a/k8s-operator/scripts/provision_04_gcp_iam.sh
+++ b/k8s-operator/scripts/provision_04_gcp_iam.sh
@@ -187,8 +187,17 @@ get_platform_agent_roles() {
         echo "${custom_roles_str//,/ }"
       fi
       ;;
-    gke-admin|*)
+    gke-admin)
       echo "${gke_admin_roles[*]}"
+      ;;
+    *)
+      # Fail closed. init_var_platform_agent_permission_set rejects unknown
+      # values, so reaching here means the script was invoked with the variable
+      # pre-set (CI, a sourced vars.sh, a typo'd export). Granting admin on an
+      # unrecognized value would make a typo an escalation; warn on stderr
+      # (never stdout — the caller captures it) and use the least-privilege set.
+      print_warning "Unrecognized PLATFORM_AGENT_PERMISSION_SET '${PLATFORM_AGENT_PERMISSION_SET}'; falling back to read-only." >&2
+      echo "${read_only_roles[*]}"
       ;;
   esac
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

`PLATFORM_AGENT_PERMISSION_SET` defaults to `gke-admin`. An operator who runs
`make gcp-provision` and accepts every prompt ends up with an agent GSA holding
`roles/container.clusterAdmin` and `roles/container.admin` over the project.

That is the wrong direction for a default. Least privilege should be what you
get for free; broad GKE write access should be something you deliberately ask
for. The `read-only` set already exists and is fully wired — it is just not what
the prompt offers first.

## What Changed

**Files:**

- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/provision_04_gcp_iam.sh`
- `docs/site/src/content/docs/reference/security-and-iam.md`
- `docs/site/src/content/docs/operator/platformagent-crd.md`
- `docs/site/src/content/docs/overview/architecture.mdx`
- `k8s-operator/README.md`
- `k8s-operator/scripts/README.md`

**Added/Changed/Fixed:**

- `common.sh` — the value `init_var` seeds the provisioning prompt with is now
  `read-only`.
- `provision_04_gcp_iam.sh` — the `:-` fallback used when the script is invoked
  directly with the variable unset is now `read-only`, so both places that
  express the default agree.
- Every doc that named `gke-admin` as the default now names `read-only`.

No role bundle changed. The `gke-admin` and `custom` sets are untouched and
still selectable.

## Why This Matters

- **This is a breaking change for existing setups.** Re-running provisioning
  without an explicit `PLATFORM_AGENT_PERMISSION_SET` now grants the read-only
  role set instead of `gke-admin`. Deployments that rely on the agent writing to
  GKE must set `PLATFORM_AGENT_PERMISSION_SET=gke-admin` explicitly.
  Already-provisioned GSAs are unaffected until the IAM script is re-run. The
  commit carries a `BREAKING CHANGE:` trailer.
- Two lines of behaviour, so it is worth seeing in isolation rather than buried
  inside the larger restructure later in this stack.

**Folded in after review (`10e9490`):** `get_platform_agent_roles` matched
`gke-admin|*)`, so an *unrecognized* value fell through to the admin bundle —
a typo'd export was a silent privilege escalation. `gke-admin)` is now split
from the wildcard, and the wildcard emits the read-only set with a warning on
stderr. It does not `exit 1`: both call sites use
`local -a roles=($(get_platform_agent_roles))`, so the function runs in a
subshell whose status `local` masks even under `set -e` — a hard failure there
would yield an empty role list rather than stopping the run. Falling back to
least privilege is what actually fails closed. Normal invocations are
unchanged; `common.sh` still validates and rejects bad values first.

## Context

**Stack position: 2 of 5 — now the head of the stack.** PR 1 (#437) has merged,
so this branch has been rebased onto `main` and **its diff is now clean**: the
seven files above are entirely this PR's own work.

Review both commits — `40aa484` (the default flip) and `0f5a9c5` (the
fail-closed follow-up from review).

## Testing

- `bash -n` on both modified scripts — clean.
- `npx prettier --check` on all five modified Markdown/MDX files — passes.
- Grepped the tree for every remaining assertion of the old default; the seven
  files above are the complete set.

---

Low blast radius in code (two literals), but a real change in provisioning
outcome. Reverting is a one-line flip back in each script.


