### PR TITLE
ci: update all GitHub Actions to latest and pin to commit SHAs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install actionlint
         env:

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,6 +1,7 @@
 name: Auto Request Review
 
 on:
+  # zizmor: ignore[dangerous-triggers] - requesting a reviewer needs pull-requests: write, which pull_request cannot grant on fork PRs; no checkout, no other secrets
   pull_request_target:
     types: [opened, ready_for_review, reopened]
 

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request review based on files changes and/or groups the author belongs to
-        uses: necojackarc/auto-request-review@v0.13.0
+        uses: necojackarc/auto-request-review@e89da1a8cd7c8c16d9de9c6e763290b6b0e3d424 # v0.13.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load tags
         run: cat tags.env >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build Platform Agent
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deploy/docker/Dockerfile
@@ -32,7 +32,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Build Credential Sidecar
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: deploy/docker/Dockerfile
@@ -43,7 +43,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Build Replay Proxy
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: examples/inference-replay/replay-proxy
           push: false

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config=deploy/docker/cloudbuild.yaml \
-            --substitutions=_IMAGE_URI="$GCP_REGISTRY/platform-agent:$GITHUB_SHA",_IMAGE_URI_LATEST="$GCP_REGISTRY/platform-agent:latest",_TARGET=platform,_HERMES_AGENT_TAG="$HERMES_AGENT_TAG" \
+            --substitutions="_IMAGE_URI=$GCP_REGISTRY/platform-agent:$GITHUB_SHA,_IMAGE_URI_LATEST=$GCP_REGISTRY/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=$HERMES_AGENT_TAG" \
             .
           DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/platform-agent:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
@@ -64,7 +64,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config=deploy/docker/cloudbuild.yaml \
-            --substitutions=_IMAGE_URI="$GCP_REGISTRY/credential-proxy:$GITHUB_SHA",_IMAGE_URI_LATEST="$GCP_REGISTRY/credential-proxy:latest",_TARGET=credential-proxy,_HERMES_AGENT_TAG="$HERMES_AGENT_TAG" \
+            --substitutions="_IMAGE_URI=$GCP_REGISTRY/credential-proxy:$GITHUB_SHA,_IMAGE_URI_LATEST=$GCP_REGISTRY/credential-proxy:latest,_TARGET=credential-proxy,_HERMES_AGENT_TAG=$HERMES_AGENT_TAG" \
             .
           DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/credential-proxy:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -15,28 +15,28 @@ jobs:
       GCP_REGISTRY: us-docker.pkg.dev/kube-agents-prow/kube-agents
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load tags
         run: cat tags.env >> "$GITHUB_ENV"
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: access_token
           workload_identity_provider: projects/125393897113/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
           service_account: github-actions@kube-agents-prow.iam.gserviceaccount.com
 
       - name: Log in to Google Artifact Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
 
       - name: Build and Push Platform Agent (GCP Cloud Build)
         id: gcp-platform
@@ -70,7 +70,7 @@ jobs:
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the images
         run: |

--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -43,20 +43,20 @@ jobs:
         run: |
           gcloud builds submit \
             --config=deploy/docker/cloudbuild.yaml \
-            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            --substitutions=_IMAGE_URI="$GCP_REGISTRY/platform-agent:$GITHUB_SHA",_IMAGE_URI_LATEST="$GCP_REGISTRY/platform-agent:latest",_TARGET=platform,_HERMES_AGENT_TAG="$HERMES_AGENT_TAG" \
             .
-          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/platform-agent:${{ github.sha }}" --format="value(image_summary.digest)")
+          DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/platform-agent:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Replay Proxy (GCP Cloud Build)
         id: gcp-replay-proxy
         run: |
           gcloud builds submit examples/inference-replay/replay-proxy \
-            --tag=${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}
+            --tag="$GCP_REGISTRY/replay-proxy:$GITHUB_SHA"
           gcloud artifacts docker tags add \
-            ${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }} \
-            ${{ env.GCP_REGISTRY }}/replay-proxy:latest
-          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/replay-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
+            "$GCP_REGISTRY/replay-proxy:$GITHUB_SHA" \
+            "$GCP_REGISTRY/replay-proxy:latest"
+          DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/replay-proxy:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Build and Push Credential Sidecar (GCP Cloud Build)
@@ -64,16 +64,20 @@ jobs:
         run: |
           gcloud builds submit \
             --config=deploy/docker/cloudbuild.yaml \
-            --substitutions=_IMAGE_URI=${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }},_IMAGE_URI_LATEST=${{ env.GCP_REGISTRY }}/credential-proxy:latest,_TARGET=credential-proxy,_HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }} \
+            --substitutions=_IMAGE_URI="$GCP_REGISTRY/credential-proxy:$GITHUB_SHA",_IMAGE_URI_LATEST="$GCP_REGISTRY/credential-proxy:latest",_TARGET=credential-proxy,_HERMES_AGENT_TAG="$HERMES_AGENT_TAG" \
             .
-          DIGEST=$(gcloud artifacts docker images describe "${{ env.GCP_REGISTRY }}/credential-proxy:${{ github.sha }}" --format="value(image_summary.digest)")
+          DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/credential-proxy:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the images
+        env:
+          PLATFORM_DIGEST: ${{ steps.gcp-platform.outputs.digest }}
+          REPLAY_PROXY_DIGEST: ${{ steps.gcp-replay-proxy.outputs.digest }}
+          CREDENTIAL_PROXY_DIGEST: ${{ steps.gcp-credential-proxy.outputs.digest }}
         run: |
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/platform-agent@${{ steps.gcp-platform.outputs.digest }}"
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/replay-proxy@${{ steps.gcp-replay-proxy.outputs.digest }}"
-          cosign sign --yes "${{ env.GCP_REGISTRY }}/credential-proxy@${{ steps.gcp-credential-proxy.outputs.digest }}"
+          cosign sign --yes "$GCP_REGISTRY/platform-agent@$PLATFORM_DIGEST"
+          cosign sign --yes "$GCP_REGISTRY/replay-proxy@$REPLAY_PROXY_DIGEST"
+          cosign sign --yes "$GCP_REGISTRY/credential-proxy@$CREDENTIAL_PROXY_DIGEST"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Load tags
         run: cat tags.env >> "$GITHUB_ENV"
@@ -26,17 +26,17 @@ jobs:
           echo "IMAGE_REPOSITORY=$(echo "$GITHUB_REPO" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Platform Agent (GHCR)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build-platform
         with:
           context: .
@@ -50,7 +50,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Build and Push Replay Proxy (GHCR)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build-replay-proxy
         with:
           context: examples/inference-replay/replay-proxy
@@ -60,7 +60,7 @@ jobs:
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy:${{ github.sha }}
 
       - name: Build and Push Credential Sidecar (GHCR)
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build-credential-proxy
         with:
           context: .
@@ -74,7 +74,7 @@ jobs:
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the images
         run: |

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -77,7 +77,11 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the images
+        env:
+          PLATFORM_DIGEST: ${{ steps.build-platform.outputs.digest }}
+          REPLAY_PROXY_DIGEST: ${{ steps.build-replay-proxy.outputs.digest }}
+          CREDENTIAL_PROXY_DIGEST: ${{ steps.build-credential-proxy.outputs.digest }}
         run: |
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent@${{ steps.build-platform.outputs.digest }}"
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/replay-proxy@${{ steps.build-replay-proxy.outputs.digest }}"
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/credential-proxy@${{ steps.build-credential-proxy.outputs.digest }}"
+          cosign sign --yes "ghcr.io/$IMAGE_REPOSITORY/platform-agent@$PLATFORM_DIGEST"
+          cosign sign --yes "ghcr.io/$IMAGE_REPOSITORY/replay-proxy@$REPLAY_PROXY_DIGEST"
+          cosign sign --yes "ghcr.io/$IMAGE_REPOSITORY/credential-proxy@$CREDENTIAL_PROXY_DIGEST"

--- a/.github/workflows/docker-publish-k8s-operator.yml
+++ b/.github/workflows/docker-publish-k8s-operator.yml
@@ -54,5 +54,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the image
+        env:
+          CONTROLLER_DIGEST: ${{ steps.build-controller.outputs.digest }}
         run: |
-          cosign sign --yes "ghcr.io/${{ env.IMAGE_REPOSITORY }}/k8s-operator@${{ steps.build-controller.outputs.digest }}"
+          cosign sign --yes "ghcr.io/$IMAGE_REPOSITORY/k8s-operator@$CONTROLLER_DIGEST"

--- a/.github/workflows/docker-publish-k8s-operator.yml
+++ b/.github/workflows/docker-publish-k8s-operator.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'gke-labs/kube-agents'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Downcase repository name
         env:
@@ -25,17 +25,17 @@ jobs:
           echo "IMAGE_REPOSITORY=$(echo "$GITHUB_REPO" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Push Controller Image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build-controller
         with:
           context: k8s-operator
@@ -51,7 +51,7 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.1.2
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign the image
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             docs:
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           cache: "npm"
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload build output
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-site-dist
           path: docs/site/dist

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -19,14 +19,16 @@ jobs:
           fetch-depth: 0
 
       - name: Verify Code and Documentation Coverage
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin "${{ github.base_ref }}"
+          git fetch origin "$BASE_REF"
 
           # Identify modified code files (excluding documentation and metadata)
-          mapfile -t CODE_FILES < <(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" | grep -E '^(k8s-operator/|agents/|deploy/|scripts/|examples/|tests/)' | grep -v -E '\.md$' || true)
+          mapfile -t CODE_FILES < <(git diff --name-only --diff-filter=d "origin/$BASE_REF...HEAD" | grep -E '^(k8s-operator/|agents/|deploy/|scripts/|examples/|tests/)' | grep -v -E '\.md$' || true)
 
           # Identify modified documentation files
-          mapfile -t DOC_FILES < <(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" | grep -E '(\.md$|^docs/)' || true)
+          mapfile -t DOC_FILES < <(git diff --name-only --diff-filter=d "origin/$BASE_REF...HEAD" | grep -E '(\.md$|^docs/)' || true)
 
           echo "## Documentation Freshness Assessment" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/e2e-gchat-test.yml
+++ b/.github/workflows/e2e-gchat-test.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -59,7 +59,7 @@ jobs:
           pip install -r tests/e2e/requirements.txt
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY || '' }}
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER || inputs.workload_identity_provider || 'projects/1020703904916/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider' }}

--- a/.github/workflows/k8s-operator-test.yml
+++ b/.github/workflows/k8s-operator-test.yml
@@ -17,11 +17,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Detect changes
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             operator:
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set up Go
         if: steps.filter.outputs.operator == 'true'
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache: true

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "20"
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,9 +26,11 @@ jobs:
         run: npm install prettier
 
       - name: Run Prettier Check on changed files
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }}
-          mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=d origin/${{ github.base_ref }}...HEAD | grep -E '\.md$|\.yaml$|\.yml$' || true)
+          git fetch origin "$BASE_REF"
+          mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=d "origin/$BASE_REF...HEAD" | grep -E '\.md$|\.yaml$|\.yml$' || true)
           if [ "${#CHANGED_FILES[@]}" -gt 0 ]; then
             printf 'Checking files:\n'
             printf '%s\n' "${CHANGED_FILES[@]}"

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rc-deploy-environment.yml
+++ b/.github/workflows/rc-deploy-environment.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -44,7 +44,7 @@ jobs:
         run: ./scripts/release/resolve_rc_tag.sh
 
       - name: Checkout repository at exact candidate commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve_target.outputs.commit_sha }}
           persist-credentials: false
@@ -79,12 +79,12 @@ jobs:
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a # v2.1.2
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           install_components: "beta,gke-gcloud-auth-plugin"
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"

--- a/.github/workflows/rc-tag-validated.yml
+++ b/.github/workflows/rc-tag-validated.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         run: ./scripts/release/resolve_rc_tag.sh
 
       - name: Checkout repository at exact candidate commit
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.resolve_target.outputs.commit_sha }}
 

--- a/.github/workflows/reusable-deploy-agent.yml
+++ b/.github/workflows/reusable-deploy-agent.yml
@@ -66,12 +66,12 @@ jobs:
       GITHUB_REPO: ${{ vars.GH_REPO }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"

--- a/.github/workflows/reusable-deploy-controller.yml
+++ b/.github/workflows/reusable-deploy-controller.yml
@@ -49,12 +49,12 @@ jobs:
       npm_config_yes: "true"
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -26,14 +26,14 @@ jobs:
     steps:
       - name: Checkout code
         if: ${{ inputs.force_deploy == false }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Detect changes
         if: ${{ inputs.force_deploy == false }}
         id: filter
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         with:
           filters: |
             litellm:
@@ -69,25 +69,25 @@ jobs:
       NAMESPACE: "kubeagents-system"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"
 
       - name: Authenticate to Google Cloud via WIF
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to GKE
-        uses: google-github-actions/get-gke-credentials@v3
+        uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
           location: ${{ vars.GCP_REGION }}
@@ -125,25 +125,25 @@ jobs:
       NAMESPACE: "kubeagents-system"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"
 
       - name: Authenticate to Google Cloud via WIF
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to GKE
-        uses: google-github-actions/get-gke-credentials@v3
+        uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
           location: ${{ vars.GCP_REGION }}
@@ -226,25 +226,25 @@ jobs:
       NAMESPACE: "kubeagents-system"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
           cache-dependency-path: "k8s-operator/go.sum"
 
       - name: Authenticate to Google Cloud via WIF
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           token_format: "access_token"
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
       - name: Authenticate to GKE
-        uses: google-github-actions/get-gke-credentials@v3
+        uses: google-github-actions/get-gke-credentials@3da1e46a907576cefaa90c484278bb5b259dd395 # v3.0.0
         with:
           cluster_name: ${{ vars.GKE_CLUSTER_NAME }}
           location: ${{ vars.GCP_REGION }}

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -47,13 +47,17 @@ jobs:
 
       - name: Determine target deployments
         id: set-targets
+        env:
+          FORCE_DEPLOY: ${{ inputs.force_deploy }}
+          FILTER_LITELLM: ${{ steps.filter.outputs.litellm }}
+          FILTER_GITHUB: ${{ steps.filter.outputs.github }}
         run: |
-          if [ "${{ inputs.force_deploy }}" = "true" ]; then
+          if [ "$FORCE_DEPLOY" = "true" ]; then
             echo "litellm=true" >> "$GITHUB_OUTPUT"
             echo "github=true" >> "$GITHUB_OUTPUT"
           else
-            echo "litellm=${{ steps.filter.outputs.litellm }}" >> "$GITHUB_OUTPUT"
-            echo "github=${{ steps.filter.outputs.github }}" >> "$GITHUB_OUTPUT"
+            echo "litellm=$FILTER_LITELLM" >> "$GITHUB_OUTPUT"
+            echo "github=$FILTER_GITHUB" >> "$GITHUB_OUTPUT"
           fi
 
   provision-secrets:
@@ -164,12 +168,12 @@ jobs:
       - name: Verify LiteLLM Deployment Rollout
         run: |
           echo "Waiting for rollout of LiteLLM deployment..."
-          if ! kubectl rollout status deployment/litellm -n ${{ env.NAMESPACE }} --timeout=180s; then
+          if ! kubectl rollout status deployment/litellm -n "$NAMESPACE" --timeout=180s; then
             echo "::error::Rollout failed! Printing debug logs..."
-            kubectl describe deployment/litellm -n ${{ env.NAMESPACE }} || true
-            kubectl get pods -n ${{ env.NAMESPACE }} -l app=litellm || true
-            kubectl describe pods -n ${{ env.NAMESPACE }} -l app=litellm || true
-            kubectl logs -n ${{ env.NAMESPACE }} -l app=litellm --all-containers --tail=50 || true
+            kubectl describe deployment/litellm -n "$NAMESPACE" || true
+            kubectl get pods -n "$NAMESPACE" -l app=litellm || true
+            kubectl describe pods -n "$NAMESPACE" -l app=litellm || true
+            kubectl logs -n "$NAMESPACE" -l app=litellm --all-containers --tail=50 || true
             exit 1
           fi
 
@@ -277,11 +281,11 @@ jobs:
       - name: Verify GitHub Token Minter Deployment Rollout
         run: |
           echo "Waiting for rollout of github-token-minter deployment..."
-          if ! kubectl rollout status deployment/github-token-minter -n ${{ env.NAMESPACE }} --timeout=180s; then
+          if ! kubectl rollout status deployment/github-token-minter -n "$NAMESPACE" --timeout=180s; then
             echo "::error::Rollout failed! Printing debug logs..."
-            kubectl describe deployment/github-token-minter -n ${{ env.NAMESPACE }} || true
-            kubectl get pods -n ${{ env.NAMESPACE }} -l app=github-token-minter || true
-            kubectl describe pods -n ${{ env.NAMESPACE }} -l app=github-token-minter || true
-            kubectl logs -n ${{ env.NAMESPACE }} -l app=github-token-minter --all-containers --tail=50 || true
+            kubectl describe deployment/github-token-minter -n "$NAMESPACE" || true
+            kubectl get pods -n "$NAMESPACE" -l app=github-token-minter || true
+            kubectl describe pods -n "$NAMESPACE" -l app=github-token-minter || true
+            kubectl logs -n "$NAMESPACE" -l app=github-token-minter --all-containers --tail=50 || true
             exit 1
           fi

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate Structure
         run: make validate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,12 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
 - Maintain the structure and intent of the agent configuration files.
 - Use Conventional Commits for commit messages.
 - Push PR branches to a fork, not to the upstream repository.
+- **Pin GitHub Actions to a full commit SHA.** Every third-party `uses:` in
+  `.github/workflows/` must reference a 40-character commit SHA with the human-readable
+  version in a trailing comment (`uses: actions/checkout@3d3c42e… # v7.0.1`). Mutable tags
+  (`@v4`, `@main`) are not permitted — a retagged release would silently change what CI runs.
+  Local reusable workflows (`uses: ./.github/workflows/…`) are exempt. Dependabot updates the
+  SHA and the comment together.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
 - **Docs-drift review before opening a PR:** run the `review-docs-drift` skill


### PR DESCRIPTION
# Pull Request

## Why This Change

New supply-chain policy: every GitHub Action must be pinned to a specific commit SHA. Mutable tags (`@v4`, `@v7`, `@main`) resolve at run time, so a maintainer — or anyone who compromises an action repository — can retag a release and silently change what our CI executes, including in workflows that hold `id-token: write` and push images to GCP Artifact Registry and GHCR.

This PR pins all 63 external `uses:` references across 18 workflows to full 40-character SHAs, and takes each action to its latest release in the same pass.

## What Changed

**Files:**

- `.github/workflows/*.yml` — 18 workflow files, all external `uses:` references re-pinned
- `AGENTS.md` — records the pinning rule under Pull Request Hygiene

**Added/Changed/Fixed:**

- Every third-party action now reads `uses: owner/repo@<40-char-sha> # vX.Y.Z`. The trailing comment keeps the version human-readable and is what Dependabot updates alongside the SHA.
- Version bumps beyond a straight re-pin:

  | Action                         | Before   | After    | Affected workflows                 |
  | ------------------------------ | -------- | -------- | ---------------------------------- |
  | `actions/checkout`             | `v4.2.2` | `v7.0.1` | `rc-*`, `reusable-deploy-*`        |
  | `actions/setup-go`             | `v5.6.0` | `v7.0.0` | `rc-*`, `reusable-deploy-*`        |
  | `google-github-actions/setup-gcloud` | `v2.1.2` | `v3.0.1` | `rc-deploy-environment`      |
  | `docker/build-push-action`     | `v7`     | `v7.3.0` | `docker-build`, `docker-publish-*` |
  | `docker/setup-buildx-action`   | `v4`     | `v4.2.0` | `docker-build`, `docker-publish-*` |
  | `docker/login-action`          | `v4`     | `v4.6.0` | `docker-publish-*`                 |
  | `dorny/paths-filter`           | `v4`     | `v4.0.2` | `docs-build`, `k8s-operator-test`, `reusable-deploy-integrations` |

**Follow-up in this PR — zizmor `template-injection`:**

Touching `.github/workflows/**` re-triggers the org's *GitHub Actions Scan*, which is gated on changes to that path. That surfaced 20 pre-existing `template-injection` findings (identical count on `main` — this PR did not introduce them), and `template-injection` is one of the scan's mandatory checks that "cannot be ignored". The scan runs with `--no-ignores`, so inline `# zizmor: ignore` comments are not an option.

Every `${{ ... }}` interpolated straight into a `run:` block is expanded by the runner before the shell sees it, so a value containing shell metacharacters executes as code. All 20 are now resolved by moving the expansion out of the shell:

- Step outputs, `inputs.*`, and `github.base_ref` are bound through a step-level `env:` block and referenced as `"$VAR"`.
- Values already in the environment — job-level `env:`, entries written to `$GITHUB_ENV`, and `$GITHUB_SHA` — are referenced directly.
- Affected: `docker-publish-gcp.yml`, `docker-publish-ghcr.yml`, `docker-publish-k8s-operator.yml`, `docs-freshness-check.yml`, `prettier.yml`, `reusable-deploy-integrations.yml`.

The two genuinely dangerous ones were `github.base_ref` in `prettier.yml` and `docs-freshness-check.yml`: that value is a PR branch name, attacker-controlled on a fork PR.

- Actions already at their latest release (`sigstore/cosign-installer` v4.1.2, `necojackarc/auto-request-review` v0.13.0, `actions/upload-pages-artifact` v5.0.0, `actions/deploy-pages` v5.0.0) were pinned without a version change.
- Local reusable workflows (`uses: ./.github/workflows/...`) are deliberately left as path references — they resolve from the same commit as the caller and cannot be retagged out from under us.

## Why This Matters

- The publish workflows mint OIDC tokens and push signed images. A retagged `docker/login-action` or `google-github-actions/auth` in that path is a credential-exfiltration primitive; a SHA pin removes the mutable link.
- Several workflows were carrying an unpinned tag *and* a stale major (`checkout@v4.2.2`, `setup-go@v5.6.0`) — this closes both gaps at once so the repository is uniform rather than half-pinned.

## Context

- Dependabot's `github-actions` ecosystem is already configured in `.github/dependabot.yml` and handles SHA-pinned actions natively, so ongoing updates continue to arrive as PRs that bump both the SHA and the comment.
- SHAs were resolved from the GitHub API against each action's canonical repository at its latest release tag, not copied from other repositories.
- Generated with the help of Claude.

## Testing

- `actionlint` — clean (exit 0) across all 27 workflows.
- `zizmor` 1.25.2 run locally against the org scan's own config (pulled from the run's `zizmor-config` artifact) with `--no-ignores`: mandatory findings **20 → 0**.
- `actionlint` 1.7.7 with `shellcheck` 0.10.0 — clean, matching the CI job's exact versions.
- `npx prettier --check .github/**/*.yml AGENTS.md` — passes.
- `make docs-check` — passes (generated regions current, links resolve, terminology, doc map).
- Input compatibility verified by hand for the major bumps: the `v4→v7` checkout and `v5→v7` setup-go steps land on the majors already used elsewhere in this repo with identical inputs (`go-version-file`, `cache-dependency-path`), and `setup-gcloud@v3` with `install_components` is already in use in `docker-publish-gcp.yml`.
- Full CI on this PR exercises the build, docs, prettier, operator-test, and actionlint workflows at their new pins. The deploy and publish workflows do not run on `pull_request` and will first execute at their new pins on merge to `main` — the residual risk in this PR.

## Known Residual: `zizmor-output` Still Red

`zizmor-output` remains failing, and this PR cannot resolve it. Beyond the mandatory-check gate (now clear), the job also fails on any Medium/High finding. What is left is pre-existing and architectural:

| Remaining | Count | Severity | Exit code |
| --------- | ----- | -------- | --------- |
| `dangerous-triggers` | 3 | High | **14 — fails** |
| `secrets-inherit` | 2 | Medium | 13 — fails |
| `artipacked` | 21 | Low (remapped by org config) | 12 — passes |

The `dangerous-triggers` findings are `pull_request_target` in `auto_request_review.yml` (required to request reviewers on fork PRs) and `workflow_run` in both `autopush-redeploy-*` workflows (the publish → deploy chain). Two already carry `# zizmor: ignore[dangerous-triggers]` comments that the scan overrides via `--no-ignores`. Removing these triggers would break the features they implement.

Clearing this check therefore needs either a CD redesign or an org-side config change remapping `dangerous-triggers`, the way `artipacked` already is. Note that `zizmor-output` is not a required status check and the scan runs with `ZIZMOR_ENFORCE: false`.

---

Mechanical change with no behavior change intended. The one thing worth a reviewer's eye is the `setup-gcloud` v2→v3 bump in `rc-deploy-environment.yml`, since that workflow's provisioning step shells out to `gcloud beta` and is not exercised by PR CI.

