### PR TITLE
fix(platform): name the event's own cluster in the triage prompt

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -249,7 +249,7 @@ def _build_agent_query(session_id: str, payload: Dict[str, Any]) -> str:
     object_kind = payload.get("kind_of_object") or payload.get("kindOfObject") or "Pod"
     object_name = payload.get("name") or ""
     message = payload.get("message") or ""
-    cluster_name = os.environ.get("GKE_CLUSTER_NAME", "platform-agent-host")
+    cluster_name = payload.get("cluster") or os.environ.get("GKE_CLUSTER_NAME", "platform-agent-host")
     gcp_project = os.environ.get("GCP_PROJECT_ID") or os.environ.get("GCP_PROJECT") or ""
     workloads_project_query = f"?project={gcp_project}" if gcp_project else ""
     logs_project_query = f";project={gcp_project}" if gcp_project else ""

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -202,6 +202,36 @@ class TestSessionKvServerQueryBuilding(unittest.TestCase):
             query = session_kv_server._build_agent_query("test-session", payload)
             self.assertIn("project=", query)
 
+    @patch.dict(os.environ, {"GKE_CLUSTER_NAME": "platform-agent-host"})
+    def test_build_agent_query_names_the_events_cluster(self):
+        # The event came from a different cluster than the one this agent runs
+        # on; the prompt must name the event's cluster, not the host's.
+        payload = {
+            "reason": "OOMKilled",
+            "namespace": "test-ns",
+            "kind_of_object": "Pod",
+            "name": "test-pod",
+            "message": "some message",
+            "cluster": "prod-us-central1"
+        }
+        query = session_kv_server._build_agent_query("test-session", payload)
+        self.assertIn("prod-us-central1", query)
+        self.assertNotIn("platform-agent-host", query)
+
+    @patch.dict(os.environ, {"GKE_CLUSTER_NAME": "platform-agent-host"})
+    def test_build_agent_query_falls_back_to_host_cluster(self):
+        # No cluster on the payload (non-watcher caller, or a watcher started
+        # without --cluster-name): fall back to the host cluster env var.
+        payload = {
+            "reason": "OOMKilled",
+            "namespace": "test-ns",
+            "kind_of_object": "Pod",
+            "name": "test-pod",
+            "message": "some message"
+        }
+        query = session_kv_server._build_agent_query("test-session", payload)
+        self.assertIn("platform-agent-host", query)
+
 
 if __name__ == "__main__":
     # Clean up temp database file on exit


### PR DESCRIPTION
# Pull Request

## Why This Change

_build_agent_query builds the diagnostic prompt handed to the Platform Agent when the event watcher reports a failure. It read the cluster name from the GKE_CLUSTER_NAME env var — which names the cluster the agent itself runs on, not the cluster the event came from.

Today those happen to be the same cluster, so the prompt is correct by coincidence. They diverge the moment the watcher reads events from anywhere else, and the agent would be told to investigate the wrong control plane.

## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  - agents/platform/scripts/session_kv_server.py
  - agents/platform/scripts/test_session_kv_server.py

**Added/Changed/Fixed:**

  - Fixed: _build_agent_query now prefers payload["cluster"], falling back to
  GKE_CLUSTER_NAME when it's absent or empty.
  - Added: two tests — one asserting the payload's cluster wins over a differing
  GKE_CLUSTER_NAME, one asserting the fallback still applies when the payload carries
  no cluster.


## Why This Matters

- As we switch to a multi clustered solution in the future, the current code would be incorrect.

## Context

<!-- Include related issues, PRs, follow-up work, or other background. -->

## Testing
  
  - [x] python3 -m unittest test_session_kv_server from agents/platform/scripts/ —
  passes, including the two new cases

<!-- Close with a short note on functional impact, risk, or rollout. -->
