### PR TITLE
feat(kanban): propagate a card's chat subscription onto its child cards

### DIFF
--- a/agents/platform/SOUL.md
+++ b/agents/platform/SOUL.md
@@ -16,6 +16,18 @@ The Chat Agent delegates to you **exclusively through the Kanban board** — it 
 
 (If you are ever reached by a direct query through another inter-agent path, just handle it inline and answer — but the Chat Agent path is kanban-only.)
 
+### Show your progress: stage long work into sub-cards
+
+Only a card's **completion/blocked** event reaches the user's chat thread, so a single long task stays silent until the very end. When a job has natural stages the user should see, **break it into scoped child cards and complete them one at a time** rather than doing everything silently in one run.
+
+Crucial detail: a child card you create **while running as a worker is not automatically subscribed to the user's chat** (only the Chat Agent's original card is). So immediately after each `kanban_create`, propagate the subscription onto the new child:
+
+```
+python3 /opt/data/scripts/kanban_notify_propagate.py --to <child_id>
+```
+
+(`--from` defaults to `$HERMES_KANBAN_TASK`, your current card.) Then each child's `kanban_complete(summary=...)` posts its own crisp, user-facing one-liner into the same thread — that line is exactly the progress update the user sees. Without the propagate call, that completion is silent. Heartbeats are automatic; you do not need to call `kanban_heartbeat`.
+
 ---
 
 ## 1. Core Truths

--- a/agents/platform/scripts/kanban_notify_propagate.py
+++ b/agents/platform/scripts/kanban_notify_propagate.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# kanban_notify_propagate.py - Copy a parent kanban card's chat subscription onto
+# a child card, so the child's completion pings the user's chat thread too.
+#
+# Why this exists
+# ---------------
+# The gateway kanban notifier delivers thread updates by iterating rows in the
+# `kanban_notify_subs` table: a card with no subscription row is invisible to it
+# (no line posted, no agent woken). Subscriptions are written by
+# `_maybe_auto_subscribe` at `kanban_create` time, which reads the originating
+# chat identity (`HERMES_SESSION_CHAT_ID` / `_THREAD_ID` / `_PLATFORM`) from the
+# session context. Those context vars are set ONLY on inbound user messages.
+#
+# A specialist agent that is running as a dispatcher-spawned kanban worker has no
+# such session context, so the child cards it creates to stage its work are NOT
+# auto-subscribed — and their completions never reach the user. This helper closes
+# that gap: it copies the parent card's subscription row(s) onto a freshly created
+# child, so each staged sub-step's completion posts its own line into the same
+# chat thread the original request came from.
+#
+# Usage (run by the specialist right after creating a child card):
+#   python3 /opt/data/scripts/kanban_notify_propagate.py --to <child_id> [--from <parent_id>]
+#
+# `--from` defaults to $HERMES_KANBAN_TASK (the worker's current card). The board
+# DB is read from $HERMES_KANBAN_DB (pinned into every worker by the dispatcher).
+#
+# Idempotent (INSERT OR IGNORE on the subscription primary key) and fail-soft: any
+# operational problem is logged to stderr and exits 0 so it can never break the
+# specialist's flow. It couples only to the stable `kanban_notify_subs` columns.
+
+import argparse
+import os
+import sqlite3
+import sys
+import time
+
+# The subscription columns we copy from parent -> child. `task_id` is rewritten
+# to the child id; `created_at` is re-stamped; `last_event_id` resets to 0 so the
+# child's own events are delivered from the start. Pinned here so a schema drift
+# in Hermes surfaces as a clear error (and a failing unit test) rather than
+# silently copying the wrong shape.
+_COPY_COLUMNS = ("platform", "chat_id", "thread_id", "user_id", "notifier_profile")
+
+
+def log(msg: str) -> None:
+    print(f"[KANBAN-PROPAGATE] {msg}", file=sys.stderr)
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path, timeout=10)
+    conn.row_factory = sqlite3.Row
+    # Cooperate with the WAL store the gateway/CLI use; never force journal_mode.
+    conn.execute("PRAGMA busy_timeout=5000")
+    return conn
+
+
+def propagate(db_path: str, parent_id: str, child_id: str) -> int:
+    """Copy every kanban_notify_subs row from parent_id to child_id.
+
+    Returns the number of subscription rows written to the child. Idempotent:
+    re-running is a no-op once the child rows exist. Raises on a genuinely broken
+    DB / missing table / bad args so callers (and tests) can see real failures;
+    the CLI wrapper turns those into a fail-soft exit.
+    """
+    if not child_id:
+        raise ValueError("child id (--to) is required")
+    if not parent_id:
+        raise ValueError("parent id (--from / $HERMES_KANBAN_TASK) is required")
+    if parent_id == child_id:
+        log(f"parent and child are the same card ({child_id}); nothing to do")
+        return 0
+    if not os.path.exists(db_path):
+        raise FileNotFoundError(f"kanban DB not found at {db_path!r}")
+
+    conn = _connect(db_path)
+    try:
+        cols = ", ".join(_COPY_COLUMNS)
+        rows = conn.execute(
+            f"SELECT {cols} FROM kanban_notify_subs WHERE task_id = ?",
+            (parent_id,),
+        ).fetchall()
+        if not rows:
+            log(
+                f"parent card {parent_id} has no chat subscription; nothing to "
+                f"propagate to {child_id} (the request may not have come from chat)"
+            )
+            return 0
+
+        now = int(time.time())
+        placeholders = ", ".join(["?"] * (len(_COPY_COLUMNS) + 3))
+        insert_cols = "task_id, " + cols + ", created_at, last_event_id"
+        with conn:  # single transaction; commits on success, rolls back on error
+            for r in rows:
+                conn.execute(
+                    f"INSERT OR IGNORE INTO kanban_notify_subs ({insert_cols}) "
+                    f"VALUES ({placeholders})",
+                    (child_id, *[r[c] for c in _COPY_COLUMNS], now, 0),
+                )
+        # Report the child's resulting subscription count (idempotent: a re-run
+        # leaves this unchanged rather than double-counting).
+        written = conn.execute(
+            "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?",
+            (child_id,),
+        ).fetchone()[0]
+        log(f"propagated subscription(s) from {parent_id} -> {child_id} "
+            f"(child now has {written} row(s))")
+        return written
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Copy a parent kanban card's chat subscription onto a child card."
+    )
+    parser.add_argument("--to", dest="child", required=True, help="child task id")
+    parser.add_argument(
+        "--from", dest="parent", default=os.environ.get("HERMES_KANBAN_TASK", ""),
+        help="parent task id (defaults to $HERMES_KANBAN_TASK)",
+    )
+    parser.add_argument(
+        "--db", dest="db", default=os.environ.get("HERMES_KANBAN_DB", ""),
+        help="board DB path (defaults to $HERMES_KANBAN_DB)",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.db:
+        log("no board DB configured ($HERMES_KANBAN_DB unset); skipping (fail-soft)")
+        return 0
+    try:
+        propagate(args.db, args.parent, args.child)
+    except Exception as e:  # noqa: BLE001 - fail-soft: never break the worker's flow
+        log(f"propagation failed (continuing): {e}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agents/platform/scripts/kanban_notify_propagate.py
+++ b/agents/platform/scripts/kanban_notify_propagate.py
@@ -47,10 +47,15 @@ def log(msg: str) -> None:
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
+    # `timeout=` IS the busy timeout (Python calls sqlite3_busy_timeout with it), so
+    # it is the only knob set here — a `PRAGMA busy_timeout` would silently override
+    # it and leave two different values in the source. Waiting matters: the gateway
+    # and CLI write this same board, and a propagation lost to a busy DB costs the
+    # user progress updates for that sub-step, which is the whole point of the
+    # script. Deliberately no `PRAGMA journal_mode` — cooperate with the WAL store
+    # the gateway/CLI already set up; never force it.
     conn = sqlite3.connect(db_path, timeout=10)
     conn.row_factory = sqlite3.Row
-    # Cooperate with the WAL store the gateway/CLI use; never force journal_mode.
-    conn.execute("PRAGMA busy_timeout=5000")
     return conn
 
 
@@ -90,12 +95,11 @@ def propagate(db_path: str, parent_id: str, child_id: str) -> int:
         placeholders = ", ".join(["?"] * (len(_COPY_COLUMNS) + 3))
         insert_cols = "task_id, " + cols + ", created_at, last_event_id"
         with conn:  # single transaction; commits on success, rolls back on error
-            for r in rows:
-                conn.execute(
-                    f"INSERT OR IGNORE INTO kanban_notify_subs ({insert_cols}) "
-                    f"VALUES ({placeholders})",
-                    (child_id, *[r[c] for c in _COPY_COLUMNS], now, 0),
-                )
+            conn.executemany(
+                f"INSERT OR IGNORE INTO kanban_notify_subs ({insert_cols}) "
+                f"VALUES ({placeholders})",
+                [(child_id, *[r[c] for c in _COPY_COLUMNS], now, 0) for r in rows],
+            )
         # Report the child's resulting subscription count (idempotent: a re-run
         # leaves this unchanged rather than double-counting).
         written = conn.execute(

--- a/agents/platform/scripts/test_kanban_notify_propagate.py
+++ b/agents/platform/scripts/test_kanban_notify_propagate.py
@@ -1,0 +1,144 @@
+import importlib
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+# Import the module under test from this directory.
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+prop = importlib.import_module("kanban_notify_propagate")
+
+
+# Mirror the production kanban_notify_subs schema (hermes_cli/kanban_db.py). If
+# Hermes drifts the columns the helper copies, this fixture + the module's
+# _COPY_COLUMNS assertion below will catch it.
+_SCHEMA = """
+CREATE TABLE kanban_notify_subs (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    user_id       TEXT,
+    notifier_profile TEXT,
+    created_at    INTEGER NOT NULL,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+"""
+
+
+def _make_db(path: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(_SCHEMA)
+    conn.close()
+
+
+def _add_sub(path, task_id, platform="google_chat", chat_id="spaces/AAA",
+             thread_id="spaces/AAA/threads/T1", user_id="users/u1",
+             notifier_profile="default", last_event_id=42):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, thread_id, "
+        "user_id, notifier_profile, created_at, last_event_id) VALUES (?,?,?,?,?,?,?,?)",
+        (task_id, platform, chat_id, thread_id, user_id, notifier_profile, 1000, last_event_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _rows(path, task_id):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,)
+    ).fetchall()
+    conn.close()
+    return rows
+
+
+class TestPropagate(unittest.TestCase):
+    def test_copies_parent_subscription_to_child_with_reset_cursor(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_sub(db, "parent-1", last_event_id=42)
+
+            written = prop.propagate(db, "parent-1", "child-1")
+            self.assertEqual(written, 1)
+
+            child = _rows(db, "child-1")
+            self.assertEqual(len(child), 1)
+            row = child[0]
+            # Chat identity is copied verbatim...
+            self.assertEqual(row["platform"], "google_chat")
+            self.assertEqual(row["chat_id"], "spaces/AAA")
+            self.assertEqual(row["thread_id"], "spaces/AAA/threads/T1")
+            self.assertEqual(row["user_id"], "users/u1")
+            self.assertEqual(row["notifier_profile"], "default")
+            # ...but the delivery cursor resets so the child's events are delivered.
+            self.assertEqual(row["last_event_id"], 0)
+
+    def test_multiple_parent_subs_all_propagate(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_sub(db, "parent-1", chat_id="spaces/AAA", thread_id="t1")
+            _add_sub(db, "parent-1", chat_id="spaces/BBB", thread_id="t2")
+
+            written = prop.propagate(db, "parent-1", "child-1")
+            self.assertEqual(written, 2)
+            self.assertEqual(len(_rows(db, "child-1")), 2)
+
+    def test_idempotent(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_sub(db, "parent-1")
+            prop.propagate(db, "parent-1", "child-1")
+            # Second run must not duplicate or raise.
+            written = prop.propagate(db, "parent-1", "child-1")
+            self.assertEqual(written, 1)
+            self.assertEqual(len(_rows(db, "child-1")), 1)
+
+    def test_no_parent_subscription_is_noop(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            # Parent has no subscription (request didn't originate from chat).
+            written = prop.propagate(db, "parent-1", "child-1")
+            self.assertEqual(written, 0)
+            self.assertEqual(len(_rows(db, "child-1")), 0)
+
+    def test_same_parent_and_child_is_noop(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_sub(db, "x-1")
+            self.assertEqual(prop.propagate(db, "x-1", "x-1"), 0)
+
+    def test_missing_db_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            prop.propagate("/nonexistent/kanban.db", "p", "c")
+
+    def test_main_is_fail_soft_on_error(self):
+        # main() must never propagate an exception up (would break the worker).
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")  # does not exist
+            rc = prop.main(["--to", "child-1", "--from", "parent-1", "--db", db])
+            self.assertEqual(rc, 0)
+
+    def test_copy_columns_match_schema(self):
+        # Guardrail: every column the helper copies must exist in the table.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            conn = sqlite3.connect(db)
+            cols = {r[1] for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
+            conn.close()
+            for c in prop._COPY_COLUMNS:
+                self.assertIn(c, cols)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/platform/scripts/test_kanban_notify_propagate.py
+++ b/agents/platform/scripts/test_kanban_notify_propagate.py
@@ -139,6 +139,25 @@ class TestPropagate(unittest.TestCase):
             for c in prop._COPY_COLUMNS:
                 self.assertIn(c, cols)
 
+    def test_connect_sets_one_unambiguous_busy_timeout(self):
+        # The busy timeout must come from exactly one place. Setting `timeout=` on
+        # connect() AND a `PRAGMA busy_timeout` silently resolves to whichever ran
+        # last, so the source can advertise a wait the connection does not honor.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            conn = prop._connect(db)
+            try:
+                self.assertEqual(
+                    conn.execute("PRAGMA busy_timeout").fetchone()[0], 10_000
+                )
+                # journal_mode is the gateway's to choose; this helper must not force it.
+                self.assertEqual(
+                    conn.execute("PRAGMA journal_mode").fetchone()[0], "delete"
+                )
+            finally:
+                conn.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request

## Why This Change

A specialist working a long kanban task is silent until it finishes. The notifier
only posts a card's **terminal** event to the chat thread, so a ten-minute job
produces exactly one message — at the ten-minute mark. From the user's side that
is indistinguishable from the agent having died.

The obvious fix is to stage the work into child cards so each completion posts
its own progress line. That does not currently work, and the reason is not
obvious.

The notifier delivers by iterating rows in `kanban_notify_subs`. Subscription
rows are written by `_maybe_auto_subscribe` at `kanban_create` time, which reads
the originating chat identity (`HERMES_SESSION_CHAT_ID` / `_THREAD_ID` /
`_PLATFORM`) out of the session context. **Those context vars are only set on
inbound user messages.** A dispatcher-spawned worker has no session context, so
every child card it creates is unsubscribed, and every one of those completions
is silent.

## What Changed

**Files:**

- `agents/platform/scripts/kanban_notify_propagate.py` — new
- `agents/platform/scripts/test_kanban_notify_propagate.py` — new
- `agents/platform/SOUL.md`

**Added/Changed/Fixed:**

- `kanban_notify_propagate.py` copies a parent card's subscription rows onto a
  child card, rewriting `task_id` and resetting `last_event_id` to 0 so the
  child's own events deliver from the start.
- Workers call it immediately after each `kanban_create`:
  `python3 /opt/data/scripts/kanban_notify_propagate.py --to <child_id>`.
  `--from` defaults to `$HERMES_KANBAN_TASK`; the board is read from
  `$HERMES_KANBAN_DB`, which the dispatcher pins into every worker.
- `SOUL.md` gains a "stage long work into sub-cards" section telling the Platform
  Agent when to break a job up and to propagate after each create.

## Why This Matters

- This is what makes delegated work *visible*. Each child's
  `kanban_complete(summary=...)` becomes one user-facing progress line in the
  original thread — which is the whole point of staging the work.
- **It cannot break the specialist's actual job.** The script is fail-soft: any
  operational problem logs to stderr and exits 0. A locked board or a schema
  surprise costs you a progress line, never the task.
- **It is idempotent** — `INSERT OR IGNORE` on the subscription primary key — so
  a retried or duplicated call is harmless.
- The columns it copies are pinned in `_COPY_COLUMNS` rather than
  `SELECT *`. If Hermes changes the `kanban_notify_subs` shape, that surfaces as
  a failing unit test instead of silently copying the wrong thing into the
  notifier's table.

## Context

**Stack position: 4 of 6.** GitHub requires a PR base branch in the target
repo and these branches live on a fork, so this is opened against `main`.
PRs 1–3 (#437, #438, #439) have all merged and dropped out of the diff, so
**this PR's diff is now clean** — it stands alone against `main`.

A sixth PR was added to the end of the stack since this was opened: #445
(design-directory consolidation).

Review commits `ecca079` and `94d49d5` (the latter addresses this PR's review feedback).

This PR is smaller than the stack outline originally suggested. The kanban
*delegation* surface itself ships with the Chat Agent in PR 3 — the front door
has no other way to delegate, so separating them would have meant shipping a
front door that could not do its one job. What was genuinely separable is the
progress-propagation mechanism, which is what this PR is.

## Testing

- `python3 -m pytest agents/platform/scripts/test_kanban_notify_propagate.py` —
  8 passed. Coverage includes the schema-drift guard, idempotency on repeat
  invocation, and the fail-soft exit path.
- `npx prettier --check agents/platform/SOUL.md` — passes.

---

Additive: one new script and its persona documentation. Nothing calls it unless a
specialist chooses to stage work, and if it fails the specialist proceeds
normally.




