### PR TITLE
fix(platform): relay Slack calls to the team bolt resolved

### DIFF
--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -15,9 +15,15 @@ from pathlib import Path
 from typing import Any
 
 
-
 LOGGER = logging.getLogger("slack-relay-patch")
 DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+# The agent container starts before the credential-proxy sidecar, and the
+# sidecar has been observed taking the better part of a minute to come up.
+# Waiting that out has to be generous: the real bot token lives in the relay,
+# so a connect that gives up early leaves the gateway with no bot credential
+# on the queued config, which drops Slack from the retry queue for the life
+# of the pod.
+DEFAULT_RELAY_READY_TIMEOUT = 120.0
 
 
 def read_upload(path: Path, max_file_bytes: int) -> bytes:
@@ -143,10 +149,16 @@ def install() -> None:
         class RemoteSlackClient(real_async_client):
             """Slack SDK client whose generic API calls execute in the proxy."""
 
-            def __init__(self, token: str | None = None, **_kwargs: Any) -> None:
+            def __init__(
+                self, token: str | None = None, team_id: str = "", **_kwargs: Any
+            ) -> None:
                 placeholder = token or "relay:"
                 super().__init__(token=placeholder)
-                self.team_id = (
+                # Prefer the team Bolt resolved from the inbound event. Across
+                # several workspaces the token is a comma-joined list, so
+                # splitting it yields every team at once rather than the one
+                # this request belongs to.
+                self.team_id = team_id or (
                     placeholder.split(":", 1)[1]
                     if placeholder.startswith("relay:")
                     else ""
@@ -173,19 +185,27 @@ def install() -> None:
                     "headers": json_value(headers) if headers else None,
                     "auth": json_value(auth) if auth else None,
                 }
+                supplied = {
+                    key: value
+                    for key, value in arguments.items()
+                    if value is not None
+                }
                 response = await asyncio.to_thread(
                     request,
                     "/v1/chat/slack/api",
                     {
                         "teamId": self.team_id,
                         "method": api_method,
-                        "arguments": {
-                            key: value
-                            for key, value in arguments.items()
-                            if value is not None
-                        },
+                        "arguments": supplied,
                     },
                 )
+                # Hand back the SDK's own response type rather than the bare
+                # payload. Everything downstream is written against the real
+                # client: Bolt's authorization middleware reads .headers off
+                # this to pick up x-oauth-scopes, and a plain dict makes it
+                # die with "'dict' object has no attribute 'headers'" before
+                # any listener runs. The relay forwards the scope headers it
+                # captured under "__headers".
                 payload = response.get("response") or {}
                 headers = {}
                 if isinstance(payload, dict):
@@ -200,16 +220,11 @@ def install() -> None:
                     client=self,
                     http_verb=http_verb,
                     api_url=api_method,
-                    req_args={},
+                    req_args=supplied,
                     data=data,
                     headers=headers,
                     status_code=200,
                 )
-
-        def remote_client_factory(
-            token: str | None = None, **kwargs: Any
-        ) -> RemoteSlackClient:
-            return RemoteSlackClient(token=token, **kwargs)
 
         def remote_app_factory(
             *_args: Any, token: str | None = None, **kwargs: Any
@@ -221,7 +236,7 @@ def install() -> None:
                 **kwargs,
             )
 
-        module.AsyncWebClient = remote_client_factory
+        module.AsyncWebClient = RemoteSlackClient
         module.AsyncApp = remote_app_factory
 
         # slack_bolt >= 1.15 ignores the client passed to AsyncApp(...) when
@@ -245,13 +260,16 @@ def install() -> None:
             # startup race.
             try:
                 wait_seconds = float(
-                    os.getenv("SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS", "20")
+                    os.getenv(
+                        "SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS",
+                        str(DEFAULT_RELAY_READY_TIMEOUT),
+                    )
                 )
             except ValueError:
                 LOGGER.warning(
                     "Invalid SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS; using the default"
                 )
-                wait_seconds = 20.0
+                wait_seconds = DEFAULT_RELAY_READY_TIMEOUT
             deadline = time.monotonic() + wait_seconds
             while True:
                 if time.monotonic() >= deadline:

--- a/agents/platform/scripts/test_slack_relay_patch.py
+++ b/agents/platform/scripts/test_slack_relay_patch.py
@@ -310,6 +310,38 @@ class SlackRelayPatchTest(unittest.TestCase):
         self.assertEqual(dict(result.data), {"ok": True, "team_id": "T123"})
         self.assertEqual(getattr(result, "headers", None), {"x-oauth-scopes": "chat:write"})
 
+    def test_the_team_bolt_resolved_wins_over_the_joined_token(self):
+        """Across workspaces the token lists every team, so it cannot be split.
+
+        connect() joins one "relay:<teamId>" per authenticated workspace into
+        config.token. Deriving team_id from that yields "T1,relay:T2" for the
+        first team and relays every call to the wrong workspace. Bolt resolves
+        the team from the inbound event and passes it per request; prefer it.
+        """
+        self._create_adapter()
+        patched = self.bolt_async_app.AsyncWebClient
+
+        client = patched(token="relay:T1,relay:T2", team_id="T2")
+        self.assertEqual("T2", client.team_id)
+
+        captured = {}
+
+        def fake_urlopen(req, timeout=None):
+            captured["payload"] = json.loads(req.data.decode("utf-8"))
+            return FakeHTTPResponse({"response": {"ok": True}})
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            asyncio.run(client.api_call("auth.test"))
+
+        self.assertEqual("T2", captured["payload"]["teamId"])
+
+    def test_a_single_workspace_token_still_yields_its_team(self):
+        """With no team_id from bolt, the placeholder token remains the source."""
+        self._create_adapter()
+        patched = self.bolt_async_app.AsyncWebClient
+
+        self.assertEqual("T1", patched(token="relay:T1").team_id)
+
     def test_connect_waits_for_relay_readiness(self):
         adapter = self._create_adapter()
         attempts = {"count": 0}


### PR DESCRIPTION
# Pull Request

## Why This Change

[#480](https://github.com/gke-labs/kube-agents/pull/480) and [#505](https://github.com/gke-labs/kube-agents/pull/505) were written against the same broken credential-free Slack path and overlap on three of four defects. #480 merged first. This PR carries the part of #505 that #480 did not cover, rebased onto current `main`.

The surviving defect is a multi-workspace one. `RemoteSlackClient` derives `team_id` by splitting its placeholder token:

```python
self.team_id = placeholder.split(":", 1)[1] if placeholder.startswith("relay:") else ""
```

That holds for a single workspace. But `connect()` builds the token by joining one `relay:<teamId>` per authenticated workspace:

```python
self.config.token = ",".join("relay:" + str(w.get("teamId", "")) for w in workspaces)
```

So with two workspaces the split yields `"T1,relay:T2"`, and every relayed call is addressed to a workspace that does not exist.

## What Changed

**Files:**

- `agents/platform/scripts/slack_relay_patch.py`
- `agents/platform/scripts/test_slack_relay_patch.py`

**Added/Changed/Fixed:**

- Prefer the `team_id` bolt resolves from the inbound event and passes per request; fall back to parsing the token only when it is absent (single-workspace case).
- Bind the client **class** rather than a factory to the adapter module, matching what is already bound into `slack_bolt`. `AsyncApp` isinstance-checks the client it is handed, which a function cannot satisfy.
- Raise the bootstrap wait default from 20s to 120s (`SLACK_RELAY_BOOTSTRAP_WAIT_SECONDS`, unchanged as an override) and name it `DEFAULT_RELAY_READY_TIMEOUT`.
- Carry `req_args` through to the `AsyncSlackResponse` so a relayed call is introspectable the way a direct one is.
- Two tests covering the multi-workspace token and the single-workspace fallback.

## Why This Matters

- Any deployment with more than one authenticated Slack workspace relays every call to a bogus team. The existing test passes `team_id="T123"` alongside a *single*-workspace token, so it cannot catch this — it passes with or without the fix.
- The 20s bootstrap default is worth a second opinion. #505 reported the credential-proxy sidecar taking **49s** to come up, which 20s does not survive. Failing here is not merely slow: the bot token lives in the relay, so the gateway finds no bot credential on the queued config and drops Slack from its reconnect queue for the life of the pod. If that 49s observation does not match what others have seen, say so and I will drop this hunk.

## Context

- Supersedes the remaining delta of #505 (@adamparco). Authorship of the `team_id` fix is preserved on the commit. #505 can be closed once this lands.
- Builds on #480 (@sergiu1spiridon), which owns the `SlackResponse` wrapping, the `__headers` scope forwarding, the `bolt_async_app`/`bolt_async_context` rebind, and the bootstrap retry loop. This PR deliberately keeps all of that as-is.

## Testing

- `python3 -m unittest test_slack_relay_patch test_credential_proxy` — 60 tests, all passing.
- Verified the new multi-workspace test actually fails without the fix (`AssertionError: 'T2' != 'T1,relay:T2'`) rather than merely passing alongside it.
- `make docs-check` passes. No documentation references the changed identifiers or the env var default, so there is no docs drift.

---

Low risk and additive: the `team_id` fallback preserves existing single-workspace behavior exactly, and the timeout change only widens a window that already exists. The one judgement call worth reviewing is the 20s → 120s default.

This PR was generated with the help of Claude.
