### PR TITLE
fix(security): isolate credential sidecar process namespace

### DIFF
--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -118,6 +118,12 @@ Deployment and Pod. If the sidecar is not ready, the Pod is not ready. If either
 Envoy or the credential runtime exits, the sidecar exits and Kubernetes restarts
 it.
 
+The Pod explicitly disables process-namespace sharing. The sandbox, dashboard,
+and credential sidecar therefore cannot inspect one another's processes through
+`/proc`, including credential-sidecar environment variables. They still share
+the Pod network namespace, which preserves the loopback proxy and API paths, and
+the existing shared volumes preserve workspace and session-data access.
+
 ## Credential Placement
 
 | Data                            | Sandbox     | Credential sidecar        |
@@ -204,6 +210,8 @@ only command output, never a mounted Git credential file.
 
 - The Pod uses the configured PlatformAgent KSA for the credential sidecar's
   Workload Identity.
+- `shareProcessNamespace: false` isolates the sandbox and dashboard from
+  credential-sidecar process state.
 - `automountServiceAccountToken: false` applies to the Pod.
 - Separate projected ServiceAccount token volumes are mounted only by the
   credential sidecar and event watcher; neither is mounted by the agent or
@@ -277,4 +285,6 @@ CI and deployment tests should assert that:
 7. the old proxy Deployment and Service are absent after reconciliation; and
 8. the external PlatformAgent API key is accepted by the sidecar and replaced
    before forwarding to the loopback-only sandbox API; and
-9. Pod readiness fails when either Envoy or the credential runtime fails.
+9. Pod readiness fails when either Envoy or the credential runtime fails; and
+10. generated Pods set `shareProcessNamespace: false` with the dashboard both
+    enabled and disabled.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -71,7 +71,7 @@ Required attribution depends on the source of an operation:
 
 Google Chat session and requester attribution is implemented. Complete autonomous-trigger attribution, immutable skill, script, and workflow versions, and a version-controlled automation changelog are planned capabilities.
 
-See [Google Chat Session Metadata Data Flow](designs/gchat-session-metadata-data-flow.md) for the implemented Google Chat session-to-requester correlation path.
+See [Google Chat Session Metadata Data Flow](../designs/gchat-session-metadata-data-flow.md) for the implemented Google Chat session-to-requester correlation path.
 
 ### 6. Credential Isolation
 
@@ -83,11 +83,11 @@ See [Google Chat Session Metadata Data Flow](designs/gchat-session-metadata-data
 - Chat and source-control credentials remain behind explicitly configured relay or command interfaces.
 - The current command proxy supports `gcloud`, `kubectl`, `gh`, and `git`. Additional CLIs require explicit proxy support.
 
-The sandbox and credential sidecar must not share a process namespace while the sidecar holds credentials. The current dashboard-enabled Pod configuration shares the process namespace and runs both containers as the same user, which may expose sidecar environment variables through `/proc`. This must be removed or otherwise isolated before the credential-isolation requirement is satisfied.
+The sandbox, dashboard, and credential sidecar use separate process namespaces. This prevents the untrusted containers from inspecting credential-sidecar process state, including environment variables exposed through `/proc/<pid>/environ`. Containers continue to share the Pod network namespace so the sandbox can use the credential proxy on loopback without receiving its credentials.
 
 Credential values deliberately returned by an approved command or integration response are outside the filesystem and environment isolation scope.
 
-See [Credential Isolation Design](credential-isolation-design.md) for the credential-proxy architecture, sandbox boundary, command paths, and known limitations.
+See [Credential Isolation Design](../credential-isolation-design.md) for the credential-proxy architecture, sandbox boundary, command paths, and known limitations.
 
 ### 7. Audit and Git Attribution
 
@@ -112,4 +112,11 @@ The selected configuration is accepted when:
 6. direct, autonomous, and automation-mediated actions remain distinguishable in telemetry; and
 7. the configured chat access policy accepts only authorized initiators.
 
-Acceptance criterion 3 and the complete source-attribution portions of criterion 6 depend on planned capabilities. Criterion 5 is not satisfied while the sandbox shares a process namespace with the credential sidecar. Implementation status for the remaining criteria is stated in the corresponding sections above.
+Acceptance criterion 3 and the complete source-attribution portions of criterion 6 depend on planned capabilities. Implementation status for the remaining criteria is stated in the corresponding sections above.
+
+## Related Documentation
+
+- [Security and Trust Model](../architecture/03-security-model.md) describes the end-state trust boundaries, identity model, and security controls.
+- [Audit Logging and User Attribution Design](../designs/audit-logging-user-attribution.md) records the design rationale and delivery plan for attribution.
+- [Google Chat Session Metadata Data Flow](../designs/gchat-session-metadata-data-flow.md) documents the implemented session-to-requester correlation path.
+- [Credential Isolation Design](../credential-isolation-design.md) specifies the credential-proxy architecture and its current limitations.

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -51,6 +51,8 @@ The sandbox image contains only **wrapper binaries** for `gcloud`, `kubectl`, `g
 
 Pod-wide `automountServiceAccountToken` is `false`. The sidecar's projected token uses the audience `kubeagents-credential-proxy` and expires after one hour; the event watcher gets a separate one-hour Kubernetes-API token projection. Neither token is mounted in the agent or dashboard containers.
 
+Pod-wide process-namespace sharing is explicitly disabled. The agent and dashboard therefore cannot inspect credential-sidecar process state through `/proc`; they retain the shared Pod network needed to call the local proxy and API endpoints.
+
 ## Request paths
 
 - **CLI commands** — only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy rejects known credential-disclosure, credential-replacement, and self-modification operations; interactive TTY programs, unbounded streaming, sandbox-only file paths, and background processes fail closed.

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -787,13 +787,6 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 		Value: "/opt/defaults/scripts",
 	})
 
-	dashboardEnabled := isDashboardEnabled(agent)
-
-	var shareProcessNamespace *bool
-	if dashboardEnabled {
-		shareProcessNamespace = ptr.To(true)
-	}
-
 	var runtimeClassName *string
 	if agent.Spec.Deployment != nil && agent.Spec.Deployment.Availability != nil {
 		runtimeClassName = agent.Spec.Deployment.Availability.RuntimeClassName
@@ -840,7 +833,10 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 			Annotations: mergeAnnotations(defaultAnnotations, podAnnotations),
 		},
 		Spec: corev1.PodSpec{
-			ShareProcessNamespace:        shareProcessNamespace,
+			// Keep the untrusted agent and dashboard out of the credential
+			// sidecar's process namespace. In particular, this prevents them
+			// from reading sidecar process state such as /proc/<pid>/environ.
+			ShareProcessNamespace:        ptr.To(false),
 			RuntimeClassName:             runtimeClassName,
 			InitContainers:               initContainers,
 			ServiceAccountName:           saName,

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -360,8 +360,8 @@ func TestBuildDeployment(t *testing.T) {
 		t.Errorf("expected settings-config-hash annotation to be ijkl9012, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/settings-config-hash"])
 	}
 
-	if dep.Spec.Template.Spec.ShareProcessNamespace == nil || !*dep.Spec.Template.Spec.ShareProcessNamespace {
-		t.Errorf("expected ShareProcessNamespace true, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
+	if dep.Spec.Template.Spec.ShareProcessNamespace == nil || *dep.Spec.Template.Spec.ShareProcessNamespace {
+		t.Errorf("expected ShareProcessNamespace false, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
 	}
 
 	if dep.Spec.Template.Spec.RuntimeClassName == nil || *dep.Spec.Template.Spec.RuntimeClassName != "gvisor" {
@@ -749,8 +749,8 @@ func TestBuildDeployment_DashboardEnabled(t *testing.T) {
 			}
 
 			dep := buildDeployment(agent, "hash1", "hash2", "hash3", "hash4")
-			if dep.Spec.Template.Spec.ShareProcessNamespace == nil || !*dep.Spec.Template.Spec.ShareProcessNamespace {
-				t.Errorf("expected ShareProcessNamespace to be true, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
+			if dep.Spec.Template.Spec.ShareProcessNamespace == nil || *dep.Spec.Template.Spec.ShareProcessNamespace {
+				t.Errorf("expected ShareProcessNamespace to be false, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
 			}
 			if len(dep.Spec.Template.Spec.Containers) != 5 {
 				t.Fatalf("expected dashboard deployment plus credential sidecar to have 5 containers, got %d", len(dep.Spec.Template.Spec.Containers))
@@ -806,8 +806,8 @@ func TestBuildDeployment_DashboardDisabled(t *testing.T) {
 	}
 
 	dep := buildDeployment(agent, "hash1", "hash2", "hash3", "hash4")
-	if dep.Spec.Template.Spec.ShareProcessNamespace != nil {
-		t.Errorf("expected ShareProcessNamespace to be nil, got %v", *dep.Spec.Template.Spec.ShareProcessNamespace)
+	if dep.Spec.Template.Spec.ShareProcessNamespace == nil || *dep.Spec.Template.Spec.ShareProcessNamespace {
+		t.Errorf("expected ShareProcessNamespace to be false, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
 	}
 	if len(dep.Spec.Template.Spec.Containers) != 4 {
 		t.Fatalf("expected dashboard-disabled deployment plus credential sidecar to have 4 containers, got %d", len(dep.Spec.Template.Spec.Containers))

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -708,7 +708,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
-      shareProcessNamespace: true
+      shareProcessNamespace: false
       volumes:
         - name: platform-agent-data-vol
           persistentVolumeClaim:


### PR DESCRIPTION
# Pull Request

## Why This Change

Dashboard-enabled PlatformAgent Pods shared a process namespace while the
credential proxy held secrets. Because the sandbox and proxy also inherit the
same UID, sandbox code could inspect credential-sidecar process state such as
`/proc/<pid>/environ`.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`
- `docs/security/README.md`
- `docs/credential-isolation-design.md`
- `docs/site/src/content/docs/reference/credential-isolation.md`

**Added/Changed/Fixed:**

- Set `shareProcessNamespace: false` explicitly for every generated
  PlatformAgent Pod, regardless of dashboard configuration.
- Updated dashboard-enabled and dashboard-disabled tests plus the golden
  manifest to enforce the isolation boundary.
- Renamed the security requirements document to `docs/security/README.md`,
  corrected its related-document links, and documented the implemented
  process-namespace boundary.

## Why This Matters

- Prevents the untrusted agent and dashboard containers from enumerating or
  reading credential-proxy processes through `/proc`.
- Closes the documented credential-isolation gap without splitting the Pod or
  changing its credential-proxy architecture.

## Intended Capability Impact

This imposes no restrictions on the agent's intended capabilities. Containers
still share the Pod network namespace and the existing scoped volumes, so
loopback CLI proxying (`gcloud`, `kubectl`, `gh`, and `git`), chat relays,
PlatformAgent API access, dashboard serving, workspace access, session data,
event watching, and readiness behavior remain unchanged. The only removed
capability is cross-container process inspection, which is not part of the
agent's intended contract and is the credential-exposure path being closed.

## Context

This completes the process-namespace requirement documented by the credential
isolation and security specifications.

## Testing

- `make test` in `k8s-operator/`
- `go test ./...` in `k8s-operator/`
- `go build ./cmd/main.go` in `k8s-operator/`
- `make docs-check`
- `git diff --check`

---

Functional agent and dashboard paths are preserved; rollout replaces existing
Pods so the new PID-namespace boundary takes effect.
