### PR TITLE
fix(fleet-audit): use a non-credential base64 payload in the redaction test

### DIFF
--- a/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
+++ b/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
@@ -4458,7 +4458,11 @@ class TestRedaction(unittest.TestCase):
             'token: "ghs_liveLiveLiveLiveLive"',
             "  api_key = AKIAIOSFODNN7EXAMPLE",
             "client-key-data: LS0tLS1CRUdJTiBSU0E=",
-            "- authorization: Basic Zm9vOmJhcg==",
+            # Deliberately not a `user:pass` base64 payload — decodes to
+            # "not-a-real-credential" — so secret scanners do not flag the
+            # fixture. The redactor keys off the field name and `Basic` prefix,
+            # never the payload's contents.
+            "- authorization: Basic bm90LWEtcmVhbC1jcmVkZW50aWFs",
         ):
             with self.subTest(line=line):
                 out = audit_report.redact_secrets(line)


### PR DESCRIPTION
# Pull Request

## Why This Change

Secret-scanning alert [#1](https://github.com/gke-labs/kube-agents/security/secret-scanning/1) (`http_basic_authentication_header`) fires on a test fixture in the fleet-audit redaction suite.

The flagged string is `Basic Zm9vOmJhcg==` — base64 for `foo:bar`. It is not a live credential; it is a sample line fed to `audit_report.redact_secrets()` to prove the redactor blanks an `authorization:` field. But GitHub's detector matches any `Basic <base64>` whose payload decodes to a `user:pass` shape, and `foo:bar` qualifies. The alert is a false positive that will keep re-firing on every scan of this blob, so it is worth removing the trigger rather than only dismissing it.

## What Changed

**Files:**

- `agents/platform/skills/fleet-audit/scripts/test_audit_report.py`

**Added/Changed/Fixed:**

- Replaced the fixture payload with `bm90LWEtcmVhbC1jcmVkZW50aWFs`, which decodes to `not-a-real-credential`. No colon means no `user:pass` shape, so the detector does not match.
- Added a comment recording why the payload is deliberately colon-free, so a future edit does not reintroduce the alert.

## Why This Matters

- The test still covers the same behaviour. `redact_secrets()` keys off the field name (`_SECRET_KEY_RE`, which lists `authorization`) and the `Basic` prefix (`_BEARER_RE`, which needs a payload of 12+ chars — the new one is 28). Neither looks at the payload's contents, so the assertion is unchanged in strength.
- Keeps the secret-scanning queue signal-bearing: a standing false positive trains reviewers to skim past real alerts.

## Context

- Fixture was introduced in cc11068 (#517).
- No production code changes; `audit_report.py` is untouched.

## Testing

- `python3 -m unittest test_audit_report` in `agents/platform/skills/fleet-audit/scripts/` — 446 tests, all pass.
- Verified the new fixture is genuinely redacted rather than passing vacuously: `redact_secrets("- authorization: Basic bm90LWEtcmVhbC1jcmVkZW50aWFs")` returns `- authorization: [redacted by audit_report.py]`, with the payload absent from the output.
- `make docs-check` passes.

---

Test-fixture change only; no runtime or behavioural impact. Once merged, alert #1 should be closed as a false positive.

This PR was generated with the help of Claude.
