### PR TITLE
fix(platform): make Slack ingress work through the credential proxy relay

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -368,7 +368,9 @@ class SlackRelay:
         response = self._client(team_id).api_call(
             method, **self._decode_argument(arguments)
         )
-        return dict(response)
+        # SlackResponse defines no keys(), so dict() would fall back to the
+        # iterator protocol and raise. The parsed payload lives on .data.
+        return dict(response.data)
 
     def download(self, team_id: str, url: str) -> bytes:
         def is_slack_url(value: str) -> bool:

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -242,6 +242,16 @@ class GoogleChatRelay:
         return operation.execute()
 
 
+def _slack_error_detail(exc: Exception) -> str:
+    """Slack's machine-readable error code (e.g. invalid_auth) from a SlackApiError."""
+    response = getattr(exc, "response", None)
+    try:
+        detail = response.get("error") if response is not None else None
+    except Exception:
+        detail = None
+    return str(detail) if detail else "unknown"
+
+
 class SlackRelay:
     """Credentialed Slack Socket Mode and Web API transport."""
 
@@ -264,8 +274,9 @@ class SlackRelay:
                 identity = client.auth_test()
             except Exception as exc:
                 LOGGER.error(
-                    "Slack bot token authentication failed type=%s",
+                    "Slack bot token authentication failed type=%s error=%s",
                     type(exc).__name__,
+                    _slack_error_detail(exc),
                 )
                 continue
             team_id = str(identity.get("team_id", ""))
@@ -907,9 +918,10 @@ class CredentialProxyHandler(BaseHTTPRequestHandler):
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
         except Exception as exc:
             LOGGER.warning(
-                "Slack relay operation failed path=%s type=%s",
+                "Slack relay operation failed path=%s type=%s error=%s",
                 self.path,
                 type(exc).__name__,
+                _slack_error_detail(exc),
             )
             self._json(HTTPStatus.BAD_GATEWAY, {"error": "Slack operation failed"})
 

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -8,6 +8,8 @@ import json
 import logging
 import os
 import sys
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -197,37 +199,105 @@ def install() -> None:
         module.AsyncWebClient = remote_client_factory
         module.AsyncApp = remote_app_factory
 
-        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
-            bootstrap = await asyncio.to_thread(
-                request, "/v1/chat/slack/bootstrap", {}
+        # slack_bolt >= 1.15 ignores the client passed to AsyncApp(...) when
+        # dispatching events: AsyncApp._init_context builds a new plain
+        # AsyncWebClient per request, and the AsyncSingleTeamAuthorization
+        # middleware then calls auth.test directly against slack.com with the
+        # "relay:<teamId>" placeholder token, rejecting every inbound event
+        # with invalid_auth. Rebind the name those modules construct so
+        # per-request clients are relay-backed too. RemoteSlackClient
+        # subclasses the real AsyncWebClient, so bolt's isinstance() check on
+        # AsyncApp(client=...) still passes.
+        try:
+            import slack_bolt.app.async_app as bolt_async_app
+            import slack_bolt.context.async_context as bolt_async_context
+
+            bolt_async_app.AsyncWebClient = RemoteSlackClient
+            bolt_async_context.AsyncWebClient = RemoteSlackClient
+        except ImportError:
+            LOGGER.warning(
+                "slack_bolt is unavailable; per-request Slack clients are not relayed"
             )
-            workspaces = bootstrap.get("workspaces") or []
-            if not workspaces:
-                LOGGER.error("Slack credential proxy has no authenticated workspace")
-                return False
-            first_connect = not hasattr(
-                self, "_credential_proxy_original_slack_token"
-            )
-            if first_connect:
-                self._credential_proxy_original_slack_token = self.config.token
-                self._credential_proxy_original_slack_app_token = os.environ.get(
-                    "SLACK_APP_TOKEN"
-                )
-            self.config.token = ",".join(
-                "relay:" + str(workspace.get("teamId", ""))
-                for workspace in workspaces
-            )
-            os.environ["SLACK_APP_TOKEN"] = "relay"
-            self._shutting_down = False
+
+        async def bootstrap_workspaces() -> list[dict[str, Any]]:
+            # The credential proxy sidecar can come up tens of seconds after
+            # the gateway starts connecting platforms; a connection error or
+            # 503 ("Slack relay disabled") here usually means the relay is
+            # not ready yet, not that Slack is unconfigured. Retry within a
+            # bounded window instead of failing the whole connect on the
+            # startup race.
             try:
-                connected = await original_connect(self, is_reconnect=is_reconnect)
-            except Exception:
+                wait_seconds = float(
+                    os.getenv("SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS", "20")
+                )
+            except ValueError:
+                LOGGER.warning(
+                    "Invalid SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS; using the default"
+                )
+                wait_seconds = 20.0
+            deadline = time.monotonic() + wait_seconds
+            while True:
+                try:
+                    bootstrap = await asyncio.to_thread(
+                        request, "/v1/chat/slack/bootstrap", {}
+                    )
+                    return bootstrap.get("workspaces") or []
+                except urllib.error.HTTPError as exc:
+                    if exc.code != 503 or time.monotonic() >= deadline:
+                        raise
+                except urllib.error.URLError:
+                    if time.monotonic() >= deadline:
+                        raise
+                LOGGER.info("Slack relay is not ready yet; retrying bootstrap")
+                await asyncio.sleep(2)
+
+        async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
+            try:
+                try:
+                    workspaces = await bootstrap_workspaces()
+                except (urllib.error.URLError, OSError) as exc:
+                    LOGGER.error(
+                        "Slack credential proxy bootstrap failed type=%s",
+                        type(exc).__name__,
+                    )
+                    return False
+                if not workspaces:
+                    LOGGER.error(
+                        "Slack credential proxy has no authenticated workspace"
+                    )
+                    return False
+                first_connect = not hasattr(
+                    self, "_credential_proxy_original_slack_token"
+                )
                 if first_connect:
+                    self._credential_proxy_original_slack_token = self.config.token
+                    self._credential_proxy_original_slack_app_token = os.environ.get(
+                        "SLACK_APP_TOKEN"
+                    )
+                self.config.token = ",".join(
+                    "relay:" + str(workspace.get("teamId", ""))
+                    for workspace in workspaces
+                )
+                os.environ["SLACK_APP_TOKEN"] = "relay"
+                self._shutting_down = False
+                try:
+                    connected = await original_connect(self, is_reconnect=is_reconnect)
+                except Exception:
+                    if first_connect:
+                        restore_slack_placeholders(self)
+                    raise
+                if not connected and first_connect:
                     restore_slack_placeholders(self)
-                raise
-            if not connected and first_connect:
-                restore_slack_placeholders(self)
-            return connected
+                return connected
+            finally:
+                # The gateway never holds a real bot token in this deployment,
+                # and Hermes permanently drops platforms whose queued config
+                # has no bot credential from its reconnect queue. Keep a
+                # placeholder on every exit path (including cancellation by
+                # the gateway's connect timeout) so a failed connect stays
+                # eligible for reconnect retries.
+                if not getattr(self.config, "token", None):
+                    self.config.token = "relay:"
 
         async def disconnect(self: Any) -> None:
             self._shutting_down = True

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -344,11 +344,27 @@ class GoogleChatRelayTest(unittest.TestCase):
 
 
 class SlackRelayTest(unittest.TestCase):
+    class FakeResponse:
+        """Stands in for slack_sdk's SlackResponse.
+
+        The payload lives on ``data``; the object itself is not a mapping and
+        defines no ``keys()``, so ``dict(response)`` falls back to the iterator
+        protocol and raises, exactly as the real class does.
+        """
+
+        def __init__(self, data):
+            self.data = data
+
+        def __iter__(self):
+            return iter([self])
+
     class FakeClient:
         token = "xoxb-not-returned"
 
         def api_call(self, method, **arguments):
-            return {"ok": True, "method": method, "arguments": arguments}
+            return SlackRelayTest.FakeResponse(
+                {"ok": True, "method": method, "arguments": arguments}
+            )
 
     def relay(self):
         relay = SlackRelay.__new__(SlackRelay)

--- a/agents/platform/scripts/test_slack_relay_patch.py
+++ b/agents/platform/scripts/test_slack_relay_patch.py
@@ -1,0 +1,233 @@
+import asyncio
+import json
+import os
+import sys
+import types
+import unittest
+import urllib.error
+from email.message import Message
+from unittest import mock
+
+import slack_relay_patch
+
+
+RELAY_URL = "http://127.0.0.1:8765"
+ADAPTER_MODULE_NAME = "fake_slack_adapter_module"
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload):
+        self._data = json.dumps(payload).encode("utf-8")
+
+    def read(self, *_args):
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class SlackRelayPatchTest(unittest.TestCase):
+    """Exercise install() against a fake Hermes adapter and fake slack_bolt.
+
+    slack_bolt >= 1.15 constructs a new plain AsyncWebClient per dispatched
+    request (AsyncApp._init_context), so the patch must rebind the client
+    symbol inside slack_bolt's own modules — not only the adapter module —
+    or bolt's authorization middleware calls slack.com directly with the
+    "relay:<teamId>" placeholder token and rejects every inbound event.
+    """
+
+    def setUp(self):
+        self._saved_environ = {
+            name: os.environ.get(name)
+            for name in (
+                "SLACK_RELAY_URL",
+                "SLACK_APP_TOKEN",
+                "SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS",
+            )
+        }
+        os.environ["SLACK_RELAY_URL"] = RELAY_URL
+
+        class FakeAsyncWebClient:
+            def __init__(self, token=None, **kwargs):
+                self.token = token
+                self.base_url = kwargs.get("base_url", "https://slack.com/api/")
+
+            async def api_call(self, *_args, **_kwargs):
+                raise AssertionError("the real Slack client must never be used")
+
+        class FakeAsyncApp:
+            def __init__(self, client=None, **kwargs):
+                self.client = client
+                self.kwargs = kwargs
+
+        adapter_module = types.ModuleType(ADAPTER_MODULE_NAME)
+        adapter_module.AsyncApp = FakeAsyncApp
+        adapter_module.AsyncWebClient = FakeAsyncWebClient
+
+        class FakeAdapter:
+            def __init__(self, config):
+                self.config = config
+                self.connect_results = [True]
+
+            async def connect(self, *, is_reconnect=False):
+                return self.connect_results.pop(0)
+
+            async def disconnect(self):
+                return None
+
+        FakeAdapter.__module__ = ADAPTER_MODULE_NAME
+        adapter_module.FakeAdapter = FakeAdapter
+        sys.modules[ADAPTER_MODULE_NAME] = adapter_module
+        self.adapter_module = adapter_module
+        self.fake_real_client = FakeAsyncWebClient
+        self.fake_real_app = FakeAsyncApp
+
+        self.bolt_async_app = types.ModuleType("slack_bolt.app.async_app")
+        self.bolt_async_app.AsyncWebClient = FakeAsyncWebClient
+        self.bolt_async_context = types.ModuleType("slack_bolt.context.async_context")
+        self.bolt_async_context.AsyncWebClient = FakeAsyncWebClient
+        bolt_package = types.ModuleType("slack_bolt")
+        bolt_app_package = types.ModuleType("slack_bolt.app")
+        bolt_context_package = types.ModuleType("slack_bolt.context")
+        bolt_package.app = bolt_app_package
+        bolt_package.context = bolt_context_package
+        bolt_app_package.async_app = self.bolt_async_app
+        bolt_context_package.async_context = self.bolt_async_context
+        self._fake_modules = {
+            "slack_bolt": bolt_package,
+            "slack_bolt.app": bolt_app_package,
+            "slack_bolt.app.async_app": self.bolt_async_app,
+            "slack_bolt.context": bolt_context_package,
+            "slack_bolt.context.async_context": self.bolt_async_context,
+        }
+        self._saved_modules = {
+            name: sys.modules.get(name) for name in self._fake_modules
+        }
+        sys.modules.update(self._fake_modules)
+
+        class PlatformRegistry:
+            def create_adapter(self, name, config):
+                if name == "slack":
+                    return FakeAdapter(config)
+                return None
+
+        registry_module = types.ModuleType("gateway.platform_registry")
+        registry_module.PlatformRegistry = PlatformRegistry
+        gateway_module = types.ModuleType("gateway")
+        gateway_module.platform_registry = registry_module
+        self._saved_modules["gateway"] = sys.modules.get("gateway")
+        self._saved_modules["gateway.platform_registry"] = sys.modules.get(
+            "gateway.platform_registry"
+        )
+        sys.modules["gateway"] = gateway_module
+        sys.modules["gateway.platform_registry"] = registry_module
+        self.registry_class = PlatformRegistry
+
+        slack_relay_patch.install()
+
+    def tearDown(self):
+        for name, value in self._saved_environ.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        for name, module in self._saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        sys.modules.pop(ADAPTER_MODULE_NAME, None)
+
+    def _create_adapter(self, token=""):
+        config = types.SimpleNamespace(token=token)
+        return self.registry_class().create_adapter("slack", config)
+
+    def test_bolt_per_request_client_symbol_is_relay_backed(self):
+        adapter = self._create_adapter()
+        self.assertIsNotNone(adapter)
+        patched = self.bolt_async_app.AsyncWebClient
+        self.assertIsNot(patched, self.fake_real_client)
+        self.assertTrue(issubclass(patched, self.fake_real_client))
+        self.assertIs(self.bolt_async_context.AsyncWebClient, patched)
+
+        # bolt's AsyncApp._init_context constructor call shape must be accepted
+        # and the resulting client must send API calls to the relay.
+        client = patched(
+            token="relay:T123",
+            base_url="https://slack.com/api/",
+            timeout=30,
+            ssl=None,
+            proxy=None,
+            session=None,
+            trust_env_in_session=False,
+            headers=None,
+            team_id="T123",
+            logger=None,
+            retry_handlers=None,
+        )
+        self.assertEqual(client.team_id, "T123")
+
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["url"] = req.full_url
+            captured["payload"] = json.loads(req.data.decode("utf-8"))
+            return FakeHTTPResponse({"response": {"ok": True, "team_id": "T123"}})
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result = asyncio.run(client.api_call("auth.test"))
+
+        self.assertEqual(result, {"ok": True, "team_id": "T123"})
+        self.assertEqual(captured["url"], RELAY_URL + "/v1/chat/slack/api")
+        self.assertEqual(captured["payload"]["teamId"], "T123")
+        self.assertEqual(captured["payload"]["method"], "auth.test")
+
+    def test_connect_waits_for_relay_readiness(self):
+        adapter = self._create_adapter()
+        attempts = {"count": 0}
+
+        def fake_urlopen(req, timeout=None):
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            if attempts["count"] == 2:
+                raise urllib.error.HTTPError(
+                    req.full_url, 503, "Service Unavailable", Message(), None
+                )
+            return FakeHTTPResponse({"workspaces": [{"teamId": "T123"}]})
+
+        async def fast_sleep(_seconds):
+            return None
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), mock.patch(
+            "asyncio.sleep", side_effect=fast_sleep
+        ):
+            connected = asyncio.run(adapter.connect())
+
+        self.assertTrue(connected)
+        self.assertEqual(attempts["count"], 3)
+        self.assertEqual(adapter.config.token, "relay:T123")
+        self.assertEqual(os.environ.get("SLACK_APP_TOKEN"), "relay")
+
+    def test_failed_bootstrap_keeps_placeholder_credential(self):
+        # Hermes removes credential-less platforms from its reconnect queue;
+        # a connect that fails before the relay is up must leave a non-empty
+        # placeholder token behind so Slack stays eligible for retries.
+        os.environ["SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS"] = "0"
+        adapter = self._create_adapter(token="")
+
+        def fake_urlopen(req, timeout=None):
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            connected = asyncio.run(adapter.connect())
+
+        self.assertFalse(connected)
+        self.assertEqual(adapter.config.token, "relay:")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## Why This Change

Every Slack Web API call relayed through the credential proxy fails with `400 Bad Request`, so the Slack adapter can never finish connecting. On a live cluster (`slack-demo-503114`), **all** `POST /v1/chat/slack/api` requests over the last 7 days returned 400 — zero successes. Slack ingress has never worked through the relay.

The gateway surfaces it as:

```
INFO  credential-proxy http "POST /v1/chat/slack/bootstrap HTTP/1.1" 200 -
INFO  credential-proxy http "POST /v1/chat/slack/api HTTP/1.1" 400 -
ERROR hermes_plugins.slack_platform.adapter: [Slack] Connection failed: HTTP Error 400: Bad Request
  File "/opt/hermes/plugins/platforms/slack/adapter.py", line 1086, in connect
    auth_response = await client.auth_test()
WARNING gateway.run: ✗ slack failed to connect
WARNING gateway.run: Reconnect slack: no bot credential on queued config, removing from retry queue
```

The relay itself is healthy — it authenticates its bot tokens, reports `Slack relay enabled workspaces=2`, and establishes a Socket Mode session. It is the *first* `auth.test` routed back through `/v1/chat/slack/api` that fails, which is why the adapter never completes `connect()` and the workspace is dropped from the retry queue.

## What Changed

`SlackRelay.api_call` serialised the `slack_sdk` `SlackResponse` with `dict(response)`. `SlackResponse` defines `__getitem__`, `__contains__`, and `get`, but **no `keys()`** — so it is not a mapping. `dict()` therefore falls back to the iterable-of-pairs protocol, and `SlackResponse.__iter__`/`__next__` implement cursor pagination: the first yielded element is the response object itself, not a `(key, value)` pair.

**Files:**

- `agents/platform/scripts/credential_proxy.py`
- `agents/platform/scripts/test_credential_proxy.py`

**Fixed:**

- Read the parsed payload off `response.data` rather than coercing the `SlackResponse` wrapper.

**Changed:**

- `SlackRelayTest.FakeClient.api_call` returned a plain `dict`, but `slack_sdk` returns a `SlackResponse`. `dict()` accepts the former and raises on the latter, so the suite asserted a contract the real SDK never honoured — the fix would have looked like a regression against the old fake. The fake now models `SlackResponse`: payload on `.data`, and an `__iter__` yielding the object itself so `dict(response)` reproduces the production failure. A regression to `dict(response)` now fails the suite.

## Why This Matters

`_handle_slack_post` catches `ValueError` and answers `400`:

```python
except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
    self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
```

so the underlying `ValueError` was converted into an opaque `400` with no stack trace, which is why this presented as a credential/config problem rather than a serialisation bug. This affects every relayed Slack method, not just `auth.test`.

## Context

Found while investigating why Slack ingress was down on `slack-demo-503114`.

Two related observations, both **out of scope here** and not addressed by this PR:

1. **`test_credential_proxy.py` does not run in CI.** No workflow invokes it — the only Python test invocation in `.github/workflows/` is the `e2e-gchat-test.yml` pytest run. These 28 tests are currently manual-only, which is the larger reason this shipped green. Worth a follow-up.
2. **`SlackRelay.api_call` does not validate the method name.** `slack_sdk` builds the request URL with `urljoin(base_url, method)`, so a method that is an absolute URL replaces the Slack base entirely and the bot token is sent to that host. The existing `method.startswith("_")` guard does not prevent this. Being raised as a separate PR.

That cluster also has an unrelated failure: the `kubeagents-platform-gsa@slack-demo-503114.iam.gserviceaccount.com` service account was deleted, so Workload Identity token minting 404s and the Google Chat relay is down. That is an environment issue, not a code issue.

## Testing

Reproduced against the real `slack_sdk` `SlackResponse` with a representative `auth.test` payload:

```
defines keys(): False
OLD  dict(response)      -> RAISES ValueError: dictionary update sequence element #0 has length 1; 2 is required
NEW  dict(response.data) -> {'ok': True, 'team_id': 'T123', 'user_id': 'U123'}
```

The `ValueError` matches the production 400 exactly.

`python3 -m unittest test_credential_proxy` — 28 tests, all pass. Confirmed the updated fake is protective: reverting to `dict(response)` fails `test_forwards_unknown_web_api_method_and_arguments_unchanged` with the same `ValueError` seen in production.

Not yet verified end-to-end against a live Slack workspace — the target cluster's Workload Identity is broken by the deleted service account above, so a full connect cannot be exercised there until that is restored.

---

Single-line behavioural change on a path that is currently 100% failing, so the regression risk is minimal. Requires a rebuild and redeploy of the agent runner image to take effect.

This PR was generated with the help of Claude.

---

## Update (2026-07-29): two more root causes found and fixed on this branch

Deploying the serialization fix above to `slack-demo-503114` made relayed calls return 200, but Slack ingress still did not work. Live-cluster log analysis found two more independent failures; both are fixed here.

### 1. `slack_bolt` ≥ 1.15 bypasses the relay patch on every inbound event

`slack_relay_patch.py` routes Slack API calls through the credential proxy by passing a relay-backed client to `AsyncApp(client=...)`. But since slack_bolt 1.15, `AsyncApp._init_context` constructs a **new plain `AsyncWebClient` per dispatched request** (slack_bolt 1.27.0, `app/async_app.py:1412-1428`), copying only the token — the `relay:<teamId>` placeholder. Bolt's `AsyncSingleTeamAuthorization` middleware then calls `auth.test` directly against `slack.com` with that placeholder, and every inbound event dies with:

```
ERROR slack_bolt.AsyncSingleTeamAuthorization: Failed to authorize with the given token
(The request to the Slack API failed. (url: https://slack.com/api/auth.test, status: 200)
The server responded with: {'ok': False, 'error': 'invalid_auth'})
```

**Fix:** `patch_adapter_class` now also rebinds `AsyncWebClient` inside `slack_bolt.app.async_app` and `slack_bolt.context.async_context` to the relay-backed subclass. It subclasses the real `AsyncWebClient`, so bolt's `isinstance()` check on `AsyncApp(client=...)` still passes, and per-request clients (including the authorization middleware and `AsyncSay`) go through the proxy.

### 2. A lost startup race disables Slack until the next pod restart

After a `kubectl rollout restart` at 16:10Z, the gateway initialized platforms at 16:11:46 while the credential-proxy sidecar only started listening at 16:12:15. The first connect failed, and it can never heal: Hermes' reconnect loop drops platforms whose queued config has no bot credential (`Reconnect slack: no bot credential on queued config, removing from retry queue`) — and in this deployment the gateway *never* holds a real token by design. The pod then makes zero Slack calls while events pile up unread in the proxy's queue.

**Fix:** the patched `connect()` now (a) retries `/v1/chat/slack/bootstrap` on connection errors and 503 within a bounded window (`SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS`, default 20s — under the gateway's 30s platform-connect timeout), and (b) guarantees `config.token` is left with a non-empty `relay:` placeholder on every exit path (including cancellation by the gateway's connect timeout), so a failed connect stays in the reconnect queue and heals once the proxy is up.

### Also: the proxy now logs Slack's error code

`Slack relay operation failed path=/v1/chat/slack/api type=SlackApiError` hid whether Slack answered `invalid_auth`, `missing_scope`, or something else, which cost hours of diagnosis. The relay warning and the startup token-authentication error now include the machine-readable error code from the `SlackResponse`. HTTP response bodies are unchanged — no new information is exposed to the agent side.

### Tests

- `python3 -m unittest test_credential_proxy` — 28 tests, pass.
- New `test_slack_relay_patch.py` — 3 tests covering: the bolt per-request client symbol is relay-backed and accepts bolt's constructor call shape while routing `api_call` to the relay; `connect()` retries bootstrap through connection-refused and 503 until the relay is ready; a failed bootstrap leaves a non-empty placeholder credential so Slack stays reconnect-eligible.
