### PR TITLE
fix(scripts): let callers point common.sh at the real vars file

### DIFF
--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -7,7 +7,11 @@
 if [ -z "${SCRIPT_DIR:-}" ]; then
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi
-VARS_FILE="${SCRIPT_DIR}/vars.sh"
+# Honour a caller-provided path. Scripts under scripts/dev/ set SCRIPT_DIR to
+# their own directory but keep the single state file in scripts/, so deriving
+# the path from SCRIPT_DIR here would point them at a scripts/dev/vars.sh that
+# load_state then creates empty — silently blanking IMAGE_TAG and AGENT_IMAGE.
+VARS_FILE="${VARS_FILE:-${SCRIPT_DIR}/vars.sh}"
 
 # ─── ANSI Colors ──────────────────────────────────────────────────────────────
 C_CYAN='\033[96m'

--- a/k8s-operator/scripts/dev/dev_rebuild_agent.sh
+++ b/k8s-operator/scripts/dev/dev_rebuild_agent.sh
@@ -113,7 +113,12 @@ execute_registry() {
       --repository-format=docker \
       --location="$REGION" \
       --project="$PROJECT_ID" \
-      --description="Kubernetes Agentic Harness repository for local development"
+      --description="Kubernetes Agentic Harness repository for local development" || return 1
+  # Only claim a registry this script actually created. teardown.sh reads this
+  # flag to decide whether to delete the repository and every image in it, and
+  # passes --no-confirm, so claiming one the provisioning pipeline created would
+  # hand `make teardown` a registry it otherwise preserves.
+  save_var "DEV_ARTIFACT_REGISTRY_CREATED" "true"
 }
 
 # Step 2: Build & Push Image
@@ -228,7 +233,6 @@ execute_redeploy() {
 
 # ─── Execution Pipeline ───────────────────────────────────────────────────────
 run_step "1. Verify/Create Artifact Registry Repository" verify_registry execute_registry 0
-save_var "DEV_ARTIFACT_REGISTRY_CREATED" "true"
 run_step "2. Build & Push Agent Image (${SELECTED_AGENT})" verify_image_build execute_image_build 0
 run_step "3. Connect to Host GKE Cluster" verify_kubeconfig execute_kubeconfig 0
 run_step "4. Trigger Redeployment in GKE" verify_redeploy execute_redeploy 0


### PR DESCRIPTION
# Pull Request

## Why This Change

`make dev-rebuild-agent` would build and push a fresh image, then roll the deployment onto a stale tag — silently. You get a successful-looking rebuild that deploys the previous build.

The cause is a `SCRIPT_DIR` mismatch. `dev_rebuild_agent.sh` sets `VARS_FILE` to `scripts/vars.sh` before sourcing, but `common.sh` overwrote it with a `SCRIPT_DIR`-derived path, and scripts under `scripts/dev/` set `SCRIPT_DIR` to their own directory. So they were pointed at a `scripts/dev/vars.sh` that does not exist. `load_state` then created it empty, blanking `IMAGE_TAG` and `AGENT_IMAGE`, and the rollout used whatever was left behind.

Repairing that connects a second, previously dormant defect to the teardown path — see commit 2.

## What Changed

**Files:**

- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/dev/dev_rebuild_agent.sh`

**Added/Changed/Fixed:**

1. **`VARS_FILE` now honours a caller-supplied value**, falling back to the `SCRIPT_DIR`-derived path: `VARS_FILE="${VARS_FILE:-${SCRIPT_DIR}/vars.sh}"`. `dev_rebuild_agent.sh:25` already set the correct path; it was simply being discarded.

2. **`DEV_ARTIFACT_REGISTRY_CREATED` is now only set for a registry this script actually created.** It was written unconditionally after step 1, but `run_step` short-circuits when `verify_registry` finds the repository already present, so the flag was also claimed for a registry the provisioning pipeline created. That was inert while it landed in the stray `scripts/dev/vars.sh` that nothing reads — fix 1 is what arms it:

   - `ensure_teardown_state` sources the flag and preserves the `true` (`common.sh:237`);
   - `teardown.sh:42-44` runs `dev/teardown_dev_01_gcp_artifact_registry.sh --no-confirm`;
   - `confirm_action` returns immediately under `--no-confirm`, so the "permanently delete … and all container images inside it" prompt never appears.

   No other teardown step deletes the Artifact Registry — `make teardown` deliberately preserves it. Without this second commit, one `make dev-rebuild-agent` against a provisioned cluster would be enough to make the next `make teardown` destroy the registry and every image in it, silently. The `save_var` moves into `execute_registry`, and a failed create now propagates with `|| return 1` instead of recording a registry that was never made.

## Why This Matters

- Fix 1's failure mode is a silent wrong deploy, not an error. Nothing in the output says the state file was empty, so a clean `dev-rebuild-agent` run reads as "the new image is live." It costs real debugging time — you chase a code change that appears not to have taken effect, in an image that genuinely does not contain it.
- Fix 2 is the more serious one, and it only becomes reachable because of fix 1. An unattended registry deletion is unrecoverable, and it would fire on a `make teardown` the operator expects to leave images alone.

## Context

Both found while iterating on a live GKE cluster with `make dev-rebuild-agent`. Unrelated to the feature work that surfaced them, so they land on their own branch.

The flag defect was spotted by `kube-agents-bot` on the first revision of this PR, which flagged that fix 1 arms it. I traced the full chain against source and confirmed it; commit 2 is the gate it suggested.

## Testing

- `make dev-rebuild-agent` against a live cluster (`platform-agent-host`) now rolls onto the tag it just built.
- Exercised the flag gate against the **real** `run_step` and `save_var` from `common.sh`, stubbing only the `gcloud` calls, across all three paths:

  | registry exists | create succeeds | flag written | `run_step` rc |
  | --------------- | --------------- | ------------ | ------------- |
  | yes             | —               | no ✅        | 0             |
  | no              | yes             | yes ✅       | 0             |
  | no              | no              | no ✅        | 1             |

  The third row also confirms the `|| return 1`: without it, `save_var` would have become the function's exit status and reported success. `set -e` does not cover this, because `run_step` invokes `execute_registry` as an `if` condition — which is why the surrounding `execute_*` functions already use that idiom.

- `bash -n` clean. `shellcheck` reports only the two pre-existing findings on this file (`SC2034` on `VARS_FILE`, a false positive it can't resolve across the `source`, and `SC1091`).

---

Commit 1 adds an override and changes no default. Commit 2 narrows when a destructive flag is set, so the only behavior it removes is an unintended registry deletion.

This PR was generated with the help of Claude.
