### PR TITLE
fix(install): default the example CR to no image and guard the air-gapped path

### DIFF
--- a/docs/site/src/content/docs/operator/index.md
+++ b/docs/site/src/content/docs/operator/index.md
@@ -60,10 +60,11 @@ spec:
         name: platformagent-secrets
         key: api-key
   deployment:
-    # Optional — omit to use the operator's default image (its
-    # PLATFORM_AGENT_IMAGE env var for private-registry installs, else the
-    # public ghcr.io image; see the Docker images page).
-    image: ghcr.io/gke-labs/kube-agents/platform-agent
+    # Image is optional and omitted here on purpose. Omit it to use the
+    # operator's default image (its PLATFORM_AGENT_IMAGE env var for
+    # private-registry installs, else the public ghcr.io image; see the Docker
+    # images page). Set it only to pin an image/registry for this agent:
+    #   image: registry.example.com/kube-agents/platform-agent
     imagePullPolicy: IfNotPresent
   security:
     serviceAccountName: kubeagents-platform-agent

--- a/k8s-operator/examples/platformagent.yaml
+++ b/k8s-operator/examples/platformagent.yaml
@@ -38,13 +38,13 @@ spec:
   # decoupling the compute payload from the agent's application logic.
   # +optional
   deployment:
-    # Image is optional. When omitted, the operator falls back to its
-    # PLATFORM_AGENT_IMAGE env var (set for private-registry installs; see
-    # config/manager/manager.yaml) and then to the public ghcr.io default —
-    # so behind-the-firewall installs should omit this field or point it at
-    # their mirror.
-    image: "ghcr.io/gke-labs/kube-agents/platform-agent"
-
+    # Image is optional and omitted here on purpose so this example is safe to
+    # copy-paste on any install. When unset, the operator uses its
+    # PLATFORM_AGENT_IMAGE env var (set for private-registry / behind-the-firewall
+    # installs; see config/manager/manager.yaml) and otherwise the public
+    # ghcr.io default. Uncomment and set this only to pin a specific image or
+    # registry for THIS agent (a mirror, a fork, or a digest):
+    #   image: "registry.example.com/kube-agents/platform-agent"
     imagePullPolicy: "IfNotPresent"
   security:
     serviceAccountName: "kubeagents-platform-agent"

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -29,6 +31,7 @@ import (
 
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
 	"gopkg.in/yaml.v3"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 func TestBuildConfigMap(t *testing.T) {
@@ -1060,6 +1063,68 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("fluent-bit sidecar container not found")
+	}
+}
+
+// TestNoPublicRegistryWhenMirrored is the end-to-end guard that #501's review
+// found missing: when the operator is configured for a private mirror (the
+// air-gapped install), a PlatformAgent that omits spec.deployment.image must
+// render EVERY container off that mirror, with no public-registry reference
+// leaking through. It also fails loudly if a new container is later added
+// without an override path.
+func TestNoPublicRegistryWhenMirrored(t *testing.T) {
+	const mirror = "registry.corp/mirror"
+	t.Setenv("PLATFORM_AGENT_IMAGE", mirror+"/platform-agent:v1.2.3")
+	t.Setenv("FLUENT_BIT_IMAGE", mirror+"/fluent-bit:5.0.7")
+	// CREDENTIAL_PROXY_IMAGE deliberately left unset: the sidecar must derive
+	// its registry from PLATFORM_AGENT_IMAGE, not fall back to ghcr.io.
+
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "mirrored-agent", Namespace: "my-ns"},
+	}
+	dep := buildDeployment(agent, "abcd1234", "efgh5678", "ijkl9012", "policy3456", nil, true)
+
+	var images []string
+	for _, c := range dep.Spec.Template.Spec.InitContainers {
+		images = append(images, c.Image)
+	}
+	for _, c := range dep.Spec.Template.Spec.Containers {
+		images = append(images, c.Image)
+	}
+	if len(images) == 0 {
+		t.Fatal("no container images rendered")
+	}
+	for _, img := range images {
+		if !strings.HasPrefix(img, mirror+"/") {
+			t.Errorf("image %q is not served from the configured mirror %q; a public-registry reference leaks on the air-gapped install path", img, mirror)
+		}
+	}
+}
+
+// TestExampleCRDoesNotPinPublicRegistry guards the copy-paste entry point from
+// #501's review issue 1: the shipped example CR must not hardcode a public
+// registry in spec.deployment.image, or a behind-the-firewall user who copies
+// it silently pins ghcr.io regardless of every override. Omitting the image
+// (the safe default) lets the operator's PLATFORM_AGENT_IMAGE / compiled-in
+// default apply.
+func TestExampleCRDoesNotPinPublicRegistry(t *testing.T) {
+	path := filepath.Join("..", "..", "examples", "platformagent.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading example CR: %v", err)
+	}
+	var agent agentv1alpha1.PlatformAgent
+	if err := k8syaml.Unmarshal(data, &agent); err != nil {
+		t.Fatalf("unmarshaling %s: %v", path, err)
+	}
+	if agent.Spec.Deployment == nil || agent.Spec.Deployment.Image == "" {
+		return // image omitted — the safe default
+	}
+	img := agent.Spec.Deployment.Image
+	for _, host := range []string{"ghcr.io", "docker.io", "quay.io", "registry.k8s.io"} {
+		if strings.HasPrefix(img, host+"/") {
+			t.Errorf("example CR pins spec.deployment.image to a public registry (%q); omit the field so private-registry installs are not silently overridden", img)
+		}
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## Why This Change

Follow-up to #501 / #509, closing the last gap from the registry-override review (https://github.com/gke-labs/kube-agents/pull/501#issuecomment-5165465332).

The review's blocking finding (issue 1) was that the feature's headline use case — a behind-the-firewall install — still fails at the two most likely copy-paste entry points, because the shipped example CR and the operator docs' CR both hardcode `image: ghcr.io/gke-labs/kube-agents/platform-agent`. `spec.deployment.image` wins over every override the feature adds (`PLATFORM_AGENT_IMAGE`, `REGISTRY_PREFIX`), so a user who copies either block silently pins the public registry. #509 documented the field as optional but left the hardcoded line in place, so copy-paste is still unsafe by default.

The review also noted that the structural gap which let issue 1 ship — no test asserts an air-gapped install pulls nothing from a public registry — was never closed. #509 added a golden case for a *tagged* image, but nothing guards the image-*less* mirror path.

## What Changed

**Files:**

- `k8s-operator/examples/platformagent.yaml`
- `docs/site/src/content/docs/operator/index.md`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`

**Added/Changed/Fixed:**

- **Fixed** (review issue 1): both CR examples now omit `spec.deployment.image` by default (a commented example remains, to uncomment for pinning a mirror/fork/digest). Omitting it lets the operator's `PLATFORM_AGENT_IMAGE` — or the compiled-in default — apply, so the example is safe to copy-paste on an air-gapped install. No behavior change for existing installs: the compiled-in default resolves to the same image, so the golden manifest renders byte-identically (`TestAgentsGolden` unchanged).
- **Added** (the missing guard): `TestNoPublicRegistryWhenMirrored` renders an image-less CR with the operator configured for a private mirror and asserts every container — init, main, credential-proxy, fluent-bit — is served from that mirror, with no public-registry reference leaking. It also fails if a new container is added later without an override path. `TestExampleCRDoesNotPinPublicRegistry` asserts the shipped example CR never hardcodes a public registry in `spec.deployment.image`.

## Why This Matters

- The documented air-gapped install now works from a straight copy-paste instead of requiring the user to notice a comment and delete a line.
- The regression class that let the original gap ship is now caught by a unit test.

## Context

- Review being addressed: https://github.com/gke-labs/kube-agents/pull/501#issuecomment-5165465332 (issue 1 + the missing end-to-end guard).
- Not in scope (acknowledged elsewhere): registry overrides for cert-manager / LiteLLM / token-minter (#500), `imagePullSecrets` for authenticated registries (#499).

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` in `k8s-operator/` — all pass, including the two new tests and the unchanged golden suite.
- `make docs-check` passes.
- `npx prettier --check` on the changed YAML/Markdown — clean.
- `docs/site` `npm run build` — succeeds.
- `review-docs-drift` skill run against the branch diff — no drift (comment-only doc edit, no identifiers/defaults/counts/generated regions/map affected).

---

Low risk: no controller behavior change (golden output identical); the substantive additions are test coverage and a safer default in two example manifests. Generated with the help of Claude.