### PR TITLE
fix(deploy): set hermes ownership on patched python files in Dockerfile

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -66,7 +66,7 @@ RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/her
 # ledger link into ".../is" in chat. Swap both slices for a whitespace-boundary
 # clip that also stops discarding every line after the first. See the module
 # docstring in deploy/docker/patches/kanban_handoff_clip.py.
-COPY --chmod=0644 deploy/docker/patches/kanban_handoff_clip.py /opt/hermes/gateway/kanban_handoff_clip.py
+COPY --chown=hermes:hermes --chmod=0644 deploy/docker/patches/kanban_handoff_clip.py /opt/hermes/gateway/kanban_handoff_clip.py
 RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/hermes/gateway/kanban_watchers.py'); c = p.read_text(); t1 = 'h = lines[0][:200] if lines else payload_summary[:200]'; t2 = 'r = lines[0][:160] if lines else task.result[:160]'; exit(1) if (t1 not in c or t2 not in c) else None; c = c.replace(t1, 'h = _clip_handoff(payload_summary)').replace(t2, 'r = _clip_handoff(task.result)'); p.write_text(c + '\n\n# kube-agents patch: see gateway/kanban_handoff_clip.py\nfrom gateway.kanban_handoff_clip import clip_handoff as _clip_handoff\n')" && \
     grep -q "h = _clip_handoff(payload_summary)" /opt/hermes/gateway/kanban_watchers.py && \
     grep -q "r = _clip_handoff(task.result)" /opt/hermes/gateway/kanban_watchers.py && \
@@ -84,7 +84,7 @@ RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/her
 # the run action json.dumps it, and the caller got a TypeError in place of the
 # report it had waited six minutes for.
 # See the module docstring in deploy/docker/patches/cron_run_scope.py.
-COPY --chmod=0644 deploy/docker/patches/cron_run_scope.py /opt/hermes/tools/cron_run_scope.py
+COPY --chown=hermes:hermes --chmod=0644 deploy/docker/patches/cron_run_scope.py /opt/hermes/tools/cron_run_scope.py
 COPY deploy/docker/patches/apply_cron_run_scope.py /tmp/apply_cron_run_scope.py
 COPY deploy/docker/patches/verify_cron_run_scope.py /tmp/verify_cron_run_scope.py
 RUN /opt/hermes/.venv/bin/python3 /tmp/apply_cron_run_scope.py /opt/hermes && \
@@ -234,7 +234,7 @@ COPY agents/platform/plugins/ /opt/hermes/plugins/
 # Every path below is guaranteed to exist at this point: /opt/hermes/skills and
 # /opt/hermes/plugins come from the base image, the rest are COPYed above.
 RUN set -eu; \
-    chown -R hermes:hermes /opt/defaults /opt/hermes/skills /opt/hermes/plugins /opt/cluster-template /opt/platform-template; \
+    chown -R hermes:hermes /opt/defaults /opt/hermes/skills /opt/hermes/plugins /opt/hermes/gateway /opt/hermes/tools /opt/cluster-template /opt/platform-template; \
     for d in /opt/defaults /opt/hermes/skills /opt/hermes/plugins /opt/hermes/gateway /opt/hermes/tools /opt/cluster-template /opt/platform-template; do \
         find "$d" -type d -exec chmod 755 {} + ; \
         find "$d" -type f -exec chmod 644 {} + ; \


### PR DESCRIPTION
# Pull Request

## Why This Change

Patched python files (`kanban_handoff_clip.py` and `cron_run_scope.py`) in `/opt/hermes/gateway` and `/opt/hermes/tools` were copied into the Docker container image without explicit `hermes:hermes` ownership, leaving potential permission issues for non-root runtime processes.

This is the **ownership** half of the problem. The **mode** half landed separately in #580, which gave the same two files `--chmod=0644` and added `/opt/hermes/gateway` and `/opt/hermes/tools` to the final `chmod` normalisation loop. The two changes are independent — a file can be world-readable and still owned by `root` — so this branch has been rebased onto #580 and now carries only what #580 did not cover.

## What Changed

**Files:**

- `deploy/docker/Dockerfile`

**Added/Changed/Fixed:**

- Added `--chown=hermes:hermes` alongside the existing `--chmod=0644` on the `COPY` commands for `kanban_handoff_clip.py` and `cron_run_scope.py`.
- Added `/opt/hermes/gateway` and `/opt/hermes/tools` to the `chown -R hermes:hermes` line in the final normalisation block, so the two directory trees match the `chmod` loop #580 already extended. Both path lists are kept in the same order so they stay readable side by side.

Net diff against `main` is three lines.

## Why This Matters

Ensures the non-root `hermes` user owns, not merely reads, all patched modules and their directory trees — consistent with `/opt/hermes/skills` and `/opt/hermes/plugins`, which the same block has always chowned.

## Context

- Rebased onto `main` after #580 merged; the two pull requests edited the same three lines and the resolution takes the union rather than either side.
- The `COPY` instructions live in the `agent-base` stage and the normalisation block in `platform`, which is `FROM agent-base` — so the recursive chown does reach the copied files.

## Testing

- `docker build --check --build-arg HERMES_AGENT_TAG=… --target platform` — no warnings.
- Full `docker build --target platform` against the `HERMES_AGENT_TAG` pinned in `tags.env` — succeeded.
- Inspected the resulting image: both patched files are `-rw-r--r-- hermes hermes`, both directories are `drwxr-xr-x hermes hermes`, and `find /opt/hermes/gateway /opt/hermes/tools ! -user hermes` returns nothing.
- `make docs-check` passed cleanly.

_This PR was generated with the help of Claude._
