### PR TITLE
chore: upgrade LiteLLM version references to v1.95.0

### DIFF
--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.92.0
+          image: ghcr.io/berriai/litellm:v1.95.0
           args: ["--config", "/app/config.yaml"]
           env:
             - name: CHATGPT_TOKEN_DIR

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.92.0
+          image: ghcr.io/berriai/litellm:v1.95.0
           args: ["--config", "/app/config.yaml"]
           env:
             - name: GEMINI_API_KEY

--- a/k8s-operator/config/integrations/litellm/base/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.92.0
+          image: ghcr.io/berriai/litellm:v1.95.0
           args: ["--config", "/app/config.yaml"]
           resources:
             requests:

--- a/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
+++ b/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
@@ -145,7 +145,7 @@ litellmGateway:
   replicaCount: 1
   image:
     repository: "ghcr.io/berriai/litellm"
-    tag: "v1.92.0"
+    tag: "v1.95.0"
   modelProvider: "gemini"
   modelName: "gemini-3.5-flash"
   useDummySecret: true


### PR DESCRIPTION
# Pull Request

## Why This Change

Update LiteLLM integration manifests and example configs to reference the latest released stable version (`v1.95.0`).

## What Changed

**Files:**

- `examples/litellm-chatgpt-subscription/deployment.yaml`
- `examples/litellm-gemini/deployment.yaml`
- `k8s-operator/config/integrations/litellm/base/deployment.yaml`
- `k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml`

**Added/Changed/Fixed:**

- Updated LiteLLM container image version tags from `v1.92.0` to `v1.95.0`.

## Why This Matters

Keeps all LiteLLM deployment references pinned to the latest stable release.

## Context

Follow-up dependency version bump for LiteLLM.

## Testing

- Ran `make docs-check`.
- Formatted YAML manifests via `npx prettier`.