### PR TITLE
fix(scripts): give Cloud KMS its own location variable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -290,6 +290,7 @@ make deploy-litellm
 export PROJECT_ID="your-gcp-project-id"
 export REGION="your-gcp-region"
 export CLUSTER_NAME="your-gke-cluster-name"
+export KMS_LOCATION="your-kms-region" # a region; Cloud KMS has no zonal locations
 export KMS_KEYRING="your-kms-keyring"
 export KMS_KEY="your-kms-key"
 export KMS_KEY_VERSION="your-kms-key-version"

--- a/k8s-operator/Makefile
+++ b/k8s-operator/Makefile
@@ -124,11 +124,11 @@ undeploy-inference-replay: kustomize ## Undeploy Inference Replay proxy integrat
 
 .PHONY: deploy-github
 deploy-github: kustomize ## Deploy GitHub integration.
-	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$KMS_LOCATION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME' | kubectl apply -n $${NAMESPACE:-kubeagents-system} -f -
 
 .PHONY: undeploy-github
 undeploy-github: kustomize ## Undeploy GitHub integration.
-	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
+	$(KUSTOMIZE) build config/integrations/github | envsubst '$$NAMESPACE $$PROJECT_ID $$REGION $$CLUSTER_NAME $$KMS_KEYRING $$KMS_KEY $$KMS_KEY_VERSION $$KMS_LOCATION $$GITHUB_ORG $$GITHUB_REPO $$GITHUB_MINTER_KSA_NAME $$GITHUB_MINTER_GSA_NAME $$PLATFORM_AGENT_GSA_NAME' | kubectl delete --ignore-not-found=$(ignore-not-found) -n $${NAMESPACE:-kubeagents-system} -f -
 
 
 

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -320,11 +320,14 @@ Before deploying the GitHub integration, ensure you have:
 
 Run the `make deploy-github` target, passing the required environment variables. The KSA/GSA names below are the same defaults the provisioning scripts use (see [`scripts/common.sh`](scripts/common.sh)), but they still have to be exported here: `make deploy-github` renders the manifests with `envsubst` and does not source `common.sh`, so an unset variable would be substituted as an empty string.
 
+`KMS_LOCATION` is the Cloud KMS location, which is separate from `REGION`, the GKE cluster location. Cloud KMS has no zonal locations, so the two differ for a zonal cluster: a cluster in `us-central1-c` needs `KMS_LOCATION=us-central1`. For a regional cluster they are the same value.
+
 ```bash
 # 1. Define the GCP and GitHub parameter variables:
 export PROJECT_ID=your-gcp-project-id
 export REGION=your-gcp-region
 export CLUSTER_NAME=your-gke-cluster-name
+export KMS_LOCATION=your-kms-region
 export KMS_KEYRING=your-kms-keyring
 export KMS_KEY=your-kms-key
 export KMS_KEY_VERSION=your-kms-key-version

--- a/k8s-operator/config/integrations/github/deployment.yaml.template
+++ b/k8s-operator/config/integrations/github/deployment.yaml.template
@@ -54,7 +54,7 @@ spec:
                   name: github-app-credentials
                   key: app-id
             - name: KMS_KEY_NAME
-              value: "projects/${PROJECT_ID}/locations/${REGION}/keyRings/${KMS_KEYRING}/cryptoKeys/${KMS_KEY}/cryptoKeyVersions/${KMS_KEY_VERSION}"
+              value: "projects/${PROJECT_ID}/locations/${KMS_LOCATION}/keyRings/${KMS_KEYRING}/cryptoKeys/${KMS_KEY}/cryptoKeyVersions/${KMS_KEY_VERSION}"
             - name: SOURCE_SYSTEM_AUTH
               value: "gha://$(GITHUB_APP_ID)?kms_id=$(KMS_KEY_NAME)"
           livenessProbe:

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -193,6 +193,22 @@ warn_on_registry_prefix_mismatch() {
   esac
 }
 
+# Cloud KMS has no zonal locations, so a zonal cluster's REGION (eg.
+# "us-central1-c") is not a valid key location. REGION doubles as the cluster
+# location, which for a zonal cluster must stay the zone, so KMS needs its own
+# variable. Default to the enclosing region and allow an explicit override.
+derive_kms_location() {
+  local loc="${1:-}"
+  if [[ "$loc" =~ ^(.+)-[a-z]$ ]]; then
+    loc="${BASH_REMATCH[1]}"
+  fi
+  echo "$loc"
+}
+
+init_var_kms_location() {
+  init_var "KMS_LOCATION" "$(derive_kms_location "${REGION:-}")" "Enter Cloud KMS Location (a region; zones are not valid)"
+}
+
 init_var_model_provider() {
   init_var "MODEL_PROVIDER" "gemini" "Enter Model Provider (gemini, anthropic, chatgpt, openai)"
 

--- a/k8s-operator/scripts/provision_10_deploy_github_minter.sh
+++ b/k8s-operator/scripts/provision_10_deploy_github_minter.sh
@@ -35,6 +35,7 @@ init_var "REGION" "us-east4" "Enter GKE GCP Region"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter GKE Cluster Name"
 init_var "KMS_KEYRING" "github-token-minter-keyring" "Enter Cloud KMS Keyring Name"
 init_var "KMS_KEY" "github-token-minter-key" "Enter Cloud KMS Key Name"
+init_var_kms_location
 
 export GOOGLE_CLOUD_QUOTA_PROJECT="${PROJECT_ID}"
 
@@ -84,14 +85,14 @@ execute_github_minter() {
 
   # Ensure KMS Keyring and Key exist.
   print_info "Ensuring KMS Keyring '${KMS_KEYRING}' exists..."
-  if ! gcloud kms keyrings describe "${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
-    gcloud kms keyrings create "${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" || return 1
+  if ! gcloud kms keyrings describe "${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+    gcloud kms keyrings create "${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" || return 1
   fi
 
   print_info "Ensuring KMS Key '${KMS_KEY}' exists..."
-  if ! gcloud kms keys describe "${KMS_KEY}" --location="${REGION}" --keyring="${KMS_KEYRING}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  if ! gcloud kms keys describe "${KMS_KEY}" --location="${KMS_LOCATION}" --keyring="${KMS_KEYRING}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
     gcloud kms keys create "${KMS_KEY}" \
-        --location="${REGION}" \
+        --location="${KMS_LOCATION}" \
         --keyring="${KMS_KEYRING}" \
         --purpose=asymmetric-signing \
         --default-algorithm=rsa-sign-pkcs1-2048-sha256 \
@@ -104,7 +105,7 @@ execute_github_minter() {
   local gsa_email="${GITHUB_MINTER_GSA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
   print_info "Ensuring GSA has signer permissions on KMS key..."
   gcloud kms keys add-iam-policy-binding "${KMS_KEY}" \
-      --location="${REGION}" \
+      --location="${KMS_LOCATION}" \
       --keyring="${KMS_KEYRING}" \
       --member="serviceAccount:${gsa_email}" \
       --role="roles/cloudkms.signerVerifier" \
@@ -113,7 +114,7 @@ execute_github_minter() {
       --quiet >/dev/null || return 1
 
   # Import PEM if provided and no version exists
-  local versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null)
+  local versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null)
   if [ -z "$versions" ]; then
     if [ -n "${GITHUB_PEM_PATH}" ] && [ -f "${GITHUB_PEM_PATH}" ]; then
       if ! command -v go &>/dev/null; then
@@ -134,7 +135,7 @@ execute_github_minter() {
             cd "$tmp_dir"
             retry 6 5 go run ./cmd/minty tools import-pk \
                 -project-id="${PROJECT_ID}" \
-                -location="${REGION}" \
+                -location="${KMS_LOCATION}" \
                 -key-ring="${KMS_KEYRING}" \
                 -key="${KMS_KEY}" \
                 -private-key="@${abs_pem}"
@@ -155,14 +156,14 @@ execute_github_minter() {
       print_warning "No GitHub Private Key PEM path provided or file not found."
       print_warning "KMS Key '${KMS_KEY}' has no active version. Minter will fail to start until you import the key."
       print_warning "You can import it later manually using Minty CLI:"
-      print_warning "  git clone --depth 1 --branch v2.7.1 https://github.com/abcxyz/github-token-minter.git /tmp/minty && cd /tmp/minty && go run ./cmd/minty tools import-pk -project-id=${PROJECT_ID} -location=${REGION} -key-ring=${KMS_KEYRING} -key=${KMS_KEY} -private-key=@/path/to/pem"
+      print_warning "  git clone --depth 1 --branch v2.7.1 https://github.com/abcxyz/github-token-minter.git /tmp/minty && cd /tmp/minty && go run ./cmd/minty tools import-pk -project-id=${PROJECT_ID} -location=${KMS_LOCATION} -key-ring=${KMS_KEYRING} -key=${KMS_KEY} -private-key=@/path/to/pem"
     fi
   fi
 
   # Resolve the latest active (ENABLED) version number dynamically
   print_info "Resolving active KMS key version number..."
   local active_version
-  active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
+  active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
   
   if [ -n "$active_version" ]; then
     export KMS_KEY_VERSION="${active_version}"
@@ -178,7 +179,7 @@ execute_github_minter() {
   
   if [ -d "$GITHUB_INTEGRATION_DIR" ]; then
     # Ensure all variables are exported for envsubst
-    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY KMS_KEY_VERSION GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME
+    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY KMS_KEY_VERSION KMS_LOCATION GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME
     make -C "${OPERATOR_DIR}" deploy-github || return 1
   else
     print_error "GitHub integration directory not found at ${GITHUB_INTEGRATION_DIR}"

--- a/k8s-operator/scripts/teardown_10_deploy_github_minter.sh
+++ b/k8s-operator/scripts/teardown_10_deploy_github_minter.sh
@@ -21,6 +21,10 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 # ─── Configuration State Restoration ──────────────────────────────────────────
 ensure_teardown_state
 
+# A vars.sh written before KMS_LOCATION existed has no value for it, and this
+# script runs under `set -u`. Derive it from REGION in that case.
+KMS_LOCATION="${KMS_LOCATION:-$(derive_kms_location "${REGION:-}")}"
+
 # ─── Confirmation Prompt ──────────────────────────────────────────────────────
 confirm_action "This will permanently delete the GitHub Token Minter and destroy the KMS key versions." \
   "GCP Project:$PROJECT_ID" \
@@ -47,9 +51,9 @@ else
   GITHUB_INTEGRATION_DIR="${OPERATOR_DIR}/config/integrations/github"
   if [ -d "$GITHUB_INTEGRATION_DIR" ]; then
     # Export variables for envsubst
-    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME
+    export PROJECT_ID REGION CLUSTER_NAME NAMESPACE GITHUB_MINTER_KSA_NAME GITHUB_MINTER_GSA_NAME KMS_KEYRING KMS_KEY KMS_LOCATION GITHUB_ORG GITHUB_REPO KSA_NAME PLATFORM_AGENT_GSA_NAME
     
-    active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" --quiet 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
+    active_version=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" --filter="state=ENABLED" --format="value(name)" --quiet 2>/dev/null | awk -F'/' '{print $NF}' | sort -n | tail -n 1)
     export KMS_KEY_VERSION="${active_version:-1}"
     
     make -C "${OPERATOR_DIR}" undeploy-github || true
@@ -69,7 +73,7 @@ echo -e "  ${C_CYAN}ℹ Cleaning up GCP KMS Key '${KMS_KEY}'...${C_RESET}"
 if [ "${DRY_RUN:-0}" -eq 1 ]; then
   echo -e "  ${C_GREEN}[DRY-RUN] Would disable and schedule all versions of KMS Key '${KMS_KEY}' for destruction.${C_RESET}"
 else
-  versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${REGION}" --project="${PROJECT_ID}" --format="value(name)" --quiet 2>/dev/null || echo "")
+  versions=$(gcloud kms keys versions list --key="${KMS_KEY}" --keyring="${KMS_KEYRING}" --location="${KMS_LOCATION}" --project="${PROJECT_ID}" --format="value(name)" --quiet 2>/dev/null || echo "")
   
   if [ -n "$versions" ]; then
     for ver_path in $versions; do


### PR DESCRIPTION
## Why This Change

`provision_10_deploy_github_minter.sh` uses `$REGION` for two things that don't accept the same values, so the GitHub token minter can't be provisioned against a zonal cluster at all.

`REGION` is the GKE cluster location, which for a zonal cluster has to stay the zone.  It's also passed to every `gcloud kms` call and into `KMS_KEY_NAME`, and Cloud KMS has no zonal locations:

```
$ gcloud kms keyrings list --location=us-central1-c
ERROR: NOT_FOUND: The request concerns location 'us-central1-c' ... Cloud KMS is not available in 'us-central1-c'

$ gcloud kms keyrings list --location=us-central1
Listed 0 items.
```

So with `REGION=us-central1-c` the keyring creation fails.  Set `REGION=us-central1` instead and KMS is satisfied, but `ISSUER_ALLOWLIST` then names a cluster that doesn't exist, the minter won't authorize the agent's tokens, and `connect_cluster` stops finding the cluster.

Fixes #518.

## What Changed

Adds a `KMS_LOCATION` variable, defaulted by stripping the zone suffix from `REGION`, and uses it everywhere Cloud KMS is addressed.  The cluster location carries on using `REGION`.

**Files:**

- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/provision_10_deploy_github_minter.sh`
- `k8s-operator/scripts/teardown_10_deploy_github_minter.sh`
- `k8s-operator/config/integrations/github/deployment.yaml.template`
- `k8s-operator/Makefile`

**Added/Changed/Fixed:**

- `derive_kms_location()` and `init_var_kms_location()` in `common.sh`.  `us-central1-c` becomes `us-central1`, and a value that is already a region comes back unchanged.
- The seven `gcloud kms` calls in `provision_10` now pass `--location="${KMS_LOCATION}"`, as do the minty `import-pk` invocation and the manual-import hint it prints on failure.
- `KMS_KEY_NAME` in `deployment.yaml.template` uses `${KMS_LOCATION}`.  `ISSUER_ALLOWLIST` still uses `${REGION}`, since that one really is the cluster location.
- `KMS_LOCATION` added to the `envsubst` allowlists for `deploy-github` and `undeploy-github`, and to the exports in both stage 10 scripts.
- `teardown_10` derives the value when it is missing.  A `vars.sh` written before this change won't have it, and that script runs under `set -u`.

## Why This Matters

Regional clusters are unaffected.  The derived value equals `REGION`, so nothing changes for an install that used `provision_01` to build its own cluster.  This only matters when pointing the pipeline at a pre-existing zonal cluster, which is a hard failure today.

## Context

Found while installing against an existing zonal GKE cluster.  Filed as #518.  Wider write-up of that install: https://gist.github.com/bnaylor/b8e7b7f9dda75c6f159815b36aec3d49

## Testing

Verified:

- `bash -n` on all three changed scripts
- `derive_kms_location` across zonal and regional inputs.  `us-central1-c -> us-central1`, `europe-west1-b -> europe-west1`, `us-east4` and `asia-northeast1` unchanged
- the rendered manifest carries both locations correctly at the same time, which wasn't possible before:
  ```
  locations/us-central1-c/clusters
  locations/us-central1/keyRings
  ```
- Cloud KMS rejects a zone and accepts the enclosing region, per the output above

Not verified:

- an end-to-end stage 10 run.  That needs a GitHub App (org, repo, app ID, private key PEM) and a live zonal cluster, and I had neither by the time I got here.  The PEM import path and the minter's runtime behaviour aren't touched by this change, but they haven't been exercised with it either.

---

Low risk: no behaviour change for regional clusters, and stage 10 is skipped entirely unless `GITHUB_ORG`, `GITHUB_REPO` and `GITHUB_APP_ID` are all set.

Generated with the help of Claude.