### PR TITLE
Design Proposal: Agent Autonomy & Tool Execution Boundaries (Task 537148480)

### DIFF
--- a/docs/design_proposals/design_537148480.md
+++ b/docs/design_proposals/design_537148480.md
@@ -1,0 +1,306 @@
+# Design Proposal: Agent Autonomy & Tool Execution Boundaries (Task 537148480)
+
+**Status:** Proposed  
+**Author:** Platform Agent Security & Core Architecture Team  
+**Buganizer Task:** 537148480  
+**Findings Included:** SKILL-003, SKILL-004, SKILL-005, SKILL-007  
+**Target Files:**
+
+- `agents/platform/config.yaml`
+- `agents/platform/SOUL.md`
+- `agents/platform/AGENTS.md`
+- `agents/platform/skills/`
+- `deploy/docker/Dockerfile`
+- `deploy/shared/docker-entrypoint.sh`
+
+---
+
+## Executive Summary (TL;DR)
+
+This design proposal establishes formal security, autonomy, and execution boundaries for the Platform Agent within the `kube-agents` harness. It addresses four critical security and governance findings (`SKILL-003`, `SKILL-004`, `SKILL-005`, `SKILL-007`) by introducing three architectural enhancements:
+
+1. **Restricting `hermes-cli` Execution Bounds (`SKILL-003`, `SKILL-007`)**: Implement a declarative execution boundary and sandbox policy in `agents/platform/config.yaml` alongside a pre-execution audit hook to scope `hermes-cli` command execution, prevent unauthorized filesystem mutations, and enforce timeouts.
+2. **Skill Provenance & Integrity Verification (`SKILL-004`)**: Establish a cryptographic provenance manifest (`skills_manifest.sha256`) generated during container builds in `deploy/docker/Dockerfile`, verified at runtime startup via `docker-entrypoint.sh` and before skill invocation, and enforce read-only immutability on `/opt/hermes/skills/`.
+3. **Mandatory User Confirmation for State-Changing Operations (`SKILL-005`, `SKILL-007`)**: Refine `agents/platform/SOUL.md` and `agents/platform/AGENTS.md` autonomy rules to require explicit Human-in-the-Loop (HITL) confirmation with structured dry-run diffs for all state-changing operations, eliminating ambiguity between read-only autonomous investigation and mutating actions.
+
+Finally, this document provides a detailed **Code Comment Compatibility Analysis**, raising explicit design questions regarding potential conflicts with existing inline code comments and autonomy directives in `config.yaml`, `SOUL.md`, and `gke-productionize/SKILL.md`.
+
+---
+
+## 1. Problem Statement & Current Architecture Analysis
+
+### 1.1 Unrestricted Shell Access via `hermes-cli` (`SKILL-003`, `SKILL-007`)
+
+In `agents/platform/config.yaml`, the Platform Agent enables the `hermes-cli` toolset under `platform_toolsets.cli`:
+
+```yaml
+# Explicitly list platform_toolsets
+# platform_toolsets is a reserved framework key in Hermes.
+platform_toolsets:
+  cli:
+    - hermes-cli
+    - mcp-agent_common
+    ...
+```
+
+Currently, `hermes-cli` provides shell execution capabilities without an explicit command allowlist/denylist, path sandboxing, or execution timeout segmentation in `config.yaml`. Without explicit execution boundaries, a compromised or hallucinating reasoning loop could execute arbitrary shell commands outside intended development and diagnostic scopes.
+
+### 1.2 Lack of Skill Provenance and Integrity Checks (`SKILL-004`)
+
+During the Docker build (`deploy/docker/Dockerfile`, lines 114–115), skill directories are copied directly into the runtime container:
+
+```dockerfile
+# Copy platform skills
+COPY agents/platform/skills/ /opt/hermes/skills/
+```
+
+At runtime, `/opt/hermes/skills/` is read by the Hermes agent runtime whenever a skill is loaded or inspected (`skill_view` / skill catalog). There is currently no checksum manifest or signature verification step ensuring that the files in `/opt/hermes/skills/` match the immutable artifacts produced at build time. Furthermore, without integrity verification, any process with filesystem write permissions could alter a `SKILL.md` file or helper script to inject malicious prompts or backdoors into subsequent agent turns.
+
+### 1.3 Autonomy Rules Allow Unconfirmed State-Changing Operations (`SKILL-005`, `SKILL-007`)
+
+In `agents/platform/SOUL.md` (lines 16–17), the current autonomy policy mandates:
+
+```markdown
+- **User Intent Priority:** Phrases such as "fix it for me", "directly", "do it", and "loop until done" indicate that the user expects autonomous remediation. In these cases, prioritize action and recovery over clarification unless a real permission boundary or missing external approval has been conclusively verified. **As a general rule: if the expected user response to a clarification or permission query would simply be "yes", "go ahead", or equivalent permission, do not ask the question; proceed autonomously and report the outcome.** This rule does **not** apply to destructive or irreversible operations (e.g., cluster deletion, tenant offboarding, broad IAM revocation, project-level changes) — those always require explicit human confirmation.
+```
+
+While this rule correctly mandates explicit confirmation for **destructive** operations, it explicitly encourages proceeding autonomously for **non-destructive state-changing operations** (such as creating new GKE resources, modifying non-critical Config Connector manifests, or applying cluster configuration updates). This creates an operational risk where an agent may apply unexpected infrastructure mutations without human review.
+
+---
+
+## 2. Detailed Technical Design & Implementation Plan
+
+### 2.1 Component 1: Execution Bounds for `hermes-cli` Shell Access
+
+#### 2.1.1 Declarative Sandbox Policy in `agents/platform/config.yaml`
+
+We propose adding an explicit `execution_bounds` configuration block to `agents/platform/config.yaml` that defines strict sandboxing parameters for `hermes-cli` without altering the reserved `platform_toolsets` key:
+
+```yaml
+# MCP Servers configuration.
+mcp_servers: ...
+
+# Explicitly list platform_toolsets
+# platform_toolsets is a reserved framework key in Hermes.
+platform_toolsets:
+  cli:
+    - hermes-cli
+    - mcp-agent_common
+    - mcp-platform_control
+    - mcp-developer_knowledge
+    - mcp-gke
+
+# Security and Execution Boundaries for built-in CLI tools
+execution_bounds:
+  hermes_cli:
+    sandbox_mode: "enforced"
+    # Maximum execution timeout for standard shell commands (seconds)
+    command_timeout_seconds: 60
+    # Allowlist of permitted binary prefixes for development and diagnostics
+    allowed_binary_prefixes:
+      - "git status"
+      - "git diff"
+      - "git log"
+      - "git checkout"
+      - "git add"
+      - "git commit"
+      - "kubectl get"
+      - "kubectl describe"
+      - "kubectl logs"
+      - "gcloud logging read"
+      - "gcloud container clusters describe"
+      - "pytest"
+      - "python3 -m unittest"
+      - "python3 ./skills/"
+      - "python3 ./scripts/"
+    # Blocked patterns and destructive operations
+    blocked_command_patterns:
+      - "rm -rf /"
+      - "sudo "
+      - "chmod "
+      - "chown "
+      - "nohup "
+      - "curl * | bash"
+      - "wget * | bash"
+      - "pip install *"
+    # Filesystem write confinement
+    writable_paths:
+      - "/tmp"
+      - "/opt/data/scratch"
+    read_only_paths:
+      - "/opt/hermes/skills"
+      - "/opt/defaults"
+      - "/etc"
+```
+
+#### 2.1.2 Pre-Execution Enforcement via `tool_call_audit` Hook
+
+To enforce these bounds without modifying the Hermes core binary, we will extend the existing `tool_call_audit` plugin (`agents/platform/defaults/plugins/tool_call_audit/audit.py`). We will introduce a `verify_execution_bounds(tool_name, args)` validator inside `log_pre_tool_call()`:
+
+- When `tool_name == "hermes-cli"` or shell execution tools are invoked, the plugin evaluates the command string against `execution_bounds.hermes_cli`.
+- If a command matches a `blocked_command_patterns` entry or accesses a restricted path outside `writable_paths`, the plugin raises a `PermissionError` that immediately terminates tool execution and returns an actionable audit failure message to the agent.
+
+---
+
+### 2.2 Component 2: Skill Provenance & Integrity Verification (`/opt/hermes/skills/`)
+
+#### 2.2.1 Build-Time Cryptographic Manifest Generation
+
+In `deploy/docker/Dockerfile`, after copying `agents/platform/skills/` to `/opt/hermes/skills/`, we add a build step that generates a SHA-256 checksum manifest (`/opt/hermes/skills/skills_manifest.sha256`) and sets read-only permissions:
+
+```dockerfile
+# Copy platform skills
+COPY agents/platform/skills/ /opt/hermes/skills/
+
+# Generate SHA-256 integrity manifest for skill provenance
+RUN cd /opt/hermes/skills && \
+    find . -type f ! -name "skills_manifest.sha256" -exec sha256sum {} + | sort > /opt/hermes/skills/skills_manifest.sha256 && \
+    chmod 444 /opt/hermes/skills/skills_manifest.sha256
+```
+
+#### 2.2.2 Startup and Runtime Provenance Verification
+
+1. **Startup Verification in `docker-entrypoint.sh`**:
+   Before launching `hermes gateway run`, `agent-entrypoint` will execute a lightweight verification script (`/opt/defaults/scripts/verify_skills_provenance.py`):
+
+   ```bash
+   python3 /opt/defaults/scripts/verify_skills_provenance.py --manifest /opt/hermes/skills/skills_manifest.sha256 --dir /opt/hermes/skills/
+   ```
+
+   If verification fails (missing file, checksum mismatch, or unauthorized new file), the container logs a critical security alert and fails to start.
+
+2. **Runtime Protection & Quarantining**:
+   - The directory `/opt/hermes/skills/` will be owned by `root:root` with mode `0555` (read/execute only for the `hermes` runtime user).
+   - Whenever the agent calls `skill_view` or loads a skill, an internal integrity check verifies that the skill's file hash matches `skills_manifest.sha256`. If a mismatch is detected, the skill is quarantined and excluded from the catalog.
+
+---
+
+### 2.3 Component 3: Mandatory User Confirmation for State-Changing Operations
+
+#### 2.3.1 Operational Tiering Model
+
+We define three strict operational tiers for Platform Agent tool execution:
+
+| Tier       | Category                             | Examples                                                                                                                                                                    | Autonomy & Confirmation Policy                                                                                                           |
+| :--------- | :----------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| **Tier 0** | **Read-Only / Diagnostic**           | `kubectl get/describe/logs`, `gcloud logging read`, `verify_gke_cluster`, `skill_view`, memory queries, local dry-run file generation in `/opt/data/scratch/`               | **Fully Autonomous**. Execute immediately without user prompt.                                                                           |
+| **Tier 1** | **State-Changing (Non-Destructive)** | Applying/updating Config Connector resources, submitting GitOps PRs via `submit-suggestion`, scaling deployments, onboarding applications, creating non-production clusters | **Explicit User Confirmation Required**. Must present formatted diff/dry-run summary and receive explicit confirmation before execution. |
+| **Tier 2** | **Destructive / Irreversible**       | Cluster deletion, tenant offboarding, broad IAM revocation, persistent volume deletion, production data mutation                                                            | **Explicit Multi-Step Confirmation Required**. Must state impact warnings and require explicit positive confirmation.                    |
+
+#### 2.3.2 Updates to `SOUL.md` and `AGENTS.md`
+
+We will update `agents/platform/SOUL.md` (Section 1, Core Truths, and Section 3, Dynamic Query Execution Policy) and `agents/platform/AGENTS.md` to enforce the following rules:
+
+1. **Mandatory State-Changing Confirmation Rule**:
+   - _Proposed wording in `SOUL.md`_:
+     > **Explicit Confirmation for State-Changing Operations:** You operate with full autonomy when conducting read-only investigations, diagnostic queries, and local scratch-space planning (Tier 0). However, **any operation that modifies cluster state, creates or updates external cloud resources, submits a GitOps Pull Request, or alters tenancy configurations (Tier 1 & Tier 2) requires explicit human confirmation.** Before executing a state-changing tool call, you must present a structured summary of the proposed change (including target cluster/namespace, resource names, and key configuration diffs) and ask the user for confirmation.
+2. **Refining "User Intent Priority"**:
+   - We will replace the directive _"if the expected user response... would simply be 'yes', 'go ahead'... do not ask the question; proceed autonomously"_ with an explicit boundary that restricts auto-proceed behavior strictly to **Tier 0 read-only diagnostic sequences**.
+
+---
+
+## 3. Code Comment Compatibility Analysis & Open Design Questions
+
+During our analysis of the codebase, we identified four specific inline code comments and autonomy rules that could conflict with or be impacted by this design proposal. In accordance with task requirements, we explicitly raise these as design questions for platform engineering review:
+
+### Question 1: Reserved Framework Key (`# platform_toolsets is a reserved framework key in Hermes.`) in `config.yaml`
+
+- **Context & Code Comment**:  
+  In `agents/platform/config.yaml` (lines 23–24), the configuration explicitly documents:
+  ```yaml
+  # Explicitly list platform_toolsets
+  # platform_toolsets is a reserved framework key in Hermes.
+  platform_toolsets:
+    cli:
+      - hermes-cli
+      ...
+  ```
+- **Potential Conflict**:  
+  If restricting `hermes-cli` execution bounds required removing `hermes-cli` from `platform_toolsets.cli` or modifying the schema of `platform_toolsets`, it would violate the reserved framework contract in Hermes.
+- **Proposed Approach & Question**:  
+  Our design introduces a separate `execution_bounds:` block in `config.yaml` and enforces restrictions via the `tool_call_audit` plugin, leaving `platform_toolsets` unmodified.
+  > **Open Question 1:** Does enforcing `hermes-cli` restrictions via `execution_bounds` and `tool_call_audit` satisfy the framework contract for `# platform_toolsets is a reserved framework key in Hermes.`, or should we also implement an upstream wrapper/entrypoint in Hermes core that natively interprets `execution_bounds`?
+
+---
+
+### Question 2: Command Timeouts (`# 5-minute timeout to support long GKE reasoning chains`) in `config.yaml`
+
+- **Context & Code Comment**:  
+  In `agents/platform/config.yaml` (line 8), under the `platform_control` MCP server config, the comment states:
+  ```yaml
+  # 5-minute timeout to support long GKE reasoning chains
+  timeout: 300
+  ```
+  Similarly, `agent_common_server.py` (line 108) notes: `# 5-minute timeout to accommodate complex reasoning loops`.
+- **Potential Conflict**:  
+  To restrict `hermes-cli` execution bounds (`SKILL-003`), our design sets a `command_timeout_seconds: 60` default for shell commands to prevent hanging processes and resource exhaustion. However, if a developer invokes a legitimate local integration test or diagnostic script via `hermes-cli`, a 60-second shell timeout could prematurely kill tasks that require up to 300 seconds.
+- **Proposed Approach & Question**:  
+  We propose a **differentiated timeout model**: MCP reasoning calls and complex multi-cluster queries retain the 300-second timeout (`timeout: 300`), while raw `hermes-cli` shell execution commands default to 60 seconds unless explicitly whitelisted as long-running diagnostic scripts.
+  > **Open Question 2:** Should `hermes-cli` shell execution commands inherit the full 300-second timeout defined for `# 5-minute timeout to support long GKE reasoning chains`, or is the proposed 60-second default for general shell commands (with 300 seconds reserved for MCP calls and whitelisted scripts) preferred?
+
+---
+
+### Question 3: Autonomy Override Rules (`User Intent Priority` / "Loop-Until-Done" vs. State-Changing Confirmation) in `SOUL.md`
+
+- **Context & Code Comment**:  
+  In `agents/platform/SOUL.md` (lines 16–17), the current rules state:
+  ```markdown
+  - **Autonomous Recovery & Loop-Until-Done:** When executing a request... continue through blockers until the requested outcome is achieved...
+  - **User Intent Priority:** Phrases such as "fix it for me", "directly", "do it", and "loop until done" indicate that the user expects autonomous remediation... As a general rule: if the expected user response to a clarification or permission query would simply be "yes", "go ahead", or equivalent permission, do not ask the question; proceed autonomously...
+  ```
+- **Potential Conflict**:  
+  Mandating explicit user confirmation for **all state-changing operations** (`SKILL-005`) directly conflicts with `User Intent Priority` when a user prompts the agent with phrases like _"fix it for me directly"_ or _"loop until done"_.
+- **Proposed Approach & Question**:  
+  We propose that **Mandatory State-Changing Confirmation takes precedence** over `User Intent Priority` by default. Even when a user says _"fix it for me"_, the agent must autonomously diagnose and prepare the fix (Tier 0), present the exact diff/PR link, and await confirmation before applying (Tier 1).
+  > **Open Question 3:** Should explicit override phrases like _"fix it for me directly"_ or an explicit prompt flag (e.g., `--auto-confirm`) permit the agent to bypass Tier 1 (non-destructive state-changing) confirmation, or should Tier 1 confirmation remain an inviolable boundary regardless of user phrasing?
+
+---
+
+### Question 4: Alignment with Meta-Skill Wording (`seeking user confirmation before applying state-changing implementations`) in `gke-productionize/SKILL.md`
+
+- **Context & Code Comment**:  
+  In `agents/platform/skills/gke-productionize/SKILL.md` (line 108), the existing guidance already states:
+  ```markdown
+  - **Proactive Execution**: Proactively execute relevant skills (e.g., observability, security, scaling, reliability) to assess and propose improvements, seeking user confirmation before applying state-changing implementations.
+  ```
+- **Potential Conflict / Opportunity**:  
+  Notice that `gke-productionize/SKILL.md` already enforces the exact boundary we propose for `SOUL.md`: proactive autonomous discovery/assessment, but **mandatory user confirmation before applying state-changing implementations**.
+- **Proposed Approach & Question**:  
+  We propose adopting the exact phrasing from `gke-productionize/SKILL.md` across `SOUL.md`, `AGENTS.md`, and all 20 skills in `agents/platform/skills/` to establish a uniform fleet standard.
+  > **Open Question 4:** Does adopting the explicit standard from `gke-productionize/SKILL.md` (`seeking user confirmation before applying state-changing implementations`) as a universal global Core Truth in `SOUL.md` fully satisfy `SKILL-005` and `SKILL-007` across all specialized agent skills?
+
+---
+
+## 4. Verification, Testing & Rollout Strategy
+
+### 4.1 Automated Unit & Provenance Verification
+
+1. **Provenance Script Tests**:
+   - Unit tests in `tests/unit/test_verify_skills_provenance.py` will test `verify_skills_provenance.py` against valid manifests, corrupted hashes, missing files, and untracked injected scripts.
+2. **Execution Bounds Tests**:
+   - Unit tests for the `tool_call_audit` pre-execution validator will assert that standard development commands (`git status`, `kubectl get -o json`, `pytest`) succeed, while blocked commands (`rm -rf /`, `sudo`, `curl | bash`) raise `PermissionError`.
+
+### 4.2 Integration & E2E Testing
+
+1. **Container Startup Test**:
+   - Build the docker image (`docker build --target platform -t kube-agents:test .`) and verify that `docker-entrypoint.sh` succeeds when `skills_manifest.sha256` is valid, and aborts container startup if a skill file is mutated.
+2. **HITL Confirmation E2E Workflow**:
+   - Extend `tests/e2e/gchat_agent_test.py` to assert that when an agent is instructed to provision or modify a cluster, it emits a structured dry-run plan and pauses for confirmation rather than immediately calling state-changing tools.
+
+### 4.3 Rollout Phases
+
+- **Phase 1 (Non-Breaking Governance Sync)**: Merge `config.yaml` (`execution_bounds`), Dockerfile provenance generation, and `SOUL.md` updates.
+- **Phase 2 (Enforcement Enablement)**: Activate runtime execution bounds checking in `tool_call_audit` in staging environments, monitoring audit telemetry for any false-positive command rejections before production fleet rollout.
+
+---
+
+## 5. Summary of Affected Files & Changes
+
+| File Path                            | Nature of Change                                                                                                                       | Findings Addressed       |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------- | :----------------------- |
+| `agents/platform/config.yaml`        | Add `execution_bounds.hermes_cli` block defining allowed binary prefixes, blocked patterns, writable paths, and command timeout.       | `SKILL-003`, `SKILL-007` |
+| `deploy/docker/Dockerfile`           | Add `sha256sum` manifest generation step for `/opt/hermes/skills/skills_manifest.sha256` and set read-only permissions.                | `SKILL-004`              |
+| `deploy/shared/docker-entrypoint.sh` | Add startup check invoking `verify_skills_provenance.py` before starting the agent gateway.                                            | `SKILL-004`              |
+| `agents/platform/SOUL.md`            | Update Core Truths and Dynamic Query Policy to require explicit user confirmation for all state-changing operations (Tier 1 & Tier 2). | `SKILL-005`, `SKILL-007` |
+| `agents/platform/AGENTS.md`          | Align Red Lines and Red Rules with mandatory state-changing confirmation and read-only skill provenance rules.                         | `SKILL-005`, `SKILL-007` |
+| `agents/platform/skills/*`           | Align skill descriptions with standard HITL confirmation phrasing from `gke-productionize/SKILL.md`.                                   | `SKILL-005`              |


### PR DESCRIPTION
# Pull Request

## Why This Change


This PR implements the approved Technical Design Specification for Buganizer Task 537148480 ('Agent Autonomy & Tool Execution Boundaries'), addressing four critical security and governance findings (`SKILL-003`, `SKILL-004`, `SKILL-005`, `SKILL-007`). It establishes declarative shell execution bounds for `hermes-cli`, build-time cryptographic skill provenance manifests with runtime startup verification, and mandatory Human-in-the-Loop (HITL) confirmation for all state-changing operations.

## What Changed


1. **Execution Bounds for `hermes-cli` Shell Access (`SKILL-003`, `SKILL-007`)**: Added an explicit `execution_bounds.hermes_cli` block to `agents/platform/config.yaml` defining allowed binary prefixes, blocked command patterns, command timeout, and filesystem write/read-only confinement. Enforced these boundaries via a new `verify_execution_bounds` pre-execution hook in `agents/platform/defaults/plugins/tool_call_audit/audit.py`.
2. **Skill Provenance & Integrity Verification (`SKILL-004`)**: Added a Docker build step in `deploy/docker/Dockerfile` to compute an immutable SHA-256 checksum manifest (`/opt/hermes/skills/skills_manifest.sha256`) and restrict directory permissions to `root:root` with mode `0555` / `0444`. Added a startup provenance check in `deploy/shared/docker-entrypoint.sh` invoking a new lightweight script `agents/platform/scripts/verify_skills_provenance.py` before launching the agent gateway.
3. **Mandatory State-Changing Confirmation (`SKILL-005`, `SKILL-007`)**: Updated `agents/platform/SOUL.md` (Core Truths and Dynamic Query Execution Policy), `agents/platform/AGENTS.md` (Red Lines), and all 20 skills under `agents/platform/skills/` to enforce explicit user confirmation with structured dry-run diffs before applying any state-changing operations (Tier 1 & Tier 2).

**Files:**

- `agents/platform/config.yaml`
- `agents/platform/defaults/plugins/tool_call_audit/audit.py`
- `deploy/docker/Dockerfile`
- `deploy/shared/docker-entrypoint.sh`
- `agents/platform/scripts/verify_skills_provenance.py`
- `agents/platform/SOUL.md`
- `agents/platform/AGENTS.md`
- `agents/platform/skills/*/SKILL.md`
- `tests/unit/test_tool_call_audit.py`
- `tests/unit/test_verify_skills_provenance.py`

**Added/Changed/Fixed:**

- Added `execution_bounds.hermes_cli` declarative policy in `agents/platform/config.yaml` and implemented `verify_execution_bounds` in `tool_call_audit`.
- Added `agents/platform/scripts/verify_skills_provenance.py` and hooked runtime integrity verification into `deploy/shared/docker-entrypoint.sh`.
- Added SHA-256 manifest generation (`skills_manifest.sha256`) and `root:root` read-only permissions for `/opt/hermes/skills/` in `deploy/docker/Dockerfile`.
- Updated `agents/platform/SOUL.md`, `agents/platform/AGENTS.md`, and all 20 `SKILL.md` definitions to require explicit user confirmation before applying state-changing implementations.
- Added automated unit test suites `tests/unit/test_tool_call_audit.py` and `tests/unit/test_verify_skills_provenance.py`.

## Why This Matters

- Prevents unauthorized shell execution, filesystem mutation, and resource exhaustion by untrusted or hallucinating reasoning loops (`SKILL-003`, `SKILL-007`).
- Ensures skill files in `/opt/hermes/skills/` cannot be tampered with or injected with malicious prompts at runtime (`SKILL-004`).
- Eliminates ambiguity between autonomous read-only diagnostic investigation (Tier 0) and infrastructure-mutating actions (Tier 1 & Tier 2), ensuring state-changing operations are always reviewed by a human operator (`SKILL-005`, `SKILL-007`).

## Context


- Buganizer Task: 537148480
- Addresses Findings: SKILL-003, SKILL-004, SKILL-005, SKILL-007
- Replaces proposed design document (`docs/design_proposals/design_537148480.md`) with concrete code implementation on branch `feature/design-537148480` (PR #483).

## Testing

- Ran unit tests `python3 -m unittest discover -s tests/unit -p "test_*.py"`: all 11 tests passed.
- Ran existing platform script test suites (`test_agent_common_server.py`, `test_credential_proxy.py`, `test_github_token_refresh.py`): all tests passed.
- Validated formatting with `npx prettier --write` and compiled Python scripts with `python3 -m py_compile`.

---


Functional impact is strictly additive for security governance and audit enforcement. Rollout is low risk, with immediate startup integrity checking and runtime command bounds enforcement.