### PR TITLE
feat(scripts): add a kubectl-exec tunnel for the Hermes dashboard

### DIFF
--- a/scripts/hermes-dashboard-tunnel.py
+++ b/scripts/hermes-dashboard-tunnel.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Open the Hermes dashboard of a running Platform Agent in a local browser.
+
+    scripts/hermes-dashboard-tunnel.py       # then browse to 127.0.0.1:9119
+
+The Service advertises a dashboard port, but nothing answers on it: `hermes
+dashboard` binds 127.0.0.1:9119 inside the pod, so `9119 -> podIP:9119` routes
+to a closed address. That bind is not incidental -- the dashboard's auth gate
+keys on the bind host, so binding 0.0.0.0 switches authentication on, and with
+no auth provider registered the server exits at startup instead of serving
+unauthenticated. The loopback bind is what keeps the dashboard usable, so
+reaching it means getting inside the pod's network namespace rather than
+changing how it listens.
+
+`kubectl port-forward` cannot do that on a GKE Sandbox (gVisor) node pool: the
+kubelet sets the forward up in the host-side CNI netns, while the listener
+lives in the sandbox's own network stack, so every port on the pod refuses the
+connection. `kubectl exec` does enter the sandbox correctly, so this relays
+bytes through an exec channel instead.
+
+Three things this has to get right, each of which broke it once:
+
+1. Under `bufsize=0` the subprocess pipes are raw FileIO. There is no
+   `.read1()` -- only `.read()`.
+2. Raw pipe `write()` may consume only part of the buffer and return a short
+   count. Discarding that count silently dropped 32-64KB chunks mid-stream and
+   truncated the SPA's 1.9MB entrypoint, so the module would not parse.
+3. The pod name changes on every redeploy. Pinning one produces a tunnel that
+   accepts connections and returns zero bytes (ERR_EMPTY_RESPONSE) the moment
+   the Deployment rolls. The pod is resolved by label and re-resolved whenever
+   an exec fails to come up.
+"""
+
+import argparse
+import socket
+import socketserver
+import subprocess
+import sys
+import threading
+
+# The remote end writes READY (one NUL) as soon as it has actually connected to
+# the dashboard, before relaying anything. That single byte is what lets the
+# local side distinguish "container reachable and dashboard listening" from a
+# stale pod name, without having to buffer and replay the client's request.
+REMOTE_RELAY = """
+import os, sys, socket, threading, time
+
+def write_all(fd, buf):
+    mv = memoryview(buf)
+    while mv:
+        mv = mv[os.write(fd, mv):]
+
+s = socket.create_connection(("127.0.0.1", {port}))
+os.write(1, b"\\x00")
+
+def up():
+    try:
+        while True:
+            d = os.read(0, 65536)
+            if not d:
+                break
+            s.sendall(d)
+    except Exception:
+        pass
+    try:
+        s.shutdown(socket.SHUT_WR)
+    except Exception:
+        pass
+
+threading.Thread(target=up, daemon=True).start()
+try:
+    while True:
+        d = s.recv(65536)
+        if not d:
+            break
+        write_all(1, d)
+except Exception:
+    pass
+finally:
+    # kubectl tears down the stdout stream when this process exits; give the
+    # final frames a moment to ship before we go away.
+    time.sleep(0.25)
+"""
+
+
+def write_all(fileobj, buf):
+    """Write every byte of buf, tolerating short writes on a raw pipe."""
+    mv = memoryview(buf)
+    while mv:
+        n = fileobj.write(mv)
+        if not n:
+            continue
+        mv = mv[n:]
+    fileobj.flush()
+
+
+class PodResolver:
+    """Cache the pod name; re-resolve by label when an exec fails to start."""
+
+    def __init__(self, cfg):
+        self.cfg = cfg
+        self.lock = threading.Lock()
+        self.pod = cfg.pod
+
+    def get(self, refresh=False):
+        with self.lock:
+            if self.pod and not refresh:
+                return self.pod
+            out = subprocess.run(
+                ["kubectl", "get", "pods", "-n", self.cfg.namespace,
+                 "-l", self.cfg.selector,
+                 "--field-selector=status.phase=Running",
+                 "-o", "jsonpath={.items[0].metadata.name}"],
+                capture_output=True, text=True, timeout=60,
+            )
+            name = out.stdout.strip()
+            if not name:
+                raise RuntimeError(
+                    f"no Running pod matches -l {self.cfg.selector} "
+                    f"in {self.cfg.namespace}"
+                )
+            if name != self.pod:
+                print(f"  pod → {name}", flush=True)
+            self.pod = name
+            return name
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def _spawn(self, pod):
+        """Start an exec relay; return it only once it reports READY."""
+        cmd = [
+            "kubectl", "exec", "-i",
+            "-n", self.server.cfg.namespace, pod,
+            "-c", self.server.cfg.container,
+            "--", self.server.cfg.python, "-u", "-c",
+            REMOTE_RELAY.format(port=self.server.cfg.remote_port),
+        ]
+        try:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=None, bufsize=0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"  exec failed: {exc}", file=sys.stderr, flush=True)
+            return None
+        if proc.stdout.read(1) != b"\x00":
+            proc.terminate()
+            return None
+        return proc
+
+    def handle(self):
+        resolver = self.server.resolver
+        proc = None
+        for refresh in (False, True):
+            try:
+                pod = resolver.get(refresh=refresh)
+            except Exception as exc:  # noqa: BLE001
+                print(f"  {exc}", file=sys.stderr, flush=True)
+                return
+            proc = self._spawn(pod)
+            if proc:
+                break
+        if not proc:
+            return
+
+        def to_pod():
+            try:
+                while True:
+                    data = self.request.recv(65536)
+                    if not data:
+                        break
+                    write_all(proc.stdin, data)
+            except Exception:  # noqa: BLE001
+                pass
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        threading.Thread(target=to_pod, daemon=True).start()
+        try:
+            while True:
+                # raw FileIO: .read(n) is one read() syscall, no .read1()
+                data = proc.stdout.read(65536)
+                if not data:
+                    break
+                self.request.sendall(data)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            try:
+                self.request.shutdown(socket.SHUT_WR)
+            except Exception:  # noqa: BLE001
+                pass
+            proc.terminate()
+
+
+class Server(socketserver.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+    request_queue_size = 64
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--namespace", default="kubeagents-system")
+    ap.add_argument("--selector", default="app=platform-agent-gateway")
+    ap.add_argument("--pod", default="", help="pin a pod (default: by label)")
+    ap.add_argument("--container", default="platform-agent-dashboard")
+    ap.add_argument("--remote-port", type=int, default=9119)
+    ap.add_argument("--local-port", type=int, default=9119)
+    ap.add_argument("--python", default="/opt/hermes/.venv/bin/python3")
+    cfg = ap.parse_args()
+
+    resolver = PodResolver(cfg)
+    resolver.get()
+
+    server = Server(("127.0.0.1", cfg.local_port), Handler)
+    server.cfg = cfg
+    server.resolver = resolver
+    print(f"Hermes dashboard → http://127.0.0.1:{cfg.local_port}", flush=True)
+    print(f"  via kubectl exec into -l {cfg.selector} "
+          f"({cfg.namespace}), Ctrl-C to stop", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nstopped")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Pull Request

## Why This Change

There is currently no working way to open the Hermes dashboard of a running Platform Agent.

The documented approach — `kubectl port-forward svc/<agent-service> -n kubeagents-system 9119:9119` — does not work on a GKE Sandbox (gVisor) node pool, which is where the Platform Agent runs (`runtimeClassName: gvisor`). The kubelet sets the forward up in the **host-side CNI network namespace**, while the container's listener lives inside the sandbox's own userspace network stack. The two never meet, so the forward is established and then every connection is refused. This is not specific to 9119 — it affects **every** port on the pod.

`kubectl exec` does enter the sandbox correctly, so this adds a small script that relays bytes over an exec channel instead.

Two related facts that make this the right shape of fix, rather than a configuration change:

- **The dashboard's loopback bind is load-bearing.** `hermes dashboard` binds `127.0.0.1:9119`. Hermes' auth gate keys on the bind host string at startup, so switching to `0.0.0.0` turns authentication *on*; with no auth provider registered the server then exits at startup rather than serve unauthenticated. Binding wider is not a fix — it trades a closed port for a crashed container.
- **The Service's `dashboard` port cannot work as-is.** It targets `podIP:9119`, which is a closed address given the loopback bind. On a live cluster the Endpoint is published (`10.60.4.13:9119`) but has never been able to serve; `/proc/net/tcp` in the dashboard container shows `0100007F:239F` — loopback only. Reaching the dashboard means getting *inside* the pod's netns, not changing how it listens.

## What Changed

**Files:**

- `scripts/hermes-dashboard-tunnel.py`

**Added/Changed/Fixed:**

- Added a local tunnel that forwards `127.0.0.1:9119` into the `platform-agent-dashboard` container over `kubectl exec`. Run it and browse to `http://127.0.0.1:9119`.
- Pods are resolved **by label** (`-l app=platform-agent-gateway`, `--field-selector=status.phase=Running`) and re-resolved when an exec fails to come up, so the tunnel survives a Deployment roll.
- The remote relay emits a one-byte READY sentinel once it has actually connected to the dashboard, letting the local side tell "container reachable and dashboard listening" apart from a stale pod name without buffering the client's request.
- Namespace, selector, container, ports, and the remote interpreter path are all flags; `--pod` pins a specific pod if needed.

Three implementation details are called out in the module docstring because each one broke the script during development:

1. Under `bufsize=0` the subprocess pipes are raw `FileIO` — there is no `.read1()`, only `.read()`.
2. A raw pipe `write()` may consume only part of the buffer and return a short count. Discarding that count silently dropped 32–64 KB chunks mid-stream and truncated the dashboard SPA's 1.9 MB entrypoint, so the module failed to parse in the browser.
3. Pinning a pod name produces a tunnel that accepts connections and returns zero bytes (`ERR_EMPTY_RESPONSE`) the moment the Deployment rolls.

## Why This Matters

- The dashboard is currently unreachable in practice on gVisor node pools, and the failure mode is silent and misleading: `port-forward` reports success, the browser shows a connection refused or an empty page, and nothing in the logs explains why.
- The gVisor/`port-forward` interaction is not obvious and costs real debugging time. Even with the script as the deliverable, the docstring and this description are the record of *why* the obvious approach fails.
- Script-only, additive, zero runtime impact: nothing in the operator, the images, or the deployed manifests changes.

## Context

Scoped deliberately to the script. Two follow-ups worth doing separately, not fixed here:

- **The Service advertises a dead `dashboard` port.** `buildPlatformService` in `k8s-operator/internal/controller/platformagent_manifests.go` appends `{Name: "dashboard", Port: 9119, TargetPort: "dashboard"}` when the dashboard is enabled. Given the loopback bind, that Endpoint can never serve. Since binding `0.0.0.0` is fail-closed, the honest change is to drop the port rather than try to make it work — a behavior change that deserves its own PR and review.
- **`agents/platform/skills/kube-agents-observability/SKILL.md` (~L160–166) still tells the agent to `kubectl port-forward … 9119:9119`.** That instruction cannot succeed on a gVisor pool and should point at this script instead.

Documentation for the script is intentionally left as a follow-up.

## Testing

Validated end-to-end against a live Platform Agent on a GKE Sandbox node pool (bound to `--local-port 9129` to avoid colliding with an existing tunnel):

- Pod auto-discovery by label resolved the running pod and logged it.
- `GET /` returned HTTP 200 on three consecutive requests.
- The 1.9 MB SPA entrypoint transferred at exactly 1,984,852 bytes on three consecutive requests — byte-identical each time, confirming the short-write fix.
- Confirmed the baseline failure it replaces: `kubectl port-forward` against the same pod establishes the forward and then refuses every connection.

Repo gates (re-verified after rebasing onto `2a5815d`):

- `npx prettier --check` — no-op; the workflow's changed-file filter is `\.md$|\.yaml$|\.yml$` and the diff is a single `.py` file.
- `make test-python` (the `Run Python Unit Tests` check) — 913 tests across 8 discovery directories, all green, and identical to the `main` baseline: 0 new failures, 0 test-count change. Correcting an earlier claim in this description: the root `scripts/` directory **is** in scope on current `main` — `Makefile` gained `$(wildcard scripts/test_*.py)` in #517. This script is not named `test_*.py`, so it contributes no test; a cluster-free unit test for `write_all` and the `REMOTE_RELAY` round-trip is a reasonable follow-up.
- `make docs-check` — passes (all four sub-targets). This was the one red check on the pre-rebase branch, failing with `Stated document total is 141, but git tracks 142`. That was pre-existing breakage on `main`, since fixed there; rebasing onto `2a5815d` picks the fix up. The tree now tracks 155 `.md`/`.mdx` files and `docs/README.md:17` states 155.

**Rebased onto `2a5815d`** to clear the stale `Documentation Checks` failure. No content change: still one commit adding one file. The rebase also brings the PR under two checks it had never faced (`Run Python Unit Tests`, added to `main` a day after this PR's last run, and `Run Agent Startup Tests`) plus a widened `validate`; all were reproduced green locally.

---

Additive and low risk: one new standalone script, no changes to the operator, images, or deployed manifests. Nothing behaves differently unless someone runs it.

This PR was generated with the help of Claude.

