### PR TITLE
feat(scripts): support an opt-in Cloud Build private worker pool

### DIFF
--- a/docs/site/src/content/docs/operator/development.md
+++ b/docs/site/src/content/docs/operator/development.md
@@ -65,6 +65,16 @@ make dev-rebuild-agent ARGS="platform"
 
 This builds the Platform Agent image, pushes to Artifact Registry, and restarts the Deployment. First run creates a dev Artifact Registry repo; clean it up later with `make gcp-teardown-dev-artifact-registry`.
 
+### Building on a private worker pool
+
+Cloud Build runs on the project's default pool (2 vCPU) unless you point it elsewhere. To use a [private pool](https://cloud.google.com/build/docs/private-pools/private-pools-overview) with more CPU, export its full resource name:
+
+```bash
+export CLOUD_BUILD_WORKER_POOL=projects/PROJECT/locations/REGION/workerPools/POOL
+```
+
+`dev_rebuild_agent.sh` and `hack/ci-deploy.sh` both read this variable and pass `--worker-pool` (plus the pool's region, parsed from the name) to every `gcloud builds submit`. Leave it unset to keep the default pool. The pool must allow public egress, or builds fail pulling base images and packages.
+
 ## Integrations (Kustomize)
 
 Integrations have dedicated deploy/undeploy targets:

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -43,6 +43,27 @@ export USER_PROFILE_ENABLED="false"
 export GOOGLE_CHAT_ENABLED="false"
 export SLACK_ENABLED="false"
 
+# Optional Cloud Build private worker pool. Unset by default, so builds keep
+# going to the project's default pool. Opt in by exporting a full resource
+# name: projects/PROJECT/locations/REGION/workerPools/POOL
+# The region is read back out of that name because `gcloud builds submit`
+# otherwise falls back to the `global` region, which cannot reach a regional
+# pool.
+BUILD_POOL_ARGS=()
+if [ -n "${CLOUD_BUILD_WORKER_POOL:-}" ]; then
+  case "$CLOUD_BUILD_WORKER_POOL" in
+    projects/*/locations/*/workerPools/*) ;;
+    *)
+      echo "ERROR: CLOUD_BUILD_WORKER_POOL must be a full resource name: projects/PROJECT/locations/REGION/workerPools/POOL"
+      exit 1
+      ;;
+  esac
+  BUILD_POOL_ARGS=(
+    --worker-pool="$CLOUD_BUILD_WORKER_POOL"
+    --region="$(echo "$CLOUD_BUILD_WORKER_POOL" | cut -d'/' -f4)"
+  )
+fi
+
 START_TIME=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
 
@@ -57,13 +78,13 @@ STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Building Container Images (platform, credential-proxy, operator) ==="
 gcloud builds submit --config="deploy/docker/cloudbuild.yaml" \
   --substitutions="_IMAGE_URI=${AR_REPO}/platform-agent:${TAG},_IMAGE_URI_LATEST=${AR_REPO}/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=latest" \
-  --project="${PROJECT_ID}" --quiet .
+  --project="${PROJECT_ID}" ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} --quiet .
 
 gcloud builds submit --config="deploy/docker/cloudbuild.yaml" \
   --substitutions="_IMAGE_URI=${AR_REPO}/credential-proxy:${TAG},_IMAGE_URI_LATEST=${AR_REPO}/credential-proxy:latest,_TARGET=credential-proxy,_HERMES_AGENT_TAG=latest" \
-  --project="${PROJECT_ID}" --quiet .
+  --project="${PROJECT_ID}" ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} --quiet .
 
-gcloud builds submit --tag="${AR_REPO}/kube-agents-operator:${TAG}" --project="${PROJECT_ID}" --quiet k8s-operator
+gcloud builds submit --tag="${AR_REPO}/kube-agents-operator:${TAG}" --project="${PROJECT_ID}" ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} --quiet k8s-operator
 echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 
 # ─── 5. Provisioning Pipeline Execution ───────────────────────────────────────

--- a/k8s-operator/scripts/dev/dev_rebuild_agent.sh
+++ b/k8s-operator/scripts/dev/dev_rebuild_agent.sh
@@ -83,6 +83,27 @@ init_var "REGION" "us-east4" "Enter GCP Region for Artifact Registry & GKE"
 init_var "CLUSTER_NAME" "platform-agent-host" "Enter Host GKE Cluster Name"
 init_var "GCP_ARTIFACT_REGISTRY_REPO_NAME" "${GCP_ARTIFACT_REGISTRY_REPO_NAME:-${REPO_NAME:-kube-agents}}" "Enter Artifact Registry Repository Name"
 
+# Optional Cloud Build private worker pool. Unset by default, so builds keep
+# going to the project's default pool. Opt in by exporting a full resource
+# name: projects/PROJECT/locations/REGION/workerPools/POOL
+# The region is read back out of that name because `gcloud builds submit`
+# otherwise falls back to the `global` region, which cannot reach a regional
+# pool.
+BUILD_POOL_ARGS=()
+if [ -n "${CLOUD_BUILD_WORKER_POOL:-}" ]; then
+  case "$CLOUD_BUILD_WORKER_POOL" in
+    projects/*/locations/*/workerPools/*) ;;
+    *)
+      print_error "CLOUD_BUILD_WORKER_POOL must be a full resource name: projects/PROJECT/locations/REGION/workerPools/POOL"
+      exit 1
+      ;;
+  esac
+  BUILD_POOL_ARGS=(
+    --worker-pool="$CLOUD_BUILD_WORKER_POOL"
+    --region="$(echo "$CLOUD_BUILD_WORKER_POOL" | cut -d'/' -f4)"
+  )
+fi
+
 # Resolve HERMES_AGENT_TAG from tags.env
 HERMES_AGENT_TAG=""
 if [ -f "${REPO_ROOT}/tags.env" ]; then
@@ -146,6 +167,7 @@ execute_image_build() {
           --config="deploy/docker/cloudbuild.yaml" \
           --substitutions="_IMAGE_URI=${IMAGE_URI},_IMAGE_URI_LATEST=${IMAGE_URI_LATEST},_TARGET=${AGENT_TARGET},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
           --project="${PROJECT_ID}" \
+          ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} \
           .
     ) || return 1
     (
@@ -154,6 +176,7 @@ execute_image_build() {
           --config="deploy/docker/cloudbuild.yaml" \
           --substitutions="_IMAGE_URI=${PROXY_IMAGE_URI},_IMAGE_URI_LATEST=${PROXY_IMAGE_URI_LATEST},_TARGET=credential-proxy,_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
           --project="${PROJECT_ID}" \
+          ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} \
           .
     ) || return 1
   fi


### PR DESCRIPTION
# Pull Request

## Why This Change

Cloud Build runs every build on the project's default pool (`e2-standard-2`, 2 vCPU) unless the build explicitly names a private pool. Creating a pool does not route builds to it — the pool has to be passed per submit.

Image builds dominate both the dev rebuild loop and the Prow deploy. Recent default-pool builds in a personal project measured 2m49s–6m01s for `platform-agent` and 3m51s–10m25s for `credential-proxy`, roughly 12–20 min for a full three-image deploy. A private pool with more CPU is a straightforward win for anyone who has one, but there was no way to select it short of editing shared config.

## What Changed

**Files:**

- `hack/ci-deploy.sh`
- `k8s-operator/scripts/dev/dev_rebuild_agent.sh`
- `docs/site/src/content/docs/operator/development.md`

**Added/Changed/Fixed:**

- Added `CLOUD_BUILD_WORKER_POOL`, an opt-in env var taking a full pool resource name (`projects/PROJECT/locations/REGION/workerPools/POOL`).
- Both scripts pass `--worker-pool` to every `gcloud builds submit` when it is set — five call sites total, including the operator's `--tag` build, which has no config file and can only take the flag.
- The pool's region is parsed out of the resource name rather than taken as a second variable. `gcloud builds submit` otherwise falls back to the `global` region, which cannot reach a regional pool — the failure mode anyone setting only the pool would have hit.
- A malformed value exits 1 with a usage message instead of silently building `--region=`.
- Documented under "Fast agent iteration (dev only)".

## Why This Matters

- **Default is unchanged.** When `CLOUD_BUILD_WORKER_POOL` is unset the scripts emit byte-identical `gcloud` commands, so contributors and CI projects without a pool are unaffected.
- **Nothing is pinned.** No project, region, or pool name is committed anywhere.
- `deploy/docker/cloudbuild.yaml` is deliberately left alone — an `options.pool` entry there would pin every consumer of the shared config to a single project.

## Context

- `.github/workflows/docker-publish-gcp.yml` is intentionally out of scope. It is gated on `github.repository == 'gke-labs/kube-agents'` and runs in `kube-agents-prow`; wiring a pool there is cross-project and needs a repo variable plus a `WorkerPool User` grant. Happy to follow up if maintainers want it.
- Empty-array expansion uses the `${arr[@]+"${arr[@]}"}` form rather than a plain splat: `ci-deploy.sh` runs `set -euo pipefail`, and expanding an empty array under `set -u` is an error in bash 3.2, which is what macOS ships.

## Testing

- `bash -n` clean on both scripts.
- Behavior verified under `set -euo pipefail` on bash 3.2 across all three paths: unset → flags absent; set → `--worker-pool=... --region=us-east4`; malformed → exit 1.
- Verified end to end against a real private pool (`c3-standard-22`, us-east4) with a throwaway `--no-source` build: SUCCESS, 22 vCPU / 86 GB / 1.1 TB visible to the build, public egress working.
- `make docs-check` passes.
- `npx prettier --check` passes on the changed Markdown.
- `cd docs/site && npm run build` passes (43 pages).
- The `review-docs-drift` skill procedure was run against this diff: no generated-region sources touched, no doc added/moved/renamed/deleted so the map needs no update, and the other pages referencing these scripts describe them at a level this additive change does not invalidate.

Not yet exercised through a full `make dev-rebuild-agent` or a Prow run — the flag composition is verified, but a maintainer may want one real deploy on a pool before relying on it.

---

Low risk and fully inert unless the new variable is set. This PR was generated with the help of Claude.
