### PR TITLE
fix(operator): pin the API server's model to the profile's model

### DIFF
--- a/docs/site/src/content/docs/concepts/inference-gateway.md
+++ b/docs/site/src/content/docs/concepts/inference-gateway.md
@@ -39,6 +39,8 @@ model_list:
       model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
 ```
 
+Two things have to name that alias, not one. The profile config covers Chat, which resolves the model on every message; sessions created through the agent's HTTP API instead take a model resolved once at gateway startup, and that path reads `API_SERVER_MODEL_NAME`. The operator sets both from the same constant so they cannot drift — if they do, Chat keeps working while every API-created session (autonomous event triage, for one) dies asking LiteLLM for a model it does not serve.
+
 The two substituted values come from provisioning (`MODEL_PROVIDER` and `MODEL_DEFAULT_NAME`, cached in `vars.sh`). Supported providers and their shipping defaults:
 
 | `MODEL_PROVIDER`   | Default `MODEL_DEFAULT_NAME` | Notes                                  |

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -69,6 +69,19 @@ const (
 	sharedStateSetupSkip   = "skip"
 )
 
+// The single model name LiteLLM is configured to serve, used both in the profile
+// config the gateway reads and in the API server's own default. The two must agree:
+// the API server resolves its model once at startup, and a mismatch means every
+// session it creates asks LiteLLM for a model that does not exist.
+const agentModelName = "model-default"
+
+// The API server picks its model from API_SERVER_MODEL_NAME, then the active profile
+// name, then a hardcoded "hermes-agent". The profile name is skipped for a custom
+// provider, so without this the fallback wins and LiteLLM rejects every request the
+// API server makes. Chat is unaffected — it resolves per message, not at startup —
+// which is why only sessions created through the API fail.
+const apiServerModelEnvVar = "API_SERVER_MODEL_NAME"
+
 // getDefaultStorageConfig returns the access modes and storage class name based on the replica count and user configuration.
 func getDefaultStorageConfig(agent *agentv1alpha1.PlatformAgent) ([]corev1.PersistentVolumeAccessMode, *string) {
 	replicas, _ := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
@@ -605,8 +618,8 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent, agentPlugins []*agentv
 
 	// Model & Terminal configuration
 	cfg.Model.Provider = "custom"
-	cfg.Model.Default = "model-default"
-	cfg.Model.Model = "model-default"
+	cfg.Model.Default = agentModelName
+	cfg.Model.Model = agentModelName
 	cfg.Model.BaseURL = fmt.Sprintf("http://litellm.%s.svc.cluster.local/v1", agent.Namespace)
 	cfg.Model.APIKey = "none"
 	cfg.Terminal.Backend = "local"
@@ -1937,6 +1950,12 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 	gatewayEnvVars := append(append([]corev1.EnvVar{}, envVars...), corev1.EnvVar{
 		Name:  sharedStateSetupEnvVar,
 		Value: sharedStateSetupOwner,
+	}, corev1.EnvVar{
+		// Appended after the merge for the same reason as the variable above: it has
+		// to agree with the model in the generated profile config, and an override
+		// that disagrees breaks every API-created session rather than failing visibly.
+		Name:  apiServerModelEnvVar,
+		Value: agentModelName,
 	})
 
 	containers := []corev1.Container{

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -2072,6 +2072,31 @@ func TestSharedStateOwnershipIsDeclaredNotInferred(t *testing.T) {
 	}
 }
 
+// TestAPIServerModelMatchesTheProfileModel pins the two halves of the model name
+// together. The gateway's API server resolves its model once at startup, preferring
+// API_SERVER_MODEL_NAME and falling back to a hardcoded "hermes-agent" that LiteLLM
+// does not serve; the profile name in between is skipped because the provider is
+// custom. Without the variable every session created through the API asks for a model
+// that does not exist and dies on its first completion, while Chat keeps working
+// because it resolves per message — so the failure is invisible in manual testing.
+func TestAPIServerModelMatchesTheProfileModel(t *testing.T) {
+	agent := haAgent("model-agent", 1)
+	dep := buildDeployment(agent, "h1", "h2", "h3", "h4", nil, true)
+
+	got, found := envValue(containerNamed(t, dep, "platform-agent"), "API_SERVER_MODEL_NAME")
+	if !found {
+		t.Fatal("API_SERVER_MODEL_NAME is unset; the API server will fall back to hermes-agent " +
+			"and LiteLLM will reject every session it creates")
+	}
+
+	yamlContent := buildConfigMap(agent, nil).Data["config.yaml"]
+	if !strings.Contains(yamlContent, "model: "+got) {
+		t.Errorf("API_SERVER_MODEL_NAME=%s does not match the model in the generated profile config; "+
+			"the two must agree or API-created sessions request a model LiteLLM does not serve:\n%s",
+			got, yamlContent)
+	}
+}
+
 // TestDashboardReadsTheRenderedConfig covers the fresh-PVC gap. In the gateway container
 // $HOME/config.yaml is a ConfigMap mount, and ConfigMap volumes are always read-only, so
 // the entrypoint's copy from /opt/defaults can never land a config.yaml on the PVC

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -642,6 +642,8 @@ spec:
               value: /opt/defaults/scripts
             - name: AGENT_SHARED_STATE_SETUP
               value: owner
+            - name: API_SERVER_MODEL_NAME
+              value: model-default
           image: ghcr.io/gke-labs/kube-agents/platform-agent:v9.9.9
           imagePullPolicy: IfNotPresent
           name: platform-agent

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -642,6 +642,8 @@ spec:
               value: /opt/defaults/scripts
             - name: AGENT_SHARED_STATE_SETUP
               value: owner
+            - name: API_SERVER_MODEL_NAME
+              value: model-default
           image: ghcr.io/gke-labs/kube-agents/platform-agent:latest
           imagePullPolicy: IfNotPresent
           name: platform-agent


### PR DESCRIPTION
# Pull Request

## Why This Change

 Autonomous event triage has never produced a report. An alert reaches Chat, the agent posts
  "🌱 Digging down to the root cause…", and then nothing follows — no report, no error surfaced
  to the user.
  
  The cause is the model name. The Hermes API server resolves which model to use once, at 
  gateway startup, with this precedence:
  
  1. API_SERVER_MODEL_NAME (or extra["model_name"] in config)
  2. the active profile name
  3. a hardcoded fallback, "hermes-agent"
  
  Step 2 is skipped because our provider is custom, and nothing set the variable in step 1 — so
  every session created through the HTTP API asked LiteLLM for hermes-agent. LiteLLM only serves
  model-default, returns 400 BadRequestError: Invalid model name, and the session dies on its
  first completion call, before it runs a single diagnostic.
  
  Chat was unaffected because it resolves the model per message rather than at startup. That
  asymmetry is why the bug survived: human conversations worked perfectly while every automated
  session failed silently, and the only trace was a 400 in gateway.log. The watcher and the
  session server both reported success.
## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  - k8s-operator/internal/controller/platformagent_manifests.go
  - k8s-operator/internal/controller/platformagent_manifests_test.go
  - k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
  - k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
  - docs/site/src/content/docs/concepts/inference-gateway.md

**Added/Changed/Fixed:**

  - Added an agentModelName constant and used it for both halves of the model name — the profile
  config (cfg.Model.Model / cfg.Model.Default) and the new env var — so the two cannot drift
  apart.
  - Set API_SERVER_MODEL_NAME on the platform-agent container. It is appended after the plugin
  env merge, matching the existing treatment of AGENT_SHARED_STATE_SETUP: an override that
  disagrees with the profile config breaks every API-created session rather than failing
  visibly, so it is operator-owned.
  - Added TestAPIServerModelMatchesTheProfileModel, which reads the value off the rendered
  container and asserts it matches the model in the generated profile config. It fails on drift
  in either direction, not just on the variable going missing.
  - Updated both golden manifests.
  - Updated inference-gateway.md. That page already asserted "the agent always requests a single
  logical model, model-default" — which was not true before this change. Added a short
  paragraph explaining that two separate things have to name the alias, and what breaks when
  they disagree.


## Testing

  - gofmt -l ., go build ./..., and go test ./internal/... in k8s-operator/.
  - New unit test fails without the change and passes with it.
  - Golden manifests regenerated; the two differ only by image tag, as before.
  - Verified live on a GKE cluster. Applied the same variable by hand with kubectl set env and
  confirmed the gateway startup line changed from (model: hermes-agent) to:
  [Api_Server] API server listening on http://127.0.0.1:8642 (model: model-default)
  - Then triggered a real CrashLoopBackOff, and the pipeline ran past the point where it
  previously stopped — session created (201), injected (200), and a triage task dispatched.
  - The base-image precedence chain was confirmed directly rather than inferred, at
  /opt/hermes/gateway/platforms/api_server.py:1539-1557.

<!-- Close with a short note on functional impact, risk, or rollout. -->
