### PR TITLE
fix(scripts): drop the unnecessary gcloud beta from cluster creation

### DIFF
--- a/docs/site/src/content/docs/reference/attribution.md
+++ b/docs/site/src/content/docs/reference/attribution.md
@@ -28,7 +28,7 @@ Every agent action can be traced back to a requester. The full design rationale 
 The provisioner enables Managed OTel on new clusters. For an existing cluster:
 
 ```bash
-gcloud beta container clusters update "$CLUSTER_NAME" \
+gcloud container clusters update "$CLUSTER_NAME" \
   --project "$PROJECT_ID" \
   --location "$LOCATION" \
   --managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS

--- a/k8s-operator/scripts/provision_01_gcp_cluster.sh
+++ b/k8s-operator/scripts/provision_01_gcp_cluster.sh
@@ -53,7 +53,7 @@ verify_cluster() {
 }
 execute_cluster() {
   print_info "Creating GKE Standard Cluster with Workload Identity. This takes approximately 5-8 minutes in Google Cloud..."
-  gcloud beta container clusters create "$CLUSTER_NAME" \
+  gcloud container clusters create "$CLUSTER_NAME" \
       --region "$REGION" \
       --machine-type="e2-standard-4" \
       --num-nodes=1 \


### PR DESCRIPTION
## Why This Change

`provision_01` creates the cluster with `gcloud beta container clusters create`, which makes the gcloud `beta` component a hard prerequisite of the very first stage.  It is not in INSTALL.md's tooling matrix, and on a machine without it the stage dies before creating anything:

```
You do not currently have this command group installed.  Using it
requires the installation of components: [beta]

Do you want to continue (Y/n)?
ERROR: (gcloud) This prompt could not be answered because you are not in an
interactive session.
```

Installing the component is not always an option, either.  On a managed gcloud install the SDK is partly root-owned, and the obvious remedy fails for the user running the pipeline:

```
$ gcloud components install beta
ERROR: (gcloud.components.install) Permission denied:
[.../google-cloud-sdk/lib/surface/beta]
```

That combination means a first-time installer can be blocked at stage 01 with no self-service fix.

Every flag the command passes exists on the GA surface, checked against `gcloud container clusters create --help` on 576.0.0:

| Flag | GA |
| --- | --- |
| `--region`, `--machine-type`, `--num-nodes` | yes |
| `--workload-pool`, `--addons` (including the `GcpFilestoreCsiDriver` value) | yes |
| `--managed-otel-scope`, `--project`, `--quiet` | yes |

So the beta surface buys nothing here.

## What Changed

**Files:**

- `k8s-operator/scripts/provision_01_gcp_cluster.sh`
- `docs/site/src/content/docs/reference/attribution.md`

**Added/Changed/Fixed:**

- `gcloud beta container clusters create` becomes `gcloud container clusters create`.  Nothing else about the command changes.
- The Managed OTel example in `attribution.md` drops `beta` too.  `--managed-otel-scope` is on GA `clusters update` as well, and leaving the doc on the beta surface would tell readers to install a component the pipeline no longer needs.

## Why This Matters

Stage 01 always runs.  Anything that stops it stops the whole install, and this one stops it on a machine where the documented remedy is not available to the user.

**One thing this does not do:** `provision_05_gcp_gchat.sh` still calls `gcloud beta services identity create`, and that command is genuinely beta-only — there is no GA equivalent.  So the `beta` component remains a real prerequisite for anyone setting `GOOGLE_CHAT_ENABLED=true`.  This PR removes it from the default path, not from every path.  That distinction belongs in the tooling matrix, which is #524's territory rather than this PR's; I have noted it there.

## Testing

- Verified every flag against `gcloud container clusters create --help` on gcloud 576.0.0, including that `GcpFilestoreCsiDriver` is a valid GA addon value.
- Ran the patched stage 01 for real against a fresh project.  It created a regional `e2-standard-4` cluster in `us-east4`, k8s 1.35.6-gke, with Workload Identity and the Filestore CSI addon both enabled at creation, and connected kubectl.  Stage 01 exited 0.
- Carried on through the rest of the pipeline on that cluster (operator, IAM, secrets, agent, LiteLLM) and ended with a working agent, so the GA-created cluster is not subtly different in a way later stages care about.
- `bash -n` clean; `make docs-check` passes.

---

One word removed from a command, plus the matching doc example.  No behavioural change to the cluster that gets created.

Generated with the help of Claude.