### PR TITLE
docs(drift): add Phase 0 spike findings and attribution tooling

### DIFF
--- a/agents/platform/docs/drift-detection/README.md
+++ b/agents/platform/docs/drift-detection/README.md
@@ -1,0 +1,35 @@
+# Drift Detection
+
+Design, spike results, and tooling for the drift-detection domain.
+
+| Document | What it is |
+|---|---|
+| [`../drift-detection.md`](../drift-detection.md) | Design doc: what drift is, the two-signal model, the MVP CUJs |
+| [`spike-findings.md`](./spike-findings.md) | Phase 0 spike results (A: attribution, B: noise profile). Verdict: **GO** |
+| [`drift_attribute.sh`](./drift_attribute.sh) | Reusable join: `managedFields` + audit log for one namespace |
+| [`baseline-manifests.yaml`](./baseline-manifests.yaml) | Baseline manifests used to stage the spike |
+
+## What the spike settled
+
+Four findings that shape the build, and that are counterintuitive enough to be worth
+re-reading before changing the detector:
+
+1. **The audit log is the primary trigger; `managedFields` is enrichment.** Inverting that
+   order produces false positives on a real cluster.
+2. **The audit principal is required, not optional.** CI applying client-side records
+   `kubectl-client-side-apply` — the exact manager string a human running `kubectl apply`
+   produces. A `managedFields`-only detector flags every CI deploy as drift.
+3. **Two static filters remove ~99% of the noise** — drop `principalEmail =~ "^system:"`,
+   then drop a configurable automation-service-account allowlist. The allowlist is
+   per-cluster config and is the single most important tuning knob.
+4. **Volume after filtering is low** (~7 human changes/day on an active cluster), so
+   per-change agent judgment is affordable. No sampling needed.
+
+## Caveats on the measurements
+
+Measured on `platform-agent-host`, a control-plane/admin cluster whose human activity is
+operator work on kube-agents itself, not app-team drift. It also runs no in-cluster GitOps
+controller — the GitOps owner was simulated with
+`kubectl apply --server-side --field-manager=argocd-controller`, which produces the same
+`managedFields` entry Argo or Flux SSA would. Re-run the census on a production app cluster
+with a real GitOps controller before finalizing filter defaults.

--- a/agents/platform/docs/drift-detection/README.md
+++ b/agents/platform/docs/drift-detection/README.md
@@ -8,6 +8,7 @@ Design, spike results, and tooling for the drift-detection domain.
 | [`spike-findings.md`](./spike-findings.md) | Phase 0 spike results (A: attribution, B: noise profile). Verdict: **GO** |
 | [`drift_attribute.sh`](./drift_attribute.sh) | Reusable join: `managedFields` + audit log for one namespace |
 | [`baseline-manifests.yaml`](./baseline-manifests.yaml) | Baseline manifests used to stage the spike |
+| [`cuj3-task-breakdown.md`](./cuj3-task-breakdown.md) | Ticket: CUJ 3 (noise-filtered triage), the enabling implementation |
 
 ## What the spike settled
 

--- a/agents/platform/docs/drift-detection/baseline-manifests.yaml
+++ b/agents/platform/docs/drift-detection/baseline-manifests.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: drift-spike
+spec:
+  type: ClusterIP
+  selector:
+    app: web
+  ports:
+    - port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: drift-spike
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: drift-spike
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: registry.k8s.io/pause:3.9
+          securityContext:
+            privileged: false
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -1,8 +1,5 @@
 # CUJ 3 — Noise-filtered drift triage
 
-**Type:** Implementation · **Domain:** Drift detection · **Phase:** 1
-**Depends on:** none — this is the enabling CUJ; CUJs 1, 2, and 4 are blocked on it.
-
 ## Context
 
 Out-of-band changes to a cluster are buried in reconciliation churn. On a real cluster,

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -62,10 +62,7 @@ the whole detector design rests on that.
 
 *Adapter — transport and parsing. Equivalent to the event watcher's informer setup.*
 
-Stand up the transport and a consumer that parses what comes out of it.
-
-**Infrastructure.** A Log Router sink at project scope, a Pub/Sub topic, and a pull subscription.
-Sink filter, taken from the spike:
+Log Router sink at project scope → Pub/Sub topic → pull subscription. Sink filter from the spike:
 
 ```
 logName="projects/PROJECT/logs/cloudaudit.googleapis.com%2Factivity"
@@ -74,30 +71,17 @@ resource.labels.cluster_name="CLUSTER"
 protoPayload.methodName=~"create|patch|update|delete"
 ```
 
-Do the principal filtering in the consumer, not the sink — you want the unfiltered volume visible
-for T2's measurement, and sink filters are awkward to iterate on.
+Filter principals in the consumer, not the sink — T2 needs the unfiltered volume visible. The sink's
+writer identity needs `roles/pubsub.publisher` on the topic, the consumer `roles/pubsub.subscriber`
+on the subscription; pair on the IAM rather than burning days on permission errors.
 
-**IAM.** The sink's writer identity needs `roles/pubsub.publisher` on the topic; the consumer's
-service account needs `roles/pubsub.subscriber` on the subscription. Pair on this rather than
-burning days on permission errors.
+Consumer is a pull loop, ack on successful parse. Extract `principalEmail`, `methodName`,
+`resourceName`, `callerSuppliedUserAgent`, `timestamp` from `protoPayload`. `resourceName` arrives as
+a path (`core/v1/namespaces/foo/services/web`) — decompose it into `(group, version, namespace, kind,
+name)` for T3's live-object lookup. Cluster-scoped and core-group variants are the fiddly part.
 
-**Consumer.** Pull loop, ack on successful parse, structured log per message. Extract:
-
-| Field | Path |
-|---|---|
-| Principal | `protoPayload.authenticationInfo.principalEmail` |
-| Verb | `protoPayload.methodName` |
-| Resource | `protoPayload.resourceName` |
-| User agent | `protoPayload.callerSuppliedUserAgent` |
-| Time | `timestamp` |
-
-`resourceName` arrives as a path like `core/v1/namespaces/foo/services/web`. Parse it into
-`(group, version, namespace, kind, name)` — you need those components for the live-object lookup
-in T3, and getting the cluster-scoped and core-group variants right is the fiddly part.
-
-**Accept:** a `kubectl patch` appears in the consumer's structured log within 90s, with all five
-fields populated and the resource path decomposed. The spike measured 30–60s ingestion delay; the
-margin is deliberate.
+**Accept:** a `kubectl patch` appears in the consumer's structured log within 90s, all five fields
+populated and the path decomposed. Spike measured 30–60s ingestion delay.
 
 ---
 
@@ -105,10 +89,9 @@ margin is deliberate.
 
 *Adapter — noise control. Equivalent to the event watcher's namespace rules, flapping guard, and dedup window.*
 
-**Two filters, both config-driven.** Drop `principalEmail` matching `^system:`. Then drop principals
-in an automation allowlist. That allowlist is per-cluster configuration, not a constant — it is the
-single most important tuning knob in the system, and getting it wrong makes every CI deploy look
-like drift. Something in the shape of:
+Two config-driven filters: drop `^system:` principals, then drop an automation allowlist. That
+allowlist is per-cluster config, not a constant — it is the single most important tuning knob, and
+getting it wrong makes every CI deploy look like drift.
 
 ```yaml
 drift:
@@ -118,22 +101,15 @@ drift:
   gitops_managers: ["argocd", "flux", "helm", "kube-controller-manager", ".*-controller$"]
 ```
 
-Classify every message into one of three tiers — `system`, `automation`, `human` — and emit a
-counter per tier rather than silently discarding. You need those counts for the measurement below
-and for debugging a misconfigured allowlist later.
-
-**Tests.** Table-driven, over recorded audit payloads. Capture real fixtures from the subscription;
-do not hand-write them. Cover at minimum: a `system:` controller, a CI service account applying
-client-side, a human `kubectl patch`, and a delete.
-
-**Measurement.** Run 24–48h against a live cluster and produce a short report of counts by tier,
-before and after filtering.
+Classify into `system` / `automation` / `human` and emit a counter per tier rather than silently
+discarding — you need the counts for measurement and for debugging a bad allowlist later.
+Table-driven tests over fixtures captured from the live subscription (not hand-written): a `system:`
+controller, CI applying client-side, a human `kubectl patch`, a delete. Then run 24–48h against a
+live cluster and report counts by tier, before and after filtering.
 
 **Accept:** tier counts land near the spike's (~78% system, ~20% automation, ~1% human), and the
-allowlist can be changed without a rebuild.
-
-**If the numbers are wildly off, that is a finding, not a bug.** Report it. Do not tune the filters
-until reality matches the document.
+allowlist changes without a rebuild. **If the numbers are wildly off, that is a finding, not a bug** —
+report it, don't tune until reality matches the document.
 
 ---
 
@@ -141,18 +117,16 @@ until reality matches the document.
 
 *Adapter — enrichment. No equivalent in the event watcher; drift needs a second signal to be actionable.*
 
-For each message classified `human`, fetch the live object using the components parsed in T1 and
-extract field-level ownership. This is a direct port of the first half of `drift_attribute.sh`, so
-you have a known-good output to diff against.
+For each `human` message, fetch the live object using T1's parsed components and keep `managedFields`
+entries where `operation == "Update"` and the manager does not match `gitops_managers`. Direct port of
+the first half of `drift_attribute.sh`, so you have known-good output to diff against.
 
-Keep entries where `operation == "Update"` and the manager does *not* match `gitops_managers`.
-`fieldsV1` arrives as a nested structure with `f:`-prefixed keys — flatten it to dotted paths
-(`spec.replicas`, `spec.template.spec.containers[0].securityContext.privileged`) so the output is
-readable by a human and by the agent downstream. That flattening is the substantive part of this
-task; the lookup is not.
+The substantive part is flattening `fieldsV1` — nested, `f:`-prefixed keys — into dotted paths
+(`spec.replicas`, `spec.template.spec.containers[0].securityContext.privileged`) readable by a human
+and by the agent downstream. The lookup itself is not the work.
 
-**Deletes have no live object.** They are audit-log-only, so the join must short-circuit rather than
-404 and crash the consumer. Carry the audit record through with an explicit "object gone" marker.
+**Deletes have no live object**, so the join must short-circuit rather than 404 and crash the
+consumer. Carry the audit record through with an explicit "object gone" marker.
 
 **Accept:** output matches `drift_attribute.sh` for the same namespace, and deleting a NetworkPolicy
 produces a clean attributed record with no live-object lookup attempted.
@@ -182,21 +156,3 @@ within ~90s; one full CI deploy produces zero.
 A drift skill under `agents/platform/skills/` plus a minimal judgment prompt that reports the day's
 real human changes in plain language. No revert-or-codify decision — that is CUJ 1. This one just
 answers "what actually changed on this cluster today, and who did it."
-
-## Escalate immediately if
-
-- The audit sink requires org-level IAM you do not have.
-- The automation allowlist looks cluster-specific in a way configuration cannot express.
-- Post-filter volume is an order of magnitude above the spike's ~7/day.
-
-## Findings you should not re-derive
-
-From the Phase 0 spike. Each is counterintuitive enough to be worth restating:
-
-1. **The audit log is the primary trigger; `managedFields` is enrichment.** Inverting the
-   order produces false positives on a real cluster.
-2. **The audit principal is required, not optional.** CI applying client-side records
-   `kubectl-client-side-apply` — the same manager string a human running `kubectl apply`
-   produces.
-3. **Two static filters remove ~99% of the noise.**
-4. **Post-filter volume is low enough that no sampling is needed.**

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -44,6 +44,32 @@ Named explicitly, because each is a plausible-looking rabbit hole:
 
 ---
 
+## What layer you are working in
+
+**You are writing one ingestion adapter.** Nothing downstream of the inject changes.
+
+The AutoOps pipeline is five contracts (see
+[`autoops-architecture.md`](../autoops-architecture.md)). This CUJ lives almost entirely in
+Contract 1:
+
+| Contract | Who owns it here |
+|---|---|
+| **1 · Ingestion** | **You.** Detect the signal, filter its noise, enrich it, emit the inject. |
+| 2 · Session & state | Already built. Sessions, thread routing, and follow-up come for free. |
+| 3 · Judgment | Already built for k8s events; T5 adds drift's own skill and prompt. |
+| 4 · Context reach | Already wired. `kubectl` / `gcloud` is enough for this CUJ. |
+| 5 · Remediation | Already built. Not reached by this CUJ — no PR is opened here. |
+
+Concretely: your deliverable is the drift equivalent of `k8s-event-watcher`. That component
+watches the Kubernetes API and emits `kind: k8s-event`; yours consumes an audit-log subscription
+and emits `kind: gitops-drift`. Same envelope, same endpoint, same everything after it.
+
+**The handoff is T4.** Once the inject POSTs successfully, the existing pipeline takes over and
+your work is done. If you find yourself editing the session server, the agent gateway, or the PR
+logic, stop — you have left the adapter.
+
+---
+
 ## Before you start
 
 Run `drift_attribute.sh` against a namespace, make a `kubectl patch`, and watch it land in both
@@ -58,6 +84,8 @@ the whole detector design rests on that.
 ---
 
 ## T1 · Audit-log ingestion path
+
+*Adapter — transport and parsing. Equivalent to the event watcher's informer setup.*
 
 Stand up the transport and a consumer that parses what comes out of it.
 
@@ -100,6 +128,8 @@ margin is deliberate.
 
 ## T2 · Principal classification and the noise profile
 
+*Adapter — noise control. Equivalent to the event watcher's namespace rules, flapping guard, and dedup window.*
+
 **Two filters, both config-driven.** Drop `principalEmail` matching `^system:`. Then drop principals
 in an automation allowlist. That allowlist is per-cluster configuration, not a constant — it is the
 single most important tuning knob in the system, and getting it wrong makes every CI deploy look
@@ -134,6 +164,8 @@ until reality matches the document.
 
 ## T3 · `managedFields` attribution join
 
+*Adapter — enrichment. No equivalent in the event watcher; drift needs a second signal to be actionable.*
+
 For each message classified `human`, fetch the live object using the components parsed in T1 and
 extract field-level ownership. This is a direct port of the first half of `drift_attribute.sh`, so
 you have a known-good output to diff against.
@@ -154,6 +186,8 @@ produces a clean attributed record with no live-object lookup attempted.
 
 ## T4 · Emit the `gitops-drift` inject
 
+*Adapter — the pipeline boundary. Everything past this line already exists.*
+
 Mint a session (`POST /sessions`), then `POST /sessions/{session_id}/inject`.
 
 Match the envelope the event watcher already sends — see `injector.go`. Note that the payload is
@@ -167,6 +201,8 @@ within ~90s; one full CI deploy produces zero.
 ---
 
 ## T5 · Daily digest *(stretch — only if T1–T4 land clean)*
+
+*Contract 3 — judgment. The one piece of this CUJ that is not adapter work.*
 
 A drift skill under `agents/platform/skills/` plus a minimal judgment prompt that reports the day's
 real human changes in plain language. No revert-or-codify decision — that is CUJ 1. This one just

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -12,6 +12,9 @@ roughly seven real human changes a day on an active cluster — a volume small e
 per-change agent judgment. This ticket implements that filter and the attribution join
 behind it, and emits the result as an inject on the AutoOps pipeline.
 
+Everything else in the drift domain waits on this. CUJs 1, 2, and 4 all consume the filtered,
+attributed stream this CUJ produces.
+
 **Read before starting:**
 [`drift-detection.md`](../drift-detection.md) (design) and
 [`spike-findings.md`](./spike-findings.md) (measured results, verdict GO).

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -44,86 +44,133 @@ Named explicitly, because each is a plausible-looking rabbit hole:
 
 ---
 
-## M0 · Ramp
+## Before you start
 
-### T1 · Reproduce Spike A by hand
-Run `drift_attribute.sh` against a namespace. Make a `kubectl patch` and watch it appear in
-both halves of the output. Make the same change as a service account and note the
-difference.
+Run `drift_attribute.sh` against a namespace, make a `kubectl patch`, and watch it land in both
+halves of the output. Then make the same change as a service account and compare. You should be
+able to explain why `managedFields` alone cannot separate CI from a human before writing any code —
+the whole detector design rests on that.
 
-**Accept:** you can explain, without looking it up, why `managedFields` alone cannot
-separate CI from a human. Do not start M1 until this is true — the whole detector design
-rests on it.
-
----
-
-## M1 · The trigger
-
-### T3 · Stand up the audit path
-Cloud Audit Logs → Log Router sink → Pub/Sub topic → subscription. IAM: the sink writer
-service account needs `pubsub.publisher`; the consumer needs subscriber.
-
-**Accept:** `gcloud pubsub subscriptions pull` returns a real mutating-call entry.
-**Note:** pair on the IAM rather than debugging permission errors alone.
-
-### T4 · Consumer skeleton
-Pull, parse, and log `principalEmail`, `methodName`, `resourceName`, `timestamp`. No
-filtering yet.
-
-**Accept:** a `kubectl patch` appears in the consumer log within 90s. The spike measured
-30–60s ingestion delay; the margin is deliberate.
-
-### T5 · The two static filters
-Drop `principalEmail =~ "^system:"`. Then drop a configurable automation-service-account
-allowlist. The allowlist must be configuration, not a constant — it is per-cluster and it is
-the single most important tuning knob in the system.
-
-**Accept:** unit tests over recorded audit payloads covering a system principal, a CI service
-account, and a human. Capturing those fixtures is part of this task.
-
-### T6 · Measure the noise profile
-Run 24–48h against a live cluster. Produce a short report: events by tier, before and after
-filtering.
-
-**Accept:** the numbers land near the spike's (~78% system, ~20% automation, ~1% human).
-
-**If the numbers are wildly off, that is a finding, not a bug.** Report it. Do not tune the
-filters until reality matches the document.
+**Placement decision to confirm with your reviewer:** the existing adapter
+(`k8s-operator/cmd/k8s-event-watcher`) is Go, so the natural home is a sibling
+`k8s-operator/cmd/drift-detector`. Confirm before scaffolding.
 
 ---
 
-## M2 · Attribution
+## T1 · Audit-log ingestion path
 
-### T7 · Port the join to the consumer
-For each surviving event, fetch the live object and extract field-level `managedFields`
-attribution. This is a direct port of `drift_attribute.sh`, which gives you a known-good
-output to diff against.
+Stand up the transport and a consumer that parses what comes out of it.
 
-**Accept:** output matches the shell script for the same namespace.
+**Infrastructure.** A Log Router sink at project scope, a Pub/Sub topic, and a pull subscription.
+Sink filter, taken from the spike:
 
-### T8 · Handle deletes
-Deletes are audit-log-only — the object is gone, so there is nothing to read.
+```
+logName="projects/PROJECT/logs/cloudaudit.googleapis.com%2Factivity"
+resource.type="k8s_cluster"
+resource.labels.cluster_name="CLUSTER"
+protoPayload.methodName=~"create|patch|update|delete"
+```
 
-**Accept:** deleting a NetworkPolicy produces a clean attributed record and does not crash
-the consumer.
+Do the principal filtering in the consumer, not the sink — you want the unfiltered volume visible
+for T2's measurement, and sink filters are awkward to iterate on.
 
-### T9 · Emit the inject
-POST a `gitops-drift` inject to `/sessions/{session_id}/inject`.
+**IAM.** The sink's writer identity needs `roles/pubsub.publisher` on the topic; the consumer's
+service account needs `roles/pubsub.subscriber` on the subscription. Pair on this rather than
+burning days on permission errors.
 
-**Accept:** the definition of done above — one change, one inject; one CI deploy, zero
-injects.
+**Consumer.** Pull loop, ack on successful parse, structured log per message. Extract:
+
+| Field | Path |
+|---|---|
+| Principal | `protoPayload.authenticationInfo.principalEmail` |
+| Verb | `protoPayload.methodName` |
+| Resource | `protoPayload.resourceName` |
+| User agent | `protoPayload.callerSuppliedUserAgent` |
+| Time | `timestamp` |
+
+`resourceName` arrives as a path like `core/v1/namespaces/foo/services/web`. Parse it into
+`(group, version, namespace, kind, name)` — you need those components for the live-object lookup
+in T3, and getting the cluster-scoped and core-group variants right is the fiddly part.
+
+**Accept:** a `kubectl patch` appears in the consumer's structured log within 90s, with all five
+fields populated and the resource path decomposed. The spike measured 30–60s ingestion delay; the
+margin is deliberate.
 
 ---
 
-## M3 · Stretch
+## T2 · Principal classification and the noise profile
 
-### T10 · Daily digest
-A drift skill plus a minimal judgment prompt that reports the day's real human changes in
-plain language. No revert-or-codify decision — just what happened.
+**Two filters, both config-driven.** Drop `principalEmail` matching `^system:`. Then drop principals
+in an automation allowlist. That allowlist is per-cluster configuration, not a constant — it is the
+single most important tuning knob in the system, and getting it wrong makes every CI deploy look
+like drift. Something in the shape of:
 
-Only start this if M1 and M2 have landed cleanly.
+```yaml
+drift:
+  automation_principals:
+    - github-deploy-sa@PROJECT.iam.gserviceaccount.com
+    - gitops-infra-sa@PROJECT.iam.gserviceaccount.com
+  gitops_managers: ["argocd", "flux", "helm", "kube-controller-manager", ".*-controller$"]
+```
+
+Classify every message into one of three tiers — `system`, `automation`, `human` — and emit a
+counter per tier rather than silently discarding. You need those counts for the measurement below
+and for debugging a misconfigured allowlist later.
+
+**Tests.** Table-driven, over recorded audit payloads. Capture real fixtures from the subscription;
+do not hand-write them. Cover at minimum: a `system:` controller, a CI service account applying
+client-side, a human `kubectl patch`, and a delete.
+
+**Measurement.** Run 24–48h against a live cluster and produce a short report of counts by tier,
+before and after filtering.
+
+**Accept:** tier counts land near the spike's (~78% system, ~20% automation, ~1% human), and the
+allowlist can be changed without a rebuild.
+
+**If the numbers are wildly off, that is a finding, not a bug.** Report it. Do not tune the filters
+until reality matches the document.
 
 ---
+
+## T3 · `managedFields` attribution join
+
+For each message classified `human`, fetch the live object using the components parsed in T1 and
+extract field-level ownership. This is a direct port of the first half of `drift_attribute.sh`, so
+you have a known-good output to diff against.
+
+Keep entries where `operation == "Update"` and the manager does *not* match `gitops_managers`.
+`fieldsV1` arrives as a nested structure with `f:`-prefixed keys — flatten it to dotted paths
+(`spec.replicas`, `spec.template.spec.containers[0].securityContext.privileged`) so the output is
+readable by a human and by the agent downstream. That flattening is the substantive part of this
+task; the lookup is not.
+
+**Deletes have no live object.** They are audit-log-only, so the join must short-circuit rather than
+404 and crash the consumer. Carry the audit record through with an explicit "object gone" marker.
+
+**Accept:** output matches `drift_attribute.sh` for the same namespace, and deleting a NetworkPolicy
+produces a clean attributed record with no live-object lookup attempted.
+
+---
+
+## T4 · Emit the `gitops-drift` inject
+
+Mint a session (`POST /sessions`), then `POST /sessions/{session_id}/inject`.
+
+Match the envelope the event watcher already sends — see `injector.go`. Note that the payload is
+marshalled to JSON and then **wrapped as a string** in `{"message": "<escaped JSON>"}`; it is not
+posted as a nested object. Carry the principal, verb, resource, timestamp, and the attributed field
+list, with `kind: gitops-drift`.
+
+**Accept:** the ticket's definition of done — one out-of-band change produces exactly one inject
+within ~90s; one full CI deploy produces zero.
+
+---
+
+## T5 · Daily digest *(stretch — only if T1–T4 land clean)*
+
+A drift skill under `agents/platform/skills/` plus a minimal judgment prompt that reports the day's
+real human changes in plain language. No revert-or-codify decision — that is CUJ 1. This one just
+answers "what actually changed on this cluster today, and who did it."
 
 ## Escalate immediately if
 

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -1,0 +1,150 @@
+# CUJ 3 — Noise-filtered drift triage
+
+**Type:** Implementation · **Domain:** Drift detection · **Phase:** 1
+**Depends on:** none — this is the enabling CUJ; CUJs 1, 2, and 4 are blocked on it.
+
+## Context
+
+Out-of-band changes to a cluster are buried in reconciliation churn. On a real cluster,
+roughly 78% of mutating calls come from `system:*` controllers and another 20% from CI
+service accounts, leaving about 1% that a human actually made. Argo reports
+`OutOfSync: 40` with no actor and no filter, so nobody looks at it.
+
+The Phase 0 spike established that two static filters remove ~99% of that noise, leaving
+roughly seven real human changes a day on an active cluster — a volume small enough for
+per-change agent judgment. This ticket implements that filter and the attribution join
+behind it, and emits the result as an inject on the AutoOps pipeline.
+
+**Read before starting:**
+[`drift-detection.md`](../drift-detection.md) (design) and
+[`spike-findings.md`](./spike-findings.md) (measured results, verdict GO).
+
+## Goal
+
+Turn raw cluster mutation activity into a small, attributed stream of real human changes,
+emitted as `gitops-drift` injects on the existing pipeline.
+
+## Definition of done
+
+- One out-of-band `kubectl` change produces **exactly one** inject within ~90s.
+- One full CI deploy produces **zero** injects.
+- Filter configuration is per-cluster config, not code.
+- A measured noise report exists for at least one live cluster.
+
+## Out of scope
+
+Named explicitly, because each is a plausible-looking rabbit hole:
+
+- **`_build_agent_query()` and the inject envelope.** Both are hardcoded k8s-event-shaped.
+  Generalizing them is platform work with a separate owner.
+- **Desired-state resolution and Helm/Kustomize rendering.** That is the diff work in a
+  later phase, and it is unbounded.
+- **Revert-or-codify judgment.** That is CUJ 1. This ticket reports what happened; it does
+  not decide what to do about it.
+
+---
+
+## M0 · Ramp
+
+### T1 · Reproduce Spike A by hand
+Run `drift_attribute.sh` against a namespace. Make a `kubectl patch` and watch it appear in
+both halves of the output. Make the same change as a service account and note the
+difference.
+
+**Accept:** you can explain, without looking it up, why `managedFields` alone cannot
+separate CI from a human. Do not start M1 until this is true — the whole detector design
+rests on it.
+
+### T2 · Read and summarize
+Write half a page on what you expect to build, based on the design doc and spike findings.
+
+**Accept:** the summary states that the audit log is the primary trigger and `managedFields`
+is enrichment, not the other way round.
+
+---
+
+## M1 · The trigger
+
+### T3 · Stand up the audit path
+Cloud Audit Logs → Log Router sink → Pub/Sub topic → subscription. IAM: the sink writer
+service account needs `pubsub.publisher`; the consumer needs subscriber.
+
+**Accept:** `gcloud pubsub subscriptions pull` returns a real mutating-call entry.
+**Note:** pair on the IAM rather than debugging permission errors alone.
+
+### T4 · Consumer skeleton
+Pull, parse, and log `principalEmail`, `methodName`, `resourceName`, `timestamp`. No
+filtering yet.
+
+**Accept:** a `kubectl patch` appears in the consumer log within 90s. The spike measured
+30–60s ingestion delay; the margin is deliberate.
+
+### T5 · The two static filters
+Drop `principalEmail =~ "^system:"`. Then drop a configurable automation-service-account
+allowlist. The allowlist must be configuration, not a constant — it is per-cluster and it is
+the single most important tuning knob in the system.
+
+**Accept:** unit tests over recorded audit payloads covering a system principal, a CI service
+account, and a human. Capturing those fixtures is part of this task.
+
+### T6 · Measure the noise profile
+Run 24–48h against a live cluster. Produce a short report: events by tier, before and after
+filtering.
+
+**Accept:** the numbers land near the spike's (~78% system, ~20% automation, ~1% human).
+
+**If the numbers are wildly off, that is a finding, not a bug.** Report it. Do not tune the
+filters until reality matches the document.
+
+---
+
+## M2 · Attribution
+
+### T7 · Port the join to the consumer
+For each surviving event, fetch the live object and extract field-level `managedFields`
+attribution. This is a direct port of `drift_attribute.sh`, which gives you a known-good
+output to diff against.
+
+**Accept:** output matches the shell script for the same namespace.
+
+### T8 · Handle deletes
+Deletes are audit-log-only — the object is gone, so there is nothing to read.
+
+**Accept:** deleting a NetworkPolicy produces a clean attributed record and does not crash
+the consumer.
+
+### T9 · Emit the inject
+POST a `gitops-drift` inject to `/sessions/{session_id}/inject`.
+
+**Accept:** the definition of done above — one change, one inject; one CI deploy, zero
+injects.
+
+---
+
+## M3 · Stretch
+
+### T10 · Daily digest
+A drift skill plus a minimal judgment prompt that reports the day's real human changes in
+plain language. No revert-or-codify decision — just what happened.
+
+Only start this if M1 and M2 have landed cleanly.
+
+---
+
+## Escalate immediately if
+
+- The audit sink requires org-level IAM you do not have.
+- The automation allowlist looks cluster-specific in a way configuration cannot express.
+- Post-filter volume is an order of magnitude above the spike's ~7/day.
+
+## Findings you should not re-derive
+
+From the Phase 0 spike. Each is counterintuitive enough to be worth restating:
+
+1. **The audit log is the primary trigger; `managedFields` is enrichment.** Inverting the
+   order produces false positives on a real cluster.
+2. **The audit principal is required, not optional.** CI applying client-side records
+   `kubectl-client-side-apply` — the same manager string a human running `kubectl apply`
+   produces.
+3. **Two static filters remove ~99% of the noise.**
+4. **Post-filter volume is low enough that no sampling is needed.**

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -22,7 +22,8 @@ attributed stream this CUJ produces.
 ## Goal
 
 Turn raw cluster mutation activity into a small, attributed stream of real human changes,
-emitted as `gitops-drift` injects on the existing pipeline.
+emitted as `gitops-drift` injects on the existing pipeline. You are writing one ingestion adapter —
+nothing downstream of the inject changes.
 
 ## Definition of done
 
@@ -41,32 +42,6 @@ Named explicitly, because each is a plausible-looking rabbit hole:
   later phase, and it is unbounded.
 - **Revert-or-codify judgment.** That is CUJ 1. This ticket reports what happened; it does
   not decide what to do about it.
-
----
-
-## What layer you are working in
-
-**You are writing one ingestion adapter.** Nothing downstream of the inject changes.
-
-The AutoOps pipeline is five contracts (see
-[`autoops-architecture.md`](../autoops-architecture.md)). This CUJ lives almost entirely in
-Contract 1:
-
-| Contract | Who owns it here |
-|---|---|
-| **1 · Ingestion** | **You.** Detect the signal, filter its noise, enrich it, emit the inject. |
-| 2 · Session & state | Already built. Sessions, thread routing, and follow-up come for free. |
-| 3 · Judgment | Already built for k8s events; T5 adds drift's own skill and prompt. |
-| 4 · Context reach | Already wired. `kubectl` / `gcloud` is enough for this CUJ. |
-| 5 · Remediation | Already built. Not reached by this CUJ — no PR is opened here. |
-
-Concretely: your deliverable is the drift equivalent of `k8s-event-watcher`. That component
-watches the Kubernetes API and emits `kind: k8s-event`; yours consumes an audit-log subscription
-and emits `kind: gitops-drift`. Same envelope, same endpoint, same everything after it.
-
-**The handoff is T4.** Once the inject POSTs successfully, the existing pipeline takes over and
-your work is done. If you find yourself editing the session server, the agent gateway, or the PR
-logic, stop — you have left the adapter.
 
 ---
 

--- a/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
+++ b/agents/platform/docs/drift-detection/cuj3-task-breakdown.md
@@ -55,12 +55,6 @@ difference.
 separate CI from a human. Do not start M1 until this is true — the whole detector design
 rests on it.
 
-### T2 · Read and summarize
-Write half a page on what you expect to build, based on the design doc and spike findings.
-
-**Accept:** the summary states that the audit log is the primary trigger and `managedFields`
-is enrichment, not the other way round.
-
 ---
 
 ## M1 · The trigger

--- a/agents/platform/docs/drift-detection/drift_attribute.sh
+++ b/agents/platform/docs/drift-detection/drift_attribute.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# drift_attribute.sh — Spike A join: attribute out-of-band changes in a namespace
+# usage: drift_attribute.sh <namespace> <project> <cluster> [freshness]
+set -euo pipefail
+NS="$1"; PROJECT="$2"; CLUSTER="$3"; FRESH="${4:-1h}"
+
+# GitOps/controller managers to treat as "not human". Extend as needed.
+GITOPS_RE='argocd|flux|helm|kube-controller-manager|kube-scheduler|.*-controller$'
+
+echo "### managedFields: fields owned by a NON-GitOps manager (operation=Update) ###"
+for r in $(kubectl get svc,deploy,networkpolicy,rolebinding -n "$NS" -o name 2>/dev/null); do
+  kubectl get "$r" -n "$NS" --show-managed-fields -o json 2>/dev/null | jq -r --arg r "$r" --arg re "$GITOPS_RE" '
+    .metadata.managedFields[]?
+    | select(.operation=="Update" and (.manager | test($re) | not))
+    | "  \($r)  ->  owner: \(.manager) (\(.operation))  fields: \((.fieldsV1 // {}) | keys | join(","))"'
+done
+
+echo
+echo "### audit log: non-system principals mutating $NS (who / verb / when) ###"
+gcloud logging read "
+  logName=\"projects/$PROJECT/logs/cloudaudit.googleapis.com%2Factivity\"
+  AND resource.type=\"k8s_cluster\"
+  AND resource.labels.cluster_name=\"$CLUSTER\"
+  AND protoPayload.resourceName:\"$NS\"
+  AND protoPayload.methodName=~\"create|patch|update|delete\"
+  AND NOT protoPayload.authenticationInfo.principalEmail=~\"^system:\"
+" --project "$PROJECT" --limit 50 --format=json --freshness="$FRESH" 2>/dev/null \
+  | jq -r '.[] | "  \(.timestamp)  \(.protoPayload.authenticationInfo.principalEmail)  \(.protoPayload.methodName|sub("io.k8s.";"")|sub(".v1";""))  \(.protoPayload.resourceName)"' | sort -u

--- a/agents/platform/docs/drift-detection/spike-findings.md
+++ b/agents/platform/docs/drift-detection/spike-findings.md
@@ -1,0 +1,171 @@
+# Phase 0 findings — drift attribution spike (Spike A)
+
+**Date:** 2026-07-28
+**Environment:** cluster `platform-agent-host` (us-east4), project `kube-agents-autopush`, GKE 1.35
+**Run by:** jayantid@google.com
+**Artifacts:** [`drift_attribute.sh`](./drift_attribute.sh) (reusable join), [`baseline-manifests.yaml`](./baseline-manifests.yaml)
+
+## Verdict: GO — build as designed (two-signal model)
+
+Attribution works. `managedFields` cleanly separates a GitOps owner from a human out-of-band
+change, and audit logs supply who/when (and catch deletes that `managedFields` can't). The one
+real challenge is audit-log noise, and it is trivially filtered by principal.
+
+## Environment note (important for the eng)
+
+- **No in-cluster GitOps controller** on this cluster (no Argo / Flux / Config Sync pods or CRDs).
+  Existing workloads are deployed via **Helm using server-side apply** (`manager: helm, operation: Apply`),
+  so real SSA managers do exist here.
+- For the spike I **simulated the GitOps owner** with `kubectl apply --server-side --field-manager=argocd-controller`,
+  which produces the exact `managedFields` entry Argo/Flux SSA would (`operation: Apply`).
+- To validate on a true GitOps setup, re-run on a cluster where Argo/Flux is actually syncing.
+
+## Spike A results
+
+### 1. Attribution works — `managedFields` separates GitOps from human
+
+| Field changed | Method used | `managedFields` owner | operation |
+|---|---|---|---|
+| Service `spec.type` (open) | `kubectl patch` | `kubectl-patch` | Update |
+| Deployment `securityContext` (privileged) | `kubectl patch` | `kubectl-patch` | Update |
+| Deployment `replicas` (hotfix scale) | `kubectl scale` | `kubectl` | Update |
+| (baseline, all fields) | SSA `--field-manager=argocd-controller` | `argocd-controller` | **Apply** |
+
+**Discriminator:** GitOps owner = `operation: Apply` under a stable manager; human out-of-band =
+`operation: Update` under a `kubectl*` manager. The `operation` field + manager-name prefix is robust.
+
+### 2. `managedFields` alone is NOT sufficient — deletes need audit logs
+
+Deleting the NetworkPolicy left **no `managedFields`** (object is gone). The delete appeared
+**only in the audit log**. Confirms the two-signal design: `managedFields` = "what field / who owns
+it" on live objects; audit log = "who/when + deletes".
+
+### 3. Manager-name stability matrix (clean, distinguishable)
+
+| Method | manager | operation |
+|---|---|---|
+| `apply --server-side --field-manager=X` | `X` (e.g. argocd-controller, helm) | **Apply** |
+| `kubectl patch` | `kubectl-patch` | Update |
+| `kubectl scale` | `kubectl` | Update |
+| `kubectl apply` (client-side) | `kubectl-client-side-apply` | Update |
+| `kubectl annotate` | `kubectl-annotate` | Update |
+
+### 4. Audit log NOISE is the real work (preview of Spike B)
+
+A single `scale 1 -> 5` triggered a **storm** of controller events (endpoint-controller,
+endpointslice-controller, replicaset-controller, kube-scheduler bindings, node pod-deletes). With
+`--limit 20` newest-first, the human change was buried under reconciliation churn.
+
+**Filter that fixes it:** exclude `principalEmail =~ "^system:"`. Doing so isolates the human
+out-of-band change instantly (all showed `jayantid@google.com`, UA `kubectl/v1.35.6`).
+
+### 5. Caveat — real GitOps principal is even cleaner
+
+My simulated GitOps apply showed principal `jayantid@google.com` in the audit log (I ran it
+myself). A real GitOps controller runs as a distinct service account
+(`system:serviceaccount:argocd:...`), so the audit-log discriminator is *stronger* in production:
+GitOps SA vs human user vs `system:` controllers are three separable buckets.
+
+### 6. GKE audit-log facts confirmed
+
+- Admin Activity logs are **on by default**, queryable directly (no sink needed to prototype).
+- Ingestion delay observed ~30–60s.
+- Each entry carries `principalEmail`, `methodName`, `resourceName`, `timestamp`,
+  `callerSuppliedUserAgent` — everything attribution needs.
+
+## Implications for Phase 1 (detection + attribution)
+
+- **Detection trigger:** an audit-log subscription filtered to `NOT principal =~ ^system:` + mutating
+  verbs is a high-signal trigger (reuse the `pubsub-platform` adapter). On each hit, read the live
+  object's `managedFields` for field-level attribution.
+- **Noise filter (CUJ #3) is two-layer:**
+  1. audit side — drop `system:*` principals;
+  2. `managedFields` side — keep `operation==Update` fields whose manager is NOT in the
+     GitOps/controller allowlist (`argocd|flux|helm|kube-controller-manager|*-controller`).
+- **Config:** the GitOps owner identity (manager name + SA) must be configurable per cluster
+  (here it's `helm`/SSA; customer clusters will be argocd/flux).
+- **Deletes:** handle as audit-log-only events — no object to read.
+
+## Reusable join script
+
+`./drift_attribute.sh <namespace> <project> <cluster> [freshness]` prints, for a namespace:
+non-GitOps-owned fields (from `managedFields`) + non-system mutations (from audit logs). Verified
+working against the spike namespace.
+
+---
+
+# Spike B — Noise profile
+
+**Method:** no wait needed. The audit log already holds history, so signal-to-noise was measured
+**retroactively over 7 days** of real cluster activity, plus a `managedFields` manager census.
+
+## Verdict: noise is very high but trivially filterable (~99% reduction with 2 static rules)
+
+## Signal-to-noise, 7 days of mutating calls
+
+| Tier | Principal class | Events (7d) | Share | Action |
+|---|---|---|---|---|
+| 1 | `system:*` controllers | **≥4,707** | ~78% | **Drop** (prefix match) |
+| 2 | CI / automation service accounts | **1,222** | ~20% | **Drop** (the desired-state applier) |
+| 3 | **Real humans** (`@google.com`) | **63** | **~1%** | **THE SIGNAL** |
+
+Tier 1 is dominated by heartbeat/reconciliation churn: `cloud-controller-manager` (421),
+`pdcsi-controller` (337), `cluster-autoscaler` (278), `filestorecsi-controller` (252),
+`gke-common-webhooks` (237), plus ~15 more controllers at ~210 each.
+
+Tier 2 breakdown: `github-deploy-sa` **1,141**, `gitops-infra-sa` 43, `container-engine-robot` 32,
+`kubeagents-platform-gsa` 3, `kubelet-nodepool-bootstrap` 3.
+
+Tier 3 breakdown: three individual engineers, at 42, 18 (14 of which were this spike), and 3 changes.
+**Organic human changes ≈ 49 in 7 days — roughly 7/day on an active cluster.** Very tractable
+for an agent to triage.
+
+## THE KEY FINDING: `managedFields` alone cannot separate CI from humans
+
+On this cluster the CI service account (`github-deploy-sa`) applies **client-side**, so it records
+the generic manager **`kubectl-client-side-apply`** — the *exact same manager string a human
+running `kubectl apply` would produce*.
+
+Verified by overlap: `cert-manager/cert-manager`, `kubeagents-system/litellm-config-*`, and
+`kubeagents-system/github-token-minter-config` all show `kubectl-client-side-apply` in
+`managedFields` **and** appear as `github-deploy-sa` targets in the audit log.
+
+**Implication:** the audit-log principal is **required**, not optional. `managedFields` gives
+field-level "what changed"; only the audit log can say whether the actor was CI or a human. This
+validates the two-signal design decisively — a `managedFields`-only detector would flag every CI
+deploy as human drift.
+
+## `managedFields` manager census (241 field-ownership entries cluster-wide)
+
+| Manager | Op | Entries | Class |
+|---|---|---|---|
+| `kube-addon-manager` | Apply | 106 | platform |
+| `kube-controller-manager` | Update | 72 | controller churn |
+| **`kubectl-client-side-apply`** | Update | **20** | **ambiguous: CI *or* human** |
+| `kube-apiserver` | Update | 10 | platform |
+| `platformagent-controller` | Apply | 7 | our controller |
+| `kubectl-rollout` / `kubectl-patch` / `kubectl` | Update | 8 | human-ish |
+| `helm` | Apply | 3 | deploy tool |
+
+Only ~30 of 241 entries (12%) carry a `kubectl*` manager, so the `managedFields` side is small
+and cheap to scan — but 20 of those 30 are the ambiguous generic manager.
+
+## Implications for Phase 1 (updated)
+
+1. **Filter in two static layers** (cheap, no ML, ~99% reduction):
+   - drop `principalEmail =~ "^system:"`;
+   - drop a **configurable automation-SA allowlist** (`github-deploy-sa`, `gitops-infra-sa`, …).
+2. **The automation allowlist is per-customer config and is the single most important tuning
+   knob.** Get it wrong and every CI deploy looks like drift.
+3. **Audit log is the primary trigger; `managedFields` is the enrichment.** Inverting that order
+   produces false positives on this cluster.
+4. **Volume is low after filtering** (~7 human changes/day), so per-drift agent judgment is
+   affordable; no sampling needed.
+5. **Prefer SSA-based GitOps** where possible: an Argo/Flux controller using SSA records a distinct
+   manager, which would make `managedFields` self-sufficient. Client-side CI is the muddy case.
+
+## Caveat
+
+Measured on `platform-agent-host`, a control-plane/admin cluster (its human activity is operator
+work on kube-agents itself, not app-team drift). A production app cluster will have a different
+mix and likely more Tier-3 volume. Re-run the census there before finalizing filter defaults.


### PR DESCRIPTION
## What

Adds `agents/platform/docs/drift-detection/` with the Phase 0 spike results and the tooling that produced them, so they live in the repo rather than on a laptop.

| File | What it is |
|---|---|
| `README.md` | Folder index, the four findings that shape the build, and the caveats on the measurements |
| `spike-findings.md` | Spike A (attribution) and Spike B (noise profile). Verdict: **GO** |
| `drift_attribute.sh` | Reusable join: `managedFields` + audit log for one namespace |
| `baseline-manifests.yaml` | Baseline manifests used to stage the spike |
| `cuj3-task-breakdown.md` | Ticket for CUJ 3 (noise-filtered triage), the enabling implementation the other CUJs are blocked on |

## Why

The spike validated the two-signal design and produced numbers the implementation will be measured against, but the artifacts only existed in `/tmp` and a local file. This is the material a new engineer needs on day one.

## The findings that matter

- **Audit log is the primary trigger; `managedFields` is enrichment.** Inverting the order produces false positives on a real cluster.
- **The audit principal is required, not optional.** CI applying client-side records `kubectl-client-side-apply` — byte-identical to a human running `kubectl apply`. A `managedFields`-only detector flags every CI deploy as drift.
- **Two static filters remove ~99% of noise.** Drop `^system:` principals, then a configurable automation-SA allowlist. That allowlist is per-cluster config and the most important tuning knob in the system.
- **Post-filter volume is ~7 human changes/day**, so per-change agent judgment is affordable.

## Caveats, stated in the docs

Measured on a control-plane/admin cluster with no in-cluster GitOps controller; the GitOps owner was simulated with `--field-manager=argocd-controller`. The census should be re-run on a production app cluster before filter defaults are finalized.

Per-user change counts from the audit census are reported unattributed, since this repository is public.

Companion to #444, which adds the design doc at `agents/platform/docs/drift-detection.md`.

