### PR TITLE
feat(install): make container image registry configurable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,6 +110,20 @@ make gcp-provision
 > `cd k8s-operator && make help` for the complete, always-current list of provisioning and teardown
 > targets.
 
+- **Private container registry**: If your clusters cannot pull from `ghcr.io`, mirror the
+  kube-agents images into your own registry and export `REGISTRY_PREFIX` before provisioning:
+
+  ```bash
+  export REGISTRY_PREFIX=registry.example.com/kube-agents
+  make gcp-provision
+  ```
+
+  The prefix replaces `ghcr.io/gke-labs/kube-agents` as the default for the operator, agent, and
+  replay-proxy images (the individual `OPERATOR_IMAGE`, `AGENT_IMAGE`, and `REPLAY_IMAGE`
+  variables still win). See the
+  [Docker images guide](docs/site/src/content/docs/deploy/docker-images.md) for the full list of
+  images to mirror and the operator-level override env vars.
+
 #### Step 3: Verify Running Components
 
 Verify that the operator, LiteLLM gateway, and custom resources are healthy:
@@ -242,6 +256,18 @@ Install the Custom Resource Definitions (CRDs) and deploy the controller manager
 make install
 make deploy IMG=$IMG
 ```
+
+If the agent images are mirrored into a private registry as well, tell the operator where to
+find them (used whenever a `PlatformAgent` CR does not set `spec.deployment.image`):
+
+```bash
+kubectl set env deployment/kubeagents-controller-manager -n kubeagents-system \
+  PLATFORM_AGENT_IMAGE=registry.example.com/kube-agents/platform-agent:latest \
+  FLUENT_BIT_IMAGE=registry.example.com/mirror/fluent-bit:5.0.7
+```
+
+See the [Docker images guide](docs/site/src/content/docs/deploy/docker-images.md) for all
+override env vars and their precedence.
 
 Verify controller readiness:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,17 +109,19 @@ PR that touches one of these files as a change to documented identifiers and
 uses this table to find what to re-verify; when a new category of documented
 identifier appears, add its source here.
 
-| Identifier                                                | Source of truth                                                                        |
-| --------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Service-account names, namespace, permission-set defaults | `k8s-operator/scripts/common.sh`                                                       |
-| Go toolchain version                                      | `k8s-operator/go.mod`                                                                  |
-| Toolsets, plugins, and MCP servers of an agent profile    | that profile's `config.yaml` (`agents/platform/`, `agents/chat/`, `agents/cluster/`)   |
-| Cron job rosters and schedules                            | the profile's cron `jobs.json` (`agents/platform/cron/`, `agents/chat/defaults/cron/`) |
-| Persona rules and `§N` section numbering                  | the profile's `SOUL.md`                                                                |
-| RBAC bindings and KSA defaults laid down per agent        | `k8s-operator/internal/controller/platformagent_manifests.go`                          |
-| Controller permissions                                    | `k8s-operator/config/rbac/`                                                            |
-| `make` targets                                            | the root `Makefile` and `k8s-operator/Makefile`                                        |
-| Paths baked into the agent image (`/opt/defaults/...`)    | `deploy/docker/Dockerfile`                                                             |
+| Identifier                                                           | Source of truth                                                                        |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Service-account names, namespace, permission-set defaults            | `k8s-operator/scripts/common.sh`                                                       |
+| Go toolchain version                                                 | `k8s-operator/go.mod`                                                                  |
+| Toolsets, plugins, and MCP servers of an agent profile               | that profile's `config.yaml` (`agents/platform/`, `agents/chat/`, `agents/cluster/`)   |
+| Cron job rosters and schedules                                       | the profile's cron `jobs.json` (`agents/platform/cron/`, `agents/chat/defaults/cron/`) |
+| Persona rules and `§N` section numbering                             | the profile's `SOUL.md`                                                                |
+| RBAC bindings and KSA defaults laid down per agent                   | `k8s-operator/internal/controller/platformagent_manifests.go`                          |
+| Controller permissions                                               | `k8s-operator/config/rbac/`                                                            |
+| `make` targets                                                       | the root `Makefile` and `k8s-operator/Makefile`                                        |
+| Paths baked into the agent image (`/opt/defaults/...`)               | `deploy/docker/Dockerfile`                                                             |
+| Image defaults and override env vars (`PLATFORM_AGENT_IMAGE` et al.) | `k8s-operator/internal/controller/manifest_helpers.go`                                 |
+| Registry prefix default (`REGISTRY_PREFIX`)                          | `k8s-operator/scripts/common.sh`                                                       |
 
 ## 3. Documentation eras and status
 
@@ -234,7 +236,7 @@ only what the title does not say.
 | `install/uninstall.md`                     | Site page | Removing the agent, operator, and provisioned GCP resources; agent-only vs full teardown.                                                | Teardown                                                       | —                                                                         |
 | `deploy/index.md`                          | Site page | Hub for the deploy section: Docker, Kustomize, Minty, telemetry.                                                                         | Navigation                                                     | —                                                                         |
 | `deploy/kustomize.md`                      | Site page | What ships in `deploy/kustomize/` and what the operator lays down on top of it.                                                          | Base vs operator-created objects                               | —                                                                         |
-| `deploy/docker-images.md`                  | Site page | The images shipped from this repo and how tags are managed.                                                                              | Image list, base pin, CI                                       | —                                                                         |
+| `deploy/docker-images.md`                  | Site page | The images shipped from this repo and how tags are managed.                                                                              | Image list, base pin, registry overrides, CI                   | —                                                                         |
 | `deploy/token-minter.md`                   | Site page | Minty: the in-cluster broker minting short-lived GitHub App installation tokens; no long-lived secret on disk.                           | Token flow, KMS-held key, setup                                | Operator-side README: `k8s-operator/config/integrations/github/README.md` |
 | `deploy/telemetry.md`                      | Site page | Where OTel, Prometheus, and Cloud Logging fit in the shipping deploy (GKE-managed collectors).                                           | What runs where, non-GKE clusters                              | —                                                                         |
 | `operator/index.md`                        | Site page | Overview of the Kubebuilder controller reconciling `PlatformAgent` CRs and the resources it manages.                                     | Managed resources, webhooks, layout                            | —                                                                         |

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -1205,6 +1205,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1220,6 +1223,9 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1237,6 +1243,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1252,6 +1261,9 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1269,6 +1281,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1284,6 +1299,9 @@
       "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1301,6 +1319,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1317,6 +1338,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1332,6 +1356,9 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1355,6 +1382,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1376,6 +1406,9 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1399,6 +1432,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1420,6 +1456,9 @@
       "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1443,6 +1482,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1465,6 +1507,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1486,6 +1531,9 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -1205,9 +1205,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1223,9 +1220,6 @@
       "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1243,9 +1237,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1261,9 +1252,6 @@
       "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1281,9 +1269,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1299,9 +1284,6 @@
       "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1319,9 +1301,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1338,9 +1317,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1356,9 +1332,6 @@
       "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1382,9 +1355,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1406,9 +1376,6 @@
       "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1432,9 +1399,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1456,9 +1420,6 @@
       "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1482,9 +1443,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1507,9 +1465,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1531,9 +1486,6 @@
       "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -67,6 +67,41 @@ FROM nousresearch/hermes-agent:${HERMES_AGENT_TAG} AS agent-base
 
 Bumping Hermes = updating `tags.env` (a single-line change) and rebuilding.
 
+## Private / custom registry
+
+Installs that cannot pull from public registries (behind-the-firewall clusters) can mirror the
+images into their own registry and point every layer of the install at it. Mirror the four
+published images above, plus the `fluent/fluent-bit:5.0.7` logging sidecar the operator injects
+into agent pods.
+
+The registry is configurable at three layers, from broadest to most specific:
+
+1. **Provisioning scripts** — export `REGISTRY_PREFIX` (e.g.
+   `registry.example.com/kube-agents`) before running the `provision_*.sh` scripts. It replaces
+   `ghcr.io/gke-labs/kube-agents` as the default for the operator image (`provision_03`), the
+   agent image (`provision_08`), and the replay proxy (`provision_11`). The individual
+   `OPERATOR_IMAGE`, `AGENT_IMAGE`, and `REPLAY_IMAGE` variables still override the prefix.
+   When `REGISTRY_PREFIX` (or an explicit `PLATFORM_AGENT_IMAGE`) is set, `provision_03` also
+   sets `PLATFORM_AGENT_IMAGE` on the operator Deployment; `AGENT_IMAGE` itself only feeds the
+   CR rendered in `provision_08`.
+2. **Operator environment** — the controller manager reads three optional env vars (see the
+   commented block in `k8s-operator/config/manager/manager.yaml`):
+   - `PLATFORM_AGENT_IMAGE` — default agent image when a `PlatformAgent` CR omits
+     `spec.deployment.image`.
+   - `CREDENTIAL_PROXY_IMAGE` — explicit credential-proxy sidecar image. When unset, the proxy
+     image is derived from the agent image (same registry and tag, image name `platform-agent`
+     mapped to `credential-proxy`), so mirrors that keep the image names only need
+     `PLATFORM_AGENT_IMAGE`.
+   - `FLUENT_BIT_IMAGE` — replaces the Docker Hub `fluent/fluent-bit` sidecar image.
+3. **Per-agent CR** — `spec.deployment.image` / `spec.deployment.tag` on a `PlatformAgent`
+   override the defaults above for that agent's containers, and the credential-proxy image is
+   derived from them — unless an explicit `CREDENTIAL_PROXY_IMAGE` is set, which always wins
+   for the sidecar. See the
+   [PlatformAgent CRD reference](/kube-agents/operator/platformagent-crd/).
+
+If the private registry requires authentication, configure node-level pull credentials (or
+mirror through a pull-through cache); the operator does not currently manage `imagePullSecrets`.
+
 ## Local builds
 
 For development iteration, `make dev-rebuild-agent` (from `k8s-operator/`) is the fast path — it builds and pushes to a dev Artifact Registry repo and restarts the Deployment. See [Development](/kube-agents/operator/development/#fast-agent-iteration-dev-only).

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -66,7 +66,7 @@ Abstracts the pod/deployment configuration. The controller synthesises a `Deploy
 - `podAnnotations` — annotations applied to the generated pod template.
 - `scaleToZero` — when `true`, scales the deployment to 0 replicas (idle cost saving).
 
-Default image: `ghcr.io/gke-labs/kube-agents/platform-agent:latest`. Rebuild with `make dev-rebuild-agent ARGS="platform"` for local iteration.
+Default image: `ghcr.io/gke-labs/kube-agents/platform-agent:latest`, overridable operator-wide via the `PLATFORM_AGENT_IMAGE` env var on the controller manager (see [Docker images § Private / custom registry](/kube-agents/deploy/docker-images/#private--custom-registry)). Rebuild with `make dev-rebuild-agent ARGS="platform"` for local iteration.
 
 ## `spec.security`
 

--- a/k8s-operator/config/manager/manager.yaml
+++ b/k8s-operator/config/manager/manager.yaml
@@ -46,6 +46,18 @@ spec:
           env:
             - name: ENABLE_WEBHOOKS
               value: "true"
+            # Private-registry installs: uncomment (or patch via kustomize) to
+            # point the images the operator deploys at your own registry.
+            # PLATFORM_AGENT_IMAGE is the default agent image when a
+            # PlatformAgent CR omits spec.deployment.image; the credential-proxy
+            # sidecar image is derived from the agent image unless
+            # CREDENTIAL_PROXY_IMAGE is set explicitly.
+            # - name: PLATFORM_AGENT_IMAGE
+            #   value: "registry.example.com/kube-agents/platform-agent:latest"
+            # - name: CREDENTIAL_PROXY_IMAGE
+            #   value: "registry.example.com/kube-agents/credential-proxy:latest"
+            # - name: FLUENT_BIT_IMAGE
+            #   value: "registry.example.com/mirror/fluent-bit:5.0.7"
           ports:
             - containerPort: 8081
               name: health

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,7 +36,15 @@ import (
 )
 
 const (
-	defaultPlatformAgentImage = "ghcr.io/gke-labs/kube-agents/platform-agent:latest"
+	fallbackPlatformAgentImage = "ghcr.io/gke-labs/kube-agents/platform-agent:latest"
+	fallbackFluentBitImage     = "fluent/fluent-bit:5.0.7"
+
+	// Operator-level image overrides for installs that mirror images into a
+	// private registry. Set on the controller-manager Deployment; a CR's
+	// spec.deployment.image still takes precedence over PLATFORM_AGENT_IMAGE.
+	platformAgentImageEnvVar   = "PLATFORM_AGENT_IMAGE"
+	credentialProxyImageEnvVar = "CREDENTIAL_PROXY_IMAGE"
+	fluentBitImageEnvVar       = "FLUENT_BIT_IMAGE"
 
 	// managedOTelEndpoint is the OTLP/HTTP endpoint of the GKE Managed OpenTelemetry
 	// collector. The same endpoint is already used by the LiteLLM integration, so agent
@@ -71,6 +80,25 @@ func otelTelemetryEnvVars(agentType, name, namespace string) []corev1.EnvVar {
 			),
 		},
 	}
+}
+
+// defaultPlatformAgentImage returns the agent image used when a CR omits
+// spec.deployment.image: the PLATFORM_AGENT_IMAGE env var if set, else the
+// public ghcr.io default.
+func defaultPlatformAgentImage() string {
+	if img := os.Getenv(platformAgentImageEnvVar); img != "" {
+		return img
+	}
+	return fallbackPlatformAgentImage
+}
+
+// fluentBitImage returns the logging sidecar image: the FLUENT_BIT_IMAGE env
+// var if set, else the public Docker Hub default.
+func fluentBitImage() string {
+	if img := os.Getenv(fluentBitImageEnvVar); img != "" {
+		return img
+	}
+	return fallbackFluentBitImage
 }
 
 // resolveAgentImage determines the full image reference using the optional deployment spec and a fallback default.

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -1256,15 +1256,14 @@ func buildCredentialProxyVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Vo
 
 // resolveCredentialProxyImage returns the credential-proxy sidecar image. An
 // explicit CREDENTIAL_PROXY_IMAGE env var wins; otherwise the image is derived
-// from the agent image (same registry, name platform-agent → credential-proxy).
+// from the resolved agent image — same registry and tag as the image the agent
+// container actually runs, with the name platform-agent → credential-proxy —
+// so agent and sidecar can never end up on different versions.
 func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) string {
 	if override := os.Getenv(credentialProxyImageEnvVar); override != "" {
 		return override
 	}
-	image := defaultPlatformAgentImage()
-	if deployment != nil && deployment.Image != "" {
-		image = deployment.Image
-	}
+	image := resolveAgentImage(deployment, defaultPlatformAgentImage())
 	lastSlash := strings.LastIndex(image, "/")
 	prefix, name := "", image
 	if lastSlash >= 0 {
@@ -1272,7 +1271,12 @@ func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) strin
 	}
 	suffix := ""
 	if digest := strings.Index(name, "@"); digest >= 0 {
-		suffix, name = name[digest:], name[:digest]
+		// The agent image's digest cannot name the proxy image; fall back to
+		// the tag field or latest.
+		name = name[:digest]
+		if deployment != nil && deployment.Tag != nil && *deployment.Tag != "" {
+			suffix = ":" + *deployment.Tag
+		}
 	} else if tag := strings.LastIndex(name, ":"); tag >= 0 {
 		suffix, name = name[tag:], name[:tag]
 	}
@@ -1280,9 +1284,6 @@ func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) strin
 		name = "credential-proxy"
 	} else {
 		name += "-credential-proxy"
-	}
-	if deployment != nil && deployment.Tag != nil && *deployment.Tag != "" {
-		return prefix + name + ":" + *deployment.Tag
 	}
 	if suffix == "" {
 		suffix = ":latest"

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -21,6 +21,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 
@@ -632,7 +633,7 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 		saName = agent.Spec.Security.ServiceAccountName
 	}
 
-	image := resolveAgentImage(agent.Spec.Deployment, defaultPlatformAgentImage)
+	image := resolveAgentImage(agent.Spec.Deployment, defaultPlatformAgentImage())
 	pullPolicy := corev1.PullAlways
 	if agent.Spec.Deployment != nil && agent.Spec.Deployment.ImagePullPolicy != nil {
 		pullPolicy = *agent.Spec.Deployment.ImagePullPolicy
@@ -1253,8 +1254,14 @@ func buildCredentialProxyVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Vo
 	}
 }
 
+// resolveCredentialProxyImage returns the credential-proxy sidecar image. An
+// explicit CREDENTIAL_PROXY_IMAGE env var wins; otherwise the image is derived
+// from the agent image (same registry, name platform-agent → credential-proxy).
 func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) string {
-	image := defaultPlatformAgentImage
+	if override := os.Getenv(credentialProxyImageEnvVar); override != "" {
+		return override
+	}
+	image := defaultPlatformAgentImage()
 	if deployment != nil && deployment.Image != "" {
 		image = deployment.Image
 	}
@@ -1414,7 +1421,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 
 	containers = append(containers, corev1.Container{
 		Name:  "fluent-bit",
-		Image: "fluent/fluent-bit:5.0.7",
+		Image: fluentBitImage(),
 		Args: []string{
 			"-c",
 			"/fluent-bit/etc/fluent-bit.conf",

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -995,6 +995,18 @@ func TestResolveCredentialProxyImagePreservesTag(t *testing.T) {
 	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: "example/platform-agent"}); got != "example/credential-proxy:latest" {
 		t.Fatalf("expected explicit latest tag for untagged sidecar image: %s", got)
 	}
+	// A tag embedded in the image wins over the tag field, matching the agent container.
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: "example/platform-agent:v2", Tag: ptr.To("latest")}); got != "example/credential-proxy:v2" {
+		t.Fatalf("expected sidecar tag to follow the agent image's embedded tag: %s", got)
+	}
+	// The agent image's digest cannot name the proxy image; fall back to latest.
+	digestImage := "example/platform-agent@sha256:a6ce64e2038867885c2c90f6602425e6e70293d5e6d952a0e603a99265e01c40"
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: digestImage}); got != "example/credential-proxy:latest" {
+		t.Fatalf("expected latest tag for digest-pinned agent image: %s", got)
+	}
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: digestImage, Tag: ptr.To("v3")}); got != "example/credential-proxy:v3" {
+		t.Fatalf("expected tag field for digest-pinned agent image: %s", got)
+	}
 }
 
 func TestImageEnvOverrides(t *testing.T) {
@@ -1006,6 +1018,12 @@ func TestImageEnvOverrides(t *testing.T) {
 	// The credential proxy follows the overridden agent image's registry.
 	if got := resolveCredentialProxyImage(nil); got != "registry.corp/mirror/credential-proxy:v1.2.3" {
 		t.Fatalf("expected credential proxy derived from PLATFORM_AGENT_IMAGE, got %s", got)
+	}
+	// A deployment block without an image gets tag: "latest" defaulted by the
+	// CRD/webhook; the sidecar must still follow PLATFORM_AGENT_IMAGE's tag,
+	// exactly like the agent container does.
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Tag: ptr.To("latest")}); got != "registry.corp/mirror/credential-proxy:v1.2.3" {
+		t.Fatalf("expected sidecar tag in lockstep with PLATFORM_AGENT_IMAGE despite defaulted tag field, got %s", got)
 	}
 	// A CR-level image still wins over the operator-level default.
 	if got := resolveAgentImage(&agentv1alpha1.DeploymentSpec{Image: "gcr.io/my-proj/agent:v9"}, defaultPlatformAgentImage()); got != "gcr.io/my-proj/agent:v9" {

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -997,6 +997,52 @@ func TestResolveCredentialProxyImagePreservesTag(t *testing.T) {
 	}
 }
 
+func TestImageEnvOverrides(t *testing.T) {
+	t.Setenv("PLATFORM_AGENT_IMAGE", "registry.corp/mirror/platform-agent:v1.2.3")
+
+	if got := defaultPlatformAgentImage(); got != "registry.corp/mirror/platform-agent:v1.2.3" {
+		t.Fatalf("expected PLATFORM_AGENT_IMAGE to override the default agent image, got %s", got)
+	}
+	// The credential proxy follows the overridden agent image's registry.
+	if got := resolveCredentialProxyImage(nil); got != "registry.corp/mirror/credential-proxy:v1.2.3" {
+		t.Fatalf("expected credential proxy derived from PLATFORM_AGENT_IMAGE, got %s", got)
+	}
+	// A CR-level image still wins over the operator-level default.
+	if got := resolveAgentImage(&agentv1alpha1.DeploymentSpec{Image: "gcr.io/my-proj/agent:v9"}, defaultPlatformAgentImage()); got != "gcr.io/my-proj/agent:v9" {
+		t.Fatalf("expected spec.deployment.image to win over PLATFORM_AGENT_IMAGE, got %s", got)
+	}
+
+	// An explicit proxy override beats derivation, including from a CR image.
+	t.Setenv("CREDENTIAL_PROXY_IMAGE", "registry.corp/mirror/kube-agents-proxy:v1.2.3")
+	if got := resolveCredentialProxyImage(&agentv1alpha1.DeploymentSpec{Image: "example/platform-agent"}); got != "registry.corp/mirror/kube-agents-proxy:v1.2.3" {
+		t.Fatalf("expected CREDENTIAL_PROXY_IMAGE to win, got %s", got)
+	}
+}
+
+func TestFluentBitImageEnvOverride(t *testing.T) {
+	if got := fluentBitImage(); got != "fluent/fluent-bit:5.0.7" {
+		t.Fatalf("unexpected default fluent-bit image: %s", got)
+	}
+	t.Setenv("FLUENT_BIT_IMAGE", "registry.corp/mirror/fluent-bit:5.0.7")
+
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
+	}
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
+	found := false
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		if c.Name == "fluent-bit" {
+			found = true
+			if c.Image != "registry.corp/mirror/fluent-bit:5.0.7" {
+				t.Fatalf("expected FLUENT_BIT_IMAGE override on sidecar, got %s", c.Image)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("fluent-bit sidecar container not found")
+	}
+}
+
 func TestBuildDeploymentGoogleChatAllowedUsersEmpty(t *testing.T) {
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -19,6 +19,17 @@ When any script is run:
 > [!NOTE]
 > Because the provisioning scripts persist configuration state in `vars.sh`, running the script again will reuse the same options selected on the first run. If you want to change configuration variables, manually edit `vars.sh` or perform a teardown first.
 
+### Container images
+
+All kube-agents images default to the `ghcr.io/gke-labs/kube-agents` registry prefix. Export
+`REGISTRY_PREFIX` before running the pipeline to pull mirrored images from a private registry
+instead; it becomes the default for `OPERATOR_IMAGE` (step 03), `AGENT_IMAGE` (step 08), and
+`REPLAY_IMAGE` (step 11), each of which can still be set individually. Step 03 also forwards
+`PLATFORM_AGENT_IMAGE`, `CREDENTIAL_PROXY_IMAGE`, and `FLUENT_BIT_IMAGE` overrides to the
+operator Deployment. See the docs site's
+[Docker images page](../../docs/site/src/content/docs/deploy/docker-images.md) for the list of
+images to mirror and override precedence.
+
 ---
 
 ## File Directory

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -147,6 +147,18 @@ init_var() {
   fi
 }
 
+# ─── Container Registry ───────────────────────────────────────────────────────
+# All kube-agents images (k8s-operator, platform-agent, credential-proxy,
+# replay-proxy) default to this public registry prefix. Behind-the-firewall
+# installs export REGISTRY_PREFIX to pull the mirrored images from a private
+# registry instead; individual *_IMAGE variables still win over the prefix.
+DEFAULT_REGISTRY_PREFIX="ghcr.io/gke-labs/kube-agents"
+
+registry_prefix() {
+  local prefix="${REGISTRY_PREFIX:-$DEFAULT_REGISTRY_PREFIX}"
+  echo "${prefix%/}"
+}
+
 init_var_model_provider() {
   init_var "MODEL_PROVIDER" "gemini" "Enter Model Provider (gemini, anthropic, chatgpt, openai)"
 

--- a/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
+++ b/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
@@ -32,7 +32,7 @@ init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 
-DEFAULT_OPERATOR_IMAGE="ghcr.io/gke-labs/kube-agents/k8s-operator"
+DEFAULT_OPERATOR_IMAGE="$(registry_prefix)/k8s-operator"
 init_var "OPERATOR_IMAGE" "$DEFAULT_OPERATOR_IMAGE" "Enter Operator Image Path"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
@@ -103,6 +103,27 @@ execute_operator() {
   make -C "$OPERATOR_DIR" install || return 1
   print_info "Deploying Operator Controller Manager (${OPERATOR_IMAGE}:${IMAGE_TAG}) to the GKE cluster..."
   make -C "$OPERATOR_DIR" deploy IMG="${IMG:-${OPERATOR_IMAGE}:${IMAGE_TAG}}" || return 1
+
+  # Propagate image overrides to the operator so PlatformAgent CRs created
+  # without an explicit spec.deployment.image also pull from the custom
+  # registry (see PLATFORM_AGENT_IMAGE et al. in config/manager/manager.yaml).
+  local env_overrides=()
+  if [ -n "${PLATFORM_AGENT_IMAGE:-}" ]; then
+    env_overrides+=("PLATFORM_AGENT_IMAGE=${PLATFORM_AGENT_IMAGE}")
+  elif [ -n "${REGISTRY_PREFIX:-}" ]; then
+    env_overrides+=("PLATFORM_AGENT_IMAGE=$(registry_prefix)/platform-agent:${IMAGE_TAG}")
+  fi
+  if [ -n "${CREDENTIAL_PROXY_IMAGE:-}" ]; then
+    env_overrides+=("CREDENTIAL_PROXY_IMAGE=${CREDENTIAL_PROXY_IMAGE}")
+  fi
+  if [ -n "${FLUENT_BIT_IMAGE:-}" ]; then
+    env_overrides+=("FLUENT_BIT_IMAGE=${FLUENT_BIT_IMAGE}")
+  fi
+  if [ ${#env_overrides[@]} -gt 0 ]; then
+    print_info "Setting operator image overrides: ${env_overrides[*]}"
+    kubectl set env deployment/kubeagents-controller-manager -n "${NAMESPACE:-kubeagents-system}" "${env_overrides[@]}" || return 1
+  fi
+
   wait_for_k8s_resource "deployment/kubeagents-controller-manager" "${NAMESPACE:-kubeagents-system}" "Available" "180s" || return 1
 }
 

--- a/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
@@ -40,7 +40,7 @@ init_var_model_provider
 export GSA_NAME="${PLATFORM_AGENT_GSA_NAME}"
 export KSA_NAME="${PLATFORM_AGENT_KSA_NAME}"
 
-DEFAULT_AGENT_IMAGE="ghcr.io/gke-labs/kube-agents/platform-agent"
+DEFAULT_AGENT_IMAGE="$(registry_prefix)/platform-agent"
 init_var "AGENT_IMAGE" "$DEFAULT_AGENT_IMAGE" "Enter Platform Agent Image Path"
 init_var "MEMORY_ENABLED" "false" "Enable agent memory persistence? (true/false)"
 init_var "MEMORY_PROVIDER" "multiuser_memory" "Enter agent memory provider"

--- a/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
@@ -44,7 +44,7 @@ DEFAULT_PROJECT_ID="${ACTIVE_PROJECT:-$(whoami 2>/dev/null || echo "user")}"
 init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
-init_var "REPLAY_IMAGE" "ghcr.io/gke-labs/kube-agents/replay-proxy:${IMAGE_TAG:-latest}" "Enter Replay Proxy container image"
+init_var "REPLAY_IMAGE" "$(registry_prefix)/replay-proxy:${IMAGE_TAG:-latest}" "Enter Replay Proxy container image"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Pull Request

## Why This Change

Today the install assumes all kube-agents containers come from the static public registry (`ghcr.io/gke-labs/kube-agents`). Behind-the-firewall customers need to mirror the images into their own registry and point the whole install at it. Two images had no override path at all: the operator's default agent image was a compile-time Go constant, and the fluent-bit logging sidecar was hardcoded to Docker Hub.

## What Changed

**Files:**

- `k8s-operator/internal/controller/manifest_helpers.go`, `platformagent_manifests.go` — the operator reads three optional env vars: `PLATFORM_AGENT_IMAGE` (default agent image when a CR omits `spec.deployment.image`), `CREDENTIAL_PROXY_IMAGE` (explicit sidecar override; derivation from the agent image is unchanged when unset), and `FLUENT_BIT_IMAGE`. Defaults are unchanged when unset.
- `k8s-operator/config/manager/manager.yaml` — documents the env vars for kustomize patching.
- `k8s-operator/scripts/common.sh`, `provision_03/08/11` — new `REGISTRY_PREFIX` variable derives the defaults for `OPERATOR_IMAGE`, `AGENT_IMAGE`, and `REPLAY_IMAGE`; the individual variables still win. `provision_03` forwards the image overrides to the operator Deployment.
- `docs/site/.../deploy/docker-images.md` — new "Private / custom registry" section (canonical home: which images to mirror, the three override layers, precedence).
- `INSTALL.md`, `k8s-operator/scripts/README.md`, `docs/site/.../operator/platformagent-crd.md`, `docs/README.md` — pointers to the canonical section; map updated.
- `platformagent_manifests_test.go` — unit tests for the env overrides and precedence.

**Added/Changed/Fixed:**

- One knob (`REGISTRY_PREFIX`) for scripted installs; per-image variables and per-CR `spec.deployment.image`/`tag` still take precedence.
- Fluent-bit sidecar image is now overridable (previously impossible).
- No CRD/API changes; no behavior change for existing installs.

## Why This Matters

- Unblocks air-gapped / behind-the-firewall deployments that cannot pull from `ghcr.io` or Docker Hub.

## Context

- Complementary to #493 (versioned releases): that PR injects a version tag at build time and adds a Helm chart; this one adds runtime registry overrides. They touch the same lines in `manifest_helpers.go`, so whichever merges second needs a trivial rebase.
- Follow-ups filed: #499 (`imagePullSecrets` for authenticated private registries), #500 (overrides for third-party integration images: LiteLLM, GitHub token minter).

## Testing

- `make -C k8s-operator test` (includes new unit tests for override precedence)
- `make docs-check`, `make validate`, prettier check on changed files
- `docs/site` `npm ci && npm run build`
- `docker build -f deploy/docker/Dockerfile --target platform`
- `kustomize build config/default`
- `review-docs-drift` skill run against the branch; no blocking findings, advisories addressed

---

No functional impact when the new variables are unset: all defaults resolve to today's values, verified by the existing golden-manifest tests.

---

> **Post-merge note (upgrade impact):** `resolveCredentialProxyImage` now derives the sidecar image from the resolved agent image, so on operator upgrade, existing PlatformAgents with a tagged `spec.deployment.image` (e.g. `...:v5`) roll their credential-proxy sidecar from `:latest` to the agent's tag. This deliberately fixes a pre-existing version skew across the credential path (review issue 6) — "no behavior change for existing installs" above does not hold for that case. Remaining review items are addressed in follow-up #509.
