### PR TITLE
fix(platform): repair the credential-free Slack path

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -374,7 +374,11 @@ class SlackRelay:
         response = self._client(team_id).api_call(
             method, **self._decode_argument(arguments)
         )
-        return dict(response)
+        # WebClient.api_call returns a SlackResponse, which defines __iter__ but
+        # no keys(), so dict() takes it for a sequence of pairs and dies on the
+        # first key. The payload lives on .data; fall back to the response itself
+        # so a plain mapping still works.
+        return dict(getattr(response, "data", response))
 
     def download(self, team_id: str, url: str) -> bytes:
         def is_slack_url(value: str) -> bool:

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -8,13 +8,22 @@ import json
 import logging
 import os
 import sys
+import time
+import urllib.error
 import urllib.request
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 LOGGER = logging.getLogger("slack-relay-patch")
 DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+DEFAULT_RELAY_READY_TIMEOUT = 120.0
+RELAY_READY_POLL_SECONDS = 2.0
+# credential_proxy binds its port before the Slack relay finishes
+# authenticating — relay setup runs on a background thread so a Slack outage
+# cannot wedge the whole proxy — and answers 503 "Slack relay disabled" until
+# then. That is a readiness signal, unlike every other status it can return.
+RELAY_NOT_READY_STATUS = 503
 
 
 def read_upload(path: Path, max_file_bytes: int) -> bytes:
@@ -28,6 +37,46 @@ def read_upload(path: Path, max_file_bytes: int) -> bytes:
     return content
 
 
+def wait_for_relay(
+    send: Callable[[], dict[str, Any]],
+    *,
+    timeout: float,
+    poll: float = RELAY_READY_POLL_SECONDS,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    """Call ``send``, retrying while the relay is still coming up.
+
+    The agent container starts before the credential-proxy sidecar, so the
+    first connect can beat the relay by the better part of a minute. Letting
+    that surface is fatal rather than merely slow: the real bot token lives in
+    the relay, so when the gateway retries it finds no bot credential on the
+    queued config and drops Slack from the retry queue for the life of the pod.
+    Absorb the startup race here, where the relay is the thing being waited on.
+
+    Coming up has two stages, and both have to be waited out — the socket
+    refuses connections until the proxy binds it, then the proxy answers
+    ``RELAY_NOT_READY_STATUS`` until Slack authentication completes.
+    """
+    deadline = monotonic() + timeout
+    while True:
+        try:
+            return send()
+        except urllib.error.HTTPError as error:
+            if error.code != RELAY_NOT_READY_STATUS:
+                # The relay answered; a real error is not a readiness problem.
+                raise
+            if monotonic() >= deadline:
+                raise
+            reason = "has no authenticated workspace yet"
+        except (urllib.error.URLError, OSError):
+            if monotonic() >= deadline:
+                raise
+            reason = "is not accepting connections yet"
+        LOGGER.warning("Slack relay %s; retrying", reason)
+        sleep(poll)
+
+
 def install() -> None:
     relay_url = os.getenv("SLACK_RELAY_URL", "").rstrip("/")
     if not relay_url:
@@ -39,6 +88,15 @@ def install() -> None:
     except ValueError:
         LOGGER.warning("Invalid Slack relay file limit; using the default")
         max_file_bytes = DEFAULT_MAX_FILE_BYTES
+    try:
+        relay_ready_timeout = float(
+            os.getenv(
+                "SLACK_RELAY_READY_TIMEOUT_SECONDS", str(DEFAULT_RELAY_READY_TIMEOUT)
+            )
+        )
+    except ValueError:
+        LOGGER.warning("Invalid Slack relay readiness timeout; using the default")
+        relay_ready_timeout = DEFAULT_RELAY_READY_TIMEOUT
 
     def request(path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
         body = None if payload is None else json.dumps(payload).encode("utf-8")
@@ -125,6 +183,8 @@ def install() -> None:
         if getattr(adapter_class, "_credential_proxy_relay_patched", False):
             return
 
+        from slack_sdk.web.async_slack_response import AsyncSlackResponse
+
         module = sys.modules[adapter_class.__module__]
         real_async_app = module.AsyncApp
         real_async_client = module.AsyncWebClient
@@ -134,10 +194,16 @@ def install() -> None:
         class RemoteSlackClient(real_async_client):
             """Slack SDK client whose generic API calls execute in the proxy."""
 
-            def __init__(self, token: str | None = None, **_kwargs: Any) -> None:
+            def __init__(
+                self, token: str | None = None, team_id: str = "", **_kwargs: Any
+            ) -> None:
                 placeholder = token or "relay:"
                 super().__init__(token=placeholder)
-                self.team_id = (
+                # Prefer the team Bolt resolved from the inbound event. Across
+                # several workspaces the token is a comma-joined list, so
+                # splitting it yields every team at once rather than the one
+                # this request belongs to.
+                self.team_id = team_id or (
                     placeholder.split(":", 1)[1]
                     if placeholder.startswith("relay:")
                     else ""
@@ -164,25 +230,36 @@ def install() -> None:
                     "headers": json_value(headers) if headers else None,
                     "auth": json_value(auth) if auth else None,
                 }
+                supplied = {
+                    key: value
+                    for key, value in arguments.items()
+                    if value is not None
+                }
                 response = await asyncio.to_thread(
                     request,
                     "/v1/chat/slack/api",
                     {
                         "teamId": self.team_id,
                         "method": api_method,
-                        "arguments": {
-                            key: value
-                            for key, value in arguments.items()
-                            if value is not None
-                        },
+                        "arguments": supplied,
                     },
                 )
-                return response.get("response") or {}
-
-        def remote_client_factory(
-            token: str | None = None, **kwargs: Any
-        ) -> RemoteSlackClient:
-            return RemoteSlackClient(token=token, **kwargs)
+                # Hand back the SDK's own response type rather than the bare
+                # payload. Everything downstream is written against the real
+                # client: Bolt's authorization middleware reads .headers off
+                # this to pick up x-oauth-scopes, and a plain dict makes it
+                # die with "'dict' object has no attribute 'headers'" before
+                # any listener runs. The relay does not forward Slack's
+                # response headers, so scope introspection sees none.
+                return AsyncSlackResponse(
+                    client=self,
+                    http_verb=http_verb,
+                    api_url=api_method,
+                    req_args=supplied,
+                    data=response.get("response") or {},
+                    headers={},
+                    status_code=200,
+                ).validate()
 
         def remote_app_factory(
             *_args: Any, token: str | None = None, **kwargs: Any
@@ -194,12 +271,25 @@ def install() -> None:
                 **kwargs,
             )
 
-        module.AsyncWebClient = remote_client_factory
+        module.AsyncWebClient = RemoteSlackClient
         module.AsyncApp = remote_app_factory
+
+        # Bolt does not reuse the client the app was built with. _init_context
+        # constructs a fresh one per request from the AsyncWebClient bound in
+        # its own module, so rebinding only the adapter's name leaves every
+        # request talking to slack.com directly with the "relay:" placeholder
+        # for a token — which fails authorization and silently drops the
+        # message. Rebind the name Bolt actually reads. It has to stay a class,
+        # not a factory: AsyncApp isinstance-checks the client it is handed.
+        from slack_bolt.app import async_app as bolt_async_app
+
+        bolt_async_app.AsyncWebClient = RemoteSlackClient
 
         async def connect(self: Any, *, is_reconnect: bool = False) -> bool:
             bootstrap = await asyncio.to_thread(
-                request, "/v1/chat/slack/bootstrap", {}
+                wait_for_relay,
+                lambda: request("/v1/chat/slack/bootstrap", {}),
+                timeout=relay_ready_timeout,
             )
             workspaces = bootstrap.get("workspaces") or []
             if not workspaces:

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -1,4 +1,7 @@
+import asyncio
+import io
 import json
+import os
 import queue
 import socket
 import subprocess
@@ -25,7 +28,8 @@ from credential_proxy import (
     parse_gke_context,
     read_current_context,
 )
-from slack_relay_patch import read_upload
+import slack_relay_patch
+from slack_relay_patch import read_upload, wait_for_relay
 
 
 class AgentAPIProxyTest(unittest.TestCase):
@@ -680,12 +684,29 @@ class GoogleChatRelayTest(unittest.TestCase):
         self.assertEqual(arguments, result["arguments"])
 
 
+class FakeSlackResponse:
+    """Stand-in for slack_sdk's SlackResponse.
+
+    The real object carries its payload on ``.data`` and defines ``__iter__``
+    without ``keys()``, so ``dict(response)`` raises rather than returning the
+    payload. A fake that is a plain mapping cannot catch that regression.
+    """
+
+    def __init__(self, data):
+        self.data = data
+
+    def __iter__(self):
+        return iter(self.data)
+
+
 class SlackRelayTest(unittest.TestCase):
     class FakeClient:
         token = "xoxb-not-returned"
 
         def api_call(self, method, **arguments):
-            return {"ok": True, "method": method, "arguments": arguments}
+            return FakeSlackResponse(
+                {"ok": True, "method": method, "arguments": arguments}
+            )
 
     def relay(self):
         relay = SlackRelay.__new__(SlackRelay)
@@ -812,6 +833,272 @@ class SlackRelayTest(unittest.TestCase):
             path = Path(directory) / "upload"
             path.write_bytes(b"1234")
             self.assertEqual(b"1234", read_upload(path, 4))
+
+
+class RelayReadinessTest(unittest.TestCase):
+    """The agent container starts before the credential-proxy sidecar.
+
+    A connection error out of the bootstrap call is not recoverable further up:
+    the gateway's reconnect path finds no bot credential on the queued config
+    (the token lives in the relay) and drops Slack until the pod restarts.
+    """
+
+    def clock(self):
+        """A monotonic clock that only advances when the caller sleeps."""
+        now = [0.0]
+        return now, lambda: now[0], lambda seconds: now.__setitem__(0, now[0] + seconds)
+
+    def test_bootstrap_retries_until_the_relay_binds_its_port(self):
+        attempts = []
+
+        def send():
+            attempts.append(None)
+            if len(attempts) < 4:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            return {"workspaces": [{"teamId": "T1"}]}
+
+        _, monotonic, sleep = self.clock()
+        with self.assertLogs("slack-relay-patch", level="WARNING"):
+            result = wait_for_relay(
+                send, timeout=120.0, poll=2.0, monotonic=monotonic, sleep=sleep
+            )
+
+        self.assertEqual({"workspaces": [{"teamId": "T1"}]}, result)
+        self.assertEqual(4, len(attempts))
+
+    def test_bootstrap_gives_up_once_the_deadline_passes(self):
+        def send():
+            raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+
+        _, monotonic, sleep = self.clock()
+        with self.assertLogs("slack-relay-patch", level="WARNING"):
+            with self.assertRaises(urllib.error.URLError):
+                wait_for_relay(
+                    send, timeout=10.0, poll=2.0, monotonic=monotonic, sleep=sleep
+                )
+
+    def http_error(self, status):
+        return urllib.error.HTTPError(
+            "http://127.0.0.1:8765/v1/chat/slack/bootstrap",
+            status,
+            "boom",
+            {},  # type: ignore[arg-type]
+            None,
+        )
+
+    def test_bootstrap_retries_while_the_relay_reports_no_workspace(self):
+        """The proxy binds its port before Slack auth finishes, answering 503."""
+        attempts = []
+
+        def send():
+            attempts.append(None)
+            if len(attempts) < 3:
+                raise self.http_error(503)
+            return {"workspaces": [{"teamId": "T1"}]}
+
+        _, monotonic, sleep = self.clock()
+        with self.assertLogs("slack-relay-patch", level="WARNING"):
+            result = wait_for_relay(
+                send, timeout=120.0, poll=2.0, monotonic=monotonic, sleep=sleep
+            )
+
+        self.assertEqual({"workspaces": [{"teamId": "T1"}]}, result)
+        self.assertEqual(3, len(attempts))
+
+    def test_bootstrap_waits_out_both_startup_stages_in_turn(self):
+        """Connection refused until the port binds, then 503 until auth lands."""
+        attempts = []
+
+        def send():
+            attempts.append(None)
+            if len(attempts) <= 2:
+                raise urllib.error.URLError(ConnectionRefusedError(111, "refused"))
+            if len(attempts) <= 4:
+                raise self.http_error(503)
+            return {"workspaces": [{"teamId": "T1"}]}
+
+        _, monotonic, sleep = self.clock()
+        with self.assertLogs("slack-relay-patch", level="WARNING") as logs:
+            result = wait_for_relay(
+                send, timeout=120.0, poll=2.0, monotonic=monotonic, sleep=sleep
+            )
+
+        self.assertEqual({"workspaces": [{"teamId": "T1"}]}, result)
+        self.assertEqual(5, len(attempts))
+        self.assertEqual(2, sum("not accepting connections" in m for m in logs.output))
+        self.assertEqual(2, sum("no authenticated workspace" in m for m in logs.output))
+
+    def test_a_relay_error_response_is_not_retried(self):
+        attempts = []
+
+        def send():
+            attempts.append(None)
+            raise self.http_error(500)
+
+        _, monotonic, sleep = self.clock()
+        with self.assertRaises(urllib.error.HTTPError):
+            wait_for_relay(
+                send, timeout=120.0, poll=2.0, monotonic=monotonic, sleep=sleep
+            )
+
+        self.assertEqual(1, len(attempts))
+
+    def test_a_relay_stuck_at_503_eventually_gives_up(self):
+        def send():
+            raise self.http_error(503)
+
+        _, monotonic, sleep = self.clock()
+        with self.assertLogs("slack-relay-patch", level="WARNING"):
+            with self.assertRaises(urllib.error.HTTPError):
+                wait_for_relay(
+                    send, timeout=10.0, poll=2.0, monotonic=monotonic, sleep=sleep
+                )
+
+
+class BoltClientPatchTest(unittest.TestCase):
+    """Every Slack client Bolt builds has to route through the relay.
+
+    Bolt does not reuse the client its app was constructed with: ``_init_context``
+    builds a fresh one per request from the ``AsyncWebClient`` bound in its own
+    module. Patch only the adapter's name and each request talks to slack.com
+    directly holding the ``relay:`` placeholder, fails authorization, and drops
+    the user's message with no reply.
+    """
+
+    class FakeAsyncWebClient:
+        def __init__(self, token=None, **kwargs):
+            self.token = token
+            self.kwargs = kwargs
+
+    class FakeAsyncApp:
+        def __init__(self, client=None, **kwargs):
+            self.client = client
+            self.kwargs = kwargs
+
+    class FakeAsyncSlackResponse:
+        """Mirrors the SDK response Bolt expects: .headers, .data, .validate()."""
+
+        def __init__(self, *, client, http_verb, api_url, req_args, data, headers, status_code):
+            self.client = client
+            self.http_verb = http_verb
+            self.api_url = api_url
+            self.req_args = req_args
+            self.data = data
+            self.headers = headers
+            self.status_code = status_code
+
+        def get(self, key, default=None):
+            return self.data.get(key, default)
+
+        def validate(self):
+            if not self.data.get("ok", False):
+                raise AssertionError("slack api error")
+            return self
+
+    def install_against_fakes(self):
+        """Run install() over stand-ins and hand back the patched modules."""
+        adapter_module = types.ModuleType("gateway.platforms.slack_adapter")
+        adapter_module.AsyncWebClient = self.FakeAsyncWebClient
+        adapter_module.AsyncApp = self.FakeAsyncApp
+
+        class SlackAdapter:
+            async def connect(self, *, is_reconnect=False):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        SlackAdapter.__module__ = adapter_module.__name__
+        adapter_module.SlackAdapter = SlackAdapter
+
+        bolt_module = types.ModuleType("slack_bolt.app.async_app")
+        bolt_module.AsyncWebClient = self.FakeAsyncWebClient
+
+        class PlatformRegistry:
+            def create_adapter(self, name, config):
+                return SlackAdapter()
+
+        registry_module = types.ModuleType("gateway.platform_registry")
+        registry_module.PlatformRegistry = PlatformRegistry
+
+        response_module = types.ModuleType("slack_sdk.web.async_slack_response")
+        response_module.AsyncSlackResponse = self.FakeAsyncSlackResponse
+
+        modules = {
+            "gateway": types.ModuleType("gateway"),
+            "gateway.platform_registry": registry_module,
+            adapter_module.__name__: adapter_module,
+            "slack_bolt": types.ModuleType("slack_bolt"),
+            "slack_bolt.app": types.ModuleType("slack_bolt.app"),
+            "slack_bolt.app.async_app": bolt_module,
+            "slack_sdk": types.ModuleType("slack_sdk"),
+            "slack_sdk.web": types.ModuleType("slack_sdk.web"),
+            "slack_sdk.web.async_slack_response": response_module,
+        }
+        with mock.patch.dict(sys.modules, modules):
+            with mock.patch.dict(
+                os.environ, {"SLACK_RELAY_URL": "http://127.0.0.1:8765"}
+            ):
+                slack_relay_patch.install()
+            # Creating the adapter is what triggers the class-level patching.
+            PlatformRegistry().create_adapter("slack", object())
+        return adapter_module, bolt_module
+
+    def test_bolt_per_request_client_is_rebound_to_the_relay_client(self):
+        adapter_module, bolt_module = self.install_against_fakes()
+
+        self.assertIsNot(bolt_module.AsyncWebClient, self.FakeAsyncWebClient)
+        self.assertIs(bolt_module.AsyncWebClient, adapter_module.AsyncWebClient)
+        self.assertTrue(issubclass(bolt_module.AsyncWebClient, self.FakeAsyncWebClient))
+
+    def test_the_rebound_client_is_a_class_so_bolt_can_isinstance_it(self):
+        """AsyncApp raises BoltError unless the client passes isinstance."""
+        _, bolt_module = self.install_against_fakes()
+
+        self.assertIsInstance(bolt_module.AsyncWebClient, type)
+        client = bolt_module.AsyncWebClient(token="relay:T1")
+        self.assertIsInstance(client, bolt_module.AsyncWebClient)
+
+    def test_the_team_bolt_resolved_wins_over_the_joined_token(self):
+        """Bolt passes team_id per request; the token lists every workspace."""
+        _, bolt_module = self.install_against_fakes()
+
+        client = bolt_module.AsyncWebClient(
+            token="relay:T1,relay:T2", team_id="T2", base_url="https://slack.com/api/"
+        )
+        self.assertEqual("T2", client.team_id)
+
+    def test_a_single_workspace_token_still_yields_its_team(self):
+        _, bolt_module = self.install_against_fakes()
+
+        self.assertEqual("T1", bolt_module.AsyncWebClient(token="relay:T1").team_id)
+
+    def relayed_call(self, client, method, payload):
+        """Drive one api_call with the relay's HTTP response stubbed out."""
+        body = json.dumps({"response": payload}).encode("utf-8")
+        with mock.patch.object(slack_relay_patch.urllib.request, "urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value = io.BytesIO(body)
+            return asyncio.run(client.api_call(method))
+
+    def test_api_call_returns_a_response_object_not_a_bare_dict(self):
+        """Bolt reads .headers off this; a dict raises AttributeError."""
+        _, bolt_module = self.install_against_fakes()
+        client = bolt_module.AsyncWebClient(token="relay:T1")
+
+        payload = {"ok": True, "user_id": "U1", "team_id": "T1", "bot_id": "B1"}
+        result = self.relayed_call(client, "auth.test", payload)
+
+        self.assertNotIsInstance(result, dict)
+        self.assertEqual({}, result.headers)
+        self.assertEqual(payload, result.data)
+        self.assertEqual("U1", result.get("user_id"))
+
+    def test_a_failed_slack_call_raises_the_way_the_real_client_does(self):
+        _, bolt_module = self.install_against_fakes()
+        client = bolt_module.AsyncWebClient(token="relay:T1")
+
+        with self.assertRaises(AssertionError):
+            self.relayed_call(client, "auth.test", {"ok": False, "error": "nope"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## Why This Change

Slack was dead on the credential-free path. A message sent to the Platform Agent produced no reply and no obvious error — the pod looked healthy, the relay reported an authenticated workspace, and the bootstrap call returned 200. Nothing surfaced because the failures happen after startup, on the inbound request, and the gateway swallows them.

Four distinct defects were stacked, each one hidden behind the one ahead of it. Fixing any single one just moved the silence a few seconds later.

## What Changed

**Files:**

- `agents/platform/scripts/credential_proxy.py`
- `agents/platform/scripts/slack_relay_patch.py`
- `agents/platform/scripts/test_credential_proxy.py`

**Added/Changed/Fixed:**

1. **`SlackRelay.api_call` mangled every response.** It built its reply with `dict(response)`. A `SlackResponse` defines `__iter__` but no `keys()`, so `dict()` treated it as a sequence of pairs and choked on the first key — every relayed call came back HTTP 400. Now reads the payload off `.data`, falling back to the response itself so a plain mapping still works.

2. **The adapter bootstrapped before the sidecar existed.** Regular sidecars have no start-ordering guarantee, and the agent container was observed winning by 5–49s. The resulting connection error was fatal rather than merely slow: the bot token lives in the relay, so the gateway's reconnect found no bot credential on the queued config and dropped Slack from the retry queue **for the life of the pod**. New `wait_for_relay` absorbs it.

3. **Surviving the refused connection wasn't enough.** `credential_proxy.py` binds its HTTP port before Slack authentication completes — relay setup runs on a daemon thread so a Slack outage can't wedge the whole proxy — and answers `503 Slack relay disabled` until it finishes. `wait_for_relay` treats 503 as the readiness signal it is and retries; every other status still raises, because the relay answering is not a readiness problem. Bounded by `SLACK_RELAY_READY_TIMEOUT_SECONDS` (default 120s).

4. **Bolt never used the relay client.** `AsyncApp._init_context` does not reuse the client the app was built with — it constructs a fresh `AsyncWebClient` per request from the name bound in `slack_bolt.app.async_app`. Rebinding only the adapter module's copy left every request calling `slack.com` directly holding the `"relay:"` placeholder for a token, which failed authorization with `invalid_auth`. The patch now rebinds the name Bolt actually reads. It has to stay a class, not a factory — `AsyncApp` isinstance-checks the client it is handed.

5. **And then the response type.** With requests finally routed through the relay, Bolt's authorization middleware died with `'dict' object has no attribute 'headers'`: `_to_authorize_result` reads `x-oauth-scopes` off the response. `RemoteSlackClient.api_call` now returns a real `AsyncSlackResponse`. The relay does not forward Slack's response headers, so scope introspection sees none.

Also: `RemoteSlackClient` now takes the `team_id` Bolt resolved from the inbound event, rather than splitting it out of the token. Across several workspaces that token is a comma-joined list, so splitting yields every team at once instead of the one the request belongs to.

## Why This Matters

- Slack is one of two chat front doors. On this path it was completely non-functional, and it failed silently — no listener ever ran, and the only trace was a `Reconnect slack: no bot credential on queued config` line at startup.
- Defects 3 and 4 only fire when a message actually arrives, which is why the pod looks healthy and the smoke tests pass while every message vanishes.
- Defect 2 is unrecoverable without a pod restart. Once the adapter leaves the retry queue it never rejoins.

## Context

Found while testing the fleet-audit cron work end-to-end on a live GKE cluster; the Slack breakage is independent of that feature and pre-exists it on `main`, so it lands on its own branch.

`k8s-operator/internal/controller/platformagent_manifests.go` already injects `SLACK_RELAY_URL=http://127.0.0.1:8765`; no operator or manifest change is needed. The new timeout knob follows the precedent of its sibling `SLACK_RELAY_MAX_FILE_BYTES` — an env-tunable default, not part of the documented surface.

## Testing

- Platform suite: 207 tests, green. Fleet-audit suite: 346 tests, green.
- Two new test classes, `RelayReadinessTest` (6) and `BoltClientPatchTest` (6). The Bolt-client binding had **zero** coverage despite carrying four fatal bugs. `BoltClientPatchTest` stubs `slack_bolt`/`slack_sdk` into `sys.modules`, so it runs without either package installed — matching what CI has available.
- Confirmed the new tests actually catch the regression rather than just passing: replacing the `bolt_async_app.AsyncWebClient = RemoteSlackClient` line with `pass` fails 3 of 4, and restoring it re-passes.
- Hardened `SlackRelayTest`'s fake, which was a plain `dict` — precisely what let defect 1 ship.
- Verified end-to-end against a live GKE cluster (`platform-agent-host`): relay authenticated, bootstrap 200, and a Slack message now gets a reply, with zero `invalid_auth`, middleware, or traceback errors in the pod log.

---

Behavior change is confined to the Slack path, which was previously non-functional, so the blast radius is bounded by definition. The startup wait is the one thing worth a second look: it is bounded, it only retries the two specific failures that mean "not up yet," and it runs on a thread that was already doing blocking I/O.

This PR was generated with the help of Claude.
