### PR TITLE
fix(agent): take the default profile's config.yaml from the directory mount

### DIFF
--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -39,6 +39,24 @@ if [ -d "/opt/defaults" ]; then
     done
 fi
 
+# 2a-bis. The operator owns the default profile's config.yaml, and delivers it two
+# ways: as a subPath mount straight onto $TARGET_DIR/config.yaml, and as part of the
+# whole-ConfigMap directory mount at /opt/agent-config. The subPath is not reliable —
+# on a first boot against a brand-new PVC kubelet does not establish it (its sibling
+# subPath from the same volume, leader_elect.py, mounts fine), and step 2a above then
+# leaves the image default live. The agent starts with no `platforms.slack` entry, no
+# Slack consumer runs, and chat is silently dead while every health check passes.
+#
+# So take config.yaml from the directory mount, which is a plain projected volume and
+# always present. When the subPath *did* mount, this copy fails with EBUSY against the
+# mount point and the already-correct content stays — hence the `|| true`, which is a
+# no-op rather than a fallback. This touches only the default profile's config.yaml;
+# the cluster profiles are identity-stamped at scaffold time and are synced separately
+# below, so they are unaffected.
+if [ -f "/opt/agent-config/config.yaml" ]; then
+    cp -f "/opt/agent-config/config.yaml" "$TARGET_DIR/config.yaml" 2>/dev/null || true
+fi
+
 # 2b. Force-sync the shared scripts, for the reason step 2a gives for the default
 # profile's files: they are image-owned, never runtime state, and `cp -ru` above can skip
 # them. It skips whenever the destination looks newer, which covers both a rollback to an


### PR DESCRIPTION
## Why This Change

On a clean install, Slack connects and then ignores everything, with no error anywhere: the Pod is `5/5 Running` with `restartCount=0`, the CR reports `phase: Ready`, and the sidecar logs `A new session has been established` / `Slack relay enabled workspaces=1`.

The agent's live `config.yaml` has no `platforms.slack` entry, so Hermes starts no Slack consumer and nothing ever polls `/v1/chat/slack/events`. Messages queue in the sidecar unread. Restarting the Pod fixes it permanently and the queued messages replay.

The operator's ConfigMap is correct throughout — it contains `slack: enabled: true`. It just is not what the agent reads.

Fixes the root cause behind #538.

## Root cause

The operator mounts the same ConfigMap two ways:

- a `subPath` mount straight onto `$HERMES_HOME/config.yaml`
- the whole ConfigMap as a directory at `/opt/agent-config`, outside `$HERMES_HOME`

On a first boot against a brand-new PVC, kubelet does **not** establish the subPath. From `/proc/mounts` in a failing Pod:

```
/dev/sdc  /opt/data                   ext4 rw     <- the PVC
/dev/sda1 /opt/data/leader_elect.py   ext4 ro     <- subPath, mounted
/dev/sda1 /opt/data/SETTINGS.md       ext4 ro     <- subPath, mounted
                                                  <- config.yaml absent
```

`leader_elect.py` is a subPath from the *same* volume and it mounts. Both are declared in the Pod spec, both keys exist in the ConfigMap, and there are no `FailedMount` events.

With no mount there, step 2a's unconditional `cp -f /opt/defaults/config.yaml` wins, and the image default — which has no `slack` key — is what the agent loads.

## Isolating it

Changing one thing at a time, three runs:

| PVC | Deployment | ConfigMap | `config.yaml` mounted | Slack |
| --- | --- | --- | --- | --- |
| **fresh** | fresh | fresh | no | dead |
| populated | **fresh** | same | yes | works |
| populated | same | same | yes | works |

Deleting the `PlatformAgent` CR also deletes the PVC, which is what makes a first install the exposed case. Deployment recreation and ConfigMap age are both ruled out.

I also ruled out the entrypoint being what removes the mount. `cp -f` cannot replace a live subPath — tested against `SETTINGS.md` in a running Pod:

```
cp: cannot remove '/opt/data/SETTINGS.md': Device or resource busy
```

and the mount survived. So on a populated PVC the force-copy fails harmlessly and the ConfigMap content wins; on a fresh PVC there is no mount for it to lose against.

**What this does not explain** is why kubelet skips one file subPath from a volume and not its sibling, deterministically, only when the PVC is new. That needs kubelet logs I could not get at on GKE. The fix does not depend on knowing.

## What Changed

**Files:** `deploy/shared/docker-entrypoint.sh`

One copy, after the image sync, taking `config.yaml` from the directory mount that is always present:

```bash
if [ -f "/opt/agent-config/config.yaml" ]; then
    cp -f "/opt/agent-config/config.yaml" "$TARGET_DIR/config.yaml" 2>/dev/null || true
fi
```

When the subPath *did* mount, this fails with EBUSY against the mount point and the already-correct content stays — the `|| true` is a no-op on that path, not a fallback. The `-f` guard also keeps it inert against an operator too old to create `/opt/agent-config` (added in #514).

Only the default profile's `config.yaml` is touched; cluster profiles are identity-stamped at scaffold time and synced by the separate loop further down.

## Testing

Verified against a live cluster on **current `main`**, after force-pulling today's operator image (the first reproduction ran against an operator that predated #514, so I redid it):

- Reproduced the failure twice on a fresh PVC: `config.yaml` unmounted, `slack` absent from the live config, `leader_elect.py` mounted.
- Confirmed `/opt/agent-config/config.yaml` is the correct source: 1598 bytes, byte-identical to the ConfigMap, contains the `slack` entry. The live file was the 1241-byte image default.
- Ran the exact line this PR adds, inside a failing Pod: the live config went from 1241 bytes with `slack=0` to 1598 bytes with `slack=1`, byte-identical to the ConfigMap.

**Not verified in-cluster:** the entrypoint executing it at the right point in the sequence, and Slack coming up as a result. That needs a rebuilt agent image, which I could not produce on this machine. The end state it produces is the same one a Pod restart produces today, and that is known to bring Slack up — but the sequencing itself is unverified, so it is worth a smoke test on a fresh PVC before this is trusted.

---

One line of behaviour change, on the path where the config is currently wrong.

Generated with the help of Claude.