### PR TITLE
fix(ci): deploy Platform Agent with gke-admin permissions in Prow smoke test

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -38,6 +38,7 @@ export MODEL_DEFAULT_NAME="gemini-3.1-pro-preview"
 
 export KSA_NAME="kubeagents-platform-agent"
 export GSA_NAME="kubeagents-platform-gsa"
+export PLATFORM_AGENT_PERMISSION_SET="gke-admin"
 export MEMORY_ENABLED="false"
 export USER_PROFILE_ENABLED="false"
 export GOOGLE_CHAT_ENABLED="false"


### PR DESCRIPTION
# Pull Request

## Why This Change

The prow smoke test deploy platform agents using the default `PLATFORM_AGENT_PERMISSION_SET`. Before it was set to `gke-admin` and is changed to `read-only` recently. However, we need the full `gke-admin` to run against the eval.

## What Changed
**Files:**
    - `hack/ci-deploy.sh`

**Added/Changed/Fixed:**
    - Exported `PLATFORM_AGENT_PERMISSION_SET="gke-admin"` in `hack/ci-deploy.sh` so CI and Prow smoke-test deployments automatically deploy the Platform Agent with full `gke-admin` permissions.

## Why This Matters
- Ensures the Platform Agent deployed during CI smoke tests has `gke-admin` privileges (`roles/container.admin`) necessary to execute DevOps benchmark evaluation tasks

## Testing
- Validated bash syntax with `bash -n hack/ci-deploy.sh`.
- Verified non-interactive execution exports `PLATFORM_AGENT_PERMISSION_SET=gke-admin`.
