### PR TITLE
PR3: feat(ci): add main pipeline orchestrator for release candidate pipeline

### DIFF
--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Verify Prebuilt Container Images Exist in Registry
         env:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
+          REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX }}
         run: ./scripts/release/verify_candidate_images.sh
 
       - name: Create Git Tag & Push

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -34,6 +34,7 @@ on:
 jobs:
   create-tag:
     runs-on: ubuntu-latest
+    environment: rc
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -66,4 +66,6 @@ jobs:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           RC_TAG: ${{ steps.resolve_target.outputs.rc_tag }}
           RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          GH_ORG: ${{ vars.GH_ORG }}
+          GH_REPO: ${{ vars.GH_REPO }}
         run: ./scripts/release/create_release_tag.sh

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -21,6 +21,10 @@ on:
         description: "Release Candidate Tag (Optional, Default: Auto-generated rc_YYMMDDHHMM)"
         required: false
         type: string
+    secrets:
+      RELEASE_BOT_TOKEN:
+        description: "Release Bot PAT Token"
+        required: false
     outputs:
       commit_sha:
         value: ${{ jobs.create-tag.outputs.commit_sha }}
@@ -41,6 +45,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Resolve Commit SHA and Tag Name
         id: resolve_target

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -65,4 +65,5 @@ jobs:
         env:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           RC_TAG: ${{ steps.resolve_target.outputs.rc_tag }}
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/create_release_tag.sh

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -1,0 +1,91 @@
+name: RC Release E2E Pipeline
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: "Target Commit SHA for Release Candidate (Mandatory)"
+        required: true
+        type: string
+      rc_tag:
+        description: "Release Candidate Tag Name (Optional, auto-generated if omitted)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  step-1-create-tag:
+    name: Step 1 - Create Release Candidate Tag
+    uses: ./.github/workflows/rc-create-tag.yml
+    with:
+      commit_sha: ${{ inputs.commit_sha }}
+      rc_tag: ${{ inputs.rc_tag }}
+
+  step-2-deploy-env:
+    name: Step 2 - Provision RC Environment
+    needs: step-1-create-tag
+    uses: ./.github/workflows/rc-deploy-environment.yml
+    with:
+      rc_tag: ${{ needs.step-1-create-tag.outputs.rc_tag }}
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+  step-3-run-e2e-tests:
+    name: Step 3 - Run E2E Tests
+    needs: [step-1-create-tag, step-2-deploy-env]
+    runs-on: ubuntu-latest
+    environment: rc
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python Environment
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install Python Dependencies
+        run: ./scripts/release/install_e2e_deps.sh
+
+      - name: Authenticate to Google Cloud via Workload Identity Federation (WIF)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
+        with:
+          install_components: "beta,gke-gcloud-auth-plugin"
+
+      - name: Connect to GKE & Wait for Pod Readiness
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          GCP_REGION: ${{ vars.GCP_REGION }}
+          GKE_CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
+        run: ./scripts/release/wait_for_gke_readiness.sh
+
+      - name: Execute E2E Suite
+        env:
+          GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+          CHAT_TOPIC_NAME: ${{ vars.CHAT_TOPIC_NAME }}
+          E2E_CHAT_CLIENT_ID: ${{ secrets.E2E_CHAT_CLIENT_ID }}
+          E2E_CHAT_CLIENT_SECRET: ${{ secrets.E2E_CHAT_CLIENT_SECRET }}
+          E2E_CHAT_REFRESH_TOKEN: ${{ secrets.E2E_CHAT_REFRESH_TOKEN }}
+          E2E_CHAT_SPACE_ID: ${{ secrets.E2E_CHAT_SPACE_ID }}
+        run: ./scripts/release/execute_e2e_tests.sh
+
+  step-4-tag-validated:
+    name: Step 4 - Tag Validated Release
+    needs: [step-1-create-tag, step-3-run-e2e-tests]
+    uses: ./.github/workflows/rc-tag-validated.yml
+    with:
+      rc_tag: ${{ needs.step-1-create-tag.outputs.rc_tag }}

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -12,14 +12,12 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-  id-token: write
-
 jobs:
   step-1-create-tag:
     name: Step 1 - Create Release Candidate Tag
     uses: ./.github/workflows/rc-create-tag.yml
+    permissions:
+      contents: write
     with:
       commit_sha: ${{ inputs.commit_sha }}
       rc_tag: ${{ inputs.rc_tag }}
@@ -30,6 +28,9 @@ jobs:
     name: Step 2 - Provision RC Environment
     needs: step-1-create-tag
     uses: ./.github/workflows/rc-deploy-environment.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       rc_tag: ${{ needs.step-1-create-tag.outputs.rc_tag }}
     secrets:
@@ -90,6 +91,8 @@ jobs:
     name: Step 4 - Tag Validated Release
     needs: [step-1-create-tag, step-3-run-e2e-tests]
     uses: ./.github/workflows/rc-tag-validated.yml
+    permissions:
+      contents: write
     with:
       rc_tag: ${{ needs.step-1-create-tag.outputs.rc_tag }}
     secrets:

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          ref: ${{ inputs.commit_sha }}
           persist-credentials: false
 
       - name: Set up Python Environment

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -83,7 +83,7 @@ jobs:
           E2E_CHAT_CLIENT_ID: ${{ secrets.E2E_CHAT_CLIENT_ID }}
           E2E_CHAT_CLIENT_SECRET: ${{ secrets.E2E_CHAT_CLIENT_SECRET }}
           E2E_CHAT_REFRESH_TOKEN: ${{ secrets.E2E_CHAT_REFRESH_TOKEN }}
-          E2E_CHAT_SPACE_ID: ${{ secrets.E2E_CHAT_SPACE_ID }}
+          CHAT_SPACE_ID: ${{ secrets.E2E_CHAT_SPACE_ID }}
         run: ./scripts/release/execute_e2e_tests.sh
 
   step-4-tag-validated:

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -22,6 +22,8 @@ jobs:
     with:
       commit_sha: ${{ inputs.commit_sha }}
       rc_tag: ${{ inputs.rc_tag }}
+    secrets:
+      RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
 
   step-2-deploy-env:
     name: Step 2 - Provision RC Environment
@@ -89,3 +91,5 @@ jobs:
     uses: ./.github/workflows/rc-tag-validated.yml
     with:
       rc_tag: ${{ needs.step-1-create-tag.outputs.rc_tag }}
+    secrets:
+      RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -13,7 +13,8 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
 
 jobs:
   step-1-create-tag:

--- a/.github/workflows/rc-tag-validated.yml
+++ b/.github/workflows/rc-tag-validated.yml
@@ -47,4 +47,5 @@ jobs:
         env:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           RC_TAG: ${{ steps.resolve_target.outputs.rc_tag }}
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/tag_validated_release.sh

--- a/.github/workflows/rc-tag-validated.yml
+++ b/.github/workflows/rc-tag-validated.yml
@@ -48,4 +48,6 @@ jobs:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           RC_TAG: ${{ steps.resolve_target.outputs.rc_tag }}
           RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+          GH_ORG: ${{ vars.GH_ORG }}
+          GH_REPO: ${{ vars.GH_REPO }}
         run: ./scripts/release/tag_validated_release.sh

--- a/.github/workflows/rc-tag-validated.yml
+++ b/.github/workflows/rc-tag-validated.yml
@@ -13,6 +13,10 @@ on:
         description: "Release Candidate Tag or Commit SHA"
         required: true
         type: string
+    secrets:
+      RELEASE_BOT_TOKEN:
+        description: "Release Bot PAT Token"
+        required: false
 
 jobs:
   validate-tag:
@@ -26,6 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Resolve Commit SHA from Release Tag
         id: resolve_target

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -41,10 +41,11 @@ ensure_git_tag() {
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
   if [ -n "${RELEASE_BOT_TOKEN:-}" ]; then
-    if git push "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${rc_tag}" 2>/dev/null; then
+    local push_err
+    if push_err=$(git push "https://${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${rc_tag}" 2>&1); then
       echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
     else
-      echo "⚠️ Notice: Could not push git tag '${rc_tag}' to remote repository. Tag created locally."
+      echo "⚠️ Notice: Could not push git tag '${rc_tag}' to remote repository (${push_err}). Tag created locally."
     fi
   elif git push origin "${rc_tag}" 2>/dev/null; then
     echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -41,9 +41,16 @@ ensure_git_tag() {
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
   if [ -n "${RELEASE_BOT_TOKEN:-}" ]; then
+    local target_repo
+    if [ -n "${GH_ORG:-}" ] && [ -n "${GH_REPO:-}" ]; then
+      target_repo="${GH_ORG}/${GH_REPO}"
+    else
+      target_repo="${GITHUB_REPOSITORY:-}"
+    fi
+
     local push_err
-    if push_err=$(git push "https://${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${rc_tag}" 2>&1); then
-      echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
+    if push_err=$(git push "https://${RELEASE_BOT_TOKEN}@github.com/${target_repo}.git" "${rc_tag}" 2>&1); then
+      echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository (${target_repo})!"
     else
       echo "⚠️ Notice: Could not push git tag '${rc_tag}' to remote repository (${push_err}). Tag created locally."
     fi

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -40,6 +40,9 @@ ensure_git_tag() {
 
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
-  git push origin "${rc_tag}"
-  echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
+  if git push origin "${rc_tag}" 2>/dev/null; then
+    echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
+  else
+    echo "⚠️ Notice: Could not push git tag '${rc_tag}' to origin remote (PR context / restricted permissions). Tag created locally."
+  fi
 }

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -40,7 +40,13 @@ ensure_git_tag() {
 
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
-  if git push origin "${rc_tag}" 2>/dev/null; then
+  if [ -n "${RELEASE_BOT_TOKEN:-}" ]; then
+    if git push "https://x-access-token:${RELEASE_BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${rc_tag}" 2>/dev/null; then
+      echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
+    else
+      echo "⚠️ Notice: Could not push git tag '${rc_tag}' to remote repository. Tag created locally."
+    fi
+  elif git push origin "${rc_tag}" 2>/dev/null; then
     echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
   else
     echo "⚠️ Notice: Could not push git tag '${rc_tag}' to origin remote (PR context / restricted permissions). Tag created locally."

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -52,11 +52,16 @@ ensure_git_tag() {
     if push_err=$(git push "https://${RELEASE_BOT_TOKEN}@github.com/${target_repo}.git" "${rc_tag}" 2>&1); then
       echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository (${target_repo})!"
     else
-      echo "⚠️ Notice: Could not push git tag '${rc_tag}' to remote repository (${push_err}). Tag created locally."
+      echo "❌ ERROR: Could not push git tag '${rc_tag}' to remote repository (${target_repo}): ${push_err}" >&2
+      return 1
     fi
-  elif git push origin "${rc_tag}" 2>/dev/null; then
-    echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
   else
-    echo "⚠️ Notice: Could not push git tag '${rc_tag}' to origin remote (PR context / restricted permissions). Tag created locally."
+    local push_err
+    if push_err=$(git push origin "${rc_tag}" 2>&1); then
+      echo "✅ Git tag '${rc_tag}' successfully pushed to remote repository!"
+    else
+      echo "❌ ERROR: Could not push git tag '${rc_tag}' to origin remote: ${push_err}" >&2
+      return 1
+    fi
   fi
 }

--- a/scripts/release/execute_e2e_tests.sh
+++ b/scripts/release/execute_e2e_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Runs the pytest E2E test suite for Google Chat platform agent.
+set -euo pipefail
+
+echo "======================================================================"
+echo "🧪 EXECUTING E2E TEST SUITE"
+echo "======================================================================"
+pytest tests/e2e/gchat_agent_test.py -v -s

--- a/scripts/release/install_e2e_deps.sh
+++ b/scripts/release/install_e2e_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Installs Python E2E test dependencies.
+set -euo pipefail
+
+echo "======================================================================"
+echo "📦 INSTALLING PYTHON E2E DEPENDENCIES"
+echo "======================================================================"
+python -m pip install --upgrade pip
+pip install -r tests/e2e/requirements.txt

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -12,9 +12,17 @@ if [ -n "${COMMIT_INPUT}" ]; then
     exit 1
   fi
 elif [ -n "${RC_TAG}" ]; then
+  git fetch --tags >/dev/null 2>&1 || true
   if ! COMMIT_SHA=$(git rev-parse --verify "${RC_TAG}^{commit}" 2>/dev/null); then
-    echo "❌ ERROR: Cannot resolve valid Git commit SHA from release tag '${RC_TAG}'!" >&2
-    exit 1
+    TAG_SHA="${RC_TAG##*_}"
+    if COMMIT_SHA=$(git rev-parse --verify "${TAG_SHA}^{commit}" 2>/dev/null); then
+      echo "ℹ️ Resolved target commit SHA ${COMMIT_SHA} from tag suffix."
+    elif [ -n "${GITHUB_SHA:-}" ]; then
+      COMMIT_SHA="${GITHUB_SHA}"
+    else
+      echo "❌ ERROR: Cannot resolve valid Git commit SHA from release tag '${RC_TAG}'!" >&2
+      exit 1
+    fi
   fi
 elif [ -n "${GITHUB_SHA:-}" ]; then
   COMMIT_SHA="${GITHUB_SHA}"

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -17,8 +17,6 @@ elif [ -n "${RC_TAG}" ]; then
     TAG_SHA="${RC_TAG##*_}"
     if COMMIT_SHA=$(git rev-parse --verify "${TAG_SHA}^{commit}" 2>/dev/null); then
       echo "ℹ️ Resolved target commit SHA ${COMMIT_SHA} from tag suffix."
-    elif [ -n "${GITHUB_SHA:-}" ]; then
-      COMMIT_SHA="${GITHUB_SHA}"
     else
       echo "❌ ERROR: Cannot resolve valid Git commit SHA from release tag '${RC_TAG}'!" >&2
       exit 1

--- a/scripts/release/wait_for_gke_readiness.sh
+++ b/scripts/release/wait_for_gke_readiness.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Connects to GKE cluster and verifies that required deployments reach Ready state.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
+readonly READINESS_TIMEOUT="300s" # 5 minutes timeout for GKE pod readiness
+
+CLUSTER_NAME="${GKE_CLUSTER_NAME:-${CLUSTER_NAME:-platform-agent-host}}"
+REGION="${GCP_REGION:-${REGION:-us-east4}}"
+PROJECT_ID="${GCP_PROJECT_ID:-${PROJECT_ID:-kube-agents-rc}}"
+
+echo "======================================================================"
+echo "⏳ CONNECTING TO GKE & WAITING FOR POD READINESS"
+echo "Project ID:        ${PROJECT_ID}"
+echo "Region:            ${REGION}"
+echo "Cluster Name:      ${CLUSTER_NAME}"
+echo "Readiness Timeout: ${READINESS_TIMEOUT} (5 minutes)"
+echo "======================================================================"
+
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --location "${REGION}" --project "${PROJECT_ID}"
+
+echo "Waiting for litellm deployment readiness..."
+kubectl rollout status deployment/litellm -n kubeagents-system --timeout="${READINESS_TIMEOUT}"
+
+echo "Waiting for platform-agent-gateway deployment readiness..."
+kubectl rollout status deployment/platform-agent-gateway -n kubeagents-system --timeout="${READINESS_TIMEOUT}"


### PR DESCRIPTION
## Summary

This PR introduces the main release pipeline orchestrator workflow (`.github/workflows/rc-release-pipeline.yml`) to automate the end-to-end Release Candidate (RC) release, deployment, validation, and promotion lifecycle.

It builds directly upon the modular child workflows from PR 2 #450  (`feat/release-e2e-child-workflows`).

### Key Changes

1. **Main Pipeline Orchestrator Workflow (`rc-release-pipeline.yml`)**:
-  **Step 1 (`step-1-create-tag`)**: Reuses `./.github/workflows/rc-create-tag.yml` to resolve target `commit_sha` and create a timestamped Release Candidate tag (`rc_YYMMDDHHMM`).
-  **Step 2 (`step-2-deploy-env`)**: Reuses `./.github/workflows/rc-deploy-environment.yml` to deploy the candidate release to the GCP/GKE `rc` environment.
-  **Step 3 (`step-3-run-e2e-tests`)**: Runs inline E2E validation against the live GKE cluster:
 - Sets up Python environment with pip caching.
 - Executes `./scripts/release/install_e2e_deps.sh`.
 - Executes `./scripts/release/wait_for_gke_readiness.sh` to verify GKE pod readiness (`litellm` first, then `platform-agent-gateway`) with a strict `readonly READINESS_TIMEOUT="300s"` (5 minutes) timeout.
  - Executes `./scripts/release/execute_e2e_tests.sh` to run the pytest suite.
  - **Step 4 (`step-4-tag-validated`)**: Reuses `./.github/workflows/rc-tag-validated.yml` to mark the tested candidate commit with a verified tag (`*_validated`) upon test success.

2. **Modular Release Scripts (`scripts/release/`)**:
- All executable code moved to a separate scripts


Validated on private fork to workaround permission access to work with env and secrets not from the main branch. 
**Success run:** https://github.com/eLeontev/kube-agents-private/actions/runs/30639587419

Note: the test run after the merge will be required to polish any missing criteria, since validation was performed from the different repo.
