### PR TITLE
fix(session-kv): remove quadratic backtracking from the PDB message parser

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -126,10 +126,13 @@ def clean_reason_label(reason: str) -> str:
 
 def clean_event_message(message: str) -> str:
     msg = message.replace("PodDisruptionBudget", "PDB")
-    # Simplify PDB eviction violation message:
-    m = re.search(r"cannot be evicted:\s*(would violate PDB\s+(?:[^/]+/)?([a-zA-Z0-9_-]+))", msg)
+    # Simplify PDB eviction violation message. The namespace segment excludes
+    # whitespace so it cannot overlap the preceding `\s+`: two adjacent
+    # quantifiers that can match the same characters make the engine try every
+    # split point, which is quadratic on hostile input (CodeQL py/polynomial-redos).
+    m = re.search(r"cannot be evicted:\s*would violate PDB\s+(?:[^\s/]+/)?([a-zA-Z0-9_-]+)", msg)
     if m:
-        clean_pdb = m.group(2)
+        clean_pdb = m.group(1)
         return f"Eviction would violate PDB {clean_pdb}"
     return msg
 

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
@@ -40,9 +41,21 @@ class TestSessionKvServerUtils(unittest.TestCase):
         msg = "cannot be evicted: would violate PDB default/billing-processor-pdb"
         self.assertEqual(clean_event_message(msg), "Eviction would violate PDB billing-processor-pdb")
         
+        # PodDisruptionBudget is abbreviated, and the namespace is optional
+        msg_long = "cannot be evicted: would violate PodDisruptionBudget billing-processor-pdb"
+        self.assertEqual(clean_event_message(msg_long), "Eviction would violate PDB billing-processor-pdb")
+
         # General messages remain unchanged
         msg_general = "MountVolume.SetUp failed for volume \"config\""
         self.assertEqual(clean_event_message(msg_general), msg_general)
+
+    def test_clean_event_message_pathological_whitespace(self):
+        # A long whitespace run with no PDB name must not trigger quadratic
+        # backtracking (CodeQL py/polynomial-redos).
+        msg = "cannot be evicted:would violate PDB " + " " * 60000
+        start = time.monotonic()
+        self.assertEqual(clean_event_message(msg), msg)
+        self.assertLess(time.monotonic() - start, 1.0)
 
     def test_get_severity_details(self):
         # Blocker warnings -> Critical


### PR DESCRIPTION
# Pull Request

## Why This Change

CodeQL alert [#11](https://github.com/gke-labs/kube-agents/security/code-scanning/11) (`py/polynomial-redos`, high) flags the PDB eviction regex in `clean_event_message`:

```python
re.search(r"cannot be evicted:\s*(would violate PDB\s+(?:[^/]+/)?([a-zA-Z0-9_-]+))", msg)
```

`\s+` sits next to `[^/]+`, which also matches whitespace. When two adjacent unbounded quantifiers can consume the same characters, the engine retries every split point between them, so matching is quadratic in the length of the whitespace run.

The input is attacker-influenced: `message` arrives in the POST body of `/sessions/{session_id}/inject` and flows unbounded into `clean_event_message`.

Measured on `"cannot be evicted:would violate PDB " + " " * N`:

| N spaces | before  | after    |
| -------- | ------- | -------- |
| 5,000    | 0.026s  | 0.0007s  |
| 20,000   | 0.394s  | 0.0014s  |

4x the input for 16x the time before; linear after.

## What Changed

**Files:**

- `agents/platform/scripts/session_kv_server.py`
- `agents/platform/scripts/test_session_kv_server.py`

**Added/Changed/Fixed:**

- Excluded whitespace from the optional namespace segment (`[^/]+` -> `[^\s/]+`) so it can no longer overlap the preceding `\s+`. The two quantifiers are now disjoint and the match is linear.
- Dropped the outer capture group, which was never read (`m.group(2)` -> `m.group(1)`).
- Added a comment recording why the character class is narrowed, so it is not widened back.
- Added a regression test asserting a 60k-space message parses in under a second, plus a case covering the `PodDisruptionBudget` -> `PDB` expansion with no namespace.

A length guard alone does not clear this rule (see #395 / #396, where the identical pattern was re-flagged as a new alert); the ambiguous adjacency has to be removed.

## Why This Matters

`/sessions/{session_id}/inject` is the ingress for Kubernetes event payloads. A crafted `message` field could pin a request thread on regex backtracking, and the parse happens before any other work on the payload.

## Context

- Fixes CodeQL alert #11.
- Same class of fix as #396, which cleared alert #12 in `credential_proxy.py` by removing an ambiguous adjacency rather than bounding input length.

## Testing

- `python -m pytest agents/platform/scripts/test_session_kv_server.py` — 16 passed (deps per `.github/workflows/python-tests.yml`).
- Verified the old and new patterns produce identical captures on namespaced (`default/billing-processor-pdb`), bare (`mypdb`), extra-whitespace, trailing-punctuation (`ns/my-pdb.`), and multi-slash (`a/b/c`) messages.
- Timed both patterns at 5k and 20k spaces (table above).
- `make docs-check` passes; no doc states anything about this parser.

---

Behavior-preserving on every well-formed message; the only change is that malformed ones fail fast instead of backtracking. No config, schema, or interface changes.

Generated with the help of Claude.