### PR TITLE
fix(event-watcher): fallback to in-cluster config when kubeconfig file is missing

### DIFF
--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -162,8 +162,11 @@ func buildKubeClient(f *flags) (kubernetes.Interface, error) {
 				return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)
 			}
 			break
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("kubeconfig %s stat: %w", f.kubeconfig, statErr)
 		}
 		// Fallback to in-cluster config if explicit kubeconfig file does not exist
+		log.Printf("kubeconfig file %s not found, falling back to in-cluster config", f.kubeconfig)
 		fallthrough
 	case f.inCluster || os.Getenv("KUBERNETES_SERVICE_HOST") != "":
 		cfg, err = rest.InClusterConfig()

--- a/k8s-operator/cmd/k8s-event-watcher/main.go
+++ b/k8s-operator/cmd/k8s-event-watcher/main.go
@@ -156,10 +156,15 @@ func buildKubeClient(f *flags) (kubernetes.Interface, error) {
 	)
 	switch {
 	case f.kubeconfig != "":
-		cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
-		if err != nil {
-			return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)
+		if _, statErr := os.Stat(f.kubeconfig); statErr == nil {
+			cfg, err = clientcmd.BuildConfigFromFlags("", f.kubeconfig)
+			if err != nil {
+				return nil, fmt.Errorf("kubeconfig %s: %w", f.kubeconfig, err)
+			}
+			break
 		}
+		// Fallback to in-cluster config if explicit kubeconfig file does not exist
+		fallthrough
 	case f.inCluster || os.Getenv("KUBERNETES_SERVICE_HOST") != "":
 		cfg, err = rest.InClusterConfig()
 		if err != nil {


### PR DESCRIPTION
Fall back to in-cluster config when explicit kubeconfig file does not exist on disk

Autopush failure: `event-watcher
k8s-event-watcher: kubeconfig /var/run/event-watcher/watcher.config: stat /var/run/event-watcher/watcher.config: no such file or directory` - the deployment is in [Error status](https://screenshot.googleplex.com/3Y8fX4vyQpYFLch), but agent works, so the error was not visible originally.

Looks like missed scenario after #378 