### PR TITLE
feat(provision): label kube-agents host clusters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -143,6 +143,7 @@ identifier appears, add its source here.
 | Image defaults and override env vars (`PLATFORM_AGENT_IMAGE` et al.) | `k8s-operator/internal/controller/manifest_helpers.go` |
 | OTLP endpoint default, discovery candidates, and `otlpEndpointSource` values | `k8s-operator/internal/controller/telemetry.go` |
 | Registry prefix default (`REGISTRY_PREFIX`) | `k8s-operator/scripts/common.sh` |
+| GKE host-discovery label | `k8s-operator/scripts/common.sh` |
 | GitOps clone layout (`/opt/data/gitops/...`) and leases | `agents/platform/scripts/gitops_workspace.py` |
 | fleet-audit finding-id pattern and rendering caps | `agents/platform/skills/fleet-audit/scripts/audit_report.py` |
 | Helm chart value defaults (KSA/secret names, image repos, tag rules) | `charts/kube-agents/values.yaml` |

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -97,7 +97,7 @@ flowchart TB
     A --> F["05: Google Chat Pub/Sub (opt-in)"]
     A --> G["06: Slack (opt-in)"]
     A --> H["07: LLM API key Secret"]
-    A --> I["08: PlatformAgent CR"]
+    A --> I["08: PlatformAgent CR<br/>host-discovery label"]
     A --> J["09: LiteLLM Deployment"]
     A --> K["10: GitHub token minter + Cloud KMS (opt-in)"]
     A --> L["11: inference-replay (opt-in)"]

--- a/docs/site/src/content/docs/install/uninstall.md
+++ b/docs/site/src/content/docs/install/uninstall.md
@@ -47,6 +47,13 @@ Once the CR is gone, the operator's finalizer first removes the cluster-scoped R
 
 ## Full teardown
 
+The shell teardown is for environments created by `k8s-operator/scripts/provision.sh`. For the
+Terraform full-install example, follow its
+[Terraform teardown procedure](https://github.com/gke-labs/kube-agents/tree/main/terraform/examples/full-install#teardown)
+instead. In particular, do not run `teardown_08_deploy_platform_agent.sh` against a
+Terraform-managed cluster: it removes the `kube-agents-host` label that Terraform owns and creates
+plan drift.
+
 ```bash
 cd k8s-operator/scripts
 ./teardown.sh
@@ -64,7 +71,7 @@ You can also run individual `teardown_NN_*.sh` scripts to remove one layer at a 
 | `teardown_11_deploy_inference_replay.sh` | Inference-replay proxy + PVC; restores original LiteLLM Service                            |
 | `teardown_10_deploy_github_minter.sh`    | Minty deployment, GSAs, KMS resources                                                      |
 | `teardown_09_deploy_litellm.sh`          | LiteLLM Gateway                                                                            |
-| `teardown_08_deploy_platform_agent.sh`   | `PlatformAgent` CR and rendered manifests                                                  |
+| `teardown_08_deploy_platform_agent.sh`   | `PlatformAgent` CR, script-managed host-discovery label, and rendered manifest             |
 | `teardown_07_gcp_k8s_secrets.sh`         | Kubernetes secrets in the target namespace                                                 |
 | `teardown_06_slack.sh`                   | Slack tokens and state                                                                     |
 | `teardown_05_gcp_gchat.sh`               | Google Chat Pub/Sub topic + subscription                                                   |

--- a/hack/check-docs-terminology.sh
+++ b/hack/check-docs-terminology.sh
@@ -63,6 +63,27 @@ forbid 'platform-agent-ksa' \
 forbid 'platform-agent-system' \
   "Stale namespace. The namespace is kubeagents-system."
 
+# --- GKE host-discovery label -------------------------------------------
+# Ground truth: k8s-operator/scripts/common.sh. The Terraform full-install
+# composition must mirror the stable key because it cannot source Bash.
+HOST_LABEL=$(awk -F'"' '/^KUBE_AGENTS_HOST_LABEL=/{print $2; exit}' k8s-operator/scripts/common.sh)
+if [ -z "$HOST_LABEL" ]; then
+  echo "ERROR: could not read KUBE_AGENTS_HOST_LABEL from k8s-operator/scripts/common.sh." >&2
+  exit 1
+fi
+
+WRONG_HOST_LABEL=$(search 'kube-?agents-host=true' | grep -vF "${HOST_LABEL}=true" || true)
+if [ -n "$WRONG_HOST_LABEL" ]; then
+  echo "::error::Documented host-discovery label does not match KUBE_AGENTS_HOST_LABEL=${HOST_LABEL}."
+  printf '%s\n\n' "$WRONG_HOST_LABEL" | sed 's/^/    /'
+  FAILED=1
+fi
+
+if ! grep -qE "\"${HOST_LABEL}\"[[:space:]]*=[[:space:]]*\"true\"" terraform/examples/full-install/main.tf; then
+  echo "::error::Terraform full-install composition does not apply ${HOST_LABEL}=true."
+  FAILED=1
+fi
+
 # --- Go toolchain ---------------------------------------------------------
 # Ground truth: k8s-operator/go.mod
 GO_MOD_VERSION=$(awk '/^go /{print $2; exit}' k8s-operator/go.mod)

--- a/k8s-operator/scripts/README.md
+++ b/k8s-operator/scripts/README.md
@@ -112,7 +112,7 @@ Generated from each script's own comment banner.
 | 5 | [`provision_05_gcp_gchat.sh`](provision_05_gcp_gchat.sh) | **Google Chat & Pub/Sub Setup** — Configures the Google Chat backend: Pub/Sub routing, the Agent's Service Account, and grants the Service Account permission to read incoming chat messages. Also enables the Workspace Add-ons and Chat APIs and provisions their service identities — without the Chat API identity, Google Chat fails silently. |
 | 6 | [`provision_06_slack.sh`](provision_06_slack.sh) | **Slack Integration Setup** — Configures Slack bot tokens, app tokens, and home channel settings. |
 | 7 | [`provision_07_gcp_k8s_secrets.sh`](provision_07_gcp_k8s_secrets.sh) | **GKE Kubernetes Secrets Setup** — Idempotent setup script to validate and configure Kubernetes secrets directly. Requires CMEK database encryption unless ALLOW_UNENCRYPTED_SECRETS=true is set. |
-| 8 | [`provision_08_deploy_platform_agent.sh`](provision_08_deploy_platform_agent.sh) | **Deploy PlatformAgent Custom Resource Manifest** — Idempotent script that connects to GKE, renders the platform-agent.yaml template, deploys it to the cluster, and fails unless the operator reconciles the change into the agent Deployment (override the wait budget with AGENT_READY_TIMEOUT, default 600s). Whether the Deployment then rolls out is verified by step 13, after the agent's dependencies exist. |
+| 8 | [`provision_08_deploy_platform_agent.sh`](provision_08_deploy_platform_agent.sh) | **Deploy PlatformAgent Custom Resource Manifest** — Idempotent script that connects to GKE, renders the platform-agent.yaml template, deploys it to the cluster, labels the host cluster for discovery, and fails unless the operator reconciles the change into the agent Deployment (override the wait budget with AGENT_READY_TIMEOUT, default 600s). Whether the Deployment then rolls out is verified by step 13, after the agent's dependencies exist. |
 | 9 | [`provision_09_deploy_litellm.sh`](provision_09_deploy_litellm.sh) | **Deploy LiteLLM Gateway** — Idempotent script that connects to GKE and deploys the LiteLLM Gateway. |
 | 10 | [`provision_10_deploy_github_minter.sh`](provision_10_deploy_github_minter.sh) | **Deploy GitHub Token Minter** — Idempotent script that deploys the GitHub Token Minter. Runs only when GITHUB_ORG, GITHUB_REPO, and GITHUB_APP_ID are all set; skipped otherwise. |
 | 11 | [`provision_11_deploy_inference_replay.sh`](provision_11_deploy_inference_replay.sh) | **Deploy Inference Replay Proxy (optional)** — Idempotent script that deploys the Inference Replay proxy in front of the LiteLLM gateway. Skipped unless INFERENCE_REPLAY_ENABLED=true. The proxy intercepts the `litellm` Service so agents need no configuration changes. With REPLAY_MODE=off (default) it is a pure pass-through; flip the `inference-replay-config` ConfigMap to `on` to start recording/replaying. |
@@ -131,7 +131,7 @@ Generated from each script's own comment banner.
 | 5 | [`teardown_05_gcp_gchat.sh`](teardown_05_gcp_gchat.sh) | **Teardown Google Chat & Pub/Sub Setup** — Idempotent script to clean up GChat Pub/Sub Topic/Subscription and the Bot GSA. |
 | 6 | [`teardown_06_slack.sh`](teardown_06_slack.sh) | **Teardown Slack Integration Setup** — Idempotent script to clean up Slack integration state and tokens. |
 | 7 | [`teardown_07_gcp_k8s_secrets.sh`](teardown_07_gcp_k8s_secrets.sh) | **Teardown GKE Secrets** — Idempotent script to clean up Kubernetes secrets and sanitize local state. |
-| 8 | [`teardown_08_deploy_platform_agent.sh`](teardown_08_deploy_platform_agent.sh) | **Teardown PlatformAgent Custom Resource** — Idempotent script to clean up the applied PlatformAgent Custom Resource (CR) and delete the local generated manifest file. |
+| 8 | [`teardown_08_deploy_platform_agent.sh`](teardown_08_deploy_platform_agent.sh) | **Teardown PlatformAgent Custom Resource** — Idempotent script to clean up the applied PlatformAgent Custom Resource (CR), remove the host-discovery label, and delete the local generated manifest file. |
 | 9 | [`teardown_09_deploy_litellm.sh`](teardown_09_deploy_litellm.sh) | **Teardown LiteLLM Gateway** — Idempotent script to undeploy the LiteLLM gateway. |
 | 10 | [`teardown_10_deploy_github_minter.sh`](teardown_10_deploy_github_minter.sh) | **Teardown GitHub Token Minter** — Idempotent script to clean up the GitHub Token Minter. |
 | 11 | [`teardown_11_deploy_inference_replay.sh`](teardown_11_deploy_inference_replay.sh) | **Teardown Inference Replay Proxy** — Idempotent script to undeploy the Inference Replay proxy and restore the original LiteLLM Service. Safe to run even when the proxy was never deployed. |
@@ -166,6 +166,12 @@ To run a dry-run check (simulates commands without modifying cloud resources):
 ```bash
 ./provision.sh --dry-run
 ```
+
+After the `PlatformAgent` resource is applied, provisioning labels its GKE cluster
+`kube-agents-host=true` so the admin portal can discover the host. Label registration is advisory:
+if it fails, provisioning continues and the portal can still connect through manual cluster
+selection. The in-repository runtime receives its host identity from the configured
+`PlatformAgent` cluster name rather than discovering it by label.
 
 ### Run Teardown Pipeline
 

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -37,6 +37,10 @@ else
   C_WHITE='\033[97m'
 fi
 
+# Stable project-level discovery marker for the GKE cluster hosting kube-agents.
+# Keep this value aligned with the Terraform full-install composition and admin portal.
+KUBE_AGENTS_HOST_LABEL="kube-agents-host"
+
 # ─── UI Helpers ───────────────────────────────────────────────────────────────
 print_step() { echo -e "\n${C_MAGENTA}${C_BOLD}>>>  $1  <<<${C_RESET}"; }
 print_success() { echo -e "  ${C_GREEN}✓ $1${C_RESET}"; }
@@ -686,6 +690,29 @@ cluster_exists() {
   gcloud container clusters list --filter="name=${CLUSTER_NAME} AND location=${REGION}" --format="value(name)" --project="${PROJECT_ID}" 2>/dev/null || echo ""
 }
 
+host_label_value() {
+  gcloud container clusters describe "$CLUSTER_NAME" \
+    --location="$REGION" \
+    --project="$PROJECT_ID" \
+    --format="value(resourceLabels.${KUBE_AGENTS_HOST_LABEL})" 2>/dev/null
+}
+
+verify_host_label() {
+  [ "$(host_label_value)" = "true" ]
+}
+
+update_host_label() {
+  gcloud container clusters update "$CLUSTER_NAME" \
+    --location="$REGION" \
+    --project="$PROJECT_ID" \
+    --update-labels="${KUBE_AGENTS_HOST_LABEL}=true" \
+    --quiet
+}
+
+execute_host_label() {
+  retry 3 5 update_host_label
+}
+
 connect_cluster() {
   print_info "Fetching cluster credentials..."
   gcloud container clusters get-credentials "$CLUSTER_NAME" --location "$REGION" --project "$PROJECT_ID" --quiet
@@ -746,6 +773,29 @@ wait_for_k8s_resource() {
   # Step 2: Wait for condition availability
   kubectl wait --for="condition=${condition}" "${resource}" -n "${namespace}" --timeout="${timeout}" || return 1
   print_success "${resource} reached state: ${condition}."
+}
+
+register_host_label() {
+  print_step "3. Register kube-agents host"
+  print_info "Verifying current state..."
+
+  if verify_host_label; then
+    print_success "Already completed: 3. Register kube-agents host"
+    return 0
+  fi
+
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    print_info "[DRY-RUN] Would execute: 3. Register kube-agents host"
+    return 0
+  fi
+
+  print_info "Applying ${KUBE_AGENTS_HOST_LABEL}=true to '${CLUSTER_NAME}'..."
+  if execute_host_label; then
+    print_success "Registered the kube-agents host."
+  else
+    print_warning "Could not apply ${KUBE_AGENTS_HOST_LABEL}=true. Provisioning will continue; rerun step 08 to retry host discovery registration."
+  fi
+  return 0
 }
 
 confirm_action() {

--- a/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
@@ -3,10 +3,11 @@
 # 🤖 Step 8: Deploy PlatformAgent Custom Resource Manifest
 # ==============================================================================
 # Idempotent script that connects to GKE, renders the platform-agent.yaml
-# template, deploys it to the cluster, and fails unless the operator reconciles
-# the change into the agent Deployment (override the wait budget with
-# AGENT_READY_TIMEOUT, default 600s). Whether the Deployment then rolls out is
-# verified by step 13, after the agent's dependencies exist.
+# template, deploys it to the cluster, labels the host cluster for discovery,
+# and fails unless the operator reconciles the change into the agent Deployment
+# (override the wait budget with AGENT_READY_TIMEOUT, default 600s). Whether the
+# Deployment then rolls out is verified by step 13, after the agent's
+# dependencies exist.
 # ==============================================================================
 
 set -e
@@ -216,6 +217,7 @@ execute_custom_resource() {
 # ─── Execution Pipeline ───────────────────────────────────────────────────────
 run_step "1. Connect kubectl" verify_kubeconfig execute_kubeconfig 0
 run_step "2. Apply PlatformAgent Custom Resource" verify_custom_resource execute_custom_resource 0
+register_host_label
 
 # ─── Conclusion Checklist ─────────────────────────────────────────────────────
 echo -e "\n${C_GREEN}${C_BOLD}✓ PlatformAgent Custom Resource applied and reconciled by the operator!${C_RESET}"

--- a/k8s-operator/scripts/teardown_08_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/teardown_08_deploy_platform_agent.sh
@@ -2,8 +2,8 @@
 # ==============================================================================
 # 🧹 Step 8: Teardown PlatformAgent Custom Resource
 # ==============================================================================
-# Idempotent script to clean up the applied PlatformAgent Custom Resource (CR)
-# and delete the local generated manifest file.
+# Idempotent script to clean up the applied PlatformAgent Custom Resource (CR),
+# remove the host-discovery label, and delete the local generated manifest file.
 # ==============================================================================
 
 set -euo pipefail
@@ -23,7 +23,7 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 ensure_teardown_state
 
 # ─── Confirmation Prompt ──────────────────────────────────────────────────────
-confirm_action "This will permanently delete the PlatformAgent Custom Resource and its generated manifest file." \
+confirm_action "This will permanently delete the PlatformAgent Custom Resource and its generated manifest file, and remove the host-discovery label." \
   "GCP Project:$PROJECT_ID" \
   "GKE Cluster:$CLUSTER_NAME" \
   "Namespace:$NAMESPACE"
@@ -72,6 +72,34 @@ if [ -f "$local_yaml" ]; then
     rm -f "$local_yaml"
     echo -e "  ${C_GREEN}✓ Deleted platform-agent.yaml${C_RESET}"
   fi
+fi
+
+# ─── Step 4: Remove Host Discovery Label ──────────────────────────────────────
+label_cleanup_failed=0
+if ! HOST_LABEL=$(host_label_value); then
+  print_warning "Could not inspect the '${KUBE_AGENTS_HOST_LABEL}' cluster label; verify it manually."
+  label_cleanup_failed=1
+elif [ "$HOST_LABEL" = "true" ]; then
+  if [ "${DRY_RUN:-0}" -eq 1 ]; then
+    echo -e "  ${C_GREEN}[DRY-RUN] Would remove the '${KUBE_AGENTS_HOST_LABEL}' cluster label.${C_RESET}"
+  else
+    print_info "Removing the '${KUBE_AGENTS_HOST_LABEL}' cluster label..."
+    if gcloud container clusters update "$CLUSTER_NAME" \
+      --location="$REGION" \
+      --project="$PROJECT_ID" \
+      --remove-labels="$KUBE_AGENTS_HOST_LABEL" \
+      --quiet; then
+      print_success "Removed the kube-agents host label."
+    else
+      print_warning "Could not remove the '${KUBE_AGENTS_HOST_LABEL}' label; remove it manually."
+      label_cleanup_failed=1
+    fi
+  fi
+fi
+
+if [ "$label_cleanup_failed" -eq 1 ]; then
+  print_error "PlatformAgent teardown completed with warnings; review the messages above."
+  exit 1
 fi
 
 echo -e "\n${C_GREEN}${C_BOLD}✅ PlatformAgent Custom Resource successfully cleaned up!${C_RESET}"

--- a/scripts/test_host_label_provisioning.py
+++ b/scripts/test_host_label_provisioning.py
@@ -1,0 +1,123 @@
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_ROOT = REPO_ROOT / "k8s-operator" / "scripts"
+
+
+class HostLabelProvisioningTest(unittest.TestCase):
+    def test_registration_uses_portal_label_and_is_advisory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            call_log = Path(temp_dir) / "gcloud.log"
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    textwrap.dedent(
+                        f"""
+                        source {SCRIPT_ROOT / 'common.sh'}
+                        PROJECT_ID=test-project
+                        CLUSTER_NAME=test-cluster
+                        REGION=us-central1
+                        DRY_RUN=0
+                        gcloud() {{
+                          printf '%s\n' "$*" >> "$CALL_LOG"
+                          case "$*" in
+                            *"clusters describe"*) printf 'false\n' ;;
+                            *"clusters update"*) return 42 ;;
+                          esac
+                        }}
+                        retry() {{ shift 2; "$@"; }}
+                        register_host_label
+                        """
+                    ),
+                ],
+                cwd=REPO_ROOT,
+                env={**os.environ, "CALL_LOG": str(call_log), "TERM": "dumb"},
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("Provisioning will continue", result.stdout)
+            calls = call_log.read_text()
+            self.assertIn("--update-labels=kube-agents-host=true", calls)
+            self.assertNotIn("--update-labels=kubeagents-host=true", calls)
+
+    def test_failed_label_removal_happens_after_local_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scripts = Path(temp_dir)
+            shutil.copy2(SCRIPT_ROOT / "common.sh", scripts / "common.sh")
+            shutil.copy2(
+                SCRIPT_ROOT / "min_versions.sh", scripts / "min_versions.sh"
+            )
+            shutil.copy2(
+                SCRIPT_ROOT / "teardown_08_deploy_platform_agent.sh",
+                scripts / "teardown_08_deploy_platform_agent.sh",
+            )
+            (scripts / "vars.sh").write_text(
+                "export PROJECT_ID=test-project\n"
+                "export CLUSTER_NAME=test-cluster\n"
+                "export REGION=us-central1\n"
+            )
+            manifest = scripts / "platform-agent.yaml"
+            manifest.write_text("apiVersion: v1\n")
+            call_log = scripts / "gcloud.log"
+            bin_dir = scripts / "bin"
+            bin_dir.mkdir()
+            gcloud = bin_dir / "gcloud"
+            gcloud.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    printf '%s\n' "$*" >> "$CALL_LOG"
+                    case "$*" in
+                      "config set project"*) exit 0 ;;
+                      *"container clusters list"*) echo test-cluster; exit 0 ;;
+                      *"container clusters get-credentials"*) exit 0 ;;
+                      *"container clusters describe"*) echo true; exit 0 ;;
+                      *"container clusters update"*) echo PERMISSION_DENIED >&2; exit 1 ;;
+                      *) exit 0 ;;
+                    esac
+                    """
+                )
+            )
+            gcloud.chmod(0o755)
+            kubectl = bin_dir / "kubectl"
+            kubectl.write_text("#!/usr/bin/env bash\nexit 0\n")
+            kubectl.chmod(0o755)
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    str(scripts / "teardown_08_deploy_platform_agent.sh"),
+                    "--no-confirm",
+                ],
+                env={
+                    **os.environ,
+                    "CALL_LOG": str(call_log),
+                    "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                    "TERM": "dumb",
+                },
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertFalse(manifest.exists())
+            self.assertIn(
+                "--remove-labels=kube-agents-host", call_log.read_text()
+            )
+            self.assertIn("teardown completed with warnings", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -12,7 +12,8 @@ same cluster, service accounts, and IAM bindings.
   destroy), including the Cloud KMS API for GKE database encryption and the Chat
   API when Google Chat is enabled.
 - A GKE Autopilot cluster ([`gke-cluster`](../../modules/gke-cluster) module)
-  with Workload Identity and Cloud KMS database encryption (CMEK) enabled.
+  with Workload Identity and Cloud KMS database encryption (CMEK) enabled, and
+  the `kube-agents-host=true` discovery label applied.
 - The agent's GCP identity ([`kube-agents-iam`](../../modules/kube-agents-iam)
   module): the `kubeagents-platform-gsa` service account, its read-only
   project roles, and the Workload Identity binding to the
@@ -143,6 +144,10 @@ would install the chart from the OCI registry rather than a local path — see
 the [chart README](../../../charts/kube-agents/README.md).
 
 ## Teardown
+
+Use Terraform for teardown; do not mix this install path with the shell provisioner's
+`teardown_*.sh` scripts. In particular, `teardown_08_deploy_platform_agent.sh` removes the
+Terraform-managed `kube-agents-host` label out of band and causes plan drift.
 
 `terraform destroy` removes the Helm release, but that also removes the
 operator — and the `PlatformAgent` CR carries a finalizer only the operator

--- a/terraform/examples/full-install/main.tf
+++ b/terraform/examples/full-install/main.tf
@@ -74,6 +74,9 @@ module "gke_cluster" {
   enable_database_encryption = var.enable_database_encryption
   kms_keyring_name           = var.kms_keyring_name
   kms_key_name               = var.kms_key_name
+  resource_labels = {
+    "kube-agents-host" = "true"
+  }
 
   depends_on = [google_project_service.required]
 }

--- a/terraform/modules/gke-cluster/README.md
+++ b/terraform/modules/gke-cluster/README.md
@@ -1,6 +1,6 @@
 # GKE Autopilot Cluster Module
 
-Reusable Terraform module for provisioning a GKE Autopilot cluster configured for Kube-Agents workloads. Autopilot clusters are regional: `location` must be a region (a zone is rejected at plan time).
+Reusable Terraform module for provisioning a GKE Autopilot cluster configured for Kube-Agents workloads. Autopilot clusters are regional: `location` must be a region (a zone is rejected at plan time). The full-install composition passes `kube-agents-host=true` through `resource_labels` so the admin portal can discover the deployed host; standalone callers can use the same input when they install kube-agents on the cluster.
 
 By default (`enable_database_encryption = true`), the module provisions a Cloud KMS Keyring and CryptoKey, binds `roles/cloudkms.cryptoKeyEncrypterDecrypter` to the GKE Service Agent, and enables etcd database encryption (CMEK).
 
@@ -15,10 +15,13 @@ By default (`enable_database_encryption = true`), the module provisions a Cloud 
 
 ```hcl
 module "gke_cluster" {
-  source       = "git::https://github.com/gke-labs/kube-agents.git//terraform/modules/gke-cluster?ref=vX.Y.Z"
-  project_id   = "my-gcp-project"
-  cluster_name = "production-host-01"
-  location     = "us-central1"
+  source          = "git::https://github.com/gke-labs/kube-agents.git//terraform/modules/gke-cluster?ref=vX.Y.Z"
+  project_id      = "my-gcp-project"
+  cluster_name    = "production-host-01"
+  location        = "us-central1"
+  resource_labels = {
+    "kube-agents-host" = "true"
+  }
 }
 ```
 

--- a/terraform/modules/gke-cluster/main.tf
+++ b/terraform/modules/gke-cluster/main.tf
@@ -35,6 +35,7 @@ resource "google_container_cluster" "autopilot" {
 
   enable_autopilot    = true
   deletion_protection = var.deletion_protection
+  resource_labels     = var.resource_labels
 
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"

--- a/terraform/modules/gke-cluster/variables.tf
+++ b/terraform/modules/gke-cluster/variables.tf
@@ -24,6 +24,12 @@ variable "deletion_protection" {
   default     = true
 }
 
+variable "resource_labels" {
+  description = "GCP resource labels to apply to the cluster. Set kube-agents-host=true when the cluster hosts kube-agents."
+  type        = map(string)
+  default     = {}
+}
+
 variable "release_channel" {
   description = "GKE release channel for the cluster"
   type        = string


### PR DESCRIPTION
# Pull Request

## Why This Change

The admin console discovers the GKE cluster hosting kube-agents through a project-level resource label. Both supported full-install paths need to apply that marker consistently, while a label update failure must not prevent the functional agent stack from being provisioned.

## What Changed

**Files:**

- `k8s-operator/scripts/{common.sh,provision_08_deploy_platform_agent.sh,teardown_08_deploy_platform_agent.sh}`
- `terraform/examples/full-install/{main.tf,README.md}` and `terraform/modules/gke-cluster/`
- Provisioning, uninstall, generated step, and documentation-map references
- `scripts/test_host_label_provisioning.py` and `hack/check-docs-terminology.sh`

**Added/Changed/Fixed:**

- Define the admin console discovery contract as `kube-agents-host=true` and centralize shell reads/updates in `common.sh`.
- Register the label after applying the `PlatformAgent` CR, retry transient update failures, and treat registration as advisory so later provisioning steps still run.
- Remove the script-managed label during shell teardown only after local manifest cleanup; report a deferred nonzero status when label cleanup fails.
- Pass the label through the Terraform full-install composition while keeping the reusable module input optional for standalone callers.
- Document that Terraform installations must use their Terraform teardown path to avoid out-of-band state drift.
- Add CI-discovered tests for advisory registration and teardown continuation, plus a terminology guard that keeps shell, Terraform, and docs aligned.

## Why This Matters

- The admin console can automatically select the single labeled host and can surface zero or multiple labeled hosts for manual selection.
- A missing permission or in-flight GKE operation cannot abort provisioning before LiteLLM and the remaining functional components are installed.
- Shell and Terraform ownership remain explicit, avoiding unexplained Terraform plan drift.
- The existing provisioning `-y` behavior and current-main cluster discovery helpers are unchanged.

## Context

The label is consumed by the admin console. The agent runtime itself continues to receive its host identity from the configured `PlatformAgent` cluster name. The reusable GKE module does not assume every standalone cluster hosts kube-agents; the full-install composition opts in explicitly.

## Testing

- `python3 -m unittest scripts.test_host_label_provisioning -v`
- `bash -n k8s-operator/scripts/*.sh k8s-operator/scripts/dev/*.sh hack/check-docs-terminology.sh`
- `go build ./...` in `k8s-operator`
- Terraform 1.15.8 `fmt -check -recursive`, `init -backend=false`, and `validate` for every module/example
- `make docs-generate` followed by a clean generated-file check
- `make docs-check`
- Prettier check for changed Markdown/MDX files
- `npm run build` in `docs/site`
- `git diff --check origin/main...HEAD`

---

Both full-install paths now expose the host to the admin console without making discovery-label availability a prerequisite for a working deployment.