### PR TITLE
fix(platform): give each Google Chat relay call its own transport

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import contextlib
 import hmac
 import http.client
 import io
@@ -188,8 +189,44 @@ class GoogleChatRelay:
             else self.subscriber.subscription_path(project_id, subscription_name)
         )
         self.chat = build("chat", "v1", credentials=credentials, cache_discovery=False)
+        self._credentials = credentials
+        # build() hands the discovery resource a single AuthorizedHttp, and so
+        # a single httplib2.Http holding a single TLS socket. httplib2 is not
+        # thread safe, and this proxy serves a thread per connection: two
+        # concurrent api_call threads interleaving records on that one socket
+        # surface as ssl.SSLError, which the handler answers 502. Each call
+        # therefore checks out its own transport. A pool rather than a
+        # thread-local because request threads are per-connection and the
+        # agent-side client opens a connection per call, so thread-locals would
+        # mean a fresh TLS handshake to chat.googleapis.com every time.
+        self._http_pool: queue.LifoQueue = queue.LifoQueue()
+        self._http_pool_size = int(os.getenv("GOOGLE_CHAT_HTTP_POOL_SIZE", "8"))
+        self.num_retries = int(os.getenv("GOOGLE_CHAT_API_NUM_RETRIES", "3"))
         self._receipts: dict[str, Any] = {}
         self._lock = threading.Lock()
+
+    def _build_http(self) -> Any:
+        import google_auth_httplib2
+        from googleapiclient.http import build_http
+
+        return google_auth_httplib2.AuthorizedHttp(
+            self._credentials, http=build_http()
+        )
+
+    @contextlib.contextmanager
+    def _checkout_http(self) -> Any:
+        """Lend one authorized transport to a single caller at a time."""
+        try:
+            http = self._http_pool.get_nowait()
+        except queue.Empty:
+            http = self._build_http()
+        yield http
+        # Deliberately not a finally: a transport whose call raised may have
+        # failed mid-record, and handing that socket to the next caller would
+        # spread one failure across every call after it. It is dropped, and the
+        # next checkout builds a clean one.
+        if self._http_pool.qsize() < self._http_pool_size:
+            self._http_pool.put(http)
 
     def pull(self, timeout_seconds: int = 20) -> dict[str, Any] | None:
         from google.api_core import retry
@@ -246,7 +283,39 @@ class GoogleChatRelay:
         if not method or method.startswith("_"):
             raise ValueError("invalid Google Chat API method")
         operation = getattr(target, method)(**arguments)
-        return operation.execute()
+        # num_retries opts into googleapiclient's own jittered backoff, which
+        # covers ssl.SSLError, socket timeouts and 5xx. Left at its default of
+        # 0 the library attempts the call exactly once. Every Chat method is
+        # retried, messages.create included: a duplicate message is a better
+        # outcome than a reply the user never sees, and the window in which a
+        # retried create duplicates is narrow (the request reached Google and
+        # the failure landed on the response).
+        with self._checkout_http() as http:
+            return operation.execute(http=http, num_retries=self.num_retries)
+
+
+def _chat_error_fields(exc: Exception) -> dict[str, Any] | None:
+    """Return the whitelisted diagnostics a Google Chat API error carried.
+
+    ``None`` means the failure was not an API rejection at all — a transport
+    fault, most often — and the caller has nothing to relay beyond the
+    exception type. Only the status line crosses this boundary. An HttpError
+    stringifies to a message embedding the request URI, and that URI names the
+    space and carries the query the relay's own credential authorized, so it is
+    never logged nor returned to the agent.
+    """
+    response = getattr(exc, "resp", None)
+    status = getattr(response, "status", None)
+    try:
+        fields: dict[str, Any] = {"status": int(status)}  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        # No parseable status: this runs inside an exception handler, so a
+        # second exception here would mask the first.
+        return None
+    reason = getattr(response, "reason", None)
+    if reason:
+        fields["reason"] = str(reason)
+    return fields
 
 
 def _slack_error_fields(exc: Exception) -> dict[str, Any] | None:
@@ -1448,8 +1517,23 @@ class CredentialProxyHandler(BaseHTTPRequestHandler):
         except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
             self._json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
         except Exception as exc:
-            LOGGER.warning("chat relay operation failed path=%s type=%s", self.path, type(exc).__name__)
-            self._json(HTTPStatus.BAD_GATEWAY, {"error": "Google Chat operation failed"})
+            # Carry the status line of a Google Chat rejection back to the
+            # agent and into this log. Without it a transport fault, a 404 for
+            # an unknown space and a 403 for a missing scope are one
+            # indistinguishable "operation failed", and the retries inside
+            # api_call have already absorbed everything genuinely transient —
+            # so what reaches here is usually worth naming.
+            fields = _chat_error_fields(exc)
+            LOGGER.warning(
+                "chat relay operation failed path=%s type=%s status=%s",
+                self.path,
+                type(exc).__name__,
+                (fields or {}).get("status", "none"),
+            )
+            body: dict[str, Any] = {"error": "Google Chat operation failed"}
+            if fields:
+                body["chat"] = fields
+            self._json(HTTPStatus.BAD_GATEWAY, body)
 
     def _handle_slack_post(self) -> None:
         if self.slack_relay is None:

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -25,6 +25,7 @@ from credential_proxy import (
     GoogleChatRelay,
     Policy,
     SlackRelay,
+    _chat_error_fields,
     _slack_error_detail,
     _slack_error_fields,
     is_valid_repository,
@@ -1047,34 +1048,77 @@ class RepositoryValidationTest(unittest.TestCase):
 
 class GoogleChatRelayTest(unittest.TestCase):
     class FakeRequest:
-        def __init__(self, response):
+        def __init__(self, response, hook=None):
             self.response = response
+            self.hook = hook
 
-        def execute(self):
+        def execute(self, http=None, num_retries=0):
+            # Signature matches googleapiclient's HttpRequest.execute. A call
+            # made without ``http`` would share the discovery resource's single
+            # httplib2 transport across threads, and one without ``num_retries``
+            # gets a single attempt, so both are part of what is under test.
+            if self.hook is not None:
+                self.hook(http, num_retries)
             return self.response
 
     class FakeResource:
-        def __init__(self, calls, path=()):
+        def __init__(self, calls, path=(), hook=None):
             self.calls = calls
             self.path = path
+            self.hook = hook
 
         def __getattr__(self, name):
             def invoke(**arguments):
                 if not arguments:
                     return GoogleChatRelayTest.FakeResource(
-                        self.calls, (*self.path, name)
+                        self.calls, (*self.path, name), self.hook
                     )
                 self.calls.append((self.path, name, arguments))
                 return GoogleChatRelayTest.FakeRequest(
-                    {"path": self.path, "method": name, "arguments": arguments}
+                    {"path": self.path, "method": name, "arguments": arguments},
+                    self.hook,
                 )
 
             return invoke
 
-    def test_forwards_unknown_resource_method_and_body_unchanged(self):
-        calls = []
+    def relay(self, hook=None, pool_size=8, num_retries=3):
+        """A relay wired to fake transports, standing in for __init__.
+
+        ``_build_http`` hands out a distinguishable token per call so a test
+        can tell one transport from another, and counts how many were built.
+        """
         relay = GoogleChatRelay.__new__(GoogleChatRelay)
-        relay.chat = self.FakeResource(calls)
+        relay.calls = []
+        relay.chat = self.FakeResource(relay.calls, hook=hook)
+        relay._http_pool = queue.LifoQueue()
+        relay._http_pool_size = pool_size
+        relay.num_retries = num_retries
+        relay.built = []
+
+        def build_http():
+            transport = f"http-{len(relay.built)}"
+            relay.built.append(transport)
+            return transport
+
+        relay._build_http = build_http
+        return relay
+
+    def send(self, relay):
+        return relay.api_call(["spaces", "messages"], "create", {"body": {}})
+
+    def concurrently(self, relay, count):
+        """Run ``count`` api_calls at once, all held open by the hook."""
+        threads = [
+            threading.Thread(target=self.send, args=(relay,)) for _ in range(count)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+            self.assertFalse(thread.is_alive(), "api_call thread did not finish")
+
+    def test_forwards_unknown_resource_method_and_body_unchanged(self):
+        relay = self.relay()
         arguments = {"body": {"futureSchema": {"nested": [1, 2, 3]}}}
 
         result = relay.api_call(
@@ -1082,9 +1126,159 @@ class GoogleChatRelayTest(unittest.TestCase):
         )
 
         self.assertEqual(
-            [(("futureResource", "messages"), "futureMethod", arguments)], calls
+            [(("futureResource", "messages"), "futureMethod", arguments)], relay.calls
         )
         self.assertEqual(arguments, result["arguments"])
+
+    def test_the_call_carries_a_transport_and_the_retry_budget(self):
+        seen = []
+        relay = self.relay(
+            hook=lambda http, num_retries: seen.append((http, num_retries))
+        )
+
+        self.send(relay)
+
+        self.assertEqual([("http-0", 3)], seen)
+
+    def test_concurrent_calls_do_not_share_a_transport(self):
+        """The bug: one httplib2 socket shared by two threads raises SSLError.
+
+        Both calls are held inside execute until the other arrives, so they are
+        genuinely in flight together — which is the only condition under which
+        a shared transport corrupts.
+        """
+        both_in_flight = threading.Barrier(2, timeout=10)
+        seen = []
+
+        def hook(http, _num_retries):
+            seen.append(http)
+            both_in_flight.wait()
+
+        relay = self.relay(hook=hook)
+
+        self.concurrently(relay, 2)
+
+        self.assertEqual(2, len(seen))
+        self.assertEqual(2, len(set(seen)))
+
+    def test_sequential_calls_reuse_a_transport(self):
+        """Reuse is the point of pooling rather than building per call.
+
+        A fresh transport per call means a fresh TLS handshake to
+        chat.googleapis.com for every message the agent sends.
+        """
+        seen = []
+        relay = self.relay(hook=lambda http, _n: seen.append(http))
+
+        self.send(relay)
+        self.send(relay)
+
+        self.assertEqual(["http-0", "http-0"], seen)
+        self.assertEqual(1, len(relay.built))
+
+    def test_a_failed_call_retires_its_transport(self):
+        """A socket that failed mid-record must not be lent out again.
+
+        Returning it would turn one transport fault into a fault on every
+        call that follows.
+        """
+        seen = []
+
+        def hook(http, _num_retries):
+            seen.append(http)
+            if len(seen) == 1:
+                raise RuntimeError("record layer failure")
+
+        relay = self.relay(hook=hook)
+
+        with self.assertRaises(RuntimeError):
+            self.send(relay)
+        self.send(relay)
+
+        self.assertEqual(["http-0", "http-1"], seen)
+        self.assertEqual(1, relay._http_pool.qsize())
+
+    def test_the_pool_does_not_grow_past_its_bound(self):
+        all_in_flight = threading.Barrier(4, timeout=10)
+        relay = self.relay(hook=lambda _http, _n: all_in_flight.wait(), pool_size=2)
+
+        self.concurrently(relay, 4)
+
+        self.assertEqual(4, len(relay.built))
+        self.assertEqual(2, relay._http_pool.qsize())
+
+    def test_error_fields_name_the_status_and_nothing_else(self):
+        rejection = Exception("<HttpError 404 when requesting https://chat...>")
+        rejection.resp = types.SimpleNamespace(status=404, reason="Not Found")
+
+        self.assertEqual(
+            {"status": 404, "reason": "Not Found"}, _chat_error_fields(rejection)
+        )
+        self.assertIsNone(_chat_error_fields(RuntimeError("connection reset")))
+
+    def _chat_api_post(self, api_call):
+        """Drive the relay's POST handler with an api_call of our choosing."""
+        relay = self.relay()
+        relay.api_call = api_call
+        handler = CredentialProxyHandler.__new__(CredentialProxyHandler)
+        handler.chat_relay = relay
+        handler.max_request_bytes = 1024
+        handler.path = "/v1/chat/api"
+        handler._read_json_body = lambda: {
+            "resource": ["spaces", "messages"],
+            "method": "create",
+            "arguments": {},
+        }
+        captured = {}
+        handler._json = lambda status, payload: captured.update(
+            status=status, payload=payload
+        )
+        with self.assertLogs("credential-proxy", level="WARNING") as logs:
+            handler._handle_chat_post()
+        captured["logs"] = logs.output
+        return captured
+
+    def test_a_rejected_call_tells_the_agent_the_status(self):
+        """A 404 for an unknown space must not read like a transport blip.
+
+        api_call already retries everything transient, so a failure reaching
+        the handler is usually Google refusing the request — and the agent
+        cannot tell which unless the status crosses back.
+        """
+
+        def rejected(*_args, **_kwargs):
+            exc = Exception(
+                "<HttpError 404 when requesting "
+                "https://chat.googleapis.com/v1/spaces/AAAA/messages?alt=json>"
+            )
+            exc.resp = types.SimpleNamespace(status=404, reason="Not Found")
+            raise exc
+
+        captured = self._chat_api_post(rejected)
+
+        self.assertEqual(HTTPStatus.BAD_GATEWAY, captured["status"])
+        self.assertEqual(
+            {
+                "error": "Google Chat operation failed",
+                "chat": {"status": 404, "reason": "Not Found"},
+            },
+            captured["payload"],
+        )
+        # The URI in an HttpError names the space and the credentialed query.
+        self.assertNotIn("chat.googleapis.com", json.dumps(captured["payload"]))
+        self.assertNotIn("chat.googleapis.com", "\n".join(captured["logs"]))
+
+    def test_a_transport_failure_carries_no_chat_object(self):
+        def broken(*_args, **_kwargs):
+            raise RuntimeError("record layer failure")
+
+        captured = self._chat_api_post(broken)
+
+        self.assertEqual(HTTPStatus.BAD_GATEWAY, captured["status"])
+        self.assertEqual(
+            {"error": "Google Chat operation failed"}, captured["payload"]
+        )
+        self.assertIn("type=RuntimeError status=none", "\n".join(captured["logs"]))
 
 
 class SlackRelayTest(unittest.TestCase):


### PR DESCRIPTION
# Pull Request

## Why This Change

The `envoy-credential-proxy` sidecar in `platform-agent-gateway` answered `502 Bad Gateway` to
`POST /v1/chat/api` in bursts:

```
WARNING credential-proxy chat relay operation failed path=/v1/chat/api type=SSLError
INFO    credential-proxy http "POST /v1/chat/api HTTP/1.1" 502 -
INFO    credential-proxy http "POST /v1/chat/api HTTP/1.1" 200 -
```

Each 502 is an outbound Google Chat call the agent lost — in practice a reply that never reached the
user. The immediate recovery reads like a transient network blip, but the code produces exactly this
signature on its own.

`GoogleChatRelay.__init__` builds one discovery service. `build()` resolves credentials through
`googleapiclient._auth.authorized_http()`, which creates a **single** `AuthorizedHttp` wrapping a
**single** `httplib2.Http` — one TLS socket, no locking, and httplib2 is documented as not thread
safe. The proxy serving those requests runs a thread per connection (`ThreadingUnixHTTPServer`), so
concurrent `/v1/chat/api` posts — an agent reply, the kanban notifier, a second session — interleave
records on that one socket. OpenSSL reports that as `ssl.SSLError`; the next call re-handshakes and
succeeds.

Two smaller defects compounded it. `api_call` executed with the default `num_retries=0`, opting out
of googleapiclient's own retry over `ssl.SSLError`, socket timeouts and 5xx. And the handler logged
only `type(exc).__name__`, so a transport fault, a `404` for an unknown space and a `403` for a
missing scope were one indistinguishable `"Google Chat operation failed"` — which is why diagnosing
this from the logs took a guess.

## What Changed

**Files:**

- `agents/platform/scripts/credential_proxy.py`
- `agents/platform/scripts/test_credential_proxy.py`

**Added/Changed/Fixed:**

- **Fixed:** each `api_call` checks out its own `AuthorizedHttp` from a bounded LIFO pool
  (`_checkout_http`). Pooled rather than thread-local because request threads are per-connection and
  the agent-side client opens a connection per call, so thread-locals would mean a fresh TLS
  handshake to `chat.googleapis.com` for every message the agent sends. A transport whose call
  raised is dropped rather than returned — a socket that failed mid-record would otherwise spread
  one failure across every call after it.
- **Changed:** `execute(http=…, num_retries=…)` opts into googleapiclient's jittered backoff.
  `messages.create` retries too: a duplicate message is a better outcome than a reply the user never
  sees, and the duplicate window is narrow (request reached Google, failure landed on the response).
- **Added:** `_chat_error_fields`, modelled on the existing `_slack_error_fields`, whitelists the
  status line onto both the log (`status=404`) and the 502 body (`{"chat": {"status": 404,
  "reason": "Not Found"}}`). Only the status crosses the boundary: an `HttpError` stringifies to a
  message embedding the request URI, and that URI names the space and the credentialed query.
- **Added:** eight tests in `GoogleChatRelayTest`, including a `threading.Barrier` test that holds
  two calls genuinely in flight and asserts they get different transports.

Two new knobs, `GOOGLE_CHAT_HTTP_POOL_SIZE` (default 8) and `GOOGLE_CHAT_API_NUM_RETRIES`
(default 3), are read with defaults in the same style as `SLACK_RELAY_MAX_REQUEST_BYTES`, so the
operator manifests and their golden testdata are untouched.

## Why This Matters

- Dropped Chat replies are silent from the user's side — the agent simply never answers.
- The shared-socket race scales with load: the more concurrent chat traffic, the more 502s.
- Any 502 that does remain now names its cause in the log line, so the next occurrence needs no
  guesswork.

## Context

Generated with the help of Claude.

The client side (`agents/platform/scripts/google_chat_relay_patch.py`) is deliberately unchanged —
the retry belongs behind the credential boundary, where the transport actually lives.

## Testing

- `make test-python` — 336 tests. The 4 errors present are pre-existing on `main` (verified by
  stashing): local-environment failures in `test_platform_mcp_server`, `test_session_kv_server` and
  `test_slack_relay_patch`, none touched here.
- Mutation-checked: reverting `execute(http=…, num_retries=…)` to bare `execute()` fails 5 of the
  new tests, so they genuinely pin the fix.
- Smoke-tested `_build_http` against the real `google_auth_httplib2.AuthorizedHttp` — builds, pools,
  and reuses.
- `make docs-check` passes; `review-docs-drift` run against the branch diff found nothing. The
  Chat section of `docs/credential-isolation-design.md` describes the relay at a level this change
  does not touch, and no page documents these env knobs.

---

Behaviour change is confined to the Google Chat relay path inside the credential sidecar. Rollout
risk is low: worst case is a duplicate Chat message where a retry lands after the request already
reached Google, against dropped replies today.
