### PR TITLE
chore(litellm): serve the gateway on 8080 instead of 4000

### DIFF
--- a/charts/kube-agents/templates/litellm.yaml
+++ b/charts/kube-agents/templates/litellm.yaml
@@ -57,7 +57,7 @@ spec:
         - name: litellm-container
           image: "{{ .Values.litellm.image.repository }}:{{ .Values.litellm.image.tag }}"
           imagePullPolicy: {{ .Values.litellm.image.pullPolicy }}
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           resources:
             {{- toYaml .Values.litellm.resources | nindent 12 }}
           env:
@@ -92,7 +92,7 @@ spec:
               value: litellm
             {{- end }}
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml
@@ -119,7 +119,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP
 {{- if .Values.litellm.networkPolicy }}
 ---
@@ -184,14 +184,14 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
   podSelector:
     matchLabels:
@@ -215,7 +215,7 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: 8080
       path: /metrics
       interval: 30s
 {{- end }}

--- a/docs/site/src/content/docs/concepts/observability.md
+++ b/docs/site/src/content/docs/concepts/observability.md
@@ -11,7 +11,7 @@ The Platform Agent (Hermes) Deployment exports OpenTelemetry traces, and LiteLLM
 
 ### Prometheus metrics
 
-- **LiteLLM** — request latency, per-model token counts, error rates on its `/metrics` endpoint (port 4000). Scraped by GKE Managed Prometheus via the `litellm-monitoring` `PodMonitoring` shipped in the LiteLLM integration base (`k8s-operator/config/integrations/litellm/base/podmonitoring.yaml`).
+- **LiteLLM** — request latency, per-model token counts, error rates on its `/metrics` endpoint (port 8080). Scraped by GKE Managed Prometheus via the `litellm-monitoring` `PodMonitoring` shipped in the LiteLLM integration base (`k8s-operator/config/integrations/litellm/base/podmonitoring.yaml`).
 - **vLLM** — per-request latency histograms, queue depth, and GPU/KV-cache stats when running local models on GPU node pools. Exposed on its own `/metrics` endpoint and scraped by GKE Managed Prometheus.
 
 The Platform Agent (Hermes) Deployment does **not** expose a Prometheus `/metrics` endpoint — it serves only the API (`8642`) and Dashboard (`9119`) ports. Its runtime signals surface as OpenTelemetry traces (below) and `tool_call_audit` log records; pod-level CPU/memory is available through the Kubernetes metrics API (`kubectl top`). The `event-watcher` sidecar can expose watcher metrics (`k8s_event_watcher_*`) via a `--metrics-addr` flag, but this is disabled by default in the shipping deploy.

--- a/docs/site/src/content/docs/deploy/telemetry.md
+++ b/docs/site/src/content/docs/deploy/telemetry.md
@@ -20,7 +20,7 @@ For what's exported and how the agent surfaces it in Chat replies, see [Concepts
 
 ## GKE Managed Prometheus
 
-Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints (LiteLLM on port 4000, vLLM on port 8000); managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration (the LiteLLM operator base at `k8s-operator/config/integrations/litellm/base/podmonitoring.yaml` and the vLLM example manifests under `examples/`).
+Enabled at the cluster level (default on new GKE Standard clusters, opt-in on older). LiteLLM and vLLM expose Prometheus `/metrics` endpoints (LiteLLM on port 8080, vLLM on port 8000); managed Prometheus scrapes them via `PodMonitoring` resources shipped with each integration (the LiteLLM operator base at `k8s-operator/config/integrations/litellm/base/podmonitoring.yaml` and the vLLM example manifests under `examples/`).
 
 ## OpenTelemetry
 

--- a/examples/inference-replay/README.md
+++ b/examples/inference-replay/README.md
@@ -14,7 +14,7 @@ graph TD
     end
 
     ProxyPod -->|Cache Miss| RealSvc[Service: litellm-gateway]
-    RealSvc -->|Port 4000| RealPod[Original LiteLLM Pod]
+    RealSvc -->|Port 8080| RealPod[Original LiteLLM Pod]
 ```
 
 - **Zero-Configuration Interception**: We re-route the primary `litellm` service address to hit our Replay Proxy pod. Agents require zero configuration changes.

--- a/examples/inference-replay/service-gateway.yaml
+++ b/examples/inference-replay/service-gateway.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP

--- a/examples/litellm-chatgpt-subscription/README.md
+++ b/examples/litellm-chatgpt-subscription/README.md
@@ -67,5 +67,5 @@ kubectl get configmap litellm-config -n kubeagents-system -o yaml
 
 You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
 
-- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Directly: Query `/metrics` on port 8080 of the LiteLLM container.
 - Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.95.0
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: CHATGPT_TOKEN_DIR
               value: "/data/litellm/chatgpt"
@@ -45,7 +45,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/examples/litellm-chatgpt-subscription/networkpolicy.yaml
+++ b/examples/litellm-chatgpt-subscription/networkpolicy.yaml
@@ -63,12 +63,12 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP

--- a/examples/litellm-chatgpt-subscription/podmonitoring.yaml
+++ b/examples/litellm-chatgpt-subscription/podmonitoring.yaml
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: 8080
       path: /metrics
       interval: 30s

--- a/examples/litellm-chatgpt-subscription/service.yaml
+++ b/examples/litellm-chatgpt-subscription/service.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP

--- a/examples/litellm-gemini/README.md
+++ b/examples/litellm-gemini/README.md
@@ -30,5 +30,5 @@ This directory contains an example of deploying a LiteLLM proxy configured to us
 
 You can verify that metrics are being successfully exported by querying the endpoint directly or via Cloud Monitoring:
 
-- Directly: Query `/metrics` on port 4000 of the LiteLLM container.
+- Directly: Query `/metrics` on port 8080 of the LiteLLM container.
 - Cloud Monitoring: Look for the metric `prometheus.googleapis.com/litellm_requests_metric_total/counter` under the `prometheus_target` resource.

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.95.0
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: GEMINI_API_KEY
               valueFrom:
@@ -39,7 +39,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/examples/litellm-gemini/networkpolicy.yaml
+++ b/examples/litellm-gemini/networkpolicy.yaml
@@ -63,12 +63,12 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP

--- a/examples/litellm-gemini/podmonitoring.yaml
+++ b/examples/litellm-gemini/podmonitoring.yaml
@@ -8,6 +8,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: 8080
       path: /metrics
       interval: 30s

--- a/examples/litellm-gemini/service.yaml
+++ b/examples/litellm-gemini/service.yaml
@@ -9,5 +9,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP

--- a/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
+++ b/k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP

--- a/k8s-operator/config/integrations/litellm/base/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/base/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: litellm-container
           image: ghcr.io/berriai/litellm:v1.95.0
-          args: ["--config", "/app/config.yaml"]
+          args: ["--config", "/app/config.yaml", "--port", "8080"]
           resources:
             requests:
               cpu: "100m"
@@ -58,7 +58,7 @@ spec:
             - name: OTEL_SERVICE_NAME
               value: litellm
           ports:
-            - containerPort: 4000
+            - containerPort: 8080
           volumeMounts:
             - name: config-volume
               mountPath: /app/config.yaml

--- a/k8s-operator/config/integrations/litellm/base/networkpolicy.yaml
+++ b/k8s-operator/config/integrations/litellm/base/networkpolicy.yaml
@@ -55,14 +55,14 @@ spec:
     - from:
         - podSelector: {}
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-gmp-system
       ports:
-        - port: 4000
+        - port: 8080
           protocol: TCP
   podSelector:
     matchLabels:

--- a/k8s-operator/config/integrations/litellm/base/podmonitoring.yaml
+++ b/k8s-operator/config/integrations/litellm/base/podmonitoring.yaml
@@ -7,6 +7,6 @@ spec:
     matchLabels:
       app: litellm
   endpoints:
-    - port: 4000
+    - port: 8080
       path: /metrics
       interval: 30s

--- a/k8s-operator/config/integrations/litellm/base/service.yaml
+++ b/k8s-operator/config/integrations/litellm/base/service.yaml
@@ -8,5 +8,5 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 4000
+      targetPort: 8080
   type: ClusterIP


### PR DESCRIPTION
# Pull Request

## Why This Change

LiteLLM listens on its upstream default of 4000. That port is blocked by a fair number of corporate egress proxies and cluster firewall rules, so reaching the gateway — port-forwarding to it, curling `/metrics`, or letting a scraper or sidecar talk to it — needs a firewall exception that many environments will not grant. 8080 is the conventional HTTP-alt port and is far more often already open, so moving the gateway onto it removes a class of "the gateway is up but nothing can reach it" install friction.

## What Changed

The gateway now binds 8080 on every path that ships one, and everything that addresses it by port moves with it.

**Files:**

- `charts/kube-agents/templates/litellm.yaml`
- `k8s-operator/config/integrations/litellm/base/{deployment,service,networkpolicy,podmonitoring}.yaml`
- `k8s-operator/config/integrations/inference-replay/base/service-gateway.yaml`
- `examples/litellm-gemini/{deployment,service,networkpolicy,podmonitoring}.yaml`, `README.md`
- `examples/litellm-chatgpt-subscription/{deployment,service,networkpolicy,podmonitoring}.yaml`, `README.md`
- `examples/inference-replay/{service-gateway.yaml,README.md}`
- `docs/site/src/content/docs/concepts/observability.md`, `docs/site/src/content/docs/deploy/telemetry.md`

**Added/Changed/Fixed:**

- **Deployment** — `--port 8080` added to the container args, `containerPort: 8080`. The flag is the part that matters: `containerPort` is documentation only, so without `--port` the proxy would keep binding 4000 and every Service, scrape, and NetworkPolicy rule would point at a closed port.
- **Service** — `targetPort: 8080`. The published `port: 80` is unchanged, so the agent's baked `http://litellm.<namespace>.svc.cluster.local/v1` endpoint still resolves.
- **NetworkPolicy** — both ingress rules (in-cluster pods, and `gke-gmp-system` for the metrics scrape) now allow 8080.
- **PodMonitoring** — scrape endpoint moved to 8080. Not strictly part of the ask, but a PodMonitoring left on 4000 stops scraping with no error surfaced anywhere.
- **`litellm-gateway` Service** (inference-replay, both the operator base and the example) — selects `app: litellm`, so its `targetPort` had to follow or the replay bundle would front a closed port.
- **Docs** — the two site pages that state the metrics port as fact, plus the example READMEs and the inference-replay architecture diagram.

## Why This Matters

- Removes a firewall/proxy exception from the set of things an operator has to arrange before the gateway is usable.
- Keeps the two shipped install paths — the Helm chart and the kustomize base the provisioning scripts apply — consistent about the port, so neither path can drift into being the one that works.
- No API surface change: the Service still publishes 80 and the agent's model endpoint is untouched, so this is invisible to the agent and to anything talking to the gateway through the Service.

## Context

Two references to 4000 are deliberately left alone:

- `examples/inference-replay/replay-proxy/replay_proxy.py` — `INFERENCE_URL` falls back to `http://localhost:4000` only when the proxy runs outside the cluster against a stock `litellm` binary, which still defaults to 4000. In-cluster the Deployment sets `INFERENCE_URL` explicitly. Changing it would make the local-dev path wrong rather than right.
- `k8s-operator/testing/staging_workloads/.../specialized-01-litellm-gateway.yaml.tmpl` and the URLs pointing at it — a synthetic fake workload for the fleet-testing harness, not an install artifact.

Rolling this out to a live cluster is a normal rolling update; the Service cuts over as new pods become ready.

## Testing

- `helm template` on `charts/kube-agents` — renders, all six port sites on 8080, no 4000 left.
- `kubectl kustomize` on `config/integrations/litellm/base` and the `chatgpt` overlay — both build, both on 8080.
- YAML parse over every changed example manifest — all parse.
- `npx prettier --check` on all 20 changed files — clean.
- `make docs-check` — generated regions current, links resolve, terminology and map inventory pass.
- `cd docs/site && npm run build` — 43 pages built.
- Docs-drift review (`.agents/skills/review-docs-drift`) run against the branch diff: no Blocking findings. No docs added/moved/deleted so the map is unaffected, no generated-region sources touched, and a repo-wide grep confirms no doc still states the port as 4000.

Not deployed to a live cluster — the manifests are validated by rendering only.

---

Low risk and self-contained: manifest-only, no code paths, no change to how anything addresses the gateway through its Service. The failure mode if `--port` were ever dropped from the args is loud (the Service fronts a closed port immediately), not silent.

This PR was generated with the help of Claude.
