### PR TITLE
feat(dev): add --admin flag to WIF setup script for autonomous E2E pipeline support

### DIFF
--- a/docs/site/src/content/docs/operator/provisioning-scripts.md
+++ b/docs/site/src/content/docs/operator/provisioning-scripts.md
@@ -37,7 +37,7 @@ Mirror the provisioning steps in reverse. Full table on [Uninstall](/kube-agents
 ## Development helpers (`dev/`)
 
 - **[`dev/dev_rebuild_agent.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/dev_rebuild_agent.sh)** — Fast local iteration on the Platform Agent workspace image.
-- **[`dev/setup-gcp-github-wif.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/setup-gcp-github-wif.sh)** — Sets up GCP Workload Identity Federation (pool + OIDC provider + service account) so GitHub Actions can deploy to the project keylessly. Requires `PROJECT_ID`, `SA_NAME`, and `GITHUB_REPO` env vars.
+- **[`dev/setup-gcp-github-wif.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/setup-gcp-github-wif.sh)** — Sets up GCP Workload Identity Federation (pool + OIDC provider + service account) so GitHub Actions can deploy to the project keylessly. Requires `PROJECT_ID`, `SA_NAME`, and `GITHUB_REPO` env vars. Supports `--admin` for full autonomous E2E provision/teardown role grants.
 - **[`dev/teardown_dev_01_gcp_artifact_registry.sh`](https://github.com/gke-labs/kube-agents/blob/main/k8s-operator/scripts/dev/teardown_dev_01_gcp_artifact_registry.sh)** — Deletes the dev-only Artifact Registry created by `dev_rebuild_agent.sh`.
 
 ## Common gotchas

--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -10,9 +10,9 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 
 ### What it does
 
-1. **Enables Required APIs**: Ensures fundamental APIs like `iamcredentials`, `cloudresourcemanager`, `container`, and `storage` are enabled on your GCP project.
+1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, and optionally `pubsub`, `secretmanager` for admin mode) are enabled on your GCP project.
 2. **Creates a Service Account**: Provisions a dedicated GCP Service Account for GitHub Actions to impersonate.
-3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account.
+3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/secretmanager.admin`) required by `provision.sh` / `teardown.sh`.
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
 6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.
@@ -26,6 +26,11 @@ Before running the script, you must have the Google Cloud CLI (`gcloud`) install
 - `SA_NAME`: The desired name for the new Service Account (e.g., `github-actions-deploy-sa`).
 - `GITHUB_REPO`: Your GitHub repository in `owner/repo` format (must be exact to allow access).
 
+#### Options
+
+- `--admin`: Grants extended IAM roles for full autonomous `provision.sh` / `teardown.sh` lifecycle operations.
+- `ADMIN=true`: Can also be enabled via environment variable.
+
 #### Example Execution
 
 ```bash
@@ -35,7 +40,12 @@ export GITHUB_REPO="your-github-username/your-repo-name"
 
 cd k8s-operator/scripts/dev/
 chmod +x setup-gcp-github-wif.sh
+
+# Standard roles for CI deployment
 ./setup-gcp-github-wif.sh
+
+# Or with full lifecycle admin roles for autonomous provision/teardown cycles:
+./setup-gcp-github-wif.sh --admin
 ```
 
 When the script finishes, it will print three variables (`GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT`, and `GCP_WORKLOAD_IDENTITY_PROVIDER`). To complete the setup, copy those three values and add them to your GitHub Repository > Settings > Environments as Environment Variables.

--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -28,8 +28,10 @@ Before running the script, you must have the Google Cloud CLI (`gcloud`) install
 
 #### Options
 
-- `--admin`: Grants extended IAM roles for full autonomous `provision.sh` / `teardown.sh` lifecycle operations.
-- `ADMIN=true`: Can also be enabled via environment variable.
+- `--admin`: Grants extended IAM roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`) for full autonomous `provision.sh` / `teardown.sh` lifecycle operations.
+- `ADMIN=true`: Environment variable alternative to `--admin`.
+
+> **Note:** IAM role grants made with `--admin` are additive and remain assigned to the service account in your GCP project until manually revoked.
 
 #### Example Execution
 

--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -10,9 +10,9 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 
 ### What it does
 
-1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, and optionally `pubsub`, `secretmanager` for admin mode) are enabled on your GCP project.
+1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, `pubsub`) are enabled on your GCP project.
 2. **Creates a Service Account**: Provisions a dedicated GCP Service Account for GitHub Actions to impersonate.
-3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/secretmanager.admin`) required by `provision.sh` / `teardown.sh`.
+3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`) required by `provision.sh` / `teardown.sh`.
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
 6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # 1. Check for required environment variables
 MISSING_VAR=false
-if [ -z "$PROJECT_ID" ]; then
-  PROJECT_ID=$(gcloud config get-value project 2>/dev/null)
+if [ -z "${PROJECT_ID:-}" ]; then
+  PROJECT_ID=$(gcloud config get-value project 2>/dev/null || echo "")
   if [ -z "$PROJECT_ID" ]; then
     echo "Error: PROJECT_ID environment variable is not set and no default project found in gcloud config."
     MISSING_VAR=true
   fi
 fi
-if [ -z "$SA_NAME" ]; then
+if [ -z "${SA_NAME:-}" ]; then
   echo "Error: SA_NAME environment variable is not set."
   MISSING_VAR=true
 fi
-if [ -z "$GITHUB_REPO" ]; then
+if [ -z "${GITHUB_REPO:-}" ]; then
   echo "Error: GITHUB_REPO environment variable is not set."
   MISSING_VAR=true
 fi
@@ -22,20 +22,45 @@ fi
 POOL_NAME="github-pool"
 PROVIDER_NAME="github-deploy-provider"
 
+# Parse optional CLI flags and environment variables
+IS_ADMIN="${ADMIN:-false}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --admin)
+      IS_ADMIN=true
+      shift
+      ;;
+    -*)
+      echo "Error: Unknown option '$1'." >&2
+      exit 1
+      ;;
+    *)
+      echo "Error: Unexpected argument '$1'." >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [ "$MISSING_VAR" = true ]; then
   echo ""
   echo "Please set the required variables before running this script. For example:"
   echo 'export PROJECT_ID="your-gcp-project-id"'
   echo 'export SA_NAME="github-actions-sa"'
   echo 'export GITHUB_REPO="your-github-username/your-repo-name"'
+  echo 'Optionally pass --admin to grant full autonomous E2E lifecycle roles.'
   exit 1
 fi
 
 # 2. Prompt user for confirmation
 echo "The script will perform the setup for GitHub Actions WIF in the following project: $PROJECT_ID"
+if [ "$IS_ADMIN" = true ]; then
+  echo "Mode: ADMIN (Includes extended IAM roles for teardown.sh + provision.sh cycles)"
+else
+  echo "Mode: STANDARD (Base roles only. Use --admin for autonomous E2E pipeline support)"
+fi
 echo ""
 
-read -p "Do you want to proceed? (y/N): " confirm
+read -r -p "Do you want to proceed? (y/N): " confirm || confirm="n"
 if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
   echo "Setup aborted by user."
   exit 1
@@ -44,14 +69,14 @@ fi
 echo ""
 echo "Starting GCP Setup..."
 
-
-
 # Enable necessary services (optional but helpful)
 echo "Ensuring required APIs are enabled..."
 gcloud services enable iamcredentials.googleapis.com \
   cloudresourcemanager.googleapis.com \
   container.googleapis.com \
   storage.googleapis.com \
+  pubsub.googleapis.com \
+  secretmanager.googleapis.com \
   --project="${PROJECT_ID}"
 
 # 3. Create Service Account
@@ -62,7 +87,33 @@ gcloud iam service-accounts create "${SA_NAME}" \
 
 # 4. Grant necessary permissions
 echo "Granting necessary roles to the Service Account..."
-for role in roles/cloudkms.admin roles/container.admin roles/serviceusage.serviceUsageAdmin roles/serviceusage.serviceUsageConsumer; do
+# Base roles required for standard CI deployments:
+ROLES=(
+  "roles/cloudkms.admin"
+  "roles/container.admin"
+  "roles/serviceusage.serviceUsageAdmin"
+  "roles/serviceusage.serviceUsageConsumer"
+)
+
+# Extended roles required for full autonomous E2E lifecycle (teardown.sh + provision.sh):
+if [ "$IS_ADMIN" = true ]; then
+  echo "Admin mode selected. Adding extended lifecycle administration roles..."
+  ROLES+=(
+    # Required by provision_04_gcp_iam.sh & provision_05_gcp_gchat.sh to create and manage Service Accounts
+    "roles/iam.serviceAccountAdmin"
+
+    # Required by provision_04_gcp_iam.sh & teardown_04_gcp_iam.sh to bind/unbind IAM policies on GCP resources
+    "roles/resourcemanager.projectIamAdmin"
+
+    # Required by provision_05_gcp_gchat.sh & teardown_05 for Google Chat Pub/Sub topic and subscription management
+    "roles/pubsub.admin"
+
+    # Required by provision_07_gcp_k8s_secrets.sh & teardown_07 to store and cleanup runtime secrets
+    "roles/secretmanager.admin"
+  )
+fi
+
+for role in "${ROLES[@]}"; do
   gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
     --member="serviceAccount:${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com" \
     --role="$role" >/dev/null

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -76,7 +76,6 @@ gcloud services enable iamcredentials.googleapis.com \
   container.googleapis.com \
   storage.googleapis.com \
   pubsub.googleapis.com \
-  secretmanager.googleapis.com \
   --project="${PROJECT_ID}"
 
 # 3. Create Service Account
@@ -99,7 +98,7 @@ ROLES=(
 if [ "$IS_ADMIN" = true ]; then
   echo "Admin mode selected. Adding extended lifecycle administration roles..."
   ROLES+=(
-    # Required by provision_04_gcp_iam.sh & provision_05_gcp_gchat.sh to create and manage Service Accounts
+    # Required by provision_04_gcp_iam.sh & teardown_04_gcp_iam.sh to create and manage Service Accounts
     "roles/iam.serviceAccountAdmin"
 
     # Required by provision_04_gcp_iam.sh & teardown_04_gcp_iam.sh to bind/unbind IAM policies on GCP resources
@@ -107,9 +106,6 @@ if [ "$IS_ADMIN" = true ]; then
 
     # Required by provision_05_gcp_gchat.sh & teardown_05 for Google Chat Pub/Sub topic and subscription management
     "roles/pubsub.admin"
-
-    # Required by provision_07_gcp_k8s_secrets.sh & teardown_07 to store and cleanup runtime secrets
-    "roles/secretmanager.admin"
   )
 fi
 

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -1,28 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# 1. Check for required environment variables
-MISSING_VAR=false
-if [ -z "${PROJECT_ID:-}" ]; then
-  PROJECT_ID=$(gcloud config get-value project 2>/dev/null || echo "")
-  if [ -z "$PROJECT_ID" ]; then
-    echo "Error: PROJECT_ID environment variable is not set and no default project found in gcloud config."
-    MISSING_VAR=true
-  fi
-fi
-if [ -z "${SA_NAME:-}" ]; then
-  echo "Error: SA_NAME environment variable is not set."
-  MISSING_VAR=true
-fi
-if [ -z "${GITHUB_REPO:-}" ]; then
-  echo "Error: GITHUB_REPO environment variable is not set."
-  MISSING_VAR=true
-fi
-
 POOL_NAME="github-pool"
 PROVIDER_NAME="github-deploy-provider"
 
-# Parse optional CLI flags and environment variables
+# 1. Parse optional CLI flags and environment variables
 IS_ADMIN="${ADMIN:-false}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -41,6 +23,24 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# 2. Check for required environment variables
+MISSING_VAR=false
+if [ -z "${PROJECT_ID:-}" ]; then
+  PROJECT_ID=$(gcloud config get-value project 2>/dev/null || echo "")
+  if [ -z "$PROJECT_ID" ]; then
+    echo "Error: PROJECT_ID environment variable is not set and no default project found in gcloud config."
+    MISSING_VAR=true
+  fi
+fi
+if [ -z "${SA_NAME:-}" ]; then
+  echo "Error: SA_NAME environment variable is not set."
+  MISSING_VAR=true
+fi
+if [ -z "${GITHUB_REPO:-}" ]; then
+  echo "Error: GITHUB_REPO environment variable is not set."
+  MISSING_VAR=true
+fi
+
 if [ "$MISSING_VAR" = true ]; then
   echo ""
   echo "Please set the required variables before running this script. For example:"
@@ -51,7 +51,7 @@ if [ "$MISSING_VAR" = true ]; then
   exit 1
 fi
 
-# 2. Prompt user for confirmation
+# 3. Prompt user for confirmation
 echo "The script will perform the setup for GitHub Actions WIF in the following project: $PROJECT_ID"
 if [ "$IS_ADMIN" = true ]; then
   echo "Mode: ADMIN (Includes extended IAM roles for teardown.sh + provision.sh cycles)"


### PR DESCRIPTION
**Reason:** missed roles were observed during the run teardown + provision full cycle of the release candidate pipeline validation

**Changes:**
- additional flag provided to manage scope of roles depending on the env requirements. Each roles are explained with the comment why we need them
- additional services added to be enabled to follow full teardown/provision cycle
- the mode is changed to strict `set -euo pipefail`, related code aligned
- docs are aligned