### PR TITLE
fix(litellm): move the gateway listen port from 4000 to 8080

### DIFF
--- a/charts/kube-agents/templates/litellm.yaml
+++ b/charts/kube-agents/templates/litellm.yaml
@@ -57,7 +57,9 @@ spec:
         - name: litellm-container
           image: "{{ .Values.litellm.image.repository }}:{{ .Values.litellm.image.tag }}"
           imagePullPolicy: {{ .Values.litellm.image.pullPolicy }}
-          args: ["--config", "/app/config.yaml"]
+          # --port is explicit: LiteLLM's own default is 4000, so the port only
+          # moves if the flag says so — containerPort alone would not bind it.
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           resources:
             {{- toYaml .Values.litellm.resources | nindent 12 }}
           env:
@@ -92,7 +94,10 @@ spec:
               value: litellm
             {{- end }}
           ports:
-            - containerPort: 4000
+            # Named so the Service and PodMonitoring below reference the name,
+            # not a second copy of the number.
+            - containerPort: 8080
+              name: http
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml
@@ -119,7 +124,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP
 {{- if .Values.litellm.networkPolicy }}
 ---
@@ -181,17 +186,20 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
   ingress:
+    # Numeric rather than the "http" port name: named-port support in
+    # NetworkPolicy varies by CNI dataplane, and a rule that fails to match
+    # here fails closed.
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
   podSelector:
     matchLabels:
@@ -215,7 +223,7 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: http
       path: /metrics
       interval: 30s
 {{- end }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@ identifier appears, add its source here.
 | Registry prefix default (`REGISTRY_PREFIX`)                          | `k8s-operator/scripts/common.sh`                                                       |
 | GitOps clone layout (`/opt/data/gitops/...`) and leases              | `agents/platform/scripts/gitops_workspace.py`                                          |
 | Helm chart value defaults (KSA/secret names, image repos, tag rules) | `charts/kube-agents/values.yaml`                                                       |
+| LiteLLM gateway listen port (`--port`, `containerPort`)              | `k8s-operator/config/integrations/litellm/base/deployment.yaml`                        |
 | Terraform module defaults (GSA/KSA/namespace, role set, channel)     | `terraform/modules/*/variables.tf`                                                     |
 
 ## 3. Documentation eras and status

--- a/docs/site/src/content/docs/concepts/observability.md
+++ b/docs/site/src/content/docs/concepts/observability.md
@@ -11,7 +11,7 @@ The Platform Agent (Hermes) Deployment exports OpenTelemetry traces, and LiteLLM
 
 ### Prometheus metrics
 
-- **LiteLLM** — request latency, per-model token counts, error rates on its `/metrics` endpoint (port 4000). Scraped by GKE Managed Prometheus via the `litellm-monitoring` `PodMonitoring` shipped in the LiteLLM integration base (`k8s-operator/config/integrations/litellm/base/podmonitoring.yaml`).
+- **LiteLLM** — request latency, per-model token counts, error rates on its `/metrics` endpoint (port 8080). Scraped by GKE Managed Prometheus via the `litellm-monitoring` `PodMonitoring` shipped in the LiteLLM integration base (`k8s-operator/config/integrations/litellm/base/podmonitoring.yaml`).
 - **vLLM** — per-request latency histograms, queue depth, and GPU/KV-cache stats when running local models on GPU node pools. Exposed on its own `/metrics` endpoint and scraped by GKE Managed Prometheus.
 
 The Platform Agent (Hermes) Deployment does **not** expose a Prometheus `/metrics` endpoint — it serves only the API (`8642`) and Dashboard (`9119`) ports. Its runtime signals surface as OpenTelemetry traces (below) and `tool_call_audit` log records; pod-level CPU/memory is available through the Kubernetes metrics API (`kubectl top`). The `event-watcher` sidecar can expose watcher metrics (`k8s_event_watcher_*`) via a `--metrics-addr` flag, but this is disabled by default in the shipping deploy.

--- a/docs/site/src/content/docs/deploy/telemetry.md
+++ b/docs/site/src/content/docs/deploy/telemetry.md
@@ -20,7 +20,7 @@ For what's exported and how the agent surfaces it in Chat replies, see [Concepts
 
 ## GKE Managed Prometheus
 
-Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints (LiteLLM on port 4000, vLLM on port 8000); managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration (the LiteLLM operator base at `k8s-operator/config/integrations/litellm/base/podmonitoring.yaml` and the vLLM example manifests under `examples/`).
+Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints (LiteLLM on port 8080, vLLM on port 8000); managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration (the LiteLLM operator base at `k8s-operator/config/integrations/litellm/base/podmonitoring.yaml` and the vLLM example manifests under `examples/`).
 
 ## OpenTelemetry
 

--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -14,7 +14,7 @@ graph TD
     end
 
     ProxyPod -->|Cache Miss| RealSvc[Service: litellm-gateway]
-    RealSvc -->|Port 4000| RealPod[Original LiteLLM Pod]
+    RealSvc -->|Port 8080| RealPod[Original LiteLLM Pod]
 ```
 
 - **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.

--- a/examples/inference-replay/replay-proxy/replay_proxy.py
+++ b/examples/inference-replay/replay-proxy/replay_proxy.py
@@ -11,6 +11,9 @@ import httpx
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("replay-proxy-v1")
 
+# Local-dev fallback only; in-cluster the Deployment sets INFERENCE_URL to the
+# litellm-gateway Service. Point this at whatever local port you forward the
+# gateway to -- it must not be 8080, which this proxy binds itself.
 INFERENCE_URL = os.environ.get("INFERENCE_URL", "http://localhost:4000")
 CACHE_FILE = os.environ.get("CACHE_FILE", "/data/replay_cache.json")
 MODE_FILE = os.environ.get("MODE_FILE", "/etc/replay/mode")

--- a/examples/inference-replay/service-gateway.yaml
+++ b/examples/inference-replay/service-gateway.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP

--- a/examples/litellm-chatgpt-subscription/README.md
+++ b/examples/litellm-chatgpt-subscription/README.md
@@ -67,5 +67,5 @@ kubectl get configmap litellm-config -n kubeagents-system -o yaml
 
 You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
 
-- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Directly: Query `/metrics` on port 8080 of the LiteLLM container.
 - Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.92.0
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: CHATGPT_TOKEN_DIR
               value: "/data/litellm/chatgpt"
@@ -45,7 +45,8 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
+              name: http
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -63,12 +63,12 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP

--- a/examples/litellm-chatgpt-subscription/podmonitoring.yaml
+++ b/examples/litellm-chatgpt-subscription/podmonitoring.yaml
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: http
       path: /metrics
       interval: 30s

--- a/examples/litellm-chatgpt-subscription/service.yaml
+++ b/examples/litellm-chatgpt-subscription/service.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP

--- a/examples/litellm-gemini/README.md
+++ b/examples/litellm-gemini/README.md
@@ -30,5 +30,5 @@ This directory contains an example of deploying a LiteLLM proxy configured to us
 
 You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
 
-- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Directly: Query `/metrics` on port 8080 of the LiteLLM container.
 - Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.92.0
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: GEMINI_API_KEY
               valueFrom:
@@ -39,7 +39,8 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
+              name: http
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -63,12 +63,12 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP

--- a/examples/litellm-gemini/podmonitoring.yaml
+++ b/examples/litellm-gemini/podmonitoring.yaml
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: http
       path: /metrics
       interval: 30s

--- a/examples/litellm-gemini/service.yaml
+++ b/examples/litellm-gemini/service.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP

--- a/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP

--- a/k8s-operator/config/integrations/litellm/base/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/base/deployment.yaml
@@ -20,7 +20,9 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.92.0
-          args: ["--config", "/app/config.yaml"]
+          # --port is explicit: LiteLLM's own default is 4000, so the port only
+          # moves if the flag says so — containerPort alone would not bind it.
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           resources:
             requests:
               cpu: "100m"
@@ -58,7 +60,10 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            # Named so service.yaml and podmonitoring.yaml reference the name,
+            # not a second copy of the number.
+            - containerPort: 8080
+              name: http
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/k8s-operator/config/integrations/litellm/base/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/base/networkpolicy.yaml
@@ -52,17 +52,20 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-otel
   ingress:
+    # Numeric rather than the "http" port name: named-port support in
+    # NetworkPolicy varies by CNI dataplane, and a rule that fails to match
+    # here fails closed.
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
   podSelector:
     matchLabels:

--- a/k8s-operator/config/integrations/litellm/base/podmonitoring.yaml
+++ b/k8s-operator/config/integrations/litellm/base/podmonitoring.yaml
@@ -7,6 +7,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: http
       path: /metrics
       interval: 30s

--- a/k8s-operator/config/integrations/litellm/base/service.yaml
+++ b/k8s-operator/config/integrations/litellm/base/service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: http
   type: ClusterIP


### PR DESCRIPTION
# Pull Request

## Why This Change

In-cluster callers have been intermittently unable to reach the LiteLLM gateway on port 4000. This moves the pod-side listen port to 8080 — a conventional, rarely-filtered HTTP port — to remove the unusual port number as a variable.

Two things are worth knowing before reviewing:

1. **`containerPort: 4000` was decorative, not configuration.** No manifest in the repo passed `--port`; the process bound 4000 because that is LiteLLM's CLI default. Renumbering `containerPort` alone would have been a silent no-op that left the Service pointing at a port nothing listens on. Every Deployment now passes `--port 8080` explicitly.
2. **This may not be the whole fix.** `litellm-policy` admits ingress only from pods in the release namespace (`podSelector: {}`) plus `gke-gmp-system`. A caller in any other namespace is denied at the NetworkPolicy regardless of port number. That diagnosis is still outstanding — see Context.

**The Service port stays 80**, so no client configuration changes. Consumers continue to reach the gateway at `http://litellm.kubeagents-system.svc.cluster.local/v1` (baked into `deploy/shared/defaults/config.yaml`).

## What Changed

**Files:**

- `charts/kube-agents/templates/litellm.yaml`
- `k8s-operator/config/integrations/litellm/base/{deployment,service,networkpolicy,podmonitoring}.yaml`
- `k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml`
- `examples/litellm-gemini/*`, `examples/litellm-chatgpt-subscription/*`, `examples/inference-replay/*`
- `docs/README.md`, `docs/site/src/content/docs/concepts/observability.md`, `docs/site/src/content/docs/deploy/telemetry.md`

**Added/Changed/Fixed:**

- Deployments gain `--port 8080` in `args`; `containerPort` becomes `8080` and is named `http`.
- Service `targetPort` and the GMP `PodMonitoring` endpoint now reference the port name `http` rather than repeating the number, dropping the port from four places per manifest set to two.
- NetworkPolicy ingress stays **numeric** (`8080`). Named-port support in NetworkPolicy varies by CNI dataplane, and a rule that fails to match there fails closed.
- `litellm-gateway` in the inference-replay integration moves in lockstep — it selects `app: litellm`, so its `targetPort` would break otherwise.
- The `chatgpt` overlay needed no edit: it merges by container name and inherits the new base args (confirmed by rendering it).
- Added a row to the identifier-sources table in `docs/README.md` — the port is now stated as fact in two site pages, and per the map's own rule every documented identifier needs a source of truth.

## Why This Matters

- 8080 is far less likely to collide with environment-level filtering than 4000.
- The `--port` flag makes the bound port explicit rather than an inherited upstream default, so a future renumber cannot silently half-apply.
- Naming the container port removes three of the four duplicated copies of the number per manifest set.

## Context

- **`k8s-operator/testing/staging_workloads/` is deliberately excluded.** The synthetic `litellm-gateway` fleet workload, its open-webui client URL, and the `targetLiteLLM` readiness probe are self-consistent test fixtures simulating a customer workload, not the shipped gateway.
- **`replay_proxy.py`'s `INFERENCE_URL` fallback stays at `localhost:4000`**, now with a comment. The replay proxy binds 8080 itself (`replay-proxy/Dockerfile`), so an 8080 fallback would make it forward cache misses to itself.
- **Follow-up:** if the blocked caller turns out to live outside `kubeagents-system`, `litellm-policy` needs a scoped `namespaceSelector` for that namespace in both the chart template and the kustomize base. Deliberately not a blanket `namespaceSelector: {}` — this gateway holds provider API keys.

## Testing

- `helm template` and `helm lint` on `charts/kube-agents` — renders with `targetPort: http`, `containerPort: 8080` / `name: http`, `--port 8080`, PodMonitoring `port: http`, NetworkPolicy `8080`; no stray `4000`.
- `kubectl kustomize` on the LiteLLM base, the `chatgpt` overlay, and the inference-replay base — all render matching named ports; the overlay correctly inherits `--port 8080`.
- `make docs-check` and `make docs-generate` (clean afterwards — no generated regions affected).
- `npx prettier --check` on all changed Markdown/YAML, and `npm run build` in `docs/site` (42 pages).
- `review-docs-drift` skill run against the branch diff; its one finding (the missing identifier-source row) is fixed in this PR.

**Not yet verified on a live cluster.** Needs a rollout plus a `curl .../health/readiness` from a pod in `kubeagents-system` to prove Service → named port → `--port 8080` line up end to end, and a check that LiteLLM series still land in Cloud Monitoring after one 30s scrape interval — a named port that fails to resolve shows up as a silently empty target. Draft until that passes.

---

Low risk to roll back: the change is confined to manifests, and reverting restores the previous port in one commit. The rollout itself is a rolling update with `maxUnavailable: 0`.

_This PR was generated with the help of Claude._
