### PR TITLE
fix(kanban): refuse to propagate a subscription to a card that does not exist

### DIFF
--- a/agents/platform/scripts/kanban_notify_propagate.py
+++ b/agents/platform/scripts/kanban_notify_propagate.py
@@ -26,7 +26,9 @@
 #
 # Idempotent (INSERT OR IGNORE on the subscription primary key) and fail-soft: any
 # operational problem is logged to stderr and exits 0 so it can never break the
-# specialist's flow. It couples only to the stable `kanban_notify_subs` columns.
+# specialist's flow. It couples only to the stable `kanban_notify_subs` columns,
+# plus a soft read of `tasks` to confirm the child card is real before writing a
+# subscription row that nothing would ever clean up (see `propagate`).
 
 import argparse
 import os
@@ -59,6 +61,16 @@ def _connect(db_path: str) -> sqlite3.Connection:
     return conn
 
 
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table,),
+        ).fetchone()
+        is not None
+    )
+
+
 def propagate(db_path: str, parent_id: str, child_id: str) -> int:
     """Copy every kanban_notify_subs row from parent_id to child_id.
 
@@ -66,6 +78,13 @@ def propagate(db_path: str, parent_id: str, child_id: str) -> int:
     re-running is a no-op once the child rows exist. Raises on a genuinely broken
     DB / missing table / bad args so callers (and tests) can see real failures;
     the CLI wrapper turns those into a fail-soft exit.
+
+    Refuses to write for a child card that is not on the board, because such a
+    row can never be cleaned up: the notifier unsubscribes only when a task turns
+    terminal, and `delete_task` opens with `DELETE FROM tasks WHERE id = ?` and
+    returns early when that matches nothing, so its cascade never reaches
+    `kanban_notify_subs`. A typo'd `--to` would therefore leave a row scanned on
+    every notifier tick for the life of the board.
     """
     if not child_id:
         raise ValueError("child id (--to) is required")
@@ -79,6 +98,19 @@ def propagate(db_path: str, parent_id: str, child_id: str) -> int:
 
     conn = _connect(db_path)
     try:
+        # Soft coupling on purpose. This module's contract is that it depends only
+        # on `kanban_notify_subs`; a board that somehow lacks `tasks` gets the old
+        # unguarded behaviour rather than losing propagation entirely, because
+        # failing every propagation would be a worse bug than the orphan row this
+        # prevents. On a real board `tasks` is always there and the guard is live.
+        if _table_exists(conn, "tasks"):
+            if not conn.execute(
+                "SELECT 1 FROM tasks WHERE id = ?", (child_id,)
+            ).fetchone():
+                raise ValueError(f"child card {child_id!r} not found on this board")
+        else:
+            log("board has no `tasks` table; skipping the child-card existence check")
+
         cols = ", ".join(_COPY_COLUMNS)
         rows = conn.execute(
             f"SELECT {cols} FROM kanban_notify_subs WHERE task_id = ?",

--- a/agents/platform/scripts/test_kanban_notify_propagate.py
+++ b/agents/platform/scripts/test_kanban_notify_propagate.py
@@ -27,10 +27,34 @@ CREATE TABLE kanban_notify_subs (
 );
 """
 
+# The board's card table. Only the primary key matters here — the helper reads
+# nothing else from it — but a real board always has this table, so the fixture
+# must too, or the tests would exercise the no-`tasks` degradation path instead
+# of the production one.
+_TASKS_SCHEMA = """
+CREATE TABLE tasks (
+    id     TEXT PRIMARY KEY,
+    title  TEXT,
+    status TEXT
+);
+"""
 
-def _make_db(path: str) -> None:
+
+def _make_db(path: str, with_tasks: bool = True) -> None:
     conn = sqlite3.connect(path)
     conn.executescript(_SCHEMA)
+    if with_tasks:
+        conn.executescript(_TASKS_SCHEMA)
+    conn.close()
+
+
+def _add_card(path: str, *task_ids: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executemany(
+        "INSERT OR IGNORE INTO tasks (id, title, status) VALUES (?, ?, 'todo')",
+        [(t, f"card {t}") for t in task_ids],
+    )
+    conn.commit()
     conn.close()
 
 
@@ -62,6 +86,7 @@ class TestPropagate(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db)
+            _add_card(db, "parent-1", "child-1")
             _add_sub(db, "parent-1", last_event_id=42)
 
             written = prop.propagate(db, "parent-1", "child-1")
@@ -83,6 +108,7 @@ class TestPropagate(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db)
+            _add_card(db, "parent-1", "child-1")
             _add_sub(db, "parent-1", chat_id="spaces/AAA", thread_id="t1")
             _add_sub(db, "parent-1", chat_id="spaces/BBB", thread_id="t2")
 
@@ -94,6 +120,7 @@ class TestPropagate(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db)
+            _add_card(db, "parent-1", "child-1")
             _add_sub(db, "parent-1")
             prop.propagate(db, "parent-1", "child-1")
             # Second run must not duplicate or raise.
@@ -105,6 +132,7 @@ class TestPropagate(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db)
+            _add_card(db, "parent-1", "child-1")
             # Parent has no subscription (request didn't originate from chat).
             written = prop.propagate(db, "parent-1", "child-1")
             self.assertEqual(written, 0)
@@ -114,8 +142,51 @@ class TestPropagate(unittest.TestCase):
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db)
+            _add_card(db, "x-1")
             _add_sub(db, "x-1")
             self.assertEqual(prop.propagate(db, "x-1", "x-1"), 0)
+
+    def test_unknown_child_card_writes_nothing(self):
+        # A typo'd or stale --to must not leave a subscription row behind. Nothing
+        # would ever remove it: the notifier unsubscribes only when a task turns
+        # terminal, and delete_task returns early when no `tasks` row matches, so
+        # its cascade never reaches kanban_notify_subs. The row would be scanned on
+        # every notifier tick for the life of the board.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_card(db, "parent-1")  # child-typo is NOT on the board
+            _add_sub(db, "parent-1")
+
+            with self.assertRaises(ValueError):
+                prop.propagate(db, "parent-1", "child-typo")
+            self.assertEqual(len(_rows(db, "child-typo")), 0)
+
+    def test_unknown_child_card_stays_fail_soft_through_main(self):
+        # The guard raises so tests and callers see a real failure, but the CLI
+        # wrapper must still exit 0 — a bad --to cannot break the worker's flow.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db)
+            _add_card(db, "parent-1")
+            _add_sub(db, "parent-1")
+
+            rc = prop.main(["--to", "child-typo", "--from", "parent-1", "--db", db])
+            self.assertEqual(rc, 0)
+            self.assertEqual(len(_rows(db, "child-typo")), 0)
+
+    def test_board_without_tasks_table_still_propagates(self):
+        # Documented degradation. This module's contract is a dependency on
+        # kanban_notify_subs alone; if Hermes ever renames or drops `tasks`,
+        # losing every propagation would be a worse bug than the orphan row the
+        # guard prevents, so the check is skipped rather than fatal.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            _make_db(db, with_tasks=False)
+            _add_sub(db, "parent-1")
+
+            self.assertEqual(prop.propagate(db, "parent-1", "child-1"), 1)
+            self.assertEqual(len(_rows(db, "child-1")), 1)
 
     def test_missing_db_raises(self):
         with self.assertRaises(FileNotFoundError):


### PR DESCRIPTION
## Why This Change

Follow-up to a review comment on #440 ([comment](https://github.com/gke-labs/kube-agents/pull/440#issuecomment-5096601108)), which @dshnayder offered to take separately:

> `propagate()` doesn't check that the child task exists before inserting, so a typo'd or stale `--to` writes subscription rows for a card that will never exist. Those rows are permanent.

Verified against the Hermes source rather than taken on faith, and the analysis is exactly right — including the "permanent" part, which is the sharp edge:

- The notifier unsubscribes only when a task turns **terminal**. A card that does not exist never turns terminal.
- `delete_task` in `hermes_cli/kanban_db.py` opens with `DELETE FROM tasks WHERE id = ?` and returns `False` when `rowcount != 1`, so its cascade into `kanban_notify_subs` never runs for an id that was never a card.
- Nothing else prunes the table.

So a single typo'd `--to` leaves a row that is scanned on every notifier tick for the life of the board. Low severity, unbounded duration.

## What Changed

`agents/platform/scripts/kanban_notify_propagate.py`

- `propagate()` now confirms the child id is a real card before writing, and raises `ValueError` if it is not. `main()` is unchanged and still fail-soft: a bad `--to` logs and exits 0 rather than breaking the specialist's flow.
- New `_table_exists()` helper, and the module header + `propagate()` docstring now state the coupling and the reasoning above.

`agents/platform/scripts/test_kanban_notify_propagate.py`

- The fixture only mirrored `kanban_notify_subs`. Left as-is, every existing test would have exercised the new *degradation* path instead of production. It now creates a `tasks` table too, and the existing tests insert their child cards.
- Three new tests: an unknown `--to` writes zero rows; `main()` stays fail-soft for that case; a board with no `tasks` table still propagates.

### One deliberate divergence from the suggestion

The suggested fix was a hard dependency on `tasks`. This gates the check on the table being present instead:

```python
if _table_exists(conn, "tasks"):
    ...raise if the child card is missing...
else:
    log("board has no `tasks` table; skipping the child-card existence check")
```

The module's stated contract is that it couples only to the `kanban_notify_subs` columns, so that a Hermes schema change surfaces as one clear failure rather than a silent behaviour change. If `tasks` were ever renamed or dropped, a hard dependency would fail *every* propagation — users silently stop getting progress updates for sub-steps, which is worse than the orphan row being fixed here. On a real board `tasks` is always present and the guard is live; the fallback exists so the failure mode degrades in the safe direction. Happy to make it a hard dependency if you'd rather the coupling be explicit.

## Why This Matters

The orphan rows are invisible — no error, no user-facing symptom — and they accumulate for as long as the board lives. Catching a bad `--to` at write time is the only point where the mistake is still attributable to something.

## Context

Split out of #440 at the reviewer's suggestion; branches from `main` and touches no other file, so it is independent of the remaining stack.

## Testing

- `python3 -m pytest agents/platform/scripts/test_kanban_notify_propagate.py` — 12 passed.
- Confirmed the new tests actually catch the reported bug: reverted **only** the source file, keeping the tests, and re-ran. 2 failed, with the pre-guard code logging `propagated subscription(s) from parent-1 -> child-typo (child now has 1 row(s))` for a card that does not exist. Restored, 12 passed.
- `python3 -m pytest` across all `agents/*/scripts/test_*.py` — 85 passed.
- `make docs-check` — clean. `npx prettier --check agents/platform/scripts/` — clean.

---

Generated with the help of Claude.
