### PR TITLE
fix(scripts): guard empty array expansions in teardown_04 for bash 3.2

### DIFF
--- a/k8s-operator/scripts/teardown_04_gcp_iam.sh
+++ b/k8s-operator/scripts/teardown_04_gcp_iam.sh
@@ -42,17 +42,22 @@ cleanup_agent_iam() {
   fi
 
   if [ "$gsa_exists" -eq 1 ]; then
-    echo -e "  ${C_CYAN}ℹ Removing project-level IAM policy bindings for ${gsa_name}...${C_RESET}"
-    for role in "${roles[@]}"; do
-      if [ "${DRY_RUN:-0}" -eq 1 ]; then
-        echo -e "  ${C_GREEN}[DRY-RUN] Would remove project-level IAM policy binding '${role}' for ${gsa_name}.${C_RESET}"
-      else
-        gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
-            --member="serviceAccount:${gsa_email}" \
-            --role="${role}" \
-            --quiet 2>/dev/null || true
-      fi
-    done
+    # bash 3.2, which is what macOS ships, treats "${arr[@]}" on an empty array
+    # as an unbound variable under `set -u`. This function is called with no
+    # roles for the minter GSA, so guard the expansion the way provision_03 does.
+    if [ ${#roles[@]} -gt 0 ]; then
+      echo -e "  ${C_CYAN}ℹ Removing project-level IAM policy bindings for ${gsa_name}...${C_RESET}"
+      for role in "${roles[@]}"; do
+        if [ "${DRY_RUN:-0}" -eq 1 ]; then
+          echo -e "  ${C_GREEN}[DRY-RUN] Would remove project-level IAM policy binding '${role}' for ${gsa_name}.${C_RESET}"
+        else
+          gcloud projects remove-iam-policy-binding "${PROJECT_ID}" \
+              --member="serviceAccount:${gsa_email}" \
+              --role="${role}" \
+              --quiet 2>/dev/null || true
+        fi
+      done
+    fi
 
     echo -e "  ${C_CYAN}ℹ Removing Workload Identity Policy Binding for ${gsa_name}...${C_RESET}"
     local wi_member="serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${ksa_name}]"
@@ -102,7 +107,10 @@ if [ -n "${PLATFORM_AGENT_CUSTOM_ROLES:-}" ]; then
     custom_roles_str="${PLATFORM_AGENT_CUSTOM_ROLES}"
   fi
   custom_roles=(${custom_roles_str//,/ })
-  platform_roles+=("${custom_roles[@]}")
+  # Same bash 3.2 caveat: a value that word-splits to nothing leaves this empty.
+  if [ ${#custom_roles[@]} -gt 0 ]; then
+    platform_roles+=("${custom_roles[@]}")
+  fi
 fi
 
 cleanup_agent_iam "${PLATFORM_AGENT_KSA_NAME}" "${PLATFORM_AGENT_GSA_NAME}" "${platform_roles[@]}"


### PR DESCRIPTION
## Why This Change

`teardown_04_gcp_iam.sh` runs under `set -euo pipefail`.  bash 3.2 treats `"${arr[@]}"` on an empty array as an unbound variable, so the script aborts:

```
./teardown_04_gcp_iam.sh: line 29: roles[@]: unbound variable
```

macOS ships bash 3.2.57 and on a stock machine it is the only bash present, so this hits any Mac user.  bash 4.4 and later expand an empty array to nothing and carry on, which is why Linux and CI never see it.

Minimal repro:

```bash
/bin/bash -c 'set -euo pipefail; f(){ shift 2; local r=("$@"); for x in "${r[@]}"; do :; done; }; f a b'
# -> r[@]: unbound variable
```

`cleanup_agent_iam` is called with no roles for the minter GSA, which leaves `roles` empty:

```bash
cleanup_agent_iam "${GITHUB_MINTER_KSA_NAME}" "${GITHUB_MINTER_GSA_NAME}"
```

That always fires under `--dry-run`, because dry-run sets `gsa_exists=1` unconditionally and so reaches the loop even when the GSA is absent.  On a real run it fires whenever the minter GSA exists; if it doesn't, the existence check short-circuits first and the teardown completes, which is how this went unnoticed.

Fixes #529.

## What Changed

**Files:**

- `k8s-operator/scripts/teardown_04_gcp_iam.sh`

**Added/Changed/Fixed:**

- Guarded the role loop in `cleanup_agent_iam` with `[ ${#roles[@]} -gt 0 ]`.  The "Removing project-level IAM policy bindings" line moved inside the guard, so a call with no roles no longer announces work it isn't doing.
- Guarded `platform_roles+=("${custom_roles[@]}")` the same way.  `custom_roles` ends up empty when `PLATFORM_AGENT_CUSTOM_ROLES` word-splits to nothing, a lone comma for instance.

`${#arr[@]}` is itself safe on an empty array in bash 3.2, so the guard works on the affected shell.  The pattern matches `provision_03_gcp_gke_operator.sh`, which already does this.

## Why This Matters

`make gcp-teardown-04-iam` and any full `gcp-teardown` are currently broken on macOS in dry-run, and in real runs once the GitHub token minter has been provisioned.  Dry-run is the mode you would reach for first when checking what a destructive teardown is about to do.

## Context

Found while cleaning up after an install.  Filed as #529.  Wider write-up: https://gist.github.com/bnaylor/b8e7b7f9dda75c6f159815b36aec3d49

Worth deciding separately whether bash 4+ is a supported requirement.  INSTALL.md's tooling matrix doesn't mention bash at all, so macOS is implicitly in scope today.

## Testing

On bash 3.2.57 (macOS), against a project with the platform GSA present and no minter GSA:

- `./teardown_04_gcp_iam.sh --dry-run` previously aborted at the minter cleanup.  It now runs to completion.
- `PLATFORM_AGENT_CUSTOM_ROLES="," ./teardown_04_gcp_iam.sh --dry-run` completes rather than aborting.
- `PLATFORM_AGENT_CUSTOM_ROLES="roles/storage.admin" ./teardown_04_gcp_iam.sh --dry-run` still passes the custom role through.
- A real (non dry-run) teardown removed the seven bindings and deleted the GSA, and reported the absent minter GSA as skipped.
- `bash -n` clean.
- `make docs-check` passes, and `make docs-generate` produces no diff.  The change is confined to the function body, so the comment banner that feeds the `provisioning-steps` generated region is untouched.

---

No behaviour change on bash 4.4+.  On bash 3.2 it is the difference between the script running and aborting.

Generated with the help of Claude.