### PR TITLE
fix(install): persist registry/tag settings and close registry-override gaps from #501 review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ editing any doc.
 
 ## 1. Directory overview
 
-The repository tracks **141** `.md`/`.mdx` documents outside the root-level
+The repository tracks **142** `.md`/`.mdx` documents outside the root-level
 dot-directories — `docs-check-map` verifies this total against `git ls-files`
 and fails CI when it drifts. Dot-directories at the repository root
 (`.agents/`, `.github/`, `.claude/`) hold tooling — review skills, PR

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -71,19 +71,35 @@ Bumping Hermes = updating `tags.env` (a single-line change) and rebuilding.
 
 Installs that cannot pull from public registries (behind-the-firewall clusters) can mirror the
 images into their own registry and point every layer of the install at it. Mirror the four
-published images above, plus the `fluent/fluent-bit:5.0.7` logging sidecar the operator injects
-into agent pods.
+published images above, plus the `fluent/fluent-bit` logging sidecar the operator injects into
+agent pods (version pinned in `k8s-operator/internal/controller/manifest_helpers.go`).
+
+Not every image in the install path has an override yet. The following are pulled from their
+upstream registries regardless of the settings below:
+
+- **cert-manager** — `provision_03` applies the upstream cert-manager manifest, which pulls
+  `quay.io/jetstack/*` images. Behind a firewall this step fails before the operator deploys;
+  mirror the manifest and images manually.
+- **LiteLLM** — the optional LiteLLM integration deploys `ghcr.io/berriai/litellm`
+  (`k8s-operator/config/integrations/litellm/`).
+- **GitHub token minter** — the optional GitHub integration deploys the
+  `github-token-minter-server` image from `us-docker.pkg.dev`
+  (`k8s-operator/config/integrations/github/`).
 
 The registry is configurable at three layers, from broadest to most specific:
 
 1. **Provisioning scripts** — export `REGISTRY_PREFIX` (e.g.
-   `registry.example.com/kube-agents`) before running the `provision_*.sh` scripts. It replaces
+   `registry.example.com/kube-agents`) before the first `provision_*.sh` run. It replaces
    `ghcr.io/gke-labs/kube-agents` as the default for the operator image (`provision_03`), the
-   agent image (`provision_08`), and the replay proxy (`provision_11`). The individual
+   agent image (`provision_08`), and the replay proxy (`provision_11`), and is persisted to the
+   state file (`vars.sh`) like every other knob, so re-runs reuse it. The individual
    `OPERATOR_IMAGE`, `AGENT_IMAGE`, and `REPLAY_IMAGE` variables still override the prefix.
-   When `REGISTRY_PREFIX` (or an explicit `PLATFORM_AGENT_IMAGE`) is set, `provision_03` also
-   sets `PLATFORM_AGENT_IMAGE` on the operator Deployment; `AGENT_IMAGE` itself only feeds the
-   CR rendered in `provision_08`.
+   `provision_03` also sets `PLATFORM_AGENT_IMAGE` on the operator Deployment whenever an
+   explicit `PLATFORM_AGENT_IMAGE`, a custom `AGENT_IMAGE`, or a custom `REGISTRY_PREFIX` is in
+   effect, so CRs that omit `spec.deployment.image` follow the mirror too. Changing the
+   registry _after_ a first run requires editing the saved `REGISTRY_PREFIX` and `*_IMAGE`
+   values in `vars.sh` (saved state wins over a new export); the scripts warn when an export
+   is ignored or a saved image no longer matches the effective prefix.
 2. **Operator environment** — the controller manager reads three optional env vars (see the
    commented block in `k8s-operator/config/manager/manager.yaml`):
    - `PLATFORM_AGENT_IMAGE` — default agent image when a `PlatformAgent` CR omits
@@ -96,7 +112,8 @@ The registry is configurable at three layers, from broadest to most specific:
 3. **Per-agent CR** — `spec.deployment.image` / `spec.deployment.tag` on a `PlatformAgent`
    override the defaults above for that agent's containers, and the credential-proxy image is
    derived from them — unless an explicit `CREDENTIAL_PROXY_IMAGE` is set, which always wins
-   for the sidecar. See the
+   for the sidecar. The fluent-bit sidecar has no CR-level equivalent; `FLUENT_BIT_IMAGE` is
+   its only override. See the
    [PlatformAgent CRD reference](/kube-agents/operator/platformagent-crd/).
 
 If the private registry requires authentication, configure node-level pull credentials (or

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -40,7 +40,7 @@ The `./provision.sh` script bootstraps everything you need for a running Platfor
    ./provision.sh
    ```
 
-   The first run is interactive: it prompts for the values it needs (project ID, region, cluster name, model provider and API key, agent permission set, and opt-in integrations such as Google Chat, Slack, and GitHub). Answers are cached in `k8s-operator/scripts/vars.sh` (git-ignored) so re-runs are non-interactive. Every sub-step is idempotent, so you can safely Ctrl-C and re-run.
+   The first run is interactive: it prompts for the values it needs (project ID, region, cluster name, base image tag, container registry prefix, model provider and API key, agent permission set, and opt-in integrations such as Google Chat, Slack, and GitHub). Answers are cached in `k8s-operator/scripts/vars.sh` (git-ignored) so re-runs are non-interactive — except the base image tag, which is asked once per run because it usually changes between deploys. Every sub-step is idempotent, so you can safely Ctrl-C and re-run.
 
 3. **Configure Google Chat** (only if you enabled the Google Chat integration). In the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com), point the bot's Pub/Sub connection at the topic created in step 5 (`projects/<PROJECT_ID>/topics/<CHAT_TOPIC_NAME>`). The provisioner prints the exact topic name and step-by-step instructions when it finishes.
 

--- a/docs/site/src/content/docs/operator/index.md
+++ b/docs/site/src/content/docs/operator/index.md
@@ -60,6 +60,9 @@ spec:
         name: platformagent-secrets
         key: api-key
   deployment:
+    # Optional — omit to use the operator's default image (its
+    # PLATFORM_AGENT_IMAGE env var for private-registry installs, else the
+    # public ghcr.io image; see the Docker images page).
     image: ghcr.io/gke-labs/kube-agents/platform-agent
     imagePullPolicy: IfNotPresent
   security:

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -1458,9 +1458,13 @@ func resolveCredentialProxyImage(deployment *agentv1alpha1.DeploymentSpec) strin
 		// The agent image's digest cannot name the proxy image; fall back to
 		// the tag field or latest.
 		name = name[:digest]
+		sidecarTag := "latest"
 		if deployment != nil && deployment.Tag != nil && *deployment.Tag != "" {
 			suffix = ":" + *deployment.Tag
+			sidecarTag = *deployment.Tag
 		}
+		manifestsLog.Info("digest-pinned agent image cannot pin the credential-proxy sidecar; using a mutable tag instead",
+			"agentImage", image, "sidecarTag", sidecarTag)
 	} else if tag := strings.LastIndex(name, ":"); tag >= 0 {
 		suffix, name = name[tag:], name[:tag]
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -1048,7 +1048,7 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
 	}
-	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456")
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456", nil, true)
 	found := false
 	for _, c := range dep.Spec.Template.Spec.Containers {
 		if c.Name == "fluent-bit" {

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -50,6 +50,15 @@ func TestAgentsGolden(t *testing.T) {
 				return &controller.PlatformAgentReconciler{Client: c, Scheme: s}
 			},
 		},
+		{
+			name:         "PlatformAgentTaggedImage",
+			inputPath:    filepath.Join("testdata", "platform", "platformagent-tagged.yaml"),
+			expectedPath: filepath.Join("testdata", "platform", "expected", "platformagent-tagged.yaml"),
+			newAgent:     func() client.Object { return &agentv1alpha1.PlatformAgent{} },
+			newReconciler: func(c client.Client, s *runtime.Scheme) reconcile.Reconciler {
+				return &controller.PlatformAgentReconciler{Client: c, Scheme: s}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -1,0 +1,828 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: kubeagents-platform-gsa@kube-agents-gkedemos.iam.gserviceaccount.com
+  creationTimestamp: null
+  name: kubeagents-platform-agent
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubeagents:viewer:kubeagents-system:platformagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kubeagents:explorer:kubeagents-system:platformagent
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubeagents:explorer:kubeagents-system:platformagent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeagents:explorer:kubeagents-system:platformagent
+subjects:
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: kubeagents:leader:kubeagents-system:platformagent
+  namespace: kubeagents-system
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: kubeagents:leader:kubeagents-system:platformagent
+  namespace: kubeagents-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubeagents:leader:kubeagents-system:platformagent
+subjects:
+  - kind: ServiceAccount
+    name: kubeagents-platform-agent
+    namespace: kubeagents-system
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: platformagent-data
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+status: {}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  name: system-metadata
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+status: {}
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    agent:
+      disabled_toolsets:
+      - terminal
+      - file
+      - skills
+      - code_execution
+      - delegation
+      - browser
+      - computer_use
+      - cronjob
+      - web
+      - search
+      - x_search
+      - vision
+      - video
+      - image_gen
+      - video_gen
+      - tts
+      - todo
+      - session_search
+      - project
+      - homeassistant
+      - discord
+      - discord_admin
+      - spotify
+    approvals:
+      cron_mode: approve
+    display:
+      platforms:
+        google_chat:
+          busy_ack_detail: false
+          interim_assistant_messages: false
+          long_running_notifications: true
+          memory_notifications: "off"
+          tool_progress: "off"
+    kanban:
+      auto_subscribe_on_create: true
+      dispatch_in_gateway: true
+      dispatch_interval_seconds: 5
+    leader_election:
+      enabled: false
+    mcp_servers:
+      router:
+        args:
+        - /opt/data/scripts/router_server.py
+        command: /opt/hermes/.venv/bin/python3
+        env:
+          HERMES_HOME: ${HERMES_HOME}
+    memory:
+      memory_enabled: false
+      provider: multiuser_memory
+      user_profile_enabled: false
+    model:
+      api_key: none
+      base_url: http://litellm.kubeagents-system.svc.cluster.local/v1
+      default: model-default
+      model: model-default
+      provider: custom
+    platform_toolsets:
+      api_server:
+      - mcp-router
+      - kanban
+      - memory
+      cli:
+      - mcp-router
+      - kanban
+      - memory
+      google_chat:
+      - mcp-router
+      - kanban
+      - memory
+    platforms:
+      google_chat:
+        enabled: true
+        typing_status_text: Kage is thinking…
+      slack:
+        enabled: false
+    plugins:
+      enabled:
+      - hermes_otel
+      - session_store
+      - session_otel_bridge
+      - tool_call_audit
+      - incident_context
+      - bootstrap_onboarding
+    terminal:
+      backend: local
+      cwd: /opt/data
+    toolsets:
+    - kanban
+    web:
+      backend: ddgs
+  leader_elect.py: <OMITTED_FOR_TESTS>
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-config
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: v1
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Daemon        Off
+        Log_Level     info
+        Parsers_File  parsers.conf
+
+    [INPUT]
+        Name              tail
+        Tag               agent.logs
+        Path              /opt/data/logs/*.log
+        DB                /fluent-bit/state/fluent-bit.db
+        Refresh_Interval  5
+        Rotate_Wait       30
+        Mem_Buf_Limit     20MB
+        Skip_Long_Lines   On
+        Read_from_Head    On
+        Path_Key          file_path
+
+    [FILTER]
+        Name          parser
+        Match         agent.logs
+        Key_Name      log
+        Parser        gchat_event
+        Reserve_Data  On
+        Preserve_Key  On
+
+    [FILTER]
+        Name              record_modifier
+        Match             agent.logs
+        Record            app agent
+        Record            log_source agent-file
+
+    [OUTPUT]
+        Name              stdout
+        Match             agent.logs
+        Format            json_lines
+  parsers.conf: |
+    [PARSER]
+        Name    gchat_event
+        Format  regex
+        Regex   User=(?<gchat_user>[^,\s]+),\s*Session=(?<gchat_session>[^,\s]+)
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-fluent-bit-config
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: v1
+data:
+  SETTINGS.md: |
+    # GKE Scope Configuration
+    - **Git Repo:** None
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-settings
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: v1
+data:
+  policy.json: |-
+    {
+      "apiVersion": "cli.proxy.kubeagents.io/v1alpha1",
+      "blockedMessage": "Command blocked for security reasons.",
+      "rules": [
+        {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+print-(?:access|identity)-token\\b"},
+        {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+config-helper\\b"},
+        {"id":"github.token-disclosure","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+token\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+status\\b(?:\\s+\\S+)*?\\s+--show-token\\b"},
+        {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\b(?:\\s+\\S+)*?\\s+create\\b(?:\\s+\\S+)*?\\s+token\\b|\\bkubectl\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+view\\b(?:\\s+\\S+)*?\\s+--raw\\b"},
+        {"id":"git.credential-disclosure","pattern":"\\bgit\\b(?:\\s+\\S+)*?\\s+credential\\b(?:\\s+\\S+)*?\\s+fill\\b"},
+        {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|activate-service-account)\\b"},
+        {"id":"github.credential-replacement","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|refresh|switch|logout)\\b"},
+        {"id":"tool.self-modification","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+components\\b(?:\\s+\\S+)*?\\s+(?:install|update|remove)\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+extension\\b(?:\\s+\\S+)*?\\s+(?:install|upgrade|remove)\\b"}
+      ]
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: platformagent-credential-proxy-policy
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: platformagent-gateway
+    kubeagents.x-k8s.io/has-credential-proxy: "true"
+  name: platformagent-gateway
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platformagent-gateway
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kubeagents.x-k8s.io/config-hash: 1088ea5ecf4bb6f1f9c1c0a6262d6c83f22e717a5a655ea8d232dccbccd8b115
+        kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
+        kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
+        kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9
+      creationTimestamp: null
+      labels:
+        app: platformagent-gateway
+        kubeagents.x-k8s.io/has-credential-proxy: "true"
+    spec:
+      automountServiceAccountToken: false
+      containers:
+        - env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: PLATFORM_AGENT_PLUGINS_DEBUG
+              value: "0"
+            - name: API_SERVER_ENABLED
+              value: "true"
+            - name: API_SERVER_HOST
+              value: 127.0.0.1
+            - name: API_SERVER_KEY
+              value: cluster-internal-trusted
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+            - name: OTEL_SERVICE_NAME
+              value: platformagent-gateway
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: http/protobuf
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.namespace=kubeagents-system,k8s.namespace.name=kubeagents-system,kubeagents.agent_type=platform,kubeagents.agent_name=platformagent
+            - name: GKE_PROJECT_ID
+              value: example-project
+            - name: GKE_CLUSTER_NAME
+              value: cluster-a
+            - name: GKE_LOCATION
+              value: us-central1-a
+            - name: GCP_PROJECT_ID
+              value: example-project
+            - name: KUBE_CONTEXT_NAME
+              value: gke_example-project_us-central1-a_cluster-a
+            - name: KUBE_DEFAULT_NAMESPACE
+              value: kubeagents-system
+            - name: GOOGLE_CHAT_RELAY_URL
+              value: http://127.0.0.1:8765
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: GOOGLE_CHAT_ALLOWED_USERS
+            - name: GOOGLE_CHAT_HOME_CHANNEL
+            - name: GOOGLE_CHAT_ALLOW_ALL_USERS
+              value: "true"
+            - name: CREDENTIAL_PROXY_URL
+              value: http://127.0.0.1:8765
+            - name: PATH
+              value: /opt/credential-proxy/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+            - name: PYTHONPATH
+              value: /opt/defaults/scripts
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9
+          imagePullPolicy: IfNotPresent
+          name: platform-agent
+          ports:
+            - containerPort: 8642
+              name: api
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /opt/data/config.yaml
+              name: platform-agent-config-vol
+              subPath: config.yaml
+            - mountPath: /opt/data/leader_elect.py
+              name: platform-agent-config-vol
+              subPath: leader_elect.py
+            - mountPath: /opt/data/SETTINGS.md
+              name: settings-volume
+              readOnly: true
+              subPath: SETTINGS.md
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - hermes
+            - dashboard
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /opt/data
+            - name: HOME
+              value: /opt/data/home
+            - name: SESSION_KV_DB_PATH
+              value: /var/lib/kube-agents/session/session_kv.db
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9
+          imagePullPolicy: IfNotPresent
+          name: platform-agent-dashboard
+          ports:
+            - containerPort: 9119
+              name: dashboard
+          resources:
+            limits:
+              cpu: "1"
+              memory: 2Gi
+            requests:
+              cpu: 256m
+              memory: 512Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+            - mountPath: /var/lib/kube-agents/session
+              name: system-metadata
+              subPath: session
+        - args:
+            - -c
+            - /fluent-bit/etc/fluent-bit.conf
+          image: fluent/fluent-bit:5.0.7
+          name: fluent-bit
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 1Gi
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 1Gi
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+              readOnly: true
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: fluent-bit.conf
+            - mountPath: /fluent-bit/etc/parsers.conf
+              name: fluent-bit-config
+              readOnly: true
+              subPath: parsers.conf
+            - mountPath: /fluent-bit/state
+              name: fluent-bit-state
+        - args:
+            - --cluster-name=cluster-a
+            - --daemon-url=http://127.0.0.1:8699
+            - --token-env=API_SERVER_KEY
+            - --owner=platform
+            - --reason=Failed,FailedToDrainNode,CrashLoopBackOff,BackOff,ImagePullBackOff,ErrImagePull,OOMKilled
+            - --kubeconfig=/var/run/event-watcher/watcher.config
+          command:
+            - /usr/local/bin/k8s-event-watcher
+          env:
+            - name: API_SERVER_KEY
+              value: cluster-internal-trusted
+            - name: HOME
+              value: /opt/data/home
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9
+          imagePullPolicy: IfNotPresent
+          name: event-watcher
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /var/run/event-watcher
+              name: event-watcher-kubeconfig
+              readOnly: true
+            - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+              name: event-watcher-ksa-token
+              readOnly: true
+        - command:
+            - /usr/local/bin/envoy-credential-sidecar
+          env:
+            - name: PLATFORM_AGENT_HOME
+              value: /tmp/credential-proxy
+            - name: HOME
+              value: /tmp/credential-proxy/home
+            - name: CREDENTIAL_PROXY_POLICY
+              value: /etc/credential-proxy/policy.json
+            - name: CREDENTIAL_PROXY_STATE_DIR
+              value: /var/lib/credential-proxy
+            - name: CREDENTIAL_PROXY_UNIX_SOCKET
+              value: /var/run/credential-proxy/backend.sock
+            - name: KUBECONFIG
+              value: /var/run/event-watcher/watcher.config
+            - name: KSA_TOKEN_FILE
+              value: /var/run/secrets/kubeagents/serviceaccount/token
+            - name: TOKEN_BROKER_URL
+              value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+            - name: AGENT_API_PROXY_PORT
+              value: "8643"
+            - name: AGENT_API_UPSTREAM_KEY
+              value: cluster-internal-trusted
+            - name: API_SERVER_EXTERNAL_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: platformagent-secrets
+            - name: GKE_PROJECT_ID
+              value: example-project
+            - name: GKE_CLUSTER_NAME
+              value: cluster-a
+            - name: GKE_LOCATION
+              value: us-central1-a
+            - name: KUBE_CONTEXT_NAME
+              value: gke_example-project_us-central1-a_cluster-a
+            - name: KUBE_DEFAULT_NAMESPACE
+              value: kubeagents-system
+            - name: CREDENTIAL_PROXY_BOOTSTRAP_COMMAND
+              value: |-
+                gcloud config set project "$GKE_PROJECT_ID" >/dev/null &&
+                gcloud container clusters get-credentials "$GKE_CLUSTER_NAME" --location "$GKE_LOCATION" --project "$GKE_PROJECT_ID" &&
+                kubectl config use-context "$KUBE_CONTEXT_NAME" >/dev/null &&
+                kubectl config set-context "$KUBE_CONTEXT_NAME" --namespace="$KUBE_DEFAULT_NAMESPACE" >/dev/null
+            - name: GOOGLE_CHAT_PROJECT_ID
+              value: kube-agents-gkedemos
+            - name: GOOGLE_CHAT_SUBSCRIPTION_NAME
+              value: projects/kube-agents-gkedemos/subscriptions/kubeagents-google-chat-events-sub
+            - name: CREDENTIAL_PROXY_WORKSPACE_ROOT
+              value: /opt/data
+          image: ghcr.io/gke-labs/kube-agents/credential-proxy:v9.9.9
+          imagePullPolicy: IfNotPresent
+          name: envoy-credential-proxy
+          ports:
+            - containerPort: 8765
+              name: cred-proxy
+            - containerPort: 8643
+              name: proxy-api
+          readinessProbe:
+            exec:
+              command:
+                - curl
+                - --fail
+                - --silent
+                - --show-error
+                - http://127.0.0.1:8765/healthz
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          resources:
+            limits:
+              cpu: "2"
+              ephemeral-storage: 2Gi
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /etc/credential-proxy/policy.json
+              name: credential-proxy-policy
+              readOnly: true
+              subPath: policy.json
+            - mountPath: /tmp
+              name: credential-proxy-tmp
+            - mountPath: /var/lib/credential-proxy
+              name: credential-proxy-state
+            - mountPath: /var/run/credential-proxy
+              name: credential-proxy-runtime
+            - mountPath: /var/run/event-watcher
+              name: event-watcher-kubeconfig
+            - mountPath: /var/run/secrets/kubeagents/serviceaccount
+              name: credential-proxy-ksa-token
+              readOnly: true
+            - mountPath: /opt/data
+              name: platform-agent-data-vol
+      initContainers:
+        - args:
+            - |-
+              rm -rf -- \
+                /workspace/home/.config/gcloud \
+                /workspace/home/.config/gh \
+                /workspace/home/.aws/credentials \
+                /workspace/home/.aws/cli/cache \
+                /workspace/home/.aws/sso/cache \
+                /workspace/home/.azure \
+                /workspace/home/.docker/config.json \
+                /workspace/home/.git-credentials \
+                /workspace/home/.hermes/.env \
+                /workspace/home/.kube/config \
+                /workspace/home/.netrc \
+                /workspace/home/.npmrc \
+                /workspace/home/.pypirc
+          command:
+            - sh
+            - -ec
+          image: ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9
+          imagePullPolicy: IfNotPresent
+          name: sandbox-credential-cleanup
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /workspace
+              name: platform-agent-data-vol
+      securityContext:
+        fsGroup: 10000
+        runAsNonRoot: true
+        runAsUser: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: kubeagents-platform-agent
+      shareProcessNamespace: true
+      volumes:
+        - name: platform-agent-data-vol
+          persistentVolumeClaim:
+            claimName: platformagent-data
+        - configMap:
+            defaultMode: 493
+            name: platformagent-config
+          name: platform-agent-config-vol
+        - configMap:
+            defaultMode: 420
+            name: platformagent-fluent-bit-config
+          name: fluent-bit-config
+        - emptyDir: {}
+          name: fluent-bit-state
+        - name: system-metadata
+          persistentVolumeClaim:
+            claimName: system-metadata
+        - configMap:
+            defaultMode: 420
+            name: platformagent-settings
+          name: settings-volume
+        - configMap:
+            name: platformagent-credential-proxy-policy
+          name: credential-proxy-policy
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: credential-proxy-tmp
+        - emptyDir:
+            sizeLimit: 5Gi
+          name: credential-proxy-state
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: credential-proxy-runtime
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+          name: event-watcher-kubeconfig
+        - name: credential-proxy-ksa-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  audience: kubeagents-credential-proxy
+                  expirationSeconds: 3600
+                  path: token
+        - name: event-watcher-ksa-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  expirationSeconds: 3600
+                  path: token
+              - configMap:
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+                  name: kube-root-ca.crt
+              - downwardAPI:
+                  items:
+                    - fieldRef:
+                        apiVersion: v1
+                        fieldPath: metadata.namespace
+                      path: namespace
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: platformagent
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+spec:
+  ports:
+    - name: api
+      port: 8642
+      targetPort: 8643
+    - name: dashboard
+      port: 9119
+      targetPort: dashboard
+  selector:
+    app: platformagent-gateway
+status:
+  loadBalancer: {}

--- a/k8s-operator/internal/testing/testdata/platform/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/platformagent-tagged.yaml
@@ -38,12 +38,13 @@ spec:
   # decoupling the compute payload from the agent's application logic.
   # +optional
   deployment:
-    # Image is optional. When omitted, the operator falls back to its
-    # PLATFORM_AGENT_IMAGE env var (set for private-registry installs; see
-    # config/manager/manager.yaml) and then to the public ghcr.io default —
-    # so behind-the-firewall installs should omit this field or point it at
-    # their mirror.
-    image: "ghcr.io/gke-labs/kube-agents/platform-agent"
+    # Golden fixture: identical to examples/platformagent.yaml except that the
+    # image embeds a tag, and the tag field carries the "latest" the CRD
+    # default / mutating webhook persists on a real cluster. The embedded tag
+    # must win for the agent container AND the derived credential-proxy
+    # sidecar (no version skew).
+    image: "ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9"
+    tag: "latest"
 
     imagePullPolicy: "IfNotPresent"
   security:

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -22,9 +22,16 @@ When any script is run:
 ### Container images
 
 All kube-agents images default to the `ghcr.io/gke-labs/kube-agents` registry prefix. Export
-`REGISTRY_PREFIX` before running the pipeline to pull mirrored images from a private registry
-instead; it becomes the default for `OPERATOR_IMAGE` (step 03), `AGENT_IMAGE` (step 08), and
-`REPLAY_IMAGE` (step 11), each of which can still be set individually. Step 03 also forwards
+`REGISTRY_PREFIX` before the first pipeline run to pull mirrored images from a private registry
+instead; it is persisted in `vars.sh` like every other option and becomes the default for
+`OPERATOR_IMAGE` (step 03), `AGENT_IMAGE` (step 08), and `REPLAY_IMAGE` (step 11), each of
+which can still be set individually. Changing it after a first run requires editing the saved
+`REGISTRY_PREFIX` and `*_IMAGE` values in `vars.sh` (saved state wins over a new export); the
+scripts warn when an export is ignored or a saved image no longer matches the prefix.
+
+`IMAGE_TAG` is the deliberate exception to `vars.sh` reuse: tags change between deploys, so
+`provision.sh` asks for it once per pipeline run (or takes an exported `IMAGE_TAG`) and shares
+it with every step without saving it. Step 03 also forwards
 `PLATFORM_AGENT_IMAGE`, `CREDENTIAL_PROXY_IMAGE`, and `FLUENT_BIT_IMAGE` overrides to the
 operator Deployment. See the docs site's
 [Docker images page](../../docs/site/src/content/docs/deploy/docker-images.md) for the list of

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -159,6 +159,36 @@ registry_prefix() {
   echo "${prefix%/}"
 }
 
+init_var_registry_prefix() {
+  init_var "REGISTRY_PREFIX" "$DEFAULT_REGISTRY_PREFIX" "Enter Container Registry Prefix"
+  case "$REGISTRY_PREFIX" in
+    *"://"*)
+      print_error "REGISTRY_PREFIX must be a bare registry path without a scheme (got '$REGISTRY_PREFIX'). Use e.g. 'registry.example.com/kube-agents'."
+      exit 1
+      ;;
+  esac
+  # init_var only saves values it prompted for; persist an env-exported
+  # prefix too, so the remaining steps and later re-runs reuse it.
+  save_var "REGISTRY_PREFIX" "$REGISTRY_PREFIX"
+}
+
+# Warn when a persisted *_IMAGE value no longer lives under the effective
+# registry prefix — e.g. REGISTRY_PREFIX was exported after a first run
+# already saved image defaults derived from another registry. The saved
+# value still wins (state reuse), so surface the mixed state instead of
+# silently applying it halfway.
+warn_on_registry_prefix_mismatch() {
+  local var_name=$1
+  local image_val="${!var_name:-}"
+  [ -z "$image_val" ] && return 0
+  case "$image_val" in
+    "$(registry_prefix)"/*) ;;
+    *)
+      print_warning "${var_name}='${image_val}' does not match REGISTRY_PREFIX '$(registry_prefix)'. The saved value wins; edit ${VARS_FILE} (or unset ${var_name}) to migrate this image to the new registry."
+      ;;
+  esac
+}
+
 init_var_model_provider() {
   init_var "MODEL_PROVIDER" "gemini" "Enter Model Provider (gemini, anthropic, chatgpt, openai)"
 
@@ -206,6 +236,10 @@ is_non_interactive() {
   [ ! -t 0 ] || [ "${NO_CONFIRM:-0}" -eq 1 ] || [ "${DRY_RUN:-0}" -eq 1 ] || is_ci_pipeline
 }
 
+# IMAGE_TAG is deliberately NOT persisted to vars.sh: the tag usually changes
+# between deploys, so it is scoped to a single pipeline execution. provision.sh
+# prompts once up front and exports it; the per-step scripts inherit it from
+# the environment and only prompt when run standalone.
 init_var_image_tag() {
   if [ -z "${IMAGE_TAG:-}" ]; then
     if is_non_interactive; then
@@ -213,7 +247,8 @@ init_var_image_tag() {
       exit 1
     else
       local default_tag="latest"
-      echo -ne "  ${C_CYAN}Enter Base Image Tag [${C_WHITE}${default_tag}${C_CYAN}]: ${C_RESET}"
+      echo -e "  ${C_CYAN}The base image tag is used for all images built from the kube-agents repo.${C_RESET}"
+      echo -ne "  ${C_CYAN}Enter Base Image Tag (a commit SHA; 'latest' = latest commit on main) [${C_WHITE}${default_tag}${C_CYAN}]: ${C_RESET}"
       read -r input_tag
       export IMAGE_TAG="${input_tag:-$default_tag}"
     fi
@@ -221,13 +256,22 @@ init_var_image_tag() {
 }
 
 load_state() {
+  local env_registry_prefix="${REGISTRY_PREFIX:-}"
   if [ -f "$VARS_FILE" ]; then
     source "$VARS_FILE"
   elif [ "${DRY_RUN:-0}" -ne 1 ]; then
     echo "# SRE Sourced Variables for GKE & GCP Setup" > "$VARS_FILE"
     source "$VARS_FILE"
   fi
+  # Sourcing vars.sh restores the saved REGISTRY_PREFIX over a freshly
+  # exported one (saved state wins, as for every knob). Say so instead of
+  # silently ignoring the export.
+  if [ -n "$env_registry_prefix" ] && [ -n "${REGISTRY_PREFIX:-}" ] \
+    && [ "$env_registry_prefix" != "$REGISTRY_PREFIX" ]; then
+    print_warning "Ignoring exported REGISTRY_PREFIX='${env_registry_prefix}': the saved value '${REGISTRY_PREFIX}' from ${VARS_FILE} wins. Edit ${VARS_FILE} (REGISTRY_PREFIX and the saved *_IMAGE values) to change registries."
+  fi
   init_var_image_tag
+  init_var_registry_prefix
   export NAMESPACE="kubeagents-system"
   export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"
   export PLATFORM_AGENT_SANDBOX_KSA_NAME="platform-agent-sandbox"

--- a/k8s-operator/scripts/provision.sh
+++ b/k8s-operator/scripts/provision.sh
@@ -19,6 +19,11 @@ fi
 
 echo -e "${C_MAGENTA}${C_BOLD}🚀 Starting GKE Platform Agent provisioning pipeline...${C_RESET}"
 
+# Ask for the base image tag once for the whole pipeline. The exported value
+# is inherited by every step below, so none of them re-prompts; it is not
+# saved to vars.sh because the tag typically changes between runs.
+init_var_image_tag
+
 "${SCRIPT_DIR}/provision_01_gcp_cluster.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_02_gvisor_nodepool.sh" $DRY_RUN_ARG
 "${SCRIPT_DIR}/provision_03_gcp_gke_operator.sh" $DRY_RUN_ARG

--- a/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
+++ b/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
@@ -34,6 +34,7 @@ init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 
 DEFAULT_OPERATOR_IMAGE="$(registry_prefix)/k8s-operator"
 init_var "OPERATOR_IMAGE" "$DEFAULT_OPERATOR_IMAGE" "Enter Operator Image Path"
+warn_on_registry_prefix_mismatch "OPERATOR_IMAGE"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 
@@ -107,10 +108,23 @@ execute_operator() {
   # Propagate image overrides to the operator so PlatformAgent CRs created
   # without an explicit spec.deployment.image also pull from the custom
   # registry (see PLATFORM_AGENT_IMAGE et al. in config/manager/manager.yaml).
+  # Precedence: explicit PLATFORM_AGENT_IMAGE > custom AGENT_IMAGE > custom
+  # REGISTRY_PREFIX. Nothing is set for a default install so the operator's
+  # compiled-in default stays authoritative.
   local env_overrides=()
   if [ -n "${PLATFORM_AGENT_IMAGE:-}" ]; then
     env_overrides+=("PLATFORM_AGENT_IMAGE=${PLATFORM_AGENT_IMAGE}")
-  elif [ -n "${REGISTRY_PREFIX:-}" ]; then
+  elif [ -n "${AGENT_IMAGE:-}" ] && [ "${AGENT_IMAGE}" != "$(registry_prefix)/platform-agent" ]; then
+    # A custom AGENT_IMAGE feeds the CR rendered in provision_08; mirror it to
+    # the operator so hand-written CRs that omit spec.deployment.image pull
+    # from the same place. Only append IMAGE_TAG when the value is bare.
+    local agent_image_ref="${AGENT_IMAGE}"
+    case "${agent_image_ref##*/}" in
+      *:* | *@*) ;;
+      *) agent_image_ref="${agent_image_ref}:${IMAGE_TAG}" ;;
+    esac
+    env_overrides+=("PLATFORM_AGENT_IMAGE=${agent_image_ref}")
+  elif [ "$(registry_prefix)" != "$DEFAULT_REGISTRY_PREFIX" ]; then
     env_overrides+=("PLATFORM_AGENT_IMAGE=$(registry_prefix)/platform-agent:${IMAGE_TAG}")
   fi
   if [ -n "${CREDENTIAL_PROXY_IMAGE:-}" ]; then

--- a/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
@@ -42,6 +42,7 @@ export KSA_NAME="${PLATFORM_AGENT_KSA_NAME}"
 
 DEFAULT_AGENT_IMAGE="$(registry_prefix)/platform-agent"
 init_var "AGENT_IMAGE" "$DEFAULT_AGENT_IMAGE" "Enter Platform Agent Image Path"
+warn_on_registry_prefix_mismatch "AGENT_IMAGE"
 init_var "MEMORY_ENABLED" "false" "Enable agent memory persistence? (true/false)"
 init_var "MEMORY_PROVIDER" "multiuser_memory" "Enter agent memory provider"
 init_var "USER_PROFILE_ENABLED" "false" "Enable per-user memory profiling? (true/false)"

--- a/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
@@ -45,6 +45,7 @@ init_var "PROJECT_ID" "$DEFAULT_PROJECT_ID" "Enter Target GCP Project ID"
 init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var "REPLAY_IMAGE" "$(registry_prefix)/replay-proxy:${IMAGE_TAG:-latest}" "Enter Replay Proxy container image"
+warn_on_registry_prefix_mismatch "REPLAY_IMAGE"
 
 # ─── Step Implementations ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
# Pull Request

## Why This Change

Follow-up to #501 (`feat(install): make container image registry configurable`), addressing the post-merge review (https://github.com/gke-labs/kube-agents/pull/501#issuecomment-5165465332). As merged, the registry override was half-wired: `REGISTRY_PREFIX` was read directly and never persisted to `vars.sh`, so a second provisioning run applied it to some derived values and not others; `AGENT_IMAGE` never reached the operator-level override; the shipped example CRs hardcode `ghcr.io` so the headline air-gapped use case failed at the two most likely copy-paste entry points; the docs overstated mirror coverage; and a digest-pinned agent image silently dropped its pin for the credential-proxy sidecar. Separately, every provisioning step re-prompted `Enter Base Image Tag [latest]:` because each step script prompts independently and nothing shared the answer across the pipeline, and the #501 merge left `go vet ./...` broken on `main`.

## What Changed

**Files:**

- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/provision.sh`
- `k8s-operator/scripts/provision_03_gcp_gke_operator.sh`
- `k8s-operator/scripts/provision_08_deploy_platform_agent.sh`
- `k8s-operator/scripts/provision_11_deploy_inference_replay.sh`
- `k8s-operator/scripts/README.md`
- `k8s-operator/examples/platformagent.yaml`
- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/internal/testing/golden_test.go`
- `k8s-operator/internal/testing/testdata/platform/platformagent-tagged.yaml` (new)
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml` (new)
- `docs/site/src/content/docs/deploy/docker-images.md`
- `docs/site/src/content/docs/operator/index.md`
- `docs/site/src/content/docs/install/quickstart-gke.mdx`
- `docs/README.md`

**Added/Changed/Fixed:**

- **Fixed** (#501 review issue 2): `REGISTRY_PREFIX` is initialised via `init_var` and persisted to `vars.sh` — including env-exported values — so re-runs apply it consistently instead of half-migrating. `load_state` now warns when a freshly exported `REGISTRY_PREFIX` conflicts with the saved one (saved state wins, as for every knob), the provisioning steps warn when a saved `*_IMAGE` no longer lives under the effective prefix, and prefixes carrying a URL scheme are rejected outright.
- **Fixed** (issue 3): `provision_03` also derives the operator-level `PLATFORM_AGENT_IMAGE` from a custom `AGENT_IMAGE` (appending `IMAGE_TAG` only when the value is bare), with precedence explicit `PLATFORM_AGENT_IMAGE` > custom `AGENT_IMAGE` > custom `REGISTRY_PREFIX`; nothing is set on a default install so the operator's compiled-in default stays authoritative.
- **Fixed** (issue 1): `examples/platformagent.yaml` and the operator docs' CR example now state that `spec.deployment.image` is optional and that omitting it lets the operator-level override / default apply — the two copy-paste entry points no longer silently pin `ghcr.io`.
- **Fixed** (issue 4): `docker-images.md` now lists the images the overrides do *not* yet cover (cert-manager via `provision_03`, LiteLLM, GitHub token minter), documents the fluent-bit CR-level gap, drops the restated fluent-bit version pin, and describes the state-edit path for changing registries after a first run. `scripts/README.md` and the quickstart prompt roster are synced.
- **Fixed** (issue 5): `resolveCredentialProxyImage` logs when a digest-pinned agent image forces the sidecar onto a mutable tag instead of dropping the pin silently.
- **Added** (issue 6): a golden case (`PlatformAgentTaggedImage`) pinning agent/credential-proxy tag agreement for a CR whose `image` embeds a tag while `spec.deployment.tag` carries the CRD-defaulted `latest`. The fixture is identical to `examples/platformagent.yaml` except for the deployment block, and the expected file differs from the existing golden only in the five image tag lines.
- **Fixed** (UX): `provision.sh` now asks for the base image tag once per pipeline run and exports it to every step, so `Enter Base Image Tag [latest]:` no longer appears per script. `IMAGE_TAG` is deliberately **not** saved to `vars.sh` — the tag usually changes between deploys, so it is scoped to a single execution (standalone step runs still prompt for themselves; CI still requires an exported `IMAGE_TAG`). This intent is now documented in `common.sh` and `scripts/README.md`.
- **Fixed** (main breakage, #501 merge fallout): `TestBuildDeploymentFluentBitImageOverride` called `buildDeployment` with the pre-#381 signature, breaking `go vet ./...` and test compilation on `main`; and the docs map count was one short since #381 (`141` → `142`).

## Why This Matters

- Behind-the-firewall installs now get a consistent, persisted registry configuration across all provisioning steps and re-runs, with warnings instead of silent half-migrations.
- The interactive provisioning flow asks for the image tag once instead of once per step.
- `go vet ./...` and `make docs-check` pass on this branch; both are currently broken on `main`.

## Context

- Review being addressed: https://github.com/gke-labs/kube-agents/pull/501#issuecomment-5165465332
- Not covered here (acknowledged in the review as separate work): registry overrides for cert-manager/LiteLLM/token-minter images (#499/#500 territory) — now explicitly documented as not covered; `imagePullSecrets` support (#499).

## Testing

- `go build ./...` and `go vet ./...` pass (vet fails on current `main`; fixed here).
- Shell behavior verified empirically with an isolated `VARS_FILE`: an exported `REGISTRY_PREFIX` persists on first run and is reused without prompting on the next; a conflicting export triggers the new warning; a scheme-carrying prefix is rejected; the `*_IMAGE`-vs-prefix mismatch warning fires only on mismatch; `IMAGE_TAG` set once in the orchestrator is inherited by child steps without re-prompting and is *not* written to `vars.sh`; the CI hard-fail without `IMAGE_TAG` is unchanged. `bash -n` passes on all touched scripts.
- `make docs-check` passes (fails on current `main` due to the stale count).
- The new golden expected file is a mechanical transform of the existing one (verified identical except the five image lines). **Note:** local Go *test execution* is blocked on this workstation by endpoint security (binaries are SIGKILLed), so `go test ./...` — including the new golden case — needs CI (or a reviewer's machine) to confirm. Everything compiles and vets clean.

---

Low risk: changes are confined to provisioning-script state handling, docs, one log line, and test coverage; no controller behavior changes beyond the added log. Generated with the help of Claude.
