### PR TITLE
fix(e2e): stop printing OAuth credentials to stdout in the token generator

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -115,11 +115,13 @@ _(To teardown CI IAM resources when no longer needed, run `./tests/e2e/scripts/t
 2. Open the printed authorization URL in Chrome Incognito (logged into your OTA test account).
 3. Click **Allow** (if prompted with an unverified app warning, click **Advanced ➔ Go to E2E Chat Verifier (unsafe) ➔ Allow**).
 4. When Chrome redirects to `http://localhost:8080/?code=...` (`ERR_CONNECTION_REFUSED`), copy the **entire URL from your browser address bar** and paste it into the terminal prompt.
-5. Save the 4 credentials as **GitHub Repository Secrets** (**Settings ➔ Secrets and variables ➔ Actions**):
-   - `E2E_CHAT_CLIENT_ID`
-   - `E2E_CHAT_CLIENT_SECRET`
-   - `E2E_CHAT_REFRESH_TOKEN`
+5. The generator writes its output to a `0600` file under your temp directory and prints the path. It does not print the credentials themselves, so they do not linger in terminal scrollback. Open that file to read the values.
+6. Save the 4 credentials as **GitHub Repository Secrets** (**Settings ➔ Secrets and variables ➔ Actions**):
+   - `E2E_CHAT_CLIENT_ID` — from the credentials file
+   - `E2E_CHAT_CLIENT_SECRET` — the Client Secret from step 4.3; the generator never echoes it back
+   - `E2E_CHAT_REFRESH_TOKEN` — from the credentials file
    - `E2E_CHAT_SPACE_ID`
+7. Delete the credentials file (`rm <printed path>`). The refresh token does not expire once the OAuth app is published, so a stray copy on disk is a standing liability.
 
 ---
 

--- a/tests/e2e/scripts/generate_token.py
+++ b/tests/e2e/scripts/generate_token.py
@@ -8,6 +8,7 @@ Usage:
 
 import os
 import sys
+import tempfile
 from urllib.parse import parse_qs, urlparse
 from google_auth_oauthlib.flow import InstalledAppFlow
 
@@ -69,8 +70,29 @@ except Exception as e:
 
 creds = flow.credentials
 
+if not creds.refresh_token:
+    print("[ERROR] Google returned no refresh token, only a short-lived access token.")
+    print("        This happens when the account has already granted consent. Revoke")
+    print("        it at https://myaccount.google.com/permissions and re-run.")
+    sys.exit(1)
+
+# Neither credential is printed. The client secret is an *input* to this script,
+# so echoing it tells the operator nothing they did not already type. The refresh
+# token is the one genuine output, and once the OAuth app is published it does not
+# expire — writing it to stdout would leave it in terminal scrollback, screen
+# shares, and any log that captures this run. Both go to a 0600 file instead.
+fd, cred_path = tempfile.mkstemp(prefix="e2e-chat-credentials-", suffix=".env")
+with os.fdopen(fd, "w") as handle:
+    handle.write(f"E2E_CHAT_CLIENT_ID={creds.client_id}\n")
+    handle.write(f"E2E_CHAT_REFRESH_TOKEN={creds.refresh_token}\n")
+
 print("\n================ SUCCESS ================")
-print(f"E2E_CHAT_CLIENT_ID: {creds.client_id}")
-print(f"E2E_CHAT_CLIENT_SECRET: {creds.client_secret}")
-print(f"E2E_CHAT_REFRESH_TOKEN: {creds.refresh_token}")
+print("Wrote E2E_CHAT_CLIENT_ID and E2E_CHAT_REFRESH_TOKEN (mode 0600) to:")
+print(f"  {cred_path}")
+print("")
+print("E2E_CHAT_CLIENT_SECRET is the Client Secret you supplied above; copy it")
+print("from where you already have it rather than from this run.")
+print("")
+print("Save each value as a GitHub Repository Secret of the same name, then:")
+print(f"  rm {cred_path}")
 print("=========================================")


### PR DESCRIPTION
# Pull Request

## Why This Change

CodeQL alert [#7](https://github.com/gke-labs/kube-agents/security/code-scanning/7) (`py/clear-text-logging-sensitive-data`, high) fires on `tests/e2e/scripts/generate_token.py:74`, which printed `creds.client_secret` to stdout.

The alert is legitimate. The client secret is an **input** to this script — the operator passes it as `CLIENT_SECRET` — so echoing it back tells them nothing they did not already type, while writing a live credential into terminal scrollback, screen shares, and anything that captures the run.

Reviewing the surrounding block, the adjacent `refresh_token` print is the bigger exposure even though CodeQL did not flag it (its heuristic does not classify `refresh_token` as sensitive). Per this repo's own README, publishing the OAuth app removes the 7-day expiry so the token "lives indefinitely and self-renews" — a long-lived credential left in scrollback. Fixing only the flagged line would have left the worse leak in place.

## What Changed

**Files:**

- `tests/e2e/scripts/generate_token.py`
- `tests/e2e/README.md`

**Added/Changed/Fixed:**

- Removed the `client_secret` print entirely. The operator already has this value; the success block now points them back to it instead.
- Moved the client ID and refresh token out of stdout into a `0600` file created with `tempfile.mkstemp`, whose path is printed. The token is the script's one genuine output, so it is delivered differently rather than suppressed.
- Added a guard for the case where Google returns no refresh token (already-granted consent). Previously this silently printed `E2E_CHAT_REFRESH_TOKEN: None`, and the operator would paste `None` into a GitHub secret and debug a confusing CI failure later.
- Updated the setup guide for the new flow, including a step to delete the credentials file once the secrets are saved.

## Why This Matters

- Clears a high-severity alert, and closes the unflagged leak next to it rather than just the one the scanner named.
- The client secret is now never written anywhere by this script — not stdout, not the file — so the fix cannot regress into `py/clear-text-storage-sensitive-data`.

## Context

- Alert #7, open since 2026-07-20, `classifications: ["test"]`.
- Companion to #535, which cleared secret-scanning alert #1. Unrelated code, same cleanup pass.
- Consumers of these secret names (`.github/workflows/e2e-gchat-test.yml`, `rc-release-pipeline.yml`, `tests/e2e/gchat_agent_test.py`) read them from the environment and are unaffected — only how the operator obtains the values changes.

## Testing

This is an interactive script requiring a live Google OAuth consent flow, so the credential-handling block was exercised directly with a stub `credentials` object rather than run end to end:

- Success path: client secret and refresh token both absent from stdout; file created mode `0600` (asserted, not assumed); refresh token present in the file; client secret absent from the file.
- No-refresh-token path: exits `1` with the guidance message and leaves no stray credentials file behind.
- `python3 -m py_compile tests/e2e/scripts/generate_token.py` passes.
- `npx prettier --check tests/e2e/README.md` and `make docs-check` pass.

Not verified: the real end-to-end OAuth flow against Google, which needs the OTA test account.

---

Developer-tooling change; no runtime or CI behaviour is affected. Operators who have already stored the four secrets need to do nothing. Alert #7 should close on the next CodeQL run against `main` after merge.

This PR was generated with the help of Claude.
