### PR TITLE
refactor(image): consolidate the Hermes patch surface and close the kanban and cron correctness gaps

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -61,16 +61,12 @@ RUN sed -i 's/for key, value in placeholders.items():/for key, value in reversed
 # Hotfix: Allow explicit target routing for google_chat spaces/threads in send_message_tool
 RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/hermes/tools/send_message_tool.py'); c = p.read_text(); t = 'def _parse_target_ref(platform_name: str, target_ref: str):\n    \"\"\"Parse a tool target into chat_id/thread_id and whether it is explicit.\"\"\"'; r = t + '\n    if platform_name == \"google_chat\":\n        parts = target_ref.split(\":\", 1)\n        if len(parts) == 2 and parts[0].startswith(\"spaces/\"):\n            return parts[0].strip(), parts[1].strip(), True\n        elif target_ref.startswith(\"spaces/\"):\n            return target_ref.strip(), None, True'; p.write_text(c.replace(t, r)) if t in c else exit(1)"
 
-# Hotfix: stop the kanban notifier from severing URLs in a card's completion line.
-# Upstream hard-slices the handoff at a fixed width, which turned a published
-# ledger link into ".../is" in chat. Swap both slices for a whitespace-boundary
-# clip that also stops discarding every line after the first. See the module
-# docstring in deploy/docker/patches/kanban_handoff_clip.py.
+# A dependency-free text utility, copied in on its own and ahead of both of its
+# callers. tools/cron_run_scope.py imports it a few layers below for a different
+# clip entirely, and gateway/kanban_watchers.py is wired to it by the
+# kanban_notifier patch much further down. See the module docstring in
+# deploy/docker/patches/kanban_handoff_clip.py.
 COPY --chmod=0644 deploy/docker/patches/kanban_handoff_clip.py /opt/hermes/gateway/kanban_handoff_clip.py
-RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/hermes/gateway/kanban_watchers.py'); c = p.read_text(); t1 = 'h = lines[0][:200] if lines else payload_summary[:200]'; t2 = 'r = lines[0][:160] if lines else task.result[:160]'; exit(1) if (t1 not in c or t2 not in c) else None; c = c.replace(t1, 'h = _clip_handoff(payload_summary)').replace(t2, 'r = _clip_handoff(task.result)'); p.write_text(c + '\n\n# kube-agents patch: see gateway/kanban_handoff_clip.py\nfrom gateway.kanban_handoff_clip import clip_handoff as _clip_handoff\n')" && \
-    grep -q "h = _clip_handoff(payload_summary)" /opt/hermes/gateway/kanban_watchers.py && \
-    grep -q "r = _clip_handoff(task.result)" /opt/hermes/gateway/kanban_watchers.py && \
-    /opt/hermes/.venv/bin/python3 -c "import ast, pathlib; ast.parse(pathlib.Path('/opt/hermes/gateway/kanban_watchers.py').read_text())"
 
 # Hotfix: make a dispatched cron run report back, and stop it closing the
 # kanban card of the caller that dispatched it. Upstream discards the run's
@@ -85,8 +81,15 @@ RUN /opt/hermes/.venv/bin/python3 -c "import pathlib; p = pathlib.Path('/opt/her
 # report it had waited six minutes for.
 # See the module docstring in deploy/docker/patches/cron_run_scope.py.
 COPY --chmod=0644 deploy/docker/patches/cron_run_scope.py /opt/hermes/tools/cron_run_scope.py
-COPY deploy/docker/patches/apply_cron_run_scope.py /tmp/apply_cron_run_scope.py
-COPY deploy/docker/patches/verify_cron_run_scope.py /tmp/verify_cron_run_scope.py
+# patchlib.py is the shared build-time helper every apply_*.py below imports:
+# the exact-once anchor check, the ast.parse gate, the write. It is staged
+# beside the appliers rather than installed -- Python puts the running script's
+# own directory first on sys.path, so /tmp/apply_*.py resolves `import patchlib`
+# to this copy. Removed with the last applier that uses it (mcp-remote, below).
+COPY deploy/docker/patches/patchlib.py \
+     deploy/docker/patches/apply_cron_run_scope.py \
+     deploy/docker/patches/verify_cron_run_scope.py \
+     /tmp/
 RUN /opt/hermes/.venv/bin/python3 /tmp/apply_cron_run_scope.py /opt/hermes && \
     grep -q "outcome=None) -> bool:" /opt/hermes/cron/scheduler.py && \
     grep -q "with cron_run_scope(job_id):" /opt/hermes/tools/cronjob_tools.py && \
@@ -100,18 +103,525 @@ exit(1) if ('https://' in clipped or not 3000 < len(clipped) <= 4000) else None"
     /opt/hermes/.venv/bin/python3 /tmp/verify_cron_run_scope.py && \
     rm /tmp/apply_cron_run_scope.py /tmp/verify_cron_run_scope.py
 
+# Fix: give a spawned `hermes cron tick` the scheduler lifecycle it never had.
+# The platform profile has no ticker thread -- it is ticked once a minute by
+# spawning `hermes cron tick`, whose body is verbatim `tick(verbose=True)` --
+# so everything Hermes hangs off the ticker's lifetime is absent or wrong there.
+# Three consequences, all fixed by the eleven anchored edits in the applier:
+#   * `tick()` defaults to sync=True and held <HERMES_HOME>/cron/.tick.lock
+#     across the whole `as_completed` wait, so a fleet audit starved every other
+#     job for its full runtime. Measured over 17h: 3 of 35
+#     github-issue-resolver firings 418s / 179s / 1142s late, each unblocking
+#     within seconds of the blocking audit finishing. The lock now covers only
+#     what its own comment says it is for -- get_due_jobs, advance_next_runs,
+#     create_execution, pool.submit -- and a per-job flock replaces the
+#     cross-process in-flight guard the wide lock was implicitly providing.
+#     flock rather than a ledger row on purpose: the kernel drops it when the
+#     holder dies, so unlike a `running` row it cannot wedge a job id forever.
+#   * `cronjob(action='run')` took no per-job lock at all, and the
+#     claim_job_for_fire CAS it relied on never blocked a tick, so a dispatched
+#     audit could run on top of a scheduled one and share its output file.
+#   * recover_interrupted_executions() runs only from the two gateway-ticker
+#     lifecycles, so nothing ever reaped an abandoned attempt on this profile:
+#     the live ledger held 6 permanently `running` rows, the oldest a day old,
+#     against 0 of 1000 on the default store the gateway does sweep.
+# Must stay AFTER the cron_run_scope block: every anchor was verified against
+# the post-cron_run_scope source.
+# See the module docstring in deploy/docker/patches/cron_tick_lock_scope.py.
+COPY deploy/docker/patches/cron_tick_lock_scope.py /opt/hermes/tools/cron_tick_lock_scope.py
+COPY deploy/docker/patches/apply_cron_tick_lock_scope.py /tmp/apply_cron_tick_lock_scope.py
+COPY deploy/docker/patches/verify_cron_tick_lock_scope.py /tmp/verify_cron_tick_lock_scope.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_cron_tick_lock_scope.py /opt/hermes && \
+    grep -q "from tools.cron_tick_lock_scope import AdvisoryLock, JobLocks" /opt/hermes/cron/scheduler.py && \
+    grep -q "_tick_lock = AdvisoryLock(lock_fd, fcntl, globals().get(\"msvcrt\"))" /opt/hermes/cron/scheduler.py && \
+    grep -q "_job_lock = _job_locks.claim(job_id)" /opt/hermes/cron/scheduler.py && \
+    grep -q "_run_lock = _job_locks.claim(job_id)" /opt/hermes/tools/cronjob_tools.py && \
+    grep -q "recover_interrupted_executions" /opt/hermes/hermes_cli/cron.py && \
+    ! grep -q "fcntl.flock(lock_fd, fcntl.LOCK_UN)" /opt/hermes/cron/scheduler.py && \
+    ! grep -q "_job_locks.release(" /opt/hermes/cron/scheduler.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_cron_tick_lock_scope.py && \
+    rm /tmp/apply_cron_tick_lock_scope.py /tmp/verify_cron_tick_lock_scope.py
+
+# Cron ledger: record occurrences that were due but did not run, and retain
+# history per job rather than per board.
+#
+# Upstream's status CHECK admits only claimed/running/completed/failed/unknown,
+# so a skipped occurrence leaves no trace at all -- a watchdog that silently
+# stops firing looks exactly like one with nothing to report. The applier
+# widens the CHECK to include 'skipped', migrates the existing ledger in place
+# (table rebuild under BEGIN IMMEDIATE, refused rather than guessed if the DDL
+# is ambiguous), and writes a row at each of the five places the scheduler
+# drops an occurrence today.
+#
+# Upstream also prunes to the newest 1000 terminal rows across ALL jobs, so the
+# minute-ly ticker evicts a daily watchdog's only row inside 17 hours.
+# Retention becomes per job, with a global ceiling and a per-job floor.
+#
+# Must stay AFTER the cron_tick_lock_scope block: two of the fourteen anchors
+# are text that patch inserts.
+COPY --chmod=0644 deploy/docker/patches/cron_skip_ledger.py /opt/hermes/tools/cron_skip_ledger.py
+COPY deploy/docker/patches/apply_cron_skip_ledger.py /tmp/apply_cron_skip_ledger.py
+COPY deploy/docker/patches/verify_cron_skip_ledger.py /tmp/verify_cron_skip_ledger.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_cron_skip_ledger.py /opt/hermes && \
+    grep -q "from tools.cron_skip_ledger import (" /opt/hermes/cron/executions.py && \
+    grep -q "'claimed','running','completed','failed','unknown','skipped'" /opt/hermes/cron/executions.py && \
+    grep -q "_ensure_skip_schema(conn)" /opt/hermes/cron/executions.py && \
+    grep -q "def record_skipped_execution(" /opt/hermes/cron/executions.py && \
+    grep -q "def skip_execution(" /opt/hermes/cron/executions.py && \
+    grep -q "reason=SKIP_ALREADY_RUNNING_ELSEWHERE" /opt/hermes/cron/scheduler.py && \
+    grep -q "reason=SKIP_INTERPRETER_SHUTDOWN" /opt/hermes/cron/scheduler.py && \
+    grep -q "reason=SKIP_DISPATCH_CLAIM_REJECTED" /opt/hermes/cron/scheduler.py && \
+    grep -q "reason=SKIP_MISSED_WINDOW" /opt/hermes/cron/jobs.py && \
+    grep -q '"unknown", "skipped"}' /opt/hermes/agent/monitoring/cron_health.py && \
+    ! grep -q "LIMIT -1 OFFSET" /opt/hermes/cron/executions.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_cron_skip_ledger.py && \
+    rm /tmp/apply_cron_skip_ledger.py /tmp/verify_cron_skip_ledger.py
+
+# Security: scan the cron commands that skip the approval prompt.
+# approvals.cron_mode: approve is a fleet-wide default here -- a scheduled run
+# has nobody at the keyboard, so it cannot answer an approval prompt. Upstream
+# read that as permission to skip the Tirith content scan as well: the scanner
+# is called only from the cron `deny` arm of check_all_command_guards, so under
+# `approve` every command in every watchdog run executed unscanned. Measured
+# against the live image, not inferred: the scanner is consulted 0 times.
+# That is the wrong half to drop. github-issue-resolver fires every 30 minutes
+# over issue text written by anyone with a GitHub account, and Tirith's whole
+# subject is the content-level threats that arrive that way -- homograph and
+# lookalike-TLD URLs, pipe-to-interpreter, terminal escape injection, encoded
+# payloads -- none of which DANGEROUS_PATTERNS is looking for. The patch runs
+# the scan on both arms; the mode goes on deciding only what happens to a
+# pattern-flagged command, which is the part that genuinely needs a human.
+# The applier proves the anchor matched; it cannot prove the gate now refuses
+# anything, and every way this patch fails is silent -- an unscanned run looks
+# exactly like a clean one. verify_cron_tirith_scan.py drives the real patched
+# check_all_command_guards and asserts on its verdict.
+# See the module docstring in deploy/docker/patches/cron_tirith_scan.py.
+COPY --chmod=0644 deploy/docker/patches/cron_tirith_scan.py /opt/hermes/tools/cron_tirith_scan.py
+COPY deploy/docker/patches/apply_cron_tirith_scan.py /tmp/apply_cron_tirith_scan.py
+COPY deploy/docker/patches/verify_cron_tirith_scan.py /tmp/verify_cron_tirith_scan.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_cron_tirith_scan.py /opt/hermes && \
+    grep -q "from tools.cron_tirith_scan import cron_tirith_block" /opt/hermes/tools/approval.py && \
+    grep -q "describe=_format_tirith_description" /opt/hermes/tools/approval.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_cron_tirith_scan.py && \
+    rm /tmp/apply_cron_tirith_scan.py /tmp/verify_cron_tirith_scan.py
+
+# One patch for the kanban notifier's terminal-event path, because clipping the
+# handoff, delivering `result`, and deciding whether to wake the creator are
+# three edits to the same twenty lines of gateway/kanban_watchers.py. Three
+# appliers meant four anchors into one function and four ways for an upstream
+# edit to break the build; this is two.
+#   * Clip: upstream hard-slices the handoff at 200/160 characters and discards
+#     every line after the first, which delivered a severed GitHub link -- a
+#     ledger URL cut to ".../is" -- on 2026-08-03. Both slices are swapped for a
+#     whitespace-boundary clip, so a URL survives whole or is dropped, never
+#     truncated into a dead link.
+#   * Deliver: `result` goes into the completion message the notifier already
+#     builds -- one send, inheriting the existing failure counter, cursor
+#     rewind, and subscription-drop machinery. It REPLACES the handoff rather
+#     than appending to it, because in the branch with no event summary the
+#     handoff is itself a 1200-character clip of `result`, and appending sent
+#     the opening of a report and then the report.
+#   * Wake: on a terminal event the notifier both sends the worker's summary to
+#     the thread AND injects a synthetic message that costs the creator a full
+#     model turn, which re-reads the card and paraphrases a message the user is
+#     already looking at. Measured at 5.9s and 32,460 input tokens on task
+#     t_c31a1f00. Upstream hardcodes the wake set with no config key; this makes
+#     it read kanban.wake_on_events, defaulting to the upstream tuple. The
+#     narrowing is scoped to push-capable adapters: where the notifier skips its
+#     own send(), the wake is the delivery rather than a duplicate of it.
+#   * Record: the wake was doing two jobs and only one was redundant. It told
+#     the user (already done by the send above) and it told the AGENT -- the
+#     synthetic message was the only thing that ever entered the creator's
+#     transcript to say the card had finished. Dropping it left the front door
+#     with `subscribed: true` as the last thing it knew, so on task t_a8f58a2a
+#     it promised results that had been on screen for 106 seconds and the user
+#     waited 9m46s. A one-shot note is parked on the creator's session state
+#     instead, riding the next user message's api_content sidecar: no model
+#     turn, ~70 tokens, no new config key -- it fires only where
+#     kanban.wake_on_events suppressed a wake.
+#
+# The anchors prove only that the text landed, and every way the wake half can
+# go wrong is silent: it fails towards upstream, so a moved hermes_cli.config, a
+# moved gateway.wake, or a DEFAULT_WAKE_KINDS whitelist that fell behind the
+# notifier all look exactly like an operator who never set the key.
+# verify_kanban_notifier.py therefore drives the patched runtime -- the real
+# config loader, the real APIServerAdapter (the non-push adapter the carve-out
+# exists for), and the notifier's own list of describable kinds -- rather than
+# hand-rolled stand-ins. The marker is worse again -- it writes into gateway
+# session state that nothing else in the build reads back, so a note parked on a
+# session id instead of a session key is a silent no-op -- so section 9 drives a
+# real SessionStore, the real GatewayRunner sidecar-note methods, and the real
+# consume_gateway_turn_context_notes the next turn calls.
+# See the module docstring in deploy/docker/patches/kanban_notifier.py.
+COPY deploy/docker/patches/kanban_notifier.py /opt/hermes/gateway/kanban_notifier.py
+# Applier and verifier share one COPY into a directory: this stage is the base
+# for `credential-proxy`, which has already hit Docker's layer-depth ceiling
+# once (build f9f1747c, 2026-08-07), so patches here do not each buy a layer.
+COPY deploy/docker/patches/apply_kanban_notifier.py \
+     deploy/docker/patches/verify_kanban_notifier.py \
+     deploy/docker/patches/patchlib.py \
+     /tmp/kanban-notifier/
+RUN /opt/hermes/.venv/bin/python3 /tmp/kanban-notifier/apply_kanban_notifier.py /opt/hermes && \
+    grep -q "h = _clip_handoff(payload_summary)" /opt/hermes/gateway/kanban_watchers.py && \
+    grep -q "r = _clip_handoff(task.result)" /opt/hermes/gateway/kanban_watchers.py && \
+    grep -q "handoff = _kanban_handoff_with_result(handoff, task)" /opt/hermes/gateway/kanban_watchers.py && \
+    grep -q '_wake_kinds = _wake_kinds_for(d\["events"\], adapter=adapter)' /opt/hermes/gateway/kanban_watchers.py && \
+    grep -q "_kanban_note_suppressed(" /opt/hermes/gateway/kanban_watchers.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/kanban-notifier/verify_kanban_notifier.py && \
+    rm -rf /tmp/kanban-notifier
+
+# Perf: hide worker-only kanban tools from orchestrator profiles. Upstream gates
+# every lifecycle tool with _check_kanban_mode, which is true for any profile
+# carrying the kanban toolset — so the Chat Agent front door is shipped
+# kanban_complete/block/heartbeat/link/attach* on every call despite SOUL.md
+# §1.5 forbidding it from calling them. Hermes has no per-tool denylist, so the
+# 10,041 characters (~2,510 tokens) of schema cannot be dropped by config.
+#
+# The gate is also closed for a delegate_task child, which runs in its parent's
+# own process and inherits its HERMES_KANBAN_TASK: upstream's two kanban gates
+# both draw that line, and a gate that read the env var alone was the only one
+# in the file that called a child a worker. The grep proves the anchors landed;
+# verify_kanban_worker_tools.py proves the gate answers correctly against the
+# real agent.delegation_context and that the schemas actually disappear.
+# See the module docstring in deploy/docker/patches/kanban_worker_tools.py.
+COPY deploy/docker/patches/kanban_worker_tools.py /opt/hermes/tools/kanban_worker_tools.py
+# The three ownership predicates -- dispatcher worker, delegate_task child, cron
+# run -- shared with hermes_cli/kanban_guardrail_exit.py further down, which asks
+# the same two questions with the opposite `on_unknown`. Landed in this block
+# because it is the first that needs it; the guardrail block imports the same
+# tools.kanban_ownership and adds no COPY of its own.
+COPY deploy/docker/patches/kanban_ownership.py /opt/hermes/tools/kanban_ownership.py
+# Also staged next to the applier: it imports WORKER_ONLY_TOOLS from
+# kanban_worker_tools, which imports kanban_ownership, and only the script's own
+# directory is on sys.path.
+COPY deploy/docker/patches/kanban_worker_tools.py /tmp/kanban_worker_tools.py
+COPY deploy/docker/patches/kanban_ownership.py /tmp/kanban_ownership.py
+COPY deploy/docker/patches/apply_kanban_worker_tools.py /tmp/apply_kanban_worker_tools.py
+COPY deploy/docker/patches/verify_kanban_worker_tools.py /tmp/verify_kanban_worker_tools.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_kanban_worker_tools.py /opt/hermes && \
+    test "$(grep -c 'check_fn=_check_kanban_worker_mode' /opt/hermes/tools/kanban_tools.py)" = "7" && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_kanban_worker_tools.py && \
+    rm /tmp/apply_kanban_worker_tools.py /tmp/kanban_worker_tools.py \
+       /tmp/kanban_ownership.py /tmp/verify_kanban_worker_tools.py
+
+# Hotfix: make a card's answer reach the person who asked for it. On 2026-08-07
+# a user asked which cron jobs were enabled; three cards ran, all closed `done`,
+# and the list never arrived. The board shows why: `tasks.result IS NULL` on all
+# three. The workers built the catalogue, printed it to their own stdout, and
+# dropped it at the kanban_complete call -- because upstream's schema calls
+# `result` a "Short result log line (legacy field)... Use ``summary`` instead"
+# and accepts `summary or result`, while the kernel stores the chat line as
+# `(summary or result).strip().splitlines()[0][:400]`. So the only field that
+# can carry a report is marked legacy, the field the model is steered to holds
+# one line of 400 characters, and nothing posts `result` to chat at all.
+#
+# Applied last so it composes with the patches above rather than competing for
+# the same lines, and deterministic -- it does not try to classify a card as
+# "asked for information", because every card has an answer.
+#   * kanban_result_required: rewrites the schema wording and requires `result`.
+#     Refuses a card once, remembers that refusal for NUDGE_TTL_SECONDS (15
+#     minutes, the dispatcher's claim TTL), and lets the retry through --
+#     promoting `summary` into `result` -- so the gate can never wedge a card
+#     shut. The memory expires rather than lasting for the process's life: a
+#     refusal older than the claim belongs to a run that is already gone, and
+#     the fresh worker now holding that card has not been nudged yet.
+# Getting that answer into the chat message is the other half of the fix and
+# belongs to the kanban_notifier patch above; verify_kanban_result.py still owns
+# the seam, replaying a real refusal through the real gate and into the real
+# delivery path.
+# See the module docstring in deploy/docker/patches/kanban_result_required.py.
+COPY deploy/docker/patches/kanban_result_required.py /opt/hermes/tools/kanban_result_required.py
+COPY deploy/docker/patches/apply_kanban_result_required.py /tmp/apply_kanban_result_required.py
+COPY deploy/docker/patches/verify_kanban_result.py /tmp/verify_kanban_result.py
+# The applier imports OLD_GATE/NEW_GATE from the module, and only the script's
+# own directory is on sys.path.
+COPY deploy/docker/patches/kanban_result_required.py /tmp/kanban_result_required.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_kanban_result_required.py /opt/hermes && \
+    grep -q "_result_err, result = _require_result(tid, summary, result)" /opt/hermes/tools/kanban_tools.py && \
+    grep -q "_apply_result_schema(KANBAN_COMPLETE_SCHEMA)" /opt/hermes/tools/kanban_tools.py && \
+    ! grep -q "provide at least one of: summary (preferred), result" /opt/hermes/tools/kanban_tools.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_kanban_result.py && \
+    rm /tmp/apply_kanban_result_required.py /tmp/verify_kanban_result.py \
+       /tmp/kanban_result_required.py
+
+# Hotfix: three kanban scheduler faults, all measured on the cluster 2026-08-07,
+# all in `hermes_cli/kanban_db.py`. One patch, because three appliers rewriting
+# the same file could not see each other's anchors and their ordering lived in a
+# comment rather than in a constraint.
+#
+#   * Self-parenting deadlock. `task_links` is a predecessor edge, so a card
+#     that creates work with `parents=[<itself>]` and then blocks on it can
+#     never be satisfied -- claim_task refuses the children until the parent is
+#     done, and the parent is waiting on them. Worse, a `dependency` block
+#     routes to `todo` rather than `blocked`, which skips the block-recurrence
+#     loop breaker, so the parent respawned a full agent run every few seconds.
+#     One worker escaped by shelling out to sqlite3 and closing three cards
+#     `done` with a fabricated 27-character result. The patch inverts the
+#     mis-directed edges at the block point, but only for children the blocking
+#     card fanned out after it started running and is the last unfinished parent
+#     of. A pipeline successor someone else planned predates the card's first
+#     `claimed` event, so real pipelines and fan-ins are untouched.
+#
+#   * Claim tokens outlive the process that made them. `_claimer_id()` is
+#     `hostname:pid`, and under Kubernetes hostname is the pod name --
+#     pod-scoped, not restart-scoped. When the gateway took a SIGBUS (exit 135)
+#     the replacement container kept the pod name, reset its PID namespace, and
+#     adjudicated its predecessor's worker PIDs: six cards marked `crashed`.
+#     `_error_fingerprint` then normalised the PID out of "pid <N> not alive",
+#     so six independent crashes read as one systemic fault, which drops
+#     failure_limit to 1 -- every one of them gave up on its first failure.
+#     The fence narrows the liveness check to this exact process life and hands
+#     back cards whose owner is provably gone, closing the 900s dark window a
+#     rollout otherwise costs. The fence is what keeps a predecessor's workers
+#     out of the fingerprint bucket, so `_error_fingerprint` itself is left
+#     alone -- every message on that path is pid-prefixed, and dropping the
+#     substitution gives each worker its own bucket, which the systemic
+#     heuristic can then never fill.
+#
+#     A handed-back card is charged one failure against the dispatcher's own
+#     retry budget *unless* the reclaim was infrastructure rather than fault.
+#     Free reclaims across the board were a closed loop: a card that kills the
+#     gateway is reclaimed by the replacement process, dispatched, and kills it
+#     again, with nothing counting. Charging all of them was the opposite
+#     failure: DEFAULT_FAILURE_LIMIT is 2 and nothing overrides it, so two
+#     ordinary rollouts in a long-lived card's life parked it in `blocked`. The
+#     discriminator charges unless the claim came from a *different* pod AND
+#     predates this process's start -- the only combination that proves nobody
+#     watched the owner die. Same pod is a container restart, which is exactly
+#     the poison-card signature, and is still charged. The charge also runs
+#     outside the fingerprint pass, so an in-place death releasing every
+#     in-flight card at once still cannot collapse into one systemic verdict.
+#
+#   * The circuit breaker's trip does not survive the tick that wrote it.
+#     `dispatch_once` calls `detect_crashed_workers` and then, twenty lines
+#     later, `recompute_ready`. Both decide whether a card is over its retry
+#     budget, and they do not use the same threshold. `_record_task_failure`
+#     persists `consecutive_failures = old + 1` -- the raw attempt count --
+#     while the two callers that trip early pass a threshold the dispatcher
+#     never sees: the clean-exit protocol-violation path adjudicates its own
+#     streak and passes `force_trip=True`, and the systemic same-error path
+#     passes `failure_limit=1`. `recompute_ready` re-derives the verdict from
+#     the column alone against the dispatcher's limit (2), sees 1 < 2, flips the
+#     card back to `ready` and emits `promoted`; the next lines of the same tick
+#     claim and respawn it. The policy "stop after 3 protocol violations and
+#     hand to a human" silently means 4. The fix stores the exhausted budget
+#     rather than the raw attempt count, so the counter -- which stays the
+#     single arbiter -- says what the trip decided. That matters more than it
+#     sounds: the obvious alternative, having `recompute_ready` read the
+#     `gave_up` event, was built and rejected because `assign_task` zeroes the
+#     counter and emits `assigned`, not `unblocked`, so an event-stickiness
+#     guard pins every reassigned card in `blocked` forever.
+#
+#     Two consequences operators need. `assign_task` to the SAME profile no
+#     longer frees a tripped card -- it only zeroes the counter when the
+#     assignee actually changes, which was survivable while a systemic trip
+#     stored 1 (below the dispatcher's 2). Reassign elsewhere or
+#     `hermes kanban unblock`. And the floor is `DEFAULT_FAILURE_LIMIT`, not the
+#     configured limit, because `detect_crashed_workers` never sees the latter:
+#     raise `kanban.failure_limit` above 2 and systemic trips become revertible
+#     again, above 3 and protocol trips follow.
+#
+# All three are emergent scheduling behaviour rather than a bad string, so the
+# anchors alone prove nothing: verify_kanban_scheduling.py replays every
+# incident against a real board through the patched engine, and -- the part that
+# actually earns its runtime -- asserts that `assign_task`, `unblock_task`,
+# parent-dependency promotion and worker `kanban_block` stickiness all still
+# behave exactly as they did before.
+#
+# Must stay ahead of the kanban_wake_nudge block below, which anchors on
+# `create_task`, `complete_task` and `unblock_task` in the same file. The six
+# anchors here touch none of those three, and test_kanban_scheduling.py asserts
+# that rather than leaving it to a reader.
+# See the module docstring in deploy/docker/patches/kanban_scheduling.py and the
+# applier docstring in deploy/docker/patches/apply_kanban_scheduling.py.
+COPY deploy/docker/patches/kanban_scheduling.py /opt/hermes/hermes_cli/kanban_scheduling.py
+COPY deploy/docker/patches/apply_kanban_scheduling.py /tmp/apply_kanban_scheduling.py
+COPY deploy/docker/patches/verify_kanban_scheduling.py /tmp/verify_kanban_scheduling.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_kanban_scheduling.py /opt/hermes && \
+    grep -q "_kanban_repair_inverted_deps(conn, task_id, reason)" /opt/hermes/hermes_cli/kanban_db.py && \
+    grep -q "conn, _kanban_claimer, _pid_alive, _resolve_crash_grace_seconds" /opt/hermes/hermes_cli/kanban_db.py && \
+    grep -q "_kanban_claim_is_self(lock, _kanban_claimer)" /opt/hermes/hermes_cli/kanban_db.py && \
+    grep -q "conn, _kanban_reclaimed.chargeable, _record_task_failure" /opt/hermes/hermes_cli/kanban_db.py && \
+    grep -q "persisted_failures = max(failures, effective_limit)" /opt/hermes/hermes_cli/kanban_db.py && \
+    test "$(grep -c 'lock.startswith(host_prefix)' /opt/hermes/hermes_cli/kanban_db.py)" = "2" && \
+    test "$(grep -c '(persisted_failures, error\[:500\], task_id),' /opt/hermes/hermes_cli/kanban_db.py)" = "2" && \
+    test "$(grep -c '(failures, error\[:500\], task_id),' /opt/hermes/hermes_cli/kanban_db.py)" = "2" && \
+    test "$(grep -c 'from hermes_cli.kanban_scheduling import' /opt/hermes/hermes_cli/kanban_db.py)" = "1" && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_kanban_scheduling.py && \
+    rm /tmp/apply_kanban_scheduling.py /tmp/verify_kanban_scheduling.py
+
+# Hotfix: kanban workers leaving `run_conversation` without a board write.
+#
+# Upstream guards this in exactly one place -- the end of the no-tool-calls
+# branch, where `build_kanban_stop_nudge` gives a worker that is about to stop
+# talking another turn to call `kanban_complete`/`kanban_block`. Every other way
+# out of that loop is a bare `break` several hundred lines earlier and jumps
+# straight over it. The worker exits rc=0 having never touched the board and the
+# reaper stamps a `protocol_violation` after the fact -- a failure with no
+# explanation in it, because by then the reason is gone.
+#
+# Card t_d3efabef burned four runs and 38 minutes this way on 2026-08-07. Each
+# run halted on `loop_web_search_cap` with 173 successful searches in hand and
+# was never told; the halt path breaks out of the tool-call branch without
+# showing the model the block result.
+#
+#   * kanban_guardrail_exit's first edit makes that halt kanban-aware: reuse
+#     upstream's own nudge helper (already bounded at two attempts, already a
+#     no-op for non-workers) and add the one thing its text does not say -- the
+#     tool is gone for this run, stop trying to use it. Clearing
+#     `_tool_guardrail_halt_decision` is mandatory; `reset_for_turn` clears it
+#     per turn, not per iteration.
+#   * The second edit backstops the six sibling exits that leak identically, in
+#     `finalize_turn` -- the single funnel every `break` passes through. An
+#     unexplained protocol violation becomes a counted `timed_out` whose error
+#     text names the exit reason. Goal-mode workers are excluded: they call
+#     `finalize_turn` once per turn, so recording on turn 1 of N would release
+#     the claim underneath the loop. Dispatched cron runs are excluded for the
+#     same reason from the other end: cron_run_scope (above) leaves
+#     HERMES_KANBAN_TASK pointing at the DISPATCHER's card so its claim keeps
+#     heart-beating, and the run may not terminate that card -- so recording
+#     would charge a caller that is still blocked on the run. `delegate_task`
+#     children are excluded on the same argument once more: they run in the
+#     parent's process with the parent's HERMES_KANBAN_TASK still set and own no
+#     card, which is why upstream's `_reject_delegated_child_mutation` refuses
+#     every board mutation from one.
+#
+# The anchors prove only that the text landed. verify_kanban_guardrail_exit.py
+# additionally parses the patched loop to prove the nudge is reachable, ahead of
+# the break, and terminal; drives it against the real `agent.kanban_stop` (whose
+# signature the patch would otherwise absorb in silence); and records a leak on a
+# real board through the real `_record_task_failure`.
+#
+# The per-turn `max_web_searches` ceiling that triggered this is a config change
+# rather than a patch -- see the /opt/platform-template/config.yaml assertion
+# further down. It must not ship alone: raising the cap only moves when the bug
+# fires.
+# See the module docstring in deploy/docker/patches/kanban_guardrail_exit.py.
+COPY deploy/docker/patches/kanban_guardrail_exit.py /opt/hermes/hermes_cli/kanban_guardrail_exit.py
+COPY deploy/docker/patches/apply_kanban_guardrail_exit.py /tmp/apply_kanban_guardrail_exit.py
+COPY deploy/docker/patches/verify_kanban_guardrail_exit.py /tmp/verify_kanban_guardrail_exit.py
+RUN /opt/hermes/.venv/bin/python3 /tmp/apply_kanban_guardrail_exit.py /opt/hermes && \
+    grep -q "if _kanban_halt_nudge:" /opt/hermes/agent/conversation_loop.py && \
+    grep -q "_kanban_should_record_missing(" /opt/hermes/agent/turn_finalizer.py && \
+    cd /opt/hermes && /opt/hermes/.venv/bin/python3 /tmp/verify_kanban_guardrail_exit.py && \
+    rm /tmp/apply_kanban_guardrail_exit.py /tmp/verify_kanban_guardrail_exit.py
+
+# Perf: let a board mutation wake the kanban watchers instead of waiting out a
+# poll. The dispatcher and notifier are pure 5s polls, so every hop of a task
+# chain pays avg 2.5s (max 5s) for rows that were already committed: measured
+# 2026-08-07, 4.9s coordinator claim wait + 2.2s synthesizer claim wait +
+# notify delays on an 87s round trip. Workers are separate processes, so the
+# nudge is a wake file derived from the board DB path (<db>.wake):
+# create/complete/unblock bump its mtime after their commits, and each watcher
+# loop swaps its fixed sleep for a wait sliced at <=0.25s that breaks early on
+# the bump. Claims and heartbeats deliberately do not nudge -- a dispatcher
+# that wakes on its own tick's writes is a busy loop. Everything fails towards
+# upstream: an unwritable wake file means 5s polling again, and
+# verify_kanban_wake_nudge.py proves that property (and the nudges, and the
+# dispatcher's silence) against the real patched engine on a real board.
+# Must stay AFTER the scheduling/breaker/guardrail blocks above: the anchors
+# were derived from the fully-patched tree.
+# See the module docstring in deploy/docker/patches/kanban_wake_nudge.py.
+#
+# Hotfix: a worker's child cards inherit the chat subscription of the card the
+# worker is running. `_maybe_auto_subscribe` needs session context that exists
+# only on inbound user messages, and upstream's create-time inheritance only
+# follows explicit `parents=[...]` edges -- a worker's own card is neither, so
+# the user's thread lost the fan-out at the first hop. Measured 2026-08-07
+# 12:58: coordinator t_b9659077 was subscribed, the 4 cards it created as a
+# WORKER were not, and the synthesizer's answer sat undelivered for 91.3s
+# (gateway.log: zero Slack sends 12:59:02-13:02:15) until the user asked. The
+# manual remedy (scripts/kanban_notify_propagate.py) relies on the worker
+# remembering to run it; it didn't. Same column set and INSERT OR IGNORE
+# idempotency as that script, so keeping it around as a back-fill tool
+# double-writes harmlessly. verify_kanban_auto_subscribe.py replays the
+# incident through the real patched create handler on a real board.
+# See the module docstring in deploy/docker/patches/kanban_auto_subscribe.py.
+#
+# Hotfix: kanban_comment tells the caller what the card is doing. On 2026-08-08
+# card t_a8f58a2a completed at 19:09:43 and its 6,191-char report reached the
+# Slack thread at 19:09:44; at 19:11:30 the front door commented on that card and
+# told the user "You'll see the results post here as soon as the agent
+# completes." The user waited 9m46s for an answer already sitting above the
+# question. The comment succeeded and said nothing: a comment does not respawn a
+# done card, the subscription was already reaped, and `commented` is not one of
+# the notifier's TERMINAL_KINDS -- so a comment never posts to chat on ANY card,
+# only transitively via a worker that reads it and then completes. The handler now
+# returns task_status, who will read the comment, and -- for open cards only --
+# whether completing posts to chat. Terminal cards get an explicit note instead:
+# the write always lands (annotating a finished audit is legitimate, and losing a
+# comment is worse than the incident), but it can no longer read as pending.
+# Order-independent w.r.t. the other kanban_tools.py patches -- it shares no line
+# with any of them; it rides in this group only for the layer budget below.
+# See the module docstring in deploy/docker/patches/kanban_comment_status.py.
+#
+# All three patches ship in ONE COPY + ONE RUN on purpose. `credential-proxy`
+# builds FROM `platform`, and the block-per-patch layout these would normally get
+# pushed that stage past Docker's layer-depth ceiling ("max depth exceeded" on
+# build f9f1747c, 2026-08-07). The guarantees are unchanged — same appliers,
+# same grep guards, same behavioural verifies — only the layer count differs.
+COPY deploy/docker/patches/kanban_wake_nudge.py \
+     deploy/docker/patches/apply_kanban_wake_nudge.py \
+     deploy/docker/patches/verify_kanban_wake_nudge.py \
+     deploy/docker/patches/kanban_auto_subscribe.py \
+     deploy/docker/patches/apply_kanban_auto_subscribe.py \
+     deploy/docker/patches/verify_kanban_auto_subscribe.py \
+     deploy/docker/patches/kanban_comment_status.py \
+     deploy/docker/patches/apply_kanban_comment_status.py \
+     deploy/docker/patches/verify_kanban_comment_status.py \
+     deploy/docker/patches/patchlib.py \
+     /tmp/latency-patches/
+RUN cp /tmp/latency-patches/kanban_wake_nudge.py /opt/hermes/hermes_cli/kanban_wake_nudge.py && \
+    cp /tmp/latency-patches/kanban_auto_subscribe.py /opt/hermes/tools/kanban_auto_subscribe.py && \
+    cp /tmp/latency-patches/kanban_comment_status.py /opt/hermes/tools/kanban_comment_status.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/apply_kanban_wake_nudge.py /opt/hermes && \
+    test "$(grep -c '_kanban_record_wake(conn)' /opt/hermes/hermes_cli/kanban_db.py)" = "3" && \
+    test "$(grep -c '_wake_monitor = _KanbanWakeMonitor(_kb.kanban_db_path)' /opt/hermes/gateway/kanban_watchers.py)" = "2" && \
+    test "$(grep -c 'await _kanban_wait_interval(' /opt/hermes/gateway/kanban_watchers.py)" = "2" && \
+    ! grep -q "Sleep with cancellation checks" /opt/hermes/gateway/kanban_watchers.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/apply_kanban_auto_subscribe.py /opt/hermes && \
+    grep -q "_kanban_inherit_worker_subs(conn, new_tid)" /opt/hermes/tools/kanban_tools.py && \
+    grep -q "from tools.kanban_auto_subscribe import" /opt/hermes/tools/kanban_tools.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/apply_kanban_comment_status.py /opt/hermes && \
+    grep -qF '**_comment_delivery_fields(kb, conn, tid)' /opt/hermes/tools/kanban_tools.py && \
+    grep -q "from tools.kanban_comment_status import" /opt/hermes/tools/kanban_tools.py && \
+    cd /opt/hermes && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/verify_kanban_wake_nudge.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/verify_kanban_auto_subscribe.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/latency-patches/verify_kanban_comment_status.py && \
+    rm -rf /tmp/latency-patches
+
 
 # 3. Clone and build mcp-remote proxy. Git is a build-only dependency here;
 # the sandbox runtime exposes only the credential-proxy Git wrapper.
+#
+# The source is a fork, and deliberately so: it is the only build that speaks
+# Google ADC. Its commits ahead of upstream add `google-auth-library`, mint a
+# fresh bearer token per call (handling expiry), and attach the
+# `X-Goog-User-Project` header. Upstream geelen/mcp-remote has none of that, so
+# switching the clone URL to the official repository would break every GKE and
+# developer_knowledge MCP call. Do not "clean this up" without replacing the
+# auth path first.
+#
+# The SDK is pinned explicitly because the git SHA alone does not pin it. The
+# fork commits only a `pnpm-lock.yaml`, which `npm install` ignores, and
+# declares `^1.23.0`; with tsup's `external: []` the SDK is bundled into the
+# shipped chunk. Without this line the transport baked into the image is
+# whatever was latest on build day, so two builds of this same Dockerfile can
+# ship different error semantics (1.24.0 changed the thrown class).
+COPY deploy/docker/patches/apply_mcp_remote_forward_errors.py /tmp/apply_mcp_remote_forward_errors.py
 RUN apt-get update && apt-get install -y --no-install-recommends git && \
     git clone https://github.com/bradhoekstra/mcp-remote.git /opt/mcp-remote && \
     cd /opt/mcp-remote && \
     git checkout 2ff8f16753d8c744e6982b99e6ed5ab62f44f311 && \
+    npm pkg set devDependencies.@modelcontextprotocol/sdk=1.30.0 && \
     npm install && \
+    /opt/hermes/.venv/bin/python3 /tmp/apply_mcp_remote_forward_errors.py /opt/mcp-remote && \
     npm run build && \
+    grep -q 'Failed to forward message to remote server' dist/*.js && \
     npm prune --production && \
     npm cache clean --force && \
-    rm -rf .git
+    rm -rf .git /tmp/apply_mcp_remote_forward_errors.py /tmp/patchlib.py
 
 # 5. Create base defaults directory and copy shared defaults
 RUN mkdir -p /opt/defaults && chown hermes:hermes /opt/defaults

--- a/deploy/docker/patches/apply_cron_run_scope.py
+++ b/deploy/docker/patches/apply_cron_run_scope.py
@@ -16,9 +16,10 @@ Why each edit is needed is documented in the module docstring of
 
 from __future__ import annotations
 
-import ast
 import sys
 from pathlib import Path
+
+import patchlib
 
 # --- cron/scheduler.py: stop discarding the run's own report ----------------
 
@@ -252,29 +253,10 @@ PATCHES = (
 def apply(root: Path) -> None:
     """Apply every patch under ``root``, or raise SystemExit with the reason."""
     for relative, edits in PATCHES:
-        path = root / relative
-        if not path.is_file():
-            raise SystemExit(f"cron_run_scope patch: {path} does not exist")
-        source = path.read_text()
+        patch = patchlib.Patch(root, relative, prefix="cron_run_scope")
         for anchor, replacement, expected in edits:
-            found = source.count(anchor)
-            if found != expected:
-                raise SystemExit(
-                    f"cron_run_scope patch: {relative}: expected {expected} "
-                    f"occurrence(s) of anchor, found {found}. Upstream Hermes "
-                    f"changed — re-derive the anchor before bumping the base "
-                    f"image.\n--- anchor ---\n{anchor}"
-                )
-            source = source.replace(anchor, replacement)
-        try:
-            ast.parse(source)
-        except SyntaxError as e:
-            raise SystemExit(
-                f"cron_run_scope patch: {relative} no longer parses after "
-                f"patching: {e}"
-            )
-        path.write_text(source)
-        print(f"cron_run_scope patch: {relative} ({len(edits)} anchors)")
+            patch.substitute(anchor, replacement, expected=expected)
+        patch.commit(f"{len(edits)} anchors")
 
 
 if __name__ == "__main__":

--- a/deploy/docker/patches/apply_cron_skip_ledger.py
+++ b/deploy/docker/patches/apply_cron_skip_ledger.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""Wire tools/cron_skip_ledger.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. Fourteen anchored
+replacements across four files, with the same guarantee as every other patch in
+that Dockerfile: each anchor must be found the exact number of times expected,
+each edited file must still parse, and anything else fails the build loudly
+rather than shipping a half-patched image.
+
+**Must run after ``apply_cron_tick_lock_scope.py``.** Two of the anchors here
+are text that patch inserts — the cross-process ``_job_locks.claim`` guard in
+``tick`` — so applying this one first would fail on a missing anchor rather
+than silently mis-apply, but the ordering is still load-bearing and the
+Dockerfile records it.
+
+Why each edit is needed is documented in the module docstring of
+``deploy/docker/patches/cron_skip_ledger.py``. Usage::
+
+    python3 apply_cron_skip_ledger.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+# Two of the anchors below are text that apply_cron_tick_lock_scope.py inserts,
+# so "not found" here has a second, likelier cause than upstream drift: the
+# Dockerfile ran the two patches out of order. Say so in the failure.
+DRIFT_NOTE = (
+    "Upstream Hermes changed (or apply_cron_tick_lock_scope.py has not run "
+    "yet) — re-derive the anchor before bumping the base image."
+)
+
+# --- cron/executions.py: a fifth terminal status, and per-job retention -----
+
+EXEC_CONSTANTS = '''MAX_TERMINAL_EXECUTIONS = 1000
+_TERMINAL_STATES = ("completed", "failed", "unknown")
+'''
+
+EXEC_CONSTANTS_PATCHED = '''# kube-agents patch: retention is per job rather than global, and the ledger
+# has a fifth terminal status. Both live in tools/cron_skip_ledger.py; the
+# names are imported rather than restated so the prune SQL, the CHECK
+# constraint and these module-level constants cannot drift apart.
+from tools.cron_skip_ledger import (  # noqa: E402
+    MAX_TERMINAL_EXECUTIONS,
+    MAX_TERMINAL_EXECUTIONS_PER_JOB,
+    MIN_TERMINAL_EXECUTIONS_PER_JOB,
+    TERMINAL_STATES as _TERMINAL_STATES,
+    ensure_schema as _ensure_skip_schema,
+    normalize_reason as _normalize_skip_reason,
+    prune_terminal_executions as _prune_terminal_executions,
+)
+
+'''
+
+EXEC_CREATE_TABLE = '''    conn.execute(
+        """CREATE TABLE IF NOT EXISTS executions (
+             id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             source TEXT NOT NULL,
+             process_id TEXT NOT NULL,
+             pid INTEGER NOT NULL,
+             process_started_at INTEGER,
+             status TEXT NOT NULL CHECK(status IN
+               ('claimed','running','completed','failed','unknown')),
+             claimed_at TEXT NOT NULL,
+             started_at TEXT,
+             finished_at TEXT,
+             error TEXT
+           )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
+'''
+
+# The CREATE TABLE gains 'skipped' and skip_reason so a fresh ledger is born
+# migrated. ensure_schema() then sits between the table and the indexes on
+# purpose: it only fires on a ledger that predates this patch, and its rebuild
+# drops the indexes along with the old table, so the CREATE INDEX statements
+# below must run after it.
+EXEC_CREATE_TABLE_PATCHED = '''    conn.execute(
+        """CREATE TABLE IF NOT EXISTS executions (
+             id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             source TEXT NOT NULL,
+             process_id TEXT NOT NULL,
+             pid INTEGER NOT NULL,
+             process_started_at INTEGER,
+             status TEXT NOT NULL CHECK(status IN
+               ('claimed','running','completed','failed','unknown','skipped')),
+             claimed_at TEXT NOT NULL,
+             started_at TEXT,
+             finished_at TEXT,
+             error TEXT,
+             skip_reason TEXT
+           )"""
+    )
+    # kube-agents patch: bring a pre-existing ledger up to the schema above.
+    # SQLite cannot alter a CHECK constraint in place, so this rebuilds the
+    # table; it is idempotent, it never raises, and it must run before the
+    # indexes below because its rebuild drops them with the old table. See
+    # tools/cron_skip_ledger.py.
+    _ensure_skip_schema(conn)
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
+'''
+
+EXEC_PRUNE = '''def _prune_unlocked(conn: sqlite3.Connection) -> None:
+    limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
+    conn.execute(
+        """DELETE FROM executions WHERE id IN (
+             SELECT id FROM executions
+             WHERE status IN ('completed','failed','unknown')
+             ORDER BY claimed_at DESC, id DESC LIMIT -1 OFFSET ?
+           )""",
+        (limit,),
+    )
+'''
+
+EXEC_PRUNE_PATCHED = '''def _prune_unlocked(conn: sqlite3.Connection) -> None:
+    """Retain history per job, not per board.
+
+    kube-agents patch. The upstream body kept the newest
+    MAX_TERMINAL_EXECUTIONS rows across ALL jobs, so the busiest job evicted
+    every other job's evidence: on the live Chat Agent board the cap was
+    saturated at 1000/1000 with 980 of those rows belonging to one minute-ly
+    ticker, leaving a 16.7-hour horizon for the daily watchdogs sharing it.
+    See tools/cron_skip_ledger.py for the replacement rule and the reasoning
+    behind its three limits.
+    """
+    _prune_terminal_executions(conn)
+'''
+
+EXEC_NEW_FUNCTIONS_ANCHOR = "def recover_interrupted_executions() -> int:"
+
+EXEC_NEW_FUNCTIONS_PATCHED = '''def record_skipped_execution(
+    job_id: str, *, source: str, reason: str, detail: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Persist an occurrence that came due and did not run.
+
+    kube-agents patch. Written straight into a terminal state because there is
+    no claim to transition from: the decision not to run is taken before
+    dispatch, which is precisely why upstream had nowhere to put it. See
+    tools/cron_skip_ledger.py for the five ways this happens.
+
+    ``pid`` and ``process_started_at`` describe the process that made the
+    decision, not a runner — they are what tells two racing tickers apart once
+    a board starts filling with ``already_running_elsewhere``.
+
+    ``started_at`` stays NULL and ``finished_at`` equals ``claimed_at``, so
+    ``cron_health._duration_ms`` reports 0 instead of inventing a runtime, and
+    any reader keying off ``started_at`` can still see that nothing ran.
+    """
+    now = _hermes_now().isoformat()
+    execution_id = uuid.uuid4().hex
+    pid = os.getpid()
+    code = _normalize_skip_reason(reason)
+    text = str(detail).strip() or f"Occurrence skipped: {code}."
+    with _transaction() as conn:
+        conn.execute(
+            """INSERT INTO executions
+               (id, job_id, source, process_id, pid, process_started_at,
+                status, claimed_at, finished_at, error, skip_reason)
+               VALUES (?, ?, ?, ?, ?, ?, 'skipped', ?, ?, ?, ?)""",
+            (execution_id, str(job_id), str(source), _PROCESS_ID, pid,
+             _process_start_time(pid), now, now, text, code),
+        )
+        _prune_unlocked(conn)
+        row = conn.execute(
+            "SELECT * FROM executions WHERE id=?", (execution_id,)
+        ).fetchone()
+    record = _record(row)
+    _emit_execution_state(record)
+    return record
+
+
+def skip_execution(
+    execution_id: str, *, reason: str, detail: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Close an already-claimed attempt as skipped rather than failed.
+
+    kube-agents patch. For the one path that claims first and only then learns
+    the occurrence must not run: a finite one-shot whose dispatch budget was
+    already spent. Upstream closed that as ``failed``, which both inflates the
+    failure rate cron_health derives and libels an at-most-once guarantee that
+    is working exactly as designed. Terminal-once, like ``finish_execution``.
+    """
+    now = _hermes_now().isoformat()
+    code = _normalize_skip_reason(reason)
+    text = str(detail).strip() or f"Occurrence skipped: {code}."
+    with _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE executions SET status='skipped', finished_at=?, error=?,
+                   skip_reason=?
+               WHERE id=? AND status IN ('claimed','running')""",
+            (now, text, code, execution_id),
+        )
+        if cur.rowcount != 1:
+            return None
+        _prune_unlocked(conn)
+        record = _record(conn.execute(
+            "SELECT * FROM executions WHERE id=?", (execution_id,)
+        ).fetchone())
+    _emit_execution_state(record)
+    return record
+
+
+''' + EXEC_NEW_FUNCTIONS_ANCHOR
+
+# --- cron/scheduler.py: record the four ways a due occurrence is dropped ----
+
+SCHED_IMPORT = (
+    "from cron.executions import create_execution, finish_execution, "
+    "mark_execution_running"
+)
+
+SCHED_IMPORT_PATCHED = (
+    "from cron.executions import (\n"
+    "    create_execution,\n"
+    "    finish_execution,\n"
+    "    mark_execution_running,\n"
+    "    skip_execution,\n"
+    ")\n"
+    "\n"
+    "# kube-agents patch: a due occurrence that never ran used to leave nothing\n"
+    "# behind but a log line. See tools/cron_skip_ledger.py.\n"
+    "from tools.cron_skip_ledger import (\n"
+    "    SKIP_ALREADY_RUNNING,\n"
+    "    SKIP_ALREADY_RUNNING_ELSEWHERE,\n"
+    "    SKIP_DISPATCH_CLAIM_REJECTED,\n"
+    "    SKIP_INTERPRETER_SHUTDOWN,\n"
+    "    record_skip,\n"
+    ")"
+)
+
+# advance_next_runs() has already moved next_run_at for the whole due set by
+# the time any of the three guards below runs, so each one drops the
+# occurrence permanently rather than deferring it.
+SCHED_SHUTDOWN_GUARD = '''            if _interpreter_shutting_down():
+                logger.warning(
+                    "Job '%s' not dispatched — interpreter is shutting down",
+                    job.get("name", job_id),
+                )
+                return None
+'''
+
+SCHED_SHUTDOWN_GUARD_PATCHED = '''            if _interpreter_shutting_down():
+                logger.warning(
+                    "Job '%s' not dispatched — interpreter is shutting down",
+                    job.get("name", job_id),
+                )
+                # kube-agents patch: next_run_at was advanced for this whole
+                # due set before dispatch, so the occurrence is gone, not
+                # deferred. See tools/cron_skip_ledger.py.
+                record_skip(
+                    job_id,
+                    source="builtin",
+                    reason=SKIP_INTERPRETER_SHUTDOWN,
+                    detail=(
+                        "Interpreter began finalizing before this occurrence "
+                        "could be dispatched; the job was not run and its "
+                        "schedule had already advanced."
+                    ),
+                )
+                return None
+'''
+
+# The ledger write is deliberately moved OUT of the _running_lock critical
+# section. That lock is held by every dispatching thread in the tick; a SQLite
+# write behind a 5s busy timeout inside it would serialise the whole dispatch
+# pass on the ledger.
+SCHED_RUNNING_GUARD = '''            with _running_lock:
+                if job_id in _running_job_ids:
+                    logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                    return None
+                _running_job_ids.add(job_id)
+'''
+
+SCHED_RUNNING_GUARD_PATCHED = '''            with _running_lock:
+                _already_running = job_id in _running_job_ids
+                if not _already_running:
+                    _running_job_ids.add(job_id)
+            if _already_running:
+                logger.info("Job '%s' already running — skipping", job.get("name", job_id))
+                # kube-agents patch: recorded outside _running_lock on purpose
+                # — every dispatching thread in this tick takes that lock, and
+                # a ledger write behind a 5s busy timeout inside it would
+                # serialise the whole dispatch pass. See
+                # tools/cron_skip_ledger.py.
+                record_skip(
+                    job_id,
+                    source="builtin",
+                    reason=SKIP_ALREADY_RUNNING,
+                    detail=(
+                        "A previous run of this job was still in flight in "
+                        "this process when the occurrence came due; the "
+                        "occurrence was dropped, not queued."
+                    ),
+                )
+                return None
+'''
+
+# Inserted by apply_cron_tick_lock_scope.py — this applier must run after it.
+SCHED_JOB_LOCK_GUARD = '''            _job_lock = _job_locks.claim(job_id)
+            if _job_lock is None:
+                logger.info(
+                    "Job '%s' already running in another process — skipping",
+                    job.get("name", job_id),
+                )
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
+                return None
+'''
+
+SCHED_JOB_LOCK_GUARD_PATCHED = '''            _job_lock = _job_locks.claim(job_id)
+            if _job_lock is None:
+                logger.info(
+                    "Job '%s' already running in another process — skipping",
+                    job.get("name", job_id),
+                )
+                with _running_lock:
+                    _running_job_ids.discard(job_id)
+                # kube-agents patch: distinct from SKIP_ALREADY_RUNNING because
+                # the remedy is distinct — that one says the job outruns its
+                # own period, this one says two tickers are racing for the same
+                # profile. See tools/cron_skip_ledger.py.
+                record_skip(
+                    job_id,
+                    source="builtin",
+                    reason=SKIP_ALREADY_RUNNING_ELSEWHERE,
+                    detail=(
+                        "Another process held this job's run lock when the "
+                        "occurrence came due; the occurrence was dropped, not "
+                        "queued."
+                    ),
+                )
+                return None
+'''
+
+SCHED_DISPATCH_CLAIM = '''            finish_execution(
+                execution_id,
+                success=False,
+                error="Dispatch claim rejected; execution was not started.",
+            )
+            return True  # not an error — already handled/removed
+'''
+
+SCHED_DISPATCH_CLAIM_PATCHED = '''            # kube-agents patch: a one-shot that has already spent its dispatch
+            # budget is an at-most-once guarantee working, not a failure. Closed
+            # as failed it inflated the failure rate cron_health derives from
+            # this ledger. See tools/cron_skip_ledger.py.
+            skip_execution(
+                execution_id,
+                reason=SKIP_DISPATCH_CLAIM_REJECTED,
+                detail="Dispatch claim rejected; execution was not started.",
+            )
+            return True  # not an error — already handled/removed
+'''
+
+# --- cron/jobs.py: the outage that hides itself -----------------------------
+
+JOBS_CATCH_UP = '''                        record_catch_up_occurrence()
+                        # Fall through to due.append(job) — execute once now
+'''
+
+JOBS_CATCH_UP_PATCHED = '''                        record_catch_up_occurrence()
+                        # kube-agents patch: record_catch_up_occurrence() bumps
+                        # one profile-wide integer in a file — no job id, no
+                        # window, no count — so a gateway outage long enough to
+                        # blow the grace window leaves a daily watchdog looking
+                        # as though it ran on schedule. One ledger row per gap,
+                        # not per lost occurrence: a three-hour outage of a
+                        # minute-ly job would otherwise write 180 rows and evict
+                        # the history somebody is reading. The catch-up fire
+                        # itself is recorded separately by the ticker.
+                        # See tools/cron_skip_ledger.py.
+                        try:
+                            from tools.cron_skip_ledger import (
+                                SKIP_MISSED_WINDOW,
+                                missed_window_detail,
+                                record_skip,
+                            )
+
+                            record_skip(
+                                job["id"],
+                                source="builtin",
+                                reason=SKIP_MISSED_WINDOW,
+                                detail=missed_window_detail(
+                                    schedule, next_run_dt, now, grace
+                                ),
+                            )
+                        except Exception:
+                            logger.debug(
+                                "could not record missed window for job %s",
+                                job.get("id"),
+                                exc_info=True,
+                            )
+                        # Fall through to due.append(job) — execute once now
+'''
+
+# --- agent/monitoring/cron_health.py: do not launder a skip into "unknown" --
+
+HEALTH_STATUSES = (
+    '_KNOWN_STATUSES = {"claimed", "running", "completed", "failed", "unknown"}'
+)
+
+HEALTH_STATUSES_PATCHED = (
+    "# kube-agents patch: without 'skipped' here, project_execution_event\n"
+    "# coerces every skip to 'unknown' — the state that means an owner process\n"
+    "# died mid-run. That corrupts a real signal on top of hiding a new one.\n"
+    "# See tools/cron_skip_ledger.py.\n"
+    '_KNOWN_STATUSES = {"claimed", "running", "completed", "failed", "unknown", "skipped"}'
+)
+
+HEALTH_IMPORT = "from cron.scheduler import get_running_job_ids"
+
+HEALTH_IMPORT_PATCHED = (
+    "from cron.scheduler import get_running_job_ids\n"
+    "\n"
+    "# kube-agents patch: see tools/cron_skip_ledger.py\n"
+    "from tools.cron_skip_ledger import normalize_reason as _normalize_skip_reason"
+)
+
+HEALTH_ERROR_CLASS = '''        error_class=(
+            classify_cron_error(record.get("error"))
+            if status in {"failed", "unknown"}
+            else None
+        ),
+'''
+
+HEALTH_ERROR_CLASS_PATCHED = '''        error_class=(
+            # kube-agents patch: a skip already carries a machine-readable,
+            # content-free reason, so project that instead of running the
+            # free-text classifier over it. See tools/cron_skip_ledger.py.
+            _normalize_skip_reason(record.get("skip_reason"))
+            if status == "skipped"
+            else classify_cron_error(record.get("error"))
+            if status in {"failed", "unknown"}
+            else None
+        ),
+'''
+
+HEALTH_FLUSH = '''        if event.status in {"completed", "failed", "unknown"}:
+            target.flush(timeout=1.0)
+'''
+
+HEALTH_FLUSH_PATCHED = '''        # kube-agents patch: 'skipped' is terminal, so it crosses the queue
+        # barrier synchronously like the other terminal states — a skip
+        # recorded moments before the gateway exits is exactly the one worth
+        # keeping. See tools/cron_skip_ledger.py.
+        if event.status in {"completed", "failed", "unknown", "skipped"}:
+            target.flush(timeout=1.0)
+'''
+
+# (relative path, [(anchor, replacement, expected occurrences)])
+PATCHES = (
+    (
+        "cron/executions.py",
+        (
+            (EXEC_CONSTANTS, EXEC_CONSTANTS_PATCHED, 1),
+            (EXEC_CREATE_TABLE, EXEC_CREATE_TABLE_PATCHED, 1),
+            (EXEC_PRUNE, EXEC_PRUNE_PATCHED, 1),
+            (EXEC_NEW_FUNCTIONS_ANCHOR, EXEC_NEW_FUNCTIONS_PATCHED, 1),
+        ),
+    ),
+    (
+        "cron/scheduler.py",
+        (
+            (SCHED_IMPORT, SCHED_IMPORT_PATCHED, 1),
+            (SCHED_SHUTDOWN_GUARD, SCHED_SHUTDOWN_GUARD_PATCHED, 1),
+            (SCHED_RUNNING_GUARD, SCHED_RUNNING_GUARD_PATCHED, 1),
+            (SCHED_JOB_LOCK_GUARD, SCHED_JOB_LOCK_GUARD_PATCHED, 1),
+            (SCHED_DISPATCH_CLAIM, SCHED_DISPATCH_CLAIM_PATCHED, 1),
+        ),
+    ),
+    (
+        "cron/jobs.py",
+        ((JOBS_CATCH_UP, JOBS_CATCH_UP_PATCHED, 1),),
+    ),
+    (
+        "agent/monitoring/cron_health.py",
+        (
+            (HEALTH_STATUSES, HEALTH_STATUSES_PATCHED, 1),
+            (HEALTH_IMPORT, HEALTH_IMPORT_PATCHED, 1),
+            (HEALTH_ERROR_CLASS, HEALTH_ERROR_CLASS_PATCHED, 1),
+            (HEALTH_FLUSH, HEALTH_FLUSH_PATCHED, 1),
+        ),
+    ),
+)
+
+
+def apply(root: Path) -> None:
+    """Apply every patch under ``root``, or raise SystemExit with the reason."""
+    for relative, edits in PATCHES:
+        patch = patchlib.Patch(
+            root, relative, prefix="cron_skip_ledger", note=DRIFT_NOTE
+        )
+        for anchor, replacement, expected in edits:
+            patch.substitute(anchor, replacement, expected=expected)
+        patch.commit(f"{len(edits)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_cron_tick_lock_scope.py
+++ b/deploy/docker/patches/apply_cron_tick_lock_scope.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Wire tools/cron_tick_lock_scope.py into the Hermes source tree.
+
+Eleven anchored edits across three files -- six in ``cron/scheduler.py``, four
+in ``tools/cronjob_tools.py``, one in ``hermes_cli/cron.py``. See the module
+docstring in ``deploy/docker/patches/cron_tick_lock_scope.py`` for what each
+group is for. Usage::
+
+    python3 apply_cron_tick_lock_scope.py [HERMES_ROOT]   # default /opt/hermes
+
+Must run AFTER apply_cron_run_scope.py: every anchor below was verified against
+the post-cron_run_scope source in the running image, count == 1 for each.
+
+Not idempotent, deliberately. A second run raises SystemExit because every
+anchor has been consumed by the first -- that is the intended signal that the
+build is applying the same surgery twice.
+"""
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+# --- 1. import + the per-job lock registry ----------------------------------
+# `msvcrt` is only bound in the ImportError branch of the fcntl import, so on
+# Unix the NAME does not exist. globals().get() rather than a bare reference.
+IMPORT_ANCHOR = "def _get_lock_paths() -> tuple[Path, Path]:"
+IMPORT_PATCHED = (
+    "# kube-agents patch: see tools/cron_tick_lock_scope.py\n"
+    "from tools.cron_tick_lock_scope import AdvisoryLock, JobLocks\n"
+    "\n"
+    "# Cross-process mirror of _running_job_ids. flock, not a ledger row: the\n"
+    "# kernel releases the claim when a tick process dies, so it cannot wedge.\n"
+    "_job_locks = JobLocks(\n"
+    "    lambda: _get_lock_paths()[0], fcntl, globals().get(\"msvcrt\")\n"
+    ")\n"
+    "\n"
+    "\n"
+    "def _get_lock_paths() -> tuple[Path, Path]:"
+)
+
+# --- 2. own the tick lock's handle ------------------------------------------
+ACQUIRE_ANCHOR = (
+    "    except (OSError, IOError):\n"
+    '        logger.debug("Tick skipped — another instance holds the lock")\n'
+    "        if lock_fd is not None:\n"
+    "            lock_fd.close()\n"
+    "        return 0\n"
+    "\n"
+    "    try:\n"
+)
+ACQUIRE_PATCHED = (
+    "    except (OSError, IOError):\n"
+    '        logger.debug("Tick skipped — another instance holds the lock")\n'
+    "        if lock_fd is not None:\n"
+    "            lock_fd.close()\n"
+    "        return 0\n"
+    "\n"
+    "    # kube-agents patch: the tick lock guards the scheduling decision, not\n"
+    "    # job execution. See tools/cron_tick_lock_scope.py.\n"
+    '    _tick_lock = AdvisoryLock(lock_fd, fcntl, globals().get("msvcrt"))\n'
+    "\n"
+    "    try:\n"
+)
+
+# --- 3. release once dispatch is done, before the sync wait -----------------
+RELEASE_ANCHOR = (
+    "        if sync:\n"
+    "            # Sync mode (tests / manual ticks): wait for all dispatched jobs,\n"
+)
+RELEASE_PATCHED = (
+    "        # kube-agents patch: every due job's next_run_at has been advanced\n"
+    "        # and every job has been submitted by this point, so at-most-once is\n"
+    "        # already secured. Releasing here instead of in the finally stops one\n"
+    "        # slow job blocking the whole profile for its entire runtime.\n"
+    "        # See tools/cron_tick_lock_scope.py.\n"
+    "        _tick_lock.release()\n"
+    "\n"
+    "        if sync:\n"
+    "            # Sync mode (tests / manual ticks): wait for all dispatched jobs,\n"
+)
+
+# --- 4. the finally becomes the idempotent backstop -------------------------
+FINALLY_ANCHOR = (
+    "    finally:\n"
+    "        if fcntl:\n"
+    "            try:\n"
+    "                fcntl.flock(lock_fd, fcntl.LOCK_UN)\n"
+    "            except (OSError, IOError):\n"
+    "                pass\n"
+    "        elif msvcrt:\n"
+    "            try:\n"
+    "                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)\n"
+    "            except (OSError, IOError):\n"
+    "                pass\n"
+    "        lock_fd.close()\n"
+)
+FINALLY_PATCHED = (
+    "    finally:\n"
+    "        # kube-agents patch: idempotent — a no-op when the dispatch path\n"
+    "        # already released, and still the only release on the early-return\n"
+    "        # and exception paths. See tools/cron_tick_lock_scope.py.\n"
+    "        _tick_lock.release()\n"
+)
+
+# --- 5. claim the per-job lock beside the process-local guard ---------------
+# The claim object travels into the worker as a default argument rather than
+# being looked up again by job id on the way out: the worker thread cannot
+# resolve the lock path the claim was taken under. See the "caller owns its
+# claim" section of tools/cron_tick_lock_scope.py.
+GUARD_ANCHOR = (
+    "            with _running_lock:\n"
+    "                if job_id in _running_job_ids:\n"
+    "                    logger.info(\"Job '%s' already running — skipping\", job.get(\"name\", job_id))\n"
+    "                    return None\n"
+    "                _running_job_ids.add(job_id)\n"
+    "            # Record the attempt before executor dispatch. Recovery classifies\n"
+    "            # abandoned records as unknown; it never automatically retries them.\n"
+    '            execution = create_execution(job_id, source="builtin")\n'
+    '            dispatched_job = dict(job, execution_id=execution["id"])\n'
+    "            _ctx = contextvars.copy_context()\n"
+    "\n"
+    "            def _run_and_release(j=dispatched_job, ctx=_ctx):\n"
+    "                try:\n"
+    "                    return ctx.run(_process_job, j)\n"
+    "                finally:\n"
+    "                    with _running_lock:\n"
+    '                        _running_job_ids.discard(j["id"])\n'
+)
+GUARD_PATCHED = (
+    "            with _running_lock:\n"
+    "                if job_id in _running_job_ids:\n"
+    "                    logger.info(\"Job '%s' already running — skipping\", job.get(\"name\", job_id))\n"
+    "                    return None\n"
+    "                _running_job_ids.add(job_id)\n"
+    "            # kube-agents patch: _running_job_ids is module-level, so it is\n"
+    "            # empty in every freshly spawned `hermes cron tick`. With the tick\n"
+    "            # lock now released at dispatch, a second process can reach here\n"
+    "            # for the same job if that job outlives its own period. Mirror the\n"
+    "            # claim with a per-job flock the kernel releases on process death.\n"
+    "            # See tools/cron_tick_lock_scope.py.\n"
+    "            _job_lock = _job_locks.claim(job_id)\n"
+    "            if _job_lock is None:\n"
+    "                logger.info(\n"
+    "                    \"Job '%s' already running in another process — skipping\",\n"
+    '                    job.get("name", job_id),\n'
+    "                )\n"
+    "                with _running_lock:\n"
+    "                    _running_job_ids.discard(job_id)\n"
+    "                return None\n"
+    "            # Record the attempt before executor dispatch. Recovery classifies\n"
+    "            # abandoned records as unknown; it never automatically retries them.\n"
+    '            execution = create_execution(job_id, source="builtin")\n'
+    '            dispatched_job = dict(job, execution_id=execution["id"])\n'
+    "            _ctx = contextvars.copy_context()\n"
+    "\n"
+    "            def _run_and_release(j=dispatched_job, ctx=_ctx, lock=_job_lock):\n"
+    "                try:\n"
+    "                    return ctx.run(_process_job, j)\n"
+    "                finally:\n"
+    "                    with _running_lock:\n"
+    '                        _running_job_ids.discard(j["id"])\n'
+    "                    lock.release()\n"
+)
+
+# --- 6. release it on the dispatch-failure path too -------------------------
+SUBMIT_ERR_ANCHOR = (
+    "            except Exception as submit_err:\n"
+    "                with _running_lock:\n"
+    "                    _running_job_ids.discard(job_id)\n"
+)
+SUBMIT_ERR_PATCHED = (
+    "            except Exception as submit_err:\n"
+    "                with _running_lock:\n"
+    "                    _running_job_ids.discard(job_id)\n"
+    "                _job_lock.release()\n"
+)
+
+# --- 7. _execute_job_now's docstring said the CAS was the guard -------------
+DISPATCH_DOC_ANCHOR = (
+    "    Atomically claims the job first via ``claim_job_for_fire`` — the same\n"
+    "    at-most-once CAS the scheduler/external-provider fire path uses — so a\n"
+    "    concurrently-running gateway ticker cannot also fire it (the claim both\n"
+    "    blocks a duplicate fire and advances ``next_run_at`` for recurring jobs).\n"
+    "    If the claim is lost (another fire is in flight), this is a no-op.\n"
+)
+DISPATCH_DOC_PATCHED = (
+    "    Claims the job's per-job flock first — the same lock ``cron/scheduler.py``\n"
+    "    takes at dispatch — and refuses outright when a scheduled tick or another\n"
+    "    dispatch is already running the job. Then the ``claim_job_for_fire`` CAS,\n"
+    "    which advances ``next_run_at`` for recurring jobs and settles a race\n"
+    "    between two fires of the same occurrence; if that claim is lost, this is\n"
+    "    a no-op. The CAS on its own never blocked a concurrent tick — see the\n"
+    "    kube-agents patch note below, and ``tools/cron_tick_lock_scope.py``.\n"
+)
+
+# --- 8. a dispatched run claims the same lock, before the store CAS ---------
+# Before, not after: claim_job_for_fire advances next_run_at, so a refusal
+# discovered afterwards would have skipped a scheduled occurrence for a run
+# that never happened.
+DISPATCH_CLAIM_ANCHOR = (
+    '    job_id = job["id"]\n'
+    "    try:\n"
+    "        from cron.scheduler import run_one_job\n"
+    "\n"
+    "        # At-most-once claim: bail without running if a tick/other fire owns it.\n"
+    "        if not claim_job_for_fire(job_id):\n"
+)
+DISPATCH_CLAIM_PATCHED = (
+    '    job_id = job["id"]\n'
+    "    # kube-agents patch: a dispatched run overlapped a scheduled one, and\n"
+    "    # two runs of one fleet audit share the job's output file and scratch\n"
+    "    # state. Take the same per-job flock tick takes, for the whole run.\n"
+    "    # See tools/cron_tick_lock_scope.py.\n"
+    "    _run_lock = None\n"
+    "    try:\n"
+    "        from cron.scheduler import _job_locks, run_one_job\n"
+    "\n"
+    "        _run_lock = _job_locks.claim(job_id)\n"
+    "        if _run_lock is None:\n"
+    "            return {\n"
+    '                "claimed": False,\n'
+    '                "success": False,\n'
+    '                "error": (\n'
+    '                    "Job is already running — a scheduled tick or another "\n'
+    '                    "dispatch holds it, and a second copy would share this "\n'
+    "                    \"run's output file and scratch state. Not started. The \"\n"
+    '                    "run in flight records its own result; check it with "\n'
+    '                    "`hermes cron runs <job_id>` before dispatching again."\n'
+    "                ),\n"
+    "            }\n"
+    "\n"
+    "        # At-most-once claim: bail without running if a tick/other fire owns it.\n"
+    "        if not claim_job_for_fire(job_id):\n"
+)
+
+# --- 9. release it on every path out of _execute_job_now --------------------
+DISPATCH_RELEASE_ANCHOR = (
+    "    except Exception as e:\n"
+    '        logger.error("Failed to execute cron job %s immediately: %s", job_id, e)\n'
+    "        try:\n"
+    "            mark_job_run(job_id, False, str(e))\n"
+    "        except Exception:\n"
+    "            pass\n"
+    '        return {"claimed": True, "success": False, "error": str(e)}\n'
+)
+DISPATCH_RELEASE_PATCHED = (
+    "    except Exception as e:\n"
+    '        logger.error("Failed to execute cron job %s immediately: %s", job_id, e)\n'
+    "        try:\n"
+    "            mark_job_run(job_id, False, str(e))\n"
+    "        except Exception:\n"
+    "            pass\n"
+    '        return {"claimed": True, "success": False, "error": str(e)}\n'
+    "    finally:\n"
+    "        # kube-agents patch: every path out, including the BaseException the\n"
+    "        # except above does not catch. The claim was taken on this thread and\n"
+    "        # is released on it. See tools/cron_tick_lock_scope.py.\n"
+    "        if _run_lock is not None:\n"
+    "            _run_lock.release()\n"
+)
+
+# --- 10. correct the comment that said the CAS was enough --------------------
+# It is load-bearing prose: it is why nobody looked for the overlap.
+STALE_COMMENT_ANCHOR = (
+    "            # Execute the job immediately rather than only scheduling it for the\n"
+    "            # next scheduler tick — a manual `run` should actually run, even when\n"
+    "            # no gateway/ticker is active (the #41037 case). The claim inside\n"
+    "            # _execute_job_now advances next_run_at and blocks a concurrent tick\n"
+    "            # from double-firing.\n"
+)
+STALE_COMMENT_PATCHED = (
+    "            # Execute the job immediately rather than only scheduling it for the\n"
+    "            # next scheduler tick — a manual `run` should actually run, even when\n"
+    "            # no gateway/ticker is active (the #41037 case).\n"
+    "            # kube-agents patch: claim_job_for_fire does NOT block a concurrent\n"
+    "            # tick, whatever this comment used to claim. tick() reaches\n"
+    "            # run_one_job via advance_next_runs, which never stamps a\n"
+    "            # fire_claim, and the claim a dispatch does stamp goes stale after\n"
+    "            # 300s while an audit runs for twenty minutes. The per-job flock\n"
+    "            # _execute_job_now now holds is what actually blocks the overlap.\n"
+    "            # See tools/cron_tick_lock_scope.py.\n"
+)
+
+# --- 11. a spawned tick is a scheduler restart, so it sweeps first ----------
+# recover_interrupted_executions() runs only from the two gateway-ticker
+# lifecycles, so the platform profile -- ticked by spawning this CLI -- had
+# never once reaped an abandoned attempt. See the module docstring.
+RECOVER_ANCHOR = (
+    "def cron_tick():\n"
+    '    """Run due jobs once and exit."""\n'
+    "    from cron.scheduler import tick\n"
+    "    tick(verbose=True)\n"
+)
+RECOVER_PATCHED = (
+    "def cron_tick():\n"
+    '    """Run due jobs once and exit."""\n'
+    "    from cron.scheduler import tick\n"
+    "\n"
+    "    # kube-agents patch: this process IS the platform profile's whole\n"
+    "    # scheduler lifecycle, so the recovery sweep that\n"
+    "    # InProcessCronScheduler.start runs at startup has to happen here or it\n"
+    "    # never happens at all. It only touches rows whose owner process is\n"
+    "    # proved gone, and a sweep that fails must not cost us the tick.\n"
+    "    # See tools/cron_tick_lock_scope.py.\n"
+    "    try:\n"
+    "        from cron.executions import recover_interrupted_executions\n"
+    "\n"
+    "        recovered = recover_interrupted_executions()\n"
+    "        if recovered:\n"
+    "            print(\n"
+    '                f"Recovered {recovered} interrupted execution(s) whose owner "\n'
+    '                f"process is gone; marked unknown."\n'
+    "            )\n"
+    "    except Exception as recover_err:\n"
+    '        print(f"Execution recovery skipped: {recover_err}", file=sys.stderr)\n'
+    "\n"
+    "    tick(verbose=True)\n"
+)
+
+PATCHES = (
+    (
+        "cron/scheduler.py",
+        (
+            (IMPORT_ANCHOR, IMPORT_PATCHED, 1),
+            (ACQUIRE_ANCHOR, ACQUIRE_PATCHED, 1),
+            (RELEASE_ANCHOR, RELEASE_PATCHED, 1),
+            (FINALLY_ANCHOR, FINALLY_PATCHED, 1),
+            (GUARD_ANCHOR, GUARD_PATCHED, 1),
+            (SUBMIT_ERR_ANCHOR, SUBMIT_ERR_PATCHED, 1),
+        ),
+    ),
+    (
+        "tools/cronjob_tools.py",
+        (
+            (DISPATCH_DOC_ANCHOR, DISPATCH_DOC_PATCHED, 1),
+            (DISPATCH_CLAIM_ANCHOR, DISPATCH_CLAIM_PATCHED, 1),
+            (DISPATCH_RELEASE_ANCHOR, DISPATCH_RELEASE_PATCHED, 1),
+            (STALE_COMMENT_ANCHOR, STALE_COMMENT_PATCHED, 1),
+        ),
+    ),
+    (
+        "hermes_cli/cron.py",
+        (
+            (RECOVER_ANCHOR, RECOVER_PATCHED, 1),
+        ),
+    ),
+)
+
+
+def apply(root: Path) -> None:
+    for relative, edits in PATCHES:
+        patch = patchlib.Patch(root, relative, prefix="cron_tick_lock_scope")
+        for anchor, replacement, expected in edits:
+            patch.substitute(anchor, replacement, expected=expected)
+        patch.commit(f"{len(edits)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_cron_tirith_scan.py
+++ b/deploy/docker/patches/apply_cron_tirith_scan.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Wire tools/cron_tirith_scan.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. One anchored
+replacement, in ``tools/approval.py``: the cron arm of
+``check_all_command_guards`` learns to run the Tirith content scan on the
+``approve`` path, where upstream ran it only on the ``deny`` path. Why that
+matters is in the module docstring of
+``deploy/docker/patches/cron_tirith_scan.py``.
+
+The guarantee is the same as every other patch the Dockerfile applies: the
+anchor must be found the exact number of times expected, the edited file must
+still parse, and anything else fails the build loudly rather than shipping an
+image whose security posture is not the one the config describes. That last
+clause is the point here — a silently-missing edit leaves cron running
+unscanned, which looks identical to it working.
+
+Usage::
+
+    python3 apply_cron_tirith_scan.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+# --- tools/approval.py: scan the command even when the prompt is waived -----
+#
+# The three inner lines are NOT unique on their own: `_run_approval_gate` opens
+# with the same comment, the same `_is_cron_approval_context()` test and the
+# same `== "deny"` compare at the same indentation. The `is_ask` line above them
+# is what distinguishes `check_all_command_guards`, so the anchor starts there.
+APPROVAL_CRON_ARM = (
+    "    if not is_cli and not is_gateway and not is_ask:\n"
+    "        # Cron sessions: respect cron_mode config\n"
+    "        if _is_cron_approval_context():\n"
+    '            if _get_cron_approval_mode() == "deny":\n'
+)
+
+# The mode is read once into a local and then branched on twice. Reading it
+# twice would be two config loads per command and, worse, would let a config
+# reload land between them — the scan arm and the deny arm could then disagree
+# about which mode this command is running under.
+#
+# `_cron_mode != "deny"` rather than `== "approve"`: `_get_cron_approval_mode`
+# normalises anything unrecognised to "deny", so those two are exhaustive today,
+# but if upstream ever adds a third value the scan should cover it by default
+# rather than be silently skipped on it.
+#
+# The scan runs BEFORE the auto-approve return and does not touch the deny arm,
+# so the deny arm keeps upstream's own Tirith call verbatim and no command is
+# ever scanned twice — each scan is a subprocess spawn.
+#
+# `_format_tirith_description` is passed in rather than reimplemented so the
+# model reads the same rendering of a finding that an interactive user would.
+# It is a module-level function defined above this one in the same file.
+APPROVAL_CRON_ARM_PATCHED = (
+    "    if not is_cli and not is_gateway and not is_ask:\n"
+    "        # Cron sessions: respect cron_mode config\n"
+    "        if _is_cron_approval_context():\n"
+    "            _cron_mode = _get_cron_approval_mode()\n"
+    "            # kube-agents patch: approvals.cron_mode answers the approval\n"
+    "            # PROMPT, which an unattended run cannot answer. It does not\n"
+    "            # answer the content scanner, and upstream ran Tirith only on\n"
+    "            # the deny arm below — so cron_mode: approve shipped every\n"
+    "            # command in every cron run unscanned. Scan here too; the mode\n"
+    "            # still decides what happens to a pattern-flagged command.\n"
+    "            # See tools/cron_tirith_scan.py.\n"
+    '            if _cron_mode != "deny":\n'
+    "                from tools.cron_tirith_scan import cron_tirith_block\n"
+    "                _scan_block = cron_tirith_block(\n"
+    "                    command, describe=_format_tirith_description\n"
+    "                )\n"
+    "                if _scan_block is not None:\n"
+    "                    return _scan_block\n"
+    '            if _cron_mode == "deny":\n'
+)
+
+# (relative path, [(anchor, replacement, expected occurrences)])
+PATCHES = (
+    (
+        "tools/approval.py",
+        ((APPROVAL_CRON_ARM, APPROVAL_CRON_ARM_PATCHED, 1),),
+    ),
+)
+
+
+def apply(root: Path) -> None:
+    """Apply every patch under ``root``, or raise SystemExit with the reason."""
+    for relative, edits in PATCHES:
+        patch = patchlib.Patch(root, relative, prefix="cron_tirith_scan")
+        for anchor, replacement, expected in edits:
+            patch.substitute(anchor, replacement, expected=expected)
+        patch.commit(f"{len(edits)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_auto_subscribe.py
+++ b/deploy/docker/patches/apply_kanban_auto_subscribe.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Wire tools/kanban_auto_subscribe.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. One anchored edit
+plus an import trailer: the ``kanban_create`` handler gains a call to
+``maybe_inherit_worker_subscriptions`` immediately after the
+``_maybe_auto_subscribe`` attempt it complements — the session-context path
+covers in-chat creators, the new call covers dispatcher-spawned workers, and
+between them every creator with a route back to a chat thread passes it on.
+
+The anchor sits AFTER ``kb.create_task`` returned, so the child exists and
+upstream's own parent-edge inheritance (``_inherit_notify_subs``) has already
+run; ``INSERT OR IGNORE`` makes the overlap free when the worker's card is
+also a graph parent.
+
+Why the change is needed is documented in the module docstring of
+``deploy/docker/patches/kanban_auto_subscribe.py``. Usage::
+
+    python3 apply_kanban_auto_subscribe.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "tools/kanban_tools.py"
+
+ANCHOR = (
+    "            new_task = kb.get_task(conn, new_tid)\n"
+    "            subscribed = _maybe_auto_subscribe(conn, new_tid)\n"
+)
+
+PATCHED = ANCHOR + (
+    "            # kube-agents patch: a worker's child card inherits the chat\n"
+    "            # subscription of the card the worker is running, so the\n"
+    "            # user's thread follows fanned-out work without the worker\n"
+    "            # having to remember a propagation script.\n"
+    "            # See tools/kanban_auto_subscribe.py.\n"
+    "            _kanban_inherit_worker_subs(conn, new_tid)\n"
+)
+
+# Appended rather than inserted: the name is resolved when the tool handler
+# runs, long after the module finishes importing. Same placement the other
+# kanban patches use.
+TRAILER = (
+    "\n\n# kube-agents patch: see tools/kanban_auto_subscribe.py\n"
+    "from tools.kanban_auto_subscribe import (  # noqa: E402\n"
+    "    maybe_inherit_worker_subscriptions as _kanban_inherit_worker_subs,\n"
+    ")\n"
+)
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban_auto_subscribe")
+    # The patched text keeps the anchor (the hook is appended after it), so
+    # anchor-counting alone cannot catch a re-run. Refuse explicitly rather
+    # than stack a second hook call and a second trailer import.
+    patch.refuse_if_patched("_kanban_inherit_worker_subs(conn, new_tid)")
+    patch.substitute(ANCHOR, PATCHED)
+    patch.append(TRAILER)
+    patch.commit("1 anchor")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_comment_status.py
+++ b/deploy/docker/patches/apply_kanban_comment_status.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Wire tools/kanban_comment_status.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. One anchored edit
+plus an import trailer: the ``kanban_comment`` handler's success return grows
+the card's status alongside the comment id.
+
+One anchor on purpose. ``tools/kanban_tools.py`` is already carved up by four
+other patches — ``kanban_auto_subscribe`` (the ``kanban_create`` handler),
+``kanban_result_required`` and ``kanban_worker_tools`` (both on the
+``kanban_complete`` registration block), and ``cron_run_scope`` (the module
+import line, ``_default_task_id``, ``_enforce_worker_task_ownership``, and seven
+copies of one error string) — and every anchor added here is another way a base
+image bump breaks the build. The two lines below are inside ``_handle_comment``,
+which none of those four touch, and the schema wording is deliberately left
+alone: this patch fixes what the model reads *back*, and paying a second anchor
+on the ``kanban_comment`` registration block to also rewrite what it reads
+*first* is not worth it when the tool call itself was never the mistake.
+
+Order-independent with respect to the other four. It shares no line with any of
+them, adds no occurrence of ``cron_run_scope``'s seven-count error string, and
+appends its import the way ``apply_kanban_auto_subscribe.py`` appends its own.
+
+Why the change is needed is documented in the module docstring of
+``deploy/docker/patches/kanban_comment_status.py``. Usage::
+
+    python3 apply_kanban_comment_status.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "tools/kanban_tools.py"
+
+# `return _ok(task_id=tid, comment_id=cid)` is already unique in the file, but
+# the anchor carries the `kb.add_comment` line above it as well. The point of
+# the anchor is not just to be unique — it is to be unique *for the right
+# reason*. Pinned to the comment write, an upstream refactor that moves the
+# return somewhere else fails the build instead of quietly patching whatever
+# inherited the line.
+ANCHOR = (
+    "            cid = kb.add_comment(conn, tid, author=author, body=str(body))\n"
+    "            return _ok(task_id=tid, comment_id=cid)\n"
+)
+
+# `conn` is still open here — the `finally: conn.close()` is one line below —
+# and the comment is already committed, because add_comment runs its own
+# write_txn. So the lookup cannot cost the caller the comment, and
+# delivery_fields returns {} rather than raising if it fails anyway.
+PATCHED = (
+    "            cid = kb.add_comment(conn, tid, author=author, body=str(body))\n"
+    "            # kube-agents patch: a bare ok:true let the model promise a\n"
+    "            # delivery the card could not make. Report what the card is\n"
+    "            # doing. See tools/kanban_comment_status.py.\n"
+    "            return _ok(\n"
+    "                task_id=tid,\n"
+    "                comment_id=cid,\n"
+    "                **_comment_delivery_fields(kb, conn, tid),\n"
+    "            )\n"
+)
+
+# Appended rather than inserted: the name resolves when the handler runs, long
+# after the module finishes importing. Same placement, and the same reason, as
+# the trailer in apply_kanban_auto_subscribe.py.
+TRAILER = (
+    "\n\n# kube-agents patch: see tools/kanban_comment_status.py\n"
+    "from tools.kanban_comment_status import (  # noqa: E402\n"
+    "    delivery_fields as _comment_delivery_fields,\n"
+    ")\n"
+)
+
+# The patch keeps the anchor's first line, so anchor-counting alone cannot
+# distinguish "not yet applied" from "applied twice".
+SENTINEL = "_comment_delivery_fields(kb, conn, tid)"
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban_comment_status")
+    patch.refuse_if_patched(SENTINEL)
+    patch.substitute(ANCHOR, PATCHED)
+    patch.append(TRAILER)
+    patch.commit("1 anchor")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_guardrail_exit.py
+++ b/deploy/docker/patches/apply_kanban_guardrail_exit.py
@@ -1,0 +1,196 @@
+"""Stop kanban workers leaking out of ``run_conversation`` without a board write.
+
+Two anchored edits, one per file:
+
+1. ``agent/conversation_loop.py`` — the tool-guardrail halt branch breaks out of
+   the agent loop from inside the tool-call branch, jumping over the kanban
+   terminal-tool stop guard that lives ~760 lines below it in the *no*-tool-calls
+   branch. Nudge the worker to finish on the board before taking that break.
+2. ``agent/turn_finalizer.py`` — a backstop in ``finalize_turn``, the single
+   funnel every ``break`` in the loop passes through, for the six sibling exits
+   that leak the same way and for the halt path when its nudges are spent.
+
+Both inserts mirror code that is already in the file: edit 1 copies the shape of
+the stop guard's local-import + ``try``/``except`` at
+``conversation_loop.py``'s "Kanban worker terminal-tool stop guard", and edit 2
+copies the ``_record_task_failure`` call the iteration-budget block directly
+above it already makes. Neither is idempotent — a second run fails on the
+anchor count, which is the intent.
+
+See the module docstring in kanban_guardrail_exit.py for the incident.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+LOOP_RELATIVE = "agent/conversation_loop.py"
+FINALIZER_RELATIVE = "agent/turn_finalizer.py"
+
+# The two inner lines are each unique in the file on their own; anchoring on the
+# whole block additionally pins the insertion point to just after the assistant
+# halt message is appended, which is where ``messages`` first contains
+# everything the model needs to act on the nudge.
+HALT_ANCHOR = (
+    '                    decision = agent._tool_guardrail_halt_decision\n'
+    '                    _turn_exit_reason = "guardrail_halt"\n'
+    '                    final_response = agent._toolguard_controlled_halt_response(decision)\n'
+    '                    agent._emit_status(\n'
+    '                        f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"\n'
+    '                    )\n'
+    '                    messages.append({"role": "assistant", "content": final_response})\n'
+)
+
+HALT_INSERT = '''                    # kube-agents patch: the break below jumps over the
+                    # kanban terminal-tool stop guard further down this loop, so
+                    # a worker halted here exits rc=0 having never called
+                    # kanban_complete/kanban_block and the dispatcher records an
+                    # unexplained protocol violation. Give it the turn it needs
+                    # to close its own card.
+                    # See hermes_cli/kanban_guardrail_exit.py.
+                    try:
+                        from agent.kanban_stop import build_kanban_stop_nudge
+                        from hermes_cli.kanban_guardrail_exit import (
+                            guardrail_halt_nudge as _kanban_guardrail_halt_nudge,
+                        )
+
+                        _kanban_halt_nudge = _kanban_guardrail_halt_nudge(
+                            build_kanban_stop_nudge,
+                            messages=messages,
+                            attempts=getattr(agent, "_kanban_stop_nudges", 0),
+                            decision=decision,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "kanban guardrail-halt check failed", exc_info=True
+                        )
+                        _kanban_halt_nudge = None
+
+                    if _kanban_halt_nudge:
+                        agent._kanban_stop_nudges = (
+                            getattr(agent, "_kanban_stop_nudges", 0) + 1
+                        )
+                        messages.append({
+                            "role": "user",
+                            "content": _kanban_halt_nudge,
+                            "_kanban_stop_synthetic": True,
+                        })
+                        agent._session_messages = messages
+                        # Mandatory: reset_for_turn clears the halt decision once
+                        # per turn, not per iteration. Leave it set and the next
+                        # iteration re-enters this branch and breaks anyway.
+                        agent._tool_guardrail_halt_decision = None
+                        _turn_exit_reason = "unknown"
+                        logger.info(
+                            "kanban guardrail-halt nudge issued (attempt %d) "
+                            "task=%s tool=%s code=%s",
+                            agent._kanban_stop_nudges,
+                            os.environ.get("HERMES_KANBAN_TASK", ""),
+                            decision.tool_name,
+                            decision.code,
+                        )
+                        agent._emit_status(
+                            "⚠️ Kanban worker halted by a tool guardrail — "
+                            "nudging it to finish on the board"
+                        )
+                        # Same finalizer contract as the stop guard: withhold the
+                        # halt text as this turn's answer while continuing, so a
+                        # later budget exhaustion cannot mistake it for one.
+                        _pending_verification_response = final_response
+                        _pending_verification_response_previewed = (
+                            agent._interim_content_was_streamed(final_response or "")
+                        )
+                        final_response = None
+                        continue
+
+'''
+
+FINALIZER_ANCHOR = "    # Determine if conversation completed successfully\n"
+
+FINALIZER_INSERT = '''    # kube-agents patch: the guardrail-halt break and six sibling exits
+    # (all_retries_exhausted_no_response, partial_stream_recovery,
+    # fallback_prior_turn_content, empty_response_exhausted,
+    # local_processing_error, error_near_max_iterations) all leave failed=False
+    # with no board write, so a kanban worker exits rc=0 and the dispatcher
+    # stamps an unexplained protocol violation after the fact. This is the one
+    # funnel they all pass through. Goal-mode workers are excluded — their
+    # intermediate turns end without a terminal call by design.
+    # See hermes_cli/kanban_guardrail_exit.py.
+    _kanban_task_id = os.environ.get("HERMES_KANBAN_TASK")
+    try:
+        from hermes_cli.kanban_guardrail_exit import (
+            should_record_missing_terminal as _kanban_should_record_missing,
+        )
+
+        _kanban_leaked = _kanban_should_record_missing(
+            task_id=_kanban_task_id,
+            interrupted=interrupted,
+            failed=failed,
+            iteration_limit_fallback=iteration_limit_fallback,
+        )
+    except Exception:
+        logger.debug("kanban terminal-call backstop check failed", exc_info=True)
+        _kanban_leaked = False
+
+    if _kanban_leaked:
+        try:
+            from hermes_cli import kanban_db as _kb
+            from hermes_cli.kanban_guardrail_exit import (
+                record_missing_terminal_call as _kanban_record_missing_terminal,
+            )
+
+            if _kanban_record_missing_terminal(
+                task_id=_kanban_task_id,
+                turn_exit_reason=_turn_exit_reason,
+                connect=_kb.connect,
+                record_failure=_kb._record_task_failure,
+            ):
+                logger.info(
+                    "recorded missing-terminal-call failure for task %s "
+                    "(turn_exit_reason=%s)",
+                    _kanban_task_id,
+                    _turn_exit_reason,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to record missing-terminal-call failure for task %s",
+                _kanban_task_id,
+                exc_info=True,
+            )
+
+'''
+
+# Both inserts sit next to their anchor rather than consuming it, so the anchor
+# count alone cannot tell a fresh file from an already-patched one. These
+# markers can: each appears only in the inserted text.
+EDITS = (
+    (
+        LOOP_RELATIVE,
+        "guardrail halt nudge",
+        HALT_ANCHOR,
+        HALT_ANCHOR + HALT_INSERT,
+        "_kanban_guardrail_halt_nudge",
+    ),
+    (
+        FINALIZER_RELATIVE,
+        "finalize_turn terminal-call backstop",
+        FINALIZER_ANCHOR,
+        FINALIZER_INSERT + FINALIZER_ANCHOR,
+        "_kanban_should_record_missing",
+    ),
+)
+
+
+def apply(root: Path) -> None:
+    for relative, label, anchor, patched, marker in EDITS:
+        patch = patchlib.Patch(root, relative, prefix="guardrail-exit")
+        patch.refuse_if_patched(marker)
+        patch.substitute(anchor, patched, label=label)
+        patch.commit(label)
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_notifier.py
+++ b/deploy/docker/patches/apply_kanban_notifier.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Wire gateway/kanban_notifier.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. Two anchored edits
+in ``gateway/kanban_watchers.py`` plus one import trailer, replacing what used
+to be three appliers (a Dockerfile one-liner for the clip, one for the wake
+set, one for the result delivery) with four anchors between them.
+
+The merge is possible because the clip and the delivery are adjacent. Upstream
+builds the status line in an ``if``/``elif`` and then immediately builds the
+message from it::
+
+    if payload_summary:
+        lines = payload_summary.strip().splitlines()
+        h = lines[0][:200] if lines else payload_summary[:200]
+        handoff = f"\\n{h}"
+    elif task and task.result:
+        ...
+    msg = (
+        f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
+        f" — {title}{handoff}"
+    )
+
+The old delivery applier anchored on that ``msg = (`` block purely to have
+somewhere to insert the hook *after* the clip lines, which a different patch
+owned. Owning both, this applier can end its anchor at the last ``handoff =``
+of the ``elif`` and append the hook there — so the ``msg`` block stops being an
+anchor at all. Four anchors become two, and the ordering hazard the old
+appliers documented ("it sits after the handoff lines... so this patch composes
+with those instead of fighting them for the same lines, whatever order the
+build applies them in") stops existing: one edit produces both.
+
+The output is what the three old patches produced plus one added call —
+:data:`MARKER_CALL`, which records a terminal event whose wake the narrowing
+suppressed (section 4 of ``deploy/docker/patches/kanban_notifier.py``).
+Everything else is byte-identical, comment text aside, and
+``test_kanban_notifier.py``'s ``LegacyEquivalenceTest`` still asserts that
+against a replay of the old pipeline: it subtracts :data:`MARKER_CALL` and
+requires the remainder to match exactly, so the merge stays a refactor and the
+one new behaviour stays visible as one block. Upstream's now-unused
+``lines = …`` assignments are kept rather than tidied away: they are upstream's
+code, not ours, and a patch that also edits the thing being patched cannot
+claim to be behaviour-preserving.
+
+Not merged in, deliberately:
+
+* ``gateway/kanban_handoff_clip.py`` stays a module of its own — it is a
+  dependency-free text utility that ``tools/cron_run_scope.py`` also imports,
+  and it needs to exist earlier in the build than this applier runs. It carries
+  no anchor into upstream source, so it is not part of this patch's coupling to
+  ``kanban_watchers.py``; only its *wiring* is, and that is anchor 1 here.
+* ``hermes_cli/kanban_wake_nudge.py`` also edits this file, at the watcher
+  loops' construction and sleep sites (roughly lines 191 and 1150). Those
+  anchors are disjoint from both of ours and neither applier disturbs the
+  other's text; wake_nudge runs later in the Dockerfile and appends its own
+  trailer after ours.
+
+Why the changes are needed is documented in the module docstrings of
+``deploy/docker/patches/kanban_notifier.py`` and
+``deploy/docker/patches/kanban_handoff_clip.py``. Usage::
+
+    python3 apply_kanban_notifier.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "gateway/kanban_watchers.py"
+
+#: Nesting depth of the ``completed`` branch's body.
+HANDOFF_INDENT = " " * 28
+#: Nesting depth of the post-delivery wake block, two levels shallower.
+WAKE_INDENT = " " * 24
+
+# --- Anchor 1: the completion handoff ----------------------------------------
+#
+# Covers both of upstream's hard slices (the 200-character one that severed a
+# published ledger URL down to ".../is" on 2026-08-03, and the 160-character one
+# in the no-summary branch) and ends where the hook has to go.
+
+HANDOFF_ANCHOR = (
+    f"{HANDOFF_INDENT}if payload_summary:\n"
+    f"{HANDOFF_INDENT}    lines = payload_summary.strip().splitlines()\n"
+    f"{HANDOFF_INDENT}    h = lines[0][:200] if lines else payload_summary[:200]\n"
+    f'{HANDOFF_INDENT}    handoff = f"\\n{{h}}"\n'
+    f"{HANDOFF_INDENT}elif task and task.result:\n"
+    f"{HANDOFF_INDENT}    lines = task.result.strip().splitlines()\n"
+    f"{HANDOFF_INDENT}    r = lines[0][:160] if lines else task.result[:160]\n"
+    f'{HANDOFF_INDENT}    handoff = f"\\n{{r}}"\n'
+)
+
+# Assignment, not ``+=``. In the branch that has no event summary the notifier
+# has just put a 1200-character clip of ``task.result`` into ``handoff``, and
+# the report is about to be printed in full underneath it; only something that
+# owns the whole tail can drop that clip. Appending sent the opening of a report
+# and then the report — on a 60-line cron catalogue, jobs 1 to 19 arrived twice.
+# See the comment block in gateway/kanban_notifier.py.
+HANDOFF_PATCHED = (
+    f"{HANDOFF_INDENT}# kube-agents patch: see gateway/kanban_notifier.py\n"
+    f"{HANDOFF_INDENT}if payload_summary:\n"
+    f"{HANDOFF_INDENT}    lines = payload_summary.strip().splitlines()\n"
+    f"{HANDOFF_INDENT}    h = _clip_handoff(payload_summary)\n"
+    f'{HANDOFF_INDENT}    handoff = f"\\n{{h}}"\n'
+    f"{HANDOFF_INDENT}elif task and task.result:\n"
+    f"{HANDOFF_INDENT}    lines = task.result.strip().splitlines()\n"
+    f"{HANDOFF_INDENT}    r = _clip_handoff(task.result)\n"
+    f'{HANDOFF_INDENT}    handoff = f"\\n{{r}}"\n'
+    f"{HANDOFF_INDENT}handoff = _kanban_handoff_with_result(handoff, task)\n"
+)
+
+# --- Anchor 2: the wake set ---------------------------------------------------
+
+WAKE_ANCHOR = (
+    f'{WAKE_INDENT}_WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")\n'
+    f'{WAKE_INDENT}_wake_kinds = {{ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}}\n'
+)
+
+# `adapter=` is load-bearing, not decoration: without it the narrowing also
+# applies to adapters whose send() the notifier deliberately skips, where the
+# wake IS the delivery. See wake_kinds_for's docstring.
+#
+# The marker call is the one line here that is not upstream-equivalent. It has
+# to sit at this exact point and no earlier: control only reaches the `else`
+# clause this block lives in when every text ping for the delivery has been
+# sent, which is what makes "its result was already delivered to this
+# conversation" — the claim the note makes to the creator — true. It reads
+# `_wake_kinds` to work out what the narrowing suppressed, so it must also come
+# after the line above. `self`, `task`, `sub` and `board_slug` are all already
+# in scope (the line above this anchor computes `task_terminal` from `task`,
+# and `self._kanban_unsub(sub, board_slug)` is called further down the same
+# block). See section 4 of gateway/kanban_notifier.py.
+WAKE_PATCHED = (
+    f"{WAKE_INDENT}# kube-agents patch: see gateway/kanban_notifier.py\n"
+    f'{WAKE_INDENT}_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)\n'
+    f"{WAKE_INDENT}_kanban_note_suppressed(\n"
+    f'{WAKE_INDENT}    self, d["events"], _wake_kinds, task, sub, board_slug,\n'
+    f"{WAKE_INDENT})\n"
+)
+
+#: The marker call, as emitted — the one block of :data:`WAKE_PATCHED` that the
+#: three superseded appliers had no counterpart for. Named here so
+#: ``test_kanban_notifier.py`` can subtract it and keep checking the rest of
+#: this applier's output against the legacy pipeline byte for byte.
+MARKER_CALL = "".join(WAKE_PATCHED.splitlines(keepends=True)[2:])
+
+EDITS = (
+    ("completion handoff", HANDOFF_ANCHOR, HANDOFF_PATCHED),
+    ("wake set", WAKE_ANCHOR, WAKE_PATCHED),
+)
+
+# Appended rather than inserted: unlike a `check_fn=`, these names are resolved
+# when the notifier loop runs, long after the module finishes importing. One
+# trailer for all three, which is the other half of the merge — the notifier now
+# names a single kube-agents module instead of three.
+TRAILER = (
+    "\n\n# kube-agents patch: see gateway/kanban_notifier.py\n"
+    "from gateway.kanban_notifier import (  # noqa: E402\n"
+    "    clip_handoff as _clip_handoff,\n"
+    "    handoff_with_result as _kanban_handoff_with_result,\n"
+    "    note_suppressed_completion as _kanban_note_suppressed,\n"
+    "    wake_kinds_for as _wake_kinds_for,\n"
+    ")\n"
+)
+
+#: Text that only exists after a successful run. Both anchors are destroyed by
+#: their own replacement, so a re-run would already fail on "found 0" — but that
+#: message blames upstream drift for what is actually a duplicated build step,
+#: and before the old delivery applier grew this guard a second pass exited 0
+#: and left a second hook call and a second trailer import behind.
+SENTINELS = (
+    "handoff = _kanban_handoff_with_result(handoff, task)",
+    '_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)',
+    "_kanban_note_suppressed(",
+)
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban_notifier")
+    patch.refuse_if_patched(*SENTINELS)
+    for label, anchor, patched in EDITS:
+        patch.substitute(anchor, patched, label=label)
+    patch.append(TRAILER)
+    patch.commit(f"{len(EDITS)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_result_required.py
+++ b/deploy/docker/patches/apply_kanban_result_required.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Wire tools/kanban_result_required.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. Two edits: the
+completion gate, and an import/schema-fixup block placed immediately before
+``kanban_complete`` is registered.
+
+The schema wording is NOT edited textually — ``apply_schema`` rewrites the live
+``KANBAN_COMPLETE_SCHEMA`` dict at import time. Placing the call before
+``registry.register`` rather than at end-of-file means the registry cannot
+capture the pre-patch wording even if it copies the dict it is handed.
+
+The gate is a literal anchor because the text being replaced *is* the edit. The
+registration is not: it is only an insertion point, and the four-line slice that
+used to name it (``registry.register(``, then ``name=``, ``toolset=``,
+``schema=``, because ``registry.register(\\n    name=`` recurs for every kanban
+tool) was pure layout. ``find_call`` asks for the statement that registers
+``kanban_complete`` instead, which is the same requirement stated in a way an
+upstream reformat cannot break, and ``expect`` keeps the ``schema=`` assertion
+the old anchor's fourth line was really there for.
+
+Why the change is needed is documented in the module docstring of
+``deploy/docker/patches/kanban_result_required.py``. Usage::
+
+    python3 apply_kanban_result_required.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import patchlib  # noqa: E402
+from kanban_result_required import NEW_GATE, OLD_GATE  # noqa: E402
+
+RELATIVE = "tools/kanban_tools.py"
+
+#: The tool whose registration the fixup has to precede.
+REGISTERED_TOOL = "kanban_complete"
+
+# Imported at module scope so ``apply_schema`` runs while the module is still
+# importing — before any tool call and before the registry hands the schema to a
+# model. ``_require_result`` and ``_blank_to_none`` are resolved later, when a
+# worker actually completes.
+REGISTER_PREAMBLE = (
+    "# kube-agents patch: see tools/kanban_result_required.py\n"
+    "from tools.kanban_result_required import (\n"
+    "    apply_schema as _apply_result_schema,\n"
+    "    blank_to_none as _blank_to_none,\n"
+    "    require_result as _require_result,\n"
+    ")\n"
+    "\n"
+    "_apply_result_schema(KANBAN_COMPLETE_SCHEMA)\n"
+    "\n"
+)
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban_result_required")
+
+    patch.substitute(OLD_GATE, NEW_GATE, label="gate")
+
+    site = patch.find_call(
+        "registry.register",
+        label=f"{REGISTERED_TOOL} registration",
+        name=REGISTERED_TOOL,
+    )
+    # The schema constant is not decoration here: `_apply_result_schema` is
+    # inserted to rewrite this exact dict, and a registration that had been
+    # rewired to a different one would leave the fixup editing nothing.
+    site.expect(toolset="kanban", schema=patchlib.Ident("KANBAN_COMPLETE_SCHEMA"))
+    patch.insert(site.start, REGISTER_PREAMBLE)
+
+    patch.commit("1 anchor + 1 registration")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_scheduling.py
+++ b/deploy/docker/patches/apply_kanban_scheduling.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Wire the kanban scheduling repairs into ``hermes_cli/kanban_db.py``.
+
+Six anchored edits in one file plus a single import trailer. All six used to be
+three separate appliers (``apply_kanban_dependency_repair``,
+``apply_kanban_claim_fencing``, ``apply_kanban_breaker_counter``) rewriting the
+same source in sequence, each with its own idempotency story and two of them
+with their own trailer. They are merged because the file is the unit of risk: an
+anchor invalidated by a Hermes bump has to be re-derived against whatever the
+other five edits left behind, and that is only checkable when they are applied
+together and gated together. Behaviour is unchanged by the merge itself; the
+discriminator in edit 2 is the one deliberate behaviour change, and it is
+documented in ``kanban_scheduling.py``.
+
+    1. ``block_task`` dependency branch — call ``repair_inverted_dependencies``
+       immediately before the ``dependency_wait`` event. That point is only
+       reached once the status UPDATE has taken (``cur.rowcount != 1`` returns
+       early above it), so a block that was a no-op never touches the link
+       graph.
+    2. ``detect_crashed_workers`` head — sweep dead owners' claims back to
+       ``ready`` first, then adjudicate worker PIDs only for claims this exact
+       process made, rather than for anything sharing the pod name. The sweep is
+       handed ``_resolve_crash_grace_seconds`` so it applies the same
+       launch-window grace as the per-row loop it runs ahead of.
+    3. ``detect_crashed_workers`` tail — charge the swept cards the sweep
+       classified as faults, after its transaction has closed and outside the
+       ``crash_details`` fingerprint pass.
+    4. ``_record_task_failure`` trip branch — persist the exhausted budget
+       rather than the raw attempt count.
+    5. ``_record_task_failure`` spawn-path bind — use the floored value.
+    6. ``_record_task_failure`` crash-path bind — use the floored value.
+
+Edits 2 and 3 must stay ordered before 4-6 for reading rather than for
+correctness: the fence decides which cards reach the breaker at all, and the
+charge it adds is a caller of the very function 4-6 rewrite. The anchors do not
+overlap.
+
+``_error_fingerprint`` IS NOT PATCHED, and that is a decision rather than an
+omission. An earlier version replaced upstream's
+``re.sub(r'\\bpid \\d+\\b', 'pid N', ...)`` with a bare ``error_text[:80]``. Every
+error text that reaches the fingerprint is built by ``detect_crashed_workers``
+itself and every one of them is PID-prefixed, so keeping the PID gave each
+worker its own bucket, ``_fp_counts`` could never reach the ``>= 3`` the
+systemic heuristic tests, and the detector that halts a board where everything
+is failing identically stopped firing at all. Edit 2 removes the cause that edit
+was reaching for.
+
+The other three ``host_prefix`` comparisons (``release_stale_claims``,
+``_terminate_worker``, ``enforce_max_runtime``) are deliberately left alone.
+Narrowing them is not locally safe: ``_terminate_worker`` reports
+``host_local: False`` by returning a never-attempted termination, which
+``_worker_survived_termination`` then has to interpret, and
+``release_stale_claims`` uses the same flag to choose between extending and
+reclaiming. Edit 2 makes those paths near-unreachable for foreign claims anyway
+— dead owners are handed back long before their 900s TTL — and the 1-hour
+``last_heartbeat_at`` backstop still bounds the residual PID-collision case.
+
+WHY EDITS 4-6 EXIST (the breaker counter)
+
+``dispatch_once`` runs ``detect_crashed_workers`` and then, twenty lines later,
+``recompute_ready(conn, failure_limit=failure_limit)``. Those two functions each
+decide whether a card is over its retry budget, and they do not use the same
+threshold.
+
+``_record_task_failure`` trips on ``if force_trip or failures >= effective_limit``
+and persists ``consecutive_failures = old + 1`` -- the raw attempt count. Two
+callers reach that branch with a threshold the dispatcher never sees:
+
+* the clean-exit protocol-violation path passes ``force_trip=True`` after
+  adjudicating its own violation streak against ``_PROTOCOL_VIOLATION_FAILURE_LIMIT``
+  (3, or the card's ``max_retries``). A below-budget violation deliberately does
+  not tick the unified counter, so a card arriving here normally has
+  ``consecutive_failures == 0`` and leaves with 1.
+* the systemic same-error path passes ``failure_limit=1``, so it trips at 1.
+
+``recompute_ready`` then re-derives the verdict from ``consecutive_failures``
+alone, against ``max_retries`` or the dispatcher's ``failure_limit`` (2 by
+default), sees 1 < 2, and executes ``UPDATE tasks SET status = 'ready'`` plus a
+``promoted`` event. The next lines of the same ``dispatch_once`` claim and spawn
+the card. The block lasts zero ticks: a policy reading "stop after 3 protocol
+violations and hand to a human" actually stops after 4.
+
+It does not add a second source of truth. The obvious fix -- have
+``recompute_ready`` read the ``gave_up`` event the breaker just wrote -- was
+built and rejected: ``assign_task`` zeroes ``consecutive_failures`` on a profile
+change (its comment calls reassignment "an explicit recovery action") and emits
+kind ``assigned``, not ``unblocked``, without changing status. An event-stickiness
+fix short-circuits on the event before the zeroed counter is consulted and pins
+the reassigned card in ``blocked`` forever. It also has to ``json.loads`` a
+nullable ``payload`` column inside a write transaction, and to treat
+``task_events.id`` as a durable clock that ``_rebuild_drifted_tables``
+reassigns.
+
+Instead: keep the counter as the single source of truth and store the right
+number in it. When the breaker trips, the budget IS exhausted, so persist the
+exhausted budget rather than the raw attempt count -- the threshold the trip was
+decided against, and, when there is no per-task override, never below
+``DEFAULT_FAILURE_LIMIT``, which is the floor of what the reader will test.
+
+Because the counter stays the arbiter, every counter-zeroing recovery path keeps
+working untouched: ``unblock_task``, ``complete_task`` via
+``_clear_failure_counter``, ``assign_task`` when it changes the assignee, and
+``reassign_task``. (``reclaim_task`` is NOT one of them and never was -- it
+bails unless the card is ``running`` or still holds a ``claim_lock``, and the
+trip cleared both.) Note that ``assign_task`` to the SAME profile is a no-op on
+the counter, so post-patch it no longer frees a tripped card; reassign to a
+different profile, or use ``hermes kanban unblock``. A card blocked purely by a
+parent dependency never trips, so it still auto-recovers. ``gave_up`` does not
+become sticky.
+
+The ``gave_up`` payload is not touched: ``payload["failures"]`` still reports the
+true attempt count. Reconstructing the stored counter from that payload needs
+the floor too, because the floor is invisible in it::
+
+    stored = max(failures, effective_limit)                    # limit_source == "task"
+    stored = max(failures, effective_limit, DEFAULT_FAILURE_LIMIT)   # otherwise
+
+``limit_source == "task"`` is exactly ``task_override is not None``. A systemic
+trip is the arm that makes the naive one-line formula wrong: it stores 2 while
+its payload says ``{"failures": 1, "effective_limit": 1}``.
+
+KNOWN LIMIT: ``detect_crashed_workers`` never sees the dispatcher's configured
+``failure_limit``, so the floor makes the two derivations agree under the shipped
+configuration (``kanban.failure_limit`` unset, ``DEFAULT_FAILURE_LIMIT = 2``).
+Raise it and the trips become revertible again in order: a systemic trip (stored
+2) once ``kanban.failure_limit`` exceeds 2, and a protocol trip (stored 3) once
+it exceeds 3. Closing that needs the limit plumbed into
+``detect_crashed_workers``, which is a larger change to the function edits 2 and
+3 already touch.
+
+BEHAVIOUR CHANGE: a card that carries a breaker trip AND an undone parent no
+longer auto-promotes when the parent completes. That is the same guard #35072
+already applies to normally-tripped cards; a force-tripped card is by definition
+one whose budget was declared exhausted. Expect more cards to sit in ``blocked``
+awaiting a human. ``kanban_diagnostics._rule_repeated_failures`` (threshold 3)
+surfaces the protocol-violation case.
+
+COMPATIBILITY WITH ``apply_kanban_wake_nudge``
+
+That patch edits this same file, at ``create_task``, ``complete_task`` and
+``unblock_task``, and runs after this one. None of the six anchors here fall in
+those functions and none of the replacement text contains any of its three
+anchor strings, so this applier neither consumes nor invalidates them.
+``test_kanban_scheduling.py`` asserts that rather than leaving it to inspection,
+because the coupling is invisible from either file alone.
+
+Usage::
+
+    python3 apply_kanban_scheduling.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "hermes_cli/kanban_db.py"
+
+# Build marker the Dockerfile greps for after the breaker edits.
+BUILD_MARKER = "persisted_failures = max(failures, effective_limit)"
+
+# Written by every successful apply and by nothing else. Checked before any
+# edit, because three of the six anchors survive their own replacement (the
+# patched text keeps the anchor and inserts around it), so counting alone waves
+# a re-run straight through: replayed against the running gateway's kanban_db.py
+# the unguarded dependency applier exited 0 three times and left three copies of
+# the call and three trailer imports behind.
+ALREADY_PATCHED = (
+    "from hermes_cli.kanban_scheduling import",
+    "_kanban_repair_inverted_deps(conn, task_id, reason)",
+)
+
+# --- 1. block_task: repair inverted fan-out edges before declaring the wait ---
+
+DEPENDENCY_ANCHOR = (
+    '            _append_event(\n'
+    '                conn, task_id, "dependency_wait",\n'
+    '                {"reason": reason, "kind": kind}, run_id=run_id,\n'
+)
+
+DEPENDENCY_PATCHED = (
+    '            # kube-agents patch: a card that waits on cards which list *it*\n'
+    '            # as their parent has deadlocked — claim_task refuses them until\n'
+    '            # this card is done, and this card is waiting on them. Invert\n'
+    '            # those edges so they dispatch now and this card resumes when\n'
+    '            # they finish. See hermes_cli/kanban_scheduling.py.\n'
+    '            _kanban_repair_inverted_deps(conn, task_id, reason)\n'
+) + DEPENDENCY_ANCHOR
+
+# --- 2. detect_crashed_workers: fence the liveness check to this process ------
+
+FENCE_ANCHOR = (
+    '        rows = conn.execute(\n'
+    '            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "\n'
+    '            "WHERE status = \'running\' AND worker_pid IS NOT NULL"\n'
+    '        ).fetchall()\n'
+    '        host_prefix = f"{_claimer_id().split(\':\', 1)[0]}:"\n'
+    '        for row in rows:\n'
+    '            # Only check liveness for claims owned by this host.\n'
+    '            lock = row["claim_lock"] or ""\n'
+    '            if not lock.startswith(host_prefix):\n'
+    '                continue\n'
+)
+
+FENCE_PATCHED = (
+    '        # kube-agents patch: under Kubernetes the host half of the claim\n'
+    '        # token is the pod name, so it survives a container restart even\n'
+    '        # though every process that wrote it is gone. Hand back whatever a\n'
+    '        # dead owner still holds, then adjudicate PIDs only for claims this\n'
+    '        # exact process made. The sweep gets the same launch-window grace\n'
+    '        # period as the per-row loop below; what it hands back is split into\n'
+    '        # faults and infrastructure and charged after this transaction\n'
+    '        # closes. See hermes_cli/kanban_scheduling.py.\n'
+    '        _kanban_claimer = _claimer_id()\n'
+    '        _kanban_reclaimed = _kanban_release_dead_foreign_claims(\n'
+    '            conn, _kanban_claimer, _pid_alive, _resolve_crash_grace_seconds\n'
+    '        )\n'
+    '        rows = conn.execute(\n'
+    '            "SELECT id, worker_pid, claim_lock, started_at FROM tasks "\n'
+    '            "WHERE status = \'running\' AND worker_pid IS NOT NULL"\n'
+    '        ).fetchall()\n'
+    '        for row in rows:\n'
+    '            # Only check liveness for claims made by this process life.\n'
+    '            lock = row["claim_lock"] or ""\n'
+    '            if not _kanban_claim_is_self(lock, _kanban_claimer):\n'
+    '                continue\n'
+)
+
+# --- 3. detect_crashed_workers: charge the reclaims that are faults -----------
+#
+# The tail of the function: past the ``crash_details`` accounting loop, so
+# ``auto_blocked`` exists and the sweep's transaction is long closed, and before
+# the side-channel stash that publishes it to ``dispatch_once``.
+CHARGE_ANCHOR = (
+    "    # Stash auto-blocked ids on the function for the dispatch loop to pick up.\n"
+)
+
+CHARGE_PATCHED = (
+    "    # kube-agents patch: a card the sweep handed back ran and produced\n"
+    "    # nothing, which is a failed run whoever's claim died -- and left\n"
+    "    # uncharged it is an unbounded one, because a card that kills the\n"
+    "    # dispatcher is reclaimed by the replacement process and dispatched\n"
+    "    # again with its counter still at zero. Only ``chargeable`` is spent:\n"
+    "    # the sweep forgives a release whose owner was a pod Kubernetes\n"
+    "    # replaced, so an ordinary rollout does not cost every in-flight card a\n"
+    "    # retry. Charged here rather than inside the sweep because\n"
+    "    # ``_record_task_failure`` opens its own ``write_txn``, and in its own\n"
+    "    # loop rather than as ``crash_details`` entries because one event\n"
+    "    # releases every in-flight card with one identical error text, which the\n"
+    "    # fingerprint pass above would read as systemic and abandon.\n"
+    "    # See hermes_cli/kanban_scheduling.py.\n"
+    "    auto_blocked.extend(\n"
+    "        _kanban_charge_reclaimed_cards(\n"
+    "            conn, _kanban_reclaimed.chargeable, _record_task_failure\n"
+    "        )\n"
+    "    )\n"
+    "    # Stash auto-blocked ids on the function for the dispatch loop to pick up.\n"
+)
+
+# --- 4. _record_task_failure: store the exhausted budget, not the attempt -----
+
+TRIP_ANCHOR = (
+    "        if force_trip or failures >= effective_limit:\n"
+    "            # Trip the breaker.\n"
+)
+
+TRIP_PATCHED = (
+    "        if force_trip or failures >= effective_limit:\n"
+    "            # Trip the breaker.\n"
+    "            # kube-agents patch: persist the exhausted budget, not the raw\n"
+    "            # attempt count. ``recompute_ready`` re-derives this same verdict\n"
+    "            # from ``consecutive_failures`` alone, against its own limit, and\n"
+    "            # promotes the card straight back to ``ready`` in the same\n"
+    "            # ``dispatch_once`` tick whenever the stored count is below that\n"
+    "            # limit -- which is exactly what a ``force_trip`` (protocol\n"
+    "            # violation, decided against its own streak) or a caller-lowered\n"
+    "            # ``failure_limit`` (systemic crash, 1) leaves behind. Flooring\n"
+    "            # the stored counter at the threshold this trip was decided\n"
+    "            # against makes the two derivations agree with no new state, and\n"
+    "            # keeps the counter the single arbiter -- so every path that\n"
+    "            # zeroes it (unblock_task, complete_task, reassign_task, and\n"
+    "            # assign_task to a DIFFERENT profile) still releases the card.\n"
+    "            # reclaim_task does not: it bails unless the card is running or\n"
+    "            # still holds a claim_lock, and the trip cleared both.\n"
+    "            # See deploy/docker/patches/apply_kanban_scheduling.py.\n"
+    "            persisted_failures = max(failures, effective_limit)\n"
+    "            if task_override is None:\n"
+    "                # No per-task override, so the reader resolves against the\n"
+    "                # dispatcher's limit, whose shipped value is the module\n"
+    "                # default. Never store below it.\n"
+    "                persisted_failures = max(\n"
+    "                    persisted_failures, DEFAULT_FAILURE_LIMIT\n"
+    "                )\n"
+)
+
+# --- 5. the spawn-failure branch bind tuple -----------------------------------
+#
+# The bind line alone occurs four times in the function (two in this blocked
+# branch, two in the below-threshold branch that must keep the raw count), so
+# the preceding WHERE clause is load-bearing for uniqueness -- it is what
+# distinguishes this branch from its sibling.
+SPAWN_BIND_ANCHOR = (
+    "                    \"WHERE id = ? AND status IN ('running', 'ready')\",\n"
+    "                    (failures, error[:500], task_id),\n"
+)
+
+SPAWN_BIND_PATCHED = (
+    "                    \"WHERE id = ? AND status IN ('running', 'ready')\",\n"
+    "                    (persisted_failures, error[:500], task_id),\n"
+)
+
+# --- 6. the timeout/crash branch bind tuple -----------------------------------
+
+CRASH_BIND_ANCHOR = (
+    "                    \"WHERE id = ? AND status IN ('ready', 'running')\",\n"
+    "                    (failures, error[:500], task_id),\n"
+)
+
+CRASH_BIND_PATCHED = (
+    "                    \"WHERE id = ? AND status IN ('ready', 'running')\",\n"
+    "                    (persisted_failures, error[:500], task_id),\n"
+)
+
+TRAILER = (
+    "\n\n# kube-agents patch: see hermes_cli/kanban_scheduling.py\n"
+    "from hermes_cli.kanban_scheduling import (  # noqa: E402\n"
+    "    charge_reclaimed_cards as _kanban_charge_reclaimed_cards,\n"
+    "    claim_is_self as _kanban_claim_is_self,\n"
+    "    release_dead_foreign_claims as _kanban_release_dead_foreign_claims,\n"
+    "    repair_inverted_dependencies as _kanban_repair_inverted_deps,\n"
+    ")\n"
+)
+
+EDITS = (
+    ("block_task dependency repair", DEPENDENCY_ANCHOR, DEPENDENCY_PATCHED),
+    ("detect_crashed_workers fence", FENCE_ANCHOR, FENCE_PATCHED),
+    ("reclaim charging", CHARGE_ANCHOR, CHARGE_PATCHED),
+    ("_record_task_failure trip floor", TRIP_ANCHOR, TRIP_PATCHED),
+    ("spawn-path blocked bind", SPAWN_BIND_ANCHOR, SPAWN_BIND_PATCHED),
+    ("crash-path blocked bind", CRASH_BIND_ANCHOR, CRASH_BIND_PATCHED),
+)
+
+
+def apply(root: Path) -> None:
+    """Apply all six edits under ``root``, or raise SystemExit with the reason.
+
+    Nothing is written until every anchor has matched exactly once and the
+    result parses, so a Hermes bump that moves one anchor leaves the file
+    untouched rather than half-patched.
+    """
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban-scheduling")
+    patch.refuse_if_patched(*ALREADY_PATCHED)
+    for label, anchor, patched in EDITS:
+        patch.substitute(anchor, patched, label=label)
+    patch.append(TRAILER)
+    patch.commit(f"{len(EDITS)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_wake_nudge.py
+++ b/deploy/docker/patches/apply_kanban_wake_nudge.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Wire hermes_cli/kanban_wake_nudge.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. Seven anchored
+edits across two files plus an import trailer on each:
+
+``hermes_cli/kanban_db.py`` — the producers. One nudge after each commit that
+gives a watcher something to do:
+
+1. ``create_task`` — after the insert txn exits (a claimable card exists).
+2. ``complete_task`` — after ``recompute_ready``, so the nudge also covers
+   children the completion just promoted.
+3. ``unblock_task`` — the upstream ``return True`` sits *inside* the write
+   txn (returning through the context manager commits first), so the edit
+   dedents it out: txn exits → commit → nudge → return. The early
+   ``return False`` path is untouched.
+
+``gateway/kanban_watchers.py`` — the consumers. Per watcher loop, one
+``WakeMonitor`` constructed where the loop starts (passed
+``_kb.kanban_db_path`` uncalled, so resolution failures degrade the monitor
+instead of killing the coroutine), and the fixed sleep swapped for
+``wait_interval``:
+
+4. notifier monitor construction        5. notifier sleep swap
+6. dispatcher monitor construction      7. dispatcher sleep swap
+
+Deliberately NOT hooked: ``claim_task``, ``heartbeat_claim``, and the rest of
+what a dispatcher tick writes — nudging on those would let the dispatcher
+wake itself into a busy loop.
+
+Why the change is needed is documented in the module docstring of
+``deploy/docker/patches/kanban_wake_nudge.py``. Usage::
+
+    python3 apply_kanban_wake_nudge.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+DB_RELATIVE = "hermes_cli/kanban_db.py"
+WATCHERS_RELATIVE = "gateway/kanban_watchers.py"
+
+# --- hermes_cli/kanban_db.py -------------------------------------------------
+
+CREATE_ANCHOR = (
+    "                _inherit_notify_subs(conn, task_id, parents, created_at=now)\n"
+    "            return task_id\n"
+)
+
+CREATE_PATCHED = (
+    "                _inherit_notify_subs(conn, task_id, parents, created_at=now)\n"
+    "            # kube-agents patch: the txn above just committed a claimable\n"
+    "            # card; nudge the dispatcher so it reacts now, not next tick.\n"
+    "            # See hermes_cli/kanban_wake_nudge.py.\n"
+    "            _kanban_record_wake(conn)\n"
+    "            return task_id\n"
+)
+
+COMPLETE_ANCHOR = (
+    "    # Recompute ready status for dependents (separate txn so children see done).\n"
+    "    recompute_ready(conn)\n"
+)
+
+COMPLETE_PATCHED = (
+    "    # Recompute ready status for dependents (separate txn so children see done).\n"
+    "    recompute_ready(conn)\n"
+    "    # kube-agents patch: completion and any child promotion are committed;\n"
+    "    # nudge the watchers so the notifier delivers and the dispatcher claims\n"
+    "    # dependents now, not next tick. See hermes_cli/kanban_wake_nudge.py.\n"
+    "    _kanban_record_wake(conn)\n"
+)
+
+UNBLOCK_ANCHOR = (
+    "        _append_event(\n"
+    '            conn, task_id, "unblocked",\n'
+    '            {"status": new_status} if new_status != "ready" else None,\n'
+    "        )\n"
+    "        return True\n"
+)
+
+UNBLOCK_PATCHED = (
+    "        _append_event(\n"
+    '            conn, task_id, "unblocked",\n'
+    '            {"status": new_status} if new_status != "ready" else None,\n'
+    "        )\n"
+    "    # kube-agents patch: the return is dedented out of the write txn so the\n"
+    "    # nudge runs after the commit, not inside it — a watcher woken mid-txn\n"
+    "    # would scan pre-commit state and burn the edge for nothing.\n"
+    "    # See hermes_cli/kanban_wake_nudge.py.\n"
+    "    _kanban_record_wake(conn)\n"
+    "    return True\n"
+)
+
+DB_TRAILER = (
+    "\n\n# kube-agents patch: see hermes_cli/kanban_wake_nudge.py\n"
+    "from hermes_cli.kanban_wake_nudge import (  # noqa: E402\n"
+    "    record_wake_for_conn as _kanban_record_wake,\n"
+    ")\n"
+)
+
+# --- gateway/kanban_watchers.py ----------------------------------------------
+
+NOTIFIER_MONITOR_ANCHOR = (
+    "        # Initial delay so the gateway can finish wiring adapters.\n"
+    "        await asyncio.sleep(5)\n"
+    "\n"
+    "        while self._running:\n"
+)
+
+NOTIFIER_MONITOR_PATCHED = (
+    "        # Initial delay so the gateway can finish wiring adapters.\n"
+    "        await asyncio.sleep(5)\n"
+    "\n"
+    "        # kube-agents patch: cross-process wake monitor, one per watcher\n"
+    "        # loop. See hermes_cli/kanban_wake_nudge.py.\n"
+    "        _wake_monitor = _KanbanWakeMonitor(_kb.kanban_db_path)\n"
+    "        while self._running:\n"
+)
+
+NOTIFIER_SLEEP_ANCHOR = (
+    "            # Sleep with cancellation checks.\n"
+    "            for _ in range(int(max(1, interval))):\n"
+    "                if not self._running:\n"
+    "                    return\n"
+    "                await asyncio.sleep(1)\n"
+)
+
+NOTIFIER_SLEEP_PATCHED = (
+    "            # kube-agents patch: wake-aware wait — reacts to a board\n"
+    "            # mutation in <=0.25s, degrades to the full-interval poll when\n"
+    "            # the wake file is unavailable, and returns False on shutdown\n"
+    "            # exactly where the old loop returned.\n"
+    "            # See hermes_cli/kanban_wake_nudge.py.\n"
+    "            if not await _kanban_wait_interval(\n"
+    "                _wake_monitor, interval, lambda: self._running\n"
+    "            ):\n"
+    "                return\n"
+)
+
+DISPATCHER_MONITOR_ANCHOR = (
+    "        logger.info(\n"
+    '            "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval\n'
+    "        )\n"
+    "        while self._running:\n"
+)
+
+DISPATCHER_MONITOR_PATCHED = (
+    "        logger.info(\n"
+    '            "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval\n'
+    "        )\n"
+    "        # kube-agents patch: cross-process wake monitor, one per watcher\n"
+    "        # loop. See hermes_cli/kanban_wake_nudge.py.\n"
+    "        _wake_monitor = _KanbanWakeMonitor(_kb.kanban_db_path)\n"
+    "        while self._running:\n"
+)
+
+DISPATCHER_SLEEP_ANCHOR = (
+    "            # Sleep in 1s slices so shutdown is snappy — otherwise a stop()\n"
+    "            # waits up to `interval` seconds for the current sleep to finish.\n"
+    "            slept = 0.0\n"
+    "            while slept < interval and self._running:\n"
+    "                await asyncio.sleep(min(1.0, interval - slept))\n"
+    "                slept += 1.0\n"
+)
+
+DISPATCHER_SLEEP_PATCHED = (
+    "            # kube-agents patch: wake-aware wait; still checks self._running\n"
+    "            # before every slice so shutdown stays snappy.\n"
+    "            # See hermes_cli/kanban_wake_nudge.py.\n"
+    "            await _kanban_wait_interval(\n"
+    "                _wake_monitor, interval, lambda: self._running\n"
+    "            )\n"
+)
+
+WATCHERS_TRAILER = (
+    "\n\n# kube-agents patch: see hermes_cli/kanban_wake_nudge.py\n"
+    "from hermes_cli.kanban_wake_nudge import (  # noqa: E402\n"
+    "    WakeMonitor as _KanbanWakeMonitor,\n"
+    "    wait_interval as _kanban_wait_interval,\n"
+    ")\n"
+)
+
+FILES = (
+    (
+        DB_RELATIVE,
+        (
+            ("create_task nudge", CREATE_ANCHOR, CREATE_PATCHED),
+            ("complete_task nudge", COMPLETE_ANCHOR, COMPLETE_PATCHED),
+            ("unblock_task nudge", UNBLOCK_ANCHOR, UNBLOCK_PATCHED),
+        ),
+        DB_TRAILER,
+    ),
+    (
+        WATCHERS_RELATIVE,
+        (
+            ("notifier monitor", NOTIFIER_MONITOR_ANCHOR, NOTIFIER_MONITOR_PATCHED),
+            ("notifier sleep", NOTIFIER_SLEEP_ANCHOR, NOTIFIER_SLEEP_PATCHED),
+            ("dispatcher monitor", DISPATCHER_MONITOR_ANCHOR, DISPATCHER_MONITOR_PATCHED),
+            ("dispatcher sleep", DISPATCHER_SLEEP_ANCHOR, DISPATCHER_SLEEP_PATCHED),
+        ),
+        WATCHERS_TRAILER,
+    ),
+)
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    for relative, edits, trailer in FILES:
+        patch = patchlib.Patch(root, relative, prefix="kanban_wake_nudge")
+        for label, anchor, patched in edits:
+            patch.substitute(anchor, patched, label=label)
+        patch.append(trailer)
+        patch.commit(f"{len(edits)} anchors")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_kanban_worker_tools.py
+++ b/deploy/docker/patches/apply_kanban_worker_tools.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Wire tools/kanban_worker_tools.py into the Hermes source tree.
+
+Run by ``deploy/docker/Dockerfile`` against ``/opt/hermes``. Eight edits in one
+file — an import plus one ``check_fn`` per worker-only tool — with the same
+guarantee as the other patches here: every edit site must be found exactly once,
+the file must still parse, and anything else fails the build loudly rather than
+shipping a half-patched image.
+
+**Located by AST, not by literal anchors.** Every site here is a node with a
+name: the ``registry.register`` call that registers ``kanban_complete``, the
+``def`` the import has to land after. This applier used to spell each of those
+out as an exact slice of upstream source — five lines per tool, seven tools —
+which meant the registration block was the single largest concentration of
+literal anchors in the tree, and reformatting it (or adding one keyword
+argument, or reordering two) would have broken the build on eight of them at
+once. Eight anchors became one locator apiece and none of them care about
+layout.
+
+What the anchors *were* doing besides finding the call is preserved:
+``expect()`` re-asserts the toolset, schema and handler that the five-line slice
+used to pin, so a tool upstream has rewired underneath us still fails the build
+instead of being silently re-gated. See ``patchlib.CallSite.expect``.
+
+Why the change is needed is documented in the module docstring of
+``deploy/docker/patches/kanban_worker_tools.py``. Usage::
+
+    python3 apply_kanban_worker_tools.py [HERMES_ROOT]   # default /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+from kanban_worker_tools import WORKER_ONLY_TOOLS
+
+RELATIVE = "tools/kanban_tools.py"
+
+# The import lands after this function rather than at the end of the file the
+# way the kanban_notifier patch does. `check_fn=` is evaluated at import time,
+# several hundred lines above the end of the module, so a trailing import would
+# raise NameError before it ever ran. `_check_kanban_orchestrator_mode` is the
+# last definition above the registration block that this patch has a reason to
+# name — it is the gate `check_kanban_worker_mode` mirrors.
+IMPORT_AFTER = "_check_kanban_orchestrator_mode"
+
+IMPORT_BLOCK = (
+    "\n\n"
+    "# kube-agents patch: see tools/kanban_worker_tools.py\n"
+    "from tools.kanban_worker_tools import (\n"
+    "    check_kanban_worker_mode as _check_kanban_worker_mode,\n"
+    ")\n"
+)
+
+#: The gate upstream ships on every one of these tools, and the one this patch
+#: swaps it for. Asserting the old value is what makes a second run fail.
+UPSTREAM_CHECK_FN = "_check_kanban_mode"
+WORKER_CHECK_FN = "_check_kanban_worker_mode"
+
+# Handler name per tool. Once part of the anchor text; now an expectation, so
+# that a renamed handler fails with "sets handler=X where Y was expected"
+# rather than disappearing into a "found 0".
+HANDLERS = {
+    "kanban_complete": "_handle_complete",
+    "kanban_block": "_handle_block",
+    "kanban_heartbeat": "_handle_heartbeat",
+    "kanban_link": "_handle_link",
+    "kanban_attach": "_handle_attach",
+    "kanban_attach_url": "_handle_attach_url",
+    "kanban_attachments": "_handle_attachments",
+}
+
+
+def registration_expectations(tool: str) -> dict:
+    """The arguments a worker-only ``registry.register`` call must still pass."""
+    return {
+        "toolset": "kanban",
+        "schema": patchlib.Ident(f"{tool.upper()}_SCHEMA"),
+        "handler": patchlib.Ident(HANDLERS[tool]),
+        "check_fn": patchlib.Ident(UPSTREAM_CHECK_FN),
+    }
+
+
+def check_handler_mapping() -> None:
+    """Refuse to run if this applier and kanban_worker_tools.py have drifted."""
+    missing = set(WORKER_ONLY_TOOLS) - set(HANDLERS)
+    if missing:
+        raise SystemExit(
+            "kanban_worker_tools patch: no handler mapping for "
+            f"{', '.join(sorted(missing))} — kanban_worker_tools.py and this "
+            "applier have drifted apart."
+        )
+
+
+def apply(root: Path) -> None:
+    """Apply every edit under ``root``, or raise SystemExit with the reason."""
+    check_handler_mapping()
+    patch = patchlib.Patch(root, RELATIVE, prefix="kanban_worker_tools")
+
+    gate = patch.find_def(IMPORT_AFTER, label="worker-gate import site")
+    patch.insert(gate.after, IMPORT_BLOCK)
+
+    for tool in WORKER_ONLY_TOOLS:
+        site = patch.find_call(
+            "registry.register", label=f"{tool} registration", name=tool
+        )
+        site.expect(**registration_expectations(tool))
+        start, end = site.keyword_span("check_fn")
+        patch.splice(start, end, WORKER_CHECK_FN)
+
+    patch.commit(f"1 import + {len(WORKER_ONLY_TOOLS)} registrations")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/apply_mcp_remote_forward_errors.py
+++ b/deploy/docker/patches/apply_mcp_remote_forward_errors.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Make mcp-remote answer the client when a forward to the remote fails.
+
+Run by ``deploy/docker/Dockerfile`` against the mcp-remote clone, after
+``npm install`` and before ``npm run build``.
+
+``mcpProxy`` forwards every client message with::
+
+    transportToServer.send(message).catch(onServerError)
+
+and ``onServerError`` only logs. ``message.id`` is not even in scope there, so a
+rejected forward can never be answered: the local client is left waiting on a
+request id that will never come back, and it parks until its own deadline. The
+sibling ``ignoredTools`` path thirty lines above gets this right — it builds a
+JSON-RPC error and calls ``transportToClient.send`` — because ``request.id`` is
+in scope. This patch gives the failure path the same treatment.
+
+The trigger in production is a non-2xx HTTP status. The MCP SDK's
+``StreamableHTTPClientTransport.send`` throws on ``!response.ok`` and discards
+the body, even when that body is a perfectly good JSON-RPC message; the SDK
+*rejects the send promise*, which a direct SDK client surfaces in milliseconds.
+It is mcp-remote swallowing that rejection that turns a fast error into a hang.
+
+Measured on task t_b9544b00: ``mcp__gke__list_clusters`` was called with
+``parent="projects/-/locations/-"``. ``container.googleapis.com/mcp`` answered
+HTTP 403 carrying ``{"id":2,"jsonrpc":"2.0","result":{"content":[{"text":
+"Permission denied on resource project -.","type":"text"}],"isError":true}}``.
+The proxy logged it and dropped it; the call blocked for 300.002s and a sibling
+tool call in the same batch sat finished and unused for the whole window. With
+this patch the same scenario returns a JSON-RPC error in single-digit
+milliseconds, carrying the remote's own "Permission denied" text so the model
+gets an actionable failure instead of silence.
+
+Upstream: geelen/mcp-remote issue #293 describes this exact root cause and PR
+#308 fixes it. Both were still open when this patch was written, against a
+repository whose last commit was 2026-02-05, so there is nothing to wait for.
+Drop this patch once #308 merges and the Dockerfile pin advances past it.
+
+Note this is *not* a fork-vs-upstream problem: upstream ``geelen/mcp-remote``
+carries the identical two lines. The pinned fork is used for its Google ADC
+support, not because it introduced this bug.
+
+Usage::
+
+    python3 apply_mcp_remote_forward_errors.py [MCP_REMOTE_ROOT]  # /opt/mcp-remote
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "src/lib/utils.ts"
+
+# The only non-Hermes target in this directory, so the standard "bump the base
+# image" advice is the wrong advice: what moves this anchor is the mcp-remote
+# pin, not a Hermes release.
+PIN_NOTE = "mcp-remote changed — re-derive the anchor before advancing the pin."
+
+INDENT = " " * 4
+
+ANCHOR = f"{INDENT}transportToServer.send(message).catch(onServerError)\n"
+
+# Mirrors the `ignoredTools` branch earlier in the same function, which is the
+# codebase's own idiom for answering the client directly: same `jsonrpc`/`id`/
+# `error` shape, same -32603, same `.catch(onClientError)` tail.
+PATCHED = f"""\
+{INDENT}// kube-agents patch: see deploy/docker/patches/apply_mcp_remote_forward_errors.py
+{INDENT}transportToServer.send(message).catch((error: Error) => {{
+{INDENT}  onServerError(error)
+{INDENT}  // Upstream stops at the log above, which strands the caller: `message.id`
+{INDENT}  // is out of scope inside onServerError, so a request that failed to
+{INDENT}  // forward is never answered and the client waits out its own timeout.
+{INDENT}  // Only requests get a reply — notifications carry no id, and responses
+{INDENT}  // carry no method.
+{INDENT}  if (message.id !== undefined && message.id !== null && message.method) {{
+{INDENT}    transportToClient
+{INDENT}      .send({{
+{INDENT}        jsonrpc: '2.0' as const,
+{INDENT}        id: message.id,
+{INDENT}        error: {{
+{INDENT}          code: -32603,
+{INDENT}          message: `Failed to forward message to remote server: ${{error.message}}`,
+{INDENT}        }},
+{INDENT}      }})
+{INDENT}      .catch(onClientError)
+{INDENT}  }}
+{INDENT}}})
+"""
+
+# Asserted in the built bundle by the Dockerfile, so a patch that silently stops
+# applying fails the image build instead of shipping a hang.
+BUILD_MARKER = "Failed to forward message to remote server"
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(
+        root, RELATIVE, prefix="mcp_remote_forward_errors", note=PIN_NOTE
+    )
+    # Not patchlib.refuse_if_patched: the marker being present is more likely to
+    # mean upstream merged PR #308 than that this ran twice, and the two have
+    # different answers — drop the patch, versus fix the build step. The check
+    # has to precede the substitution either way, because the replacement text
+    # is where the marker comes from.
+    if BUILD_MARKER in patch.source:
+        raise SystemExit(
+            f"mcp_remote_forward_errors patch: {RELATIVE} already contains "
+            f"{BUILD_MARKER!r}. Upstream may have merged PR #308 — drop this "
+            f"patch rather than applying it twice."
+        )
+    patch.substitute(ANCHOR, PATCHED)
+    # TypeScript: there is no ast.parse gate to run, `npm run build` is it.
+    patch.commit("1 anchor", parse=False)
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/mcp-remote"))

--- a/deploy/docker/patches/cron_run_scope.py
+++ b/deploy/docker/patches/cron_run_scope.py
@@ -31,12 +31,49 @@ publish step against shared scratch state, restoring a stale findings file from
 a ``.bak``, and finally hand-blanking it to force the issue closed.
 
 The fix is a marker, ``HERMES_KANBAN_CRON_RUN``, held for the duration of a
-dispatched run as both a context variable and an environment variable — the
-pair ``gateway/session_context.py`` already uses for its per-job cron state. It
-says "this run is a cron job borrowing a worker's environment", which is
-precisely the distinction the kanban helpers could not previously draw. Defect
-1 is fixed separately, by an ``outcome`` out-param that lets ``run_one_job``
-hand its ``final_response`` back instead of dropping it.
+dispatched run in a ``contextvars.ContextVar``. It says "this run is a cron job
+borrowing a worker's environment", which is precisely the distinction the kanban
+helpers could not previously draw. Defect 1 is fixed separately, by an
+``outcome`` out-param that lets ``run_one_job`` hand its ``final_response`` back
+instead of dropping it.
+
+Why the scope does not also set an environment variable
+-------------------------------------------------------
+It used to, in imitation of ``gateway/session_context.py``'s cron auto-delivery
+pair, on the argument that a cron agent shelling out to ``hermes kanban …``
+should inherit the marker. That argument bought a hypothesis — nothing in this
+image reads the marker from a subprocess; every reader
+(``tools/kanban_tools.py``'s three call sites and
+``hermes_cli/kanban_guardrail_exit.py``) is in-process — and paid for it three
+times over, because an environment variable is process-global and a cron run is
+not:
+
+* **It leaked permanently.** Two *overlapping* runs — A in, B in, A out, B out —
+  restore in the wrong order: A pops the variable it never found, then B puts
+  A's marker back with no run active at all. From then on every worker in the
+  process is told it is a run of job A, so ``kanban_complete`` with no
+  ``task_id`` is refused, naming the explicit id is refused by
+  ``_enforce_worker_task_ownership``, and the guardrail backstop is suppressed
+  as well. The card sits ``running`` with no result and no failure, forever.
+  Two parallel ``cronjob(action='run')`` calls in one assistant turn reach this;
+  ``agent/tool_executor.py`` runs tool calls on a pool and ``cronjob`` is not on
+  its serial list.
+* **It bled across threads.** Any thread that never entered the scope still read
+  the marker through the fallback, so under ``dispatch_in_gateway`` an unrelated
+  worker running concurrently with somebody else's dispatch answered
+  ``current_cron_job() == '<their job>'``.
+* **It was inherited by spawned workers.** ``hermes_cli/kanban_db.py``'s spawn
+  copies ``os.environ`` and scrubs only the ``HERMES_KANBAN_*`` keys
+  ``gateway/session_context.py`` lists. This marker is not among them, so a
+  worker spawned during a run carried it for life.
+
+A ContextVar has none of those failure modes and needs no save/restore: it is
+scoped to the thread ``run_job`` submitted the run on, ``copy_context()`` carries
+it to ``run_conversation``, and ``reset(token)`` is exact under any interleaving.
+``current_cron_job`` still *reads* ``os.environ`` as a fallback, so if the fork
+case ever becomes real the marker can be stamped onto that child's environment
+deliberately — the way ``agent/delegation_context.py`` stamps its own — rather
+than onto the whole process.
 
 ``HERMES_KANBAN_TASK`` is deliberately left in place rather than unset for the
 duration. ``kanban_tools.heartbeat_current_worker_from_env()`` reads it on
@@ -66,51 +103,37 @@ CRON_RESPONSE_LIMIT = 4000
 #: Job id of the dispatch executing in this context, empty outside one.
 _CRON_RUN_JOB: ContextVar = ContextVar(CRON_RUN_ENV, default="")
 
-_UNSET = object()
-
 
 @contextlib.contextmanager
 def cron_run_scope(job_id: str) -> Iterator[None]:
     """Mark the current context as executing cron job ``job_id``.
 
-    Sets both a context variable and the environment variable, in deliberate
-    imitation of ``gateway/session_context.py`` — which keeps its cron
-    auto-delivery vars in exactly this pair "so concurrent jobs don't clobber
-    each other's delivery targets", and resolves reads context-var-first with
-    an ``os.environ`` fallback.
-
-    The context variable is what actually reaches the run: ``run_job`` takes a
+    A ``ContextVar`` and nothing else. ``run_job`` takes a
     ``contextvars.copy_context()`` immediately before submitting
     ``agent.run_conversation`` to its worker thread, so a variable set here is
     visible to every tool the cron agent calls, and to nothing else in the
-    process. The environment variable is the fallback that survives a fork —
-    a cron agent that shells out to ``hermes kanban …`` gets the marker too.
+    process — which is the whole requirement. ``reset(token)`` restores exactly
+    the value this scope displaced, on the way out and on an exception, under
+    any interleaving of concurrent or nested scopes.
 
-    Both are restored on the way out, including on an exception and including
-    the common case where there was no prior value, so a nested or repeated
-    dispatch cannot leave the marker set after the run ends.
+    The module docstring records the three ways the previous
+    ``os.environ``-writing version got that wrong.
     """
-    marker = str(job_id or "?")
-    token = _CRON_RUN_JOB.set(marker)
-    prior = os.environ.get(CRON_RUN_ENV, _UNSET)
-    os.environ[CRON_RUN_ENV] = marker
+    token = _CRON_RUN_JOB.set(str(job_id or "?"))
     try:
         yield
     finally:
         _CRON_RUN_JOB.reset(token)
-        if prior is _UNSET:
-            os.environ.pop(CRON_RUN_ENV, None)
-        else:
-            os.environ[CRON_RUN_ENV] = prior  # type: ignore[arg-type]
 
 
 def current_cron_job(environ: Optional[Mapping[str, str]] = None) -> str:
     """Return the job id of the dispatch running in this context, or ``""``.
 
-    Context variable first, environment second — the same resolution order
-    ``gateway/session_context.py:get_session_env`` uses, for the same reason:
-    the context variable is concurrency-safe where it is set, and the
-    environment is what a subprocess inherits.
+    Context variable first, environment second. Nothing in this image writes
+    the environment half — ``cron_run_scope`` deliberately does not — so today
+    the fallback only ever fires for a process launched with the marker already
+    set. It is kept because that is the one thing a ContextVar cannot do: cross
+    a fork. See the module docstring.
     """
     job_id = _CRON_RUN_JOB.get()
     if job_id:

--- a/deploy/docker/patches/cron_skip_ledger.py
+++ b/deploy/docker/patches/cron_skip_ledger.py
@@ -1,0 +1,613 @@
+"""Record cron occurrences that were due and did not run, and keep history per job.
+
+Installed into the image at ``/opt/hermes/tools/cron_skip_ledger.py`` and wired
+into ``cron/executions.py``, ``cron/scheduler.py``, ``cron/jobs.py`` and
+``agent/monitoring/cron_health.py`` by ``deploy/docker/Dockerfile``.
+
+Two independent holes in the execution ledger, both of which make a watchdog
+that stopped firing look exactly like a watchdog with nothing to report. That
+is not hypothetical here: six governance watchdogs went a whole release without
+firing and the ledger showed nothing wrong, because it had nothing to show.
+
+Hole 1 — a skipped occurrence leaves no trace
+---------------------------------------------
+Upstream's ``executions`` table constrains ``status`` to
+``('claimed','running','completed','failed','unknown')``. Every one of those
+means *a run existed*. An occurrence that came due and was then dropped has no
+representable state, so the scheduler does the only thing it can: it writes a
+log line and returns. The log is rotated out of the pod in hours; the ledger is
+on a PVC and is what anybody actually queries.
+
+Measured on the live Chat Agent board on 2026-08-08 (``/opt/data/cron/
+executions.db``): ``profile-cron-tick`` is a ``* * * * *`` job, and over a
+999-minute window it holds 980 rows in 18 runs of consecutive minutes, every
+gap ~120s. **Twenty occurrences of a minute-ly job left no record of any
+kind** — and the gaps cluster on ``:00`` and ``:30``, the minutes when the
+hourly and half-hourly jobs fire, so they are contention, not noise. Every one
+of the board's 1000 rows reads ``completed``. There is no query against the
+current schema that can find the twenty.
+
+The five ways an occurrence is lost, all now recorded with a distinguishing
+reason (the codes below are the vocabulary, and they are content-free so they
+can also be projected to monitoring):
+
+``already_running``
+    ``tick``'s in-process dedup guard: ``job_id`` is still in
+    ``_running_job_ids`` from a previous tick. The occurrence is genuinely
+    lost, because ``advance_next_runs`` has *already* moved ``next_run_at``
+    forward for the whole due set before dispatch begins. This is the common
+    case above: a job whose run outlives its own period.
+
+``already_running_elsewhere``
+    The cross-process mirror of the same thing — ``_job_locks.claim`` refused,
+    so another *process* holds the per-job flock (see
+    ``tools/cron_tick_lock_scope.py``). Distinct from ``already_running``
+    because the remedy is different: one says the job is too slow for its
+    schedule, the other says two tickers are racing for the same profile.
+
+``interpreter_shutdown``
+    The gateway began finalizing between ``advance_next_runs`` and
+    ``pool.submit``. ``next_run_at`` has moved, nothing was dispatched.
+    Deliberately separated from a real dispatch failure: it is expected during
+    a rollout and should not read as a fault.
+
+``missed_window``
+    The one that hides an outage. ``cron/jobs.py:get_due_jobs`` fast-forwards a
+    job whose ``next_run_at`` is older than ``_compute_grace_seconds`` and
+    fires it exactly once, deliberately collapsing every accumulated
+    occurrence. Upstream's only trace is
+    ``record_catch_up_occurrence()`` — a single integer in a file, profile-wide,
+    with no job id, no timestamp and no count. A four-hour gateway outage
+    therefore leaves a daily watchdog looking as though it ran on schedule. One
+    row per gap, not one per lost occurrence: a three-hour outage of a
+    minute-ly job would otherwise write 180 rows and evict the very history
+    somebody is trying to read.
+
+``dispatch_claim_rejected``
+    A finite one-shot whose ``repeat.times`` was already consumed. Upstream
+    already writes a row for this, but as ``failed`` — which is wrong twice
+    over: it inflates the failure count that ``cron_health`` derives, and it
+    describes a correctly-enforced at-most-once guarantee as a fault.
+
+Two near-misses deliberately *not* recorded, because neither loses an
+occurrence: the tick-lock contention path (``Tick skipped — another instance
+holds the lock``) returns before ``get_due_jobs``, so the other tick fires
+those jobs; and the ``can_dispatch()`` drain gate likewise leaves the due set
+untouched for the next tick. Recording either would manufacture false skips.
+The timezone-repair branch in ``get_due_jobs`` is also left alone: in the
+common case it re-anchors onto the same wall-clock time later in the same
+period and nothing is lost, so a row there would be a false positive in every
+case but a rare DST collision.
+
+Hole 2 — pruning is global, so a chatty job evicts a quiet one
+---------------------------------------------------------------
+``_prune_unlocked`` keeps the newest ``MAX_TERMINAL_EXECUTIONS`` terminal rows
+**across all jobs**, so the horizon is the same 16.7 hours for every job on the
+board and it is the busiest job that sets it. The live Chat Agent board was
+saturated at 1000/1000: ``profile-cron-tick`` owned 980 of those rows,
+``cluster-agent-reconcile`` (hourly) 16, ``github-issue-resolver`` 4. Replaying
+one more day of both cadences against a copy of that board shows what the cap
+does next — under the global rule the hourly job is left with 17 rows and
+``github-issue-resolver`` with none at all; under the rule below the hourly job
+keeps 40 and the half-hourly one keeps its 4. A daily watchdog on that board
+retains at best a single row, and the first thing anybody asks about a watchdog
+that went quiet is "when did it last succeed?".
+
+Retention is therefore per job. The numbers, against the two real rosters
+(``agents/chat/defaults/cron/jobs.json``, ``agents/platform/cron/jobs.json``):
+
+* ``MAX_TERMINAL_EXECUTIONS_PER_JOB = 1000``. Deliberately the same 1000
+  upstream already chose — the cap was scoped wrong, not sized wrong. It is
+  set by the fastest job on either roster, ``profile-cron-tick`` at
+  ``* * * * *`` (1440 rows/day): 1000 rows is a 16.7-hour horizon, which is
+  *exactly* the whole-board horizon observed today, so the busiest job loses
+  nothing and every other job stops paying for it. The same 1000 rows buy
+  ``cluster-agent-reconcile`` (``11 * * * *``) 41 days, ``github-issue-resolver``
+  (``*/30 * * * *``) 20.8 days, the three daily audits ~2.7 years, and the
+  three weekly ones roughly 19 — i.e. a daily watchdog is never pruned in
+  practice, which is the point.
+
+* ``MAX_TERMINAL_EXECUTIONS = 5000``, retained as an absolute ceiling and
+  raised from 1000. A per-job rule alone is unbounded on the one axis that
+  actually grows here: *distinct job ids*. The Platform Agent creates and
+  removes jobs at runtime (per-cluster scaffolding, one-shot follow-ups), and
+  a deleted job's rows are never reclaimed by a per-job cap. 5000 is five
+  minute-ly jobs' worth, which is more job ids than either roster carries, so
+  the ceiling only engages once dead job ids accumulate. At the ~0.6 KB/row the
+  live board measures (610,304 bytes for 1000 rows, indexes included) the
+  ceiling is ~3 MB per profile.
+
+* ``MIN_TERMINAL_EXECUTIONS_PER_JOB = 50``. The ceiling sweep may never take a
+  job's newest 50 terminal rows. Without a floor, raising the global cap only
+  moves the crowd-out threshold — the ticker would still be the last writer
+  standing. Fifty rows is 50 days for a daily watchdog and 50 weeks for a
+  weekly one, i.e. the floor alone already answers "when did it last run?".
+  The floor outranks the ceiling: with more than ``5000/50`` job ids on one
+  board the protected rows exceed the ceiling and the ceiling gives way.
+  That is the intended precedence — evidence beats a size target — and the
+  real bound is ``MAX_TERMINAL_EXECUTIONS + 50 x (job ids)``. Both boards
+  carry fewer than twenty.
+
+Why the schema change is a table rebuild
+-----------------------------------------
+``status`` is guarded by a ``CHECK`` constraint, and SQLite cannot alter a
+``CHECK`` in place. The only options are rebuild-and-rename or dropping the
+constraint, and dropping it would trade a real invariant for convenience.
+
+Both live ledgers are populated (1000 and 99 rows), on a PVC, in WAL mode,
+opened concurrently by the gateway and by spawned ``hermes cron tick``
+processes, and carry ``PRAGMA user_version = 0`` with no metadata table — so
+there is no version counter to gate on. ``migrate_executions_table`` therefore
+gates on the schema itself: it reads the live ``CREATE TABLE`` text out of
+``sqlite_master`` and no-ops if that text already admits ``'skipped'``. That is
+idempotent by construction and needs nothing persisted.
+
+The rebuild derives the new table's DDL *from the live table's own DDL* — one
+anchored regex substitution on the ``CHECK(status IN (...))`` list, one on the
+table name — rather than from a hardcoded schema. Two reasons. It cannot drop a
+column an upstream release added, because it never enumerates columns; and
+``INSERT INTO ... SELECT *`` is then trivially correct, because the column
+order is identical by construction. If either substitution does not match
+exactly once the migration raises instead of guessing, and the build-time
+verify turns that into a failed image rather than a ledger that silently
+refuses every skip row.
+
+Atomicity is explicit. ``_initialize_schema`` runs its DDL in autocommit, so
+the rebuild opens its own ``BEGIN IMMEDIATE``, re-reads the schema *inside* the
+write lock (closing the read-then-upgrade race between two ticker processes),
+compares row counts before and after the copy, and rolls the whole thing back
+on any mismatch. A failed migration leaves the original table exactly as it
+was; the caller keeps a working ledger for the four upstream statuses and only
+loses the ability to record skips.
+
+``skip_reason`` is added separately, by an idempotent ``ADD COLUMN``, because
+``ADD COLUMN`` is the one schema change SQLite *can* do in place and pairing it
+with the rebuild would make the rebuild's derived-DDL trick harder to reason
+about. It runs first, so the rebuild carries it along. A machine-readable
+column rather than a substring of ``error``: "which jobs are being skipped, and
+for what" has to be a ``GROUP BY``, not a ``LIKE``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# --- the skip vocabulary ----------------------------------------------------
+#: A due occurrence was dropped because the previous run of the same job was
+#: still in flight in this process.
+SKIP_ALREADY_RUNNING = "already_running"
+#: ...or in another process, proved by the per-job flock refusing the claim.
+SKIP_ALREADY_RUNNING_ELSEWHERE = "already_running_elsewhere"
+#: The interpreter began finalizing between the schedule advance and dispatch.
+SKIP_INTERPRETER_SHUTDOWN = "interpreter_shutdown"
+#: get_due_jobs fast-forwarded past accumulated occurrences after an outage.
+SKIP_MISSED_WINDOW = "missed_window"
+#: A finite one-shot had already consumed its dispatch budget.
+SKIP_DISPATCH_CLAIM_REJECTED = "dispatch_claim_rejected"
+
+#: Every reason the ledger will accept. An unknown code is coerced rather than
+#: rejected: a skip recorded under a bad label is still evidence, and dropping
+#: it would reintroduce the exact silence this module exists to remove.
+SKIP_REASONS = frozenset(
+    {
+        SKIP_ALREADY_RUNNING,
+        SKIP_ALREADY_RUNNING_ELSEWHERE,
+        SKIP_INTERPRETER_SHUTDOWN,
+        SKIP_MISSED_WINDOW,
+        SKIP_DISPATCH_CLAIM_REJECTED,
+    }
+)
+SKIP_REASON_UNSPECIFIED = "unspecified"
+
+#: The status added to the CHECK constraint.
+SKIPPED_STATUS = "skipped"
+
+#: States a row can never leave. ``skipped`` joins them: an occurrence that did
+#: not happen cannot later start happening, so a skip row is immutable the
+#: moment it is written and is eligible for pruning immediately.
+TERMINAL_STATES = ("completed", "failed", "unknown", SKIPPED_STATUS)
+
+# --- retention --------------------------------------------------------------
+# The module docstring justifies all three against the real rosters.
+MAX_TERMINAL_EXECUTIONS_PER_JOB = 1000
+MAX_TERMINAL_EXECUTIONS = 5000
+MIN_TERMINAL_EXECUTIONS_PER_JOB = 50
+
+# Interpolated into the prune SQL. These are module constants, never input, so
+# there is nothing here for a parameter marker to protect against — and the IN
+# list has to be literal because it also has to be identical in three
+# statements, which is exactly what a single derived constant guarantees.
+_TERMINAL_IN = ", ".join("'{}'".format(state) for state in TERMINAL_STATES)
+
+
+def terminal_states_sql() -> str:
+    """The ``IN`` list the prune and any caller-side query must agree on."""
+    return _TERMINAL_IN
+
+
+# --- schema migration -------------------------------------------------------
+
+#: The one thing the rebuild has to rewrite. Tolerant of whitespace and of the
+#: order of the existing values, strict about there being exactly one match.
+_STATUS_CHECK_RE = re.compile(
+    r"CHECK\s*\(\s*status\s+IN\s*\(\s*(?P<values>[^()]*?)\s*\)\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+#: ``CREATE TABLE [IF NOT EXISTS] [schema.]"executions"``. SQLite strips
+#: ``IF NOT EXISTS`` before storing DDL in ``sqlite_master``, but a ledger
+#: created by some future code path may not have gone through that, so accept
+#: both rather than fail a migration on a cosmetic difference.
+_CREATE_TABLE_RE = re.compile(
+    r"^\s*CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?[\"'`\[]?executions[\"'`\]]?",
+    re.IGNORECASE,
+)
+
+#: Scratch name for the rebuild. Prefixed rather than suffixed with ``_new`` so
+#: it cannot collide with a real table, and dropped unconditionally first so a
+#: process killed mid-rebuild does not poison the next attempt.
+_SCRATCH_TABLE = "executions_kubeagents_migrating"
+
+
+class LedgerMigrationError(RuntimeError):
+    """The live schema is not the shape this migration knows how to rewrite."""
+
+
+def _executions_ddl(conn: sqlite3.Connection) -> Optional[str]:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='executions'"
+    ).fetchone()
+    if row is None:
+        return None
+    return str(row[0] or "")
+
+
+def status_check_allows_skipped(ddl: str) -> bool:
+    """Does this ``CREATE TABLE`` text already admit a ``skipped`` status?
+
+    Read off the DDL rather than off a version counter. Both live ledgers have
+    ``user_version = 0`` and no metadata table, and a counter that can disagree
+    with the schema is worse than no counter — it is how a migration comes to
+    be skipped on the one board that still needed it.
+    """
+    match = _STATUS_CHECK_RE.search(ddl)
+    if match is None:
+        return False
+    return "'{}'".format(SKIPPED_STATUS) in match.group("values").replace('"', "'")
+
+
+def _rewritten_ddl(ddl: str) -> str:
+    """Derive the scratch table's DDL from the live table's own DDL.
+
+    Never enumerates columns, so a column upstream added since this patch was
+    written survives the rebuild and ``INSERT ... SELECT *`` stays correct.
+    """
+    check_matches = _STATUS_CHECK_RE.findall(ddl)
+    if len(check_matches) != 1:
+        raise LedgerMigrationError(
+            "expected exactly one CHECK(status IN (...)) in the executions "
+            "schema, found {}. Upstream Hermes changed the ledger; re-derive "
+            "the migration before bumping the base image.\n{}".format(
+                len(check_matches), ddl
+            )
+        )
+
+    def _extend(match: "re.Match[str]") -> str:
+        values = match.group("values").strip()
+        return "CHECK(status IN ({}, '{}'))".format(values, SKIPPED_STATUS)
+
+    rewritten = _STATUS_CHECK_RE.sub(_extend, ddl, count=1)
+    rewritten, renamed = _CREATE_TABLE_RE.subn(
+        "CREATE TABLE {}".format(_SCRATCH_TABLE), rewritten, count=1
+    )
+    if renamed != 1:
+        raise LedgerMigrationError(
+            "could not find the CREATE TABLE executions header to rename:\n" + ddl
+        )
+    return rewritten
+
+
+def add_skip_reason_column(conn: sqlite3.Connection) -> bool:
+    """``ADD COLUMN skip_reason``, idempotent and race-tolerant.
+
+    Returns True when this call added it. Mirrors
+    ``hermes_cli/sqlite_util.add_column_if_missing`` — reproduced rather than
+    imported so this module stays importable by the local unit suite, which has
+    no Hermes tree.
+    """
+    try:
+        conn.execute("ALTER TABLE executions ADD COLUMN skip_reason TEXT")
+        return True
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" in str(exc).lower():
+            return False
+        if "no such table" in str(exc).lower():
+            return False
+        raise
+
+
+def migrate_executions_table(conn: sqlite3.Connection) -> str:
+    """Make the live ``executions`` table accept ``skipped``. Idempotent.
+
+    Returns ``"absent"`` (no table yet — the caller's ``CREATE TABLE IF NOT
+    EXISTS`` owns that), ``"current"`` (already migrated, the steady state on
+    every connection after the first) or ``"rebuilt"``.
+
+    Safety, in the order it matters on a populated PVC:
+
+    * The whole rebuild is one ``BEGIN IMMEDIATE`` transaction. The caller runs
+      its schema DDL in autocommit, so relying on the caller's transaction
+      would leave a ``DROP TABLE`` committed on its own if the process died
+      between statements.
+    * The schema is re-read *inside* the write lock. Two ticker processes can
+      open this file at once; without the re-read both would pass the cheap
+      pre-check and the second would rebuild a table that no longer needs it.
+    * Row counts are compared across the copy and a mismatch raises, which
+      rolls back. A rebuild that silently loses rows is strictly worse than the
+      gap it is closing.
+    * Nothing references ``executions`` — no views, no triggers, no foreign
+      keys, and ``PRAGMA foreign_keys`` is off by default and never enabled by
+      the ledger — so ``DROP TABLE`` cannot cascade. The two indexes go with
+      the table and the caller's ``CREATE INDEX IF NOT EXISTS`` puts them back.
+    """
+    ddl = _executions_ddl(conn)
+    if ddl is None:
+        return "absent"
+    add_skip_reason_column(conn)
+    if status_check_allows_skipped(ddl):
+        return "current"
+
+    started_here = not conn.in_transaction
+    if started_here:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        ddl = _executions_ddl(conn)
+        if ddl is None:
+            outcome = "absent"
+        elif status_check_allows_skipped(ddl):
+            outcome = "current"
+        else:
+            before = conn.execute("SELECT count(*) FROM executions").fetchone()[0]
+            conn.execute("DROP TABLE IF EXISTS {}".format(_SCRATCH_TABLE))
+            conn.execute(_rewritten_ddl(ddl))
+            conn.execute(
+                "INSERT INTO {} SELECT * FROM executions".format(_SCRATCH_TABLE)
+            )
+            after = conn.execute(
+                "SELECT count(*) FROM {}".format(_SCRATCH_TABLE)
+            ).fetchone()[0]
+            if after != before:
+                raise LedgerMigrationError(
+                    "executions rebuild copied {} of {} rows; rolling back "
+                    "rather than shipping a truncated ledger".format(after, before)
+                )
+            conn.execute("DROP TABLE executions")
+            conn.execute(
+                "ALTER TABLE {} RENAME TO executions".format(_SCRATCH_TABLE)
+            )
+            outcome = "rebuilt"
+    except BaseException:
+        if started_here:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                # SQLite already rolled back (EIO, lock loss). Never let a
+                # spurious rollback error shadow the real one.
+                pass
+        raise
+    if started_here:
+        conn.execute("COMMIT")
+    if outcome == "rebuilt":
+        logger.info(
+            "cron ledger: rebuilt executions table to record skipped occurrences"
+        )
+    return outcome
+
+
+def ensure_schema(conn: sqlite3.Connection) -> str:
+    """Migration entry point for ``cron/executions.py:_initialize_schema``.
+
+    Never raises. A ledger that cannot be migrated must keep working for the
+    four upstream statuses — losing every ``completed`` row because a skip row
+    could not be represented would be a far larger regression than the gap.
+    The failure is logged at ERROR and the build-time verify is what stops a
+    broken migration reaching a cluster in the first place.
+    """
+    try:
+        return migrate_executions_table(conn)
+    except Exception:
+        logger.error(
+            "cron ledger: could not migrate the executions table to record "
+            "skipped occurrences; skips will not be recorded on this profile",
+            exc_info=True,
+        )
+        return "failed"
+
+
+# --- retention --------------------------------------------------------------
+
+_PRUNE_PER_JOB_SQL = """
+    DELETE FROM executions WHERE id IN (
+      SELECT id FROM (
+        SELECT id, ROW_NUMBER() OVER (
+                     PARTITION BY job_id ORDER BY claimed_at DESC, id DESC
+                   ) AS job_rank
+        FROM executions WHERE status IN (%s)
+      ) WHERE job_rank > ?
+    )
+""" % _TERMINAL_IN
+
+_PRUNE_TOTAL_SQL = """
+    DELETE FROM executions WHERE id IN (
+      SELECT id FROM (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 ORDER BY claimed_at DESC, id DESC
+               ) AS total_rank,
+               ROW_NUMBER() OVER (
+                 PARTITION BY job_id ORDER BY claimed_at DESC, id DESC
+               ) AS job_rank
+        FROM executions WHERE status IN (%s)
+      ) WHERE total_rank > ? AND job_rank > ?
+    )
+""" % _TERMINAL_IN
+
+
+def prune_terminal_executions(
+    conn: sqlite3.Connection,
+    *,
+    per_job: Optional[int] = None,
+    total: Optional[int] = None,
+    floor: Optional[int] = None,
+) -> None:
+    """Two-pass retention: a per-job cap, then a global ceiling with a floor.
+
+    Pass one bounds a single hyperactive job. Pass two bounds the file against
+    job-id churn, and is the only pass that can touch a job which is already
+    under its own cap — which is why it may never cross ``floor``. Ordered this
+    way on purpose: the ceiling should only ever see rows the per-job rule
+    already decided to keep.
+
+    ``ROW_NUMBER() OVER (PARTITION BY ...)`` rather than a correlated subquery
+    per job: one statement, one scan, and the ordering is the same
+    ``claimed_at DESC, id DESC`` the ``idx_executions_job_claimed`` index and
+    ``list_executions`` already use, so "the newest N" means the same thing to
+    the prune as it does to every reader. Window functions need SQLite >= 3.25;
+    the image ships 3.53.
+    """
+    per_job_limit = max(1, int(MAX_TERMINAL_EXECUTIONS_PER_JOB if per_job is None else per_job))
+    total_limit = max(1, int(MAX_TERMINAL_EXECUTIONS if total is None else total))
+    floor_limit = max(0, int(MIN_TERMINAL_EXECUTIONS_PER_JOB if floor is None else floor))
+    conn.execute(_PRUNE_PER_JOB_SQL, (per_job_limit,))
+    conn.execute(_PRUNE_TOTAL_SQL, (total_limit, floor_limit))
+
+
+# --- call-site helpers ------------------------------------------------------
+
+
+def normalize_reason(reason: Any) -> str:
+    """Coerce a reason to the known vocabulary without ever dropping the row."""
+    value = str(reason or "").strip().lower()
+    if value in SKIP_REASONS:
+        return value
+    if value:
+        logger.debug("cron ledger: unrecognised skip reason %r", value)
+        return value[:64]
+    return SKIP_REASON_UNSPECIFIED
+
+
+def count_missed_occurrences(
+    schedule: Dict[str, Any], stale: Any, now: Any, *, cap: int = 10000
+) -> int:
+    """How many occurrences the catch-up fast-forward is about to discard.
+
+    ``stale`` is the ``next_run_at`` that went past its grace window; ``now``
+    is when the ticker noticed. Every occurrence in ``[stale, now]`` is lost
+    except the single catch-up fire that happens now, so the answer is the
+    number of schedule steps strictly after ``stale`` and not after ``now``.
+
+    Returns ``-1`` when it cannot be computed (no croniter, an unparseable
+    expression, an unknown schedule kind). The caller reports "an unknown
+    number of" rather than a wrong number — a fabricated count in an outage
+    report is worse than an admission.
+    """
+    if not isinstance(schedule, dict):
+        return -1
+    try:
+        gap = (now - stale).total_seconds()
+    except Exception:
+        return -1
+    if gap <= 0:
+        return 0
+
+    kind = schedule.get("kind")
+    if kind == "interval":
+        try:
+            minutes = float(schedule.get("minutes") or 0)
+        except (TypeError, ValueError):
+            return -1
+        if minutes <= 0:
+            return -1
+        return min(cap, int(gap // (minutes * 60.0)))
+
+    if kind == "cron":
+        expr = schedule.get("expr")
+        if not expr:
+            return -1
+        try:
+            from datetime import datetime
+
+            from croniter import croniter
+
+            steps = croniter(expr, stale)
+            missed = 0
+            while missed < cap:
+                nxt = steps.get_next(datetime)
+                if nxt > now:
+                    break
+                missed += 1
+            return missed
+        except Exception:
+            return -1
+
+    return -1
+
+
+def missed_window_detail(
+    schedule: Dict[str, Any], stale: Any, now: Any, grace_seconds: Any
+) -> str:
+    """The human half of a ``missed_window`` row.
+
+    Carries the window and the count because the row itself carries neither:
+    one row stands for the whole gap, so without this text an operator can see
+    that *something* was collapsed but not how much or over what period.
+    """
+    missed = count_missed_occurrences(schedule, stale, now)
+    how_many = "an unknown number of" if missed < 0 else str(missed)
+    return (
+        "Scheduler did not fire this job between {} and {} ({} occurrence(s) "
+        "collapsed into a single catch-up run; grace {}s). The catch-up run "
+        "itself is recorded separately.".format(stale, now, how_many, grace_seconds)
+    )
+
+
+def record_skip(
+    job_id: Any,
+    *,
+    source: str,
+    reason: str,
+    detail: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Best-effort ledger write for an occurrence that did not run. Never raises.
+
+    The import is deferred: ``cron/executions.py`` imports *this* module at
+    module scope, and ``cron/__init__.py`` eagerly pulls in ``cron.jobs`` and
+    ``cron.scheduler``, so a module-scope import back into ``cron`` here would
+    close the cycle.
+
+    Swallowing is deliberate and is the whole reason the call sites do not each
+    wrap this. Every caller is a guard clause in ``tick``'s dispatch path that
+    must return promptly and must not raise: a ledger write that failed —
+    because the migration did not land, because the PVC is full, because
+    another process holds the write lock past the busy timeout — must degrade
+    to exactly today's behaviour (a log line), not take the tick down with it.
+    """
+    try:
+        from cron.executions import record_skipped_execution
+
+        return record_skipped_execution(
+            job_id, source=source, reason=reason, detail=detail
+        )
+    except Exception:
+        logger.warning(
+            "cron ledger: failed to record skipped occurrence for job %s (%s)",
+            job_id,
+            reason,
+            exc_info=True,
+        )
+        return None

--- a/deploy/docker/patches/cron_tick_lock_scope.py
+++ b/deploy/docker/patches/cron_tick_lock_scope.py
@@ -348,4 +348,14 @@ class JobLocks:
             handle = self._opener(path, "w", encoding="utf-8")
         except (OSError, IOError):
             return AdvisoryLock.unheld()  # cannot open the lock file -> run
-        return _lock_handle(handle, self._fcntl, self._msvcrt)
+        try:
+            return _lock_handle(handle, self._fcntl, self._msvcrt)
+        except BaseException:
+            # ``_lock_handle`` owns the handle on both paths it returns from --
+            # closing it on the refusal, handing it to the lock otherwise. It
+            # raising means neither happened, so the descriptor is still ours.
+            try:
+                handle.close()
+            except Exception:
+                pass
+            raise

--- a/deploy/docker/patches/cron_tick_lock_scope.py
+++ b/deploy/docker/patches/cron_tick_lock_scope.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Give a spawned ``hermes cron tick`` the scheduler lifecycle it never had.
+
+The platform profile has no cron ticker thread. It is ticked once a minute by
+``agents/chat/scripts/profile_cron_tick.py`` spawning ``hermes cron tick``,
+whose CLI body is verbatim ``tick(verbose=True)``. Everything Hermes attaches to
+the ticker's lifetime -- the in-flight job set, the startup recovery sweep, the
+assumption that a tick is a short scheduling pass inside a long-lived process --
+is therefore either absent or wrong on that profile. This module and the eleven
+anchored edits in ``apply_cron_tick_lock_scope.py`` supply what is missing.
+
+Head-of-line blocking: the tick lock covered execution
+------------------------------------------------------
+``cron/scheduler.py::tick`` takes an exclusive ``flock`` on
+``<HERMES_HOME>/cron/.tick.lock`` and, when ``sync=True`` (the signature
+default), does not release it until the ``finally`` that runs *after*
+``concurrent.futures.as_completed`` has waited out every job it dispatched. The
+lock therefore covered job EXECUTION, not just the scheduling decision.
+
+That is invisible on the default profile, which the gateway ticks in-process
+with ``sync=False``. It was not invisible on the platform profile, whose every
+tick takes the ``sync=True`` default. So a fleet audit held the profile's lock
+for its whole run, and every spawn during that window hit ``LOCK_EX | LOCK_NB``,
+logged a DEBUG skip, and returned 0 having dispatched nothing.
+
+Measured on the live cluster over 17 hours: 3 of 35 ``github-issue-resolver``
+firings blocked, 418s / 179s / 1142s late, each unblocking within seconds of
+the blocking audit's ``finished_at``. The dispatcher's own durations in the
+default ledger are trimodal and give the mechanism away --
+0.10 / 45.14 / 0.12 / 0.13 / 0.11 / 0.12 / 2.37 / 2.29 / 2.65 / 26.85 / 0.12
+across 06:18:55-06:38:55: ~0.12s is 'nothing due, no spawn', 45.14s is the
+budget handoff at the audit's start, ~2.4s is 'spawned and the child died on
+the flock', 26.85s is the first spawn after the audit released. Platform
+ledger: 38 terminal executions, 0 overlapping pairs. Default ledger: 707
+terminal, 190 overlapping.
+
+The lock's own comment (scheduler.py, above ``advance_next_runs``) states its
+purpose: advance ``next_run_at`` for the whole due set BEFORE any execution
+begins, 'to preserve at-most-once semantics'. That purpose is served in full by
+holding the lock through dispatch. Holding it through execution buys one extra
+thing and one only -- a cross-process in-flight guard, because
+``_running_job_ids`` is a module-level set and every platform tick is a fresh
+process. This module supplies both halves:
+
+``AdvisoryLock``
+    Owns a locked file handle with an IDEMPOTENT ``release()``, so the dispatch
+    path can release the tick lock early while the untouched ``finally`` still
+    releases it on the early-return paths (``can_dispatch`` gate, no due jobs)
+    and on any exception.
+
+``JobLocks``
+    Replaces what the wide lock was implicitly providing: one ``flock`` file
+    per job id, ``<HERMES_HOME>/cron/.job-<id>.lock``, claimed beside
+    ``_running_job_ids.add`` and released beside ``_running_job_ids.discard``.
+
+Why flock and not a ledger row
+------------------------------
+A ledger-based guard was the obvious design and is wrong here.
+``cron/executions.py::_owner_is_live`` returns True on any exception ('fail
+safe: inability to prove death must not rewrite state') -- correct for a
+recovery sweep, but for a dispatch gate True means SUPPRESS, so an import
+failure would silently kill the job forever. It also returns
+``pid == os.getpid()`` when ``process_started_at`` is None, which from a fresh
+tick process is always False for a sibling's row -- the guard would just vanish.
+And a wedged row wedges forever: a ledger row left ``running`` by a killed
+process is only cleared by ``recover_interrupted_executions``, whereas an flock
+cannot wedge at all, because the kernel drops it when the holding process exits,
+however it exits.
+
+Failure polarity is deliberate, and it is the whole safety argument. This is a
+DISPATCH gate: refusal means "do not run this job". So ``JobLocks.claim``
+returns None for exactly one reason -- a live process holds the flock -- and a
+claim for every other outcome, including an unresolvable store, an unwritable
+lock directory, and a lock file that will not open. Getting that backwards would
+stop every job on the profile while logging "already running in another
+process", which is both silent and actively misleading to whoever debugs it.
+Note that ``mkdir(parents=True, exist_ok=True)`` SUCCEEDS on an existing
+read-only directory, so the directory guard alone does not cover the case where
+``<HERMES_HOME>/cron/`` is unwritable but present -- the open has to be
+separated from the flock for the two to be told apart, which is why
+``claim`` calls the opener itself and hands the handle to ``_lock_handle``.
+
+The caller owns its claim
+-------------------------
+``claim`` hands back the ``AdvisoryLock`` rather than recording it in a registry
+the caller later releases by job id. That is not a style preference; releasing
+by id was a leak.
+
+``tick`` claims on the ticker thread and releases in ``_run_and_release``'s
+``finally``, which runs on a ``ThreadPoolExecutor`` worker -- and, crucially,
+OUTSIDE the ``contextvars.copy_context()`` that ``ctx.run(_process_job, j)``
+enters. A registry keyed by lock path has to recompute that path to release,
+and the path comes from ``_get_lock_paths`` -> ``get_hermes_home()``, whose
+override is a ``ContextVar`` in ``hermes_constants``. A worker thread starts
+with an empty context, so the recomputed path is the *process* ``HERMES_HOME``,
+not the profile the claim was taken under. Under
+``CronSchedulerProvider._start_multiplex``, which wraps each profile's tick in
+``set_hermes_home_override``, the pop misses and the claim is never released:
+that job is then suppressed on every later tick in that gateway's life, logging
+"already running in another process" about a process that finished hours ago --
+exactly the silent-stoppage failure the polarity rule above exists to prevent.
+Holding the lock object closes that hole by construction. It also deletes the
+registry dict, its mutex, and its double-check race.
+
+Releasing the flock from a thread other than the one that took it is fine in
+itself: an ``flock`` belongs to the open file description, which is shared by
+every thread in the process. The bug was never the thread, it was recomputing
+the identity.
+
+The claim's lifetime is the object's lifetime, and that is a real edge for a
+caller to get wrong. The flock lives on the handle the ``AdvisoryLock`` owns,
+so the moment nothing references the lock, CPython closes the handle and the
+job becomes claimable again -- no exception, no log line. ``if
+_job_locks.claim(job_id) is None: ...`` and nothing further would compile, pass
+a single-process smoke test, and guard nothing. That is why the patched
+``tick`` binds ``_job_lock`` and passes it into ``_run_and_release`` as a
+default argument, and why ``_execute_job_now`` binds ``_run_lock`` for the
+whole body.
+``test_cron_tick_lock_scope.py::test_dropping_the_last_reference_to_a_claim_hands_the_job_back``
+pins it.
+
+A dispatched run takes the same lock
+------------------------------------
+``tools/cronjob_tools.py::_execute_job_now`` -- the body of
+``cronjob(action='run')`` -- called ``run_one_job`` with no per-job lock at all.
+Its only guard was ``cron/jobs.py::claim_job_for_fire``, and the comment above
+the call site claiming that guard "blocks a concurrent tick from double-firing"
+was simply untrue in both directions: ``tick`` reaches ``run_one_job`` via
+``advance_next_runs``, which never stamps a ``fire_claim``, so a dispatch always
+wins the CAS against a run already in flight; and the ``fire_claim`` a dispatch
+does stamp expires after ``claim_ttl_seconds=300`` while a compliance audit runs
+for twenty minutes, so the tick then fires a second copy on top of the first.
+Two concurrent runs of one audit share the job's output file and the profile's
+scratch state, which is how a fleet audit came to publish another run's
+findings. ``_execute_job_now`` now claims the same flock before the CAS -- before,
+so that a refusal does not leave ``next_run_at`` advanced for a run that never
+happened -- and releases it in a ``finally``.
+
+A refused dispatch returns immediately rather than waiting for the lock. The
+caller is an agent blocked inside a tool call, the run it would wait for can
+last twenty minutes, and what it would get at the end is a redundant second run
+of a job that has just finished. ``cronjob``'s ``run`` branch already surfaces a
+lost claim as ``execution_skipped``, so the refusal arrives as a sentence the
+model can act on instead of as a stall.
+
+A spawned tick is a scheduler restart
+-------------------------------------
+``recover_interrupted_executions`` marks ``claimed``/``running`` ledger rows
+``unknown`` once their owner process is proved gone. It is reachable only from
+``CronSchedulerProvider.recover_interrupted()``, called by
+``InProcessCronScheduler.start`` and by ``_start_multiplex`` -- both of which
+are gateway-ticker lifecycles, and neither of which runs for a profile ticked by
+spawning a CLI. So on the platform profile nothing ever reaped an interrupted
+attempt, and ``_prune_unlocked`` only deletes rows in a terminal state, which a
+stuck row by definition is not.
+
+The live platform ledger on 2026-08-08 held 96 rows: 90 ``completed`` and 6
+permanently ``running``, the oldest from 2026-08-07T02:00:44Z, against 0 of 1000
+on the default store the gateway does sweep. Five of the six were
+``source='direct'`` -- ``cronjob(action='run')`` dispatches whose kanban worker
+process exited mid-run -- and every one of their owner pids was gone, so every
+one of them was reapable and none had been reaped. A run that dies leaves no
+failure anywhere: ``cron runs`` shows it as still in flight, ``cron_health``
+projects a run that is not running, and the row is immortal.
+
+The fix is one line in ``hermes_cli/cron.py::cron_tick``, which is that
+profile's entire scheduler lifecycle: sweep first, then tick. It cannot reap a
+live run -- ``_owner_is_live`` checks both the pid and its start time, so a
+still-running sibling tick or a live gateway is skipped -- and a sweep that
+raises is logged and stepped over, because nothing about bookkeeping may stop a
+tick from dispatching.
+
+Testing
+-------
+Everything here is dependency-injected (``fcntl``/``msvcrt``/``open`` are
+parameters) so ``test_cron_tick_lock_scope.py`` can drive it on a host without
+Hermes installed. ``verify_cron_tick_lock_scope.py`` then exercises the patched
+image itself, including a real second process holding the locks and a real
+stuck ledger row being reaped.
+
+Not fixed here, but fixed alongside: ``profile-cron-tick`` used to be scheduled
+``interval: 1 minute`` and actually ran every two -- 493 of 545 inter-run gaps
+were 120s, only 48 were 60s -- because Hermes re-anchors an ``interval`` job to
+the moment the last run FINISHED while the gateway ticker sleeps a fixed sixty
+seconds after each tick returns. That is the ``cron-tick-drift`` item, and it is
+closed in the same change set by moving every job on both rosters to a cron
+expression (``* * * * *``), which snaps up to the next wall-clock minute and so
+cannot drift. ``test_profile_cron_tick.py::test_no_job_on_this_roster_uses_an_interval_schedule``
+fails the build on any surviving ``interval`` job, so do not reintroduce one.
+What remains after that is narrower and is NOT addressed anywhere: a dispatch
+that actually ran a watchdog blocks up to ``DEFAULT_BUDGET_SECONDS`` (45) on the
+subprocess and usually costs the minute after it. See the schedule bullet in
+docs/site/src/content/docs/concepts/autonomous-watchdogs.md.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def sanitise_job_id(job_id: Any) -> str:
+    """Map a job id onto a filename component. Never empty, never a path."""
+    cleaned = _UNSAFE.sub("_", str(job_id))[:120]
+    return cleaned or "_"
+
+
+class AdvisoryLock:
+    """A held advisory file lock whose ``release()`` is idempotent.
+
+    The tick path calls ``release()`` once it has finished dispatching; the
+    untouched ``finally`` calls it again. The second call must be a no-op, and
+    must not unlock a handle some other object has since reopened -- hence the
+    ``_released`` flag rather than a bare unlock.
+    """
+
+    def __init__(self, handle, fcntl_mod=None, msvcrt_mod=None) -> None:
+        self._handle = handle
+        self._fcntl = fcntl_mod
+        self._msvcrt = msvcrt_mod
+        self._released = False
+
+    @classmethod
+    def unheld(cls) -> "AdvisoryLock":
+        """A claim that owns nothing, for ``JobLocks.claim``'s fail-open paths.
+
+        Returning this rather than None keeps one rule at the call sites: a
+        claim object means "run the job", None means "somebody else is running
+        it". A storage problem must never be mistaken for the second, so the
+        cases where there was nothing to lock still hand back something with a
+        harmless ``release()``.
+        """
+        lock = cls(None)
+        lock._released = True
+        return lock
+
+    @property
+    def released(self) -> bool:
+        return self._released
+
+    def release(self) -> None:
+        if self._released:
+            return
+        self._released = True
+        if self._fcntl is not None:
+            try:
+                self._fcntl.flock(self._handle, self._fcntl.LOCK_UN)
+            except (OSError, IOError):
+                pass
+        elif self._msvcrt is not None:
+            try:
+                self._msvcrt.locking(self._handle.fileno(), self._msvcrt.LK_UNLCK, 1)
+            except (OSError, IOError):
+                pass
+        try:
+            self._handle.close()
+        except Exception:
+            pass
+
+
+def _lock_handle(handle, fcntl_mod=None, msvcrt_mod=None) -> Optional[AdvisoryLock]:
+    """flock an already-open handle. None -- and closed -- if it is held.
+
+    Split out of ``JobLocks.claim`` so the caller can tell "the file would not
+    open" from "another process holds it". The dispatch gate has to: the first
+    must fire the job, the second must skip it.
+
+    Closing the handle on the refused path is safe with ``flock`` and would not
+    be with ``fcntl.lockf``: an flock lives on the open file description, so
+    dropping the description we failed to lock cannot disturb a lock this
+    process holds through a different one. Verified against both Linux and
+    macOS before the in-process registry was removed.
+    """
+    try:
+        if fcntl_mod is not None:
+            fcntl_mod.flock(handle, fcntl_mod.LOCK_EX | fcntl_mod.LOCK_NB)
+        elif msvcrt_mod is not None:
+            msvcrt_mod.locking(handle.fileno(), msvcrt_mod.LK_NBLCK, 1)
+    except (OSError, IOError):
+        try:
+            handle.close()
+        except Exception:
+            pass
+        return None
+    return AdvisoryLock(handle, fcntl_mod, msvcrt_mod)
+
+
+class JobLocks:
+    """Cross-process mirror of ``_running_job_ids``, one flock file per job.
+
+    ``lock_dir_fn`` is called on every claim rather than cached: the tick
+    lock's own directory is resolved per call for exactly the same reason
+    (``_get_lock_paths`` -- 'so profile/env changes are honored').
+
+    There is no in-process registry of outstanding claims. The kernel is the
+    registry: a second ``open()`` of a file this process already flocked gets
+    its own open file description, and flock refuses it exactly as it refuses
+    another process. Keeping a dict beside that duplicated the kernel's answer
+    and forced ``release`` to recompute the lock path on a thread that could no
+    longer resolve it -- see the module docstring.
+    """
+
+    def __init__(self, lock_dir_fn: Callable[[], Any], fcntl_mod=None,
+                 msvcrt_mod=None, opener=open) -> None:
+        self._lock_dir_fn = lock_dir_fn
+        self._fcntl = fcntl_mod
+        self._msvcrt = msvcrt_mod
+        self._opener = opener
+
+    def _lock_path(self, job_id: Any) -> Optional[str]:
+        """This job's lock file, or None if the store cannot be resolved.
+
+        The PATH is the identity, not the job id. ``lock_dir_fn`` is per store,
+        so one process ticking two profiles gets two different files for the
+        same id -- gateway multiplex does that, and so would per-cluster
+        profiles scaffolded from one template, which share every job id by
+        construction. One profile's claim must not refuse another profile's job.
+
+        The bare ``except`` is the same fail-open rule as ``claim``: this is a
+        dispatch gate, and nothing it cannot answer may become a skip.
+        """
+        try:
+            directory = self._lock_dir_fn()
+            directory.mkdir(parents=True, exist_ok=True)
+            return str(directory / (".job-" + sanitise_job_id(job_id) + ".lock"))
+        except Exception:
+            return None
+
+    def claim(self, job_id: Any) -> Optional[AdvisoryLock]:
+        """The claim on ``job_id``, or None if this process may not run it.
+
+        None means one thing and one thing only: a live process -- this one or
+        another -- holds the flock. An unresolvable store, an unwritable lock
+        directory and a lock file that will not open all hand back an
+        ``AdvisoryLock.unheld()``, so the job runs. See the failure-polarity
+        paragraph in the module docstring; a storage problem that answered None
+        here would silence every job on the profile.
+
+        The returned lock is the caller's to release, on whatever thread and in
+        whatever context it finishes in.
+        """
+        path = self._lock_path(job_id)
+        if path is None:
+            return AdvisoryLock.unheld()  # cannot resolve the store -> run
+        try:
+            handle = self._opener(path, "w", encoding="utf-8")
+        except (OSError, IOError):
+            return AdvisoryLock.unheld()  # cannot open the lock file -> run
+        return _lock_handle(handle, self._fcntl, self._msvcrt)

--- a/deploy/docker/patches/cron_tirith_scan.py
+++ b/deploy/docker/patches/cron_tirith_scan.py
@@ -1,0 +1,283 @@
+"""Run the Tirith content scan on cron commands that skip the approval prompt.
+
+Installed into the image at ``/opt/hermes/tools/cron_tirith_scan.py`` and wired
+into ``tools/approval.py`` by ``deploy/docker/Dockerfile``.
+
+The defect
+----------
+``tools/approval.py``'s ``check_all_command_guards`` is the single pre-exec gate
+every ``terminal()`` command passes through. Its non-interactive branch reads::
+
+    if not is_cli and not is_gateway and not is_ask:
+        # Cron sessions: respect cron_mode config
+        if _is_cron_approval_context():
+            if _get_cron_approval_mode() == "deny":
+                ...detect_dangerous_command(), then check_command_security()...
+        return {"approved": True, "message": None}
+
+Upstream put the Tirith call *inside* the ``deny`` arm. ``approvals.cron_mode``
+has exactly two effective values — ``_get_cron_approval_mode`` maps
+``{approve, off, allow, yes}`` to ``approve`` and everything else, including a
+typo, to ``deny`` — so setting ``approve`` does not merely stop the run blocking
+on a prompt it cannot answer. It returns ``approved`` before the scanner is ever
+reached, and every command in every cron run executes with no content scan at
+all.
+
+That conflation is the bug. Answering the approval prompt and scanning the
+command are separate questions, and only the first one needs a human. An
+unattended run genuinely cannot answer a prompt; it has no trouble at all being
+told "no".
+
+Why this matters here rather than in the abstract
+-------------------------------------------------
+``approvals.cron_mode: approve`` is a fleet-wide default in this deployment. It
+is written into the platform profile's template by
+``deploy/shared/defaults/config.yaml``, into the ``default`` profile's overlay by
+the operator (``platformagent_manifests.go``), and it is the value operators
+hand-write into ``AgentPlugin`` config. Every governance watchdog on
+``agents/platform/cron/jobs.json`` therefore ran unscanned.
+
+One of those seven jobs is ``github-issue-resolver``, firing every 30 minutes to
+"poll, triage, investigate, and resolve unaddressed open issues on our target
+repo". Its input is issue text written by anyone with a GitHub account, and its
+output is shell commands run with the platform agent's credentials. Tirith's
+subject matter is content-level threats in a command string — confusable
+Unicode and homograph hostnames, pipe-to-interpreter, encoded payloads — which
+is the shape of what a hostile issue body can talk a model into typing. The scan
+buys two distinct things over ``DANGEROUS_PATTERNS`` alone, both measured
+against the shipped image on 2026-08-08:
+
+* Homographs are outside the pattern layer entirely. A Cyrillic-e
+  ``kubernetеs.io`` matches no pattern, and under ``cron_mode: approve``
+  nothing else looked at it either.
+* ``curl | sh`` and base64-to-shell *are* patterns, but ``approve`` is precisely
+  the instruction not to block on a pattern. Tirith refuses them on its own
+  authority, so the waiver stops shipping them.
+
+Do not over-read the coverage. A pure-ASCII lookalike TLD
+(``kubernetes.io.evil-cdn.co``) and terminal escape injection are caught by
+neither layer — ANSI is stripped before pattern matching, and real ESC payloads
+did not trip the scanner either.
+
+What this patch does
+--------------------
+The scan is moved out from under the mode. ``cron_tirith_block`` runs the same
+``tools.tirith_security.check_command_security`` the ``deny`` arm runs, on the
+``approve`` path as well, and returns a block result when the scanner reports a
+verdict. ``cron_mode`` keeps its documented job — deciding whether a
+*pattern*-flagged dangerous command is refused or allowed to run unprompted —
+and loses the undocumented one.
+
+The wiring calls this only when the mode is not ``deny``, so the ``deny`` arm's
+own Tirith call is left exactly as upstream wrote it and no command is scanned
+twice (each scan is a subprocess spawn).
+
+Why a finding blocks the command rather than being logged
+---------------------------------------------------------
+Blocking is the safe option, and here it is also the cheap one:
+
+* **A broken scanner cannot stop the roster.** Every infrastructure failure mode
+  is already handled *inside* ``check_command_security`` and fails open under
+  the default ``security.tirith_fail_open: true`` — spawn failure, timeout,
+  unexpected exit code, the consecutive-crash circuit breaker, and an
+  unsupported platform all return ``action: allow``. Reaching a block therefore
+  requires the scanner to have actually run and actually objected to the text.
+  The one remaining failure — the module not importing at all — is handled
+  below, and honours the same ``tirith_fail_open`` flag the ``deny`` arm does.
+* **A finding on an unattended run is a statement about content, not shape.**
+  It says this command contains something the operator did not write. Logging
+  and continuing would run the exact string the scanner objected to, and nobody
+  is watching the log at 06:20 on a Sunday.
+* **It is recoverable and visible.** The agent receives an ordinary denial
+  string, keeps running, and can take another route; the gateway logs the
+  refusal (``Cron Tirith block: ...``). The execution ledger has no per-command
+  rows, so it does not record the refusal, and ``save_job_output`` persists the
+  run's final response rather than its tool results — the refusal reaches the
+  saved output only if the model narrates it. This is not a new class of
+  outcome — it is the treatment ``cron_mode: deny`` already gives the identical
+  scan, now available without also refusing every ``kubectl delete`` the
+  watchdogs legitimately issue.
+
+``approvals.cron_scan: false`` turns the scan back off for one profile, for the
+case where a watchdog trips the scanner for a reason the operator has examined
+and accepted. It is deliberately a separate key from ``cron_mode``: making the
+scan opt-in through a new ``cron_mode`` value would have left every
+already-written ``cron_mode: approve`` — the operator's overlay, every hand-authored
+``AgentPlugin`` — silently unscanned, which is the state this patch exists to end.
+
+Out of scope, recorded so it is not mistaken for covered
+--------------------------------------------------------
+``check_execute_code_guard`` still auto-approves ``execute_code`` under
+``cron_mode: approve``. Tirith scans POSIX shell strings (``--shell posix``);
+handing it a Python script would produce noise, not a verdict. A cron run can
+therefore still reach ``subprocess`` through ``execute_code`` without a content
+scan. Closing that needs a different scanner, not this one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Per-profile opt-out, read from ``approvals.cron_scan`` in config.yaml.
+#: Absent means enabled: the scan is the default and turning it off is the
+#: decision that has to be written down.
+CRON_SCAN_KEY = "cron_scan"
+
+
+def _load_config_readonly() -> dict:
+    """Read config.yaml without taking a write lock, or ``{}``.
+
+    Deferred import: ``tools/approval.py`` is imported very early in Hermes
+    startup and this module is imported from inside one of its functions, so
+    nothing here may pull in configuration at module import time.
+    """
+    from hermes_cli.config import load_config_readonly
+
+    return load_config_readonly() or {}
+
+
+def _default_scan(command: str) -> dict:
+    """Run the real Tirith scan. Raises ``ImportError`` if it is not installed.
+
+    Kept as a named default rather than inlined so the unit suite can drive
+    ``cron_tirith_block`` without ``/opt/hermes`` on ``sys.path``, and so the
+    ``ImportError`` this raises reaches the caller's handler unchanged.
+    """
+    from tools.tirith_security import check_command_security
+
+    return check_command_security(command)
+
+
+def _describe(result: dict) -> str:
+    """Last-resort renderer for a Tirith result.
+
+    The wiring passes ``tools.approval._format_tirith_description`` in, so this
+    is only reached by the unit suite, which cannot import Hermes. Keep it a
+    recognisable subset of the real thing rather than a second implementation
+    that could drift into disagreeing with the message users actually see.
+    """
+    findings = (result or {}).get("findings") or []
+    parts = []
+    for finding in findings:
+        severity = finding.get("severity", "")
+        title = finding.get("title", "")
+        if title:
+            parts.append(f"[{severity}] {title}" if severity else title)
+    if not parts:
+        summary = (result or {}).get("summary") or "security issue detected"
+        return f"Security scan: {summary}"
+    return "Security scan — " + "; ".join(parts)
+
+
+def cron_scan_enabled(config: Optional[dict]) -> bool:
+    """Whether ``approvals.cron_scan`` leaves the scan on. Default: yes.
+
+    Anything other than an explicit false-y value keeps the scan, including a
+    malformed config — an operator who cannot write the key correctly has not
+    opted out of it.
+    """
+    approvals = (config or {}).get("approvals")
+    if not isinstance(approvals, dict):
+        return True
+    return bool(approvals.get(CRON_SCAN_KEY, True))
+
+
+def tirith_fail_open(config: Optional[dict]) -> bool:
+    """Whether an unavailable scanner should allow the command through.
+
+    Mirrors the ``ImportError`` handler on ``check_all_command_guards``' cron
+    ``deny`` arm exactly, including its ordering: ``tirith_fail_open`` is only
+    consulted when ``tirith_enabled`` is true, so an operator who switched
+    Tirith off entirely is not then blocked by its absence.
+    """
+    security = (config or {}).get("security")
+    if not isinstance(security, dict):
+        return True
+    if not security.get("tirith_enabled", True):
+        return True
+    return bool(security.get("tirith_fail_open", True))
+
+
+def _block(message: str) -> dict:
+    """A refusal in the shape ``check_all_command_guards`` returns.
+
+    Two keys and no more, matching the cron ``deny`` arm above it. Callers
+    branch on ``approved`` and surface ``message`` to the model verbatim.
+    """
+    return {"approved": False, "message": message}
+
+
+def cron_tirith_block(
+    command: str,
+    *,
+    describe: Optional[Callable[[dict], str]] = None,
+    scan: Optional[Callable[[str], dict]] = None,
+    load_config: Optional[Callable[[], dict]] = None,
+) -> Optional[dict]:
+    """Scan one cron command; return a refusal, or ``None`` to let it run.
+
+    Called from ``check_all_command_guards`` when the session is a cron session
+    and ``approvals.cron_mode`` is not ``deny`` — that is, on the path where the
+    approval prompt has been waived because no one is there to answer it. The
+    waiver covers the prompt. It does not cover the scanner, and this restores
+    the scanner.
+
+    ``describe``, ``scan`` and ``load_config`` exist so the unit suite can drive
+    the decision without Hermes on ``sys.path``; the wiring passes ``describe``
+    (Hermes' own ``_format_tirith_description``, so the model sees the same
+    finding text an interactive user would) and leaves the other two default.
+    """
+    config: dict = {}
+    try:
+        config = (load_config or _load_config_readonly)() or {}
+    except Exception as exc:
+        # An unreadable config must not decide security policy by accident. Fall
+        # through on the built-in defaults, which scan and fail open — the same
+        # posture the rest of approval.py takes when its config read fails.
+        logger.debug("cron Tirith scan: config unreadable (%s); using defaults", exc)
+
+    if not cron_scan_enabled(config):
+        return None
+
+    try:
+        result = (scan or _default_scan)(command) or {}
+    except ImportError:
+        # Tirith is not installed. The deny arm's handler is reproduced rather
+        # than shared because this is a policy decision an operator can have set
+        # either way, and the two paths must not drift apart.
+        if tirith_fail_open(config):
+            return None
+        logger.warning(
+            "cron Tirith scan: scanner unavailable and security.tirith_fail_open "
+            "is false; blocking (command: %s)",
+            command[:200],
+        )
+        return _block(
+            "BLOCKED: the Tirith security scanner could not be imported and "
+            "security.tirith_fail_open is false, so this command cannot be "
+            "silently allowed — and cron jobs run without a user present to "
+            "approve it. Find an alternative approach, install tirith, or set "
+            "security.tirith_fail_open: true if an unscanned cron run is "
+            "acceptable on this profile."
+        )
+
+    if result.get("action") not in ("block", "warn"):
+        return None
+
+    description = (describe or _describe)(result)
+    logger.warning(
+        "Cron Tirith block: %s (command: %s)", description, command[:200]
+    )
+    return _block(
+        f"BLOCKED: {description} — and this is an unattended cron run. "
+        "approvals.cron_mode waives the approval prompt, which no one is here "
+        "to answer; it does not waive the content scan. The scanner objected to "
+        "what is IN this command rather than to the shape of it, so look for "
+        "something you did not author: a URL, a piped installer, or text lifted "
+        "out of an issue, a log line, or a tool result. Find another way to do "
+        "this, or narrow the command until it scans clean. Do not retry it "
+        "unchanged."
+    )

--- a/deploy/docker/patches/kanban_auto_subscribe.py
+++ b/deploy/docker/patches/kanban_auto_subscribe.py
@@ -1,0 +1,205 @@
+"""Give a kanban worker's child cards the chat subscription of its own card.
+
+Installed into the image at ``/opt/hermes/tools/kanban_auto_subscribe.py`` and
+wired into ``tools/kanban_tools.py`` (the ``kanban_create`` handler) by
+``deploy/docker/patches/apply_kanban_auto_subscribe.py``.
+
+The gap, measured
+-----------------
+The gateway notifier only sees cards with a ``kanban_notify_subs`` row. Two
+things write those rows at creation time, and both missed the worker case on
+the 2026-08-07 live run (12:58):
+
+* ``_maybe_auto_subscribe`` reads the originating chat identity
+  (``HERMES_SESSION_CHAT_ID`` / ``_THREAD_ID`` / ``_PLATFORM``) from session
+  context that exists only on inbound user messages. The coordinator card
+  ``t_b9659077`` was created in-session by the chat agent and got its row; the
+  four cards the coordinator created *as a dispatcher-spawned worker* (three
+  sleep tasks and the synthesizer ``t_f54bd6b5``) had no session context and
+  got nothing.
+* Upstream ``create_task`` does inherit subscriptions — but only from the
+  explicit ``parents=[...]`` graph edges (``_inherit_notify_subs``). A
+  worker's own card is deliberately not a graph parent of the work it fans
+  out (``parents=[<itself>]`` is the self-parenting deadlock the
+  ``kanban_scheduling`` patch exists to untangle), so the chain from
+  the user's thread to the fan-out is severed at the first worker.
+
+Result: the synthesizer's answer sat undelivered for 91.3s until the user
+asked after it — ``gateway.log`` shows zero Slack sends between 12:59:02 and
+13:02:15. The manual remedy,
+``agents/platform/scripts/kanban_notify_propagate.py``, relies on the worker
+remembering to run it; it didn't.
+
+The fix
+-------
+:func:`maybe_inherit_worker_subscriptions` runs right after
+``_maybe_auto_subscribe`` in the ``kanban_create`` tool handler. When the
+creating process is a kanban worker (``HERMES_KANBAN_TASK`` set, non-empty,
+and not the new card itself — the dispatcher pins it into every worker), the
+new card inherits every subscription row of the card the worker is running.
+So the user's thread follows the work wherever a worker fans it out, one hop
+at a time: coordinator → sleep tasks → synthesizer, each inheriting from the
+card that created it.
+
+Same contract as the manual script it automates: the copied column set is
+``platform, chat_id, thread_id, user_id, notifier_profile`` (also exactly
+what upstream ``_inherit_notify_subs`` copies), ``INSERT OR IGNORE`` on the
+subscription primary key makes it idempotent — the script remains in place
+as a manual/back-fill tool and double-writes are harmless — and
+``created_at`` is re-stamped.
+
+The cursor starts caught up
+---------------------------
+``last_event_id`` is seeded at the child's current ``MAX(task_events.id)``
+rather than at 0, because a subscriber wants the events that happen after it
+subscribes and nothing before. Both upstream seeding paths in
+``hermes_cli/kanban_db.py`` already do this and each records the bug that
+taught them to: ``add_notify_sub`` snaps to the head because a cursor of 0
+on an already-active task made the notifier replay every historical terminal
+event on its next tick, a boot-time burst of 100+ messages (issue #29905),
+and ``_inherit_notify_subs`` does it so ``link_tasks(parent,
+existing_child)`` does not replay the child's pre-link history.
+
+This patch needs it for a third reason, and the reason is not theoretical.
+``kanban_create`` accepts an ``idempotency_key``, and ``create_task`` answers
+a repeat key by returning the id of the *existing* card — before it opens
+``write_txn``, without creating anything. The ``new_tid`` this patch hooks is
+therefore not always a new card: a worker that re-issues an idempotent create
+gets back a card that may have run, blocked and completed days earlier.
+Seeded at 0, the row written below made the notifier's very next tick post
+that entire history into the user's chat thread — the status transition, the
+block, and the completion line for work nobody had just asked about. Seeded
+at the head, the same worker gets exactly what it wanted: this card's future
+events, in the thread that asked for them.
+
+Fail-soft throughout: any exception is logged and swallowed. A notification
+bookkeeping failure must never fail the ``kanban_create`` the worker is
+mid-flight on — the same posture ``_maybe_auto_subscribe`` itself takes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from typing import Union
+
+logger = logging.getLogger(__name__)
+
+#: The subscription columns copied parent -> child. ``task_id`` is rewritten,
+#: ``created_at`` re-stamped, ``last_event_id`` seeded at the child's own
+#: head. Matches both the manual propagate script and upstream
+#: ``_inherit_notify_subs`` so a schema drift shows up here as a clear error
+#: instead of a silently wrong copy.
+COPY_COLUMNS = ("platform", "chat_id", "thread_id", "user_id", "notifier_profile")
+
+#: The env var the dispatcher pins into every worker it spawns: the id of the
+#: card the worker is running. Presence (with a different id than the new
+#: card) is the definition of "this create came from a worker".
+WORKER_TASK_ENV = "HERMES_KANBAN_TASK"
+
+
+def inherit_subscriptions(
+    conn_or_db_path: Union[sqlite3.Connection, str, "os.PathLike[str]"],
+    child_task_id: str,
+    parent_task_id: str,
+) -> int:
+    """Copy ``kanban_notify_subs`` rows from parent to child. Fail-soft.
+
+    Returns the number of rows written (0 on any failure, no-op, or when the
+    child already has them — idempotent via ``INSERT OR IGNORE`` on the
+    ``(task_id, platform, chat_id, thread_id)`` primary key). Never raises.
+
+    Refuses to write for a child card not on the board, for the reason the
+    manual script documents: the notifier unsubscribes only when a task turns
+    terminal, so a row for a card that does not exist would be scanned on
+    every notifier tick for the life of the board.
+
+    The row is seeded at the child's current event head, so an already-active
+    child — the card an idempotent ``kanban_create`` hands back — does not
+    replay its history into the thread. See the module docstring.
+    """
+    try:
+        if not child_task_id or not parent_task_id:
+            return 0
+        if child_task_id == parent_task_id:
+            return 0
+
+        own_conn = not isinstance(conn_or_db_path, sqlite3.Connection)
+        if own_conn:
+            # `timeout=` IS the busy timeout; the gateway and CLI write this
+            # same board, and a nudge lost to a busy DB is a lost delivery.
+            conn = sqlite3.connect(str(conn_or_db_path), timeout=10)
+        else:
+            conn = conn_or_db_path
+        try:
+            # One statement answers both questions this function has to ask
+            # about the child: is it on the board at all, and where does its
+            # event history already end. A row means it exists; the value is
+            # the cursor to start the subscriber at.
+            row = conn.execute(
+                "SELECT COALESCE("
+                "    (SELECT MAX(id) FROM task_events WHERE task_id = ?), 0"
+                ") FROM tasks WHERE id = ?",
+                (child_task_id, child_task_id),
+            ).fetchone()
+            if row is None:
+                logger.warning(
+                    "kanban_auto_subscribe: child card %r not on this board; "
+                    "refusing to write an uncollectable subscription row",
+                    child_task_id,
+                )
+                return 0
+            head = int(row[0])
+            cols = ", ".join(COPY_COLUMNS)
+            cur = conn.execute(
+                f"""
+                INSERT OR IGNORE INTO kanban_notify_subs
+                    (task_id, {cols}, created_at, last_event_id)
+                SELECT ?, {cols}, ?, ?
+                  FROM kanban_notify_subs
+                 WHERE task_id = ?
+                """,
+                (child_task_id, int(time.time()), head, parent_task_id),
+            )
+            written = cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+            # kanban_db connections run autocommit with explicit BEGIN
+            # IMMEDIATE for multi-statement writes; a plain connect() opens a
+            # deferred txn on the INSERT instead. Commit whichever applies.
+            if getattr(conn, "in_transaction", False):
+                conn.commit()
+            if written:
+                logger.info(
+                    "kanban_auto_subscribe: %s inherited %d subscription "
+                    "row(s) from %s, watching from event %d",
+                    child_task_id, written, parent_task_id, head,
+                )
+            return written
+        finally:
+            if own_conn:
+                conn.close()
+    except Exception as exc:  # noqa: BLE001 — never break the create
+        logger.warning(
+            "kanban_auto_subscribe: inherit %r -> %r failed (continuing): %r",
+            parent_task_id, child_task_id, exc,
+        )
+        return 0
+
+
+def maybe_inherit_worker_subscriptions(conn, child_task_id: str) -> int:
+    """Inherit from the worker's own card when this process is a worker.
+
+    The single call the patched ``kanban_create`` handler makes. A process
+    with no ``HERMES_KANBAN_TASK`` (chat session, CLI, cron) is left exactly
+    as upstream — ``_maybe_auto_subscribe`` and ``_inherit_notify_subs``
+    already cover those paths.
+
+    Never raises, but the guarantee lives one level down: reading an env var
+    cannot fail, and every statement that can — the board reads and the
+    insert — is inside :func:`inherit_subscriptions`'s own catch-all.
+    """
+    parent = (os.environ.get(WORKER_TASK_ENV) or "").strip()
+    if not parent or parent == child_task_id:
+        return 0
+    return inherit_subscriptions(conn, child_task_id, parent)

--- a/deploy/docker/patches/kanban_comment_status.py
+++ b/deploy/docker/patches/kanban_comment_status.py
@@ -1,0 +1,244 @@
+"""Tell ``kanban_comment`` what the card it just wrote to is actually doing.
+
+Installed into the image at ``/opt/hermes/tools/kanban_comment_status.py`` and
+wired into ``tools/kanban_tools.py`` (the ``kanban_comment`` handler) by
+``deploy/docker/patches/apply_kanban_comment_status.py``.
+
+Why
+---
+On 2026-08-08 task ``t_a8f58a2a`` completed at 19:09:43 and its 6,191-character
+report reached the user's Slack thread one second later. At 19:11:30 the front
+door called ``kanban_comment`` on that same card and told the user "You'll see
+the results post here as soon as the agent completes." The user waited 9m46s for
+an answer that was already sitting above the question.
+
+The comment call succeeded. It was unkeepable three ways over and upstream's
+return value mentioned none of them:
+
+1. **A comment does not respawn a card.** ``task_runs`` for ``t_a8f58a2a`` still
+   held only run 97, and no new card was created between 19:11 and 19:24.
+2. **The subscription was already gone.** ``gateway/kanban_watchers.py`` deletes
+   a card's ``kanban_notify_subs`` rows on the tick that carries its terminal
+   event (``task_terminal = task and task.status in {"done", "archived"}`` →
+   ``_kanban_unsub``), so nothing could fire for that card again.
+3. **Nobody ever re-read the comment.** Comments reach a worker two ways —
+   ``build_worker_context`` folds them into the *next* worker's system prompt,
+   and ``inject_new_comments_from_env`` (``run_agent.py``) steers them into a
+   worker that is running right now. A ``done`` card has neither.
+
+There is also a fourth thing that is true of *every* card, not just closed ones,
+and is worth saying because it is the belief that produced the sentence:
+**commenting never sends a chat message.** ``add_comment`` appends a
+``commented`` event, and ``commented`` is not in the notifier's ``TERMINAL_KINDS``
+(``completed, blocked, gave_up, crashed, timed_out, status, archived, unblocked,
+block_loop_detected``). A comment can only reach a human by causing a worker to
+run and *that* worker to complete.
+
+What upstream returns is ``_ok(task_id=tid, comment_id=cid)`` —
+``{"ok": true, "task_id": ..., "comment_id": ...}``. Read by a model that has
+just written "here is the question, please answer in this thread", ``ok: true``
+means the question was asked. It wasn't.
+
+What this adds
+--------------
+Three fields, all additive; ``ok``, ``task_id`` and ``comment_id`` keep their
+upstream meaning and shape because the model parses them.
+
+``task_status``
+    The card's raw ``tasks.status``. The single fact that makes the promise
+    obviously wrong: you cannot read ``"task_status": "done"`` and still believe
+    an answer is coming.
+
+``comment_reaches``
+    A sentence, not a token, because the token would need a legend the model
+    does not have: who will read this comment. ``running`` cards are steered
+    live, open cards wait for their next worker, terminal cards have neither.
+
+``completion_posts_to_chat``
+    Whether the card has a live ``kanban_notify_subs`` row — i.e. whether this
+    card completing will post anything into a chat thread at all. This is the
+    proposition the incident's sentence actually asserted, so it is worth
+    answering directly. Emitted **only for non-terminal cards**; see below.
+
+and, for terminal cards only, ``note``: an explicit instruction not to promise
+delivery, plus where the answer already is.
+
+Success, not an error
+---------------------
+Commenting on a closed card is a legitimate thing to do — annotating a finished
+audit, recording an RCA note against a closed incident, leaving provenance on a
+card someone will read on the dashboard. Refusing it would break that, and it
+would break it in the direction this patch is least allowed to fail: an error
+returns without writing, so the comment is *lost*. Losing a comment is a worse
+outcome than the incident, which lost only a claim about a comment.
+
+A refusal is also the wrong shape for the actual defect. The write was never the
+problem; the write is fine and durable. The problem is that a bare ``ok: true``
+licensed an inference — "asked, therefore an answer is coming" — that nothing in
+the system supports. The fix is to make that inference unavailable, which a
+returned status does and an error only does by accident, at the cost of also
+destroying the legitimate call. So: always write, always report.
+
+The one thing the return value must not do is read as pending, which is why the
+terminal branch carries an imperative ``note`` rather than leaving the model to
+infer the consequence of ``"done"`` on its own — inferring it is exactly what it
+failed to do the first time.
+
+Status outranks the subscription row
+------------------------------------
+``comment_reaches`` is derived from ``task_status`` alone, never from the
+subscription count, and ``completion_posts_to_chat`` is withheld on terminal
+cards. The two can disagree for one notifier tick: the unsub happens when the
+notifier *processes* the terminal event, so a card that completed a second ago
+is ``done`` with its rows still present. That window is precisely the incident's
+window — 19:09:43 to 19:11:30 is well inside a five-second tick's blast radius
+only if the tick stalls, but the ordering hazard is real and permanent. A model
+handed ``"task_status": "done"`` next to ``"completion_posts_to_chat": true``
+would resolve the contradiction in the optimistic direction, which is the bug.
+So the racy field is simply not emitted where it could contradict the durable
+one.
+
+Fails toward upstream
+---------------------
+Every lookup here is wrapped. If ``get_task`` raises, if the row is missing, if
+the board predates ``kanban_notify_subs``, :func:`delivery_fields` returns
+``{}`` and the handler returns byte-for-byte what upstream returned. The comment
+is already committed by the time this runs — ``add_comment`` opens and closes
+its own ``write_txn`` — so there is no path on which reporting the status can
+cost the caller the comment. Omitting a status field is a regression to previous
+behaviour; failing the call would be a new way to lose data.
+
+Cost
+----
+One extra ``SELECT * FROM tasks WHERE id = ?`` on the connection the handler
+already holds open, against the primary key, plus one ``SELECT 1 FROM
+kanban_notify_subs WHERE task_id = ? LIMIT 1`` served by ``idx_notify_task``.
+The task row is *not* already loaded on this path — upstream's ``add_comment``
+checks existence with its own ``SELECT 1`` inside ``write_txn`` and returns only
+``lastrowid`` — so the status genuinely costs a query. Two indexed point lookups
+against a local SQLite file, on a path that has just done a write transaction,
+is not a cost worth trading a silent false promise for.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+#: Statuses on which the gateway notifier tears a card's chat subscriptions
+#: down. Deliberately the same set as ``task_terminal`` in
+#: ``gateway/kanban_watchers.py`` — that comparison is what makes a card
+#: undeliverable, so this one has to track it. If upstream widens its set and
+#: this stays behind, ``verify_kanban_comment_status.py`` is where it shows up:
+#: it reads the notifier's own source and compares.
+TERMINAL_STATUSES = frozenset({"done", "archived"})
+
+#: The status on which a comment reaches the worker *now*, via
+#: ``inject_new_comments_from_env`` (``run_agent.py``) steering it into the live
+#: agent rather than waiting for ``build_worker_context`` to fold it into the
+#: next run's system prompt.
+RUNNING_STATUS = "running"
+
+READER_RUNNING = "the worker running this card right now"
+READER_NEXT = "the next worker to run this card"
+READER_NONE = "nobody"
+
+#: Written at the model, not at a log reader. It has to survive being skimmed,
+#: so it leads with the refutation rather than the explanation, and it names the
+#: two tools that do what the caller was actually trying to do.
+TERMINAL_NOTE_TEMPLATE = (
+    "This card is already {status}, so nothing will happen because of this "
+    "comment: no worker is scheduled to read it, its chat subscription was "
+    "closed when the card finished, and commenting never sends a chat message "
+    "on any card. Do NOT say that results will follow from this comment, and "
+    "do not wait for them. The card's answer already exists — read it with "
+    "kanban_show({task_id!r}) and reply with it yourself. If new work is "
+    "needed, create a new card with kanban_create."
+)
+
+
+def _status_of(kb: Any, conn: Any, task_id: Any) -> str:
+    """The card's ``status``, or ``""`` when it cannot be established.
+
+    Separate from :func:`delivery_fields` so the empty string has exactly one
+    meaning at the call site — "say nothing" — whether the cause was a missing
+    card, a missing column, or a raising driver.
+    """
+    task = kb.get_task(conn, task_id)
+    if task is None:
+        return ""
+    return str(getattr(task, "status", "") or "").strip()
+
+
+def _has_chat_subscriber(conn: Any, task_id: Any) -> bool:
+    """Whether any gateway source is subscribed to this card's events.
+
+    A direct ``SELECT 1 … LIMIT 1`` rather than ``kb.list_notify_subs``: the
+    caller only needs existence, and ``list_notify_subs`` builds a dict per row
+    and JSON-decodes ``delivery_metadata`` on each one to answer it. Served by
+    ``idx_notify_task``.
+    """
+    row = conn.execute(
+        "SELECT 1 FROM kanban_notify_subs WHERE task_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return row is not None
+
+
+def delivery_fields(kb: Any, conn: Any, task_id: Any) -> dict:
+    """Extra ``kanban_comment`` result fields describing the card's state.
+
+    Returns a mapping to splat into upstream's ``_ok(...)``. Never raises and
+    never returns a key whose value it could not establish: ``{}`` means the
+    handler answers exactly as unpatched Hermes did.
+
+    See the module docstring for why a terminal card gets a ``note`` instead of
+    an error, and why ``completion_posts_to_chat`` is withheld there.
+    """
+    try:
+        status = _status_of(kb, conn, task_id)
+        if not status:
+            # No card, or a row without a usable status. add_comment would have
+            # raised ValueError("unknown task") before we got here, so this is
+            # a shape change rather than a missing card — either way, guessing
+            # is worse than staying quiet.
+            return {}
+
+        if status in TERMINAL_STATUSES:
+            return {
+                "task_status": status,
+                "comment_reaches": READER_NONE,
+                "note": TERMINAL_NOTE_TEMPLATE.format(
+                    status=status, task_id=str(task_id),
+                ),
+            }
+
+        fields = {
+            "task_status": status,
+            "comment_reaches": (
+                READER_RUNNING if status == RUNNING_STATUS else READER_NEXT
+            ),
+        }
+        try:
+            fields["completion_posts_to_chat"] = _has_chat_subscriber(
+                conn, task_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — a legacy board has no table
+            # Older boards predate kanban_notify_subs entirely (kanban_db's
+            # count_notify_subs documents the same case). The status is the
+            # load-bearing half; drop only the half that failed.
+            logger.debug(
+                "kanban_comment_status: subscription probe for %r failed "
+                "(continuing without it): %r",
+                task_id, exc,
+            )
+        return fields
+    except Exception as exc:  # noqa: BLE001 — never fail a written comment
+        logger.warning(
+            "kanban_comment_status: status lookup for %r failed "
+            "(comment already committed, returning upstream fields): %r",
+            task_id, exc,
+        )
+        return {}

--- a/deploy/docker/patches/kanban_guardrail_exit.py
+++ b/deploy/docker/patches/kanban_guardrail_exit.py
@@ -1,0 +1,319 @@
+"""Keep a kanban worker on the board when its turn ends without a terminal call.
+
+The contract and the hole
+-------------------------
+A dispatcher-spawned worker must finish with ``kanban_complete`` or
+``kanban_block``. Upstream Hermes already knows this and guards it: at the end
+of ``run_conversation``'s *no-tool-calls* branch it calls
+``build_kanban_stop_nudge`` and, if the worker is about to exit without a
+terminal call, appends a synthetic user turn and continues the loop
+(``agent/conversation_loop.py``, "Kanban worker terminal-tool stop guard").
+
+That guard sits in one branch of one loop. Every other way out of the loop is a
+bare ``break`` several hundred lines earlier, and each one jumps straight over
+it. The worker then exits ``rc=0`` having never touched the board, and the
+dispatcher's reaper stamps a ``protocol_violation`` after the fact — a failure
+with no explanation in it, because by the time it is detected the reason is
+gone.
+
+What that cost us on 2026-08-07
+-------------------------------
+Card ``t_d3efabef`` ("Evaluate Config Connector Setup Patterns") burned four
+runs and 38 minutes producing nothing. Every run ended the same way::
+
+    ⚠️ Tool guardrail halted web_search: loop_web_search_cap
+
+``ToolCallGuardrailController._check_loop_cap`` blocks the 51st ``web_search`` of
+a turn, ``_guardrail_block_result`` records the decision on the agent, and
+``conversation_loop.py`` breaks out of the tool-call branch. ``failed`` stays
+``False``. The model never sees the block result, never gets another turn, and
+never learns that it is one sentence away from a clean completion — it had 173
+successful searches in hand.
+
+The aggravating half is that the 50-search cap is documented as *per turn* and
+resets in ``reset_for_turn``, but a non-goal-mode kanban worker is a single
+``run_conversation`` for the whole card. For those workers the per-turn cap is
+really a per-card research budget, and a genuine research card blows through it.
+That part is addressed in ``agents/platform/config.yaml``; this module addresses
+the exit path, which is the defect. Raising the cap alone would only move when
+the bug fires.
+
+The two fixes here
+------------------
+1. **Make the halt kanban-aware** (``guardrail_halt_nudge``). At the halt site
+   the decision is visible and ``messages`` is still live and mutable, which is
+   what makes it the only workable seam. Reuse upstream's own nudge helper — it
+   is already bounded at two attempts and already returns ``None`` for
+   non-workers, so non-kanban sessions are untouched by construction — and add
+   the one thing the stock text does not say: the tool is gone for this run,
+   stop trying to use it.
+
+   The caller must clear ``agent._tool_guardrail_halt_decision`` before
+   continuing. ``ToolCallGuardrailController.reset_for_turn`` clears it once per
+   *turn*, not per iteration, so leaving it set makes the next iteration
+   re-enter the halt branch and break anyway.
+
+   The halt is re-armable and the search counter is still at the cap, so a model
+   that ignores the instruction and searches again will re-halt and spend
+   another nudge. Two nudges bounds that at three halts per run, after which
+   today's behaviour resumes. Do **not** paper over it by resetting
+   ``_turn_web_search_count`` — that hands out another 50 searches.
+
+2. **Backstop every other exit** (``should_record_missing_terminal`` /
+   ``record_missing_terminal_call``). ``finalize_turn`` is the single funnel
+   every ``break`` passes through, so one check there covers the halt path and
+   the six siblings that leak identically: ``all_retries_exhausted_no_response``,
+   ``partial_stream_recovery``, ``fallback_prior_turn_content``,
+   ``empty_response_exhausted``, ``local_processing_error`` and
+   ``error_near_max_iterations``. Even the guarded ``text_response`` path leaks
+   once its two nudges are spent. All of them leave ``failed=False`` with a
+   non-``text_response`` exit reason and no board write.
+
+   This converts an unexplained ``protocol_violation`` into a counted
+   ``timed_out`` that names the exit reason in its payload, using the same
+   ``_record_task_failure`` call the iteration-budget path directly above it
+   already uses.
+
+Four exclusions matter, and all of them are load-bearing:
+
+* **``delegate_task`` children.** A child agent runs ``run_conversation`` *in the
+  parent's own process*, so it reaches ``finalize_turn`` with the parent's
+  ``HERMES_KANBAN_TASK`` still in the environment and no card of its own. Upstream
+  treats that as the defining case: ``tools/kanban_tools.py``'s
+  ``_reject_delegated_child_mutation`` refuses every board mutation from a child
+  precisely because "stale or inherited ``HERMES_KANBAN_*`` env vars are not proof
+  of dispatcher ownership", and both of upstream's own kanban gates open with the
+  same short-circuit. Without it, a parent that delegates twice charges its own
+  card two ``timed_out`` failures and has its claim released underneath it — mid
+  run, while it is still working — and then completes a card it no longer holds.
+
+* **Goal mode.** ``_run_kanban_goal_loop_q`` calls ``run_conversation`` once per
+  turn, so ``finalize_turn`` runs many times for one card and intermediate turns
+  legitimately end without a terminal call. The goal loop has its own bounded
+  turn budget and its own ``block_fn``. Recording a failure on turn 1 of N would
+  release the claim and close the run underneath it.
+
+* **Cron runs.** ``cronjob(action='run')`` executes the job in-process inside the
+  dispatching worker, and ``tools/cron_run_scope.py`` deliberately leaves
+  ``HERMES_KANBAN_TASK`` pointing at the dispatcher's card for the duration —
+  ``heartbeat_current_worker_from_env`` reads it on every kanban call to keep a
+  15-minute claim alive across a 20-minute audit. So the env var this backstop
+  keys off names a card the cron run is explicitly *barred* from terminating
+  (``resolve_default_task_id`` returns ``None`` inside a run, and
+  ``cron_ownership_violation`` rejects it by name). Its not having called a
+  terminal tool is the design, not a leak. Record it and the dispatcher — still
+  blocked on the run — has its claim released and a ``timed_out`` charged to its
+  failure budget by its own child.
+
+* **The task's own status.** The board is the authority: if the card is no longer
+  ``running``, a terminal tool already moved it and there is nothing to record.
+  This is what makes a false positive impossible rather than merely unlikely.
+
+  It is also the *only* authority consulted, and that is deliberate. This check
+  used to be preceded by ``agent.kanban_stop.session_called_kanban_terminal``,
+  which asks the transcript instead of the board — and gets it wrong in both
+  directions. Compaction can drop a terminal tool call out of ``messages``
+  (false leak, harmless: the board check catches it). Worse, a terminal call
+  that was *rejected* still lands in the transcript as a tool message named
+  ``kanban_complete`` (``agent/tool_dispatch_helpers.py``), and that function
+  matches on the name alone. ``tools/kanban_result_required.py`` rejects a
+  completion with an empty ``result``, so one refused call made the transcript
+  claim the card was terminated for the rest of the run — silencing this
+  backstop, upstream's stop guard, and the halt nudge in one move, and leaving
+  the card ``running`` on a worker that has exited rc=0. The dispatcher then
+  charges it a ``protocol_violation`` naming none of that.
+
+  Dropping the transcript check costs one SQLite read on an exit path that is
+  already exceptional, and the board cannot be wrong about its own rows.
+
+What is deliberately *not* excluded is the halt nudge. It fires during a cron run
+too — ``kanban_stop_nudge_enabled()`` is on whenever ``HERMES_KANBAN_TASK`` is
+set, and upstream interpolates that id straight into the text — so the run is
+told by name to complete a card it will be refused. That wastes at most two
+turns and is upstream's behaviour in its own stop guard either way, and the two
+answers are wanted in opposite directions: for the board write, a wrong "yes,
+cron" is free (skip a record, never write a wrong one), while for the nudge it
+would silence the fix on an unrelated worker, which is the whole thing this
+module exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+
+try:  # In the image, /opt/hermes is on sys.path.
+    from tools.kanban_ownership import in_cron_run, is_delegated_child
+except ImportError:  # Local unittest discovery: the patches dir is top-level.
+    from kanban_ownership import in_cron_run, is_delegated_child
+
+# Mirrors ``agent.kanban_stop._DEFAULT_MAX_ATTEMPTS``. Duplicated rather than
+# imported so this module stays importable on a host without Hermes, which is
+# what lets the tests run outside the image.
+DEFAULT_MAX_NUDGES = 2
+
+OUTCOME = "timed_out"
+
+DETECTOR = "kanban_guardrail_exit"
+
+_HALT_SUFFIX = (
+    "\n\n[System: `{tool}` is exhausted for the rest of this run "
+    "({code}) — every further call will be blocked, so do not try again. "
+    "Write up what you already have and call `kanban_complete`, or call "
+    "`kanban_block` if what you have is genuinely unusable.]"
+)
+
+
+def guardrail_halt_nudge(build_nudge, *, messages, attempts, decision):
+    """Return the follow-up for a kanban worker whose turn a guardrail halted.
+
+    ``build_nudge`` is ``agent.kanban_stop.build_kanban_stop_nudge``, injected so
+    this module never imports Hermes. It already returns ``None`` when the guard
+    should not fire — not a kanban worker, a terminal tool was already called, or
+    the nudge budget is spent — and those are exactly the cases where the caller
+    should fall through to the original ``break``.
+
+    Returns ``None`` on any failure. A broken nudge must never wedge a worker;
+    the old exit path is always the safe answer.
+    """
+    try:
+        base = build_nudge(messages=messages, attempts=attempts)
+    except Exception:
+        return None
+    if not base:
+        return None
+    tool = getattr(decision, "tool_name", None) or "that tool"
+    code = getattr(decision, "code", None) or "tool guardrail"
+    return base + _HALT_SUFFIX.format(tool=tool, code=code)
+
+
+def missing_terminal_error(turn_exit_reason) -> str:
+    """The ``last_failure_error`` text, which names how the turn actually ended."""
+    return (
+        "worker ended without a terminal kanban call "
+        f"(turn_exit_reason={turn_exit_reason})"
+    )
+
+
+def should_record_missing_terminal(
+    *,
+    task_id,
+    interrupted,
+    failed,
+    iteration_limit_fallback,
+    goal_mode=None,
+    cron_run=None,
+    delegated_child=None,
+) -> bool:
+    """Whether this exit is one ``record_missing_terminal_call`` should look at.
+
+    A cheap pre-filter, not the verdict: it rules out the exits that are somebody
+    else's business, and ``record_missing_terminal_call`` then asks the board
+    whether the card is actually still ``running``. Deliberately says nothing
+    about the transcript — see the docstring for what that cost.
+
+    ``goal_mode`` defaults to reading ``HERMES_KANBAN_GOAL_MODE`` from the
+    environment; ``cron_run`` and ``delegated_child`` default to the predicates
+    in ``tools/kanban_ownership.py``, which read
+    ``tools.cron_run_scope.current_cron_job()`` and
+    ``agent.delegation_context.is_delegated_child_context()`` respectively.
+
+    Every uncertain answer is ``False`` — this function's verdict never writes to
+    a board it cannot justify. Both ownership predicates are asked with
+    ``on_unknown=True`` for exactly that reason: they name the contexts that must
+    *not* record, so an unreadable one has to answer "somebody else's card".
+    """
+    if not task_id:
+        return False
+    if interrupted or failed or iteration_limit_fallback:
+        # Interrupts are the caller's business, ``failed`` turns already exit
+        # nonzero, and the iteration-budget path records its own failure
+        # immediately above this check.
+        return False
+    if delegated_child is None:
+        # on_unknown=True: a reader that raises must not let this charge a
+        # ``timed_out`` to a parent's card and release its claim mid-run.
+        delegated_child = is_delegated_child(on_unknown=True)
+    if delegated_child:
+        # task_id here is the PARENT's card, inherited through the shared
+        # process. The child owns no card and must not touch that one.
+        return False
+    if cron_run is None:
+        # on_unknown=True, same rule from the other side: the dispatcher is still
+        # blocked on this run, and a wrong "not cron" releases its claim.
+        cron_run = in_cron_run(on_unknown=True)
+    if cron_run:
+        # task_id here is the DISPATCHER's card, inherited: this run has none of
+        # its own and may not terminate that one. See the docstring.
+        return False
+    if goal_mode is None:
+        goal_mode = os.environ.get("HERMES_KANBAN_GOAL_MODE") == "1"
+    return not goal_mode
+
+
+def task_is_still_running(conn, task_id: str) -> bool:
+    """Whether the board still shows this card as ``running``.
+
+    ``kanban_complete`` moves it to ``done`` and ``kanban_block`` to ``blocked``,
+    so anything else means a terminal tool ran and the transcript check was
+    wrong — most plausibly because compaction dropped the tool call out of
+    ``messages``.
+    """
+    try:
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+    except Exception:
+        return False
+    if row is None:
+        return False
+    try:
+        status = row["status"]
+    except (TypeError, IndexError, KeyError):
+        status = row[0]
+    return str(status or "") == "running"
+
+
+def record_missing_terminal_call(
+    *,
+    task_id: str,
+    turn_exit_reason,
+    connect,
+    record_failure,
+) -> bool:
+    """Charge a leaked exit to the card's failure budget. Returns whether it did.
+
+    ``connect`` is ``hermes_cli.kanban_db.connect`` and ``record_failure`` is
+    ``hermes_cli.kanban_db._record_task_failure``, both injected. The
+    ``release_claim`` / ``end_run`` pair is the same one the iteration-budget
+    path uses: the card is still ``running`` with an open run, and this hands
+    both back.
+
+    ``event_payload_extra`` reaches only the ``gave_up`` event, on the attempt
+    that trips the breaker — the per-attempt ``timed_out`` event carries a fixed
+    ``{error, failures}`` payload. So the exit reason has to travel in the error
+    *text* to be legible on every attempt, which is what
+    ``missing_terminal_error`` is for; the structured copy is a convenience for
+    the one event a human is most likely to read.
+    """
+    conn = connect()
+    try:
+        if not task_is_still_running(conn, task_id):
+            return False
+        record_failure(
+            conn,
+            task_id,
+            error=missing_terminal_error(turn_exit_reason),
+            outcome=OUTCOME,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={
+                "turn_exit_reason": str(turn_exit_reason),
+                "detector": DETECTOR,
+            },
+        )
+        return True
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/deploy/docker/patches/kanban_handoff_clip.py
+++ b/deploy/docker/patches/kanban_handoff_clip.py
@@ -1,7 +1,14 @@
 """URL-safe clipping for the kanban notifier's completion handoff.
 
 Installed into the image at ``/opt/hermes/gateway/kanban_handoff_clip.py`` and
-wired into ``gateway/kanban_watchers.py`` by ``deploy/docker/Dockerfile``.
+wired into ``gateway/kanban_watchers.py`` by
+``deploy/docker/patches/apply_kanban_notifier.py``.
+
+A module of its own rather than part of ``gateway/kanban_notifier.py``, which
+is what wires it in. It is a dependency-free text utility with no anchor into
+upstream source, ``tools/cron_run_scope.py`` uses it for a different clip
+entirely, and that patch is applied earlier in the build than the notifier one
+— so it is copied into the image on its own, ahead of both.
 
 Upstream builds the chat line for a completed card as::
 

--- a/deploy/docker/patches/kanban_notifier.py
+++ b/deploy/docker/patches/kanban_notifier.py
@@ -1,0 +1,852 @@
+"""Everything the kanban notifier does with a card's terminal event.
+
+Installed into the image at ``/opt/hermes/gateway/kanban_notifier.py`` and
+wired into ``gateway/kanban_watchers.py`` by
+``deploy/docker/patches/apply_kanban_notifier.py``.
+
+One module because it is one code path. When a card reaches a terminal state
+the notifier builds a chat line, sends it, and then decides whether to spend a
+model turn waking the agent that created the card. Three separate patches used
+to rewrite that path — a clip, a result delivery, and a wake filter — each with
+its own applier anchored into the same function, each its own way for a
+base-image bump to break the build for a reason that has nothing to do with the
+other two. They are merged here: two anchors, one applier, one verifier.
+
+The three concerns, in the order the notifier reaches them:
+
+1. **Clip** the status line. ``clip_handoff`` is re-exported from
+   ``gateway/kanban_handoff_clip.py``, which stays a module of its own because
+   ``tools/cron_run_scope.py`` imports it too and needs it earlier in the
+   build. The *wiring* of it into the notifier lives here.
+2. **Deliver** the report: :func:`handoff_with_result` puts the card's
+   ``result`` into the message the notifier already builds.
+3. **Wake**, or not: :func:`wake_kinds_for` decides which terminal kinds are
+   worth a model turn now that steps 1 and 2 have made the message carry the
+   answer.
+4. **Record** what step 3 chose not to announce:
+   :func:`note_suppressed_completion` writes a one-shot marker into the
+   creator's session state so the *next* turn knows the card finished, without
+   spending a turn to find out.
+
+Step 3 is only defensible because steps 1 and 2 happened, which is the clearest
+argument for keeping them together: ``kanban.wake_on_events`` may drop
+``completed`` on the grounds that the answer is already in the thread, and it is
+this module that put it there. Step 4 is the other half of that bargain — the
+answer being in the thread is a fact about the *user's* screen, not about the
+agent's transcript, and step 3 is only safe once something has told the agent.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Callable, Iterable, List, Optional, Tuple
+
+try:  # in-image: both modules live in the gateway package
+    from gateway.kanban_handoff_clip import DEFAULT_LIMIT, ELLIPSIS, clip_handoff
+except ImportError:  # host-side unit tests: siblings in deploy/docker/patches
+    from kanban_handoff_clip import DEFAULT_LIMIT, ELLIPSIS, clip_handoff
+
+logger = logging.getLogger("gateway.run")
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "ELLIPSIS",
+    "clip_handoff",
+    "RESULT_LIMIT",
+    "SEPARATOR",
+    "result_block",
+    "handoff_with_result",
+    "DEFAULT_WAKE_KINDS",
+    "CONFIG_KEY",
+    "resolve_wake_kinds",
+    "wake_kinds_for",
+    "NOTE_SIGNATURE",
+    "NOTE_TITLE_LIMIT",
+    "MAX_NOTES",
+    "suppressed_kinds",
+    "completion_note",
+    "creator_session_key",
+    "stage_note",
+    "note_suppressed_completion",
+]
+
+
+# ---------------------------------------------------------------------------
+# 2. Delivering the card's ``result`` into the chat that asked for it
+# ---------------------------------------------------------------------------
+#
+# The companion patch ``tools/kanban_result_required.py`` makes sure a card
+# closes with its answer in ``result``. That makes the answer *durable* — it is
+# on the card and ``kanban_show`` returns it whole. It does not make it
+# *arrive*, because nothing upstream posts ``result`` to chat.
+#
+# The chat line for a completed card is built from ``ev.payload["summary"]``,
+# which the kernel writes as (``hermes_cli/kanban_db.py``)::
+#
+#     ev_summary = (summary if summary is not None else result) or ""
+#     ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
+#
+# One line, 400 characters. The summary channel is therefore not merely the
+# wrong place for a report — it is structurally incapable of carrying one. A
+# worker that does exactly what the schema now asks (status line in ``summary``,
+# the deliverable in ``result``) would still send a chat message announcing a
+# catalogue it never shows.
+#
+# This section supplies the missing text. It goes into **the completion message
+# the notifier already builds**, rather than a second message, and that is
+# deliberate: the existing send site is wrapped in the notifier's failure
+# counter, cursor rewind, and subscription-drop logic
+# (``gateway/kanban_watchers.py``). One message inherits all of it. A follow-up
+# ``adapter.send()`` would sit outside that machinery, after the cursor has
+# advanced, and would need its own — a second failure path guarding the payload
+# that matters most.
+#
+# The notifier's own clip gives way
+# ---------------------------------
+# :func:`handoff_with_result` replaces the notifier's ``handoff`` rather than
+# appending to it, and it has to. Where the completion event carries no
+# ``summary``, ``kanban_watchers.py`` builds the status line out of the very
+# field this code exists to deliver::
+#
+#     elif task and task.result:
+#         r = _clip_handoff(task.result)
+#         handoff = f"\n{r}"
+#
+# ``delivered`` is then a 1200-character clip of ``result``, so asking whether
+# ``result`` already appears inside it — the containment test
+# :func:`result_block` does — is asking whether a report fits inside its own
+# prefix. Under ``kanban_handoff_clip.DEFAULT_LIMIT`` it does, and the block
+# correctly stays empty. Over it, it never does: the message went out carrying
+# the first 1200 characters of the report, the ``[…]`` marker, a blank line,
+# and then the same report over again from the top. Measured on a 60-line cron
+# catalogue, jobs 1 to 19 arrived twice. Every result long enough to need this
+# code at all was delivered doubled, because ``RESULT_LIMIT`` is 30000 precisely
+# for reports that outgrow a status line.
+#
+# Appending cannot fix that — only the caller of the clip can decide the clip
+# was a mistake — so the hook returns the finished tail instead. When the status
+# line is merely a clipped prefix of the report, it is dropped and the report is
+# sent once, whole. That branch got *more* reachable, not less, when
+# ``tools/kanban_result_required.py`` began folding a whitespace-only
+# ``summary`` to ``None`` to stop ``complete_task`` indexing line zero of a
+# blank string and wedging the card.
+#
+# Length is safe on both platforms this harness ships to. The notifier calls
+# ``adapter.send()`` directly, and ``send()`` chunks: the Slack adapter declares
+# ``splits_long_messages = True`` with ``MAX_MESSAGE_LENGTH = 39000`` and splits
+# on code-block boundaries; the bundled ``google_chat`` adapter chunks at 4000.
+# ``RESULT_LIMIT`` is well inside the smaller of those headrooms once the status
+# line and title are accounted for, and exists to bound a worker that dumps a
+# log rather than to fit a single message.
+
+#: How much of ``result`` reaches chat. The status line's own budget is 1200
+#: (``kanban_handoff_clip.DEFAULT_LIMIT``) because it is a status line; this is
+#: the report and needs room. Sized far above the ~5.5 KB catalogue that card
+#: t_8d1cf5cf should have delivered, and far enough below the 39000-character
+#: Slack ceiling that the status line, the title, and the clip marker all fit
+#: alongside it.
+RESULT_LIMIT = 30000
+
+#: Separates the status line from the report. A blank line is enough: the
+#: status line is already on its own line under the ``✔ … done — <title>``
+#: header, so the result reads as the body of the same message.
+SEPARATOR = "\n\n"
+
+CLIPPED_TAIL = (
+    "\n\n[Result clipped at {limit} characters — ask for the full card "
+    "to see the rest.]"
+)
+
+
+def _normalise(text: str) -> str:
+    """Collapse whitespace and case, so two renderings of one report compare equal."""
+    return " ".join(text.split()).casefold()
+
+
+def result_block(
+    delivered: object,
+    result: object,
+    limit: int = RESULT_LIMIT,
+) -> str:
+    """Return the text to append to a completion message, or ``""`` for none.
+
+    ``delivered`` is the handoff the message already carries (the clipped
+    status line). When the result is contained in it there is nothing new to
+    say and a second copy is noise — which is exactly what happens when a
+    worker puts one body of text in both fields, or when the require-result
+    gate promoted ``summary`` into ``result`` to let a card close.
+    """
+    if result is None:
+        return ""
+    body = str(result).strip()
+    if not body:
+        return ""
+    normalised = _normalise(body)
+    if delivered and normalised in _normalise(str(delivered)):
+        return ""
+    clipped = clip_handoff(body, limit)
+    if len(clipped) < len(body):
+        return SEPARATOR + clipped + CLIPPED_TAIL.format(limit=limit)
+    return SEPARATOR + clipped
+
+
+def _is_clipped_prefix_of(delivered: str, body: str) -> bool:
+    """Whether ``delivered`` is just the opening of ``body``, possibly clipped.
+
+    Written as a prefix test rather than an equality test against
+    ``clip_handoff(body)`` so it still holds if the notifier's status line is
+    built some other way. Upstream's own version of that line was a raw
+    ``lines[0][:160]`` slice before the clip wiring replaced it, and either
+    shape is the same fact about the message: the reader has seen this text
+    already, and is about to see all of it.
+    """
+    head = _normalise(delivered)
+    marker = _normalise(ELLIPSIS)
+    if marker and head.endswith(marker):
+        head = head[: -len(marker)].rstrip()
+    return bool(head) and _normalise(body).startswith(head)
+
+
+def handoff_with_result(delivered: object, task: object) -> str:
+    """Return the completion message's whole tail: status line and report.
+
+    Replaces the notifier's ``handoff`` — see the comment block above for why
+    appending to it cannot work. ``delivered`` is what the notifier built,
+    ``task`` is whatever ``_kb.get_task`` returned, which is ``None`` for a row
+    that vanished between the claim and the send.
+
+    Fails to ``delivered`` unchanged rather than raising. This runs on the
+    delivery path: a completion notification that loses its report is bad, one
+    that raises, rewinds the cursor and re-sends forever is worse, and one that
+    drops the status line it already had is worse again.
+    """
+    text = "" if delivered is None else str(delivered)
+    try:
+        result = getattr(task, "result", None)
+        block = result_block(text, result)
+        if not block:
+            return text
+        if _is_clipped_prefix_of(text, str(result).strip()):
+            return block
+        return text + block
+    except Exception:  # pragma: no cover - defensive
+        return text
+
+
+# ---------------------------------------------------------------------------
+# 3. Making the agent wake configurable
+# ---------------------------------------------------------------------------
+#
+# When a card reaches a terminal state the notifier does two separate things
+# for the same event:
+#
+# 1. ``adapter.send(...)`` posts the completion line — the worker's own summary,
+#    plus whatever :func:`handoff_with_result` added to it — straight into the
+#    originating chat thread. The user has the answer at this point.
+# 2. ``adapter.handle_message(...)`` then injects a synthetic ``MessageEvent``
+#    to *wake the agent that created the card*, which costs a full model turn.
+#
+# Upstream hardcodes which event kinds trigger step 2::
+#
+#     _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+#
+# There is no config key for it anywhere in Hermes. For the Chat Agent front
+# door that makes ``completed`` pure overhead: the summary has already been
+# delivered, so the woken turn re-reads the card with ``kanban_show`` and
+# paraphrases a message the user is already looking at. Measured on task
+# ``t_c31a1f00`` (2026-08-05): **5.9 s and 32,460 input tokens** for that third
+# hop, on a request whose actual work was a single 477 ms ``list_clusters``
+# call.
+#
+# The failure kinds are a different matter. ``gave_up`` / ``crashed`` /
+# ``timed_out`` / ``blocked`` produce a terse status line and nothing else, and
+# the front door genuinely should react — retry, escalate, or tell the user what
+# broke. So this is not "turn the wake off", it is "wake for the events that
+# need a decision, not for the one that already answered itself".
+#
+# :func:`resolve_wake_kinds` reads ``kanban.wake_on_events`` from config and
+# falls back to the upstream tuple, so an image built without that key set
+# behaves exactly as upstream does.
+#
+# All of that reasoning is conditional on step 1 having happened, which is why
+# :func:`wake_kinds_for` takes the adapter and leaves a non-push one alone:
+# where the notifier skips the send, the wake is not a third hop over a
+# delivered answer, it is the only delivery there is.
+
+#: The upstream hardcoded set, and the fallback for any config that does not
+#: say otherwise. Also the whitelist: a kind outside this set can never match
+#: ``ev.kind`` for a terminal event, so allowing it through would only hide a
+#: typo.
+DEFAULT_WAKE_KINDS: Tuple[str, ...] = (
+    "completed",
+    "gave_up",
+    "crashed",
+    "timed_out",
+    "blocked",
+)
+
+CONFIG_KEY = "wake_on_events"
+
+#: Reasons :func:`_load_kanban_config` has already reported this process.
+#: The notifier reaches it on every delivery, so a config that is permanently
+#: unreadable would otherwise warn every five seconds for the life of the
+#: gateway; one line per distinct cause is enough to explain the behaviour.
+#: Tests clear it between cases.
+_warned_config: set = set()
+
+
+def _warn_config_once(cause: str, message: str, *args: object) -> None:
+    if cause in _warned_config:
+        return
+    _warned_config.add(cause)
+    logger.warning(message, *args)
+
+
+def _load_kanban_config(load_config: Optional[Callable[[], object]]) -> Optional[dict]:
+    """Return the ``kanban`` config subtree, or None if it cannot be read.
+
+    Returning None sends :func:`resolve_wake_kinds` back to
+    :data:`DEFAULT_WAKE_KINDS`, which is the safe answer but an invisible one:
+    it is byte-for-byte what an operator who never set ``kanban.wake_on_events``
+    gets, so a loader that has genuinely broken presents as a key that was
+    never configured, and the redundant turn comes back with nothing in the
+    logs. Each failure therefore says so once before degrading.
+    """
+    if load_config is None:
+        try:
+            from hermes_cli.config import load_config as _lc
+        except Exception as exc:
+            _warn_config_once(
+                "import",
+                "kanban notifier: hermes_cli.config is not importable (%s); "
+                "kanban.%s cannot be read and the upstream wake set applies to "
+                "every card",
+                exc,
+                CONFIG_KEY,
+            )
+            return None
+        load_config = _lc
+    try:
+        cfg = load_config()
+    except Exception as exc:
+        _warn_config_once(
+            "read",
+            "kanban notifier: reading the Hermes config failed (%s); "
+            "kanban.%s is being ignored and the upstream wake set applies",
+            exc,
+            CONFIG_KEY,
+        )
+        return None
+    if not isinstance(cfg, dict):
+        _warn_config_once(
+            "shape",
+            "kanban notifier: load_config() returned %s rather than a mapping; "
+            "kanban.%s is being ignored and the upstream wake set applies",
+            type(cfg).__name__,
+            CONFIG_KEY,
+        )
+        return None
+    kcfg = cfg.get("kanban", {})
+    return kcfg if isinstance(kcfg, dict) else {}
+
+
+def resolve_wake_kinds(
+    load_config: Optional[Callable[[], object]] = None,
+) -> Tuple[str, ...]:
+    """Return the event kinds that should wake the card's creator.
+
+    Read fresh on every delivery rather than captured at gateway boot, so
+    changing ``kanban.wake_on_events`` takes effect on the next tick instead of
+    requiring a restart. The config read is cheap: ``load_config()`` is
+    mtime-cached upstream.
+
+    Fails **towards upstream behaviour**, loudly. A missing key, an unreadable
+    config, or a value of the wrong shape all yield :data:`DEFAULT_WAKE_KINDS`
+    — a transient read error must not stop waking an agent on a crash — but
+    every case except the missing key logs its reason first, so a degraded
+    read is distinguishable from a key nobody set.
+    Only an explicit, well-formed value narrows the set; an explicit empty list
+    disables the wake entirely, which is a deliberate choice a user can make.
+    """
+    kcfg = _load_kanban_config(load_config)
+    if kcfg is None or CONFIG_KEY not in kcfg:
+        return DEFAULT_WAKE_KINDS
+
+    raw = kcfg.get(CONFIG_KEY)
+    if raw is None:
+        # `wake_on_events:` with nothing after it parses as None. Read that as
+        # "no wake", matching the explicit empty list rather than falling back
+        # to the default the user was plainly trying to override.
+        return ()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        logger.warning(
+            "kanban notifier: kanban.%s must be a list of event kinds, got %r; "
+            "using the default wake set",
+            CONFIG_KEY,
+            type(raw).__name__,
+        )
+        return DEFAULT_WAKE_KINDS
+
+    kinds: list[str] = []
+    unknown: list[str] = []
+    for item in raw:
+        kind = str(item).strip()
+        if not kind:
+            continue
+        if kind not in DEFAULT_WAKE_KINDS:
+            unknown.append(kind)
+            continue
+        if kind not in kinds:
+            kinds.append(kind)
+    if unknown:
+        # Loud, because the failure mode is silent: an unknown kind never
+        # matches a real event, so a typo reads as "the wake just stopped
+        # working" with nothing in the logs to explain it.
+        logger.warning(
+            "kanban notifier: ignoring unknown kanban.%s value(s) %s; "
+            "valid kinds are %s",
+            CONFIG_KEY,
+            ", ".join(sorted(unknown)),
+            ", ".join(DEFAULT_WAKE_KINDS),
+        )
+    return tuple(kinds)
+
+
+def _adapter_can_push(adapter: object) -> bool:
+    """Whether *adapter* has a push channel.
+
+    Defers to ``gateway.wake.adapter_supports_push`` so this stays correct if
+    upstream ever makes the capability something richer than one attribute. That
+    module is not importable outside the image, so the fallback re-states its
+    current one-line contract rather than guessing: an adapter that does not
+    declare the flag is push-capable.
+    """
+    try:
+        from gateway.wake import adapter_supports_push
+    except Exception:
+        # Silent on purpose: outside the image this import is *expected* to
+        # fail, so warning here would fire on every host-side unit test while
+        # saying nothing about the deployed gateway. That the real module is
+        # reachable in the image is asserted by verify_kanban_notifier.py,
+        # which drives this against the actual APIServerAdapter.
+        return bool(getattr(adapter, "supports_async_delivery", True))
+    try:
+        return bool(adapter_supports_push(adapter))
+    except Exception:
+        logger.warning(
+            "kanban notifier: adapter_supports_push(%s) raised; treating it as "
+            "push-capable and applying kanban.%s as configured",
+            type(adapter).__name__,
+            CONFIG_KEY,
+        )
+        return True
+
+
+def wake_kinds_for(
+    events: Iterable[object],
+    load_config: Optional[Callable[[], object]] = None,
+    adapter: object = None,
+) -> set:
+    """Return the subset of ``events``' kinds that should wake the creator.
+
+    Mirrors the upstream expression it replaces::
+
+        {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+
+    ``adapter`` opts a non-push adapter out of the narrowing entirely, and
+    passing it is not optional in the notifier. The whole argument for dropping
+    ``completed`` is that ``adapter.send()`` already put the worker's summary in
+    the thread, so the wake is a third hop over an answer the user is looking
+    at. On an adapter with no push channel — the API server, whose ``send()``
+    returns ``SendResult(success=False)`` by design — the notifier skips that
+    send and says so in its own comment: *"the wake self-post below IS the
+    delivery"*. Narrow the set there and a card that completes successfully is
+    never announced to anyone; upstream added that self-post to fix the
+    api_server wrong-session bug, and dropping ``completed`` re-breaks it.
+
+    So the config key governs the push path only. On the non-push path the full
+    upstream set always applies, including an explicit ``wake_on_events: []``:
+    that key means "do not spend a turn re-reading an answer already
+    delivered", which is not a thing anyone can be asking for where nothing was
+    delivered.
+    """
+    allowed = resolve_wake_kinds(load_config)
+    if adapter is not None and not _adapter_can_push(adapter):
+        allowed = DEFAULT_WAKE_KINDS
+    return {ev.kind for ev in events if getattr(ev, "kind", None) in allowed}
+
+
+# ---------------------------------------------------------------------------
+# 4. Recording the completion the wake no longer announces
+# ---------------------------------------------------------------------------
+#
+# Section 3 saves a model turn by not waking the creator for ``completed``. The
+# saving is real and this section does not give it back. What section 3 did not
+# account for is that the wake was doing two jobs at once, and only one of them
+# was redundant:
+#
+# * it *told the user* — redundant, because ``adapter.send()`` already put the
+#   whole report in the thread;
+# * it *told the agent* — not redundant at all, because the synthetic
+#   ``MessageEvent`` was the only thing that ever entered the creator's
+#   transcript to say the card had finished.
+#
+# Dropping the wake dropped both. The creator's session is left with
+# ``kanban_create → subscribed: true`` as the last thing it knows, and no event
+# of any kind afterwards, so on its next turn the front door does not conclude
+# "the card is done" — it concludes "the card is still running", because that
+# is what its context says.
+#
+# Observed end to end on task ``t_a8f58a2a`` (2026-08-08):
+#
+#   19:08:01  front door files the card, subscribed: true
+#   19:09:43  worker completes; 6,191-character report
+#   19:09:44  notifier delivers the report to the Slack thread — succeeded
+#   19:11:30  user follows up. The front door calls ``kanban_comment`` (not
+#             ``kanban_show``) and promises "You'll see the results post here
+#             as soon as the agent completes". They had posted 106 s earlier.
+#   19:20:59  user asks whether it is still running
+#   19:21:12  front door finally calls ``kanban_show``, sees ``done``, pastes
+#             the answer it had had all along.
+#
+# Nine minutes forty-six seconds of dead wait, caused by an absence rather than
+# an error — which is why nothing in the logs or the card looked wrong.
+#
+# The marker, and why it is free
+# ------------------------------
+# The gateway already has a channel for exactly this: per-turn "must-deliver
+# notes". ``GatewayRunner._set_pending_turn_sidecar_notes(session_key, notes)``
+# parks strings on ``SessionState.conversation.sidecar_notes``; the next turn's
+# agent setup drains them into ``agent._gateway_turn_context_notes``
+# (``gateway/run.py``), and ``agent/turn_context.py`` appends them to *that
+# turn's user message* through the ``api_content`` sidecar. Upstream uses it for
+# the auto-reset notice, the first-contact intro, and Discord voice-channel
+# changes.
+#
+# It is the right channel here for three reasons:
+#
+# 1. **It costs no turn.** The note is not delivered *to* the model, it is
+#    waiting *for* the model, and it rides a user message that was going to be
+#    sent anyway. Where the wake cost 5.9 s and 32,460 input tokens (task
+#    ``t_c31a1f00``), this costs about seventy tokens on one turn.
+# 2. **It is one-shot.** ``_consume_pending_turn_sidecar_notes`` clears the
+#    list as it reads it, and ``consume_gateway_turn_context_notes`` clears the
+#    agent-side copy again, so a completion is announced to the agent exactly
+#    once and never replays out of a cached agent.
+# 3. **It rides the user message, not the system prompt.** Upstream moved these
+#    notes off the ephemeral system prompt deliberately: a note in the system
+#    prompt guarantees a turn-1/turn-2 prompt diff, which forces a full agent
+#    rebuild and re-keys the prompt cache. Writing the marker into
+#    ``ConversationState.ephemeral_pin`` — the other per-session string that
+#    reaches the model — would therefore have cost *more* than the wake it is
+#    saving, on top of being a cache slot that the next key miss overwrites.
+#
+# Not the transcript
+# ------------------
+# ``session_store.append_to_transcript`` would be durable across a gateway
+# restart, which the marker is not. It was rejected anyway: a transcript row is
+# replayed on *every* later turn rather than one, it inserts a message with no
+# matching assistant turn into a history other code assumes alternates, and it
+# is a SQLite write on the notifier's poll loop. Durability is not worth those;
+# a marker lost to a restart just restores today's behaviour.
+#
+# Independent of the subscription
+# -------------------------------
+# The note has to outlive the thing that triggered it. On a terminal event the
+# notifier calls ``self._kanban_unsub(sub, board_slug)`` and the subscription
+# row is deleted from the kanban database moments later. The marker never
+# touches that row: it lives in the gateway's in-memory
+# ``SessionState.conversation`` for a session key resolved from the session
+# store. Unsubscribing cannot reach it.
+#
+# Which completions get one
+# -------------------------
+# Exactly the ones the narrowing suppressed: the terminal kinds upstream would
+# have woken for, minus the ones this delivery is waking for. A kind that still
+# wakes needs no marker (the wake enters the transcript itself), and a gateway
+# with ``kanban.wake_on_events`` unset suppresses nothing, so it writes no notes
+# and behaves exactly as before. That makes the existing config key the on
+# switch and means this section needs no key of its own.
+
+#: Opening of every note this module writes. Doubles as the marker that tells
+#: :func:`stage_note` which of a session's staged notes are ours, so trimming
+#: to :data:`MAX_NOTES` can never evict upstream's auto-reset notice or
+#: first-contact intro.
+NOTE_SIGNATURE = "[System note: Kanban card "
+
+#: Card titles are user-supplied and can be a paragraph. Clipped with
+#: :func:`clip_handoff` rather than sliced, for the same reason the status line
+#: is: a title ending in a severed URL is worse than a title ending early.
+NOTE_TITLE_LIMIT = 120
+
+#: How many of *our* notes a session may accumulate before the oldest is
+#: dropped. Reached only when several cards finish between two user messages;
+#: the alternative is an unbounded list appended to the next user message.
+MAX_NOTES = 8
+
+
+def suppressed_kinds(events: Iterable[object], wake_kinds: object) -> set:
+    """Terminal kinds that fired but will not wake the creator.
+
+    Computed as "what upstream's hardcoded tuple would have woken for" minus
+    "what this delivery is actually waking for", which needs no second config
+    read and stays correct however :func:`resolve_wake_kinds` narrowed the set
+    — including the non-push carve-out, where nothing is narrowed and this
+    returns the empty set.
+    """
+    try:
+        woken = set(wake_kinds or ())
+    except TypeError:  # pragma: no cover - defensive
+        woken = set()
+    fired = set()
+    for ev in events or ():
+        kind = getattr(ev, "kind", None)
+        if kind in DEFAULT_WAKE_KINDS:
+            fired.add(kind)
+    return fired - woken
+
+
+def _utc_stamp(now: Optional[float] = None) -> str:
+    """``2026-08-08 19:09:44 UTC``, or ``""`` if the clock cannot be read."""
+    try:
+        ts = time.time() if now is None else float(now)
+        return time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime(ts))
+    except Exception:  # pragma: no cover - defensive
+        return ""
+
+
+def _task_id(task: object, sub: object) -> str:
+    """The card id, preferring the subscription row the notifier is iterating.
+
+    ``sub["task_id"]`` is what every log line and chat message in this delivery
+    already used, so the marker names the card by the same id even if the task
+    row went missing between the claim and the send.
+    """
+    if isinstance(sub, dict):
+        tid = str(sub.get("task_id") or "").strip()
+        if tid:
+            return tid
+    return str(getattr(task, "id", "") or "").strip()
+
+
+def completion_note(
+    task_id: str,
+    title: object = "",
+    status: object = "",
+    kinds: Iterable[str] = (),
+    board: object = "",
+    now: Optional[float] = None,
+) -> str:
+    """Render the marker the creator's next turn will read.
+
+    Written to defeat one specific wrong inference. The front door's context
+    ends at ``subscribed: true``, so its default guess is "still running"; the
+    note therefore states the outcome, states that the result has already been
+    delivered (so it does not re-post it), states *why* there is no record of
+    the finish earlier in the transcript (so the absence is not read as
+    evidence), and says what to call if it wants the content back.
+    """
+    tid = str(task_id or "").strip() or "(unknown)"
+    head = NOTE_SIGNATURE + tid
+    clipped_title = clip_handoff(title, NOTE_TITLE_LIMIT)
+    if clipped_title:
+        head += f' ("{clipped_title}")'
+    fired = ", ".join(sorted(str(k) for k in kinds if k)) or "finished"
+    head += f" fired {fired}"
+    stamp = _utc_stamp(now)
+    if stamp:
+        head += f" at {stamp}"
+    card_status = str(status or "").strip()
+    if card_status:
+        head += f"; the card's status is now {card_status}"
+    where = ""
+    board_name = str(board or "").strip()
+    if board_name:
+        where = f" (board {board_name})"
+    return (
+        head + ". Its result was already delivered to this conversation, so no "
+        "agent turn was spent announcing it and nothing about the finish "
+        "appears earlier in this transcript. The card is NOT still running — "
+        f"read it back with kanban_show{where} if you need the content again.]"
+    )
+
+
+def creator_session_key(runner: object, task: object) -> str:
+    """Resolve the gateway session key of the agent that created the card.
+
+    Two different identifiers are in play and conflating them is the whole
+    difficulty. ``task.session_id`` is the *persisted session id*
+    (``20260808_190725_6714054d``) — it is what the notifier hands
+    ``deliver_wake`` — whereas per-turn state is keyed by the *session key*
+    (``agent:main:slack:dm:T0BLH2UB516:D0BKGRBM6RH:1786216044.637229``), which
+    is what ``_set_pending_turn_sidecar_notes`` and the next turn's
+    ``ctx.session_key`` both use. ``SessionStore.lookup_by_session_id`` is
+    upstream's public, lock-held accessor for exactly that mapping and returns
+    a ``SessionEntry`` carrying ``session_key``.
+
+    Deriving the key instead from the subscription row — the way the push wake
+    path builds its ``SessionSource`` — was rejected. That derivation is
+    allowed to be approximate because ``handle_message`` get-or-creates the
+    target, so a near miss costs the wake a fresh session and nothing else;
+    here a near miss parks the note on a key nobody will ever read, which is a
+    silent no-op. The store lookup either finds the exact key the creator's
+    turns run under or finds nothing, and finding nothing is reported.
+
+    Returns ``""`` when the key cannot be resolved, which the caller treats as
+    "no marker" — the pre-existing behaviour, not a failure.
+    """
+    session_id = str(getattr(task, "session_id", "") or "").strip()
+    if not session_id:
+        # Cards filed outside a gateway session (cron, CLI) have no creator to
+        # tell. Ordinary, so debug.
+        logger.debug(
+            "kanban notifier: card has no creator session id; no completion "
+            "marker to write"
+        )
+        return ""
+    store = getattr(runner, "session_store", None)
+    lookup = getattr(store, "lookup_by_session_id", None)
+    if not callable(lookup):
+        _warn_config_once(
+            "session-store",
+            "kanban notifier: the gateway session store has no "
+            "lookup_by_session_id(); a suppressed completion cannot be "
+            "recorded on the creator's session and the next turn will not "
+            "know the card finished",
+        )
+        return ""
+    entry = lookup(session_id)
+    if entry is None:
+        # The session rotated (compression, /new, expiry) or was never a
+        # gateway session. Its conversation has moved on, so there is nothing
+        # this marker would usefully be attached to.
+        logger.debug(
+            "kanban notifier: no live session is bound to creator session id "
+            "%s; skipping the completion marker",
+            session_id,
+        )
+        return ""
+    return str(getattr(entry, "session_key", "") or "").strip()
+
+
+def _staged_notes(runner: object, session_key: str) -> List[str]:
+    """The notes already parked on this session, or ``[]``.
+
+    Read through ``_peek_session_state`` rather than ``_session_state`` so
+    merely inspecting a session cannot conjure a ``SessionState`` for it; the
+    setter creates one when there is genuinely something to store.
+    """
+    peek = getattr(runner, "_peek_session_state", None)
+    if not callable(peek):
+        return []
+    conversation = getattr(peek(session_key), "conversation", None)
+    staged = getattr(conversation, "sidecar_notes", None)
+    if not isinstance(staged, list):
+        return []
+    return [note for note in staged if isinstance(note, str)]
+
+
+def stage_note(runner: object, session_key: str, task_id: str, note: str) -> bool:
+    """Park ``note`` on the creator's session. True when it was added.
+
+    Appends rather than assigns. ``_set_pending_turn_sidecar_notes`` replaces
+    the whole list, and the list is shared with upstream's own notes — an
+    auto-reset notice staged by a turn starting in the same instant would be
+    overwritten by a blind assignment, and that notice tells the agent its
+    history is gone.
+
+    Our notes are trimmed to :data:`MAX_NOTES` and upstream's are never
+    trimmed, which is why :data:`NOTE_SIGNATURE` has to be recognisable.
+    """
+    setter = getattr(runner, "_set_pending_turn_sidecar_notes", None)
+    if not callable(setter):
+        _warn_config_once(
+            "sidecar",
+            "kanban notifier: the gateway has no "
+            "_set_pending_turn_sidecar_notes(); suppressed completions cannot "
+            "be recorded and the creator's next turn will not know the card "
+            "finished",
+        )
+        return False
+    staged = _staged_notes(runner, session_key)
+    # The id plus its trailing space: without the space, card ``t_a8`` would
+    # suppress the marker for ``t_a8f58a2a``.
+    already = NOTE_SIGNATURE + str(task_id) + " "
+    if any(existing.startswith(already) for existing in staged):
+        return False
+    ours = [n for n in staged if n.startswith(NOTE_SIGNATURE)]
+    others = [n for n in staged if not n.startswith(NOTE_SIGNATURE)]
+    ours.append(note)
+    setter(session_key, others + ours[-MAX_NOTES:])
+    return True
+
+
+def note_suppressed_completion(
+    runner: object,
+    events: Iterable[object],
+    wake_kinds: object,
+    task: object = None,
+    sub: object = None,
+    board: object = "",
+    now: Optional[float] = None,
+) -> bool:
+    """Record a terminal event that :func:`wake_kinds_for` chose not to wake for.
+
+    Called from ``gateway/kanban_watchers.py`` immediately after the wake set
+    is computed, on the path where every text ping for this delivery has
+    already been sent — so "the result is in the thread", which is what the
+    note asserts, is true by the time it is written.
+
+    Returns whether a note was staged; the notifier ignores it, but it makes
+    the behaviour testable and gives the verifier something that a silent
+    no-op cannot fake.
+
+    Fails towards the pre-existing behaviour, loudly. Nothing here is allowed
+    to disturb the delivery path: the report reaching the user is the outcome
+    that matters and this is an optimisation layered on top of it, so every
+    failure degrades to "no marker" — the exact state this code was written to
+    improve on — rather than raising into a loop that would rewind the cursor
+    and re-send the report.
+    """
+    task_id = ""
+    try:
+        task_id = _task_id(task, sub)
+        kinds = suppressed_kinds(events, wake_kinds)
+        if not kinds:
+            return False
+        session_key = creator_session_key(runner, task)
+        if not session_key:
+            return False
+        note = completion_note(
+            task_id,
+            title=getattr(task, "title", "") or "",
+            status=getattr(task, "status", "") or "",
+            kinds=kinds,
+            board=board,
+            now=now,
+        )
+        if not stage_note(runner, session_key, task_id, note):
+            return False
+        # Info, matching the "woke agent for %s" line this path replaces: on a
+        # gateway with the narrowing configured it is the only evidence that
+        # the creator was told anything at all.
+        logger.info(
+            "kanban notifier: recorded %s for %s on the creator's session %s "
+            "instead of spending a wake turn",
+            ", ".join(sorted(kinds)),
+            task_id or "(unknown card)",
+            session_key,
+        )
+        return True
+    except Exception:
+        logger.warning(
+            "kanban notifier: could not record the suppressed completion of "
+            "%s on the creator's session; the report was still delivered, but "
+            "the creator's next turn will not know the card finished",
+            task_id or "(unknown card)",
+            exc_info=True,
+        )
+        return False

--- a/deploy/docker/patches/kanban_ownership.py
+++ b/deploy/docker/patches/kanban_ownership.py
@@ -1,0 +1,186 @@
+"""Who owns the card a turn is running against, and what to answer when unsure.
+
+Installed into the image at ``/opt/hermes/tools/kanban_ownership.py`` by
+``deploy/docker/Dockerfile``. Read by ``tools/kanban_worker_tools.py`` and
+``hermes_cli/kanban_guardrail_exit.py``; ``tools/`` is already imported across
+package boundaries that way — ``kanban_guardrail_exit`` reads
+``tools.cron_run_scope`` — so reaching it costs nothing new.
+
+Three contexts, one environment variable
+----------------------------------------
+``HERMES_KANBAN_TASK`` is the only ownership signal the environment carries, and
+three different things can be running while it is set:
+
+*A dispatcher-spawned worker.* ``hermes_cli/kanban_db.py``'s ``_default_spawn``
+sets the variable before spawning the process, so here it means what it says:
+this run holds that card and is expected to end it with ``kanban_complete`` or
+``kanban_block``.
+
+*A ``delegate_task`` child.* The child runs ``run_conversation`` in the
+*parent's own process*, so the variable still holds whatever the parent's
+dispatcher set and says nothing at all about the child, which owns no card.
+Upstream treats this as the defining case: ``tools/kanban_tools.py``'s
+``_reject_delegated_child_mutation`` refuses every board mutation from a child
+precisely because stale or inherited ``HERMES_KANBAN_*`` env vars are not proof
+of dispatcher ownership, and both of upstream's kanban gates
+(``_check_kanban_mode`` and ``_check_kanban_orchestrator_mode``) open with
+``if _is_delegated_child_context(): return False``.
+
+*A cron run.* ``cronjob(action='run')`` executes the job in-process inside the
+dispatching worker, and ``tools/cron_run_scope.py`` deliberately leaves
+``HERMES_KANBAN_TASK`` pointing at the dispatcher's card for the duration, so
+``heartbeat_current_worker_from_env`` can keep a 15-minute claim alive across a
+20-minute audit. The run is explicitly barred from terminating that card:
+``resolve_default_task_id`` returns ``None`` inside a run, and
+``cron_ownership_violation`` rejects it by name.
+
+The cron marker is read through ``cron_run_scope.current_cron_job`` rather than
+from the environment, and that is the point: it lives in a context variable
+scoped to the thread ``run_job`` submitted the run on, so under
+``dispatch_in_gateway`` a second worker running concurrently with somebody
+else's dispatch does not read it as its own. ``cron_run_scope`` used to write an
+``os.environ`` half as well, which is process-wide and did exactly that; see
+that module's docstring for why it no longer does.
+
+Import failure is not the same thing as call failure
+-----------------------------------------------------
+Both readers are reached through an import that can fail, and the two failures
+mean opposite things, so they are handled apart rather than swallowed into one
+``except``:
+
+*The import fails* — the reader's module is not on the path at all. That is a
+structural fact about the process, not uncertainty: a process with no
+``agent.delegation_context`` in it is not running a delegated child. Treating it
+as uncertainty would flip these predicates on every host where this module is
+importable but Hermes is not, the local test suite included. So an absent module
+answers ``False``, except for the cron marker, which falls back to the
+environment half — that is the one thing a ContextVar cannot do, cross a fork.
+
+*The call fails* — the module is there and the reader raised. That is genuine
+uncertainty: the question was meaningful and went unanswered. Only this case
+consults ``on_unknown``.
+
+Polarity belongs to the caller
+------------------------------
+The two callers want opposite answers from the same uncertainty, because a wrong
+answer costs them different things. Passing it in keeps that visible at the call
+site instead of buried in two near-identical private helpers, which is what these
+used to be.
+
+``hermes_cli/kanban_guardrail_exit.py`` passes ``on_unknown=True``. It decides
+whether to charge a ``timed_out`` to a card and release its claim. A wrong "yes,
+a child" or "yes, a cron run" skips one record on an exit path that is already
+exceptional. A wrong "no" charges a failure to a card somebody else is still
+working and releases their claim underneath them, mid-run, after which they
+complete a card they no longer hold. Uncertainty there means "do not write to the
+board" — which, for predicates that name the contexts that must *not* write, is
+``True``.
+
+``tools/kanban_worker_tools.py`` passes ``on_unknown=False``. It only decides
+which tool schemas ship on a model call. A wrong "yes, a child" hides
+``kanban_complete`` and ``kanban_block`` from a real dispatcher worker and
+strands its card: a worker with no terminal tool cannot end its run, so it exits
+rc=0, the reaper stamps a ``protocol_violation``, and the card burns another
+attempt — and a reader that raises does so for every worker in the image, not
+for one card. A wrong "no" restores exactly the behaviour that predates that
+patch: ~2,510 tokens of schema the caller is forbidden to use, and at most one
+refused tool call, because ``_reject_delegated_child_mutation`` still stands
+between a child and every board mutation. Uncertainty there means "not a child".
+
+Neither caller is free to drop its argument for a default. There is no answer
+that is safe in both directions, so there is no default worth having.
+"""
+
+from __future__ import annotations
+
+import os
+
+#: The card id the dispatcher exports before spawning a worker. Inherited
+#: unchanged by a ``delegate_task`` child and by a cron run, which is why it is
+#: never sufficient on its own.
+WORKER_TASK_ENV = "HERMES_KANBAN_TASK"
+
+#: The marker ``tools/cron_run_scope.py`` holds for the duration of a dispatched
+#: run, as a context variable and — for a forked process launched with it
+#: already set — an environment variable. Named here only for the fallback in
+#: ``in_cron_run``; ``current_cron_job`` is the reader that matters.
+CRON_RUN_ENV = "HERMES_KANBAN_CRON_RUN"
+
+
+def _delegation_reader():
+    """``agent.delegation_context.is_delegated_child_context``, or ``None``.
+
+    ``None`` means the module is absent, which is the structural case above —
+    distinct from the reader existing and raising, which the callers handle.
+    Re-imported per call rather than bound at module import so that a test can
+    swap the module in ``sys.modules`` and have the next call see it.
+    """
+    try:
+        from agent.delegation_context import is_delegated_child_context
+    except Exception:
+        return None
+    return is_delegated_child_context
+
+
+def _cron_reader():
+    """``cron_run_scope.current_cron_job``, or ``None`` if neither path resolves.
+
+    In the image ``/opt/hermes`` is on ``sys.path`` and the module is
+    ``tools.cron_run_scope``. Under local unittest discovery the patches
+    directory is the top level and it is a plain sibling. Re-imported per call
+    for the same reason as ``_delegation_reader``: replacing the module
+    attribute has to take effect.
+    """
+    try:  # In the image, /opt/hermes is on sys.path.
+        from tools.cron_run_scope import current_cron_job
+    except Exception:
+        try:  # Local unittest discovery: the patches dir is top-level.
+            from cron_run_scope import current_cron_job
+        except Exception:
+            return None
+    return current_cron_job
+
+
+def is_delegated_child(*, on_unknown: bool) -> bool:
+    """Whether this turn is a ``delegate_task`` child sharing its parent's process.
+
+    ``on_unknown`` is the answer when ``is_delegated_child_context`` is present
+    and raises. An absent ``agent.delegation_context`` answers ``False``
+    regardless: no delegation machinery in the process means no delegated child.
+    See the module docstring for why the caller has to choose.
+    """
+    reader = _delegation_reader()
+    if reader is None:
+        return False
+    try:
+        return bool(reader())
+    except Exception:
+        return on_unknown
+
+
+def in_cron_run(*, on_unknown: bool) -> bool:
+    """Whether this turn is a cron job borrowing a worker's environment.
+
+    ``on_unknown`` is the answer when ``current_cron_job`` is present and raises.
+    If neither ``tools.cron_run_scope`` nor a top-level ``cron_run_scope``
+    resolves, the environment half of the marker is read directly — an absent
+    module is a fact about the path, and the env var is still evidence.
+    """
+    reader = _cron_reader()
+    if reader is None:
+        return bool(os.environ.get(CRON_RUN_ENV))
+    try:
+        return bool(reader())
+    except Exception:
+        return on_unknown
+
+
+def is_dispatcher_worker() -> bool:
+    """Whether ``HERMES_KANBAN_TASK`` is set, and nothing more than that.
+
+    No ``on_unknown``: an environment read has no failure mode to be uncertain
+    about. It also has no *precision* — the variable is inherited by both of the
+    other two contexts — so a caller that means "a worker running its own card"
+    composes this with the predicates above rather than using it alone.
+    """
+    return bool(os.environ.get(WORKER_TASK_ENV))

--- a/deploy/docker/patches/kanban_result_required.py
+++ b/deploy/docker/patches/kanban_result_required.py
@@ -1,0 +1,354 @@
+"""Make ``result`` the single field that carries a completed card's answer.
+
+Installed into the image at ``/opt/hermes/tools/kanban_result_required.py`` and
+wired into ``tools/kanban_tools.py`` by
+``deploy/docker/patches/apply_kanban_result_required.py``.
+
+The companion patch ``gateway/kanban_notifier.py`` posts ``result`` into the
+chat thread. This one makes sure there is something in it to post.
+
+Why
+---
+On 2026-08-07 a user asked which platform cron jobs were enabled. Three cards
+ran (``t_8d1cf5cf``, ``t_97f721b6``, ``t_68fbd0b6``); all three closed ``done``;
+the user never got the list. Dumping the board afterwards showed
+``tasks.result IS NULL`` and ``result_len: 0`` on every one of them. The workers
+had built the catalogue — it is still sitting in
+``/opt/data/kanban/logs/t_8d1cf5cf.log``, 5.5 KB of it — printed it to their own
+stdout, and then dropped it on the floor at the ``kanban_complete`` call.
+
+They were doing what they were told. Upstream's own tool schema describes
+``result`` as::
+
+    Short result log line (legacy field, maps to task.result). Use ``summary``
+    instead when possible; this exists for compatibility with callers that
+    still set --result on the CLI.
+
+and ``summary`` as "Human-readable handoff, 1-3 sentences", while the gate below
+it accepts ``summary or result``. So the model is told the only field that can
+carry a report is legacy, told to prefer a field documented as 1-3 sentences,
+and then allowed to close the card with just that. A worker holding a 5.5 KB
+answer follows the schema and throws it away.
+
+Worse, ``summary`` cannot carry a report even if a worker tries: the kernel
+writes the completion event as (``hermes_cli/kanban_db.py``)::
+
+    ev_summary = (summary if summary is not None else result) or ""
+    ev_summary = ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
+
+First line only, 400 characters, no ellipsis. The chat notifier reads that field
+and nothing else, so a multi-line summary loses everything after line one
+silently.
+
+What this changes
+-----------------
+Two things, both deterministic — there is no attempt to classify a card as
+"asked for information" or not. Every card has an answer, even if the answer is
+one line ("Restarted the deployment; 3/3 pods ready"), so every card is
+required to carry one.
+
+1. **Schema wording.** ``result`` becomes the required field that carries the
+   deliverable and says it is posted to the requester verbatim; ``summary``
+   becomes an explicitly one-line, 400-character status header. A prompt that
+   prevents the mistake is worth more than a gate that rejects it.
+
+2. **The gate.** Upstream's ``if not (summary or result)`` becomes a check that
+   ``result`` carries something.
+
+Never wedging the card
+----------------------
+A gate that can refuse forever is a worse bug than the one it fixes, so a
+refusal is never repeated back to back. The first content-free completion is
+rejected with an instruction; the retry is accepted even when it is content-free
+again, promoting ``summary`` into ``result`` so the card still carries the best
+text available. One nudge is what a model needs to correct a tool call, and the
+card reaches ``done`` on its second attempt either way.
+
+Remembering the refusal, and forgetting it
+------------------------------------------
+"The retry" only means anything if the handler remembers refusing this card, and
+that memory has to expire. It first did not: ``_nudged`` was a module-level
+``set`` that only ever grew, so a task id in it meant "accept this completion,
+whatever it contains" for the life of the process.
+
+On the worker path that was harmless by accident. ``dispatch_in_gateway`` moves
+the *dispatcher loop* into the gateway, not the worker —
+``gateway/kanban_watchers.py``'s ``_kanban_dispatcher_watcher`` calls
+``kanban_db.dispatch_once`` with no ``spawn_fn``, so ``_default_spawn`` still
+``subprocess.Popen``s ``hermes -p <profile> chat -q "work kanban task t_…"``.
+One process per dispatch means the set holds one id and dies with the attempt
+that created it.
+
+It was not harmless in the gateway. ``toolsets: [kanban]`` is set on the
+``platform`` profile and on the pod's root config, and
+``_enforce_worker_task_ownership`` deliberately exempts a caller with no
+``HERMES_KANBAN_TASK`` in its environment, because an orchestrator "sometimes
+legitimately close[s] out child tasks". So a gateway session can complete any
+card from a process that lives as long as the pod, and the first content-free
+completion of a card spent that card's nudge permanently: every later attempt,
+including one made hours afterwards on a card that had been reopened and
+retried, was accepted in silence. That is the 2026-08-07 incident, reintroduced
+by the code written to fix it.
+
+The memory is therefore ``_refused_at``, task id to ``time.monotonic()``, read
+by popping: a refusal older than ``NUDGE_TTL_SECONDS`` belongs to a different
+attempt and the new attempt gets its own nudge. Expiry does not reopen the
+wedge, because any caller that retries promptly — the only kind that ever
+completes anything — is still inside the window on its second call.
+
+Blank is empty, all the way down
+--------------------------------
+``result="   "`` used to reach the board. The gate reads it as empty, but the
+promotion branch then handed the whitespace back as the value to store, and the
+two lines quoted above run inside ``complete_task``'s ``write_txn``. ``"   "`` is
+truthy, ``"   ".strip().splitlines()`` is ``[]``, and ``[0]`` raises
+``IndexError`` with the ``UPDATE … SET status = 'done'`` already executed. The
+transaction rolls back, the handler's blanket ``except Exception`` turns the
+failure into ``kanban_complete: list index out of range``, and the card is still
+``running`` — with its nudge already spent, so the identical retry takes the
+identical path. That card never closes and its worker is never told why.
+
+The expression reads ``summary`` first, so a blank ``summary`` wedges a card the
+same way however good its ``result`` is; upstream's ``if not (summary or
+result)`` never caught that either. Both fields are folded to ``None`` by
+:func:`blank_to_none` before they leave here — ``None`` is the value
+``complete_task`` is written to handle, and a field holding only whitespace is
+not carrying anything anyway.
+
+Scope: the gate lives in the ``kanban_complete`` tool handler. The CLI and the
+scheduler write through ``kb.complete_task`` directly and are unaffected, so no
+cron run and no human at a shell can be blocked by it. Every caller that does go
+through the handler — a dispatched worker closing its own card, an orchestrator
+gateway session closing somebody else's — is gated, which is why the refusal
+memory has to be correct for a process that outlives a single card.
+"""
+
+from __future__ import annotations
+
+import time
+
+#: How long a refusal stays on file. A model corrects a rejected tool call in its
+#: next assistant turn, seconds later, so a content-free completion arriving
+#: after this long is a fresh attempt at the card and has earned its own nudge.
+#: 15 minutes is ``DEFAULT_CLAIM_TTL_SECONDS`` in ``hermes_cli/kanban_db.py``,
+#: the soonest an abandoned claim can be handed to another worker, which makes it
+#: the shortest window that cannot straddle two attempts on the worker path.
+NUDGE_TTL_SECONDS = 15 * 60
+
+#: Cards refused once and not yet completed, against the ``time.monotonic()``
+#: reading taken at the refusal. Keyed by task id rather than held as a bare flag
+#: because a worker process is nominally one card, but nothing in the tool
+#: contract promises that and a shared process must not spend card B's nudge on
+#: card A. Entries are popped by the completion that answers them and go stale on
+#: their own; the only ones that linger belong to a caller that walked away, a
+#: handful of floats in a gateway that runs for weeks.
+_refused_at: dict[str, float] = {}
+
+MISSING_RESULT_ERROR = (
+    "result is required and was empty. `result` is what the person who asked "
+    "actually receives — the gateway posts it into their chat thread verbatim. "
+    "Call kanban_complete again with the full answer to this card in `result`: "
+    "the list, the report, the findings, the numbers, whatever was asked for, "
+    "complete and not summarised away. Do not leave it only in your transcript, "
+    "in a file, or in a comment — none of those reach the user. Keep `summary` "
+    "as the one-line status header."
+)
+
+
+def blank_to_none(value: object) -> object:
+    """``None`` unless ``value`` carries printable text, otherwise ``value``.
+
+    A field holding only whitespace carries nothing, but it is truthy, which is
+    how ``"   "`` slips past an emptiness check and into the
+    ``.strip().splitlines()[0]`` in ``complete_task`` that raises ``IndexError``
+    on it. Values with content come back untouched: ``kanban_complete`` has
+    already run them through ``redact_sensitive_text`` and this is not the place
+    to trim what that produced.
+    """
+    if value is None or not str(value).strip():
+        return None
+    return value
+
+
+def require_result(
+    task_id: object,
+    summary: object,
+    result: object,
+) -> tuple[str | None, object]:
+    """Validate a completion's ``result``.
+
+    Returns ``(error, result_to_store)``. ``error`` is ``None`` when the
+    completion may proceed; otherwise it is the text to hand back to the worker
+    and the completion must not be written.
+
+    A ``result`` with content always passes — there is no length or quality
+    floor, because a card whose honest answer is one line must be able to close.
+    A blank one is refused, and the retry is accepted with ``summary`` promoted
+    into ``result`` so a worker that will not fill the field in cannot wedge the
+    card shut. ``result_to_store`` is never a blank string; see
+    :func:`blank_to_none` for what that would cost.
+    """
+    summary = blank_to_none(summary)
+    result = blank_to_none(result)
+    key = str(task_id)
+    # Popped rather than read. Whether the refusal is being answered or has gone
+    # stale, this call ends it, and popping is what keeps the mapping to the
+    # cards actually awaiting a retry.
+    refused_at = _refused_at.pop(key, None)
+
+    if result is not None:
+        return None, result
+    if refused_at is not None and time.monotonic() - refused_at <= NUDGE_TTL_SECONDS:
+        # The retry, and it is empty again. Take what we can get rather than
+        # hold the card open. ``summary`` may be ``None`` too, in which case the
+        # card closes with no result exactly as upstream would have allowed.
+        return None, summary
+    _refused_at[key] = time.monotonic()
+    return MISSING_RESULT_ERROR, None
+
+
+# --- Schema wording ---------------------------------------------------------
+# Applied to the live ``KANBAN_COMPLETE_SCHEMA`` dict at import time rather than
+# by rewriting the string literals in place. Upstream builds each description
+# from adjacent string literals wrapped at some arbitrary column, so a textual
+# anchor would break on a reflow that changed nothing semantic. Matching against
+# the assembled value is stable under rewrapping and still fails loudly when the
+# wording itself changes.
+#
+# Each OLD string is an exact copy of upstream's assembled text; ``apply_schema``
+# raises if one stops matching, which is the signal to re-derive it against the
+# new base image.
+
+OLD_TOOL_DESCRIPTION = (
+    "Mark your current task done with a structured handoff for "
+    "downstream workers and humans. Prefer ``summary`` for a "
+    "human-readable 1-3 sentence description of what you did; put "
+    "machine-readable facts in ``metadata`` (changed_files, "
+    "tests_run, decisions, findings, etc). At least one of "
+    "``summary`` or ``result`` is required. "
+)
+
+NEW_TOOL_DESCRIPTION = (
+    "Mark your current task done. ``result`` is REQUIRED and carries the "
+    "answer: whatever this card asked for goes there in full, and the "
+    "gateway posts it verbatim into the chat thread of the person who "
+    "asked. ``summary`` is a one-line status header, NOT the report — only "
+    "its first line survives and only the first 400 characters of that, so "
+    "anything you put there and nowhere else is lost. Put machine-readable "
+    "facts in ``metadata`` (changed_files, tests_run, decisions, findings, "
+    "etc). "
+)
+
+OLD_SUMMARY_DESCRIPTION = (
+    "Human-readable handoff, 1-3 sentences. Appears in "
+    "Run History on the dashboard and in downstream "
+    "workers' context."
+)
+
+NEW_SUMMARY_DESCRIPTION = (
+    "One-line status header: what happened, in a single "
+    "sentence. Only the FIRST LINE reaches chat, and only "
+    "its first 400 characters — the kernel cuts the rest "
+    "with no ellipsis. Never put the deliverable here; it "
+    "goes in ``result``. Appears in Run History on the "
+    "dashboard and in downstream workers' context."
+)
+
+OLD_RESULT_DESCRIPTION = (
+    "Short result log line (legacy field, maps to "
+    "task.result). Use ``summary`` instead when "
+    "possible; this exists for compatibility with "
+    "callers that still set --result on the CLI."
+)
+
+NEW_RESULT_DESCRIPTION = (
+    "REQUIRED. The complete answer to this card — the "
+    "list, the report, the findings, the RCA, the "
+    "numbers. Not truncated and not reduced to one line: "
+    "the gateway posts this verbatim into the chat thread "
+    "of the person who asked, so it is the only thing they "
+    "actually receive. If the card asked a question, the "
+    "whole answer goes here. Do not summarise it away, and "
+    "do not leave it only in your transcript, in a file, or "
+    "in a comment — none of those reach the user."
+)
+
+OLD_GATE = (
+    "    if not (summary or result):\n"
+    "        return tool_error(\n"
+    "            \"provide at least one of: summary (preferred), result\"\n"
+    "        )\n"
+)
+
+# ``summary`` is folded separately because ``require_result`` only owns
+# ``result``: the handler passes its own ``summary`` local straight on to
+# ``kb.complete_task``, and a blank one raises ``IndexError`` there whatever the
+# result holds. Rebinding it here rather than widening the gate's return keeps
+# the ``_require_result(tid, summary, result)`` call verbatim, which is the
+# string the Dockerfile greps for.
+NEW_GATE = (
+    "    # kube-agents patch: see tools/kanban_result_required.py\n"
+    "    summary = _blank_to_none(summary)\n"
+    "    _result_err, result = _require_result(tid, summary, result)\n"
+    "    if _result_err:\n"
+    "        return tool_error(_result_err)\n"
+)
+
+
+def _swap(schema: dict, path: tuple[str, ...], old: str, new: str) -> None:
+    """Replace ``old`` with ``new`` at ``path`` in ``schema``, or raise.
+
+    ``old`` is matched as a substring so the tool description — whose tail
+    documents ``created_cards`` and ``artifacts`` and is left alone — can have
+    its opening paragraph swapped without restating the rest.
+    """
+    missing = KeyError(
+        f"kanban_result_required: {'.'.join(path)} missing from the "
+        f"kanban_complete schema. Upstream Hermes changed — re-derive the "
+        f"schema patch before bumping the base image."
+    )
+    node: object = schema
+    for key in path[:-1]:
+        if not isinstance(node, dict) or key not in node:
+            raise missing
+        node = node[key]
+    leaf = path[-1]
+    if not isinstance(node, dict) or leaf not in node:
+        raise missing
+    current = node[leaf]
+    if not isinstance(current, str) or old not in current:
+        raise ValueError(
+            f"kanban_result_required: {'.'.join(path)} does not contain the "
+            f"expected upstream wording. Upstream Hermes changed — re-derive "
+            f"the schema patch before bumping the base image.\n"
+            f"--- expected to find ---\n{old}\n--- actual ---\n{current!r}"
+        )
+    node[leaf] = current.replace(old, new)
+
+
+def apply_schema(schema: dict) -> dict:
+    """Rewrite ``kanban_complete``'s schema in place and return it.
+
+    Called from ``tools/kanban_tools.py`` immediately before the tool is
+    registered, so the corrected wording is what the registry sees regardless of
+    whether ``registry.register`` stores the dict by reference or copies it.
+    """
+    _swap(schema, ("description",), OLD_TOOL_DESCRIPTION, NEW_TOOL_DESCRIPTION)
+    props = ("parameters", "properties")
+    _swap(
+        schema, props + ("summary", "description"),
+        OLD_SUMMARY_DESCRIPTION, NEW_SUMMARY_DESCRIPTION,
+    )
+    _swap(
+        schema, props + ("result", "description"),
+        OLD_RESULT_DESCRIPTION, NEW_RESULT_DESCRIPTION,
+    )
+    # Advertise the requirement in the place a model is most likely to honour
+    # it. The handler enforces it either way; this stops a well-behaved caller
+    # from having to be corrected at all.
+    params = schema.get("parameters")
+    if isinstance(params, dict):
+        required = params.get("required")
+        if isinstance(required, list) and "result" not in required:
+            required.append("result")
+    return schema

--- a/deploy/docker/patches/kanban_scheduling.py
+++ b/deploy/docker/patches/kanban_scheduling.py
@@ -1,0 +1,838 @@
+"""Scheduling repairs for ``hermes_cli/kanban_db.py``.
+
+Three faults share this one upstream file, so they share one patch quartet.
+Splitting them across three appliers meant three anchored rewrites of
+``kanban_db.py`` racing to stay consistent with each other, two import trailers,
+and a build gate whose halves could disagree about what the engine now does.
+They are merged here; ``apply_kanban_scheduling.py`` carries the anchors,
+``verify_kanban_scheduling.py`` replays all three against a real board inside
+the image. The breaker-counter fix (part 3) is a pure source rewrite with no
+runtime code, so its reasoning lives in the applier docstring rather than here.
+
+Part 1 — inverted fan-out dependencies (``repair_inverted_dependencies``)
+Part 2 — claims fenced to a process life (``release_dead_foreign_claims``)
+Part 3 — the breaker counter, in ``apply_kanban_scheduling.py``
+
+===========================================================================
+Part 1: repair inverted fan-out dependency edges instead of deadlocking
+===========================================================================
+
+Background — the deadlock this exists to break
+----------------------------------------------
+``task_links(parent_id, child_id)`` is a *predecessor* edge, not a hierarchy.
+``claim_task`` enforces it as a structural invariant::
+
+    SELECT 1 FROM task_links l JOIN tasks p ON p.id = l.parent_id
+     WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1
+
+A card whose parent is not ``done`` can never be claimed. ``recompute_ready``
+applies the same rule when promoting ``todo -> ready``, and declines *silently*
+— no event, no log line.
+
+Upstream's own contract, from the ``kanban_create`` tool description, is
+"create a child of the current one (pass the current task id in ``parents``)
+… then **complete your own task**". The fan-out only runs once the creator
+completes. That is a legitimate continuation idiom and this patch does not
+interfere with it.
+
+The failure is the *other* half. An orchestrator that creates cards with
+``parents=[<its own running card>]`` and then calls
+``kanban_block(kind="dependency")`` to wait for them has built an unconditional
+deadlock: the children cannot start until the parent is done, and the parent
+will not finish until the children are. Nothing in the engine detects it.
+
+What that cost us on 2026-08-07
+-------------------------------
+Card ``t_ab112f5b`` ("Fleet-wide Security Baseline Assessment") created three
+per-cluster cards parented to itself and declared ``dependency_wait`` on them
+four seconds later. The children logged ``claim_rejected
+{"reason": "parents_not_done"}`` and never ran — zero ``task_runs``, no
+``started_at``, no ``completed_at``. ``block_task(kind="dependency")`` routes to
+``todo`` rather than ``blocked``, which skips the ``block_recurrences`` loop
+breaker entirely, so the parent was re-promoted and re-spawned every few
+seconds, burning a full agent run each cycle.
+
+The worker eventually diagnosed the deadlock itself, re-created the same work as
+three *parentless* cards (which ran fine), and then escaped its own wait by
+shelling out::
+
+    python3 -c "import sqlite3; ...
+      UPDATE tasks SET status='done', result='Completed by Platform Agent'
+       WHERE id IN ('t_d3123d56','t_db5847ee','t_f342ef6d')"
+
+Three cards closed ``done`` with a 27-character fabricated ``result``, no
+``completed`` event, and no run row. A second instance (``t_e3089a85``) was
+still spinning when this patch was written, with three cluster audit cards
+starved in ``todo`` for 15 minutes and counting.
+
+The repair
+----------
+The agent's intent when it blocks is unambiguous: it wants those cards to run
+*now* and wants to resume once they finish. That is precisely the fan-in shape
+the engine already supports — it just has the edges pointing the wrong way. So
+rather than refusing the block (which leaves the worker to improvise, and we
+have seen what it improvises), invert the mis-directed edges:
+
+    delete (self -> child)   and   insert (child -> self)
+
+The children lose the parent that was gating them and get dispatched on the next
+tick. The blocking card gains them as genuine prerequisites, so
+``recompute_ready`` keeps it in ``todo`` until every one of them is ``done`` —
+which is the wait the agent asked for, now enforced by the engine instead of by
+a spin loop. No agent cooperation is required and no card is left stranded.
+
+When it is allowed to fire
+--------------------------
+``kanban_block`` takes ``reason`` and ``kind`` and nothing else, so
+``block_task`` never records *what* a card is waiting for and the shape of the
+graph is the only evidence there is. "Invert every unsettled successor" reads
+that evidence wrong — it rewrites healthy pipelines, which is the bug this
+module shipped with and which the last section describes.
+
+What separates the two shapes is *when the edge appeared*. A pipeline's
+successor was created by whoever planned the pipeline, before the card that now
+blocks had ever been claimed. The deadlocking children were created by this
+card, out of a ``kanban_create`` that named it in ``parents``, after it started
+running. So an edge is inverted only when the child's ``created`` event is newer
+than the blocking card's first ``claimed`` event. ``create_task`` writes the one
+and ``claim_task`` / ``reclaim_task`` the other, and ``task_events.id`` is a
+single ``AUTOINCREMENT`` sequence for the whole board, so the comparison is an
+exact ordering. The obvious alternative — ``tasks.created_at`` against
+``tasks.started_at`` — is whole seconds, and a planner laying out a pipeline in
+the same second the dispatcher claims its first card is indistinguishable from
+the deadlock by those.
+
+The watermark is the *first* claim, the same instant ``claim_task``'s
+``started_at = COALESCE(started_at, ?)`` records, not the current run's. A
+worker that fans out three cards and is then killed leaves them exactly as
+deadlocked as one that blocks; when the card is re-claimed and blocks for real,
+those three still need releasing.
+
+A card with no ``claimed`` event has no window at all, the comparison is NULL
+and nothing is repaired. That is the right answer for a card someone forced into
+``running`` with raw SQL.
+
+The second condition is that inverting must actually free the child: the edge is
+turned around only if this card is the *last* unfinished parent gating it. A
+child created with two parents is not released by releasing one of them, so
+turning that edge around would restructure the graph and change nothing. It also
+holds the repair to the flat fan-out we have actually observed, the one shape
+where no inversion can change the answer the cycle probe gives for the next
+child in the batch.
+
+An edge is also left alone if inverting it would create a cycle (the child
+already reaches this card by some other path). Deadlock is preferable to a
+corrupt graph, and the caller still gets told about it.
+
+The in-image gate (``verify_kanban_scheduling.py``) drives all of this against
+the real engine rather than a mock, because every one of these conditions is
+about scheduling behaviour that the schema alone does not show.
+
+The guard that did not work
+---------------------------
+Until this was measured the first condition was "the blocking card must have no
+unsettled parents of its own", on the theory that a card with a live
+prerequisite is waiting on *that* and means its block literally. It never
+discriminated anything. ``claim_task`` refuses to move a card to ``running``
+while any parent is unsettled and ``recompute_ready`` only promotes
+``todo -> ready`` once every parent is ``done`` or ``archived``, so every card
+``block_task`` will accept has settled parents by construction. Replayed against
+the engine on a throwaway board, an ordinary pipeline stage (``A`` done, ``B``
+claimed, ``B -> C``) and the ``t_ab112f5b`` deadlock both reported no unsettled
+parents — and the guard duly let the pipeline through, inverting ``B -> C`` into
+``C -> B`` so ``C`` was dispatched ahead of the stage it exists to follow. A
+two-input fan-in went the same way the moment one of its inputs finished.
+
+The only shape that makes the predicate true is ``link_tasks`` attaching a new
+parent to an already-running card, and there the card's fan-out children are
+still genuinely deadlocked — so suppressing the repair was wrong in that case
+too. The guard is deleted rather than repaired.
+
+===========================================================================
+Part 2: fence task claims to the process life that made them
+===========================================================================
+
+Background — one identity, two lifetimes
+----------------------------------------
+``_claimer_id()`` builds the lock token that stamps every claimed card::
+
+    return f"{host}:{os.getpid()}"
+
+Under Kubernetes ``socket.gethostname()`` is the **pod name**, so the token is
+pod-scoped. ``detect_crashed_workers`` then decides whose worker PIDs it is
+entitled to adjudicate using only the host half::
+
+    host_prefix = f"{_claimer_id().split(':', 1)[0]}:"
+    ...
+    if not lock.startswith(host_prefix):
+        continue
+
+Upstream's docstring says "the whole design is single-host", and on a single
+host that holds. In a container it does not: a container restart keeps the pod
+name while every process that made those claims is gone. The new process
+therefore matches ``host_prefix`` against claims made by its *predecessor* and
+runs ``os.kill(pid, 0)`` against PIDs it never issued.
+
+(The pod runs with ``shareProcessNamespace: true``, so the PID *namespace* is the
+pod's and does outlive the container — which is why the replacement dispatcher
+came up as PID 12329 rather than reusing 4. That makes a false *positive* on
+``os.kill(pid, 0)`` less likely than it would be with a fresh namespace, but it
+does not make the adjudication correct: the predecessor's workers are dead, and
+attributing their deaths to the cards is exactly the bug below.)
+
+What that cost us on 2026-08-07
+-------------------------------
+The gateway took a ``Fatal Python error: Bus error`` (exit 135) at 04:20:30 and
+the container restarted 3 seconds later. At 04:20:51 the fresh dispatcher
+adjudicated six in-flight cards claimed by the previous life — every one of them
+carrying ``claimer: platform-agent-gateway-75b5f6ddf6-7dkd7:4``, the *old*
+dispatcher PID — and marked all six ``crashed`` with ``pid <N> not alive``.
+
+They did not merely retry. ``_error_fingerprint`` normalises the PID out of the
+message::
+
+    fp = re.sub(r'\\bpid \\d+\\b', 'pid N', error_text[:80])
+
+so six independent workers killed by one infrastructure event collapsed to a
+single fingerprint. Count 6 >= 3 tripped the systemic heuristic, which passes
+``failure_limit=1``, so each card gave up on its *first* failure::
+
+    gave_up {"failures": 1, "effective_limit": 1, "limit_source": "dispatcher",
+             "error": "pid 1046 not alive", "trigger_outcome": "crashed"}
+
+One gateway crash permanently abandoned every card in flight.
+
+Separately, nothing releases a claim when a pod goes away. ``release_stale_claims``
+selects purely on ``claim_expires < now``, and the TTL is
+``DEFAULT_CLAIM_TTL_SECONDS = 900``. There is no SIGTERM drain and no startup
+adoption, so an ordinary rollout costs a full 15 minutes of dark cards. Measured
+on the same day: five cards claimed at 03:59:04, pod deleted at 04:00:11,
+reclaimed at 04:14:24 — exactly one TTL after the last heartbeat.
+
+The two fixes
+-------------
+1. **Adjudicate only your own claims.** ``claim_is_self`` compares the whole
+   token, not the host half, so a previous life's PIDs are never probed. A
+   colliding PID in a recycled namespace can no longer be mistaken for a live
+   worker, and a dead one can no longer be reported as a crash.
+
+2. **Release dead foreign claims immediately, and charge the ones that are
+   faults.** ``release_dead_foreign_claims`` sweeps ``running`` cards whose
+   claim belongs to someone else *and* whose recorded worker PID is not alive,
+   and puts them back in ``ready`` for the dispatcher to pick up. This is what
+   removes the 900-second dark window after a rollout or a crash.
+   ``charge_reclaimed_cards`` then spends one unit of retry budget on each
+   release the sweep classified as a fault — see "Which reclaims are charged"
+   below, which is the whole of part 2's subtlety.
+
+   The liveness test is what makes the sweep safe in every caller, not just the
+   gateway. A CLI invocation has its own ``_claimer_id()`` and would otherwise
+   consider the live gateway's claims foreign — but the gateway's workers have
+   live PIDs, so they are left strictly alone. Where a PID does collide with an
+   unrelated live process the card simply falls back to the existing TTL, which
+   is the behaviour we already have today.
+
+   The sweep honours the same launch-window grace period the per-row loop below
+   it applies, for the same reason and from the same source
+   (``_resolve_crash_grace_seconds``, injected). Running ahead of that check
+   would give foreign claims a stricter liveness test than the process's own —
+   a divergence with no justification behind it, since a card claimed seconds
+   ago by any process is a card whose worker may not be on ``/proc`` yet.
+
+Why a release is charged at all, and why it goes back to ``ready``
+------------------------------------------------------------------
+The first version of this module released the card for free — ``todo``, no
+failure recorded — on the reasoning that an infrastructure event is not the
+card's fault and must not spend its retry budget. That reasoning conflated two
+different questions. Whose claim it was says nothing about whether the *run*
+failed, and the sweep's own precondition is that the worker process is provably
+dead with no result written. That is a failed run by the same definition
+``detect_crashed_workers`` uses one loop later for a worker of our own.
+
+Left uncharged it is also an unbounded loop, which is the concrete failure this
+paragraph exists for. A card whose work kills the dispatcher — an OOM, the
+2026-08-07 SIGBUS — is reclaimed by the replacement process, dispatched again,
+kills it again. Nothing counts, so nothing ever stops it: replayed against a
+real board through the shipped engine, six cycles of claim → reclaim → promote
+left ``consecutive_failures`` at 0 every single time. The card burns a worker
+slot and takes the gateway down with it for as long as the pod keeps coming
+back.
+
+``todo`` was half of why the breaker could not see it. ``recompute_ready``
+applies its failure-limit guard (#35072) only to ``blocked`` rows; a ``todo``
+row is promoted unconditionally, so even a card carrying an exhausted counter
+walks straight back to ``ready``. ``ready`` is also what upstream's own crash
+path releases to, and what ``_record_task_failure(release_claim=False)``
+requires — its trip branch is gated on ``status IN ('ready', 'running')``.
+
+Charging goes through ``_record_task_failure`` with no ``failure_limit``
+argument, so the threshold is the one the dispatcher already resolves for every
+other failure: per-task ``max_retries``, else ``kanban.failure_limit``, else
+``DEFAULT_FAILURE_LIMIT``. No second budget, no new column. A poison card lands
+in ``blocked`` with a ``gave_up`` event after the second reclaim and waits for a
+human, exactly as a card whose worker crashes twice does.
+
+Which reclaims are charged: the discriminator
+---------------------------------------------
+Charging *every* reclaim was too blunt, and the arithmetic says why.
+``DEFAULT_FAILURE_LIMIT`` is 2 and no profile overrides ``kanban.failure_limit``,
+so two reclaims across a card's whole life park it in ``blocked`` behind a
+``hermes kanban unblock``. A long-running card that happens to be in flight
+during two ordinary deploys is not a failing card, and there is nothing for the
+human the trip summons to do about it.
+
+So the sweep classifies each release before handing it to the charge loop, and
+the classification turns on **whether the owner belonged to an era this process
+could have observed**. Two facts decide it, and both must hold for a release to
+be forgiven:
+
+1. *The owner was in a different pod.* Kubernetes replaces a pod for reasons
+   that have nothing to do with any card: a rollout, an eviction, a node drain,
+   a preemption. The gateway is a ``Deployment``, so a replacement pod gets a
+   new name (ReplicaSet hash plus a random suffix) and the host half of the
+   claim token changes with it. When the host half is *unchanged*, the pod is
+   still the pod this process is running in and the previous process died in
+   place — a container restart, which is what a SIGBUS, an OOM kill or a
+   liveness-probe kill produces. That is precisely the poison-card signature,
+   and it stays charged. **This is the condition that keeps the unbounded loop
+   above closed**, so it is not optional.
+
+2. *The claim predates this process.* If the claim was made before this process
+   existed, the two never ran concurrently and the owner's disappearance is part
+   of the same event that produced this process. If it was made afterwards, the
+   owner was alive alongside us and went away on its own — a ``hermes kanban``
+   CLI in another pod whose worker died, or a second replica losing a worker.
+   That is an observed fault and it is charged. Without this condition a CLI
+   invocation from anywhere outside this pod would get free retries forever.
+
+A caveat worth stating rather than discovering: during a rolling update the
+outgoing pod and the incoming one overlap, so a card the outgoing pod claims
+*after* the new gateway starts fails test 2 and is charged. The window is the
+few seconds between the new pod becoming ready and the old one finishing its
+SIGTERM drain, and erring toward charging inside it is the safe direction —
+under-charging is what reopens the loop.
+
+Two more inputs decide nothing on their own but need saying. A release whose
+claim time cannot be read (``current_run_id`` NULL, or the run row gone) is
+charged: the discriminator's job is to forgive a *provable* replacement, and an
+unknown is not one. And ``socket.gethostname()`` is only the pod name because
+the pod does not set ``hostNetwork``; with host networking every pod on a node
+would share the node's hostname, test 1 would read every replacement as an
+in-place restart, and the behaviour would degrade to charging everything —
+which is the pre-discriminator behaviour, not a new failure mode.
+
+Why "this process's start", and where it is read from
+-----------------------------------------------------
+Test 2 needs a wall-clock instant for "when this process began", comparable to
+the epoch seconds ``claim_task`` writes into ``task_runs.started_at``. Three
+candidates were considered:
+
+* **Container start** (``/proc/1/stat``, or a file the entrypoint touches).
+  Rejected: it is the wrong boundary. A gateway process restarted inside a live
+  container by a supervisor would treat its own predecessor's claims as
+  belonging to its era and charge them, which they are — but the boundary would
+  say the opposite for anything claimed after the container came up. The
+  question the discriminator asks is about *processes*, so the answer has to be
+  about processes.
+* **A timestamp captured at module import.** Nearly right for the gateway, where
+  ``kanban_db`` is imported during startup, and it is what this module falls
+  back to. Not right in general: it is later than the true process start by
+  however long the import graph takes, and it is inherited verbatim across an
+  ``os.fork()``, so a forked child would claim its parent's age.
+* **``/proc/self/stat`` field 22 against ``/proc/uptime``.** Chosen.
+  ``starttime`` is the process's own start expressed in clock ticks since system
+  boot; ``/proc/uptime`` is seconds since that same boot. Subtracting the uptime
+  from ``time.time()`` gives the boot instant on the wall clock and adding
+  ``starttime`` gives the process's. Both readings are taken against the same
+  origin, which is what makes the arithmetic correct in a container: Kubernetes
+  gives the container its own PID namespace but not its own boot clock, so both
+  numbers still refer to the host's boot and the difference between them is
+  exact regardless. Reading it fresh (per process, cached by PID) is also
+  fork-safe by construction, which the import-time constant is not.
+
+``time.time()`` is a wall clock and can be stepped by NTP. A backward step large
+enough to matter would have to exceed the gap between a claim and the next
+sweep, and the failure it produces is a charged reclaim that should have been
+forgiven — the same safe direction as the rollout overlap above. Using a
+monotonic clock instead is not an option: the value has to be comparable with
+timestamps another process wrote to the database.
+
+Why the PID stays in the fingerprint after all
+----------------------------------------------
+This patch used to make a further edit: it replaced upstream's
+``re.sub(r'\\bpid \\d+\\b', 'pid N', ...)`` in ``_error_fingerprint`` with a bare
+``error_text[:80]``, so that ``pid 1044 not alive`` and ``pid 1045 not alive``
+would count as two failures rather than one systemic fault. That edit has been
+reverted, because ``_error_fingerprint`` is reachable from exactly two call
+sites — both inside ``detect_crashed_workers``, both over the ``crash_details``
+error texts — and every message that path can produce is PID-prefixed::
+
+    f"pid {pid} exited with code {code}"
+    f"pid {pid} killed by signal {code}"
+    f"pid {pid} not alive"
+
+With the PID left in, no two concurrent workers can ever share a fingerprint, so
+``_fp_counts`` never reaches the ``>= 3`` the systemic heuristic tests and
+``is_systemic`` is dead code. Driving the shipped engine with four of its own
+workers all OOM-killed in one tick (``exited with code 137``, distinct PIDs)
+produced four fingerprints and an empty ``auto_blocked``: the detector that is
+supposed to stop a board where everything is failing the same way could not
+fire at all.
+
+The edit was aimed at a cause that fix 1 had already removed. The six
+fingerprints of 2026-08-07 existed only because the successor adjudicated its
+predecessor's workers; with ``claim_is_self`` in place those cards never enter
+``crash_details``, they go through the sweep instead. What is left in that
+bucket after the fence is a burst of *our own* workers dying the same way in a
+single tick, which is what the heuristic was built for. Reclaims are charged in
+their own loop and never join the fingerprint pass, so a rollout that hands back
+six cards at once still cannot collapse into one systemic verdict — the property
+this module was written to protect, and the reason
+``charge_reclaimed_cards`` is a separate pass rather than extra
+``crash_details`` entries.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import NamedTuple, Optional
+
+# ---------------------------------------------------------------------------
+# Part 1: inverted fan-out dependency edges
+# ---------------------------------------------------------------------------
+
+# Statuses that satisfy the parent gate in ``claim_task`` / ``recompute_ready``.
+SETTLED = "('done', 'archived')"
+
+DEPENDENCY_EVENT_KIND = "dependency_repaired"
+
+
+def _reaches(conn, start: str, target: str) -> bool:
+    """True if ``target`` is reachable walking parent->child edges from ``start``."""
+    seen: set[str] = set()
+    stack = [start]
+    while stack:
+        node = stack.pop()
+        if node == target:
+            return True
+        if node in seen:
+            continue
+        seen.add(node)
+        rows = conn.execute(
+            "SELECT child_id FROM task_links WHERE parent_id = ?", (node,)
+        ).fetchall()
+        stack.extend(r["child_id"] for r in rows)
+    return False
+
+
+def find_deadlocked_children(conn, task_id: str) -> list[str]:
+    """Unsettled cards ``task_id`` fanned out after it started and alone gates.
+
+    Two conditions beyond "is an unsettled child", both explained at length in
+    the module docstring. The run window — the child's ``created`` event is
+    newer than this card's first ``claimed`` event — is what tells a card this
+    one fanned out apart from a pipeline successor somebody else planned. The
+    ``NOT EXISTS`` is what stops the repair rewriting an edge whose inversion
+    would free nothing. Either subquery returning NULL makes the comparison NULL
+    and drops the row, which is the conservative answer for a card that reached
+    ``running`` without ever being claimed.
+    """
+    rows = conn.execute(
+        "SELECT l.child_id FROM task_links l "
+        "JOIN tasks c ON c.id = l.child_id "
+        f"WHERE l.parent_id = ? AND c.status NOT IN {SETTLED} "
+        "  AND (SELECT MIN(birth.id) FROM task_events birth "
+        "        WHERE birth.task_id = l.child_id AND birth.kind = 'created') "
+        "      > (SELECT MIN(started.id) FROM task_events started "
+        "          WHERE started.task_id = l.parent_id "
+        "            AND started.kind = 'claimed') "
+        "  AND NOT EXISTS ("
+        "        SELECT 1 FROM task_links o "
+        "        JOIN tasks op ON op.id = o.parent_id "
+        "        WHERE o.child_id = l.child_id "
+        "          AND o.parent_id <> l.parent_id "
+        f"          AND op.status NOT IN {SETTLED}"
+        "  ) "
+        "ORDER BY l.child_id",
+        (task_id,),
+    ).fetchall()
+    return [r["child_id"] for r in rows]
+
+
+def repair_inverted_dependencies(conn, task_id: str, reason: str = "") -> list[str]:
+    """Invert every edge that would deadlock a dependency-block on ``task_id``.
+
+    Returns the ids whose edge was inverted. Safe to call when there is nothing
+    to repair — the common case — in which case it returns ``[]`` and writes
+    nothing. Must be called inside an open write transaction; it does not open
+    one of its own.
+
+    Calling it twice is a no-op the second time: the first pass turned every
+    edge it touched around, so the card has no outgoing edges left for
+    ``find_deadlocked_children`` to find.
+    """
+    children = find_deadlocked_children(conn, task_id)
+    if not children:
+        return []
+
+    repaired: list[str] = []
+    skipped: list[str] = []
+    for child in children:
+        # Drop the gating edge first so the cycle probe sees the graph as it
+        # will be, not as it was.
+        conn.execute(
+            "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
+            (task_id, child),
+        )
+        # The probe has to follow the edge about to be *inserted*, not the one
+        # just deleted: adding child -> task_id closes a loop exactly when
+        # task_id can still reach child by some other path.
+        if _reaches(conn, task_id, child):
+            # Inverting would close a loop. Put it back and leave this one be.
+            conn.execute(
+                "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                (task_id, child),
+            )
+            skipped.append(child)
+            continue
+        conn.execute(
+            "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+            (child, task_id),
+        )
+        repaired.append(child)
+
+    if repaired or skipped:
+        conn.execute(
+            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                task_id,
+                None,
+                DEPENDENCY_EVENT_KIND,
+                json.dumps(
+                    {
+                        "inverted": repaired,
+                        "skipped_would_cycle": skipped,
+                        "reason": (reason or "")[:200],
+                        "detail": (
+                            "cards listed this one as a parent while it waited on "
+                            "them; edges inverted so they can be dispatched and "
+                            "this card resumes once they are done"
+                        ),
+                    }
+                ),
+                int(time.time()),
+            ),
+        )
+    return repaired
+
+
+# ---------------------------------------------------------------------------
+# Part 2: claims fenced to a process life
+# ---------------------------------------------------------------------------
+
+RECLAIM_ERROR = "released: claim held by a process that is gone"
+
+RECLAIM_EVENT_KIND = "reclaimed"
+
+# How the sweep read the owner's disappearance. Only ``POD_REPLACED`` is
+# forgiven; the module docstring's "Which reclaims are charged" section is the
+# argument for each.
+POD_REPLACED = "pod_replaced"
+PROCESS_DIED_IN_PLACE = "process_died_in_place"
+CONCURRENT_OWNER = "concurrent_owner"
+CLAIM_TIME_UNKNOWN = "claim_time_unknown"
+
+
+class Reclaimed(NamedTuple):
+    """One sweep's releases, split by whether the card owes a retry for them.
+
+    Both lists are already back at ``ready`` with their runs closed when the
+    sweep returns; the split only decides what ``charge_reclaimed_cards`` is
+    handed. Keeping ``forgiven`` rather than dropping it is deliberate — the
+    caller has no other way to report or log a release it is not charging for,
+    and a silent free reclaim is indistinguishable from a sweep that did
+    nothing.
+    """
+
+    chargeable: list[str]
+    forgiven: list[str]
+
+
+def claim_is_self(lock: Optional[str], claimer_id: str) -> bool:
+    """True when ``lock`` was written by this exact process life.
+
+    Replaces upstream's host-prefix comparison, which cannot tell a container
+    restart from the process that is currently running.
+    """
+    return bool(lock) and lock == claimer_id
+
+
+def claim_host(token: Optional[str]) -> str:
+    """The host half of a ``host:pid`` claim token — the pod name in-cluster.
+
+    Split the same way ``detect_crashed_workers`` splits it (``split(':', 1)``),
+    so a hostname that somehow contains a colon is read identically here and
+    upstream.
+    """
+    return (token or "").split(":", 1)[0]
+
+
+# Fallbacks for ``process_start_time`` when ``/proc`` is not there — a
+# developer's macOS box, or the unit tests. Captured at import because that is
+# the earliest instant this module can observe; see the docstring for why it is
+# a fallback and not the primary.
+_IMPORT_PID = os.getpid()
+_IMPORTED_AT = time.time()
+
+try:
+    _CLOCK_TICKS = float(os.sysconf("SC_CLK_TCK")) or 100.0
+except (AttributeError, ValueError, OSError):  # pragma: no cover - non-POSIX
+    _CLOCK_TICKS = 100.0
+
+# (pid, wall-clock start). Keyed by PID so a fork recomputes instead of
+# inheriting its parent's answer.
+_PROCESS_START: Optional[tuple[int, float]] = None
+
+
+def read_proc_start_time() -> Optional[float]:
+    """This process's start as wall-clock epoch seconds, from ``/proc``.
+
+    ``None`` when ``/proc`` is absent or unreadable, which is the whole of the
+    non-Linux case. Field 22 of ``/proc/self/stat`` is ``starttime`` in clock
+    ticks since system boot; ``/proc/uptime`` is seconds since the same boot, so
+    ``now - uptime`` is the boot instant and adding ``starttime`` lands on this
+    process. Field 2 (``comm``) is parenthesised and may itself contain spaces
+    and parentheses, so the only safe place to start splitting is the LAST
+    ``)`` — after which ``starttime`` is index 19, fields 1 and 2 having been
+    consumed.
+    """
+    try:
+        with open("/proc/self/stat", "rb") as fh:
+            stat = fh.read().decode("utf-8", "replace")
+        ticks = float(stat[stat.rindex(")") + 1:].split()[19])
+        with open("/proc/uptime", "rb") as fh:
+            uptime = float(fh.read().split()[0])
+    except (OSError, ValueError, IndexError):
+        return None
+    return time.time() - uptime + ticks / _CLOCK_TICKS
+
+
+def process_start_time() -> float:
+    """Wall-clock epoch seconds at which the calling process began.
+
+    Comparable with the ``int(time.time())`` values ``claim_task`` writes into
+    ``task_runs.started_at``, which is the only reason it has to be a wall clock
+    rather than a monotonic one. Cached per PID: the value is constant for a
+    process, and the fallback in particular must not drift between sweeps or the
+    discriminator's boundary would move every tick.
+    """
+    global _PROCESS_START
+    pid = os.getpid()
+    if _PROCESS_START is not None and _PROCESS_START[0] == pid:
+        return _PROCESS_START[1]
+    value = read_proc_start_time()
+    if value is None:
+        # No ``/proc``. In the process that imported this module, import time is
+        # the closest observation available; in a fork of it, the child is new,
+        # so now is closer than the parent's import.
+        value = _IMPORTED_AT if pid == _IMPORT_PID else time.time()
+    _PROCESS_START = (pid, value)
+    return value
+
+
+def classify_reclaim(
+    lock: Optional[str],
+    claimer_id: str,
+    claimed_at: Optional[float],
+    process_start: float,
+) -> str:
+    """Why a dead foreign owner disappeared, as far as the board can tell.
+
+    Returns one of the four module constants. ``POD_REPLACED`` — and only that —
+    means the release is infrastructure rather than a fault, so the card keeps
+    its retry budget. The reasoning for each arm is in the module docstring
+    under "Which reclaims are charged"; the short form is that a claim from this
+    same pod means the process died in place (crash, OOM, probe kill) and a
+    claim made after this process started means the owner was alive alongside
+    us, and both of those are faults this card has to pay for.
+
+    ``process_start`` is truncated before the comparison because ``claim_task``
+    writes ``int(time.time())``: a claim made 0.4s after this process began
+    records as a whole second *below* the fractional start and would otherwise
+    read as pre-boot. Truncating puts that whole second on the charged side,
+    which is the same direction the rollout-overlap caveat in the module
+    docstring errs in — under-charging is what reopens the loop.
+    """
+    if claim_host(lock) == claim_host(claimer_id):
+        return PROCESS_DIED_IN_PLACE
+    try:
+        claimed = float(claimed_at)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return CLAIM_TIME_UNKNOWN
+    if claimed >= int(process_start):
+        return CONCURRENT_OWNER
+    return POD_REPLACED
+
+
+def release_dead_foreign_claims(
+    conn,
+    claimer_id: str,
+    pid_alive,
+    grace_seconds=None,
+    process_start: Optional[float] = None,
+) -> Reclaimed:
+    """Return ``running`` cards whose owner is gone to ``ready``.
+
+    A card qualifies when all four hold:
+
+    * its ``claim_lock`` is not this process life's token,
+    * it has a recorded ``worker_pid``,
+    * it is past the launch-window grace period,
+    * that PID is not alive.
+
+    ``grace_seconds`` is ``_resolve_crash_grace_seconds`` — injected rather than
+    imported so this module never depends on ``kanban_db``. Omitting it skips
+    the grace check, which is what the tests want and what a caller with no
+    ``started_at`` column can live with. ``process_start`` defaults to this
+    process's own start and exists as an argument for the same reason: so a test
+    can name the boundary instead of racing it.
+
+    The claim instant comes from ``task_runs.started_at`` of the row
+    ``tasks.current_run_id`` points at, which ``claim_task`` writes in the same
+    transaction as the claim. ``tasks.started_at`` is NOT that value — it is
+    ``COALESCE(started_at, ?)``, the first start the card ever had, so a
+    re-claimed card would be judged on a run that ended long ago.
+
+    Must be called inside an open write transaction. The ``chargeable`` half of
+    the result is what the caller owes to ``charge_reclaimed_cards`` once that
+    transaction has closed.
+    """
+    if process_start is None:
+        process_start = process_start_time()
+
+    rows = conn.execute(
+        "SELECT t.id, t.worker_pid, t.claim_lock, t.current_run_id, "
+        "       t.started_at, r.started_at AS claimed_at "
+        "FROM tasks t "
+        "LEFT JOIN task_runs r ON r.id = t.current_run_id "
+        "WHERE t.status = 'running' AND t.claim_lock IS NOT NULL "
+        "AND t.worker_pid IS NOT NULL"
+    ).fetchall()
+
+    chargeable: list[str] = []
+    forgiven: list[str] = []
+    now = int(time.time())
+    grace = None
+    for row in rows:
+        lock = row["claim_lock"] or ""
+        if claim_is_self(lock, claimer_id):
+            continue
+        try:
+            pid = int(row["worker_pid"])
+        except (TypeError, ValueError):
+            continue
+        if grace_seconds is not None:
+            started_at = row["started_at"]
+            if started_at is not None:
+                if grace is None:
+                    grace = grace_seconds()
+                if now - started_at < grace:
+                    # Too new to adjudicate: the worker may not be on /proc yet.
+                    # Same test, same source as the per-row loop in
+                    # ``detect_crashed_workers``.
+                    continue
+        if pid_alive(pid):
+            # Either a real live worker or a PID collision. The TTL remains the
+            # backstop; never take a card away from something that might be
+            # running it.
+            continue
+
+        fate = classify_reclaim(lock, claimer_id, row["claimed_at"], process_start)
+        charged = fate != POD_REPLACED
+
+        # ``ready``, not ``todo``: ``recompute_ready`` promotes a ``todo`` row
+        # without consulting its failure counter, which is how a card that kills
+        # the dispatcher used to escape the breaker forever. It is also the
+        # status ``_record_task_failure`` needs to see to trip.
+        conn.execute(
+            "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, current_run_id = NULL "
+            "WHERE id = ?",
+            (row["id"],),
+        )
+        # ``ended_at IS NULL`` mirrors ``_end_run``: a run already closed by some
+        # other path must not have its outcome rewritten to ``reclaimed``.
+        conn.execute(
+            "UPDATE task_runs SET status = 'reclaimed', outcome = 'reclaimed', "
+            "ended_at = ?, error = ? WHERE task_id = ? AND status = 'running' "
+            "AND ended_at IS NULL",
+            (now, RECLAIM_ERROR, row["id"]),
+        )
+        conn.execute(
+            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                row["id"],
+                row["current_run_id"],
+                RECLAIM_EVENT_KIND,
+                json.dumps(
+                    {
+                        "stale_lock": lock,
+                        "worker_pid": pid,
+                        "claimer": claimer_id,
+                        "reason": "owner_process_gone",
+                        "fenced": True,
+                        # The discriminator's verdict, on the board rather than
+                        # only in a log line: a card that is not charged has to
+                        # say so, or the counter and the history disagree and
+                        # nobody can tell which is lying.
+                        "owner_fate": fate,
+                        "charged": charged,
+                    }
+                ),
+                now,
+            ),
+        )
+        (chargeable if charged else forgiven).append(row["id"])
+    return Reclaimed(chargeable, forgiven)
+
+
+def charge_reclaimed_cards(conn, task_ids, record_failure) -> list[str]:
+    """Spend one retry on each card the sweep handed back. Returns those parked.
+
+    ``record_failure`` is ``_record_task_failure``, injected for the same reason
+    ``pid_alive`` is. It is called the way the crash path calls it — the card is
+    already back at ``ready`` with its run closed, so no claim to release and no
+    run to end — and with no ``failure_limit``, so the threshold is the one the
+    dispatcher resolves for every other failure kind rather than a second budget
+    invented here.
+
+    Must be called OUTSIDE the transaction the sweep ran in:
+    ``_record_task_failure`` opens its own ``write_txn`` and ``write_txn`` does
+    not nest.
+
+    Deliberately a separate loop from the ``crash_details`` pass rather than an
+    extra entry in it. Every card released by one event carries the same
+    ``RECLAIM_ERROR`` text, so folding them into ``_fp_counts`` would make any
+    three of them look systemic, drop ``failure_limit`` to 1 and abandon the lot
+    on their first reclaim — the 2026-08-07 outcome, reached by a new route.
+    The discriminator does not change that: it decides *which* ids arrive here,
+    and a same-pod container restart still delivers every in-flight card at once
+    with one identical error text.
+    """
+    tripped: list[str] = []
+    for task_id in task_ids:
+        if record_failure(
+            conn,
+            task_id,
+            error=RECLAIM_ERROR,
+            outcome=RECLAIM_EVENT_KIND,
+            release_claim=False,
+            end_run=False,
+            event_payload_extra={"reason": "owner_process_gone", "fenced": True},
+        ):
+            tripped.append(task_id)
+    return tripped

--- a/deploy/docker/patches/kanban_wake_nudge.py
+++ b/deploy/docker/patches/kanban_wake_nudge.py
@@ -1,0 +1,280 @@
+"""Let a kanban board mutation wake its watchers instead of waiting out a poll.
+
+Installed into the image at ``/opt/hermes/hermes_cli/kanban_wake_nudge.py`` and
+wired into ``hermes_cli/kanban_db.py`` (producers) and
+``gateway/kanban_watchers.py`` (consumers) by
+``deploy/docker/patches/apply_kanban_wake_nudge.py``. It lives in
+``hermes_cli`` rather than ``gateway`` because both sides must import it and
+the dependency only points one way: the gateway already imports
+``hermes_cli.kanban_db`` freely, while the CLI/worker processes never import
+``gateway``.
+
+The problem, measured
+---------------------
+Both gateway watchers are pure polls. The dispatcher ticks every
+``kanban.dispatch_interval_seconds`` (5s on the live cluster; the sleep loop
+at the bottom of ``_kanban_dispatcher_watcher``) and the notifier every 5s
+(the ``interval`` default on ``_kanban_notifier_watcher``, spawned with no
+args from ``gateway/run.py``). So every hop of a task chain — card created →
+dispatcher claims it; card completed → notifier delivers and children promote
+— pays an average of half a tick and up to a whole one, for work that took
+microseconds to commit.
+
+Measured on the 2026-08-07 live run: 4.9s for the coordinator card to be
+claimed, 2.2s for the synthesizer, plus notify delays, on a request whose
+whole round trip was 87s. None of that latency bought anything; the rows were
+sitting committed in SQLite the entire time.
+
+The nudge
+---------
+Workers run in separate processes from the gateway, so an in-process event is
+useless — the signal has to cross process boundaries and survive none of the
+participants sharing anything but the board file. The cheapest primitive with
+those properties is a sibling file: :func:`record_wake` bumps the mtime of
+``<db_path>.wake`` (derived from the board DB path, never hardcoded — every
+board gets its own) after the mutations that give a watcher something to do:
+
+* ``create_task`` commit — a claimable card exists;
+* ``complete_task`` (after its ``recompute_ready``) — a terminal event to
+  deliver, and possibly children promoted to ``ready``;
+* ``unblock_task`` commit — a card returned to the claimable pool.
+
+Deliberately NOT hooked: claims, heartbeats, and everything else the
+dispatcher itself writes during a tick — hooking those would let the
+dispatcher wake itself and turn the 0.25s reaction slice into a busy loop.
+
+Consumers construct one :class:`WakeMonitor` per watcher loop and replace
+their fixed sleep with :func:`wait_interval`, which dozes in ≤0.25s slices and
+breaks early when the wake file's mtime moves. Reaction to a nudge is
+therefore ≤0.25s, while the full-interval scan remains the unconditional
+fallback — the wake file is an accelerator, never a correctness dependency.
+
+Failure posture
+---------------
+Everything here fails towards upstream behaviour, and that is a tested
+property, not an aspiration. ``record_wake`` swallows every exception (a
+read-only filesystem must not fail the board write it rides on);
+``WakeMonitor.changed`` returns False when the file cannot be statted; and
+``wait_interval`` with a dead monitor is exactly the sleep loop it replaced.
+The mtime is bumped with an explicit ``time.time_ns()`` value so two nudges
+inside one coarse filesystem-timestamp tick still compare unequal.
+
+Exactly one of those degradations is logged, and the split is deliberate:
+:meth:`WakeMonitor.__init__` runs once per watcher loop, and a resolver that
+raises there leaves the loop polling at the full interval for the lifetime of
+the gateway — a permanent, total loss of the acceleration whose only symptom
+is the per-hop latency this patch was written to remove. Everything else here
+runs either on the tail of every board write or once per 0.25s slice, where a
+log line per occurrence would be a log storm and the loss is one nudge, so
+those stay silent.
+
+Multi-board note: each watcher monitors the wake file of the board DB that
+``kanban_db_path()`` resolves for it (the ``HERMES_KANBAN_DB`` pin on the
+cluster, which is also what the dispatcher injects into every worker).
+Mutations on any *other* board still land within one full interval, exactly
+as upstream.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Callable, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+#: Longest a watcher dozes between wake-file checks. The reaction ceiling for
+#: a nudge, and the cost ceiling for an idle board: one stat() per slice.
+SLICE_SECONDS = 0.25
+
+_WAKE_SUFFIX = ".wake"
+
+
+def wake_path(db_path: Union[str, "os.PathLike[str]"]) -> str:
+    """Return the wake-file path for a board DB path.
+
+    Always derived, never fixed: ``/opt/data/kanban.db`` →
+    ``/opt/data/kanban.db.wake``, and a test board in a tmp dir gets its wake
+    file in that same tmp dir.
+    """
+    return str(db_path) + _WAKE_SUFFIX
+
+
+def record_wake(db_path: Union[str, "os.PathLike[str]"]) -> bool:
+    """Bump the wake file next to ``db_path``. Fail-soft, cheap, atomic.
+
+    Returns True when the nudge landed, False when it could not — and never
+    raises: this runs on the tail of successful board writes, and a full disk
+    or read-only filesystem must degrade to plain polling, not fail the write
+    the caller already committed.
+
+    The mtime is set to an explicit ``time.time_ns()`` pair rather than left
+    to the filesystem clock so that two nudges within one coarse timestamp
+    granule still produce distinct ``st_mtime_ns`` values.
+    """
+    try:
+        if db_path is None or not str(db_path):
+            # str(None) is a real (relative!) filename; refuse rather than
+            # scatter "None.wake" files wherever the process's cwd happens
+            # to be.
+            return False
+        path = wake_path(db_path)
+        now_ns = time.time_ns()
+        try:
+            os.utime(path, ns=(now_ns, now_ns))
+        except FileNotFoundError:
+            # First nudge for this board. open("ab") is create-if-missing and
+            # race-tolerant: two concurrent creators both succeed.
+            with open(path, "ab"):
+                pass
+            os.utime(path, ns=(now_ns, now_ns))
+        return True
+    except Exception:
+        # Silent on purpose, and the purpose is not tidiness: this runs on the
+        # tail of every committed board write in every worker process, so a
+        # board directory that is read-only or full would emit a line per card
+        # rather than the one degradation an operator needs to see. The caller
+        # gets False, the loss is a single nudge, and the write it rides on has
+        # already committed. WakeMonitor's constructor is where a permanent
+        # failure of this mechanism does get reported.
+        return False
+
+
+def record_wake_for_conn(conn) -> bool:
+    """:func:`record_wake` against the board an open connection writes to.
+
+    The producer hooks in ``kanban_db`` only have ``conn`` in scope, so the
+    path is read back from SQLite itself (``PRAGMA database_list``) — which
+    also guarantees the nudge lands next to the file the mutation actually
+    went to, whatever mix of ``HERMES_KANBAN_DB`` / board slug resolved it.
+    Fail-soft like everything else here: an in-memory database (no file) or a
+    closed connection is a False, never an exception.
+    """
+    try:
+        for row in conn.execute("PRAGMA database_list"):
+            # (seq, name, file) — index access works for tuples and
+            # sqlite3.Row alike.
+            if row[1] == "main":
+                db_file = row[2]
+                if db_file:
+                    return record_wake(db_file)
+                return False
+        return False
+    except Exception:
+        # Same write-path reasoning as record_wake: silent by design, because
+        # this is reached from inside kanban_db's producers on every create,
+        # complete, and unblock.
+        return False
+
+
+class WakeMonitor:
+    """Watches one board's wake file for nudges.
+
+    ``db_path`` may be the path itself or a zero-arg callable returning it
+    (the watchers pass ``kanban_db.kanban_db_path`` uncalled, so a resolver
+    error degrades this monitor instead of killing the watcher coroutine).
+    That degradation is logged, because it is permanent: the constructor runs
+    once, where the watcher loop starts, so a monitor born inert stays inert
+    and the loop polls at the full interval until the gateway restarts.
+
+    ``changed()`` is edge-triggered: True exactly once per observed mtime
+    move, so a burst of nudges between two polls costs one early scan, not
+    one per nudge. The first call after construction returns False unless the
+    file changed *since* construction — the monitor reports news, it does not
+    replay history.
+    """
+
+    def __init__(
+        self,
+        db_path: Union[str, "os.PathLike[str]", Callable[[], object], None],
+    ) -> None:
+        self._path: Optional[str] = None
+        try:
+            resolved = db_path() if callable(db_path) else db_path
+            if resolved is not None:
+                self._path = wake_path(resolved)
+        except Exception as exc:
+            # The one degradation in this module worth a log line. Swallowing
+            # it keeps the watcher coroutine alive, which is right, but an
+            # inert monitor makes `wait_interval` identical to the fixed sleep
+            # it replaced — so the gateway silently goes back to paying the
+            # 2.5s-average claim and notify delays measured on 2026-08-07, and
+            # nothing anywhere says why. Named at WARNING so the cause is one
+            # grep away from the symptom.
+            logger.warning(
+                "kanban wake nudge: could not resolve the board path (%s); "
+                "this watcher falls back to plain interval polling",
+                exc,
+            )
+            self._path = None
+        self._last = self._stat()
+
+    def _stat(self) -> Optional[int]:
+        if self._path is None:
+            return None
+        try:
+            return os.stat(self._path).st_mtime_ns
+        except Exception:
+            # Unlike the constructor, deliberately silent: this is called once
+            # per 0.25s slice in both watcher loops, so logging a missing or
+            # unreadable wake file would cost eight lines a second forever. A
+            # file that cannot be statted reads as "quiet", which is precisely
+            # the upstream poll.
+            return None
+
+    def changed(self) -> bool:
+        """True iff the wake file moved since the last observation."""
+        current = self._stat()
+        if current == self._last:
+            return False
+        self._last = current
+        return True
+
+
+async def wait_interval(
+    monitor: Optional[WakeMonitor],
+    interval: float,
+    running: Optional[Callable[[], object]] = None,
+) -> bool:
+    """Doze up to ``interval`` seconds, waking early on a recorded nudge.
+
+    Drop-in for the watchers' fixed sleep loops: sleeps in ≤0.25s slices,
+    returning early — True — when ``monitor.changed()``, and True after the
+    full interval otherwise. Returns False iff ``running()`` went falsy, so a
+    caller that used ``if not self._running: return`` keeps its snappy
+    shutdown (``running`` is checked before every slice, exactly where the
+    upstream loops checked it).
+
+    A monitor that is None, half-constructed, or raising is treated as "no
+    nudge ever": the wait then IS the upstream fixed sleep.
+    """
+    try:
+        seconds = float(interval)
+    except (TypeError, ValueError):
+        seconds = 5.0
+    if seconds <= 0:
+        # Upstream floors its sleeps too (the notifier at 1s per slice, the
+        # dispatcher at interval >= 1.0); a zero interval here would turn the
+        # watcher into a hot loop. One slice is the smallest honest wait.
+        seconds = SLICE_SECONDS
+    deadline = time.monotonic() + seconds
+    while True:
+        if running is not None and not running():
+            return False
+        try:
+            if monitor is not None and monitor.changed():
+                return True
+        except Exception:
+            # Same per-slice reasoning as WakeMonitor._stat, and the same
+            # outcome: a monitor that raises is read as "no nudge ever" and
+            # this wait becomes the fixed sleep it replaced. A monitor
+            # constructed by the patched watchers cannot reach here — its own
+            # _stat swallows everything — so this only catches a caller that
+            # passed something other than a WakeMonitor.
+            pass
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return True
+        await asyncio.sleep(min(SLICE_SECONDS, remaining))

--- a/deploy/docker/patches/kanban_worker_tools.py
+++ b/deploy/docker/patches/kanban_worker_tools.py
@@ -1,0 +1,139 @@
+"""Hide worker-only kanban tools from orchestrator profiles.
+
+Installed into the image at ``/opt/hermes/tools/kanban_worker_tools.py`` and
+wired into ``tools/kanban_tools.py`` by ``deploy/docker/Dockerfile`` via
+``apply_kanban_worker_tools.py``.
+
+Upstream gates each kanban tool with a ``check_fn``, and has two of them:
+
+``_check_kanban_mode``
+    True for a dispatcher-spawned worker (``HERMES_KANBAN_TASK`` is set) *or*
+    any profile carrying the ``kanban`` toolset.
+
+``_check_kanban_orchestrator_mode``
+    The board-routing surface — the mirror image, false for workers. Upstream
+    applies it to ``kanban_list`` and ``kanban_unblock``.
+
+The third case has no implementation: tools that only make sense *inside* a
+run. Closing a card, blocking it, heartbeating it, linking it, attaching an
+artifact to it — all of these belong to the specialist doing the work. Every
+one of them is nonetheless registered with ``_check_kanban_mode``, so the Chat
+Agent front door is handed the full lifecycle surface purely because it carries
+the ``kanban`` toolset to create cards.
+
+``agents/chat/SOUL.md`` §1.5 already states the boundary in prose:
+
+    Never call ``kanban_complete``, ``kanban_block``, ``kanban_heartbeat``, or
+    ``kanban_link`` — those belong to the specialist actually doing the work,
+    not the front door.
+
+Prose is not free. Hermes has no per-tool denylist — ``agent.disabled_toolsets``
+is toolset-level, and ``_strip_blocked_tools`` in ``tools/delegate_tool.py`` is
+scoped to delegation — so those schemas ship on every single front-door model
+call and the rule has to be re-read and re-obeyed each time. Measured with
+``hermes prompt-size`` on 2026-08-05, the tools below cost the Chat Agent
+**10,041 characters (~2,510 tokens) per call** for capabilities it is forbidden
+to use:
+
+======================  ======
+tool                    chars
+======================  ======
+``kanban_complete``      3,410
+``kanban_block``         1,700
+``kanban_attach``        1,356
+``kanban_attach_url``    1,156
+``kanban_heartbeat``       918
+``kanban_link``            773
+``kanban_attachments``     728
+======================  ======
+
+``check_kanban_worker_mode`` supplies the missing third gate. Nothing changes
+for a worker: the dispatcher sets ``HERMES_KANBAN_TASK`` before spawning it
+(``hermes_cli/kanban_db.py``, ``_default_spawn``), so a worker keeps every tool
+it has today. Orchestrator profiles keep ``kanban_create``, ``kanban_show``,
+``kanban_list``, ``kanban_comment`` and ``kanban_unblock`` — exactly the surface
+SOUL.md permits them.
+
+A cron run is deliberately treated as *not* a worker's own card here, which is
+consistent with ``tools/cron_run_scope.py``: a dispatched run borrows the
+worker's environment but owns no card, and is already refused if it tries to
+close the caller's.
+
+A ``delegate_task`` child is not a worker either, and that case is why this gate
+consults ``agent.delegation_context`` rather than the environment alone. The
+child runs ``run_conversation`` in the parent's own process, so
+``HERMES_KANBAN_TASK`` still holds whatever the parent's dispatcher set and says
+nothing at all about the child. Upstream treats that as the defining case: both
+``_check_kanban_mode`` and ``_check_kanban_orchestrator_mode`` open with ``if
+_is_delegated_child_context(): return False``, and
+``model_tools._compute_tool_definitions`` skips its ``HERMES_KANBAN_TASK``
+force-add of the ``kanban`` toolset for the same reason. Reading only the env
+var made this the one kanban gate in the file that answered *True* for a child —
+exactly inverted, since the child was then the only caller offered the seven
+tools below and none of the five an orchestrator keeps.
+
+Nothing reaches that inversion today, and it is worth being precise about why,
+because the reason lives in a file nobody editing this one would think to read.
+``tools/delegate_tool.py`` blocks the toolset twice over: ``_strip_blocked_tools``
+adds ``kanban`` to the names it removes from the child's inherited toolsets, and
+``child_disabled_toolsets`` appends ``"kanban"`` unconditionally, so a child's
+tool assembly contains no kanban tool and never evaluates this gate at all.
+Measured in the image on 2026-08-08 against the child's real shape
+(``enabled=[kanban, web]``, ``disabled=[kanban]``): zero kanban tools. Remove the
+strip and the same child is handed precisely the seven. Had one ever been
+called, six would have been refused anyway — ``_reject_delegated_child_mutation``
+guards ``_handle_complete``, ``_handle_block``, ``_handle_heartbeat``,
+``_handle_link``, ``_handle_attach`` and ``_handle_attach_url`` before they touch
+the board — and the seventh, ``_handle_attachments``, is a read whose default
+task id ``_default_task_id`` already withholds from a child. So this gate is the
+layer under two working layers, which is what buys it the freedom to answer
+``on_unknown=False`` below, where ``hermes_cli/kanban_guardrail_exit.py`` — which
+has no layer under it — answers ``True`` from the same predicate. Both readings
+come from ``tools/kanban_ownership.py``, which carries the full argument.
+
+One caveat travels with the short-circuit. The answer is a ContextVar, while
+``tools/registry.py`` caches ``check_fn`` results for 30 seconds keyed on
+``(fn, profile)`` alone — so a child that did evaluate this gate would leave a
+``False`` behind for its parent worker to read. Upstream's two gates carry the
+identical exposure, and it is not worth patching the registry for it: the only
+way to reach that cache write is the path ``delegate_tool.py`` already closes.
+"""
+
+from __future__ import annotations
+
+try:  # In the image, /opt/hermes is on sys.path.
+    from tools.kanban_ownership import is_delegated_child, is_dispatcher_worker
+except ImportError:  # Local unittest discovery: the patches dir is top-level.
+    from kanban_ownership import is_delegated_child, is_dispatcher_worker
+
+#: Tools registered upstream with ``_check_kanban_mode`` that only make sense
+#: inside a dispatcher-spawned run. Kept here as documentation and as the
+#: contract ``apply_kanban_worker_tools.py`` asserts against.
+WORKER_ONLY_TOOLS = (
+    "kanban_complete",
+    "kanban_block",
+    "kanban_heartbeat",
+    "kanban_link",
+    "kanban_attach",
+    "kanban_attach_url",
+    "kanban_attachments",
+)
+
+
+def check_kanban_worker_mode() -> bool:
+    """True only inside a dispatcher-spawned kanban run.
+
+    The mirror of upstream's ``_check_kanban_orchestrator_mode``, delegated-child
+    short-circuit included, so that all three kanban gates agree about who a
+    ``delegate_task`` child is. Deliberately does *not* consult the profile's
+    toolset list: carrying the ``kanban`` toolset is what lets a profile route
+    work, and routing work is precisely the case these tools must stay hidden
+    for.
+    """
+    # on_unknown=False: this gate only chooses which schemas ship, and
+    # _reject_delegated_child_mutation still refuses a child's board writes, so
+    # an unreadable delegation context must not cost a real worker its terminal
+    # tools. tools/kanban_ownership.py argues both polarities.
+    if is_delegated_child(on_unknown=False):
+        return False
+    return is_dispatcher_worker()

--- a/deploy/docker/patches/patchlib.py
+++ b/deploy/docker/patches/patchlib.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Shared machinery for the anchored source rewrites in this directory.
+
+Every ``apply_*.py`` here does the same four things to a file in the Hermes
+source tree: read it, assert that a literal anchor occurs the exact number of
+times expected, substitute, and refuse to write anything that no longer parses.
+Thirteen appliers had thirteen copies of that loop, which meant thirteen places
+for the invariant to drift — and the invariant is the entire safety story. A
+patch that silently matches nothing ships an image whose behaviour is not the
+one the config describes, and the only thing standing between us and that is
+the exact-count check. It belongs in one place.
+
+This module is **build-time only**. It is never installed into the image: the
+Dockerfile stages each applier into ``/tmp`` and deletes it in the same ``RUN``
+layer, and Python puts the running script's own directory at the front of
+``sys.path``, so ``import patchlib`` resolves to a sibling copy staged next to
+the applier. Two appliers already relied on that (``apply_kanban_worker_tools``
+imports ``kanban_worker_tools``, ``apply_kanban_result_required`` imports
+``kanban_result_required``); this is the same mechanism. Nothing inside the
+running image imports it.
+
+Two kinds of edit site
+----------------------
+**Literal anchors** (:meth:`Patch.substitute`) pin an edit to an exact slice of
+upstream source. They are precise and they fail loudly, but every one of them is
+a separate way that a base-image bump breaks the build, so the number of them is
+the cost metric this directory is managed against.
+
+**AST locators** (:meth:`Patch.find_call`, :meth:`Patch.find_def`) pin an edit to
+a *node* instead — the ``registry.register`` call that registers a named tool,
+the ``def`` whose tail an import has to land after. Reformatting upstream, or
+adding a keyword argument, moves the text but not the node, so a locator
+survives churn that a literal anchor does not.
+
+An AST locator that silently matched the wrong node would be strictly worse than
+a literal anchor that failed loudly, so every locator here asserts it matched
+exactly one node, and :meth:`CallSite.expect` re-asserts the parts of the call
+the literal anchor used to spell out. A locator that finds nothing, finds two
+things, or finds something whose shape has changed raises ``SystemExit`` naming
+the file, the site, and what it expected.
+
+Nothing is written until :meth:`Patch.commit`, so an applier that fails halfway
+through a file leaves that file untouched rather than half-patched.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+#: The standard tail on an anchor-mismatch message. Says what broke (upstream
+#: moved) and what to do about it (re-derive before bumping), because the person
+#: reading it is looking at a red build and not at this directory.
+DRIFT_NOTE = (
+    "Upstream Hermes changed — re-derive the anchor before bumping the base image."
+)
+
+
+class Ident(str):
+    """An expected keyword value that must be a bare name, not a string literal.
+
+    ``expect(toolset="kanban")`` asserts the argument is the *string* ``kanban``;
+    ``expect(handler=Ident("_handle_complete"))`` asserts it is the *name*
+    ``_handle_complete``. Without the distinction a locator could not tell
+    ``check_fn=_check_kanban_mode`` from ``check_fn="_check_kanban_mode"``.
+    """
+
+
+def _line_starts(source: str) -> list[int]:
+    """Character offset of the first character of every 1-based line.
+
+    Index ``lineno`` is the start of that line and index ``lineno + 1`` is the
+    start of the next one, which is what an insert-after-a-node needs. Index 0
+    is unused padding so the 1-based arithmetic reads straight.
+    """
+    starts = [0, 0]
+    for line in source.splitlines(keepends=True):
+        starts.append(starts[-1] + len(line))
+    return starts
+
+
+def _offset(source: str, starts: list[int], lineno: int, col: int) -> int:
+    """Translate an ``ast`` position into an index into ``source``.
+
+    ``ast`` reports columns as UTF-8 *byte* counts and the source being spliced
+    is a ``str``, so the two agree only while the line is ASCII. Every span the
+    current locators return happens to sit on an ASCII line, so this is
+    defensive rather than load-bearing today — but ``tools/kanban_tools.py``
+    carries an ``emoji=`` argument in every registration this patch touches, and
+    the next locator added has no way to know which lines are safe. Getting it
+    wrong would not raise: it would splice three characters off target.
+    """
+    start = starts[lineno]
+    line = source[start : starts[lineno + 1]]
+    return start + len(line.encode("utf-8")[:col].decode("utf-8"))
+
+
+def _render(node: ast.AST) -> str:
+    """A short, readable rendering of what a node actually is, for error text."""
+    try:
+        return ast.unparse(node)
+    except Exception:  # pragma: no cover - unparse handles every real node
+        return type(node).__name__
+
+
+def _matches(node: ast.AST, expected: object) -> bool:
+    """True when ``node`` is the name or the literal that ``expected`` describes."""
+    if isinstance(expected, Ident):
+        return isinstance(node, ast.Name) and node.id == str(expected)
+    return isinstance(node, ast.Constant) and node.value == expected
+
+
+def _describe(expected: object) -> str:
+    """How an expectation is spelled in a failure message."""
+    return str(expected) if isinstance(expected, Ident) else repr(expected)
+
+
+class _Site:
+    """A located node, and the spans of ``patch.source`` it occupies."""
+
+    def __init__(self, patch: "Patch", node: ast.AST, label: str) -> None:
+        self.patch = patch
+        self.node = node
+        self.label = label
+        starts = _line_starts(patch.source)
+        self.start = _offset(patch.source, starts, node.lineno, node.col_offset)
+        self.end = _offset(
+            patch.source, starts, node.end_lineno, node.end_col_offset
+        )
+        #: Start of the line after the node — the insertion point for anything
+        #: that has to follow a whole ``def`` rather than sit inside it.
+        self.after = starts[node.end_lineno + 1]
+
+
+class Definition(_Site):
+    """A module-level ``def`` located by name."""
+
+
+class CallSite(_Site):
+    """A module-level call statement located by its callee and its arguments."""
+
+    def __init__(
+        self, patch: "Patch", stmt: ast.stmt, call: ast.Call, label: str
+    ) -> None:
+        super().__init__(patch, stmt, label)
+        self.call = call
+
+    def _keyword(self, name: str) -> ast.keyword:
+        for keyword in self.call.keywords:
+            if keyword.arg == name:
+                return keyword
+        raise self.patch._fail(
+            f"the {self.label} sets no {name}= argument. {self.patch.note}"
+        )
+
+    def expect(self, **keywords: object) -> None:
+        """Assert each named argument is the name or literal given.
+
+        This is the half of a literal anchor worth keeping. The five-line anchor
+        this replaces was not only *finding* the registration, it was asserting
+        that the call still passed the schema and handler it was expected to;
+        drop that and a locator would happily re-gate a tool upstream had
+        rewired underneath us.
+        """
+        for name, expected in keywords.items():
+            keyword = self._keyword(name)
+            if not _matches(keyword.value, expected):
+                raise self.patch._fail(
+                    f"the {self.label} sets {name}={_render(keyword.value)} "
+                    f"where {_describe(expected)} was expected. "
+                    f"{self.patch.note}"
+                )
+
+    def keyword_span(self, name: str) -> tuple[int, int]:
+        """Offsets of the *value* of a named argument, for a surgical splice."""
+        value = self._keyword(name).value
+        starts = _line_starts(self.patch.source)
+        return (
+            _offset(self.patch.source, starts, value.lineno, value.col_offset),
+            _offset(
+                self.patch.source, starts, value.end_lineno, value.end_col_offset
+            ),
+        )
+
+
+class Patch:
+    """One file on its way from upstream source to patched source.
+
+    Holds the text in memory and writes it exactly once, in :meth:`commit`, so a
+    run that fails on the third of four edits leaves the file as upstream shipped
+    it. Every failure is a ``SystemExit`` naming the file, because the reader is
+    looking at a Docker build log.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        relative: str,
+        *,
+        prefix: str,
+        note: str = DRIFT_NOTE,
+    ) -> None:
+        self.prefix = prefix
+        self.relative = relative
+        self.note = note
+        self.path = Path(root) / relative
+        if not self.path.is_file():
+            raise SystemExit(f"{prefix} patch: {self.path} does not exist")
+        self.source = self.path.read_text()
+
+    def _fail(self, detail: str) -> SystemExit:
+        return SystemExit(f"{self.prefix} patch: {self.relative}: {detail}")
+
+    # -- guards ---------------------------------------------------------------
+
+    def refuse_if_patched(self, *markers: str) -> None:
+        """Refuse a second run, for patches whose anchors survive their own edit.
+
+        An insert that sits *next to* its anchor rather than consuming it leaves
+        the anchor count at one, so the count check cannot tell a fresh file from
+        an already-patched one, and a second pass would stack a second copy of
+        the insert. Each marker must be text that only exists after a successful
+        run.
+        """
+        for marker in markers:
+            if marker in self.source:
+                raise SystemExit(
+                    f"{self.prefix} patch: {self.relative} is already patched "
+                    f"({marker!r} is present)"
+                )
+
+    # -- literal anchors ------------------------------------------------------
+
+    def substitute(
+        self,
+        anchor: str,
+        replacement: str,
+        *,
+        label: str | None = None,
+        expected: int = 1,
+    ) -> None:
+        """Replace ``anchor`` exactly ``expected`` times, or fail the build.
+
+        The count is the whole point: an anchor found zero times means upstream
+        moved and the edit would silently not happen, and an anchor found twice
+        means it is no longer pinning what it was derived against. Either way the
+        image must not be built.
+        """
+        found = self.source.count(anchor)
+        if found != expected:
+            named = f"the {label} anchor" if label else "anchor"
+            raise self._fail(
+                f"expected {expected} occurrence(s) of {named}, found {found}. "
+                f"{self.note}\n--- anchor ---\n{anchor}"
+            )
+        self.source = self.source.replace(anchor, replacement)
+
+    def append(self, trailer: str) -> None:
+        """Add text to the end of the file, for imports resolved at call time."""
+        self.source += trailer
+
+    # -- AST locators ---------------------------------------------------------
+
+    def _tree(self) -> ast.Module:
+        try:
+            return ast.parse(self.source)
+        except SyntaxError as e:
+            raise self._fail(f"does not parse, so it cannot be located in: {e}")
+
+    def find_def(self, name: str, *, label: str) -> Definition:
+        """Locate the one module-level ``def`` called ``name``."""
+        found = [
+            node
+            for node in self._tree().body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ]
+        if len(found) != 1:
+            raise self._fail(
+                f"expected 1 module-level def {name}() for the {label}, found "
+                f"{len(found)}. {self.note}"
+            )
+        return Definition(self, found[0], label)
+
+    def find_call(self, callee: str, *, label: str, **select: object) -> CallSite:
+        """Locate the one module-level call to ``callee`` matching ``select``.
+
+        ``select`` narrows by keyword argument the way a human would read the
+        block — ``find_call("registry.register", name="kanban_complete")`` is
+        "the statement that registers kanban_complete", which stays true across
+        any reformatting of it. Use :meth:`CallSite.expect` for the arguments
+        that must be *asserted* rather than searched on, so that a renamed
+        handler fails with "sets handler=X where Y was expected" instead of
+        vanishing into a "found 0".
+        """
+        found = []
+        for stmt in self._tree().body:
+            if not isinstance(stmt, ast.Expr) or not isinstance(
+                stmt.value, ast.Call
+            ):
+                continue
+            call = stmt.value
+            if _render(call.func) != callee:
+                continue
+            if all(
+                any(
+                    kw.arg == name and _matches(kw.value, expected)
+                    for kw in call.keywords
+                )
+                for name, expected in select.items()
+            ):
+                found.append((stmt, call))
+        if len(found) != 1:
+            criteria = ", ".join(
+                f"{name}={_describe(expected)}" for name, expected in select.items()
+            )
+            raise self._fail(
+                f"expected 1 module-level {callee}({criteria}) call for the "
+                f"{label}, found {len(found)}. {self.note}"
+            )
+        return CallSite(self, found[0][0], found[0][1], label)
+
+    # -- splicing -------------------------------------------------------------
+
+    def splice(self, start: int, end: int, text: str) -> None:
+        """Replace ``source[start:end]``. Offsets come from a locator."""
+        self.source = self.source[:start] + text + self.source[end:]
+
+    def insert(self, offset: int, text: str) -> None:
+        """Insert ``text`` at ``offset``. Offsets come from a locator."""
+        self.source = self.source[:offset] + text + self.source[offset:]
+
+    # -- commit ---------------------------------------------------------------
+
+    def commit(self, summary: str, *, parse: bool = True) -> None:
+        """Parse-check and write, then report the edit on stdout.
+
+        ``parse=False`` is for the one non-Python target in this directory, the
+        mcp-remote TypeScript source; everything else must still be importable
+        Python before it is allowed to reach the image.
+        """
+        if parse:
+            try:
+                ast.parse(self.source)
+            except SyntaxError as e:
+                raise SystemExit(
+                    f"{self.prefix} patch: {self.relative} no longer parses "
+                    f"after patching: {e}"
+                )
+        self.path.write_text(self.source)
+        print(f"{self.prefix} patch: {self.relative} ({summary})")

--- a/deploy/docker/patches/test_apply_mcp_remote_forward_errors.py
+++ b/deploy/docker/patches/test_apply_mcp_remote_forward_errors.py
@@ -1,0 +1,111 @@
+"""Unit tests for the mcp-remote forward-error patch applied by the Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from apply_mcp_remote_forward_errors import ANCHOR, BUILD_MARKER, RELATIVE, apply
+
+# The shape of the region being patched, reproduced from mcp-remote
+# src/lib/utils.ts at the pinned commit. Only the anchor line matters, but the
+# surroundings keep the fixture honest about indentation.
+PRELUDE = """\
+export function mcpProxy({ transportToClient, transportToServer }: Args) {
+  transportToClient.onmessage = (_message) => {
+    const message = messageTransformer.interceptRequest(_message as any)
+"""
+
+CODA = """\
+  }
+
+  function onClientError(error: Error) {
+    log('Error from local client:', error)
+  }
+
+  function onServerError(error: Error) {
+    log('Error from remote server:', error)
+  }
+}
+"""
+
+
+def write_source(root, body):
+    """Materialise a fake mcp-remote clone containing ``body``."""
+    path = Path(root) / RELATIVE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+class ApplyTest(unittest.TestCase):
+    def test_replaces_the_anchor_and_answers_the_client(self):
+        with tempfile.TemporaryDirectory() as root:
+            path = write_source(root, PRELUDE + ANCHOR + CODA)
+            apply(Path(root))
+            patched = path.read_text()
+
+        # The fire-and-forget form is gone and the client is now answered.
+        self.assertNotIn(ANCHOR, patched)
+        self.assertIn("transportToServer.send(message).catch((error: Error) =>", patched)
+        self.assertIn("transportToClient", patched.split("onClientError(error: Error)")[0])
+        self.assertIn(BUILD_MARKER, patched)
+        self.assertIn("code: -32603", patched)
+        # onServerError still runs, so the existing stderr breadcrumb survives.
+        self.assertIn("onServerError(error)", patched)
+        # Everything outside the anchor is untouched.
+        self.assertTrue(patched.startswith(PRELUDE))
+        self.assertTrue(patched.endswith(CODA))
+
+    def test_only_requests_are_answered(self):
+        """Notifications have no id and responses have no method; neither gets a reply."""
+        with tempfile.TemporaryDirectory() as root:
+            path = write_source(root, PRELUDE + ANCHOR + CODA)
+            apply(Path(root))
+            patched = path.read_text()
+        self.assertIn(
+            "if (message.id !== undefined && message.id !== null && message.method) {",
+            patched,
+        )
+
+    def test_missing_file_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(SystemExit) as caught:
+                apply(Path(root))
+        self.assertIn("does not exist", str(caught.exception))
+
+    def test_absent_anchor_fails_loudly(self):
+        """A pin bump that moves the line must break the build, not no-op."""
+        with tempfile.TemporaryDirectory() as root:
+            write_source(root, PRELUDE + CODA)
+            with self.assertRaises(SystemExit) as caught:
+                apply(Path(root))
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_duplicate_anchor_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_source(root, PRELUDE + ANCHOR + ANCHOR + CODA)
+            with self.assertRaises(SystemExit) as caught:
+                apply(Path(root))
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_already_patched_upstream_fails_loudly(self):
+        """If PR #308 merges upstream, drop this patch rather than double-applying."""
+        with tempfile.TemporaryDirectory() as root:
+            write_source(root, PRELUDE + ANCHOR + f"// {BUILD_MARKER}\n" + CODA)
+            with self.assertRaises(SystemExit) as caught:
+                apply(Path(root))
+        self.assertIn("already contains", str(caught.exception))
+
+    def test_applying_twice_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as root:
+            write_source(root, PRELUDE + ANCHOR + CODA)
+            apply(Path(root))
+            with self.assertRaises(SystemExit):
+                apply(Path(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_cron_run_scope.py
+++ b/deploy/docker/patches/test_cron_run_scope.py
@@ -6,6 +6,7 @@ Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t dep
 import concurrent.futures
 import contextvars
 import os
+import threading
 import unittest
 
 from cron_run_scope import (
@@ -29,28 +30,81 @@ WORKER_ENV = {WORKER_TASK_ENV: CALLER_CARD}
 
 
 class CronRunScopeTest(unittest.TestCase):
-    """The marker env var must be set for the run and gone afterwards."""
+    """The marker must cover the run, and reach nothing else."""
 
     def setUp(self):
         self.addCleanup(os.environ.pop, CRON_RUN_ENV, None)
         os.environ.pop(CRON_RUN_ENV, None)
 
     def test_the_marker_is_set_during_the_run_and_cleared_after(self):
+        self.assertEqual(current_cron_job(), "")
         with cron_run_scope(JOB_ID):
-            self.assertEqual(os.environ[CRON_RUN_ENV], JOB_ID)
-        self.assertNotIn(CRON_RUN_ENV, os.environ)
+            self.assertEqual(current_cron_job(), JOB_ID)
+        self.assertEqual(current_cron_job(), "")
 
     def test_the_marker_is_cleared_when_the_run_raises(self):
         with self.assertRaises(RuntimeError):
             with cron_run_scope(JOB_ID):
                 raise RuntimeError("job blew up")
+        self.assertEqual(current_cron_job(), "")
+
+    def test_the_scope_does_not_touch_the_environment(self):
+        """The env half is gone, and its absence is the fix.
+
+        os.environ is process-global; a cron run is not. Writing the marker
+        there bled it into unrelated threads, was inherited for life by workers
+        the dispatcher spawned mid-run, and — see the next test — leaked
+        permanently under a non-nested interleaving.
+        """
+        with cron_run_scope(JOB_ID):
+            self.assertNotIn(CRON_RUN_ENV, os.environ)
         self.assertNotIn(CRON_RUN_ENV, os.environ)
 
-    def test_a_prior_value_is_restored_rather_than_dropped(self):
-        os.environ[CRON_RUN_ENV] = "outer-job"
-        with cron_run_scope(JOB_ID):
-            self.assertEqual(os.environ[CRON_RUN_ENV], JOB_ID)
-        self.assertEqual(os.environ[CRON_RUN_ENV], "outer-job")
+    def test_two_overlapping_runs_leave_nothing_behind(self):
+        """A in, B in, A out, B out — the interleaving that used to wedge.
+
+        Two `cronjob(action='run')` calls in one assistant turn reach this:
+        agent/tool_executor.py runs tool calls on a pool and `cronjob` is not on
+        its serial list. With the save/restore env pair, A popped a variable it
+        never set and B then restored A's marker with no run active at all —
+        after which every worker in the process was told it was a run of job A,
+        so it could neither default to its own card nor name it explicitly, and
+        the guardrail backstop was suppressed too. The card sat `running` with
+        no result and no failure, forever.
+
+        Held in a ContextVar the overlap is structurally impossible: each pool
+        thread starts from its own context, so neither scope can observe or
+        restore the other's value. Interleaved with real barriers rather than
+        by calling __enter__/__exit__ by hand — out-of-order resets in ONE
+        context would leak a ContextVar too, and `with` is what rules that out.
+        """
+        a_in, b_in, a_out = (threading.Event() for _ in range(3))
+        seen = {}
+
+        def run_a():
+            with cron_run_scope("job-a"):
+                a_in.set()
+                b_in.wait(5)
+                seen["a"] = current_cron_job()
+            a_out.set()
+
+        def run_b():
+            a_in.wait(5)
+            with cron_run_scope("job-b"):
+                b_in.set()
+                a_out.wait(5)
+                # A has fully exited by now and must not have disturbed B.
+                seen["b"] = current_cron_job()
+
+        threads = [threading.Thread(target=run_a), threading.Thread(target=run_b)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(10)
+
+        self.assertEqual(seen, {"a": "job-a", "b": "job-b"})
+        self.assertEqual(current_cron_job(), "")
+        self.assertNotIn(CRON_RUN_ENV, os.environ)
 
     def test_the_workers_task_env_survives_the_scope(self):
         # heartbeat_current_worker_from_env() reads HERMES_KANBAN_TASK on every
@@ -64,7 +118,7 @@ class CronRunScopeTest(unittest.TestCase):
 
     def test_an_empty_job_id_still_marks_the_run(self):
         with cron_run_scope(""):
-            self.assertTrue(os.environ[CRON_RUN_ENV])
+            self.assertTrue(current_cron_job())
 
     def test_the_marker_reaches_the_cron_agents_worker_thread(self):
         # cron/scheduler.py:run_job submits agent.run_conversation to a
@@ -78,13 +132,30 @@ class CronRunScopeTest(unittest.TestCase):
         self.assertEqual(seen, JOB_ID)
 
     def test_the_marker_does_not_leak_into_a_sibling_context(self):
-        # A context copied before the scope is what an unrelated concurrent
-        # session holds; it must still resolve to no cron run.
+        """An unrelated concurrent session must still resolve to no cron run.
+
+        Reads the REAL os.environ, not an empty stand-in. Passing environ={}
+        here was the whole defect: it isolated the assertion from the
+        process-global half that was doing the leaking, so the test named after
+        the leak could not observe it.
+        """
         sibling = contextvars.copy_context()
         with cron_run_scope(JOB_ID):
-            # environ={} isolates the context var from the process env, which
-            # the scope also sets as the cross-process fallback.
-            self.assertEqual(sibling.run(current_cron_job, {}), "")
+            self.assertEqual(sibling.run(current_cron_job), "")
+
+    def test_a_thread_outside_the_scope_sees_no_run(self):
+        """The same claim across a real thread, which is how it happened.
+
+        Under dispatch_in_gateway a second worker runs concurrently with
+        somebody else's dispatch. It never entered the scope, so it must not
+        read the marker — and while the marker lived in os.environ, it did.
+        """
+        with cron_run_scope(JOB_ID):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                # No copy_context(): a bare pool thread starts from an empty
+                # context, exactly like an unrelated worker.
+                seen = pool.submit(current_cron_job).result()
+        self.assertEqual(seen, "")
 
     def test_the_context_var_wins_over_a_stale_env_value(self):
         os.environ[CRON_RUN_ENV] = "stale-job"
@@ -92,9 +163,10 @@ class CronRunScopeTest(unittest.TestCase):
             self.assertEqual(current_cron_job(), JOB_ID)
         self.assertEqual(os.environ[CRON_RUN_ENV], "stale-job")
 
-    def test_the_env_fallback_answers_when_no_context_var_is_set(self):
-        # What a shelled-out `hermes kanban …` sees: a fresh process with the
-        # inherited environment and no context.
+    def test_the_env_fallback_still_answers_when_something_sets_it(self):
+        # Nothing in the image writes it today. Kept because it is the one
+        # thing a ContextVar cannot do — cross a fork — so a process launched
+        # with the marker already in its environment is still recognised.
         self.assertEqual(current_cron_job(DISPATCH_ENV), JOB_ID)
         self.assertEqual(current_cron_job({}), "")
 

--- a/deploy/docker/patches/test_cron_skip_ledger.py
+++ b/deploy/docker/patches/test_cron_skip_ledger.py
@@ -1,0 +1,644 @@
+#!/usr/bin/env python3
+"""Host tests for cron_skip_ledger and its applier. No Hermes install required.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py'
+
+The in-image gate (``verify_cron_skip_ledger.py``) drives the real scheduler
+and is the authority on wiring. These cover what is cheaper and sharper to test
+here: the migration's failure modes — the paths a healthy image never takes and
+so never exercises — and the retention arithmetic, whose whole point is a
+boundary.
+
+The migration fixture is the DDL both live ledgers actually carry, copied out
+of ``sqlite_master`` on 2026-08-08, because the migration derives the rebuilt
+table from that text. A tidied-up fixture would be testing a different
+migration than the one that ships.
+"""
+
+import contextlib
+import io
+import sqlite3
+import sys
+import tempfile
+import unittest
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from cron_skip_ledger import (  # noqa: E402
+    MAX_TERMINAL_EXECUTIONS,
+    MAX_TERMINAL_EXECUTIONS_PER_JOB,
+    MIN_TERMINAL_EXECUTIONS_PER_JOB,
+    SKIP_ALREADY_RUNNING,
+    SKIP_MISSED_WINDOW,
+    SKIP_REASON_UNSPECIFIED,
+    LedgerMigrationError,
+    add_skip_reason_column,
+    count_missed_occurrences,
+    ensure_schema,
+    migrate_executions_table,
+    missed_window_detail,
+    normalize_reason,
+    prune_terminal_executions,
+    status_check_allows_skipped,
+)
+
+# Verbatim from the live boards. Note the line break inside the CHECK and the
+# two-space continuation indent: the regex has to survive both.
+LEGACY_DDL = """CREATE TABLE executions (
+             id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             source TEXT NOT NULL,
+             process_id TEXT NOT NULL,
+             pid INTEGER NOT NULL,
+             process_started_at INTEGER,
+             status TEXT NOT NULL CHECK(status IN
+               ('claimed','running','completed','failed','unknown')),
+             claimed_at TEXT NOT NULL,
+             started_at TEXT,
+             finished_at TEXT,
+             error TEXT
+           )"""
+
+INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_executions_job_claimed "
+    "ON executions(job_id, claimed_at DESC, id DESC)",
+    "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
+    "ON executions(status, claimed_at DESC, id DESC)",
+)
+
+EPOCH = datetime(2026, 8, 7, tzinfo=timezone.utc)
+
+
+class LedgerFixture(unittest.TestCase):
+    """A populated pre-patch ledger in a temp file, as a live PVC holds one."""
+
+    ddl = LEGACY_DDL
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.path = Path(tmp.name) / "executions.db"
+        self.conn = sqlite3.connect(self.path)
+        self.addCleanup(self.conn.close)
+        self.conn.execute(self.ddl)
+        for statement in INDEXES:
+            self.conn.execute(statement)
+        self.conn.commit()
+
+    def insert(self, job_id, *, count=1, status="completed", offset=0, reason=None):
+        columns = "id, job_id, source, process_id, pid, status, claimed_at"
+        values = "?, ?, 'builtin', 'p', 1, ?, ?"
+        if reason is not None:
+            columns += ", skip_reason"
+            values += ", ?"
+        for i in range(count):
+            claimed = (EPOCH + timedelta(seconds=offset + i)).isoformat()
+            row = [uuid.uuid4().hex, job_id, status, claimed]
+            if reason is not None:
+                row.append(reason)
+            self.conn.execute(
+                "INSERT INTO executions ({}) VALUES ({})".format(columns, values),
+                row,
+            )
+        self.conn.commit()
+
+    def schema(self):
+        row = self.conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='executions'"
+        ).fetchone()
+        return row[0] if row else None
+
+    def tables(self):
+        return {
+            r[0]
+            for r in self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+
+    def count(self, job_id=None):
+        if job_id is None:
+            return self.conn.execute("SELECT count(*) FROM executions").fetchone()[0]
+        return self.conn.execute(
+            "SELECT count(*) FROM executions WHERE job_id=?", (job_id,)
+        ).fetchone()[0]
+
+
+class MigrationTest(LedgerFixture):
+    """The rebuild has to be survivable on a board that already has rows."""
+
+    def test_it_rebuilds_a_legacy_table_without_losing_a_row(self):
+        self.insert("profile-cron-tick", count=200)
+        self.insert("compliance-audit", count=3, offset=1000)
+        self.assertEqual(migrate_executions_table(self.conn), "rebuilt")
+        self.assertEqual(self.count(), 203)
+        self.assertIn("'skipped'", self.schema())
+        self.assertIn("skip_reason", self.schema())
+
+    def test_the_rebuilt_check_still_rejects_a_status_it_never_knew(self):
+        """The constraint is the point. A rebuild that drops it is not a fix."""
+        migrate_executions_table(self.conn)
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.conn.execute(
+                "INSERT INTO executions (id, job_id, source, process_id, pid, "
+                "status, claimed_at) VALUES ('x','j','builtin','p',1,'nope','t')"
+            )
+
+    def test_it_accepts_the_status_it_was_written_for(self):
+        migrate_executions_table(self.conn)
+        self.insert("compliance-audit", status="skipped", reason=SKIP_ALREADY_RUNNING)
+        self.assertEqual(
+            self.conn.execute(
+                "SELECT skip_reason FROM executions WHERE status='skipped'"
+            ).fetchone()[0],
+            SKIP_ALREADY_RUNNING,
+        )
+
+    def test_it_is_idempotent(self):
+        """Every connection runs _initialize_schema; only the first may rebuild."""
+        self.insert("profile-cron-tick", count=10)
+        self.assertEqual(migrate_executions_table(self.conn), "rebuilt")
+        after_first = self.schema()
+        for _ in range(3):
+            self.assertEqual(migrate_executions_table(self.conn), "current")
+        self.assertEqual(self.schema(), after_first)
+        self.assertEqual(self.count(), 10)
+
+    def test_a_second_connection_sees_the_migration_already_done(self):
+        """The read-then-upgrade race between two `hermes cron tick` processes."""
+        self.insert("profile-cron-tick", count=5)
+        other = sqlite3.connect(self.path)
+        self.addCleanup(other.close)
+        stale_ddl = self.schema()  # what `other` would have read before the lock
+        self.assertFalse(status_check_allows_skipped(stale_ddl))
+        self.assertEqual(migrate_executions_table(self.conn), "rebuilt")
+        # `other` re-reads inside its own BEGIN IMMEDIATE and backs off.
+        self.assertEqual(migrate_executions_table(other), "current")
+        self.assertEqual(self.count(), 5)
+
+    def test_it_carries_a_column_upstream_added_since_this_patch(self):
+        """Derived DDL, never an enumerated column list — that is the whole trick."""
+        self.conn.execute("ALTER TABLE executions ADD COLUMN attempt INTEGER")
+        self.conn.execute(
+            "INSERT INTO executions (id, job_id, source, process_id, pid, status, "
+            "claimed_at, attempt) VALUES ('a','j','builtin','p',1,'completed','t',7)"
+        )
+        self.conn.commit()
+        self.assertEqual(migrate_executions_table(self.conn), "rebuilt")
+        self.assertIn("attempt", self.schema())
+        self.assertEqual(
+            self.conn.execute("SELECT attempt FROM executions").fetchone()[0], 7
+        )
+
+    def test_an_interrupted_rebuild_does_not_poison_the_next_attempt(self):
+        self.insert("profile-cron-tick", count=4)
+        self.conn.execute("CREATE TABLE executions_kubeagents_migrating (junk TEXT)")
+        self.conn.commit()
+        self.assertEqual(migrate_executions_table(self.conn), "rebuilt")
+        self.assertNotIn("executions_kubeagents_migrating", self.tables())
+        self.assertEqual(self.count(), 4)
+
+    def test_there_is_nothing_to_migrate_before_the_table_exists(self):
+        self.conn.execute("DROP TABLE executions")
+        self.conn.commit()
+        self.assertEqual(migrate_executions_table(self.conn), "absent")
+
+    def test_add_column_is_idempotent_and_reports_who_added_it(self):
+        self.assertTrue(add_skip_reason_column(self.conn))
+        self.assertFalse(add_skip_reason_column(self.conn))
+
+    def test_a_fresh_post_patch_ledger_needs_no_rebuild(self):
+        """The CREATE TABLE the applier installs must satisfy the gate itself."""
+        self.conn.execute("DROP TABLE executions")
+        self.conn.execute(
+            LEGACY_DDL.replace("'unknown')),", "'unknown','skipped')),").replace(
+                "error TEXT\n", "error TEXT,\n             skip_reason TEXT\n"
+            )
+        )
+        self.conn.commit()
+        self.assertEqual(migrate_executions_table(self.conn), "current")
+
+
+class MigrationRefusalTest(LedgerFixture):
+    """When the schema is not the shape this knows, it must stop, not guess.
+
+    The fixture is a table carrying a second, table-level ``CHECK(status IN
+    ...)`` alongside the column one. Both are satisfied by the same values, so
+    the ledger works normally — it is only the *rewrite* that is ambiguous, and
+    that ambiguity is the thing under test. Rewriting the wrong one would
+    produce a table that still silently refuses every skip row.
+    """
+
+    ddl = LEGACY_DDL.replace(
+        "             error TEXT\n",
+        "             error TEXT,\n"
+        "             CHECK(status IN "
+        "('claimed','running','completed','failed','unknown'))\n",
+    )
+
+    def refuse(self):
+        """``ensure_schema`` on this fixture, with its ERROR captured.
+
+        Captured rather than silenced: a migration that gives up has to say so
+        at ERROR, since the only other symptom is skips quietly not being
+        recorded — which is indistinguishable from having none.
+        """
+        with self.assertLogs("cron_skip_ledger", level="ERROR") as logs:
+            outcome = ensure_schema(self.conn)
+        self.assertTrue(any("could not migrate" in line for line in logs.output))
+        return outcome
+
+    def test_two_status_checks_raise_rather_than_rewrite_the_wrong_one(self):
+        with self.assertRaises(LedgerMigrationError):
+            migrate_executions_table(self.conn)
+
+    def test_a_refused_migration_leaves_the_rows_and_the_constraint_alone(self):
+        """Rolled back, not half-applied: the ledger is exactly as it was.
+
+        ``skip_reason`` does survive — it is added by ``ADD COLUMN`` before the
+        rebuild is attempted, deliberately, so the rebuild can carry it. An
+        unused nullable column is inert, and it is the CHECK, not the column,
+        that decides whether a skip can be written.
+        """
+        self.insert("profile-cron-tick", count=12)
+        self.assertEqual(self.refuse(), "failed")
+        self.assertEqual(self.count(), 12)
+        self.assertNotIn("'skipped'", self.schema())
+        with self.assertRaises(sqlite3.IntegrityError):
+            self.insert("profile-cron-tick", status="skipped")
+
+    def test_ensure_schema_never_raises(self):
+        """A ledger that cannot record skips must still record everything else."""
+        self.assertEqual(self.refuse(), "failed")
+        self.insert("profile-cron-tick", count=1)
+        self.assertEqual(self.count(), 1)
+
+
+class SchemaGateTest(unittest.TestCase):
+    """Gating on the DDL text, because neither live board has a version counter."""
+
+    def test_it_reads_the_live_ddl_rather_than_a_counter(self):
+        self.assertFalse(status_check_allows_skipped(LEGACY_DDL))
+        self.assertTrue(
+            status_check_allows_skipped(
+                LEGACY_DDL.replace("'unknown')", "'unknown','skipped')")
+            )
+        )
+
+    def test_a_table_with_no_status_check_is_not_mistaken_for_migrated(self):
+        self.assertFalse(
+            status_check_allows_skipped("CREATE TABLE executions (id TEXT)")
+        )
+
+    def test_the_word_skipped_elsewhere_in_the_ddl_does_not_count(self):
+        """Only the CHECK list decides — a column named skipped_at must not."""
+        self.assertFalse(
+            status_check_allows_skipped(LEGACY_DDL.replace("error TEXT", "skipped_at TEXT"))
+        )
+
+
+class RetentionTest(LedgerFixture):
+    """Per-job retention exists so a chatty job stops evicting a quiet one."""
+
+    def setUp(self):
+        super().setUp()
+        migrate_executions_table(self.conn)
+
+    def test_a_chatty_job_no_longer_evicts_a_quiet_one(self):
+        """The live failure: 980 ticker rows, 17 hourly rows, one 1000-row board."""
+        self.insert("compliance-audit", count=5)
+        self.insert(
+            "profile-cron-tick", count=MAX_TERMINAL_EXECUTIONS_PER_JOB + 400, offset=10_000
+        )
+        prune_terminal_executions(self.conn)
+        self.assertEqual(self.count("compliance-audit"), 5)
+        self.assertEqual(
+            self.count("profile-cron-tick"), MAX_TERMINAL_EXECUTIONS_PER_JOB
+        )
+
+    def test_the_cap_keeps_the_newest_rows(self):
+        self.insert("profile-cron-tick", count=20, offset=0)
+        prune_terminal_executions(self.conn, per_job=5, floor=0)
+        kept = [
+            r[0]
+            for r in self.conn.execute("SELECT claimed_at FROM executions ORDER BY claimed_at")
+        ]
+        self.assertEqual(
+            kept, [(EPOCH + timedelta(seconds=i)).isoformat() for i in range(15, 20)]
+        )
+
+    def test_a_running_row_is_never_pruned(self):
+        """Only terminal rows are retention-managed; an in-flight run is state."""
+        self.insert("profile-cron-tick", count=3, status="running")
+        self.insert("profile-cron-tick", count=3, status="claimed", offset=100)
+        self.insert("profile-cron-tick", count=50, status="completed", offset=200)
+        prune_terminal_executions(self.conn, per_job=1, floor=0)
+        self.assertEqual(self.count(), 3 + 3 + 1)
+
+    def test_a_skip_row_is_prunable_immediately(self):
+        """It is terminal on arrival — the occurrence cannot start happening later."""
+        self.insert("compliance-audit", count=40, status="skipped", reason=SKIP_MISSED_WINDOW)
+        prune_terminal_executions(self.conn, per_job=10, floor=0)
+        self.assertEqual(self.count(), 10)
+
+    def test_the_global_ceiling_bounds_the_file_against_job_id_churn(self):
+        """A per-job rule alone is unbounded on the axis that actually grows."""
+        for n in range(30):
+            self.insert("scaffolded-cluster-%d" % n, count=100, offset=n * 1000)
+        self.assertEqual(self.count(), 3000)
+        prune_terminal_executions(self.conn, total=1000, floor=0)
+        self.assertEqual(self.count(), 1000)
+
+    def test_the_floor_outranks_the_ceiling(self):
+        """Evidence beats a size target: the newest 50 per job are never swept.
+
+        The quiet job's rows are all older than the chatty job's, so the
+        ceiling alone would take every one of them — the live crowd-out,
+        reproduced. The floor keeps 50, and the board is deliberately left over
+        its ceiling as a result: the real bound is the ceiling plus a floor per
+        job id, which the module docstring states.
+        """
+        self.insert("compliance-audit", count=60)
+        self.insert("profile-cron-tick", count=900, offset=100_000)
+        prune_terminal_executions(self.conn, total=100, floor=MIN_TERMINAL_EXECUTIONS_PER_JOB)
+        self.assertEqual(self.count("compliance-audit"), MIN_TERMINAL_EXECUTIONS_PER_JOB)
+        self.assertEqual(self.count("profile-cron-tick"), 100)
+        self.assertEqual(self.count(), 100 + MIN_TERMINAL_EXECUTIONS_PER_JOB)
+
+    def test_the_defaults_are_the_ones_the_reasoning_was_done_against(self):
+        """These three numbers are argued in the module docstring; pin them."""
+        self.assertEqual(MAX_TERMINAL_EXECUTIONS_PER_JOB, 1000)
+        self.assertEqual(MAX_TERMINAL_EXECUTIONS, 5000)
+        self.assertEqual(MIN_TERMINAL_EXECUTIONS_PER_JOB, 50)
+        # A minute-ly job's horizon must not regress from what the board has now.
+        self.assertGreaterEqual(MAX_TERMINAL_EXECUTIONS_PER_JOB / 1440.0, 0.69)
+
+    def test_pruning_an_empty_board_is_not_an_error(self):
+        prune_terminal_executions(self.conn)
+        self.assertEqual(self.count(), 0)
+
+
+class ReasonTest(unittest.TestCase):
+    def test_a_known_reason_passes_through(self):
+        self.assertEqual(normalize_reason(SKIP_ALREADY_RUNNING), SKIP_ALREADY_RUNNING)
+
+    def test_an_empty_reason_becomes_unspecified_rather_than_null(self):
+        for value in (None, "", "   "):
+            self.assertEqual(normalize_reason(value), SKIP_REASON_UNSPECIFIED)
+
+    def test_an_unknown_reason_is_kept_not_dropped(self):
+        """A skip under a bad label is still evidence; silence is the bug."""
+        self.assertEqual(normalize_reason("Something-New"), "something-new")
+
+    def test_an_unbounded_reason_is_clipped(self):
+        self.assertEqual(len(normalize_reason("x" * 500)), 64)
+
+
+class MissedWindowTest(unittest.TestCase):
+    """The count on a catch-up row, since the row itself stands for a whole gap."""
+
+    now = EPOCH + timedelta(hours=5)
+
+    def test_an_interval_schedule_counts_the_lost_occurrences(self):
+        schedule = {"kind": "interval", "minutes": 30}
+        self.assertEqual(count_missed_occurrences(schedule, EPOCH, self.now), 10)
+
+    def test_a_gap_shorter_than_the_period_lost_nothing(self):
+        schedule = {"kind": "interval", "minutes": 1440}
+        self.assertEqual(count_missed_occurrences(schedule, EPOCH, self.now), 0)
+
+    def test_a_clock_that_went_backwards_reports_zero_not_a_negative(self):
+        schedule = {"kind": "interval", "minutes": 30}
+        self.assertEqual(count_missed_occurrences(schedule, self.now, EPOCH), 0)
+
+    def test_a_runaway_gap_is_capped(self):
+        schedule = {"kind": "interval", "minutes": 1}
+        far = EPOCH + timedelta(days=365)
+        self.assertEqual(count_missed_occurrences(schedule, EPOCH, far, cap=500), 500)
+
+    def test_an_uncomputable_schedule_admits_it_rather_than_inventing_a_number(self):
+        for schedule in ({}, {"kind": "cron"}, {"kind": "sunrise"}, None,
+                         {"kind": "interval", "minutes": 0},
+                         {"kind": "interval", "minutes": "soon"}):
+            self.assertEqual(count_missed_occurrences(schedule, EPOCH, self.now), -1)
+
+    @unittest.skipUnless(
+        __import__("importlib").util.find_spec("croniter"),
+        "croniter is only in the image venv",
+    )
+    def test_a_cron_schedule_counts_the_lost_occurrences(self):
+        self.assertEqual(
+            count_missed_occurrences({"kind": "cron", "expr": "0 * * * *"}, EPOCH, self.now),
+            5,
+        )
+
+    def test_the_detail_carries_the_window_and_the_count(self):
+        detail = missed_window_detail(
+            {"kind": "interval", "minutes": 30}, EPOCH, self.now, 7200
+        )
+        self.assertIn("10 occurrence(s)", detail)
+        self.assertIn(str(EPOCH), detail)
+        self.assertIn(str(self.now), detail)
+        self.assertIn("7200s", detail)
+
+    def test_the_detail_says_unknown_rather_than_guessing(self):
+        detail = missed_window_detail({"kind": "sunrise"}, EPOCH, self.now, 120)
+        self.assertIn("an unknown number of", detail)
+
+
+# --- the applier ------------------------------------------------------------
+# Minimal stand-ins for the four Hermes modules: only the anchored regions are
+# reproduced, at their real indentation, wrapped in just enough scaffolding to
+# parse. Whether the anchors match the real tree is settled at build time by
+# the applier's own count check; what is worth testing here is that a matched
+# patch produces working code and that a second application fails loudly.
+
+from apply_cron_skip_ledger import (  # noqa: E402
+    EXEC_CONSTANTS,
+    EXEC_CREATE_TABLE,
+    EXEC_PRUNE,
+    HEALTH_ERROR_CLASS,
+    HEALTH_FLUSH,
+    HEALTH_IMPORT,
+    HEALTH_STATUSES,
+    JOBS_CATCH_UP,
+    PATCHES,
+    SCHED_DISPATCH_CLAIM,
+    SCHED_IMPORT,
+    SCHED_JOB_LOCK_GUARD,
+    SCHED_RUNNING_GUARD,
+    SCHED_SHUTDOWN_GUARD,
+    apply,
+)
+
+FAKE_EXECUTIONS = (
+    "import sqlite3\n\n"
+    + EXEC_CONSTANTS
+    + "\n\ndef _initialize_schema(conn):\n"
+    + EXEC_CREATE_TABLE
+    + '        "ON executions(job_id, claimed_at DESC, id DESC)"\n    )\n\n\n'
+    + EXEC_PRUNE
+    + "\n\ndef recover_interrupted_executions() -> int:\n    return 0\n"
+)
+
+FAKE_SCHEDULER = (
+    SCHED_IMPORT
+    + "\n\n\ndef tick():\n    def _submit_with_guard(job):\n"
+    "        job_id = job[\"id\"]\n        if True:\n"
+    + SCHED_SHUTDOWN_GUARD
+    + SCHED_RUNNING_GUARD
+    + SCHED_JOB_LOCK_GUARD
+    + "            return True\n"
+    "    return _submit_with_guard\n\n\n"
+    "def run_one_job(job):\n    execution_id = \"x\"\n    for _ in (1,):\n"
+    "        if not claim_dispatch(job[\"id\"]):\n"
+    + SCHED_DISPATCH_CLAIM
+    + "    return True\n"
+)
+
+FAKE_JOBS = (
+    "import logging\n\nlogger = logging.getLogger(__name__)\n\n\n"
+    "def get_due_jobs():\n    due = []\n    for job in ():\n"
+    "        if True:\n            if True:\n                if True:\n"
+    "                    if True:\n"
+    + JOBS_CATCH_UP
+    + "        due.append(job)\n    return due\n"
+)
+
+FAKE_HEALTH = (
+    HEALTH_IMPORT
+    + "\n\n"
+    + HEALTH_STATUSES
+    + "\n\n\ndef project_execution_event(record, status=None):\n"
+    "    return CronExecutionEvent(\n        status=status,\n"
+    + HEALTH_ERROR_CLASS
+    + "    )\n\n\ndef _emit(event, target):\n    if target is not None:\n"
+    + HEALTH_FLUSH
+)
+
+FAKE_TREE = {
+    "cron/executions.py": FAKE_EXECUTIONS,
+    "cron/scheduler.py": FAKE_SCHEDULER,
+    "cron/jobs.py": FAKE_JOBS,
+    "agent/monitoring/cron_health.py": FAKE_HEALTH,
+}
+
+
+def apply_quietly(root):
+    """``apply`` with its per-file build log swallowed.
+
+    That log belongs in ``docker build`` output, not interleaved with a test
+    summary — a suite whose last five lines are patch chatter hides its own
+    verdict.
+    """
+    with contextlib.redirect_stdout(io.StringIO()):
+        apply(root)
+
+
+class ApplierTest(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        for relative, body in FAKE_TREE.items():
+            path = self.root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body)
+
+    def read(self, relative):
+        return (self.root / relative).read_text()
+
+    def test_the_fixtures_are_the_shape_the_applier_expects(self):
+        """Guards the fixtures themselves: an anchor must appear exactly once."""
+        for relative, edits in PATCHES:
+            body = FAKE_TREE[relative]
+            for anchor, _, expected in edits:
+                self.assertEqual(
+                    body.count(anchor), expected, "%s: %r" % (relative, anchor[:60])
+                )
+
+    def test_it_patches_every_file(self):
+        apply_quietly(self.root)
+        executions = self.read("cron/executions.py")
+        self.assertIn("'claimed','running','completed','failed','unknown','skipped'", executions)
+        self.assertIn("skip_reason TEXT", executions)
+        self.assertIn("_ensure_skip_schema(conn)", executions)
+        self.assertIn("def record_skipped_execution(", executions)
+        self.assertIn("def skip_execution(", executions)
+        self.assertIn("_prune_terminal_executions(conn)", executions)
+        self.assertIn("def recover_interrupted_executions() -> int:", executions)
+
+        scheduler = self.read("cron/scheduler.py")
+        for reason in (
+            "SKIP_INTERPRETER_SHUTDOWN",
+            "SKIP_ALREADY_RUNNING",
+            "SKIP_ALREADY_RUNNING_ELSEWHERE",
+            "SKIP_DISPATCH_CLAIM_REJECTED",
+        ):
+            self.assertIn(reason, scheduler)
+        self.assertNotIn("finish_execution(\n                execution_id,", scheduler)
+
+        self.assertIn("SKIP_MISSED_WINDOW", self.read("cron/jobs.py"))
+        health = self.read("agent/monitoring/cron_health.py")
+        self.assertIn('"unknown", "skipped"}', health)
+        self.assertIn("_normalize_skip_reason(record.get(\"skip_reason\"))", health)
+
+    def test_the_ledger_write_moves_out_of_the_running_lock(self):
+        """A SQLite write inside _running_lock would serialise the dispatch pass."""
+        apply_quietly(self.root)
+        scheduler = self.read("cron/scheduler.py")
+        body = scheduler.split("with _running_lock:", 1)[1].split("if _already_running:", 1)
+        self.assertEqual(len(body), 2, "the guard was not restructured")
+        self.assertNotIn("record_skip", body[0])
+        self.assertIn("record_skip", body[1])
+
+    def test_the_job_is_released_before_the_cross_process_skip_is_recorded(self):
+        """Otherwise a slow ledger write leaves the job wedged in the running set."""
+        apply_quietly(self.root)
+        guard = self.read("cron/scheduler.py").split("_job_lock is None:", 1)[1]
+        self.assertLess(
+            guard.index("_running_job_ids.discard(job_id)"),
+            guard.index("SKIP_ALREADY_RUNNING_ELSEWHERE"),
+        )
+
+    def test_the_migration_runs_before_the_indexes_are_recreated(self):
+        """The rebuild drops them with the old table; order is load-bearing."""
+        apply_quietly(self.root)
+        executions = self.read("cron/executions.py")
+        self.assertLess(
+            executions.index("_ensure_skip_schema(conn)"),
+            executions.index("CREATE INDEX IF NOT EXISTS idx_executions_job_claimed"),
+        )
+
+    def test_a_second_application_fails_loudly(self):
+        """Half-patching an image is the failure mode worth being noisy about."""
+        apply_quietly(self.root)
+        with self.assertRaises(SystemExit):
+            apply_quietly(self.root)
+
+    def test_a_missing_file_fails_loudly(self):
+        (self.root / "cron" / "jobs.py").unlink()
+        with self.assertRaises(SystemExit):
+            apply_quietly(self.root)
+
+    def test_a_moved_anchor_fails_loudly_rather_than_mis_applying(self):
+        """The base-image bump case: upstream changed, the patch must not guess."""
+        path = self.root / "agent" / "monitoring" / "cron_health.py"
+        path.write_text(path.read_text().replace(HEALTH_FLUSH, "        pass\n"))
+        with self.assertRaises(SystemExit):
+            apply_quietly(self.root)
+
+    def test_the_patched_create_table_satisfies_the_migration_gate(self):
+        """A ledger born from the patched DDL must never trigger a rebuild."""
+        apply_quietly(self.root)
+        ddl = (
+            self.read("cron/executions.py")
+            .split('"""CREATE TABLE IF NOT EXISTS executions (', 1)[1]
+            .split('"""', 1)[0]
+        )
+        self.assertTrue(status_check_allows_skipped("CREATE TABLE executions (" + ddl))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_cron_tick_lock_scope.py
+++ b/deploy/docker/patches/test_cron_tick_lock_scope.py
@@ -56,6 +56,10 @@ class LockScopeTests(unittest.TestCase):
         readers to ignore warnings from this suite.
         """
         handle = open(self.tmp / name, "w", encoding="utf-8")
+        # close() is idempotent, so this stays correct on the paths where
+        # ``_lock_handle`` or the lock already closed it, and covers the one
+        # where it raised before either could.
+        self.addCleanup(handle.close)
         lock = _lock_handle(handle, fcntl)
         if lock is not None:
             self.addCleanup(lock.release)
@@ -82,6 +86,7 @@ class LockScopeTests(unittest.TestCase):
 
     def test_releasing_closes_the_handle_even_with_no_locking_module(self):
         handle = open(self.tmp / "b.lock", "w", encoding="utf-8")
+        self.addCleanup(handle.close)  # idempotent; the assertion below is the point
         lock = _lock_handle(handle, None, None)
         self.assertIsNotNone(lock)
         lock.release()

--- a/deploy/docker/patches/test_cron_tick_lock_scope.py
+++ b/deploy/docker/patches/test_cron_tick_lock_scope.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Host tests for cron_tick_lock_scope. No Hermes install required.
+
+These cover the properties the in-image gate cannot cheaply reach: that
+``release()`` is safe to call twice (the patch calls it twice by design, once
+at dispatch and once in the untouched ``finally``), that ``JobLocks`` fails
+toward FIRING rather than toward silence, and that a claim can be released by
+a caller that can no longer resolve the store it was taken under -- the leak
+that removing the by-id registry was meant to close.
+"""
+
+import fcntl
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from cron_tick_lock_scope import (  # noqa: E402
+    AdvisoryLock, JobLocks, _lock_handle, sanitise_job_id,
+)
+
+# A real second process, because that is the only claimant that matters: every
+# platform tick is a freshly spawned `hermes cron tick`, so the guard is
+# worthless if it only holds within one interpreter. `held` is a name and not
+# an inline expression on purpose: the claim lives exactly as long as the
+# object, so dropping the last reference to it hands the job back.
+_HOLDER = """
+import fcntl, sys, time
+sys.path.insert(0, {here!r})
+from cron_tick_lock_scope import JobLocks
+from pathlib import Path
+locks = JobLocks(lambda: Path({tmp!r}), fcntl)
+held = locks.claim("github-issue-resolver")
+print("CLAIMED" if held else "REFUSED", flush=True)
+time.sleep(30)
+"""
+
+
+class LockScopeTests(unittest.TestCase):
+    """Every case gets its own lock directory, so none can see another's files."""
+
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.tmp = Path(directory.name)
+
+    def lock_file(self, name):
+        """``_lock_handle`` on a fresh file, released at teardown, or None.
+
+        An unreleased ``AdvisoryLock`` leaks its file handle, and unittest
+        surfaces that as a ResourceWarning on every CI run — noise that trains
+        readers to ignore warnings from this suite.
+        """
+        handle = open(self.tmp / name, "w", encoding="utf-8")
+        lock = _lock_handle(handle, fcntl)
+        if lock is not None:
+            self.addCleanup(lock.release)
+        return lock
+
+    def claim(self, locks, job_id):
+        """``JobLocks.claim`` whose surviving claim is released at teardown."""
+        lock = locks.claim(job_id)
+        if lock is not None:
+            self.addCleanup(lock.release)
+        return lock
+
+    def job_locks(self, lock_dir_fn=None):
+        return JobLocks(lock_dir_fn or (lambda: self.tmp), fcntl)
+
+    def test_releasing_a_lock_twice_is_a_noop_the_second_time(self):
+        lock = self.lock_file("a.lock")
+        self.assertIsNotNone(lock)
+        self.assertFalse(lock.released)
+        lock.release()
+        self.assertTrue(lock.released)
+        lock.release()  # must not raise, must not reopen
+        self.assertIsNotNone(self.lock_file("a.lock"))
+
+    def test_releasing_closes_the_handle_even_with_no_locking_module(self):
+        handle = open(self.tmp / "b.lock", "w", encoding="utf-8")
+        lock = _lock_handle(handle, None, None)
+        self.assertIsNotNone(lock)
+        lock.release()
+        self.assertTrue(handle.closed)
+
+    def test_an_unheld_claim_starts_released_and_releases_harmlessly(self):
+        """``claim``'s fail-open paths hand this back; it must own nothing."""
+        lock = AdvisoryLock.unheld()
+        self.assertTrue(lock.released)
+        lock.release()
+
+    def test_a_second_lock_on_the_same_file_is_refused_while_the_first_is_held(self):
+        first = self.lock_file("c.lock")
+        self.assertIsNotNone(first)
+        self.assertIsNone(self.lock_file("c.lock"))
+        first.release()
+        self.assertIsNotNone(self.lock_file("c.lock"))
+
+    def test_a_refused_lock_does_not_disturb_the_claim_already_held(self):
+        """``_lock_handle`` closes the handle it failed to lock.
+
+        Safe with ``flock`` because the lock lives on the open file
+        description; with ``fcntl.lockf`` this same close would drop the claim
+        the first handle holds, and the job would run twice.
+        """
+        first = self.lock_file("d.lock")
+        self.assertIsNotNone(first)
+        self.assertIsNone(self.lock_file("d.lock"))
+        self.assertIsNone(self.lock_file("d.lock"))
+        self.assertFalse(first.released)
+
+    def test_one_store_lets_a_single_process_claim_a_job_id_only_once(self):
+        """The kernel is the registry: no dict, and still no double claim."""
+        locks = self.job_locks()
+        first = self.claim(locks, "github-issue-resolver")
+        self.assertIsNotNone(first)
+        self.assertIsNone(self.claim(locks, "github-issue-resolver"))
+        first.release()
+        self.assertIsNotNone(self.claim(locks, "github-issue-resolver"))
+
+    def test_a_sibling_claimant_is_refused_until_the_holder_releases(self):
+        a = self.job_locks()
+        b = self.job_locks()  # stands in for a sibling process
+        held = self.claim(a, "github-issue-resolver")
+        self.assertIsNotNone(held)
+        self.assertIsNone(self.claim(b, "github-issue-resolver"))
+        self.assertIsNotNone(self.claim(b, "compliance-audit"))
+        held.release()
+        self.assertIsNotNone(self.claim(b, "github-issue-resolver"))
+
+    def test_a_claim_survives_the_store_moving_out_from_under_its_owner(self):
+        """The regression that deleting the by-id registry fixed.
+
+        ``tick`` claims on the ticker thread and releases inside
+        ``_run_and_release``, on a ThreadPoolExecutor worker whose context is
+        empty — so ``get_hermes_home()`` there answers with the process home,
+        not the profile the claim was taken under. A registry keyed by lock
+        path missed on that recomputed path and left the claim held for the
+        gateway's whole life, silently suppressing the job. Holding the lock
+        object instead makes the release independent of what the store resolves
+        to by the time it runs.
+        """
+        store = [self.tmp / "profile-a" / "cron"]
+        locks = self.job_locks(lambda: store[0])
+        held = locks.claim("compliance-audit")
+        self.assertIsNotNone(held)
+        store[0] = self.tmp / "profile-b" / "cron"  # the worker's empty context
+        held.release()
+        store[0] = self.tmp / "profile-a" / "cron"
+        self.assertIsNotNone(
+            self.claim(locks, "compliance-audit"),
+            "the claim leaked when the store resolved elsewhere at release time")
+
+    def test_dropping_the_last_reference_to_a_claim_hands_the_job_back(self):
+        """Why the patch binds the claim and carries it into the worker.
+
+        The flock lives on the handle the ``AdvisoryLock`` owns, so once
+        nothing references the lock, CPython closes the handle and the job is
+        claimable again — no exception, no log line. Writing
+        ``if _job_locks.claim(job_id) is None:`` and going no further would
+        therefore have compiled, passed a single-process smoke test, and
+        guarded nothing. ``_run_and_release(..., lock=_job_lock)`` keeps the
+        reference alive for exactly the run's duration.
+        """
+        import gc
+        import warnings
+
+        locks = self.job_locks()
+        with warnings.catch_warnings():
+            # The dropped handle is the point of the test, not a leak to report.
+            warnings.simplefilter("ignore", ResourceWarning)
+            self.assertIsNotNone(locks.claim("github-issue-resolver"))
+            gc.collect()
+        self.assertIsNotNone(
+            self.claim(locks, "github-issue-resolver"),
+            "an unreferenced claim outlived the object that owned it")
+
+    def test_two_stores_sharing_a_job_id_do_not_refuse_each_other(self):
+        """One process may tick several profiles; the store is part of the id.
+
+        Per-cluster profiles are scaffolded from one template and so share
+        every job id by construction.
+        """
+        first, second = self.tmp / "a" / "cron", self.tmp / "b" / "cron"
+        store = [first]
+        locks = self.job_locks(lambda: store[0])
+        on_first = self.claim(locks, "compliance-audit")
+        self.assertIsNotNone(on_first)
+        store[0] = second
+        on_second = self.claim(locks, "compliance-audit")
+        self.assertIsNotNone(
+            on_second, "a claim on one profile refused the same id on another")
+        on_first.release()
+        store[0] = first
+        self.assertIsNotNone(self.claim(locks, "compliance-audit"))
+        store[0] = second
+        self.assertIsNone(self.claim(locks, "compliance-audit"),
+                          "releasing one store's claim released the other's")
+
+    def test_the_claim_is_honoured_across_real_operating_system_processes(self):
+        """The property the patch actually needs: two OS processes, one winner.
+
+        Also proves the kernel — not a janitor — hands the claim back, which is
+        the whole reason flock was chosen over a ledger row.
+        """
+        src = _HOLDER.format(here=str(Path(__file__).parent), tmp=str(self.tmp))
+        holder = subprocess.Popen([sys.executable, "-c", src],
+                                  stdout=subprocess.PIPE, text=True)
+        try:
+            self.assertEqual(holder.stdout.readline().strip(), "CLAIMED")
+            mine = self.job_locks()
+            self.assertIsNone(
+                self.claim(mine, "github-issue-resolver"),
+                "a second process claimed a job another process is running")
+            self.assertIsNotNone(
+                self.claim(mine, "compliance-audit"),
+                "the holder's claim leaked onto an unrelated job id")
+        finally:
+            holder.kill()
+            holder.wait(timeout=30)
+            if holder.stdout is not None:
+                holder.stdout.close()
+        # SIGKILL leaves no chance to release cleanly; the kernel must do it.
+        deadline = time.monotonic() + 10
+        reclaimed = None
+        while time.monotonic() < deadline and reclaimed is None:
+            reclaimed = self.claim(self.job_locks(), "github-issue-resolver")
+            if reclaimed is None:
+                time.sleep(0.1)
+        self.assertIsNotNone(
+            reclaimed, "the claim outlived the SIGKILLed process that held it")
+
+    def test_an_unusable_lock_directory_still_fires_the_job(self):
+        def broken():
+            raise OSError("read-only file system")
+        self.assertIsNotNone(self.claim(self.job_locks(broken), "compliance-audit"))
+
+    def test_a_surprising_exception_resolving_the_store_still_fires_the_job(self):
+        """Only a held flock may answer None — not an unexpected exception.
+
+        In the image ``lock_dir_fn`` reaches ``get_hermes_home()``. A
+        ValueError out of there once meant the whole tick aborted having
+        dispatched nothing.
+        """
+        def broken():
+            raise ValueError("HERMES_HOME is not a path")
+        self.assertIsNotNone(self.claim(self.job_locks(broken), "compliance-audit"))
+
+    def test_a_lock_file_that_will_not_open_still_fires_the_job(self):
+        """The reachable half of the fail-open rule.
+
+        ``mkdir(parents=True, exist_ok=True)`` succeeds on an EXISTING
+        read-only directory, so the directory guard never fires for the case
+        that actually happens: `<HERMES_HOME>/cron/` present but unwritable, or
+        the volume out of space. If the open failure were read as "held", every
+        job on the profile would stop firing while the log claimed each one was
+        already running elsewhere.
+        """
+        def refuse(*_args, **_kwargs):
+            raise PermissionError("read-only lock directory")
+        locks = JobLocks(lambda: self.tmp, fcntl, None, refuse)
+        lock = locks.claim("compliance-audit")
+        self.assertIsNotNone(lock)
+        self.assertTrue(lock.released, "a fail-open claim pretended to hold a lock")
+        # And it holds nothing, so a working claimant is not refused by it.
+        self.assertIsNotNone(self.claim(self.job_locks(), "compliance-audit"))
+
+    def test_a_job_id_becomes_a_safe_filename_component(self):
+        self.assertEqual(sanitise_job_id("github-issue-resolver"),
+                         "github-issue-resolver")
+        self.assertNotIn("/", sanitise_job_id("../../etc/passwd"))
+        self.assertEqual(sanitise_job_id(""), "_")
+        self.assertEqual(len(sanitise_job_id("x" * 500)), 120)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_cron_tirith_scan.py
+++ b/deploy/docker/patches/test_cron_tirith_scan.py
@@ -1,0 +1,326 @@
+"""Unit tests for the cron Tirith scan installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py'
+
+These cover the decision in isolation — is this command refused, and on whose
+authority. They cannot cover the wiring, because the edit lands inside Hermes'
+own ``tools/approval.py``; ``verify_cron_tirith_scan.py`` drives that inside the
+image at build time. The applier tests at the bottom cover the third failure
+mode, an anchor that has drifted out from under the patch.
+"""
+
+import ast
+import pathlib
+import tempfile
+import unittest
+
+import apply_cron_tirith_scan as applier
+from cron_tirith_scan import (
+    CRON_SCAN_KEY,
+    cron_scan_enabled,
+    cron_tirith_block,
+    tirith_fail_open,
+)
+
+COMMAND = "kubectl apply -f https://raw.githubusercontent.example/x/manifest.yaml"
+
+FINDING = {
+    "rule_id": "lookalike_tld",
+    "severity": "HIGH",
+    "title": "Lookalike TLD",
+    "description": "the host uses a TLD easily confused with a legitimate one",
+}
+BLOCK = {"action": "block", "findings": [FINDING], "summary": "lookalike tld"}
+WARN = {"action": "warn", "findings": [FINDING], "summary": "lookalike tld"}
+ALLOW = {"action": "allow", "findings": [], "summary": ""}
+
+
+def scanner(result):
+    """A stand-in for check_command_security that records what it saw."""
+    seen = []
+
+    def scan(command):
+        seen.append(command)
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    scan.seen = seen
+    return scan
+
+
+def config(**sections):
+    return dict(sections)
+
+
+class VerdictTest(unittest.TestCase):
+    """A verdict from the scanner refuses the command; nothing else does."""
+
+    def test_a_clean_command_runs(self):
+        scan = scanner(ALLOW)
+        self.assertIsNone(
+            cron_tirith_block(COMMAND, scan=scan, load_config=dict)
+        )
+        self.assertEqual([COMMAND], scan.seen)
+
+    def test_a_block_verdict_refuses(self):
+        out = cron_tirith_block(COMMAND, scan=scanner(BLOCK), load_config=dict)
+        self.assertIsNotNone(out)
+        self.assertFalse(out["approved"])
+
+    def test_a_warn_verdict_also_refuses(self):
+        """warn and block are both verdicts, and no one is here to weigh them.
+
+        Interactively, warn means "show the user and let them decide". On an
+        unattended run there is no one to decide, so the only two options are
+        refuse or run it anyway — and running it anyway is the behaviour this
+        patch exists to remove. This matches the cron deny arm, which has always
+        treated ("block", "warn") as one case.
+        """
+        out = cron_tirith_block(COMMAND, scan=scanner(WARN), load_config=dict)
+        self.assertIsNotNone(out)
+        self.assertFalse(out["approved"])
+
+    def test_an_unknown_action_is_not_a_verdict(self):
+        """Anything that is not block/warn runs. Fail towards upstream."""
+        weird = {"action": "quarantine", "findings": [FINDING]}
+        self.assertIsNone(
+            cron_tirith_block(COMMAND, scan=scanner(weird), load_config=dict)
+        )
+
+    def test_an_empty_result_is_not_a_verdict(self):
+        """A scanner returning None must not become a refusal by accident."""
+        self.assertIsNone(
+            cron_tirith_block(COMMAND, scan=scanner(None), load_config=dict)
+        )
+
+    def test_the_refusal_has_the_shape_the_caller_branches_on(self):
+        """check_all_command_guards returns exactly these two keys."""
+        out = cron_tirith_block(COMMAND, scan=scanner(BLOCK), load_config=dict)
+        self.assertEqual({"approved", "message"}, set(out))
+        self.assertIsInstance(out["message"], str)
+
+    def test_the_refusal_carries_the_finding_and_says_not_to_retry(self):
+        out = cron_tirith_block(COMMAND, scan=scanner(BLOCK), load_config=dict)
+        self.assertIn(FINDING["title"], out["message"])
+        self.assertIn("Do not retry", out["message"])
+
+    def test_the_injected_renderer_is_what_writes_the_message(self):
+        """The wiring passes Hermes' own formatter; honour it.
+
+        Without this the model would read a second, subtly different rendering
+        of the same finding depending on whether a human was present.
+        """
+        out = cron_tirith_block(
+            COMMAND,
+            scan=scanner(BLOCK),
+            load_config=dict,
+            describe=lambda result: "RENDERED BY HERMES",
+        )
+        self.assertIn("RENDERED BY HERMES", out["message"])
+
+
+class ScannerUnavailableTest(unittest.TestCase):
+    """Tirith downloads at runtime, so "not installed yet" is a real state."""
+
+    IMPORT_ERROR = ImportError("No module named 'tirith'")
+
+    def test_the_default_is_to_let_the_command_through(self):
+        """Matches security.tirith_fail_open's default and the deny arm's.
+
+        A first cron run can fire before the background install lands. Refusing
+        every command until it does would take the roster down for a reason
+        that has nothing to do with the command.
+        """
+        self.assertIsNone(
+            cron_tirith_block(
+                COMMAND, scan=scanner(self.IMPORT_ERROR), load_config=dict
+            )
+        )
+
+    def test_fail_closed_refuses_and_names_the_flag(self):
+        out = cron_tirith_block(
+            COMMAND,
+            scan=scanner(self.IMPORT_ERROR),
+            load_config=lambda: config(security={"tirith_fail_open": False}),
+        )
+        self.assertFalse(out["approved"])
+        self.assertIn("tirith_fail_open", out["message"])
+
+    def test_tirith_disabled_outranks_fail_closed(self):
+        """An operator who switched the scanner off is not then blocked by its
+        absence. Same ordering as the deny arm: fail_open is only consulted
+        when tirith_enabled is true."""
+        self.assertIsNone(
+            cron_tirith_block(
+                COMMAND,
+                scan=scanner(self.IMPORT_ERROR),
+                load_config=lambda: config(
+                    security={"tirith_enabled": False, "tirith_fail_open": False}
+                ),
+            )
+        )
+
+    def test_only_ImportError_is_absorbed(self):
+        """Anything else is a bug, and a swallowed bug here is an unscanned run.
+
+        check_command_security is documented to handle its own expected
+        failures — spawn errors, timeouts, odd exit codes — internally. An
+        exception escaping it means something unforeseen, which must surface as
+        a tool error rather than be quietly reinterpreted as "allow".
+        """
+        with self.assertRaises(RuntimeError):
+            cron_tirith_block(
+                COMMAND,
+                scan=scanner(RuntimeError("tirith wrapper bug")),
+                load_config=dict,
+            )
+
+
+class OptOutTest(unittest.TestCase):
+    """approvals.cron_scan is the one supported way to turn this off."""
+
+    def test_false_skips_the_scan_entirely(self):
+        scan = scanner(BLOCK)
+        self.assertIsNone(
+            cron_tirith_block(
+                COMMAND,
+                scan=scan,
+                load_config=lambda: config(approvals={CRON_SCAN_KEY: False}),
+            )
+        )
+        self.assertEqual([], scan.seen, "opting out must not still pay for a spawn")
+
+    def test_absent_means_on(self):
+        self.assertTrue(cron_scan_enabled({}))
+        self.assertTrue(cron_scan_enabled({"approvals": {}}))
+        self.assertTrue(cron_scan_enabled(None))
+
+    def test_a_malformed_approvals_block_is_not_an_opt_out(self):
+        """Someone who cannot write the key has not decided anything."""
+        self.assertTrue(cron_scan_enabled({"approvals": "cron_scan: false"}))
+        self.assertTrue(cron_scan_enabled({"approvals": ["cron_scan"]}))
+
+    def test_explicit_true_is_on(self):
+        self.assertTrue(cron_scan_enabled({"approvals": {CRON_SCAN_KEY: True}}))
+
+
+class ConfigReadTest(unittest.TestCase):
+    """An unreadable config must not silently decide security policy."""
+
+    def test_a_raising_loader_falls_back_to_scanning(self):
+        def boom():
+            raise OSError("config.yaml is a directory")
+
+        scan = scanner(BLOCK)
+        out = cron_tirith_block(COMMAND, scan=scan, load_config=boom)
+        self.assertEqual([COMMAND], scan.seen)
+        self.assertFalse(out["approved"])
+
+    def test_a_none_config_falls_back_to_scanning(self):
+        scan = scanner(BLOCK)
+        out = cron_tirith_block(COMMAND, scan=scan, load_config=lambda: None)
+        self.assertEqual([COMMAND], scan.seen)
+        self.assertFalse(out["approved"])
+
+    def test_fail_open_defaults(self):
+        self.assertTrue(tirith_fail_open(None))
+        self.assertTrue(tirith_fail_open({}))
+        self.assertTrue(tirith_fail_open({"security": {}}))
+        self.assertTrue(tirith_fail_open({"security": "nope"}))
+        self.assertFalse(tirith_fail_open({"security": {"tirith_fail_open": False}}))
+
+
+# The shape of the upstream cron arm the applier rewrites, reduced to something
+# that parses on its own. Byte-identical to /opt/hermes/tools/approval.py for the
+# four anchored lines — if upstream moves, the image build fails at the applier,
+# not here.
+UPSTREAM = '''\
+def check_all_command_guards(command, env_type):
+    is_cli = _is_interactive_cli()
+    is_gateway = _is_gateway_approval_context()
+    is_ask = False
+    if not is_cli and not is_gateway and not is_ask:
+        # Cron sessions: respect cron_mode config
+        if _is_cron_approval_context():
+            if _get_cron_approval_mode() == "deny":
+                return {"approved": False, "message": "denied"}
+        return {"approved": True, "message": None}
+    return {"approved": True, "message": None}
+'''
+
+
+class ApplierTest(unittest.TestCase):
+    """The applier must land the edit or fail the build. Never in between."""
+
+    def write(self, source):
+        root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(
+            lambda: [p.unlink() for p in sorted(root.rglob("*")) if p.is_file()]
+        )
+        target = root / "tools" / "approval.py"
+        target.parent.mkdir(parents=True)
+        target.write_text(source)
+        return root, target
+
+    def test_the_edit_lands_and_still_parses(self):
+        root, target = self.write(UPSTREAM)
+        applier.apply(root)
+        patched = target.read_text()
+        ast.parse(patched)
+        self.assertIn("from tools.cron_tirith_scan import cron_tirith_block", patched)
+        self.assertIn("describe=_format_tirith_description", patched)
+
+    def test_the_deny_arm_survives(self):
+        """The patch adds an arm; it must not consume the one already there."""
+        root, target = self.write(UPSTREAM)
+        applier.apply(root)
+        patched = target.read_text()
+        self.assertIn('if _cron_mode == "deny":', patched)
+        self.assertIn('"message": "denied"', patched)
+
+    def test_the_scan_is_skipped_on_the_deny_arm(self):
+        """Upstream already scans there; scanning twice is a second subprocess."""
+        root, target = self.write(UPSTREAM)
+        applier.apply(root)
+        self.assertIn('if _cron_mode != "deny":', target.read_text())
+
+    def test_the_mode_is_read_once(self):
+        """Two reads are two config loads, and can straddle a config reload."""
+        root, target = self.write(UPSTREAM)
+        applier.apply(root)
+        patched = target.read_text()
+        self.assertEqual(1, patched.count("_get_cron_approval_mode()"))
+
+    def test_a_missing_anchor_fails_the_build(self):
+        root, _ = self.write(UPSTREAM.replace("is_ask", "is_asked"))
+        with self.assertRaises(SystemExit) as caught:
+            applier.apply(root)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_a_duplicated_anchor_fails_the_build(self):
+        """Ambiguity is a failure, not a coin toss: replace() would hit both."""
+        root, _ = self.write(UPSTREAM + "\n\n" + UPSTREAM.replace(
+            "def check_all_command_guards", "def check_all_command_guards_two"
+        ))
+        with self.assertRaises(SystemExit) as caught:
+            applier.apply(root)
+        self.assertIn("found 2", str(caught.exception))
+
+    def test_a_missing_file_fails_the_build(self):
+        root = pathlib.Path(tempfile.mkdtemp())
+        with self.assertRaises(SystemExit) as caught:
+            applier.apply(root)
+        self.assertIn("does not exist", str(caught.exception))
+
+    def test_the_patch_is_not_applied_twice(self):
+        """Re-running must fail rather than nest a second copy of the arm."""
+        root, _ = self.write(UPSTREAM)
+        applier.apply(root)
+        with self.assertRaises(SystemExit) as caught:
+            applier.apply(root)
+        self.assertIn("found 0", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_auto_subscribe.py
+++ b/deploy/docker/patches/test_kanban_auto_subscribe.py
@@ -1,0 +1,367 @@
+"""Unit tests for worker subscription inheritance installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import ast
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import kanban_auto_subscribe as kas
+from apply_kanban_auto_subscribe import ANCHOR, RELATIVE, apply
+from kanban_auto_subscribe import (
+    COPY_COLUMNS,
+    WORKER_TASK_ENV,
+    inherit_subscriptions,
+    maybe_inherit_worker_subscriptions,
+)
+
+# The real table shape from hermes_cli/kanban_db.py SCHEMA_SQL — including the
+# two columns (chat_type, delivery_metadata) that are deliberately NOT copied,
+# matching both upstream _inherit_notify_subs and the manual propagate script.
+SUBS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS kanban_notify_subs (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    chat_type     TEXT,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    user_id       TEXT,
+    notifier_profile TEXT,
+    delivery_metadata TEXT,
+    created_at    INTEGER NOT NULL,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+CREATE TABLE IF NOT EXISTS tasks (id TEXT PRIMARY KEY, status TEXT);
+CREATE TABLE IF NOT EXISTS task_events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id    TEXT NOT NULL,
+    run_id     INTEGER,
+    kind       TEXT NOT NULL,
+    payload    TEXT,
+    created_at INTEGER NOT NULL
+);
+"""
+
+# The kinds gateway/kanban_watchers.py claims for a subscriber. A cursor left
+# behind any of these is a message the user receives.
+TERMINAL_KINDS = (
+    "completed", "blocked", "gave_up", "crashed", "timed_out",
+    "status", "archived", "unblocked", "block_loop_detected",
+)
+
+PARENT = "t_b9659077"  # the coordinator card from the 2026-08-07 incident
+CHILD = "t_f54bd6b5"   # the synthesizer whose answer sat undelivered 91.3s
+
+
+def board(path=None):
+    conn = sqlite3.connect(path if path is not None else ":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SUBS_SCHEMA)
+    conn.execute("INSERT INTO tasks VALUES (?, 'running')", (PARENT,))
+    conn.execute("INSERT INTO tasks VALUES (?, 'ready')", (CHILD,))
+    conn.commit()
+    return conn
+
+
+def subscribe(conn, task_id, chat="C123", thread="171234.5678", platform="slack"):
+    conn.execute(
+        "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, chat_type,"
+        " thread_id, user_id, notifier_profile, delivery_metadata, created_at,"
+        " last_event_id) VALUES (?, ?, ?, 'group', ?, 'U1', 'default',"
+        " '{\"thread_id\": \"x\"}', 1000, 42)",
+        (task_id, platform, chat, thread),
+    )
+    conn.commit()
+
+
+def child_rows(conn):
+    return conn.execute(
+        "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (CHILD,)
+    ).fetchall()
+
+
+def add_events(conn, task_id, *kinds):
+    """Give a card some history, the way hermes_cli.kanban_db._append_event does."""
+    conn.executemany(
+        "INSERT INTO task_events (task_id, kind, payload, created_at)"
+        " VALUES (?, ?, NULL, 0)",
+        [(task_id, k) for k in kinds],
+    )
+    conn.commit()
+
+
+def would_replay(conn, task_id):
+    """The events the notifier's next tick would post, given the stored cursor.
+
+    The query gateway/kanban_watchers.py runs through
+    hermes_cli.kanban_db.unseen_events_for_sub: the subscription's own kinds
+    filter applied to everything past its cursor.
+    """
+    marks = ",".join("?" * len(TERMINAL_KINDS))
+    return [
+        r[0]
+        for r in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ?"
+            f" AND kind IN ({marks})"
+            "   AND id > (SELECT last_event_id FROM kanban_notify_subs"
+            "              WHERE task_id = ?)"
+            " ORDER BY id",
+            (task_id, *TERMINAL_KINDS, task_id),
+        ).fetchall()
+    ]
+
+
+class InheritSubscriptionsTest(unittest.TestCase):
+    def test_the_child_gets_the_parents_subscription(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        self.assertEqual(inherit_subscriptions(conn, CHILD, PARENT), 1)
+        rows = child_rows(conn)
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row["platform"], "slack")
+        self.assertEqual(row["chat_id"], "C123")
+        self.assertEqual(row["thread_id"], "171234.5678")
+        self.assertEqual(row["user_id"], "U1")
+        self.assertEqual(row["notifier_profile"], "default")
+
+    def test_created_at_is_restamped(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        inherit_subscriptions(conn, CHILD, PARENT)
+        self.assertGreater(child_rows(conn)[0]["created_at"], 1000)
+
+    def test_a_child_with_no_history_starts_at_zero(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        inherit_subscriptions(conn, CHILD, PARENT)
+        self.assertEqual(child_rows(conn)[0]["last_event_id"], 0)
+
+    def test_the_cursor_starts_at_the_childs_own_head_not_the_parents(self):
+        # The cursor is scoped to the child's task_id, so the parent's much
+        # longer history must not move it.
+        conn = board()
+        subscribe(conn, PARENT)
+        add_events(conn, PARENT, "created", "status", "completed")
+        add_events(conn, CHILD, "created")
+        child_head = conn.execute(
+            "SELECT MAX(id) FROM task_events WHERE task_id = ?", (CHILD,)
+        ).fetchone()[0]
+        inherit_subscriptions(conn, CHILD, PARENT)
+        self.assertEqual(child_rows(conn)[0]["last_event_id"], child_head)
+
+    def test_a_card_handed_back_by_an_idempotent_create_replays_nothing(self):
+        # kanban_create takes an idempotency_key, and create_task answers a
+        # repeat key by returning the id of the existing card. A worker that
+        # re-issues one gets back a card that already ran, blocked and
+        # completed; seeded at 0 this row made the notifier's next tick post
+        # that whole history into the user's thread.
+        conn = board()
+        subscribe(conn, PARENT)
+        add_events(conn, CHILD, "created", "status", "blocked", "unblocked", "completed")
+        inherit_subscriptions(conn, CHILD, PARENT)
+        self.assertEqual(would_replay(conn, CHILD), [])
+
+    def test_events_written_after_the_subscription_are_still_delivered(self):
+        # Catching the cursor up must not make the subscription inert: the
+        # card's own future is the entire reason the row exists.
+        conn = board()
+        subscribe(conn, PARENT)
+        add_events(conn, CHILD, "created", "status")
+        inherit_subscriptions(conn, CHILD, PARENT)
+        add_events(conn, CHILD, "completed")
+        self.assertEqual(would_replay(conn, CHILD), ["completed"])
+
+    def test_only_the_documented_columns_are_copied(self):
+        # chat_type / delivery_metadata stay NULL — the same set upstream's
+        # _inherit_notify_subs and the manual propagate script copy.
+        self.assertEqual(
+            COPY_COLUMNS,
+            ("platform", "chat_id", "thread_id", "user_id", "notifier_profile"),
+        )
+        conn = board()
+        subscribe(conn, PARENT)
+        inherit_subscriptions(conn, CHILD, PARENT)
+        row = child_rows(conn)[0]
+        self.assertIsNone(row["chat_type"])
+        self.assertIsNone(row["delivery_metadata"])
+
+    def test_every_parent_row_is_copied(self):
+        conn = board()
+        subscribe(conn, PARENT, chat="C123")
+        subscribe(conn, PARENT, chat="C456", platform="google_chat")
+        self.assertEqual(inherit_subscriptions(conn, CHILD, PARENT), 2)
+        self.assertEqual(len(child_rows(conn)), 2)
+
+    def test_idempotent_like_the_script_it_automates(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        self.assertEqual(inherit_subscriptions(conn, CHILD, PARENT), 1)
+        self.assertEqual(inherit_subscriptions(conn, CHILD, PARENT), 0)
+        self.assertEqual(len(child_rows(conn)), 1)
+
+    def test_an_unsubscribed_parent_writes_nothing(self):
+        conn = board()
+        self.assertEqual(inherit_subscriptions(conn, CHILD, PARENT), 0)
+        self.assertEqual(child_rows(conn), [])
+
+    def test_parent_equal_to_child_is_a_no_op(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        self.assertEqual(inherit_subscriptions(conn, PARENT, PARENT), 0)
+
+    def test_a_phantom_child_is_refused_not_written(self):
+        # A row for a card that isn't on the board is scanned by every
+        # notifier tick forever — the manual script refuses it, so do we.
+        conn = board()
+        subscribe(conn, PARENT)
+        with self.assertLogs(kas.logger, level="WARNING"):
+            self.assertEqual(inherit_subscriptions(conn, "t_typo", PARENT), 0)
+
+    def test_a_db_path_is_accepted_in_place_of_a_connection(self):
+        db = Path(tempfile.mkdtemp()) / "kanban.db"
+        conn = board(str(db))
+        subscribe(conn, PARENT)
+        conn.close()
+        self.assertEqual(inherit_subscriptions(str(db), CHILD, PARENT), 1)
+        check = sqlite3.connect(str(db))
+        try:
+            count = check.execute(
+                "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?",
+                (CHILD,),
+            ).fetchone()[0]
+        finally:
+            check.close()
+        self.assertEqual(count, 1)
+
+    def test_a_broken_board_is_logged_and_swallowed(self):
+        # Fail-soft is the contract: this runs inside the kanban_create the
+        # worker is mid-flight on, and must never break it.
+        with self.assertLogs(kas.logger, level="WARNING"):
+            self.assertEqual(
+                inherit_subscriptions("/no/such/dir/kanban.db", CHILD, PARENT), 0
+            )
+
+    def test_empty_ids_are_a_no_op(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        self.assertEqual(inherit_subscriptions(conn, "", PARENT), 0)
+        self.assertEqual(inherit_subscriptions(conn, CHILD, ""), 0)
+
+
+class MaybeInheritWorkerSubscriptionsTest(unittest.TestCase):
+    def test_a_worker_process_propagates_its_own_cards_subscription(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        with mock.patch.dict("os.environ", {WORKER_TASK_ENV: PARENT}):
+            self.assertEqual(maybe_inherit_worker_subscriptions(conn, CHILD), 1)
+        self.assertEqual(len(child_rows(conn)), 1)
+
+    def test_a_non_worker_create_is_untouched(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        with mock.patch.dict("os.environ", clear=False) as env:
+            env.pop(WORKER_TASK_ENV, None)
+            self.assertEqual(maybe_inherit_worker_subscriptions(conn, CHILD), 0)
+        self.assertEqual(child_rows(conn), [])
+
+    def test_a_blank_env_value_is_not_a_worker(self):
+        conn = board()
+        subscribe(conn, PARENT)
+        with mock.patch.dict("os.environ", {WORKER_TASK_ENV: "   "}):
+            self.assertEqual(maybe_inherit_worker_subscriptions(conn, CHILD), 0)
+
+    def test_a_card_never_inherits_from_itself(self):
+        conn = board()
+        subscribe(conn, CHILD)
+        with mock.patch.dict("os.environ", {WORKER_TASK_ENV: CHILD}):
+            self.assertEqual(maybe_inherit_worker_subscriptions(conn, CHILD), 0)
+
+
+# The create handler, reduced to the two lines the patch anchors on.
+UPSTREAM_TOOLS = '''\
+def _handle_create(args, **kw):
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            new_tid = kb.create_task(
+                conn,
+                title=str(title).strip(),
+            )
+            new_task = kb.get_task(conn, new_tid)
+            subscribed = _maybe_auto_subscribe(conn, new_tid)
+            return _ok(
+                task_id=new_tid,
+                subscribed=subscribed,
+            )
+        finally:
+            conn.close()
+    except Exception as e:
+        return tool_error(f"kanban_create: {e}")
+'''
+
+
+def patch_tree(source):
+    root = Path(tempfile.mkdtemp())
+    target = root / RELATIVE
+    target.parent.mkdir(parents=True)
+    target.write_text(source)
+    apply(root)
+    return target.read_text()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_the_anchor_matches_upstream_exactly_once(self):
+        self.assertEqual(UPSTREAM_TOOLS.count(ANCHOR), 1)
+
+    def test_the_hook_lands_after_the_auto_subscribe_attempt(self):
+        patched = patch_tree(UPSTREAM_TOOLS)
+        auto_sub = patched.index("subscribed = _maybe_auto_subscribe(conn, new_tid)")
+        hook = patched.index("_kanban_inherit_worker_subs(conn, new_tid)")
+        result = patched.index("return _ok(")
+        self.assertTrue(auto_sub < hook < result)
+
+    def test_the_import_trailer_is_appended(self):
+        patched = patch_tree(UPSTREAM_TOOLS)
+        self.assertIn(
+            "from tools.kanban_auto_subscribe import (  # noqa: E402", patched
+        )
+        self.assertIn(
+            "maybe_inherit_worker_subscriptions as _kanban_inherit_worker_subs",
+            patched,
+        )
+
+    def test_the_patched_module_still_parses(self):
+        ast.parse(patch_tree(UPSTREAM_TOOLS))
+
+    def test_a_drifted_anchor_fails_loudly(self):
+        drifted = UPSTREAM_TOOLS.replace(
+            "_maybe_auto_subscribe(conn, new_tid)",
+            "_maybe_auto_subscribe(conn, new_tid, board)",
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(drifted)
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_applying_twice_fails_rather_than_silently_no_opping(self):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        target.write_text(UPSTREAM_TOOLS)
+        apply(root)
+        with self.assertRaises(SystemExit):
+            apply(root)
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            apply(Path(tempfile.mkdtemp()))
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_comment_status.py
+++ b/deploy/docker/patches/test_kanban_comment_status.py
@@ -1,0 +1,399 @@
+"""Unit tests for the kanban comment status patch installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import ast
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import kanban_comment_status as kcs
+from apply_kanban_comment_status import ANCHOR, RELATIVE, SENTINEL, apply
+from kanban_comment_status import (
+    READER_NEXT,
+    READER_NONE,
+    READER_RUNNING,
+    TERMINAL_STATUSES,
+    delivery_fields,
+)
+
+# The two columns of the two tables this patch reads, from the real SCHEMA_SQL
+# in hermes_cli/kanban_db.py. idx_notify_task is what makes the subscription
+# probe a point lookup rather than a scan, so it is here too.
+SCHEMA = """
+CREATE TABLE tasks (id TEXT PRIMARY KEY, status TEXT NOT NULL);
+CREATE TABLE kanban_notify_subs (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    chat_type     TEXT,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    user_id       TEXT,
+    notifier_profile TEXT,
+    delivery_metadata TEXT,
+    created_at    INTEGER NOT NULL,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+CREATE INDEX idx_notify_task ON kanban_notify_subs(task_id);
+"""
+
+CARD = "t_a8f58a2a"  # the card from the 2026-08-08 incident
+
+# Every status hermes_cli/kanban_db.py's VALID_STATUSES allows.
+ALL_STATUSES = (
+    "triage", "todo", "scheduled", "ready", "running",
+    "blocked", "review", "done", "archived",
+)
+
+
+class FakeTask:
+    def __init__(self, status):
+        self.status = status
+
+
+class FakeKb:
+    """Stands in for the hermes_cli.kanban_db module the handler is handed.
+
+    Only ``get_task`` is used by this patch; the fake makes "the row is gone"
+    and "the lookup raised" separately expressible, which a real board cannot
+    do without corrupting itself.
+    """
+
+    def __init__(self, conn, raises=None):
+        self._conn = conn
+        self._raises = raises
+
+    def get_task(self, conn, task_id):
+        if self._raises is not None:
+            raise self._raises
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        return FakeTask(row[0]) if row else None
+
+
+def board(status="running", subscribed=False, card=CARD):
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(SCHEMA)
+    conn.execute("INSERT INTO tasks VALUES (?, ?)", (card, status))
+    if subscribed:
+        conn.execute(
+            "INSERT INTO kanban_notify_subs "
+            "(task_id, platform, chat_id, thread_id, created_at) "
+            "VALUES (?, 'slack', 'C0PLATFORM', '1723033132.001', 0)",
+            (card,),
+        )
+    conn.commit()
+    return conn
+
+
+def fields(status="running", subscribed=False, raises=None, card=CARD):
+    conn = board(status, subscribed, card)
+    return delivery_fields(FakeKb(conn, raises), conn, card)
+
+
+class OpenCardTest(unittest.TestCase):
+    def test_a_running_card_names_the_live_worker(self):
+        out = fields("running")
+        self.assertEqual(out["task_status"], "running")
+        self.assertEqual(out["comment_reaches"], READER_RUNNING)
+
+    def test_an_unstarted_card_names_the_next_worker(self):
+        for status in ("triage", "todo", "scheduled", "ready", "blocked", "review"):
+            with self.subTest(status=status):
+                out = fields(status)
+                self.assertEqual(out["task_status"], status)
+                self.assertEqual(out["comment_reaches"], READER_NEXT)
+
+    def test_a_subscribed_card_reports_that_completing_reaches_chat(self):
+        self.assertIs(fields("running", subscribed=True)["completion_posts_to_chat"], True)
+
+    def test_an_unsubscribed_card_says_so_rather_than_staying_silent(self):
+        # False is the answer to "will the eventual completion post to chat";
+        # omitting it would read as "not applicable" on a card that can deliver.
+        self.assertIs(fields("running")["completion_posts_to_chat"], False)
+
+    def test_an_open_card_carries_no_note(self):
+        self.assertNotIn("note", fields("running"))
+
+    def test_another_cards_subscription_is_not_borrowed(self):
+        conn = board("running", subscribed=False)
+        conn.execute(
+            "INSERT INTO kanban_notify_subs "
+            "(task_id, platform, chat_id, thread_id, created_at) "
+            "VALUES ('t_other', 'slack', 'C0PLATFORM', '', 0)"
+        )
+        conn.commit()
+        out = delivery_fields(FakeKb(conn), conn, CARD)
+        self.assertIs(out["completion_posts_to_chat"], False)
+
+
+class TerminalCardTest(unittest.TestCase):
+    def test_done_and_archived_are_the_terminal_set(self):
+        # Coupled to gateway/kanban_watchers.py's own terminal test; the
+        # verifier is what enforces the coupling against the real source.
+        self.assertEqual(set(TERMINAL_STATUSES), {"done", "archived"})
+
+    def test_a_terminal_card_reports_that_nobody_will_read_it(self):
+        for status in ("done", "archived"):
+            with self.subTest(status=status):
+                out = fields(status)
+                self.assertEqual(out["task_status"], status)
+                self.assertEqual(out["comment_reaches"], READER_NONE)
+
+    def test_the_note_forbids_promising_a_delivery(self):
+        note = fields("done")["note"]
+        self.assertIn("Do NOT say that results will follow", note)
+
+    def test_the_note_says_where_the_answer_already_is(self):
+        note = fields("done")["note"]
+        self.assertIn("kanban_show", note)
+        self.assertIn(CARD, note)
+        self.assertIn("kanban_create", note)
+
+    def test_the_note_names_the_status_it_is_talking_about(self):
+        self.assertIn("archived", fields("archived")["note"])
+
+    def test_a_terminal_card_never_advertises_a_delivery_channel(self):
+        # The incident's whole shape: a done card whose subscription row has
+        # not been reaped yet. Status is durable, the row is one notifier tick
+        # from deletion, and a model handed both would believe the row.
+        for subscribed in (False, True):
+            with self.subTest(subscribed=subscribed):
+                out = fields("done", subscribed=subscribed)
+                self.assertNotIn("completion_posts_to_chat", out)
+
+    def test_the_comment_is_never_refused(self):
+        # delivery_fields describes; it cannot veto. There is no return value
+        # it can produce that the handler reads as an error, because the
+        # handler splats it into _ok().
+        out = fields("done")
+        self.assertNotIn("ok", out)
+        self.assertNotIn("error", out)
+
+
+class FailsTowardUpstreamTest(unittest.TestCase):
+    def test_a_raising_lookup_degrades_to_no_fields(self):
+        self.assertEqual(fields(raises=RuntimeError("board is locked")), {})
+
+    def test_a_missing_card_degrades_to_no_fields(self):
+        conn = board("running")
+        self.assertEqual(delivery_fields(FakeKb(conn), conn, "t_nope"), {})
+
+    def test_a_task_row_without_a_status_degrades_to_no_fields(self):
+        conn = board("")
+        self.assertEqual(delivery_fields(FakeKb(conn), conn, CARD), {})
+
+    def test_a_board_with_no_subscriptions_table_keeps_the_status(self):
+        # A legacy board predating kanban_notify_subs; kanban_db's
+        # count_notify_subs documents the same case.
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, status TEXT NOT NULL)")
+        conn.execute("INSERT INTO tasks VALUES (?, 'running')", (CARD,))
+        conn.commit()
+        out = delivery_fields(FakeKb(conn), conn, CARD)
+        self.assertEqual(out["task_status"], "running")
+        self.assertEqual(out["comment_reaches"], READER_RUNNING)
+        self.assertNotIn("completion_posts_to_chat", out)
+
+    def test_a_raising_subscription_probe_keeps_the_status(self):
+        conn = board("running")
+        with mock.patch.object(kcs, "_has_chat_subscriber", side_effect=OSError):
+            out = delivery_fields(FakeKb(conn), conn, CARD)
+        self.assertEqual(out["task_status"], "running")
+        self.assertNotIn("completion_posts_to_chat", out)
+
+    def test_no_status_the_kernel_allows_is_left_undescribed(self):
+        for status in ALL_STATUSES:
+            with self.subTest(status=status):
+                out = fields(status)
+                self.assertEqual(out["task_status"], status)
+                self.assertIn(
+                    out["comment_reaches"],
+                    (READER_RUNNING, READER_NEXT, READER_NONE),
+                )
+
+    def test_every_field_survives_json_encoding(self):
+        # _ok() json.dumps whatever it is splatted; a value it cannot encode
+        # would turn a written comment into a TypeError.
+        import json
+
+        for status in ALL_STATUSES:
+            json.dumps({"ok": True, **fields(status)})
+
+    def test_a_weird_status_is_reported_verbatim_not_guessed_at(self):
+        out = fields("some_new_upstream_status")
+        self.assertEqual(out["task_status"], "some_new_upstream_status")
+        self.assertEqual(out["comment_reaches"], READER_NEXT)
+
+
+# The comment handler, reduced to the two lines the patch anchors on plus the
+# neighbours that make the shape real: `conn` is still open, and add_comment has
+# already committed.
+UPSTREAM_TOOLS = '''\
+def _handle_comment(args: dict, **kw) -> str:
+    """Append a comment to a task's thread."""
+    tid = args.get("task_id")
+    body = args.get("body")
+    author = os.environ.get("HERMES_PROFILE") or "worker"
+    board = args.get("board")
+    try:
+        kb, conn = _connect(board=board)
+        try:
+            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+            return _ok(task_id=tid, comment_id=cid)
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_comment: {e}")
+'''
+
+# The other handlers' returns, verbatim from the real module, as a collision
+# guard: the anchor must not match anything outside _handle_comment.
+NEIGHBOURS = '''\
+            return _ok(task_id=tid)
+            return _ok(task_id=tid, attachment_id=aid)
+            cid = kb.add_comment(conn, tid, author=author, body=str(body))
+'''
+
+
+def patch_tree(source):
+    root = Path(tempfile.mkdtemp())
+    target = root / RELATIVE
+    target.parent.mkdir(parents=True)
+    target.write_text(source)
+    apply(root)
+    return target.read_text()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_the_anchor_matches_upstream_exactly_once(self):
+        self.assertEqual(UPSTREAM_TOOLS.count(ANCHOR), 1)
+
+    def test_the_anchor_does_not_match_a_neighbouring_return(self):
+        self.assertEqual(NEIGHBOURS.count(ANCHOR), 0)
+
+    def test_the_lookup_lands_between_the_write_and_the_return(self):
+        patched = patch_tree(UPSTREAM_TOOLS)
+        write = patched.index("cid = kb.add_comment(")
+        call = patched.index(SENTINEL)
+        close = patched.index("conn.close()")
+        self.assertTrue(write < call < close, "the lookup must see an open conn")
+
+    def test_upstream_return_fields_are_preserved(self):
+        patched = patch_tree(UPSTREAM_TOOLS)
+        self.assertIn("task_id=tid,", patched)
+        self.assertIn("comment_id=cid,", patched)
+
+    def test_the_import_trailer_is_appended(self):
+        patched = patch_tree(UPSTREAM_TOOLS)
+        self.assertIn(
+            "from tools.kanban_comment_status import (  # noqa: E402", patched
+        )
+        self.assertIn("delivery_fields as _comment_delivery_fields", patched)
+
+    def test_the_patched_module_still_parses(self):
+        ast.parse(patch_tree(UPSTREAM_TOOLS))
+
+    def test_the_patched_handler_returns_the_merged_fields(self):
+        # Execute the patched handler rather than reading it: an anchored edit
+        # that parses can still splat into the wrong call.
+        patched = patch_tree(UPSTREAM_TOOLS).replace(
+            "from tools.kanban_comment_status import (  # noqa: E402",
+            "from kanban_comment_status import (  # noqa: E402",
+        )
+        conn = board("done")
+        ns = {
+            "os": __import__("os"),
+            "_ok": lambda **f: {"ok": True, **f},
+            "tool_error": lambda m: {"ok": False, "error": m},
+            "_connect": lambda board=None: (FakeKb(conn), conn),
+        }
+        exec(compile(patched, "<patched>", "exec"), ns)
+        # The handler closes conn in its `finally`; the lookup has already run
+        # by then, which is the property this test is checking.
+        with mock.patch.object(FakeKb, "add_comment", create=True, return_value=7):
+            out = ns["_handle_comment"]({"task_id": CARD, "body": "annotating"})
+        self.assertEqual(out["ok"], True)
+        self.assertEqual(out["task_id"], CARD)
+        self.assertEqual(out["comment_id"], 7)
+        self.assertEqual(out["task_status"], "done")
+        self.assertEqual(out["comment_reaches"], READER_NONE)
+
+    def test_a_drifted_anchor_fails_loudly(self):
+        drifted = UPSTREAM_TOOLS.replace(
+            "kb.add_comment(conn, tid, author=author, body=str(body))",
+            "kb.add_comment(conn, tid, author=author, body=str(body), board=board)",
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(drifted)
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_a_duplicated_anchor_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(UPSTREAM_TOOLS + UPSTREAM_TOOLS)
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_applying_twice_fails_rather_than_stacking_a_second_import(self):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        target.write_text(UPSTREAM_TOOLS)
+        apply(root)
+        with self.assertRaises(SystemExit) as ctx:
+            apply(root)
+        self.assertIn("already patched", str(ctx.exception))
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            apply(Path(tempfile.mkdtemp()))
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+class AnchorCollisionTest(unittest.TestCase):
+    """The anchor must not overlap the four patches already in this file.
+
+    Two appliers matching the same text is the failure mode that ships a
+    half-patched image, and the ordering between them would then be silently
+    load-bearing.
+    """
+
+    def test_no_other_applier_claims_these_lines(self):
+        here = Path(__file__).resolve().parent
+        others = (
+            "apply_kanban_auto_subscribe.py",
+            "apply_kanban_result_required.py",
+            "apply_kanban_worker_tools.py",
+            "apply_cron_run_scope.py",
+        )
+        for name in others:
+            with self.subTest(applier=name):
+                src = (here / name).read_text()
+                for line in ANCHOR.strip("\n").split("\n"):
+                    self.assertNotIn(
+                        line.strip(), src,
+                        f"{name} references a line this patch anchors on",
+                    )
+
+    def test_the_patch_adds_no_copy_of_the_string_cron_run_scope_counts(self):
+        # apply_cron_run_scope.py asserts exactly 7 occurrences of this literal
+        # in tools/kanban_tools.py. An eighth from here would fail its build.
+        counted = '"task_id is required (or set HERMES_KANBAN_TASK in the env)"'
+        from apply_kanban_comment_status import PATCHED, TRAILER
+
+        self.assertNotIn(counted, PATCHED + TRAILER)
+
+    def test_the_patch_adds_no_copy_of_the_cron_run_scope_import_anchor(self):
+        # apply_cron_run_scope.py requires exactly 1 occurrence of it.
+        from apply_cron_run_scope import KANBAN_IMPORT_ANCHOR
+        from apply_kanban_comment_status import PATCHED, TRAILER
+
+        self.assertNotIn(KANBAN_IMPORT_ANCHOR, PATCHED + TRAILER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_guardrail_exit.py
+++ b/deploy/docker/patches/test_kanban_guardrail_exit.py
@@ -1,0 +1,599 @@
+"""Unit tests for the guardrail-exit fix installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+
+The scenario under test is card ``t_d3efabef`` on 2026-08-07: four runs, 38
+minutes, 208 web searches, no output. Each run ended ``⚠️ Tool guardrail halted
+web_search: loop_web_search_cap`` and the worker exited rc=0 without ever
+touching the board.
+"""
+
+import ast
+import importlib
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from apply_kanban_guardrail_exit import (
+    FINALIZER_ANCHOR,
+    FINALIZER_RELATIVE,
+    HALT_ANCHOR,
+    LOOP_RELATIVE,
+    apply,
+)
+from kanban_guardrail_exit import (
+    DETECTOR,
+    OUTCOME,
+    guardrail_halt_nudge,
+    missing_terminal_error,
+    record_missing_terminal_call,
+    should_record_missing_terminal,
+    task_is_still_running,
+)
+
+SCHEMA = """
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL
+);
+"""
+
+
+class Decision:
+    """Stands in for ``ToolGuardrailDecision``."""
+
+    def __init__(self, tool_name="web_search", code="loop_web_search_cap"):
+        self.tool_name = tool_name
+        self.code = code
+
+
+STOCK_NUDGE = "[System: You are a Hermes kanban worker. …]"
+
+
+def nudge_returning(value):
+    def build(*, messages, attempts):
+        return value
+
+    return build
+
+
+def board(rows):
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA)
+    for tid, status in rows:
+        conn.execute("INSERT INTO tasks (id, status) VALUES (?, ?)", (tid, status))
+    return conn
+
+
+class GuardrailHaltNudgeTest(unittest.TestCase):
+    def test_the_stock_nudge_gains_the_tool_is_gone_instruction(self):
+        """Without it the model retries the blocked tool and burns the budget."""
+        out = guardrail_halt_nudge(
+            nudge_returning(STOCK_NUDGE),
+            messages=[],
+            attempts=0,
+            decision=Decision(),
+        )
+        self.assertTrue(out.startswith(STOCK_NUDGE))
+        self.assertIn("web_search", out)
+        self.assertIn("loop_web_search_cap", out)
+        self.assertIn("do not try again", out)
+        self.assertIn("kanban_complete", out)
+        self.assertIn("kanban_block", out)
+
+    def test_no_nudge_means_no_nudge(self):
+        """Upstream returns None for non-workers and for a spent budget."""
+        self.assertIsNone(
+            guardrail_halt_nudge(
+                nudge_returning(None), messages=[], attempts=0, decision=Decision()
+            )
+        )
+
+    def test_an_empty_nudge_is_not_extended_into_a_real_one(self):
+        self.assertIsNone(
+            guardrail_halt_nudge(
+                nudge_returning(""), messages=[], attempts=0, decision=Decision()
+            )
+        )
+
+    def test_a_raising_helper_falls_through_to_the_old_exit(self):
+        """A broken nudge must never wedge a worker."""
+
+        def boom(*, messages, attempts):
+            raise RuntimeError("no")
+
+        self.assertIsNone(
+            guardrail_halt_nudge(boom, messages=[], attempts=0, decision=Decision())
+        )
+
+    def test_a_decision_missing_its_fields_still_produces_text(self):
+        out = guardrail_halt_nudge(
+            nudge_returning(STOCK_NUDGE),
+            messages=[],
+            attempts=0,
+            decision=Decision(tool_name=None, code=None),
+        )
+        self.assertIn("that tool", out)
+        self.assertIn("tool guardrail", out)
+
+    def test_attempts_and_messages_reach_the_upstream_helper(self):
+        seen = {}
+
+        def build(*, messages, attempts):
+            seen["messages"] = messages
+            seen["attempts"] = attempts
+            return STOCK_NUDGE
+
+        msgs = [{"role": "user", "content": "hi"}]
+        guardrail_halt_nudge(build, messages=msgs, attempts=1, decision=Decision())
+        self.assertIs(seen["messages"], msgs)
+        self.assertEqual(seen["attempts"], 1)
+
+
+def leaked(**overrides):
+    kwargs = dict(
+        task_id="t_d3efabef",
+        interrupted=False,
+        failed=False,
+        iteration_limit_fallback=False,
+        goal_mode=False,
+        delegated_child=False,
+    )
+    kwargs.update(overrides)
+    return should_record_missing_terminal(**kwargs)
+
+
+class ShouldRecordTest(unittest.TestCase):
+    def test_the_incident_shape_is_a_leak(self):
+        self.assertTrue(leaked())
+
+    def test_the_transcript_is_not_consulted(self):
+        """A terminal tool call in `messages` must not suppress the check.
+
+        It used to. A REJECTED kanban_complete still lands as a tool message
+        named kanban_complete, and session_called_kanban_terminal matches on the
+        name alone, so one refusal from kanban_result_required silenced this
+        backstop for the rest of the run and the card leaked. The board says
+        whether the card moved; the transcript only says what was attempted.
+        """
+        self.assertTrue(leaked())
+        with self.assertRaises(TypeError):
+            should_record_missing_terminal(
+                task_id="t_d3efabef",
+                interrupted=False,
+                failed=False,
+                iteration_limit_fallback=False,
+                session_called_terminal=lambda messages: True,
+            )
+
+    def test_a_non_worker_is_never_touched(self):
+        self.assertFalse(leaked(task_id=None))
+        self.assertFalse(leaked(task_id=""))
+
+    def test_goal_mode_is_excluded(self):
+        """Its intermediate turns end without a terminal call by design.
+
+        ``_run_kanban_goal_loop_q`` calls ``run_conversation`` once per turn, so
+        recording a failure on turn 1 of N would release the claim and close the
+        run underneath a loop that is working correctly.
+        """
+        self.assertFalse(leaked(goal_mode=True))
+
+    def test_goal_mode_defaults_to_the_environment(self):
+        import os
+
+        prior = os.environ.get("HERMES_KANBAN_GOAL_MODE")
+        try:
+            os.environ["HERMES_KANBAN_GOAL_MODE"] = "1"
+            self.assertFalse(leaked(goal_mode=None))
+            os.environ["HERMES_KANBAN_GOAL_MODE"] = "0"
+            self.assertTrue(leaked(goal_mode=None))
+            del os.environ["HERMES_KANBAN_GOAL_MODE"]
+            self.assertTrue(leaked(goal_mode=None))
+        finally:
+            os.environ.pop("HERMES_KANBAN_GOAL_MODE", None)
+            if prior is not None:
+                os.environ["HERMES_KANBAN_GOAL_MODE"] = prior
+
+    def test_the_budget_path_records_its_own_failure(self):
+        self.assertFalse(leaked(iteration_limit_fallback=True))
+
+    def test_a_failed_turn_already_exits_nonzero(self):
+        self.assertFalse(leaked(failed=True))
+
+    def test_an_interrupt_is_the_callers_business(self):
+        self.assertFalse(leaked(interrupted=True))
+
+
+class DelegatedChildExclusionTest(unittest.TestCase):
+    """A delegate_task child inherits its parent's card and owns none of its own.
+
+    The child runs ``run_conversation`` in the parent's process, so it reaches
+    ``finalize_turn`` with the parent's ``HERMES_KANBAN_TASK`` set. Recording
+    there charges the PARENT a ``timed_out`` and releases its claim mid-run —
+    twice, if it delegates twice — after which the parent completes a card it no
+    longer holds. Upstream draws the same line: ``_reject_delegated_child_mutation``
+    refuses every board mutation from a child for exactly this reason.
+    """
+
+    def test_a_delegated_child_is_not_a_leak(self):
+        self.assertFalse(leaked(delegated_child=True))
+
+    def test_an_explicit_false_still_leaks(self):
+        self.assertTrue(leaked(delegated_child=False))
+
+    def test_it_defaults_to_the_real_delegation_context(self):
+        """None must reach ``agent.delegation_context``, not silently pass.
+
+        The parameter exists for the tests; the runtime never passes it, so a
+        default that did not consult the real module would leave the fix inert
+        in the only place it matters.
+        """
+        module = importlib.import_module("kanban_guardrail_exit")
+        fake = types.ModuleType("agent.delegation_context")
+        fake.is_delegated_child_context = lambda: True
+        agent_pkg = types.ModuleType("agent")
+        agent_pkg.delegation_context = fake
+        with mock.patch.dict(
+            sys.modules,
+            {"agent": agent_pkg, "agent.delegation_context": fake},
+        ):
+            self.assertTrue(module.is_delegated_child(on_unknown=True))
+            self.assertFalse(
+                module.should_record_missing_terminal(
+                    task_id="t_d3efabef",
+                    interrupted=False,
+                    failed=False,
+                    iteration_limit_fallback=False,
+                    goal_mode=False,
+                    cron_run=False,
+                )
+            )
+
+    def test_a_host_without_hermes_is_not_a_delegated_child(self):
+        """An absent module is a structural fact, not uncertainty.
+
+        ``on_unknown`` covers a reader that raises; it deliberately does not
+        cover a reader that is not there. Answering True for an absent module
+        would disable the backstop everywhere this code is importable but Hermes
+        is not — including these tests.
+        """
+        module = importlib.import_module("kanban_guardrail_exit")
+        with mock.patch.dict(sys.modules, {"agent.delegation_context": None}):
+            self.assertFalse(module.is_delegated_child(on_unknown=True))
+
+    def test_a_raising_reader_withholds_the_write(self):
+        """Uncertainty must not charge a failure to a card someone is working.
+
+        This is the ``on_unknown=True`` half of the asymmetry: the same reader,
+        raising the same way, leaves ``kanban_worker_tools`` answering False.
+        """
+        module = importlib.import_module("kanban_guardrail_exit")
+
+        def boom():
+            raise RuntimeError("no delegation context")
+
+        fake = types.ModuleType("agent.delegation_context")
+        fake.is_delegated_child_context = boom
+        agent_pkg = types.ModuleType("agent")
+        agent_pkg.delegation_context = fake
+        with mock.patch.dict(
+            sys.modules,
+            {"agent": agent_pkg, "agent.delegation_context": fake},
+        ):
+            self.assertTrue(module.is_delegated_child(on_unknown=True))
+            self.assertFalse(leaked(delegated_child=None, cron_run=False))
+
+
+class CronRunExclusionTest(unittest.TestCase):
+    """A dispatched cron run has no card of its own, so it cannot leak one.
+
+    ``cronjob(action='run')`` executes in-process inside the dispatching worker
+    and inherits ``HERMES_KANBAN_TASK`` — cron_run_scope leaves it set on purpose,
+    to keep the dispatcher's claim heart-beating through a long audit. That id is
+    the caller's card, and the run is barred from terminating it. Charging the
+    caller a ``timed_out`` for that would release its claim while it is still
+    blocked on the run.
+    """
+
+    def test_a_cron_run_is_not_a_leak(self):
+        self.assertFalse(leaked(cron_run=True))
+
+    def test_an_explicit_false_still_leaks(self):
+        # The caller can overrule the ambient marker; nothing does today, but
+        # the parameter is what makes the rest of these tests hermetic.
+        self.assertTrue(leaked(cron_run=False))
+
+    def test_it_defaults_to_the_real_cron_run_scope(self):
+        from cron_run_scope import cron_run_scope
+
+        self.assertTrue(leaked(cron_run=None))
+        with cron_run_scope("fleet-audit"):
+            self.assertFalse(leaked(cron_run=None))
+        self.assertTrue(leaked(cron_run=None))
+
+    def test_a_forked_run_is_recognised_from_the_environment_alone(self):
+        # current_cron_job falls back to the environment, which is the one
+        # thing a ContextVar cannot do — cross a fork. Nothing in the image
+        # writes the marker there today (cron_run_scope deliberately does not;
+        # see its docstring), so this covers a process launched with it already
+        # set rather than anything the scope produces.
+        import os
+
+        prior = os.environ.get("HERMES_KANBAN_CRON_RUN")
+        try:
+            os.environ["HERMES_KANBAN_CRON_RUN"] = "fleet-audit"
+            self.assertFalse(leaked(cron_run=None))
+        finally:
+            os.environ.pop("HERMES_KANBAN_CRON_RUN", None)
+            if prior is not None:
+                os.environ["HERMES_KANBAN_CRON_RUN"] = prior
+        self.assertTrue(leaked(cron_run=None))
+
+    def test_an_unreadable_marker_withholds_the_write(self):
+        # Same rule as the transcript check above, stated from the other side:
+        # this function writes to a live board, so it does nothing it cannot
+        # justify — hence in_cron_run(on_unknown=True). kanban_ownership
+        # re-imports the reader per call, so replacing the module attribute is
+        # enough.
+        import cron_run_scope
+
+        def boom(environ=None):
+            raise RuntimeError("no")
+
+        original = cron_run_scope.current_cron_job
+        cron_run_scope.current_cron_job = boom
+        try:
+            self.assertFalse(leaked(cron_run=None))
+        finally:
+            cron_run_scope.current_cron_job = original
+        self.assertTrue(leaked(cron_run=None))
+
+    def test_the_nudge_is_deliberately_left_alone(self):
+        # The exclusion is scoped to the board write. in_cron_run can only
+        # over-report — the env half of the marker is process-wide, so a worker
+        # running alongside somebody else's dispatch reads it as its own — and
+        # silencing the nudge on that worker would undo the fix. Wasting two
+        # turns on a cron run that gets refused is the cheaper error.
+        from cron_run_scope import cron_run_scope
+
+        with cron_run_scope("fleet-audit"):
+            self.assertIn(
+                "do not try again",
+                guardrail_halt_nudge(
+                    nudge_returning(STOCK_NUDGE),
+                    messages=[],
+                    attempts=0,
+                    decision=Decision(),
+                ),
+            )
+
+
+class TaskIsStillRunningTest(unittest.TestCase):
+    def test_running_is_running(self):
+        self.assertTrue(task_is_still_running(board([("t1", "running")]), "t1"))
+
+    def test_done_and_blocked_are_terminal(self):
+        """The board outranks the transcript: compaction can drop a tool call."""
+        self.assertFalse(task_is_still_running(board([("t1", "done")]), "t1"))
+        self.assertFalse(task_is_still_running(board([("t1", "blocked")]), "t1"))
+
+    def test_a_missing_card_is_not_running(self):
+        self.assertFalse(task_is_still_running(board([]), "t1"))
+
+    def test_a_broken_connection_is_not_running(self):
+        class Boom:
+            def execute(self, *a):
+                raise sqlite3.OperationalError("no such table: tasks")
+
+        self.assertFalse(task_is_still_running(Boom(), "t1"))
+
+    def test_a_plain_tuple_row_factory_works(self):
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(SCHEMA)
+        conn.execute("INSERT INTO tasks (id, status) VALUES ('t1', 'running')")
+        self.assertTrue(task_is_still_running(conn, "t1"))
+
+
+class Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, conn, task_id, **kwargs):
+        self.calls.append((task_id, kwargs))
+
+
+class ClosableConn:
+    def __init__(self, conn):
+        self._conn = conn
+        self.closed = False
+
+    def execute(self, *a, **kw):
+        return self._conn.execute(*a, **kw)
+
+    def close(self):
+        self.closed = True
+
+
+class RecordMissingTerminalTest(unittest.TestCase):
+    def _record(self, status, reason="guardrail_halt"):
+        conn = ClosableConn(board([("t1", status)]))
+        rec = Recorder()
+        did = record_missing_terminal_call(
+            task_id="t1",
+            turn_exit_reason=reason,
+            connect=lambda: conn,
+            record_failure=rec,
+        )
+        return did, rec, conn
+
+    def test_a_running_card_is_charged_a_timed_out_failure(self):
+        did, rec, conn = self._record("running")
+        self.assertTrue(did)
+        self.assertEqual(len(rec.calls), 1)
+        task_id, kwargs = rec.calls[0]
+        self.assertEqual(task_id, "t1")
+        self.assertEqual(kwargs["outcome"], OUTCOME)
+        self.assertTrue(kwargs["release_claim"])
+        self.assertTrue(kwargs["end_run"])
+        self.assertTrue(conn.closed)
+
+    def test_the_exit_reason_is_carried_into_the_error_and_the_payload(self):
+        """An unexplained protocol_violation is what this replaces."""
+        did, rec, _ = self._record("running", reason="empty_response_exhausted")
+        _, kwargs = rec.calls[0]
+        self.assertIn("empty_response_exhausted", kwargs["error"])
+        self.assertEqual(
+            kwargs["event_payload_extra"],
+            {
+                "turn_exit_reason": "empty_response_exhausted",
+                "detector": DETECTOR,
+            },
+        )
+
+    def test_a_card_a_terminal_tool_already_moved_is_left_alone(self):
+        for status in ("done", "blocked", "ready", "todo"):
+            did, rec, conn = self._record(status)
+            self.assertFalse(did, status)
+            self.assertEqual(rec.calls, [], status)
+            self.assertTrue(conn.closed, status)
+
+    def test_the_connection_is_closed_even_when_recording_raises(self):
+        conn = ClosableConn(board([("t1", "running")]))
+
+        def boom(*a, **kw):
+            raise RuntimeError("db locked")
+
+        with self.assertRaises(RuntimeError):
+            record_missing_terminal_call(
+                task_id="t1",
+                turn_exit_reason="guardrail_halt",
+                connect=lambda: conn,
+                record_failure=boom,
+            )
+        self.assertTrue(conn.closed)
+
+    def test_the_error_text_names_the_contract_that_was_broken(self):
+        text = missing_terminal_error("guardrail_halt")
+        self.assertIn("terminal kanban call", text)
+        self.assertIn("guardrail_halt", text)
+
+
+# The applier is exercised against a miniature of the two real files. The real
+# anchors are asserted against the shipped image by verify_kanban_guardrail_exit.py.
+LOOP_STUB = '''import os
+
+logger = None
+
+def run_conversation(agent, messages):
+    _pending_verification_response = None
+    _pending_verification_response_previewed = False
+    final_response = None
+    while True:
+        if agent.tool_calls:
+            if agent._tool_guardrail_halt_decision is not None:
+                    decision = agent._tool_guardrail_halt_decision
+                    _turn_exit_reason = "guardrail_halt"
+                    final_response = agent._toolguard_controlled_halt_response(decision)
+                    agent._emit_status(
+                        f"⚠️ Tool guardrail halted {decision.tool_name}: {decision.code}"
+                    )
+                    messages.append({"role": "assistant", "content": final_response})
+                    break
+    return final_response
+'''
+
+FINALIZER_STUB = '''import os
+
+def finalize_turn(agent, messages, interrupted, failed, _turn_exit_reason):
+    logger = None
+    iteration_limit_fallback = False
+
+    # Determine if conversation completed successfully
+    return {}
+'''
+
+
+class ApplierTest(unittest.TestCase):
+    def _apply(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "agent").mkdir()
+        (root / LOOP_RELATIVE).write_text(LOOP_STUB)
+        (root / FINALIZER_RELATIVE).write_text(FINALIZER_STUB)
+        apply(root)
+        return (
+            (root / LOOP_RELATIVE).read_text(),
+            (root / FINALIZER_RELATIVE).read_text(),
+        )
+
+    def test_both_files_are_patched_and_stay_parseable(self):
+        loop, finalizer = self._apply()
+        ast.parse(loop)
+        ast.parse(finalizer)
+        self.assertIn("if _kanban_halt_nudge:", loop)
+        self.assertIn("_kanban_should_record_missing(", finalizer)
+
+    def test_the_nudge_runs_before_the_break_it_replaces(self):
+        loop, _ = self._apply()
+        self.assertLess(
+            loop.index("if _kanban_halt_nudge:"),
+            loop.index("\n                    break\n"),
+        )
+
+    def test_the_halt_decision_is_cleared_before_continuing(self):
+        """reset_for_turn clears it per turn, not per iteration."""
+        loop, _ = self._apply()
+        body = loop[loop.index("if _kanban_halt_nudge:") :]
+        self.assertLess(
+            body.index("agent._tool_guardrail_halt_decision = None"),
+            body.index("continue"),
+        )
+
+    def test_the_exit_reason_is_taken_back_off_guardrail_halt(self):
+        loop, _ = self._apply()
+        body = loop[loop.index("if _kanban_halt_nudge:") :]
+        self.assertIn('_turn_exit_reason = "unknown"', body)
+
+    def test_the_search_counter_is_never_reset(self):
+        """Resetting it would hand out another 50 searches, not fix the exit."""
+        loop, _ = self._apply()
+        self.assertNotIn("_turn_web_search_count", loop)
+
+    def test_the_backstop_runs_before_the_completed_determination(self):
+        _, finalizer = self._apply()
+        self.assertLess(
+            finalizer.index("_kanban_should_record_missing("),
+            finalizer.index("# Determine if conversation completed successfully"),
+        )
+
+    def test_a_missing_anchor_is_fatal_not_silent(self):
+        root = Path(tempfile.mkdtemp())
+        (root / "agent").mkdir()
+        (root / LOOP_RELATIVE).write_text("def run_conversation():\n    pass\n")
+        (root / FINALIZER_RELATIVE).write_text(FINALIZER_STUB)
+        with self.assertRaises(SystemExit) as ctx:
+            apply(root)
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_applying_twice_is_refused(self):
+        """Deliberately not idempotent: a second run means the anchor moved."""
+        root = Path(tempfile.mkdtemp())
+        (root / "agent").mkdir()
+        (root / LOOP_RELATIVE).write_text(LOOP_STUB)
+        (root / FINALIZER_RELATIVE).write_text(FINALIZER_STUB)
+        apply(root)
+        with self.assertRaises(SystemExit):
+            apply(root)
+
+    def test_the_anchors_are_the_ones_the_image_greps_for(self):
+        self.assertIn("_turn_exit_reason = \"guardrail_halt\"", HALT_ANCHOR)
+        self.assertIn("# Determine if conversation completed", FINALIZER_ANCHOR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_notifier.py
+++ b/deploy/docker/patches/test_kanban_notifier.py
@@ -1,0 +1,1129 @@
+"""Unit tests for the kanban notifier patch installed by deploy/docker/Dockerfile.
+
+Merges what were ``test_kanban_wake_kinds.py`` and ``test_kanban_result_delivery.py``,
+and adds :class:`LegacyEquivalenceTest`, which pins the claim the merge rests on:
+one applier with two anchors produces the same patched source as the three it
+replaced. ``test_kanban_handoff_clip.py`` stays separate — it tests the shared
+text utility, which has no anchor into upstream source.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import ast
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+
+from apply_kanban_notifier import (
+    HANDOFF_ANCHOR,
+    MARKER_CALL,
+    RELATIVE,
+    WAKE_ANCHOR,
+    apply,
+)
+from kanban_handoff_clip import DEFAULT_LIMIT, ELLIPSIS, clip_handoff
+from kanban_notifier import (
+    DEFAULT_WAKE_KINDS,
+    MAX_NOTES,
+    NOTE_SIGNATURE,
+    RESULT_LIMIT,
+    SEPARATOR,
+    _warned_config,
+    completion_note,
+    creator_session_key,
+    handoff_with_result,
+    note_suppressed_completion,
+    resolve_wake_kinds,
+    result_block,
+    suppressed_kinds,
+    wake_kinds_for,
+)
+
+# The status line the incident actually delivered, and the catalogue it should
+# have carried with it.
+INCIDENT_SUMMARY = (
+    "Successfully inspected and cataloged all 9 active platform-agent-level and "
+    "system-wide cron jobs. Compiled their detailed purposes, schedules, and "
+    "active configurations."
+)
+INCIDENT_RESULT = "\n".join(
+    f"{i}. cron-job-{i} — schedule `0 {i} * * *` — enabled" for i in range(1, 10)
+)
+
+# What agents/chat/config.yaml sets: wake the front door when a card fails,
+# never when it succeeds — the notifier has already delivered that summary.
+FAILURE_ONLY = ["gave_up", "crashed", "timed_out", "blocked"]
+
+
+class _Task:
+    def __init__(self, result=None):
+        self.result = result
+
+
+def loader(kanban=None, raises=False, not_a_dict=False):
+    """Build a load_config callable for a given kanban config subtree."""
+
+    def _load():
+        if raises:
+            raise RuntimeError("config unreadable")
+        if not_a_dict:
+            return "not a mapping"
+        return {"kanban": kanban} if kanban is not None else {}
+
+    return _load
+
+
+class Event:
+    def __init__(self, kind):
+        self.kind = kind
+
+
+# =============================================================================
+# Delivery
+# =============================================================================
+
+
+class ResultBlockTest(unittest.TestCase):
+    def test_the_incident_catalogue_is_delivered(self):
+        block = result_block(INCIDENT_SUMMARY, INCIDENT_RESULT)
+        self.assertTrue(block.startswith(SEPARATOR))
+        self.assertIn("cron-job-1", block)
+        self.assertIn("cron-job-9", block)
+        # Nothing was lost: every line of the catalogue is present.
+        for line in INCIDENT_RESULT.splitlines():
+            self.assertIn(line, block)
+
+    def test_multi_line_results_survive_whole(self):
+        # The failure the summary channel cannot avoid: it keeps only line one.
+        self.assertEqual(len(INCIDENT_RESULT.splitlines()), 9)
+        block = result_block("status", INCIDENT_RESULT)
+        self.assertEqual(len(block.strip().splitlines()), 9)
+
+    def test_an_empty_result_delivers_nothing(self):
+        for empty in (None, "", "   ", "\n\t "):
+            self.assertEqual(result_block(INCIDENT_SUMMARY, empty), "")
+
+    def test_a_result_already_in_the_status_line_is_not_repeated(self):
+        # What happens when a worker puts one body of text in both fields, and
+        # when the require-result gate promotes summary into result.
+        self.assertEqual(result_block(INCIDENT_SUMMARY, INCIDENT_SUMMARY), "")
+
+    def test_dedup_ignores_whitespace_and_case(self):
+        delivered = "Restarted the deployment; 3/3 pods ready"
+        self.assertEqual(result_block(delivered, "restarted  the\ndeployment;   3/3 PODS ready"), "")
+
+    def test_a_longer_result_is_delivered_even_if_it_starts_the_same(self):
+        delivered = "Found 9 jobs."
+        block = result_block(delivered, "Found 9 jobs.\n\n" + INCIDENT_RESULT)
+        self.assertIn("cron-job-5", block)
+
+    def test_no_status_line_still_delivers(self):
+        for delivered in (None, ""):
+            self.assertIn("cron-job-1", result_block(delivered, INCIDENT_RESULT))
+
+    def test_a_runaway_result_is_clipped_and_says_so(self):
+        huge = " ".join(f"token{i}" for i in range(20000))
+        self.assertGreater(len(huge), RESULT_LIMIT)
+        block = result_block("status", huge)
+        self.assertIn("clipped", block.lower())
+        self.assertIn(str(RESULT_LIMIT), block)
+
+    def test_a_result_at_the_limit_is_not_marked_clipped(self):
+        body = "x" * 100
+        block = result_block("status", body)
+        self.assertNotIn("clipped", block.lower())
+        self.assertEqual(block, SEPARATOR + body)
+
+    def test_clipping_never_severs_a_url(self):
+        url = "https://github.com/gke-agentic/adamparco-infra/issues/30"
+        body = " ".join(f"token{i}" for i in range(20000)) + " " + url
+        block = result_block("status", body, limit=200)
+        # Either the whole link or none of it — never a prefix that 404s.
+        self.assertNotIn("https://github.com/gke-agentic/adamparco-infra/is\n", block)
+        self.assertEqual(clip_handoff(body, 200), block[len(SEPARATOR):].split("\n\n[")[0])
+
+    def test_the_budget_leaves_room_under_the_slack_ceiling(self):
+        # Slack's adapter chunks at MAX_MESSAGE_LENGTH = 39000. The status line
+        # (<=1200), the title (<=120), and the clip marker must all fit too.
+        self.assertLess(RESULT_LIMIT + 1200 + 120 + len("[Result clipped at 30000 characters]"), 39000)
+
+
+def notifier_tail(payload_summary, task):
+    """Build the completion message's tail the way the patched notifier does.
+
+    The three lines before the call are copied from the ``completed`` branch of
+    ``gateway/kanban_watchers.py`` — see UPSTREAM_WATCHERS below, which carries
+    the same code at its real indentation. They matter to these tests because
+    the ``elif`` is where ``handoff`` becomes a clip of the very field this
+    module delivers, and testing ``handoff_with_result`` on a status line
+    invented by the test would miss that entirely.
+    """
+    handoff = ""
+    if payload_summary:
+        handoff = f"\n{clip_handoff(payload_summary)}"
+    elif task and task.result:
+        handoff = f"\n{clip_handoff(task.result)}"
+    return handoff_with_result(handoff, task)
+
+
+def report_of_length(length):
+    """A plausible multi-line report of exactly ``length`` characters.
+
+    Real text with whitespace in it, because ``clip_handoff`` cuts on a token
+    boundary: a run of one repeated character would take the no-whitespace
+    branch and clip somewhere these tests do not mean to exercise.
+    """
+    lines = []
+    while len("\n".join(lines)) < length:
+        i = len(lines) + 1
+        lines.append(f"{i}. cron-job-{i} — schedule `0 {i} * * *` — enabled")
+    body = "\n".join(lines)[:length]
+    # An exact cut can land on the newline between two lines, and ``result``
+    # is stripped before it is measured, which would put the body one short of
+    # the boundary the test is aiming at.
+    return body[:-1] + "." if body[-1].isspace() else body
+
+
+class HandoffWithResultTest(unittest.TestCase):
+    def test_a_missing_task_row_leaves_the_status_line_alone(self):
+        self.assertEqual(handoff_with_result("\nstatus", None), "\nstatus")
+
+    def test_a_task_without_a_result_attribute_leaves_the_status_line_alone(self):
+        self.assertEqual(handoff_with_result("\nstatus", object()), "\nstatus")
+
+    def test_a_raising_task_row_cannot_wedge_the_notifier(self):
+        class Exploding:
+            @property
+            def result(self):
+                raise RuntimeError("boom")
+
+        self.assertEqual(handoff_with_result("\nstatus", Exploding()), "\nstatus")
+
+    def test_an_absent_handoff_still_delivers_the_report(self):
+        for delivered in (None, ""):
+            self.assertIn("cron-job-1", handoff_with_result(delivered, _Task(INCIDENT_RESULT)))
+
+    def test_the_summary_branch_keeps_the_status_line_and_adds_the_report(self):
+        tail = notifier_tail(INCIDENT_SUMMARY, _Task(INCIDENT_RESULT))
+        self.assertIn(INCIDENT_SUMMARY, tail)
+        self.assertEqual(tail.count(INCIDENT_RESULT), 1)
+
+
+class ClipBoundaryTest(unittest.TestCase):
+    """The lengths at which the duplicate-delivery bug switched on.
+
+    Under ``DEFAULT_LIMIT`` the notifier's status line is the whole report, the
+    containment test in :func:`result_block` sees it, and nothing is appended.
+    Over ``DEFAULT_LIMIT`` the status line is a clipped prefix — the report can
+    no longer be found inside it, so the old ``handoff +=`` wiring sent the
+    opening of the report and then the report. A 60-line cron catalogue arrived
+    with jobs 1 to 19 printed twice.
+    """
+
+    LENGTHS = (DEFAULT_LIMIT - 1, DEFAULT_LIMIT, DEFAULT_LIMIT * 4)
+
+    def assert_delivered_once(self, tail, body):
+        opening = body.splitlines()[0]
+        self.assertEqual(tail.count(body), 1, "the report itself is duplicated")
+        self.assertEqual(
+            tail.count(opening),
+            1,
+            "the report's opening lines are duplicated by the clipped status line",
+        )
+
+    def test_the_no_summary_branch_delivers_the_report_exactly_once(self):
+        for length in self.LENGTHS:
+            with self.subTest(length=length):
+                body = report_of_length(length)
+                self.assertEqual(len(body), length)
+                self.assert_delivered_once(notifier_tail(None, _Task(body)), body)
+
+    def test_the_no_summary_branch_drops_the_clip_marker_it_no_longer_needs(self):
+        # Over budget the status line is discarded outright, so the reader
+        # never sees a "[…]" promising more above text that is already whole.
+        body = report_of_length(DEFAULT_LIMIT * 4)
+        self.assertIn(ELLIPSIS, clip_handoff(body))
+        self.assertNotIn(ELLIPSIS, notifier_tail(None, _Task(body)))
+
+    def test_the_summary_branch_delivers_the_report_exactly_once(self):
+        for length in self.LENGTHS:
+            with self.subTest(length=length):
+                body = report_of_length(length)
+                tail = notifier_tail(INCIDENT_SUMMARY, _Task(body))
+                self.assertIn(INCIDENT_SUMMARY, tail)
+                self.assert_delivered_once(tail, body)
+
+    def test_a_status_line_that_is_not_the_report_is_never_dropped(self):
+        # The distinction the fix turns on: a clipped prefix of the report is
+        # redundant, a summary that happens to be long is not.
+        summary = report_of_length(DEFAULT_LIMIT * 2).replace("cron-job", "audit-step")
+        body = report_of_length(DEFAULT_LIMIT * 4)
+        tail = notifier_tail(summary, _Task(body))
+        self.assertIn("audit-step-1 ", tail)
+        self.assert_delivered_once(tail, body)
+
+
+# =============================================================================
+# The wake decision
+# =============================================================================
+
+
+class ResolveWakeKindsTest(unittest.TestCase):
+    def setUp(self):
+        # The degraded-read warnings are one-shot per process; without this
+        # the first test to trip one hides it from every test after it.
+        _warned_config.clear()
+
+    def test_unset_key_keeps_upstream_behaviour(self):
+        self.assertEqual(resolve_wake_kinds(loader({})), DEFAULT_WAKE_KINDS)
+        self.assertEqual(resolve_wake_kinds(loader()), DEFAULT_WAKE_KINDS)
+
+    def test_failure_only_config_drops_completed(self):
+        kinds = resolve_wake_kinds(loader({"wake_on_events": FAILURE_ONLY}))
+        self.assertNotIn("completed", kinds)
+        self.assertEqual(set(kinds), set(FAILURE_ONLY))
+
+    def test_explicit_empty_list_disables_the_wake(self):
+        self.assertEqual(resolve_wake_kinds(loader({"wake_on_events": []})), ())
+
+    def test_null_value_disables_the_wake(self):
+        # `wake_on_events:` with nothing after it parses as None. Read that as
+        # the override the user was clearly attempting, not as "unset".
+        self.assertEqual(resolve_wake_kinds(loader({"wake_on_events": None})), ())
+
+    def test_a_bare_string_is_accepted_as_one_kind(self):
+        self.assertEqual(resolve_wake_kinds(loader({"wake_on_events": "crashed"})), ("crashed",))
+
+    def test_unknown_kinds_are_dropped_and_logged(self):
+        cfg = loader({"wake_on_events": ["crashed", "compleeted", "done"]})
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            kinds = resolve_wake_kinds(cfg)
+        self.assertEqual(kinds, ("crashed",))
+        # The typo has to be visible: an unknown kind never matches a real
+        # event, so silently dropping it looks like the wake breaking on its own.
+        self.assertIn("compleeted", "\n".join(captured.output))
+
+    def test_duplicates_collapse_and_order_is_preserved(self):
+        kinds = resolve_wake_kinds(loader({"wake_on_events": ["blocked", "crashed", "blocked"]}))
+        self.assertEqual(kinds, ("blocked", "crashed"))
+
+    def test_wrong_shape_falls_back_to_the_default(self):
+        with self.assertLogs("gateway.run", level=logging.WARNING):
+            kinds = resolve_wake_kinds(loader({"wake_on_events": {"crashed": True}}))
+        self.assertEqual(kinds, DEFAULT_WAKE_KINDS)
+
+    def test_an_unreadable_config_still_wakes_on_failures(self):
+        # Failing closed here would mean a crashed card silently never
+        # escalating, which is worse than an extra turn on a healthy one.
+        with self.assertLogs("gateway.run", level=logging.WARNING):
+            self.assertEqual(resolve_wake_kinds(loader(raises=True)), DEFAULT_WAKE_KINDS)
+        _warned_config.clear()
+        with self.assertLogs("gateway.run", level=logging.WARNING):
+            self.assertEqual(resolve_wake_kinds(loader(not_a_dict=True)), DEFAULT_WAKE_KINDS)
+
+    def test_a_degraded_read_says_so_instead_of_looking_like_an_unset_key(self):
+        # The failure this catches is silence, not breakage: falling back to
+        # DEFAULT_WAKE_KINDS is byte-for-byte what an operator who never set
+        # the key gets, so an unreadable config would present as "the narrowing
+        # was never configured" while the redundant turn quietly came back.
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            resolve_wake_kinds(loader(raises=True))
+        joined = "\n".join(captured.output)
+        self.assertIn("config unreadable", joined, "the cause must survive")
+        self.assertIn("wake_on_events", joined, "the affected key must be named")
+
+    def test_the_degraded_read_warning_does_not_repeat_every_delivery(self):
+        # The notifier polls every 5s per subscription; an unconditional
+        # warning here would be the loudest line in the gateway log.
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            for _ in range(20):
+                resolve_wake_kinds(loader(raises=True))
+        self.assertEqual(len(captured.output), 1)
+
+    def test_an_unset_key_is_not_a_warning(self):
+        # The overwhelmingly common case. Warning on it would train operators
+        # to ignore the line that matters.
+        logging.getLogger("gateway.run").warning("probe")
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            logging.getLogger("gateway.run").warning("probe")
+            resolve_wake_kinds(loader({}))
+        self.assertEqual(len(captured.output), 1)
+
+    def test_default_set_matches_the_upstream_tuple(self):
+        # If a base-image bump adds a terminal kind, this test is the reminder
+        # to decide whether the front door should wake for it.
+        self.assertEqual(
+            DEFAULT_WAKE_KINDS,
+            ("completed", "gave_up", "crashed", "timed_out", "blocked"),
+        )
+
+
+class WakeKindsForTest(unittest.TestCase):
+    def test_matches_the_upstream_expression_by_default(self):
+        events = [Event("completed"), Event("commented"), Event("crashed")]
+        self.assertEqual(
+            wake_kinds_for(events, loader({})),
+            {"completed", "crashed"},
+        )
+
+    def test_completion_alone_produces_no_wake_under_failure_only(self):
+        events = [Event("completed"), Event("commented")]
+        self.assertEqual(wake_kinds_for(events, loader({"wake_on_events": FAILURE_ONLY})), set())
+
+    def test_a_failure_in_the_same_batch_still_wakes(self):
+        events = [Event("completed"), Event("timed_out")]
+        self.assertEqual(
+            wake_kinds_for(events, loader({"wake_on_events": FAILURE_ONLY})),
+            {"timed_out"},
+        )
+
+    def test_events_without_a_kind_are_ignored(self):
+        self.assertEqual(wake_kinds_for([object()], loader({})), set())
+
+
+class Adapter:
+    def __init__(self, supports_async_delivery):
+        self.supports_async_delivery = supports_async_delivery
+
+
+class NonPushAdapterTest(unittest.TestCase):
+    """The narrowing applies to the push path only.
+
+    Where the notifier skips its own ``send()`` it says the wake self-post IS
+    the delivery, so a narrowed set there loses the result instead of saving a
+    turn.
+    """
+
+    def test_a_non_push_adapter_still_wakes_on_completion(self):
+        events = [Event("completed")]
+        cfg = loader({"wake_on_events": FAILURE_ONLY})
+        self.assertEqual(wake_kinds_for(events, cfg, adapter=Adapter(False)), {"completed"})
+
+    def test_a_push_adapter_still_honours_the_narrowed_set(self):
+        events = [Event("completed")]
+        cfg = loader({"wake_on_events": FAILURE_ONLY})
+        self.assertEqual(wake_kinds_for(events, cfg, adapter=Adapter(True)), set())
+
+    def test_an_adapter_that_does_not_declare_the_flag_counts_as_push(self):
+        # gateway.wake.adapter_supports_push defaults a missing attribute to
+        # True; reading it as non-push would restore the redundant turn on
+        # every Slack and Google Chat card.
+        events = [Event("completed")]
+        cfg = loader({"wake_on_events": FAILURE_ONLY})
+        self.assertEqual(wake_kinds_for(events, cfg, adapter=object()), set())
+
+    def test_an_explicit_empty_list_does_not_silence_the_non_push_path(self):
+        # `wake_on_events: []` means "do not re-read an answer already
+        # delivered". Nothing was delivered here, so there is no such answer.
+        events = [Event("completed")]
+        self.assertEqual(
+            wake_kinds_for(events, loader({"wake_on_events": []}), adapter=Adapter(False)),
+            {"completed"},
+        )
+        self.assertEqual(
+            wake_kinds_for(events, loader({"wake_on_events": []}), adapter=Adapter(True)),
+            set(),
+        )
+
+    def test_omitting_the_adapter_leaves_the_config_in_charge(self):
+        # The notifier always passes it; the default keeps every other caller
+        # (and the pre-existing tests above) on the documented config path.
+        events = [Event("completed")]
+        cfg = loader({"wake_on_events": FAILURE_ONLY})
+        self.assertEqual(wake_kinds_for(events, cfg), set())
+
+
+# =============================================================================
+# Recording a suppressed completion
+# =============================================================================
+#
+# The incident these cover: task t_a8f58a2a completed at 19:09:43 and its
+# 6,191-character report reached the Slack thread at 19:09:44, but because the
+# wake was suppressed nothing entered the creator's transcript. At 19:11:30 the
+# front door — whose context still ended at ``subscribed: true`` — told the user
+# "You'll see the results post here as soon as the agent completes". The answer
+# had been on screen for 106 seconds. Nine and three-quarter minutes later it
+# finally called kanban_show.
+
+
+class _Conversation:
+    def __init__(self):
+        self.sidecar_notes = []
+
+
+class _State:
+    def __init__(self):
+        self.conversation = _Conversation()
+
+
+class _Entry:
+    def __init__(self, session_key):
+        self.session_key = session_key
+
+
+class _Store:
+    """Stands in for ``gateway.session.SessionStore``.
+
+    Only the id→key mapping matters here. ``verify_kanban_notifier.py`` drives
+    the real store, the real ``SessionEntry`` and the real
+    ``lookup_by_session_id`` inside the image.
+    """
+
+    def __init__(self, mapping=None, raises=False):
+        self.mapping = mapping if mapping is not None else {"sid-1": "key-1"}
+        self.raises = raises
+
+    def lookup_by_session_id(self, session_id):
+        if self.raises:
+            raise RuntimeError("session store unavailable")
+        if session_id not in self.mapping:
+            return None
+        return _Entry(self.mapping[session_id])
+
+
+class _OldStore(_Store):
+    """A session store predating ``lookup_by_session_id``."""
+
+    lookup_by_session_id = None
+
+
+class _Runner:
+    """The four ``GatewayRunner`` members this module touches.
+
+    The three sidecar-note methods are transcribed from ``gateway/run.py``
+    (``_set_pending_turn_sidecar_notes`` / ``_consume_pending_turn_sidecar_notes``
+    / ``_peek_session_state``) — including the setter's early-out on an empty
+    list, which is why ``stage_note`` never hands it one.
+    """
+
+    def __init__(self, store=None):
+        self.session_store = store if store is not None else _Store()
+        self._sessions = {}
+
+    def _peek_session_state(self, session_key):
+        return self._sessions.get(session_key)
+
+    def _set_pending_turn_sidecar_notes(self, session_key, notes):
+        if not session_key or not notes:
+            return
+        self._sessions.setdefault(session_key, _State()).conversation.sidecar_notes = list(notes)
+
+    def _consume_pending_turn_sidecar_notes(self, session_key):
+        state = self._sessions.get(session_key)
+        if state is None:
+            return []
+        staged = state.conversation.sidecar_notes
+        state.conversation.sidecar_notes = []
+        return list(staged)
+
+
+class _Card:
+    def __init__(
+        self,
+        session_id="sid-1",
+        title="List configured cron jobs",
+        status="done",
+        card_id="t_a8f58a2a",
+    ):
+        self.session_id = session_id
+        self.title = title
+        self.status = status
+        self.id = card_id
+
+
+def sub_for(task_id="t_a8f58a2a"):
+    return {"task_id": task_id, "chat_id": "D0BKGRBM6RH"}
+
+
+# 2026-08-08 19:09:44 UTC — the moment the report reached the thread.
+COMPLETED_AT = 1786216184.0
+
+#: Distinguishes "the caller passed no task" from "the caller passed None",
+#: which is a case the notifier has to survive and a default cannot express.
+UNSET = object()
+
+
+class SuppressedKindsTest(unittest.TestCase):
+    def test_a_dropped_completion_is_suppressed(self):
+        events = [Event("completed"), Event("commented")]
+        self.assertEqual(suppressed_kinds(events, set()), {"completed"})
+
+    def test_a_kind_that_still_wakes_is_not_suppressed(self):
+        # The wake enters the transcript itself, so it needs no marker.
+        events = [Event("completed"), Event("crashed")]
+        self.assertEqual(suppressed_kinds(events, {"crashed"}), {"completed"})
+        self.assertEqual(suppressed_kinds(events, {"completed", "crashed"}), set())
+
+    def test_upstream_behaviour_suppresses_nothing(self):
+        events = [Event("completed"), Event("crashed")]
+        woken = wake_kinds_for(events, loader({}))
+        self.assertEqual(suppressed_kinds(events, woken), set())
+
+    def test_non_terminal_kinds_are_never_suppressed(self):
+        # archived/unblocked are silent by design upstream, not dropped by us.
+        for kind in ("commented", "archived", "unblocked", "status"):
+            self.assertEqual(suppressed_kinds([Event(kind)], set()), set())
+
+    def test_the_failure_only_config_suppresses_exactly_completion(self):
+        events = [Event("completed"), Event("timed_out")]
+        woken = wake_kinds_for(events, loader({"wake_on_events": FAILURE_ONLY}))
+        self.assertEqual(suppressed_kinds(events, woken), {"completed"})
+
+    def test_junk_inputs_do_not_raise(self):
+        self.assertEqual(suppressed_kinds([], None), set())
+        self.assertEqual(suppressed_kinds(None, set()), set())
+        self.assertEqual(suppressed_kinds([object()], set()), set())
+
+
+class CompletionNoteTest(unittest.TestCase):
+    def note(self, **kw):
+        kw.setdefault("kinds", {"completed"})
+        kw.setdefault("now", COMPLETED_AT)
+        return completion_note(kw.pop("task_id", "t_a8f58a2a"), **kw)
+
+    def test_it_names_the_card_and_the_outcome(self):
+        note = self.note(title="List configured cron jobs", status="done")
+        self.assertIn("t_a8f58a2a", note)
+        self.assertIn("List configured cron jobs", note)
+        self.assertIn("completed", note)
+        self.assertIn("done", note)
+
+    def test_it_carries_the_time_the_card_finished(self):
+        # The gap is the whole complaint: the user waited 9m46s for an answer
+        # that was already on screen. A bare "it finished" leaves the agent
+        # unable to say how stale its own silence was.
+        self.assertIn("2026-08-08 19:09:44 UTC", self.note())
+
+    def test_it_contradicts_the_still_running_guess_explicitly(self):
+        # The front door's context ends at `subscribed: true`, so absent a
+        # statement to the contrary its default inference is "still running" —
+        # which is exactly what it told the user at 19:11:30.
+        self.assertIn("NOT still running", self.note())
+
+    def test_it_says_the_result_was_already_delivered(self):
+        # Otherwise the marker's own fix is to re-post a 6,191-character report
+        # the user is already looking at.
+        self.assertIn("already delivered", self.note())
+
+    def test_it_explains_why_the_transcript_has_no_record(self):
+        # Without this the agent sees a note contradicted by its own history
+        # and has no way to tell which to believe.
+        self.assertIn("appears earlier in this transcript", self.note())
+
+    def test_it_points_at_the_tool_that_returns_the_content(self):
+        self.assertIn("kanban_show", self.note())
+
+    def test_a_non_default_board_is_named_so_the_lookup_can_succeed(self):
+        self.assertIn("(board infra)", self.note(board="infra"))
+        self.assertNotIn("board", self.note(board=""))
+
+    def test_every_note_starts_with_the_signature(self):
+        for kw in ({}, {"title": ""}, {"status": ""}, {"task_id": ""}):
+            self.assertTrue(self.note(**kw).startswith(NOTE_SIGNATURE))
+
+    def test_a_runaway_title_is_clipped_on_a_token_boundary(self):
+        # Titles are user-supplied and land in a note that rides the next user
+        # message, so an unbounded one is charged to the creator's next turn.
+        url = "https://github.com/gke-agentic/adamparco-infra/issues/30"
+        note = self.note(title="word " * 400 + url)
+        self.assertLess(len(note), 900)
+        # Same contract as the status line: a severed link is a dead link, so
+        # the URL is dropped whole rather than cut.
+        self.assertIn(ELLIPSIS + '")', note)
+        self.assertNotIn("github.com", note)
+
+    def test_a_missing_title_is_omitted_rather_than_rendered_empty(self):
+        self.assertNotIn('("")', self.note(title=""))
+        self.assertNotIn('("None")', self.note(title=None))
+
+    def test_multiple_suppressed_kinds_are_listed_deterministically(self):
+        note = self.note(kinds={"timed_out", "completed"})
+        self.assertIn("completed, timed_out", note)
+
+
+class NoteSuppressedCompletionTest(unittest.TestCase):
+    def setUp(self):
+        _warned_config.clear()
+        self.runner = _Runner()
+
+    def record(self, runner=None, events=None, woken=None, task=UNSET, **kw):
+        return note_suppressed_completion(
+            runner if runner is not None else self.runner,
+            events if events is not None else [Event("completed")],
+            woken if woken is not None else set(),
+            _Card() if task is UNSET else task,
+            kw.pop("sub", None) or sub_for(),
+            kw.pop("board", ""),
+            now=kw.pop("now", COMPLETED_AT),
+        )
+
+    # -- the incident ------------------------------------------------------
+
+    def test_the_creators_next_turn_learns_the_card_finished(self):
+        self.assertTrue(self.record())
+        notes = self.runner._consume_pending_turn_sidecar_notes("key-1")
+        self.assertEqual(len(notes), 1)
+        self.assertIn("t_a8f58a2a", notes[0])
+        self.assertIn("NOT still running", notes[0])
+
+    def test_the_marker_is_one_shot(self):
+        # A note replayed on every later turn would be worse than no note: the
+        # front door would keep announcing a card it already reported.
+        self.record()
+        self.assertTrue(self.runner._consume_pending_turn_sidecar_notes("key-1"))
+        self.assertEqual(self.runner._consume_pending_turn_sidecar_notes("key-1"), [])
+
+    def test_the_marker_lands_on_the_key_not_the_session_id(self):
+        # task.session_id is the persisted id; per-turn state is keyed by the
+        # session key. Writing to the id would be a silent no-op forever.
+        self.record()
+        self.assertIn("key-1", self.runner._sessions)
+        self.assertNotIn("sid-1", self.runner._sessions)
+
+    def test_nothing_is_recorded_when_the_wake_still_fires(self):
+        self.assertFalse(self.record(woken={"completed"}))
+        self.assertEqual(self.runner._sessions, {})
+
+    def test_an_unconfigured_gateway_records_nothing_at_all(self):
+        # kanban.wake_on_events unset ⇒ upstream wake set ⇒ nothing suppressed.
+        events = [Event("completed"), Event("crashed")]
+        self.assertFalse(self.record(events=events, woken=wake_kinds_for(events, loader({}))))
+        self.assertEqual(self.runner._sessions, {})
+
+    def test_a_failure_only_gateway_records_the_completion(self):
+        events = [Event("completed")]
+        woken = wake_kinds_for(events, loader({"wake_on_events": FAILURE_ONLY}))
+        self.assertTrue(self.record(events=events, woken=woken))
+
+    # -- independence from the subscription --------------------------------
+
+    def test_the_marker_survives_the_subscription_being_deleted(self):
+        # On a terminal event the notifier calls _kanban_unsub moments later
+        # and the row is gone. The note is gateway session state and never
+        # referred to the row, so deleting it changes nothing.
+        sub = sub_for()
+        self.record(sub=sub)
+        sub.clear()  # what _kanban_unsub amounts to, from the note's point of view
+        notes = self.runner._consume_pending_turn_sidecar_notes("key-1")
+        self.assertIn("t_a8f58a2a", notes[0])
+
+    # -- sharing the list with upstream ------------------------------------
+
+    def test_upstreams_own_notes_are_not_clobbered(self):
+        # _set_pending_turn_sidecar_notes assigns the whole list. The auto-reset
+        # notice tells the agent its history is gone; losing it to a kanban
+        # marker would be a strictly worse bug than the one being fixed.
+        reset = "[System note: The user's previous session expired due to inactivity...]"
+        self.runner._set_pending_turn_sidecar_notes("key-1", [reset])
+        self.record()
+        notes = self.runner._consume_pending_turn_sidecar_notes("key-1")
+        self.assertIn(reset, notes)
+        self.assertEqual(len(notes), 2)
+
+    def test_the_same_card_is_never_recorded_twice(self):
+        self.assertTrue(self.record())
+        self.assertFalse(self.record())
+        self.assertEqual(len(self.runner._consume_pending_turn_sidecar_notes("key-1")), 1)
+
+    def test_a_card_id_that_prefixes_another_is_still_recorded(self):
+        # Dedupe matches on the id plus a trailing space. Without the space,
+        # t_a8 finishing first would silence t_a8f58a2a.
+        self.assertTrue(self.record(sub=sub_for("t_a8")))
+        self.assertTrue(self.record(sub=sub_for("t_a8f58a2a")))
+        notes = self.runner._consume_pending_turn_sidecar_notes("key-1")
+        self.assertEqual(len(notes), 2)
+
+    def test_our_notes_are_capped_and_upstreams_are_not_evicted(self):
+        reset = "[System note: The user's previous session expired...]"
+        self.runner._set_pending_turn_sidecar_notes("key-1", [reset])
+        for i in range(MAX_NOTES + 4):
+            self.record(sub=sub_for(f"t_{i}"))
+        notes = self.runner._consume_pending_turn_sidecar_notes("key-1")
+        self.assertIn(reset, notes)
+        self.assertEqual(len(notes), MAX_NOTES + 1)
+        # The most recent completions are the ones kept.
+        self.assertTrue(any(f"t_{MAX_NOTES + 3} " in n for n in notes))
+        self.assertFalse(any("t_0 " in n for n in notes))
+
+    # -- fail-soft ---------------------------------------------------------
+
+    def test_a_card_with_no_creator_session_records_nothing(self):
+        # Cron and CLI cards have no gateway session to tell.
+        self.assertFalse(self.record(task=_Card(session_id=None)))
+        self.assertEqual(self.runner._sessions, {})
+
+    def test_a_rotated_or_unknown_session_records_nothing(self):
+        self.assertFalse(self.record(task=_Card(session_id="sid-gone")))
+        self.assertEqual(self.runner._sessions, {})
+
+    def test_a_raising_session_store_does_not_break_delivery(self):
+        runner = _Runner(_Store(raises=True))
+        with self.assertLogs("gateway.run", level=logging.WARNING):
+            self.assertFalse(self.record(runner=runner))
+
+    def test_a_store_without_the_lookup_says_so_once(self):
+        runner = _Runner(_OldStore())
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            for _ in range(20):
+                self.record(runner=runner)
+        # The notifier polls every 5s; a per-delivery warning would be the
+        # loudest line in the log.
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("lookup_by_session_id", "\n".join(captured.output))
+
+    def test_a_runner_without_the_sidecar_channel_says_so_once(self):
+        class _Bare(_Runner):
+            _set_pending_turn_sidecar_notes = None
+
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            for _ in range(20):
+                self.record(runner=_Bare())
+        self.assertEqual(len(captured.output), 1)
+        self.assertIn("_set_pending_turn_sidecar_notes", "\n".join(captured.output))
+
+    def test_a_missing_task_row_does_not_raise(self):
+        self.assertFalse(self.record(task=None))
+
+    def test_an_exploding_task_row_does_not_raise(self):
+        class Exploding:
+            @property
+            def session_id(self):
+                raise RuntimeError("boom")
+
+        with self.assertLogs("gateway.run", level=logging.WARNING) as captured:
+            self.assertFalse(self.record(task=Exploding()))
+        # The card id has to survive into the warning or the line is unactionable.
+        self.assertIn("t_a8f58a2a", "\n".join(captured.output))
+
+    def test_a_successful_record_is_logged_at_info(self):
+        # On a narrowed gateway this is the only evidence the creator was told
+        # anything; at debug it would be invisible in production.
+        with self.assertLogs("gateway.run", level=logging.INFO) as captured:
+            self.record()
+        joined = "\n".join(captured.output)
+        self.assertIn("t_a8f58a2a", joined)
+        self.assertIn("key-1", joined)
+
+
+class CreatorSessionKeyTest(unittest.TestCase):
+    def setUp(self):
+        _warned_config.clear()
+
+    def test_it_resolves_the_key_behind_the_persisted_id(self):
+        runner = _Runner(_Store({"sid-1": "agent:main:slack:dm:T0:D0:1786216044.637229"}))
+        self.assertEqual(
+            creator_session_key(runner, _Card()),
+            "agent:main:slack:dm:T0:D0:1786216044.637229",
+        )
+
+    def test_an_entry_without_a_key_resolves_to_nothing(self):
+        runner = _Runner(_Store({"sid-1": ""}))
+        self.assertEqual(creator_session_key(runner, _Card()), "")
+
+    def test_a_blank_session_id_is_debug_not_a_warning(self):
+        # Cron and CLI cards are the common case, not a fault; warning here
+        # would put a line in the log every five seconds on a busy board.
+        with self.assertLogs("gateway.run", level=logging.DEBUG) as captured:
+            self.assertEqual(creator_session_key(_Runner(), _Card(session_id="")), "")
+        self.assertEqual([r.levelno for r in captured.records], [logging.DEBUG])
+
+    def test_an_unresolvable_session_id_is_debug_not_a_warning(self):
+        with self.assertLogs("gateway.run", level=logging.DEBUG) as captured:
+            self.assertEqual(creator_session_key(_Runner(), _Card(session_id="sid-gone")), "")
+        self.assertEqual([r.levelno for r in captured.records], [logging.DEBUG])
+
+
+# =============================================================================
+# The applier
+# =============================================================================
+
+# The notifier loop reduced to the lines the patch rewrites, kept at its real
+# nesting depth because both anchors are indentation-sensitive. The `msg = (`
+# block below carries no anchor any more — it is here because the hook has to
+# land between the clip and it, and that ordering is the whole contract.
+UPSTREAM_WATCHERS = '''\
+class GatewayKanbanWatchers:
+    async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
+        while self._running:
+            try:
+                for d in deliveries:
+                    for ev in d["events"]:
+                        kind = ev.kind
+                        if kind == "completed":
+                            handoff = ""
+                            payload_summary = None
+                            if ev.payload and ev.payload.get("summary"):
+                                payload_summary = str(ev.payload["summary"])
+                            if payload_summary:
+                                lines = payload_summary.strip().splitlines()
+                                h = lines[0][:200] if lines else payload_summary[:200]
+                                handoff = f"\\n{h}"
+                            elif task and task.result:
+                                lines = task.result.strip().splitlines()
+                                r = lines[0][:160] if lines else task.result[:160]
+                                handoff = f"\\n{r}"
+                            msg = (
+                                f"✔ {board_tag}{tag}Kanban {sub['task_id']} done"
+                                f" — {title}{handoff}"
+                            )
+                        elif kind == "blocked":
+                            msg = "blocked"
+                        await adapter.send(sub["chat_id"], msg)
+                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
+                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        if "completed" in _wake_kinds:
+                            pass
+            except Exception:
+                pass
+'''
+
+
+def patch_tree(source):
+    """Write ``source`` as gateway/kanban_watchers.py under a temp root and patch it."""
+    root = Path(tempfile.mkdtemp())
+    target = root / RELATIVE
+    target.parent.mkdir(parents=True)
+    target.write_text(source)
+    apply(root)
+    return target.read_text()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_both_anchors_match_upstream_exactly_once(self):
+        self.assertEqual(UPSTREAM_WATCHERS.count(HANDOFF_ANCHOR), 1)
+        self.assertEqual(UPSTREAM_WATCHERS.count(WAKE_ANCHOR), 1)
+
+    def test_the_message_block_is_no_longer_an_anchor(self):
+        # The reduction the merge buys. The old delivery applier had to match
+        # the `msg = (` f-strings — three lines of nested quotes and unicode —
+        # purely to find an insertion point after clip lines another patch
+        # owned. Owning both, this applier appends the hook to its own
+        # replacement instead, so upstream can reword that message freely.
+        self.assertNotIn("msg = (", HANDOFF_ANCHOR + WAKE_ANCHOR)
+
+    def test_both_of_upstreams_hard_slices_are_replaced(self):
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        self.assertIn("h = _clip_handoff(payload_summary)", patched)
+        self.assertIn("r = _clip_handoff(task.result)", patched)
+        self.assertNotIn("lines[0][:200]", patched)
+        self.assertNotIn("lines[0][:160]", patched)
+
+    def test_the_hardcoded_tuple_is_replaced_by_the_helper(self):
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        # `adapter=adapter` is part of the assertion: the notifier must hand the
+        # helper the adapter, or the non-push carve-out above never engages.
+        self.assertIn('_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)', patched)
+        self.assertNotIn("_WAKE_KINDS = (", patched)
+        self.assertNotIn("in _WAKE_KINDS}", patched)
+
+    def test_the_hook_lands_after_the_clip_and_before_the_message(self):
+        # Ordering is the whole contract: the hook has to see the handoff the
+        # clip produced in order to decide the clip was redundant, and the
+        # message has to be built from what the hook returned.
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        clip = patched.rindex("r = _clip_handoff(task.result)")
+        hook = patched.index("handoff = _kanban_handoff_with_result(handoff, task)")
+        message = patched.index("msg = (")
+        self.assertTrue(clip < hook < message)
+
+    def test_the_hook_replaces_the_handoff_rather_than_appending_to_it(self):
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        self.assertNotIn("handoff +=", patched)
+
+    def test_one_import_trailer_carries_all_three_names(self):
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        self.assertIn("from gateway.kanban_notifier import", patched)
+        for name in (
+            "clip_handoff as _clip_handoff",
+            "handoff_with_result as _kanban_handoff_with_result",
+            "wake_kinds_for as _wake_kinds_for",
+        ):
+            self.assertIn(name, patched)
+        # Three trailers became one; a second would mean a duplicated build step.
+        self.assertEqual(patched.count("from gateway.kanban_notifier import"), 1)
+
+    def test_the_patched_module_still_parses(self):
+        ast.parse(patch_tree(UPSTREAM_WATCHERS))
+
+    def test_a_drifted_handoff_anchor_fails_loudly(self):
+        drifted = UPSTREAM_WATCHERS.replace("lines[0][:200]", "lines[0][:220]")
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(drifted)
+        self.assertIn("found 0", str(ctx.exception))
+        self.assertIn("completion handoff", str(ctx.exception))
+
+    def test_a_drifted_wake_anchor_fails_loudly(self):
+        # Names the failing anchor: with two edits in one applier, "found 0" on
+        # its own would not say which half of the notifier moved.
+        drifted = UPSTREAM_WATCHERS.replace('"blocked")', '"blocked", "abandoned")')
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(drifted)
+        self.assertIn("found 0", str(ctx.exception))
+        self.assertIn("wake set", str(ctx.exception))
+
+    def test_a_drifted_second_anchor_leaves_the_file_untouched(self):
+        # The applier edits a string and writes once at the end, so a failure
+        # on the second anchor must not leave the first edit on disk.
+        drifted = UPSTREAM_WATCHERS.replace('"blocked")', '"blocked", "abandoned")')
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        target.write_text(drifted)
+        with self.assertRaises(SystemExit):
+            apply(root)
+        self.assertEqual(target.read_text(), drifted)
+
+    def test_applying_twice_fails_rather_than_silently_no_opping(self):
+        # Both anchors are destroyed by their own replacement, so a re-run would
+        # fail on "found 0" anyway — but that message blames upstream drift for
+        # what is really a duplicated build step, and the old delivery applier
+        # had an anchor that survived patching and did silently stack.
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        target.write_text(UPSTREAM_WATCHERS)
+        apply(root)
+        with self.assertRaises(SystemExit) as ctx:
+            apply(root)
+        self.assertIn("already patched", str(ctx.exception))
+        patched = target.read_text()
+        self.assertEqual(
+            patched.count("handoff = _kanban_handoff_with_result(handoff, task)"), 1
+        )
+        self.assertEqual(patched.count("from gateway.kanban_notifier import"), 1)
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            apply(Path(tempfile.mkdtemp()))
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+# The three edits this applier replaces, as they were: the Dockerfile's inline
+# `kanban_handoff_clip` rewrite, `apply_kanban_wake_kinds.py`, and
+# `apply_kanban_result_delivery.py`. Kept here rather than deleted with them so
+# the equivalence claim stays checkable after the originals are gone.
+LEGACY_CLIP = (
+    (
+        "h = lines[0][:200] if lines else payload_summary[:200]",
+        "h = _clip_handoff(payload_summary)",
+    ),
+    (
+        "r = lines[0][:160] if lines else task.result[:160]",
+        "r = _clip_handoff(task.result)",
+    ),
+)
+LEGACY_WAKE = (
+    '                        _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")\n'
+    '                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}\n',
+    '                        _wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)\n',
+)
+LEGACY_DELIVERY = (
+    '                            msg = (\n',
+    "                            handoff = _kanban_handoff_with_result(handoff, task)\n"
+    "                            msg = (\n",
+)
+
+
+def legacy_pipeline(source):
+    """Replay the three superseded edits in the order the Dockerfile ran them."""
+    for old, new in LEGACY_CLIP:
+        assert source.count(old) == 1, old
+        source = source.replace(old, new)
+    for old, new in (LEGACY_WAKE, LEGACY_DELIVERY):
+        assert source.count(old) == 1, old
+        source = source.replace(old, new)
+    return source
+
+
+def strip_patch_furniture(text, drop_marker_call=True):
+    """Reduce patched source to the part the legacy pipeline can be compared to.
+
+    Three things are dropped, and only three:
+
+    * the import trailer — three trailers became one;
+    * the ``see <module>`` comments — they now name one module;
+    * the marker call, when ``drop_marker_call`` is set. This is the one piece
+      of emitted code with no legacy counterpart, because it is the one new
+      behaviour (section 4 of ``kanban_notifier.py``). Subtracting it is what
+      lets :class:`LegacyEquivalenceTest` keep making its original claim about
+      everything else; that the subtraction is the *whole* difference is
+      asserted separately, so nothing can hide behind it.
+    """
+    marker = "\n\n# kube-agents patch: see gateway/"
+    body = text[: text.index(marker)] if marker in text else text
+    if drop_marker_call:
+        body = body.replace(MARKER_CALL, "")
+    return "\n".join(
+        line for line in body.splitlines()
+        if "# kube-agents patch: see gateway/" not in line
+    )
+
+
+class LegacyEquivalenceTest(unittest.TestCase):
+    """The merge is a refactor, and this is the proof.
+
+    Two anchors in one applier produce the same patched notifier as the four
+    anchors across three appliers did. Anything else — a dropped ``lines = …``,
+    a reordered hook, a changed clip call — would be a behaviour change wearing
+    a refactor's clothes, and the duplicate-delivery bug this code path already
+    shipped once is exactly the kind of thing that hides in "while I was in
+    there".
+
+    The completion marker added afterwards is a deliberate exception and the
+    only one: it is subtracted before the comparison and pinned by
+    :meth:`test_the_marker_call_is_the_only_departure_from_legacy`, so the
+    equivalence claim narrowed by exactly one reviewable block rather than
+    quietly weakening.
+    """
+
+    def test_the_merged_applier_reproduces_the_legacy_output(self):
+        self.assertEqual(
+            strip_patch_furniture(legacy_pipeline(UPSTREAM_WATCHERS)),
+            strip_patch_furniture(patch_tree(UPSTREAM_WATCHERS)),
+        )
+
+    def test_the_marker_call_is_the_only_departure_from_legacy(self):
+        # Without this, strip_patch_furniture's replace() would be a hole any
+        # future edit could be slipped through. Compare the two outputs with
+        # nothing subtracted and require every added line to belong to the
+        # marker call.
+        legacy = strip_patch_furniture(
+            legacy_pipeline(UPSTREAM_WATCHERS), drop_marker_call=False
+        ).splitlines()
+        merged = strip_patch_furniture(
+            patch_tree(UPSTREAM_WATCHERS), drop_marker_call=False
+        ).splitlines()
+        added = [line for line in merged if line not in legacy]
+        self.assertEqual(added, MARKER_CALL.splitlines())
+        # ...and nothing was removed, either.
+        self.assertEqual([line for line in legacy if line not in merged], [])
+
+    def test_the_marker_call_is_emitted_exactly_once(self):
+        # A second copy would announce the same card twice on one turn, and is
+        # what a re-applied patch used to produce before SENTINELS grew a guard
+        # for this name.
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        self.assertEqual(patched.count("_kanban_note_suppressed("), 1)
+        self.assertEqual(patched.count("as _kanban_note_suppressed,"), 1)
+        self.assertIn(MARKER_CALL, patched)
+
+    def test_the_marker_call_reads_the_wake_set_it_is_reporting_on(self):
+        # It subtracts the wake set from what upstream would have woken for, so
+        # it cannot run before `_wake_kinds` exists.
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        wake = patched.index('_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)')
+        note = patched.index("_kanban_note_suppressed(\n")
+        self.assertLess(wake, note)
+
+    def test_upstreams_own_lines_are_left_alone(self):
+        # Both `lines = …` assignments are dead once the clip lands, but they
+        # are upstream's dead code, not ours. Removing them would put an edit
+        # in the patch that no anchor and no test was asking for.
+        patched = patch_tree(UPSTREAM_WATCHERS)
+        self.assertIn("lines = payload_summary.strip().splitlines()", patched)
+        self.assertIn("lines = task.result.strip().splitlines()", patched)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_ownership.py
+++ b/deploy/docker/patches/test_kanban_ownership.py
@@ -1,0 +1,211 @@
+"""Unit tests for the shared ownership predicates installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+
+The whole point of this module is that the two callers want opposite answers
+from the same uncertainty, so every predicate is exercised at both polarities,
+and the two failure modes are kept apart: an *absent* reader module is a
+structural fact about the process and must not consult ``on_unknown``, while a
+reader that *raises* is genuine uncertainty and must.
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+from kanban_ownership import (
+    CRON_RUN_ENV,
+    WORKER_TASK_ENV,
+    in_cron_run,
+    is_delegated_child,
+    is_dispatcher_worker,
+)
+
+
+def with_delegation_context(reader):
+    """Install a fake ``agent.delegation_context`` whose reader is *reader*.
+
+    ``_delegation_reader`` imports per call, so a fake in ``sys.modules`` is
+    enough to exercise the branch on a host with no Hermes.
+    """
+    fake = types.ModuleType("agent.delegation_context")
+    fake.is_delegated_child_context = reader
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.delegation_context = fake
+    return mock.patch.dict(
+        sys.modules, {"agent": agent_pkg, "agent.delegation_context": fake}
+    )
+
+
+def no_delegation_context():
+    """Make the import fail the way it does on a host without Hermes."""
+    return mock.patch.dict(sys.modules, {"agent.delegation_context": None})
+
+
+def boom(*args, **kwargs):
+    raise RuntimeError("reader is present and broken")
+
+
+class IsDelegatedChildTest(unittest.TestCase):
+    def test_the_real_reader_is_believed_at_either_polarity(self):
+        for answer in (True, False):
+            with with_delegation_context(lambda: answer):
+                self.assertIs(is_delegated_child(on_unknown=True), answer)
+                self.assertIs(is_delegated_child(on_unknown=False), answer)
+
+    def test_an_absent_module_is_not_uncertainty(self):
+        """No delegation machinery in the process means no delegated child.
+
+        This is the case that must ignore ``on_unknown`` — otherwise the answer
+        flips on every host where this module imports but Hermes does not,
+        including this test suite.
+        """
+        with no_delegation_context():
+            self.assertFalse(is_delegated_child(on_unknown=True))
+            self.assertFalse(is_delegated_child(on_unknown=False))
+
+    def test_a_raising_reader_is_uncertainty_and_defers_to_the_caller(self):
+        with with_delegation_context(boom):
+            self.assertTrue(is_delegated_child(on_unknown=True))
+            self.assertFalse(is_delegated_child(on_unknown=False))
+
+    def test_a_truthy_non_bool_is_normalised(self):
+        with with_delegation_context(lambda: "yes"):
+            self.assertIs(is_delegated_child(on_unknown=False), True)
+
+    def test_the_polarity_must_be_stated(self):
+        """No default: there is no answer that is safe in both directions."""
+        with self.assertRaises(TypeError):
+            is_delegated_child()
+        with self.assertRaises(TypeError):
+            is_delegated_child(False)
+
+
+class InCronRunTest(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(os.environ.pop, CRON_RUN_ENV, None)
+        os.environ.pop(CRON_RUN_ENV, None)
+
+    def test_the_real_scope_is_believed_at_either_polarity(self):
+        from cron_run_scope import cron_run_scope
+
+        self.assertFalse(in_cron_run(on_unknown=True))
+        with cron_run_scope("fleet-audit"):
+            self.assertTrue(in_cron_run(on_unknown=True))
+            self.assertTrue(in_cron_run(on_unknown=False))
+        self.assertFalse(in_cron_run(on_unknown=False))
+
+    def test_a_raising_reader_is_uncertainty_and_defers_to_the_caller(self):
+        # _cron_reader re-imports per call, so replacing the module attribute
+        # is enough to make the reader raise.
+        import cron_run_scope
+
+        original = cron_run_scope.current_cron_job
+        cron_run_scope.current_cron_job = boom
+        try:
+            self.assertTrue(in_cron_run(on_unknown=True))
+            self.assertFalse(in_cron_run(on_unknown=False))
+        finally:
+            cron_run_scope.current_cron_job = original
+        self.assertFalse(in_cron_run(on_unknown=True))
+
+    def test_an_absent_module_falls_back_to_the_environment(self):
+        """The env half of the marker is the one thing a ContextVar cannot cross
+        a fork with, so an unresolvable module is not uncertainty either — the
+        evidence is still readable.
+        """
+        with mock.patch.dict(
+            sys.modules, {"tools.cron_run_scope": None, "cron_run_scope": None}
+        ):
+            self.assertFalse(in_cron_run(on_unknown=True))
+            os.environ[CRON_RUN_ENV] = "fleet-audit"
+            self.assertTrue(in_cron_run(on_unknown=False))
+
+    def test_a_forked_run_is_recognised_through_the_real_reader_too(self):
+        # current_cron_job consults the env var itself, so the fallback above is
+        # only reached when the module is missing entirely.
+        os.environ[CRON_RUN_ENV] = "fleet-audit"
+        self.assertTrue(in_cron_run(on_unknown=False))
+
+    def test_the_polarity_must_be_stated(self):
+        with self.assertRaises(TypeError):
+            in_cron_run()
+        with self.assertRaises(TypeError):
+            in_cron_run(True)
+
+
+class IsDispatcherWorkerTest(unittest.TestCase):
+    def test_it_reads_the_variable_the_dispatcher_exports(self):
+        with mock.patch.dict(os.environ, {WORKER_TASK_ENV: "t_c31a1f00"}):
+            self.assertTrue(is_dispatcher_worker())
+
+    def test_an_empty_task_id_is_not_a_worker(self):
+        with mock.patch.dict(os.environ, {WORKER_TASK_ENV: ""}):
+            self.assertFalse(is_dispatcher_worker())
+
+    def test_an_unset_variable_is_not_a_worker(self):
+        env = {k: v for k, v in os.environ.items() if k != WORKER_TASK_ENV}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertFalse(is_dispatcher_worker())
+
+    def test_it_takes_no_polarity(self):
+        """An environment read has no failure mode to be uncertain about.
+
+        It also has no precision — the variable is inherited by a delegated
+        child and by a cron run — which is why the callers compose it with the
+        other two predicates rather than using it alone.
+        """
+        with self.assertRaises(TypeError):
+            is_dispatcher_worker(on_unknown=True)
+
+
+class CallerPolarityTest(unittest.TestCase):
+    """The asymmetry the shared module exists to make visible.
+
+    Same uncertainty, opposite answers, because a wrong answer costs the two
+    callers different things: one strands a card whose worker has lost its
+    terminal tools, the other charges a failure to a card somebody is still
+    working. Asserted here so a future edit cannot quietly align them.
+    """
+
+    def test_the_two_callers_disagree_about_a_raising_reader(self):
+        import kanban_guardrail_exit
+        import kanban_worker_tools
+
+        with with_delegation_context(boom):
+            with mock.patch.dict(os.environ, {WORKER_TASK_ENV: "t_c31a1f00"}):
+                self.assertTrue(kanban_worker_tools.check_kanban_worker_mode())
+            self.assertFalse(
+                kanban_guardrail_exit.should_record_missing_terminal(
+                    task_id="t_d3efabef",
+                    interrupted=False,
+                    failed=False,
+                    iteration_limit_fallback=False,
+                    goal_mode=False,
+                    cron_run=False,
+                )
+            )
+
+    def test_and_agree_about_an_absent_module(self):
+        import kanban_guardrail_exit
+        import kanban_worker_tools
+
+        with no_delegation_context():
+            with mock.patch.dict(os.environ, {WORKER_TASK_ENV: "t_c31a1f00"}):
+                self.assertTrue(kanban_worker_tools.check_kanban_worker_mode())
+            self.assertTrue(
+                kanban_guardrail_exit.should_record_missing_terminal(
+                    task_id="t_d3efabef",
+                    interrupted=False,
+                    failed=False,
+                    iteration_limit_fallback=False,
+                    goal_mode=False,
+                    cron_run=False,
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_result_required.py
+++ b/deploy/docker/patches/test_kanban_result_required.py
@@ -1,0 +1,268 @@
+"""Unit tests for the require-result gate installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import copy
+import time
+import unittest
+
+import kanban_result_required as krr
+from kanban_result_required import (
+    MISSING_RESULT_ERROR,
+    NEW_GATE,
+    NEW_RESULT_DESCRIPTION,
+    NEW_SUMMARY_DESCRIPTION,
+    NEW_TOOL_DESCRIPTION,
+    NUDGE_TTL_SECONDS,
+    OLD_RESULT_DESCRIPTION,
+    OLD_SUMMARY_DESCRIPTION,
+    OLD_TOOL_DESCRIPTION,
+    apply_schema,
+    blank_to_none,
+    require_result,
+)
+
+# The card that started this: the worker held a 5.5 KB catalogue, called
+# kanban_complete with a 169-character status line and no result, and the
+# catalogue was never seen again.
+INCIDENT_SUMMARY = (
+    "Successfully inspected and cataloged all 9 active platform-agent-level and "
+    "system-wide cron jobs. Compiled their detailed purposes, schedules, and "
+    "active configurations."
+)
+INCIDENT_RESULT = "\n".join(f"{i}. cron-job-{i} — schedule 0 {i} * * *" for i in range(1, 10))
+
+
+def _ev_summary(summary, result):
+    """``complete_task``'s event-summary expression, copied from upstream.
+
+    ``hermes_cli/kanban_db.py`` runs this inside ``write_txn`` after the UPDATE
+    to ``done``, so anything it raises rolls the completion back and reaches the
+    worker as ``kanban_complete: list index out of range``.
+    """
+    ev_summary = (summary if summary is not None else result) or ""
+    return ev_summary.strip().splitlines()[0][:400] if ev_summary else ""
+
+
+def _schema():
+    """A minimal stand-in shaped like upstream's KANBAN_COMPLETE_SCHEMA."""
+    return copy.deepcopy({
+        "name": "kanban_complete",
+        "description": OLD_TOOL_DESCRIPTION + "If you created new tasks, list them.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": OLD_SUMMARY_DESCRIPTION},
+                "result": {"type": "string", "description": OLD_RESULT_DESCRIPTION},
+                "metadata": {"type": "object", "description": "Free-form dict."},
+            },
+            "required": [],
+        },
+    })
+
+
+class RequireResultTest(unittest.TestCase):
+    def setUp(self):
+        krr._refused_at.clear()
+        self.addCleanup(krr._refused_at.clear)
+
+    def _expire(self, task_id):
+        """Age the outstanding refusal for ``task_id`` past NUDGE_TTL_SECONDS."""
+        krr._refused_at[str(task_id)] = time.monotonic() - NUDGE_TTL_SECONDS - 1
+
+    def test_a_result_passes_through_untouched(self):
+        err, out = require_result("t_1", INCIDENT_SUMMARY, INCIDENT_RESULT)
+        self.assertIsNone(err)
+        self.assertEqual(out, INCIDENT_RESULT)
+
+    def test_a_one_line_result_is_enough(self):
+        # No length floor: a card whose honest answer is one line must close.
+        err, out = require_result("t_1", "Restarted it.", "3/3 pods ready")
+        self.assertIsNone(err)
+        self.assertEqual(out, "3/3 pods ready")
+
+    def test_the_incident_completion_is_refused(self):
+        err, out = require_result("t_8d1cf5cf", INCIDENT_SUMMARY, None)
+        self.assertEqual(err, MISSING_RESULT_ERROR)
+        self.assertIsNone(out)
+
+    def test_the_refusal_says_what_to_do(self):
+        err, _ = require_result("t_1", INCIDENT_SUMMARY, None)
+        self.assertIn("result", err)
+        self.assertIn("kanban_complete again", err)
+        # The three dead ends the incident workers actually chose.
+        for dead_end in ("transcript", "file", "comment"):
+            self.assertIn(dead_end, err)
+
+    def test_whitespace_only_result_counts_as_empty(self):
+        err, _ = require_result("t_1", INCIDENT_SUMMARY, "   \n\t  ")
+        self.assertEqual(err, MISSING_RESULT_ERROR)
+
+    def test_the_retry_carrying_a_result_is_accepted(self):
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        err, out = require_result("t_1", INCIDENT_SUMMARY, INCIDENT_RESULT)
+        self.assertIsNone(err)
+        self.assertEqual(out, INCIDENT_RESULT)
+
+    def test_a_card_is_never_wedged_shut(self):
+        # Second empty completion for the same task closes the card rather than
+        # refusing forever; summary is promoted so something survives.
+        self.assertEqual(require_result("t_1", INCIDENT_SUMMARY, None)[0], MISSING_RESULT_ERROR)
+        err, out = require_result("t_1", INCIDENT_SUMMARY, None)
+        self.assertIsNone(err)
+        self.assertEqual(out, INCIDENT_SUMMARY)
+
+    def test_a_totally_empty_second_completion_still_closes(self):
+        require_result("t_1", None, None)
+        err, out = require_result("t_1", None, None)
+        self.assertIsNone(err)
+        self.assertIsNone(out)
+
+    def test_each_task_gets_its_own_nudge(self):
+        # A shared worker process must not spend task B's nudge on task A.
+        self.assertEqual(require_result("t_a", "s", None)[0], MISSING_RESULT_ERROR)
+        self.assertEqual(require_result("t_b", "s", None)[0], MISSING_RESULT_ERROR)
+
+    def test_non_string_task_ids_do_not_collide_by_accident(self):
+        require_result(1, "s", None)
+        # str(1) == "1" — the same key, correctly.
+        err, _ = require_result("1", "s", None)
+        self.assertIsNone(err)
+
+    def test_a_completed_card_leaves_no_refusal_behind(self):
+        # The mapping is the cards still awaiting a retry, not a ledger of every
+        # card ever refused. A gateway session completes cards for the life of
+        # the pod, so a ledger there is both a leak and a disabled gate.
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        require_result("t_1", INCIDENT_SUMMARY, INCIDENT_RESULT)
+        self.assertEqual(krr._refused_at, {})
+
+    def test_a_card_reopened_after_a_refusal_is_nudged_again(self):
+        # The 2026-08-07 regression: an orchestrator refused t_1, the card was
+        # reopened and retried, and the second content-free completion was
+        # accepted in silence because the process still remembered the refusal.
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        require_result("t_1", INCIDENT_SUMMARY, INCIDENT_RESULT)
+        err, _ = require_result("t_1", INCIDENT_SUMMARY, None)
+        self.assertEqual(err, MISSING_RESULT_ERROR)
+
+    def test_a_stale_refusal_belongs_to_a_different_attempt(self):
+        # A refusal nobody came back for within NUDGE_TTL_SECONDS is not the
+        # first half of this completion, so this completion gets its own nudge.
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        self._expire("t_1")
+        err, _ = require_result("t_1", INCIDENT_SUMMARY, None)
+        self.assertEqual(err, MISSING_RESULT_ERROR)
+
+    def test_expiry_delays_the_close_by_one_call_and_no_more(self):
+        # Expiry must not reintroduce the wedge. A caller that retries promptly
+        # is inside the window on its next call, so the card still closes.
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        self._expire("t_1")
+        require_result("t_1", INCIDENT_SUMMARY, None)
+        err, out = require_result("t_1", INCIDENT_SUMMARY, None)
+        self.assertIsNone(err)
+        self.assertEqual(out, INCIDENT_SUMMARY)
+
+    def test_a_whitespace_only_result_is_never_stored(self):
+        # It survived the gate as the promoted value and raised IndexError in
+        # complete_task's write_txn, rolling the completion back — with the
+        # nudge already spent, so the identical retry failed identically.
+        require_result("t_1", None, "   \n\t ")
+        err, out = require_result("t_1", None, "   \n\t ")
+        self.assertIsNone(err)
+        self.assertIsNone(out)
+        self.assertEqual(_ev_summary(None, out), "")
+
+    def test_a_whitespace_only_summary_is_never_promoted(self):
+        require_result("t_1", " \n ", None)
+        err, out = require_result("t_1", " \n ", None)
+        self.assertIsNone(err)
+        self.assertIsNone(out)
+
+    def test_upstream_would_have_raised_on_the_value_the_gate_now_folds(self):
+        # Guards the premise: if complete_task ever stops indexing line zero of
+        # a stripped string, this fails and blank_to_none can be reconsidered.
+        with self.assertRaises(IndexError):
+            _ev_summary(None, "   \n\t ")
+        with self.assertRaises(IndexError):
+            _ev_summary(" ", INCIDENT_RESULT)
+
+
+class BlankToNoneTest(unittest.TestCase):
+    def test_content_is_returned_byte_for_byte(self):
+        # kanban_complete has already redacted these; trimming them here would
+        # silently edit what redact_sensitive_text produced.
+        for value in (INCIDENT_RESULT, " leading and trailing ", "x"):
+            self.assertEqual(blank_to_none(value), value)
+
+    def test_every_shape_of_empty_becomes_none(self):
+        for value in (None, "", "   ", "\n", "\t \r\n"):
+            self.assertIsNone(blank_to_none(value))
+
+    def test_the_gate_folds_the_summary_the_handler_passes_on(self):
+        # require_result only owns `result`; the handler's own `summary` local
+        # goes straight to kb.complete_task, so the gate has to fold it too.
+        self.assertIn("summary = _blank_to_none(summary)", NEW_GATE)
+        self.assertIn("_require_result(tid, summary, result)", NEW_GATE)
+
+
+class ApplySchemaTest(unittest.TestCase):
+    def test_all_three_descriptions_are_rewritten(self):
+        schema = apply_schema(_schema())
+        props = schema["parameters"]["properties"]
+        self.assertIn(NEW_TOOL_DESCRIPTION, schema["description"])
+        self.assertEqual(props["summary"]["description"], NEW_SUMMARY_DESCRIPTION)
+        self.assertEqual(props["result"]["description"], NEW_RESULT_DESCRIPTION)
+
+    def test_the_legacy_framing_is_gone(self):
+        schema = apply_schema(_schema())
+        blob = repr(schema)
+        # The exact wording that told workers to throw the answer away.
+        self.assertNotIn("legacy field", blob)
+        self.assertNotIn("Use ``summary`` instead", blob)
+        self.assertNotIn("1-3 sentence", blob)
+
+    def test_the_tool_description_tail_is_preserved(self):
+        schema = apply_schema(_schema())
+        self.assertIn("If you created new tasks, list them.", schema["description"])
+
+    def test_result_becomes_a_required_parameter(self):
+        schema = apply_schema(_schema())
+        self.assertIn("result", schema["parameters"]["required"])
+
+    def test_required_is_not_double_appended(self):
+        schema = _schema()
+        apply_schema(schema)
+        schema["description"] = OLD_TOOL_DESCRIPTION
+        schema["parameters"]["properties"]["summary"]["description"] = OLD_SUMMARY_DESCRIPTION
+        schema["parameters"]["properties"]["result"]["description"] = OLD_RESULT_DESCRIPTION
+        apply_schema(schema)
+        self.assertEqual(schema["parameters"]["required"].count("result"), 1)
+
+    def test_the_new_wording_names_the_real_limits(self):
+        # The persona previously advertised 1200 characters; the kernel cuts at
+        # 400 on the first line. A worker must be told the number that is true.
+        self.assertIn("400", NEW_SUMMARY_DESCRIPTION)
+        self.assertIn("FIRST LINE", NEW_SUMMARY_DESCRIPTION)
+        self.assertIn("400", NEW_TOOL_DESCRIPTION)
+        self.assertIn("REQUIRED", NEW_RESULT_DESCRIPTION)
+
+    def test_a_changed_upstream_description_fails_loudly(self):
+        schema = _schema()
+        schema["parameters"]["properties"]["result"]["description"] = "something else"
+        with self.assertRaises(ValueError) as ctx:
+            apply_schema(schema)
+        self.assertIn("re-derive", str(ctx.exception))
+
+    def test_a_missing_field_fails_loudly(self):
+        schema = _schema()
+        del schema["parameters"]["properties"]["summary"]
+        with self.assertRaises(KeyError) as ctx:
+            apply_schema(schema)
+        self.assertIn("re-derive", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_scheduling.py
+++ b/deploy/docker/patches/test_kanban_scheduling.py
@@ -1,0 +1,1638 @@
+"""Unit tests for the kanban scheduling patches applied by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+
+Three faults in ``hermes_cli/kanban_db.py``, one quartet, one test file:
+
+  * the self-parenting dependency deadlock (``repair_inverted_dependencies``),
+  * claims fenced to a process life, and the discriminator that decides which
+    reclaims cost a retry (``release_dead_foreign_claims``),
+  * the breaker counter, which is a pure source rewrite and so is tested
+    through the applier alone.
+
+The dependency tests run against a miniature of the real schema and, crucially,
+against a copy of the *real* gating predicate that ``claim_task`` and
+``recompute_ready`` share. A repair that leaves a card unclaimable is no repair
+at all, so every one of them asserts on ``claimable()`` rather than on link rows.
+A board carries an event log as well as tasks and links, because the repair
+decides what it may touch from the order of the ``created`` and ``claimed`` rows
+in ``task_events``: an edge is a fan-out of this card's run only if the child was
+created after the card first started. ``fanned_out`` and ``planned`` spell the
+two histories that matter — the worker that creates its own children, and the
+planner that lays out a pipeline before anything runs.
+
+The fencing tests are written in the vocabulary of the 2026-08-07 gateway
+SIGBUS: the container restarted and kept its pod name, so the replacement
+dispatcher adjudicated its predecessor's worker PIDs — every one of them
+belonging to a process it never spawned — and abandoned six cards. OLD is the
+process life that died, NEW is the one that came up, and OTHER_POD is a pod
+Kubernetes replaced, which is the case the discriminator forgives.
+
+The end-to-end consequences (a poison card reaching ``blocked``, a rollout
+costing nothing, the breaker's own threshold being the one that decides) belong
+to verify_kanban_scheduling.py, which drives the real engine inside the image.
+What is pinned here is the contract these modules offer it.
+
+The last section tests that verifier's own fixture rather than the patch. It
+earns its place: a board-naming scheme there once silently stopped producing
+fresh boards, and the resulting failure read for all the world like a defect in
+``release_dead_foreign_claims``.
+"""
+
+import ast
+import itertools
+import json
+import os
+import re
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from apply_kanban_scheduling import (
+    BUILD_MARKER,
+    CHARGE_ANCHOR,
+    CRASH_BIND_ANCHOR,
+    DEPENDENCY_ANCHOR,
+    DEPENDENCY_PATCHED,
+    EDITS,
+    FENCE_ANCHOR,
+    RELATIVE,
+    SPAWN_BIND_ANCHOR,
+    TRIP_ANCHOR,
+    apply,
+)
+from apply_kanban_wake_nudge import (
+    COMPLETE_ANCHOR as WAKE_COMPLETE_ANCHOR,
+    CREATE_ANCHOR as WAKE_CREATE_ANCHOR,
+    UNBLOCK_ANCHOR as WAKE_UNBLOCK_ANCHOR,
+)
+from kanban_scheduling import (
+    CLAIM_TIME_UNKNOWN,
+    CONCURRENT_OWNER,
+    DEPENDENCY_EVENT_KIND,
+    POD_REPLACED,
+    PROCESS_DIED_IN_PLACE,
+    RECLAIM_ERROR,
+    RECLAIM_EVENT_KIND,
+    Reclaimed,
+    charge_reclaimed_cards,
+    claim_host,
+    claim_is_self,
+    classify_reclaim,
+    find_deadlocked_children,
+    process_start_time,
+    read_proc_start_time,
+    release_dead_foreign_claims,
+    repair_inverted_dependencies,
+)
+import kanban_scheduling
+
+POD = "platform-agent-gateway-75b5f6ddf6-7dkd7"
+OLD = f"{POD}:4"  # the dispatcher that took the bus error
+NEW = f"{POD}:9"  # the one that replaced it, same pod name
+OTHER_POD = "platform-agent-gateway-595bbd777f-5vlzk:7"
+
+# A claim instant safely on either side of any plausible process start.
+NOW = int(time.time())
+PRE_BOOT = NOW - 86_400
+
+# The fingerprint as ``hermes_cli/kanban_db.py`` ships it, and as this patch
+# deliberately leaves it. Mirrored rather than imported because kanban_db only
+# exists inside the image.
+UPSTREAM_FINGERPRINT_SOURCE = (
+    "def _error_fingerprint(error_text):\n"
+    "    fp = re.sub(r'\\bpid \\d+\\b', 'pid N', error_text[:80])\n"
+    "    fp = re.sub(r'\\b\\d{10,}\\b', '<TS>', fp)\n"
+    "    return fp.lower().strip()\n"
+)
+
+
+def upstream_fingerprint(error_text):
+    fp = re.sub(r"\bpid \d+\b", "pid N", error_text[:80])
+    fp = re.sub(r"\b\d{10,}\b", "<TS>", fp)
+    return fp.lower().strip()
+
+
+# ---------------------------------------------------------------------------
+# Part 1: inverted fan-out dependency edges
+# ---------------------------------------------------------------------------
+
+DEPENDENCY_SCHEMA = """
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL
+);
+CREATE TABLE task_links (
+    parent_id TEXT NOT NULL,
+    child_id TEXT NOT NULL,
+    PRIMARY KEY (parent_id, child_id)
+);
+CREATE TABLE task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    run_id INTEGER,
+    kind TEXT NOT NULL,
+    payload TEXT,
+    created_at INTEGER
+);
+"""
+
+
+def board(tasks, links=(), log=()):
+    """A miniature board. ``log`` is the ``task_events`` history, in order.
+
+    The log is inserted before the links so its ids are the low ones, matching
+    a real board where an edge is written in the same transaction as the
+    ``created`` event that records it.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(DEPENDENCY_SCHEMA)
+    for tid, status in tasks.items():
+        conn.execute("INSERT INTO tasks (id, status) VALUES (?, ?)", (tid, status))
+    for task_id, kind in log:
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind) VALUES (?, ?)", (task_id, kind)
+        )
+    for parent, child in links:
+        conn.execute(
+            "INSERT INTO task_links (parent_id, child_id) VALUES (?, ?)",
+            (parent, child),
+        )
+    return conn
+
+
+def fanned_out(parent, *children):
+    """The history a worker writes: claimed first, then it creates its cards."""
+    return [(parent, "created"), (parent, "claimed")] + [
+        (child, "created") for child in children
+    ]
+
+
+def planned(*task_ids):
+    """The history a planner writes: every card exists before anything is claimed."""
+    return [(task_id, "created") for task_id in task_ids]
+
+
+def claimable(conn, task_id):
+    """The gate ``claim_task`` and ``recompute_ready`` both apply, verbatim."""
+    undone = conn.execute(
+        "SELECT 1 FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    return undone is None
+
+
+def links_of(conn):
+    return {
+        (r["parent_id"], r["child_id"])
+        for r in conn.execute("SELECT parent_id, child_id FROM task_links")
+    }
+
+
+def repair_events(conn, task_id):
+    """The decoded payloads of whatever this module wrote about ``task_id``."""
+    return [
+        json.loads(r["payload"])
+        for r in conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = ? ORDER BY id",
+            (task_id, DEPENDENCY_EVENT_KIND),
+        )
+    ]
+
+
+class RepairTest(unittest.TestCase):
+    def test_the_reported_deadlock_is_broken(self):
+        """t_ab112f5b's shape: three cards parented to the card that waits on them."""
+        conn = board(
+            {"P": "running", "A": "todo", "B": "todo", "C": "todo"},
+            [("P", "A"), ("P", "B"), ("P", "C")],
+            log=fanned_out("P", "A", "B", "C"),
+        )
+        for child in ("A", "B", "C"):
+            self.assertFalse(claimable(conn, child), f"{child} starts deadlocked")
+
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["A", "B", "C"])
+
+        for child in ("A", "B", "C"):
+            self.assertTrue(claimable(conn, child), f"{child} must now dispatch")
+        self.assertFalse(claimable(conn, "P"), "P must wait for its prerequisites")
+
+    def test_waiting_card_becomes_claimable_once_children_finish(self):
+        conn = board(
+            {"P": "running", "A": "todo"}, [("P", "A")], log=fanned_out("P", "A")
+        )
+        repair_inverted_dependencies(conn, "P")
+        self.assertFalse(claimable(conn, "P"))
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = 'A'")
+        self.assertTrue(claimable(conn, "P"), "the wait resolves on its own")
+
+    def test_settled_children_are_left_alone(self):
+        """A finished child already satisfies the gate; inverting it would un-satisfy P."""
+        conn = board(
+            {"P": "running", "A": "done", "B": "archived"},
+            [("P", "A"), ("P", "B")],
+            log=fanned_out("P", "A", "B"),
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+        self.assertTrue(claimable(conn, "P"))
+        self.assertEqual(repair_events(conn, "P"), [])
+
+    def test_legitimate_continuation_card_is_untouched(self):
+        """Upstream's endorsed idiom: create a child, then complete yourself.
+
+        The repair fires only from ``block_task``, so a creator that completes
+        instead of blocking never reaches it and the continuation card runs on
+        the original edge. ``ApplierTest`` pins the call site; this pins that the
+        idiom needs no repair to work.
+        """
+        conn = board(
+            {"P": "running", "K": "todo"}, [("P", "K")], log=fanned_out("P", "K")
+        )
+        self.assertFalse(claimable(conn, "K"))
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = 'P'")
+        self.assertTrue(claimable(conn, "K"))
+
+    def test_real_fan_in_is_not_disturbed(self):
+        """P waits on A and B the correct way round: nothing to repair."""
+        conn = board(
+            {"P": "running", "A": "todo", "B": "running"},
+            [("A", "P"), ("B", "P")],
+            log=planned("A", "B", "P") + [("B", "claimed"), ("P", "claimed")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+        self.assertFalse(claimable(conn, "P"))
+        self.assertTrue(claimable(conn, "A"))
+
+    # --- the run window: only cards this card fanned out are repaired --------
+
+    def test_a_pipeline_stage_keeps_its_direction_when_it_blocks(self):
+        """The bug this module shipped with, reproduced against the live engine.
+
+        A is done, B was claimed, B -> C. Nothing here is a fan-out of B's run:
+        C was planned before B ever started, so B's dependency block is about
+        something else and the pipeline has to survive it. The parent-set guard
+        this replaces said B had no unsettled parents — true of every card
+        ``block_task`` accepts — and inverted B -> C, dispatching C ahead of the
+        stage it exists to follow.
+        """
+        conn = board(
+            {"A": "done", "B": "running", "C": "todo"},
+            [("A", "B"), ("B", "C")],
+            log=planned("A", "B", "C") + [("A", "claimed"), ("B", "claimed")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "B"), [])
+        self.assertEqual(links_of(conn), {("A", "B"), ("B", "C")})
+        self.assertFalse(claimable(conn, "C"), "C must still wait its turn")
+        self.assertEqual(repair_events(conn, "B"), [])
+
+    def test_a_fan_in_keeps_its_direction_after_one_input_finishes(self):
+        """The same false positive in the fan-in shape.
+
+        Once B is done it stops gating C, so "is this card the last unfinished
+        parent" says yes and A's edge was inverted. C predates A's run, so the
+        window says no.
+        """
+        conn = board(
+            {"A": "running", "B": "done", "C": "todo"},
+            [("A", "C"), ("B", "C")],
+            log=planned("A", "B", "C") + [("B", "claimed"), ("A", "claimed")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "A"), [])
+        self.assertEqual(links_of(conn), {("A", "C"), ("B", "C")})
+
+    def test_a_card_that_was_never_claimed_repairs_nothing(self):
+        """No ``claimed`` row means no run window, so the comparison is NULL.
+
+        A raw ``UPDATE tasks SET status='running'`` is not evidence that the card
+        fanned anything out. verify_kanban_scheduling.py builds this board.
+        """
+        conn = board(
+            {"P": "running", "A": "todo"},
+            [("P", "A")],
+            log=[("P", "created"), ("A", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+
+    def test_a_fan_out_from_a_run_that_died_is_still_repaired(self):
+        """The watermark is the first claim, not the current one.
+
+        A worker that creates A and is then killed leaves it as deadlocked as one
+        that blocks. When the card is re-claimed, creates B and blocks for real,
+        both children have to be released — matching ``claim_task``'s own
+        ``started_at = COALESCE(started_at, ?)``, which likewise records the
+        first start and not the latest.
+        """
+        conn = board(
+            {"P": "running", "A": "todo", "B": "todo"},
+            [("P", "A"), ("P", "B")],
+            log=[
+                ("P", "created"),
+                ("P", "claimed"),
+                ("A", "created"),
+                ("P", "reclaimed"),
+                ("P", "claimed"),
+                ("B", "created"),
+            ],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["A", "B"])
+
+    def test_find_deadlocked_children_ignores_children_older_than_the_run(self):
+        conn = board(
+            {"P": "running", "OLDER": "todo", "NEWER": "todo"},
+            [("P", "OLDER"), ("P", "NEWER")],
+            log=planned("P", "OLDER") + [("P", "claimed"), ("NEWER", "created")],
+        )
+        self.assertEqual(find_deadlocked_children(conn, "P"), ["NEWER"])
+
+    def test_a_second_repair_finds_nothing_to_do(self):
+        """The first pass turned the edge around, so the second finds no successor."""
+        conn = board(
+            {"P": "running", "A": "todo"}, [("P", "A")], log=fanned_out("P", "A")
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["A"])
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+
+    # --- inverting must actually free the child -----------------------------
+
+    def test_child_with_another_unfinished_parent_is_left_alone(self):
+        """Releasing one of two blockers frees nothing, so do not rewrite the edge."""
+        conn = board(
+            {"P": "running", "OTHER": "todo", "SINK": "todo"},
+            [("P", "SINK"), ("OTHER", "SINK")],
+            log=planned("P", "OTHER") + [("P", "claimed"), ("SINK", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+        self.assertFalse(claimable(conn, "SINK"))
+
+    def test_child_whose_other_parents_are_finished_is_repaired(self):
+        conn = board(
+            {"P": "running", "OLD": "done", "SINK": "todo"},
+            [("P", "SINK"), ("OLD", "SINK")],
+            log=planned("P", "OLD") + [("P", "claimed"), ("SINK", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["SINK"])
+        self.assertTrue(claimable(conn, "SINK"))
+
+    def test_mixed_graph_repairs_only_the_deadlocking_edges(self):
+        """One board, all three reasons to leave an edge alone.
+
+        DONE is settled, SHARED has another unfinished parent, and PRIOR was
+        planned before P ever ran. Only A is a deadlocked fan-out of P's run.
+        """
+        conn = board(
+            {"P": "running", "A": "todo", "DONE": "done", "SHARED": "todo",
+             "OTHER": "todo", "PRIOR": "todo"},
+            [("P", "A"), ("P", "DONE"), ("P", "SHARED"), ("OTHER", "SHARED"),
+             ("P", "PRIOR")],
+            log=planned("P", "OTHER", "PRIOR")
+            + [("P", "claimed"), ("A", "created"), ("DONE", "created"),
+               ("SHARED", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["A"])
+        self.assertTrue(claimable(conn, "A"))
+        self.assertEqual(
+            links_of(conn),
+            {("A", "P"), ("P", "DONE"), ("P", "SHARED"), ("OTHER", "SHARED"),
+             ("P", "PRIOR")},
+        )
+
+    # --- the cycle probe ----------------------------------------------------
+
+    def test_cycle_is_refused_when_the_new_edge_is_the_one_that_closes_it(self):
+        """T -> X -> C and T -> C, X settled. Inverting T->C would close a loop.
+
+        This is the shape the probe exists for, and the only one that produces a
+        cycle: the edge being *inserted* is C -> T, so what matters is whether T
+        can still reach C after T -> C is dropped. Here it can, via X.
+
+        Everything else passes first, which is what makes the probe load-bearing
+        — C was created inside T's run and its only other parent (X) is ``done``,
+        so C is genuinely deadlocked on T alone.
+        """
+        conn = board(
+            {"T": "running", "X": "done", "C": "todo"},
+            [("T", "X"), ("X", "C"), ("T", "C")],
+            log=planned("T", "X") + [("T", "claimed"), ("C", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "T"), [])
+        self.assertEqual(
+            links_of(conn),
+            {("T", "X"), ("X", "C"), ("T", "C")},
+            "graph restored unchanged",
+        )
+        payload = repair_events(conn, "T")[0]
+        self.assertEqual(payload["skipped_would_cycle"], ["C"])
+        self.assertEqual(payload["inverted"], [])
+
+    def test_a_pre_existing_cycle_through_the_gated_child_is_repaired(self):
+        """P -> A -> M -> P, M ``done``. Inverting P->A breaks the loop, not makes one.
+
+        The old probe walked from the child, which answered a question about the
+        edge being deleted rather than the one being inserted, and refused this
+        repair. Nothing here closes a loop: after P->A is dropped, P reaches
+        nothing, so A -> P is safe and A becomes claimable.
+        """
+        conn = board(
+            {"P": "running", "A": "todo", "M": "done"},
+            [("P", "A"), ("A", "M"), ("M", "P")],
+            log=planned("M", "P") + [("P", "claimed"), ("A", "created")],
+        )
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["A"])
+        self.assertEqual(links_of(conn), {("A", "M"), ("M", "P"), ("A", "P")})
+        self.assertTrue(claimable(conn, "A"))
+        payload = repair_events(conn, "P")[0]
+        self.assertEqual(payload["inverted"], ["A"])
+        self.assertEqual(payload["skipped_would_cycle"], [])
+
+    def test_a_card_is_never_a_fan_out_of_its_own_run(self):
+        """A self-link cannot pass the window: a card is created before it is claimed.
+
+        ``link_tasks`` refuses ``parent_id == child_id`` outright, so this only
+        arrives through raw SQL, and the window turns it away before the cycle
+        probe has to.
+        """
+        conn = board({"P": "running"}, [("P", "P")], log=fanned_out("P"))
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+
+    def test_reachability_walk_terminates_on_a_pre_existing_cycle(self):
+        """n0..n49 is a ring. The walk must not spin looking for P.
+
+        The ring is ``done`` apart from n0, so the last-unfinished-parent test
+        lets n0 through — the point of the test is the 50-hop traversal.
+        """
+        tasks = {f"n{i}": "done" for i in range(50)}
+        tasks["n0"] = "todo"
+        tasks["P"] = "running"
+        links = [(f"n{i}", f"n{i + 1}") for i in range(49)]
+        links += [("n49", "n0"), ("P", "n0")]
+        log = planned(*[f"n{i}" for i in range(1, 50)])
+        log += [("P", "created"), ("P", "claimed"), ("n0", "created")]
+        conn = board(tasks, links, log=log)
+        # P is not reachable from the ring, so the edge inverts.
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), ["n0"])
+
+    # --- the event ----------------------------------------------------------
+
+    def test_no_children_writes_nothing(self):
+        conn = board({"P": "running"}, log=fanned_out("P"))
+        self.assertEqual(repair_inverted_dependencies(conn, "P"), [])
+        self.assertEqual(repair_events(conn, "P"), [])
+
+    def test_event_records_the_repair(self):
+        conn = board(
+            {"P": "running", "A": "todo"}, [("P", "A")], log=fanned_out("P", "A")
+        )
+        repair_inverted_dependencies(conn, "P", reason="waiting on cluster audits")
+        payload = repair_events(conn, "P")[0]
+        self.assertEqual(payload["inverted"], ["A"])
+        self.assertEqual(payload["reason"], "waiting on cluster audits")
+
+    def test_long_reason_is_clipped(self):
+        conn = board(
+            {"P": "running", "A": "todo"}, [("P", "A")], log=fanned_out("P", "A")
+        )
+        repair_inverted_dependencies(conn, "P", reason="x" * 5000)
+        self.assertEqual(len(repair_events(conn, "P")[0]["reason"]), 200)
+
+    def test_find_deadlocked_children_ignores_settled(self):
+        conn = board(
+            {"P": "running", "A": "todo", "B": "done", "C": "blocked"},
+            [("P", "A"), ("P", "B"), ("P", "C")],
+            log=fanned_out("P", "A", "B", "C"),
+        )
+        self.assertEqual(find_deadlocked_children(conn, "P"), ["A", "C"])
+
+
+# ---------------------------------------------------------------------------
+# Part 2: claims fenced to a process life
+# ---------------------------------------------------------------------------
+
+FENCE_SCHEMA = """
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    status TEXT NOT NULL,
+    worker_pid INTEGER,
+    claim_lock TEXT,
+    claim_expires INTEGER,
+    current_run_id INTEGER,
+    started_at INTEGER
+);
+CREATE TABLE task_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    status TEXT,
+    outcome TEXT,
+    started_at INTEGER,
+    ended_at INTEGER,
+    error TEXT
+);
+CREATE TABLE task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    run_id INTEGER,
+    kind TEXT NOT NULL,
+    payload TEXT,
+    created_at INTEGER
+);
+"""
+
+
+def fence_board(rows):
+    """rows: (id, status, worker_pid, claim_lock[, claimed_at]).
+
+    Each row gets a running run row. ``claimed_at`` defaults to NULL, which is
+    what an un-migrated board or a card whose run row has gone looks like — and
+    which the discriminator reads as ``CLAIM_TIME_UNKNOWN``, so the default is
+    the conservative one.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(FENCE_SCHEMA)
+    for row in rows:
+        tid, status, pid, lock = row[:4]
+        claimed_at = row[4] if len(row) > 4 else None
+        cur = conn.execute(
+            "INSERT INTO task_runs (task_id, status, started_at) "
+            "VALUES (?, 'running', ?)",
+            (tid, claimed_at),
+        )
+        conn.execute(
+            "INSERT INTO tasks (id, status, worker_pid, claim_lock, claim_expires, "
+            "current_run_id) VALUES (?, ?, ?, ?, 9999999999, ?)",
+            (tid, status, pid, lock, cur.lastrowid),
+        )
+    return conn
+
+
+def task(conn, tid):
+    return conn.execute("SELECT * FROM tasks WHERE id = ?", (tid,)).fetchone()
+
+
+def run_row(conn, tid):
+    return conn.execute(
+        "SELECT * FROM task_runs WHERE task_id = ? ORDER BY id DESC", (tid,)
+    ).fetchone()
+
+
+def events(conn, tid):
+    return [
+        (r["kind"], json.loads(r["payload"]))
+        for r in conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        )
+    ]
+
+
+def released(swept):
+    """Every id the sweep handed back, charged or not.
+
+    Sorted because the split is what the dedicated tests below assert on; these
+    ones are about *whether* a card came back, and the fixtures name their cards
+    so that sorted order is board order.
+    """
+    return sorted(list(swept.chargeable) + list(swept.forgiven))
+
+
+DEAD = lambda pid: False  # noqa: E731
+ALIVE = lambda pid: True  # noqa: E731
+
+
+class ClaimIsSelfTest(unittest.TestCase):
+    def test_same_pod_different_process_is_not_self(self):
+        """The whole bug in one assertion: upstream's prefix test said True here."""
+        self.assertTrue(OLD.startswith(POD + ":"))
+        self.assertFalse(claim_is_self(OLD, NEW))
+
+    def test_exact_token_is_self(self):
+        self.assertTrue(claim_is_self(NEW, NEW))
+
+    def test_other_pod_is_not_self(self):
+        self.assertFalse(claim_is_self(OTHER_POD, NEW))
+
+    def test_empty_and_none_are_not_self(self):
+        self.assertFalse(claim_is_self("", NEW))
+        self.assertFalse(claim_is_self(None, NEW))
+
+    def test_prefix_of_our_token_is_not_self(self):
+        """`pod:4` must not match `pod:41` in either direction."""
+        self.assertFalse(claim_is_self(f"{POD}:4", f"{POD}:41"))
+        self.assertFalse(claim_is_self(f"{POD}:41", f"{POD}:4"))
+
+
+class ClaimHostTest(unittest.TestCase):
+    """``claim_host`` must split exactly the way upstream's host_prefix did."""
+
+    def test_the_host_half_is_everything_before_the_first_colon(self):
+        self.assertEqual(claim_host(OLD), POD)
+        self.assertEqual(claim_host(NEW), POD)
+
+    def test_a_hostname_containing_a_colon_splits_once_like_upstream(self):
+        self.assertEqual(claim_host("weird:host:12"), "weird")
+
+    def test_missing_and_empty_tokens_are_the_empty_host(self):
+        self.assertEqual(claim_host(None), "")
+        self.assertEqual(claim_host(""), "")
+
+    def test_a_token_with_no_pid_is_all_host(self):
+        self.assertEqual(claim_host("bare-hostname"), "bare-hostname")
+
+
+class ProcessStartTimeTest(unittest.TestCase):
+    """The boundary the discriminator draws its second test against."""
+
+    def setUp(self):
+        self.saved = kanban_scheduling._PROCESS_START
+        self.addCleanup(setattr, kanban_scheduling, "_PROCESS_START", self.saved)
+
+    def test_the_proc_reader_answers_exactly_when_proc_is_there(self):
+        """Linux in the image, absent on a developer's machine; both are fine."""
+        self.assertEqual(
+            read_proc_start_time() is not None, Path("/proc/self/stat").exists()
+        )
+
+    def test_the_proc_reading_is_a_plausible_wall_clock_instant(self):
+        value = read_proc_start_time()
+        if value is None:
+            self.skipTest("no /proc on this platform")
+        self.assertLessEqual(value, time.time())
+        self.assertGreater(value, time.time() - 86_400)
+
+    def test_the_answer_is_in_the_past_and_stable(self):
+        first = process_start_time()
+        self.assertLessEqual(first, time.time())
+        self.assertEqual(process_start_time(), first)
+
+    def test_the_cache_is_keyed_by_pid_so_a_fork_recomputes(self):
+        """A module-level constant is inherited verbatim across ``os.fork()``.
+
+        Caching by PID is what stops a forked child reporting its parent's age,
+        which would make every claim the parent made look pre-boot to the child.
+        """
+        kanban_scheduling._PROCESS_START = (os.getpid() + 1_000_000, 1.0)
+        self.assertNotEqual(process_start_time(), 1.0)
+        self.assertEqual(kanban_scheduling._PROCESS_START[0], os.getpid())
+
+    def test_the_cached_value_for_this_pid_is_returned_verbatim(self):
+        kanban_scheduling._PROCESS_START = (os.getpid(), 12345.5)
+        self.assertEqual(process_start_time(), 12345.5)
+
+
+class ClassifyReclaimTest(unittest.TestCase):
+    """Which departures are infrastructure and which are faults."""
+
+    START = 1_000_000.0
+
+    def test_same_pod_is_an_in_place_death_however_old_the_claim(self):
+        """A container restart keeps the pod name. That is the poison-card shape.
+
+        Forgiving it would reopen the loop ``charge_reclaimed_cards`` exists to
+        close: a card whose work kills the gateway is reclaimed by the process
+        that comes up next, and its claim is always older than that process.
+        """
+        self.assertEqual(
+            classify_reclaim(OLD, NEW, self.START - 5_000, self.START),
+            PROCESS_DIED_IN_PLACE,
+        )
+
+    def test_same_pod_and_a_fresh_claim_is_still_an_in_place_death(self):
+        self.assertEqual(
+            classify_reclaim(OLD, NEW, self.START + 5_000, self.START),
+            PROCESS_DIED_IN_PLACE,
+        )
+
+    def test_a_different_pod_with_an_older_claim_is_a_replacement(self):
+        self.assertEqual(
+            classify_reclaim(OTHER_POD, NEW, self.START - 1, self.START),
+            POD_REPLACED,
+        )
+
+    def test_a_different_pod_claiming_after_we_started_is_a_live_neighbour(self):
+        """A CLI elsewhere, or a second replica: we watched that owner die."""
+        self.assertEqual(
+            classify_reclaim(OTHER_POD, NEW, self.START + 1, self.START),
+            CONCURRENT_OWNER,
+        )
+
+    def test_the_boundary_second_is_charged(self):
+        """``claim_task`` writes whole seconds, so the start is truncated.
+
+        A claim 0.4s after this process began records as the second below the
+        fractional start; comparing against the truncated value keeps that
+        second on the charged side, which is the safe direction.
+        """
+        self.assertEqual(
+            classify_reclaim(OTHER_POD, NEW, 1_000_000, 1_000_000.9),
+            CONCURRENT_OWNER,
+        )
+
+    def test_an_absent_claim_time_is_not_a_provable_replacement(self):
+        self.assertEqual(
+            classify_reclaim(OTHER_POD, NEW, None, self.START), CLAIM_TIME_UNKNOWN
+        )
+
+    def test_an_unparseable_claim_time_is_not_a_provable_replacement(self):
+        self.assertEqual(
+            classify_reclaim(OTHER_POD, NEW, "whenever", self.START),
+            CLAIM_TIME_UNKNOWN,
+        )
+
+    def test_only_a_pod_replacement_escapes_the_charge(self):
+        """The property the sweep depends on, stated once rather than inferred."""
+        fates = {
+            classify_reclaim(OLD, NEW, PRE_BOOT, self.START),
+            classify_reclaim(OTHER_POD, NEW, self.START + 1, self.START),
+            classify_reclaim(OTHER_POD, NEW, None, self.START),
+        }
+        self.assertNotIn(POD_REPLACED, fates)
+
+
+class ReleaseDeadForeignClaimsTest(unittest.TestCase):
+    def test_predecessors_dead_claims_come_back(self):
+        conn = fence_board(
+            [("t1", "running", 1044, OLD), ("t2", "running", 1046, OLD)]
+        )
+        swept = release_dead_foreign_claims(conn, NEW, DEAD)
+        self.assertEqual(released(swept), ["t1", "t2"])
+        for tid in ("t1", "t2"):
+            row = task(conn, tid)
+            self.assertEqual(row["status"], "ready")
+            self.assertIsNone(row["claim_lock"])
+            self.assertIsNone(row["claim_expires"])
+            self.assertIsNone(row["worker_pid"])
+            self.assertIsNone(row["current_run_id"])
+
+    def test_the_card_comes_back_ready_not_todo(self):
+        """``todo`` is how a card used to walk past the breaker.
+
+        ``recompute_ready`` applies its failure-limit guard only to ``blocked``
+        rows and promotes ``todo`` unconditionally, and
+        ``_record_task_failure``'s trip branch is gated on
+        ``status IN ('ready', 'running')`` — so a reclaim that lands in ``todo``
+        can be neither stopped nor even counted.
+        """
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        release_dead_foreign_claims(conn, NEW, DEAD)
+        self.assertEqual(task(conn, "t1")["status"], "ready")
+
+    def test_release_is_reclaimed_not_crashed(self):
+        """The run outcome names the infrastructure event, not a worker fault."""
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        release_dead_foreign_claims(conn, NEW, DEAD)
+        run = run_row(conn, "t1")
+        self.assertEqual(run["status"], "reclaimed")
+        self.assertEqual(run["outcome"], "reclaimed")
+        self.assertEqual(run["error"], RECLAIM_ERROR)
+        self.assertIsNotNone(run["ended_at"])
+        kind, payload = events(conn, "t1")[0]
+        self.assertEqual(kind, RECLAIM_EVENT_KIND)
+        self.assertNotEqual(kind, "crashed")
+        self.assertEqual(payload["stale_lock"], OLD)
+        self.assertEqual(payload["worker_pid"], 1044)
+        self.assertEqual(payload["reason"], "owner_process_gone")
+
+    def test_our_own_claims_are_never_touched(self):
+        conn = fence_board([("mine", "running", 2001, NEW)])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), [])
+        self.assertEqual(task(conn, "mine")["status"], "running")
+
+    def test_a_live_foreign_worker_is_left_to_the_ttl(self):
+        """This is what makes the sweep safe from a CLI process.
+
+        A CLI has its own claimer id and sees the gateway's claims as foreign,
+        but the gateway's workers are alive, so nothing is taken from them.
+        """
+        conn = fence_board([("gw", "running", 2001, OLD)])
+        self.assertEqual(
+            released(release_dead_foreign_claims(conn, OTHER_POD, ALIVE)), []
+        )
+        self.assertEqual(task(conn, "gw")["status"], "running")
+
+    def test_rolled_pods_claims_come_back_without_waiting_out_the_ttl(self):
+        """claim_expires is far in the future; the sweep does not consult it."""
+        conn = fence_board([("t1", "running", 2017, OTHER_POD, PRE_BOOT)])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), ["t1"])
+
+    def test_only_running_rows_are_candidates(self):
+        conn = fence_board([("d", "done", 1044, OLD), ("b", "blocked", 1045, OLD)])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), [])
+
+    def test_rows_without_a_pid_are_left_for_the_ttl(self):
+        conn = fence_board([("t1", "running", None, OLD)])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), [])
+        self.assertEqual(task(conn, "t1")["status"], "running")
+
+    def test_mixed_board_releases_only_the_dead_foreign_rows(self):
+        conn = fence_board(
+            [
+                ("mine_live", "running", 3001, NEW),
+                ("mine_dead", "running", 3002, NEW),
+                ("prev_dead", "running", 1044, OLD),
+                ("other_live", "running", 2001, OTHER_POD),
+            ]
+        )
+        alive = {3001, 2001}
+        swept = release_dead_foreign_claims(conn, NEW, lambda p: p in alive)
+        self.assertEqual(released(swept), ["prev_dead"])
+        # mine_dead is ours: detect_crashed_workers still owns that decision.
+        self.assertEqual(task(conn, "mine_dead")["status"], "running")
+
+    def test_sweep_is_idempotent(self):
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), ["t1"])
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), [])
+
+    def test_non_integer_pid_is_skipped_not_fatal(self):
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        conn.execute("UPDATE tasks SET worker_pid = 'x' WHERE id = 't1'")
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), [])
+
+    def test_a_card_inside_the_grace_window_is_left_alone(self):
+        """The sweep must not be stricter than the per-row loop it runs ahead of.
+
+        A worker claimed one second ago may not be on ``/proc`` yet, so a dead
+        PID reading proves nothing — for a foreign claim exactly as much as for
+        our own.
+        """
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = 't1'", (time.time(),))
+        self.assertEqual(
+            released(release_dead_foreign_claims(conn, NEW, DEAD, lambda: 30)), []
+        )
+        self.assertEqual(task(conn, "t1")["status"], "running")
+
+    def test_a_card_past_the_grace_window_is_released(self):
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        conn.execute(
+            "UPDATE tasks SET started_at = ? WHERE id = 't1'", (time.time() - 31,)
+        )
+        self.assertEqual(
+            released(release_dead_foreign_claims(conn, NEW, DEAD, lambda: 30)), ["t1"]
+        )
+
+    def test_a_null_started_at_does_not_confer_grace(self):
+        """``fence_board()`` leaves ``started_at`` NULL, as an un-migrated row would."""
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        self.assertEqual(
+            released(release_dead_foreign_claims(conn, NEW, DEAD, lambda: 30)), ["t1"]
+        )
+
+    def test_the_grace_resolver_is_consulted_at_most_once(self):
+        conn = fence_board(
+            [("t1", "running", 1044, OLD), ("t2", "running", 1045, OLD)]
+        )
+        conn.execute("UPDATE tasks SET started_at = ?", (time.time() - 31,))
+        calls = []
+
+        def resolver():
+            calls.append(1)
+            return 30
+
+        self.assertEqual(
+            released(release_dead_foreign_claims(conn, NEW, DEAD, resolver)),
+            ["t1", "t2"],
+        )
+        self.assertEqual(len(calls), 1)
+
+    def test_an_already_closed_run_is_not_rewritten(self):
+        conn = fence_board([("t1", "running", 1044, OLD)])
+        conn.execute(
+            "UPDATE task_runs SET ended_at = 123, outcome = 'completed' "
+            "WHERE task_id = 't1'"
+        )
+        self.assertEqual(released(release_dead_foreign_claims(conn, NEW, DEAD)), ["t1"])
+        row = run_row(conn, "t1")
+        self.assertEqual(row["outcome"], "completed")
+        self.assertEqual(row["ended_at"], 123)
+
+
+class ReclaimDiscriminatorTest(unittest.TestCase):
+    """Which of the sweep's releases the caller is told to charge for.
+
+    The boundary is injected rather than read from ``/proc`` so these assert on
+    the rule rather than on how fast the test suite runs.
+    """
+
+    START = float(NOW - 3_600)
+
+    def sweep(self, rows, claimer=NEW):
+        conn = fence_board(rows)
+        return conn, release_dead_foreign_claims(
+            conn, claimer, DEAD, None, self.START
+        )
+
+    def test_a_replaced_pods_card_is_returned_forgiven(self):
+        conn, swept = self.sweep([("t1", "running", 1044, OTHER_POD, PRE_BOOT)])
+        self.assertEqual(list(swept.forgiven), ["t1"])
+        self.assertEqual(list(swept.chargeable), [])
+        self.assertEqual(task(conn, "t1")["status"], "ready")
+
+    def test_an_in_place_death_is_returned_chargeable(self):
+        conn, swept = self.sweep([("t1", "running", 1044, OLD, PRE_BOOT)])
+        self.assertEqual(list(swept.chargeable), ["t1"])
+        self.assertEqual(list(swept.forgiven), [])
+
+    def test_a_concurrent_owner_is_returned_chargeable(self):
+        _, swept = self.sweep(
+            [("t1", "running", 1044, OTHER_POD, int(self.START) + 60)]
+        )
+        self.assertEqual(list(swept.chargeable), ["t1"])
+
+    def test_an_unknown_claim_time_is_returned_chargeable(self):
+        _, swept = self.sweep([("t1", "running", 1044, OTHER_POD)])
+        self.assertEqual(list(swept.chargeable), ["t1"])
+
+    def test_the_two_halves_are_split_not_merged(self):
+        conn, swept = self.sweep(
+            [
+                ("rolled", "running", 1044, OTHER_POD, PRE_BOOT),
+                ("crashed", "running", 1045, OLD, PRE_BOOT),
+            ]
+        )
+        self.assertIsInstance(swept, Reclaimed)
+        self.assertEqual(list(swept.forgiven), ["rolled"])
+        self.assertEqual(list(swept.chargeable), ["crashed"])
+
+    def test_a_forgiven_card_is_released_exactly_like_a_charged_one(self):
+        """Forgiveness is about the retry budget and nothing else.
+
+        The card still comes back to ``ready``, the run is still closed with the
+        reclaim outcome, and the event is still written — otherwise a free
+        reclaim would be indistinguishable from a sweep that did nothing.
+        """
+        conn, _ = self.sweep([("t1", "running", 1044, OTHER_POD, PRE_BOOT)])
+        row = task(conn, "t1")
+        self.assertEqual(row["status"], "ready")
+        self.assertIsNone(row["claim_lock"])
+        self.assertIsNone(row["current_run_id"])
+        run = run_row(conn, "t1")
+        self.assertEqual(run["outcome"], "reclaimed")
+        self.assertEqual(run["error"], RECLAIM_ERROR)
+
+    def test_the_event_records_the_verdict_and_the_reason_for_it(self):
+        conn, _ = self.sweep([("t1", "running", 1044, OTHER_POD, PRE_BOOT)])
+        _, payload = events(conn, "t1")[0]
+        self.assertEqual(payload["owner_fate"], POD_REPLACED)
+        self.assertFalse(payload["charged"])
+
+    def test_a_charged_release_says_so_on_the_board_too(self):
+        """The counter and the history must not be able to disagree."""
+        conn, _ = self.sweep([("t1", "running", 1044, OLD, PRE_BOOT)])
+        _, payload = events(conn, "t1")[0]
+        self.assertEqual(payload["owner_fate"], PROCESS_DIED_IN_PLACE)
+        self.assertTrue(payload["charged"])
+
+    def test_the_old_payload_keys_are_all_still_there(self):
+        """Anything reading ``reclaimed`` events predates the discriminator."""
+        conn, _ = self.sweep([("t1", "running", 1044, OTHER_POD, PRE_BOOT)])
+        _, payload = events(conn, "t1")[0]
+        self.assertEqual(payload["stale_lock"], OTHER_POD)
+        self.assertEqual(payload["worker_pid"], 1044)
+        self.assertEqual(payload["claimer"], NEW)
+        self.assertEqual(payload["reason"], "owner_process_gone")
+        self.assertTrue(payload["fenced"])
+
+    def test_the_claim_instant_comes_from_the_current_run_not_the_card(self):
+        """``tasks.started_at`` is the FIRST start the card ever had.
+
+        It is ``COALESCE(started_at, ?)``, so a card first claimed last week and
+        re-claimed a moment ago still reads ancient there. Judging the owner on
+        it would forgive a claim made while we were watching.
+        """
+        conn = fence_board(
+            [("t1", "running", 1044, OTHER_POD, int(self.START) + 60)]
+        )
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = 't1'", (PRE_BOOT,))
+        swept = release_dead_foreign_claims(conn, NEW, DEAD, None, self.START)
+        self.assertEqual(list(swept.chargeable), ["t1"])
+
+    def test_repeated_pod_replacements_never_exhaust_the_budget(self):
+        """The arithmetic this exists for: DEFAULT_FAILURE_LIMIT is 2.
+
+        Charging every reclaim parked a long-lived card in ``blocked`` on the
+        second ordinary deploy it happened to sit through, and there was nothing
+        for the human that summoned to do about it.
+        """
+        for cycle in range(6):
+            conn = fence_board(
+                [("t1", "running", 1044, f"pod-{cycle}:{cycle}", PRE_BOOT)]
+            )
+            swept = release_dead_foreign_claims(conn, NEW, DEAD, None, self.START)
+            self.assertEqual(list(swept.chargeable), [], f"cycle {cycle}")
+
+    def test_the_default_boundary_is_this_processs_own_start(self):
+        """Omitting ``process_start`` must not silently forgive everything."""
+        conn = fence_board([("t1", "running", 1044, OTHER_POD, NOW + 3_600)])
+        swept = release_dead_foreign_claims(conn, NEW, DEAD)
+        self.assertEqual(list(swept.chargeable), ["t1"])
+
+
+class ChargeReclaimedCardsTest(unittest.TestCase):
+    """``_record_task_failure`` lives in kanban_db, so record what it is handed."""
+
+    def setUp(self):
+        self.calls = []
+
+    def recorder(self, trips=()):
+        def record_failure(conn, task_id, **kwargs):
+            self.calls.append((task_id, kwargs))
+            return task_id in trips
+
+        return record_failure
+
+    def test_every_released_card_is_charged_one_failure(self):
+        parked = charge_reclaimed_cards(None, ["t1", "t2"], self.recorder())
+        self.assertEqual(parked, [])
+        self.assertEqual([tid for tid, _ in self.calls], ["t1", "t2"])
+
+    def test_the_cards_the_breaker_parked_are_returned(self):
+        """``dispatch_once`` reports these as auto-blocked, so a human hears."""
+        parked = charge_reclaimed_cards(
+            None, ["t1", "t2", "t3"], self.recorder(trips={"t2"})
+        )
+        self.assertEqual(parked, ["t2"])
+
+    def test_nothing_released_means_nothing_charged(self):
+        self.assertEqual(charge_reclaimed_cards(None, [], self.recorder()), [])
+        self.assertEqual(self.calls, [])
+
+    def test_the_charge_uses_the_dispatchers_own_threshold(self):
+        """No second retry budget: no ``failure_limit``, no ``force_trip``.
+
+        ``_record_task_failure`` then resolves per-task ``max_retries``, else
+        ``kanban.failure_limit``, else ``DEFAULT_FAILURE_LIMIT`` — the same
+        ladder every other failure kind is judged on.
+        """
+        charge_reclaimed_cards(None, ["t1"], self.recorder())
+        _, kwargs = self.calls[0]
+        self.assertNotIn("failure_limit", kwargs)
+        self.assertNotIn("force_trip", kwargs)
+
+    def test_the_charge_neither_releases_a_claim_nor_ends_a_run(self):
+        """The sweep already did both, inside its own transaction."""
+        charge_reclaimed_cards(None, ["t1"], self.recorder())
+        _, kwargs = self.calls[0]
+        self.assertFalse(kwargs["release_claim"])
+        self.assertFalse(kwargs["end_run"])
+
+    def test_the_gave_up_event_says_why_the_card_was_parked(self):
+        charge_reclaimed_cards(None, ["t1"], self.recorder(trips={"t1"}))
+        _, kwargs = self.calls[0]
+        self.assertEqual(kwargs["error"], RECLAIM_ERROR)
+        self.assertEqual(kwargs["outcome"], RECLAIM_EVENT_KIND)
+        self.assertEqual(
+            kwargs["event_payload_extra"],
+            {"reason": "owner_process_gone", "fenced": True},
+        )
+
+    def test_only_the_chargeable_half_is_ever_handed_over(self):
+        """The wiring the applier emits, asserted as a rule rather than a string.
+
+        ``charge_reclaimed_cards`` has no idea a forgiven list exists; the sweep
+        is what decides, and the caller passes ``.chargeable``. If that ever
+        becomes the whole ``Reclaimed`` tuple again, the forgiven cards are
+        charged and the discriminator is a no-op.
+        """
+        swept = Reclaimed(chargeable=["c1"], forgiven=["f1"])
+        charge_reclaimed_cards(None, swept.chargeable, self.recorder())
+        self.assertEqual([tid for tid, _ in self.calls], ["c1"])
+
+
+class FingerprintTest(unittest.TestCase):
+    """Why ``_error_fingerprint`` is left exactly as upstream ships it."""
+
+    def test_normalising_the_pid_is_what_makes_a_burst_detectable(self):
+        """Every message on this path is PID-prefixed, so the sub is load-bearing.
+
+        ``detect_crashed_workers`` builds all three of these itself. Without the
+        substitution no two concurrent workers can share a bucket, ``_fp_counts``
+        never reaches the ``>= 3`` the systemic heuristic tests, and the
+        detector is dead code.
+        """
+        for template in (
+            "pid {} not alive",
+            "pid {} exited with code 137",
+            "pid {} killed by signal 9",
+        ):
+            messages = [template.format(p) for p in (1044, 1045, 1046, 1047)]
+            with self.subTest(template=template):
+                self.assertEqual(
+                    len({upstream_fingerprint(m) for m in messages}),
+                    1,
+                    "four workers felled by one event must land in one bucket",
+                )
+                self.assertEqual(
+                    len({m[:80] for m in messages}),
+                    4,
+                    "and the unnormalised text is what used to split them",
+                )
+
+    def test_distinct_faults_still_keep_their_own_buckets(self):
+        self.assertNotEqual(
+            upstream_fingerprint("pid 1044 exited with code 137"),
+            upstream_fingerprint("pid 1044 killed by signal 9"),
+        )
+
+    def test_timestamp_normalisation_is_untouched(self):
+        self.assertEqual(
+            upstream_fingerprint("failed at 1754539230"),
+            upstream_fingerprint("failed at 1754539999"),
+        )
+
+    def test_a_reclaim_never_reaches_the_fingerprint_at_all(self):
+        """Six identical reclaim texts would otherwise read as one systemic fault.
+
+        ``charge_reclaimed_cards`` runs its own loop precisely so that a
+        container restart handing back every in-flight card cannot collapse into
+        ``failure_limit=1`` and abandon the lot — the 2026-08-07 outcome by
+        another route. The discriminator does not make that loop unnecessary: an
+        in-place death is still charged, and still delivers every card at once
+        with one identical error text.
+        """
+        self.assertEqual(
+            len({upstream_fingerprint(RECLAIM_ERROR) for _ in range(6)}), 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part 3: the applier
+# ---------------------------------------------------------------------------
+
+# A stand-in for block_task's dependency branch with the same indentation as
+# upstream, so the applier's ast.parse guard is exercised for real.
+BLOCK_TASK_PREAMBLE = (
+    "def block_task(conn, task_id, kind, reason, expected_run_id=None):\n"
+    "    with write_txn(conn):\n"
+    '        if kind == "dependency":\n'
+    "            cur = conn.execute(SQL)\n"
+    "            if cur.rowcount != 1:\n"
+    "                return False\n"
+    "            run_id = _end_run(conn, task_id)\n"
+)
+BLOCK_TASK_EPILOGUE = "            )\n            return True\n"
+
+DETECT_CRASHED_PREAMBLE = (
+    "\n\ndef detect_crashed_workers(conn):\n    with write_txn(conn):\n"
+)
+DETECT_CRASHED_MIDDLE = "            pass\n    auto_blocked = []\n"
+DETECT_CRASHED_EPILOGUE = (
+    "    detect_crashed_workers._last_auto_blocked = auto_blocked\n"
+    "    return crashed\n\n"
+)
+
+# The shape of the region the breaker edits patch, reproduced from
+# hermes_cli/kanban_db.py at the pinned Hermes version. Only the anchors
+# matter, but the surroundings keep the fixture honest about indentation and
+# about the two sibling UPDATEs in the else-branch that must NOT be touched.
+RECORD_FAILURE_FIXTURE = '''\
+def _record_task_failure(conn, task_id, error, *, outcome, failure_limit=None,
+                        force_trip=False, release_claim=False, end_run=False,
+                        event_payload_extra=None):
+    if failure_limit is None:
+        failure_limit = DEFAULT_FAILURE_LIMIT
+    blocked = False
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT consecutive_failures, status, max_retries "
+            "FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        failures = int(row["consecutive_failures"]) + 1
+        task_override = (
+            row["max_retries"] if "max_retries" in row.keys() else None
+        )
+        if task_override is not None:
+            effective_limit = int(task_override)
+            limit_source = "task"
+        else:
+            effective_limit = int(failure_limit)
+            limit_source = "dispatcher"
+
+        if force_trip or failures >= effective_limit:
+            # Trip the breaker.
+            if release_claim:
+                # Spawn path: still running, also clear claim state.
+                conn.execute(
+                    "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, "
+                    "consecutive_failures = ?, last_failure_error = ? "
+                    "WHERE id = ? AND status IN ('running', 'ready')",
+                    (failures, error[:500], task_id),
+                )
+            else:
+                # Timeout/crash path: task is already at ``ready``
+                # with claim cleared; just flip to blocked + update
+                # counter fields.
+                conn.execute(
+                    "UPDATE tasks SET status = 'blocked', "
+                    "consecutive_failures = ?, last_failure_error = ? "
+                    "WHERE id = ? AND status IN ('ready', 'running')",
+                    (failures, error[:500], task_id),
+                )
+            payload = {
+                "failures": failures,
+                "effective_limit": effective_limit,
+                "limit_source": limit_source,
+            }
+            blocked = True
+        else:
+            # Below threshold. These two must keep binding the raw count.
+            if release_claim:
+                conn.execute(
+                    "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                    "claim_expires = NULL, worker_pid = NULL, "
+                    "consecutive_failures = ?, last_failure_error = ? "
+                    "WHERE id = ? AND status = 'running'",
+                    (failures, error[:500], task_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE tasks SET consecutive_failures = ?, "
+                    "last_failure_error = ? WHERE id = ?",
+                    (failures, error[:500], task_id),
+                )
+    return blocked
+
+
+'''
+
+
+def pristine():
+    """A fake ``kanban_db.py`` carrying exactly one of each of the six anchors."""
+    return (
+        "import re\n\n"
+        + BLOCK_TASK_PREAMBLE
+        + DEPENDENCY_ANCHOR
+        + BLOCK_TASK_EPILOGUE
+        + DETECT_CRASHED_PREAMBLE
+        + FENCE_ANCHOR
+        + DETECT_CRASHED_MIDDLE
+        + CHARGE_ANCHOR
+        + DETECT_CRASHED_EPILOGUE
+        + RECORD_FAILURE_FIXTURE
+        + UPSTREAM_FINGERPRINT_SOURCE
+    )
+
+
+class ApplierTest(unittest.TestCase):
+    """The applier is the thing that fails the build, so exercise it directly."""
+
+    def _tree(self, body):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body)
+        return root, target
+
+    def _applied(self):
+        root, target = self._tree(pristine())
+        apply(root)
+        return target.read_text()
+
+    def test_the_fixture_is_a_faithful_stand_in(self):
+        """Every anchor exactly once, and the whole thing parses as Python."""
+        source = pristine()
+        for label, anchor, _ in EDITS:
+            with self.subTest(anchor=label):
+                self.assertEqual(source.count(anchor), 1)
+        ast.parse(source)
+
+    def test_all_six_edits_land_and_the_result_parses(self):
+        out = self._applied()
+        self.assertIn("_kanban_repair_inverted_deps(conn, task_id, reason)", out)
+        self.assertIn(
+            "_kanban_reclaimed = _kanban_release_dead_foreign_claims(\n"
+            "            conn, _kanban_claimer, _pid_alive, "
+            "_resolve_crash_grace_seconds\n        )",
+            out,
+        )
+        self.assertIn("_kanban_claim_is_self(lock, _kanban_claimer)", out)
+        self.assertIn(
+            "_kanban_charge_reclaimed_cards(\n"
+            "            conn, _kanban_reclaimed.chargeable, _record_task_failure\n"
+            "        )",
+            out,
+        )
+        self.assertIn(BUILD_MARKER, out)
+        ast.parse(out)
+
+    def test_one_trailer_imports_everything_the_edits_call(self):
+        """Three appliers used to write two trailers between them."""
+        out = self._applied()
+        self.assertEqual(out.count("from hermes_cli.kanban_scheduling import"), 1)
+        for name in (
+            "_kanban_charge_reclaimed_cards",
+            "_kanban_claim_is_self",
+            "_kanban_release_dead_foreign_claims",
+            "_kanban_repair_inverted_deps",
+        ):
+            with self.subTest(name=name):
+                self.assertIn(f"as {name},", out)
+
+    def test_only_the_chargeable_half_is_passed_to_the_charge_loop(self):
+        """Passing the whole tuple would charge the forgiven cards as well."""
+        out = self._applied()
+        self.assertIn("_kanban_reclaimed.chargeable, _record_task_failure", out)
+        self.assertNotIn("conn, _kanban_reclaimed, _record_task_failure", out)
+
+    def test_call_precedes_the_dependency_wait_event(self):
+        out = self._applied()
+        self.assertLess(
+            out.index("_kanban_repair_inverted_deps"),
+            out.index('"dependency_wait"'),
+            "the repair must land before the event that reports the wait",
+        )
+
+    def test_host_prefix_comparison_is_gone_from_the_crash_reaper(self):
+        self.assertNotIn("lock.startswith(host_prefix)", self._applied())
+
+    def test_the_fingerprint_is_left_exactly_as_upstream_wrote_it(self):
+        """The regression this file used to carry, pinned so it cannot return."""
+        out = self._applied()
+        self.assertIn(UPSTREAM_FINGERPRINT_SOURCE, out)
+        self.assertNotIn("fp = error_text[:80]", out)
+
+    def test_sweep_runs_before_the_rows_are_read(self):
+        out = self._applied()
+        self.assertLess(
+            out.index("_kanban_release_dead_foreign_claims"),
+            out.index('"SELECT id, worker_pid, claim_lock, started_at FROM tasks "'),
+        )
+
+    def test_the_charge_runs_after_the_sweeps_transaction_has_closed(self):
+        """``_record_task_failure`` opens its own txn, and ``write_txn`` cannot nest."""
+        out = self._applied()
+        charge = out.index("_kanban_charge_reclaimed_cards")
+        self.assertLess(out.index("with write_txn(conn):"), charge)
+        self.assertLess(charge, out.index("_last_auto_blocked"))
+        # Nothing the charge does may sit at the transaction's indentation.
+        self.assertIn("\n    auto_blocked.extend(\n", out)
+
+    def test_floors_the_persisted_counter_on_the_trip_path_only(self):
+        patched = self._applied()
+
+        # The floor landed, and it consults the per-task override.
+        self.assertIn(BUILD_MARKER, patched)
+        self.assertIn("if task_override is None:", patched)
+        self.assertIn("persisted_failures, DEFAULT_FAILURE_LIMIT", patched)
+
+        # Both blocked-branch UPDATEs now bind the floored value...
+        self.assertEqual(
+            patched.count("(persisted_failures, error[:500], task_id),"), 2
+        )
+        # ...and the two below-threshold UPDATEs still bind the raw count.
+        self.assertEqual(patched.count("(failures, error[:500], task_id),"), 2)
+
+        # The gave_up payload keeps reporting the true attempt count, so the
+        # audit trail does not silently change meaning.
+        self.assertIn('"failures": failures,', patched)
+
+    def test_floor_is_computed_before_the_updates_that_use_it(self):
+        patched = self._applied()
+        assign = patched.index(BUILD_MARKER)
+        first_use = patched.index("(persisted_failures, error[:500], task_id),")
+        self.assertLess(assign, first_use)
+
+    def test_every_anchor_is_load_bearing(self):
+        """Remove any one of the six and the build must stop."""
+        for label, anchor, _ in EDITS:
+            with self.subTest(anchor=label):
+                root, _ = self._tree(pristine().replace(anchor, "", 1))
+                with self.assertRaises(SystemExit):
+                    apply(root)
+
+    def test_partial_apply_does_not_write(self):
+        """One anchor missing: leave the file exactly as it was found."""
+        body = pristine().replace(CHARGE_ANCHOR, "", 1)
+        root, target = self._tree(body)
+        with self.assertRaises(SystemExit):
+            apply(root)
+        self.assertEqual(target.read_text(), body)
+
+    def test_duplicate_anchor_fails_the_build(self):
+        for anchor in (FENCE_ANCHOR, TRIP_ANCHOR, SPAWN_BIND_ANCHOR,
+                       CRASH_BIND_ANCHOR):
+            with self.subTest(anchor=anchor.splitlines()[0]):
+                root, _ = self._tree(pristine() + anchor)
+                with self.assertRaises(SystemExit):
+                    apply(root)
+
+    def test_a_missing_target_file_fails_the_build(self):
+        with self.assertRaises(SystemExit):
+            apply(Path(tempfile.mkdtemp()))
+
+    def test_the_patched_text_still_contains_the_anchor(self):
+        """Which is exactly why counting the anchor cannot detect a re-run."""
+        self.assertIn(DEPENDENCY_ANCHOR, DEPENDENCY_PATCHED)
+
+    def test_a_second_run_is_refused_instead_of_stacking_the_call(self):
+        """Replayed against the running gateway's kanban_db.py, the unguarded
+        applier exited 0 three times in a row and left three copies of the call
+        and three trailer imports behind.
+        """
+        root, target = self._tree(pristine())
+        apply(root)
+        once = target.read_text()
+        with self.assertRaises(SystemExit):
+            apply(root)
+        self.assertEqual(target.read_text(), once, "a refused run must not write")
+
+
+class WakeNudgeCompatibilityTest(unittest.TestCase):
+    """``apply_kanban_wake_nudge`` rewrites the same file, immediately after.
+
+    Its three ``kanban_db.py`` anchors sit in ``create_task``,
+    ``complete_task`` and ``unblock_task`` — functions none of the six edits
+    here touch. The coupling is invisible from either applier alone, so it is
+    asserted rather than left to inspection: a future edit that widens an anchor
+    into one of those functions fails here instead of in the image build.
+    """
+
+    # Each anchor is an indented fragment, so it only parses inside the shape
+    # of the function it was cut from. The scaffolds reproduce just enough of
+    # that shape for ast.parse to accept the combined fixture.
+    WAKE_ANCHORS = (
+        (
+            "create_task",
+            "\n\ndef create_task(conn, parents=None):\n"
+            "    with write_txn(conn):\n"
+            "        if True:\n"
+            "            if parents:\n",
+            WAKE_CREATE_ANCHOR,
+        ),
+        (
+            "complete_task",
+            "\n\ndef complete_task(conn, task_id):\n    pass\n",
+            WAKE_COMPLETE_ANCHOR,
+        ),
+        (
+            "unblock_task",
+            "\n\ndef unblock_task(conn, task_id, new_status='ready'):\n"
+            "    with write_txn(conn):\n",
+            WAKE_UNBLOCK_ANCHOR,
+        ),
+    )
+
+    def test_no_scheduling_anchor_overlaps_a_wake_nudge_anchor(self):
+        for label, _, wake in self.WAKE_ANCHORS:
+            for edit_label, anchor, _ in EDITS:
+                with self.subTest(wake=label, edit=edit_label):
+                    self.assertNotIn(anchor, wake)
+                    self.assertNotIn(wake, anchor)
+
+    def test_no_replacement_text_emits_a_wake_nudge_anchor(self):
+        """Emitting one would give wake_nudge two matches and fail its count."""
+        for label, _, wake in self.WAKE_ANCHORS:
+            for edit_label, _, patched in EDITS:
+                with self.subTest(wake=label, edit=edit_label):
+                    self.assertNotIn(wake, patched)
+
+    def test_the_wake_anchors_survive_a_full_scheduling_apply(self):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True, exist_ok=True)
+        body = pristine() + "".join(
+            scaffold + wake for _, scaffold, wake in self.WAKE_ANCHORS
+        )
+        ast.parse(body)
+        target.write_text(body)
+        apply(root)
+        out = target.read_text()
+        for label, _, wake in self.WAKE_ANCHORS:
+            with self.subTest(wake=label):
+                self.assertEqual(
+                    out.count(wake), 1, "still exactly one match for wake_nudge"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Part 4: the verifier's own fixture
+# ---------------------------------------------------------------------------
+
+VERIFIER = Path(__file__).with_name("verify_kanban_scheduling.py")
+
+
+def name_from_listing(directory):
+    """The scheme that shipped and failed: index by how many files are here."""
+    return directory / f"kanban{len(list(directory.iterdir()))}.db"
+
+
+class FreshBoardNamingTest(unittest.TestCase):
+    """``fresh()`` must actually hand back an empty board every time.
+
+    The Cloud Build failure this pins looked like a discriminator bug -- a sweep
+    returning one more chargeable card than the board had -- and was not. Every
+    "fresh" board after a certain point was reopening one file, so the sweep was
+    correctly reporting a card an earlier section had left ``running``.
+
+    The trigger is not reproducible off-Linux: ``K.connect`` opens each board in
+    WAL mode, and whether closing the last connection unlinks the ``-wal`` and
+    ``-shm`` sidecars depends on the SQLite build (it does in the image, it does
+    not on macOS). So these tests do not try to reproduce WAL cleanup. They
+    reproduce the property that made it fatal -- a name derived from a quantity
+    that can go *down* -- which is portable, and is the thing that was wrong.
+    """
+
+    def test_naming_from_a_directory_listing_hands_out_a_live_boards_name(self):
+        """The transition measured inside the image, reduced to bare files.
+
+        Three boards are open and each holds four files -- ``.db``, ``-wal``,
+        ``-shm`` and an ``.init.lock`` -- so the directory holds twelve and the
+        scheme picks ``kanban12``. Opening that board adds four more. Meanwhile
+        two earlier connections have been dropped, and SQLite unlinks the
+        ``-wal`` and ``-shm`` of each, taking four away. The count is unchanged,
+        so the very next call hands out ``kanban12`` a second time -- a board
+        that is open and already has cards on it.
+
+        This is the test that would have caught it. The scheme is correct only
+        while the directory grows monotonically, and that is an assumption
+        about SQLite's sidecar handling which nothing stated or checked.
+        """
+        root = Path(tempfile.mkdtemp())
+
+        def open_board(stem):
+            for suffix in (".db", ".db-shm", ".db-wal", ".db.init.lock"):
+                (root / f"{stem}{suffix}").touch()
+
+        def close_board(stem):
+            for suffix in (".db-shm", ".db-wal"):
+                (root / f"{stem}{suffix}").unlink()
+
+        for n in range(3):
+            open_board(f"kanban{n}")
+        self.assertEqual(len(list(root.iterdir())), 12)
+
+        first = name_from_listing(root)
+        self.assertEqual(first.name, "kanban12.db")
+        open_board(first.stem)
+        close_board("kanban1")
+        close_board("kanban2")
+
+        self.assertEqual(
+            name_from_listing(root),
+            first,
+            "the scheme handed out a board that is open and already has cards",
+        )
+
+    def test_a_counter_survives_the_same_removals(self):
+        """The replacement, exercised against the same hostile directory."""
+        root = Path(tempfile.mkdtemp())
+        counter = itertools.count()
+        handed_out = []
+        for _ in range(6):
+            path = root / f"kanban{next(counter)}.db"
+            handed_out.append(path)
+            path.touch()
+            (root / f"{path.name}-wal").touch()
+            for stale in root.glob("*.db-wal"):
+                if stale.name != f"{path.name}-wal":
+                    stale.unlink()
+        self.assertEqual(len(set(handed_out)), 6)
+
+    def test_the_verifier_names_its_boards_from_a_counter(self):
+        """Tied to the shipped file, so the property above is not hypothetical.
+
+        The verifier imports ``hermes_cli`` at module scope and only exists
+        inside the image, so this reads the source rather than importing it.
+        """
+        source = VERIFIER.read_text()
+        self.assertIn("itertools.count()", source)
+        # The name expression, not the prose: the docstring that explains the
+        # failure necessarily quotes the scheme it replaced.
+        self.assertIn('f"kanban{next(_BOARDS)}.db"', source)
+        self.assertNotIn('f"kanban{len(list(TMP.iterdir()))}.db"', source)
+
+    def test_the_verifier_refuses_a_board_that_is_not_empty(self):
+        """The second half of the fix: fail loudly at the cause, not downstream.
+
+        Without this, the next recurrence is once again a confusing assertion
+        about a sweep result somewhere far from the actual mistake.
+        """
+        source = VERIFIER.read_text()
+        self.assertIn("SELECT count(*) FROM tasks", source)
+        self.assertIn("fixture defect", source)
+
+    def test_every_verifier_board_comes_from_the_fresh_helper(self):
+        """A stray ``K.connect`` would bypass both halves of the guard."""
+        source = VERIFIER.read_text()
+        connects = [
+            line.strip()
+            for line in source.splitlines()
+            if "K.connect(" in line and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual(
+            connects,
+            ['conn = K.connect(TMP / f"kanban{next(_BOARDS)}.db")'],
+            "a board is being opened outside fresh()",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_wake_nudge.py
+++ b/deploy/docker/patches/test_kanban_wake_nudge.py
@@ -1,0 +1,510 @@
+"""Unit tests for the kanban wake nudge installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import ast
+import asyncio
+import logging
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+from apply_kanban_wake_nudge import (
+    CREATE_ANCHOR,
+    DB_RELATIVE,
+    DISPATCHER_SLEEP_ANCHOR,
+    NOTIFIER_SLEEP_ANCHOR,
+    UNBLOCK_ANCHOR,
+    WATCHERS_RELATIVE,
+    apply,
+)
+from kanban_wake_nudge import (
+    WakeMonitor,
+    record_wake,
+    record_wake_for_conn,
+    wait_interval,
+    wake_path,
+)
+import kanban_wake_nudge
+
+LOGGER_NAME = kanban_wake_nudge.logger.name
+
+
+def tmp_db_path():
+    return Path(tempfile.mkdtemp()) / "kanban.db"
+
+
+class RecordWakeTest(unittest.TestCase):
+    def test_the_wake_file_is_derived_from_the_db_path(self):
+        db = tmp_db_path()
+        self.assertEqual(wake_path(db), str(db) + ".wake")
+        self.assertTrue(record_wake(db))
+        self.assertTrue(Path(str(db) + ".wake").exists())
+
+    def test_two_nudges_produce_distinct_mtimes(self):
+        # The whole edge-detection scheme rests on this: mtime_ns is set
+        # explicitly from time.time_ns(), not left to filesystem granularity.
+        db = tmp_db_path()
+        record_wake(db)
+        first = os.stat(wake_path(db)).st_mtime_ns
+        record_wake(db)
+        second = os.stat(wake_path(db)).st_mtime_ns
+        self.assertNotEqual(first, second)
+
+    def test_an_unwritable_location_degrades_instead_of_raising(self):
+        # The nudge rides on the tail of a committed board write; a read-only
+        # filesystem must cost the nudge, never the write.
+        missing = Path(tempfile.mkdtemp()) / "no" / "such" / "dir" / "kanban.db"
+        self.assertFalse(record_wake(missing))
+
+    def test_a_hostile_path_type_degrades_instead_of_raising(self):
+        self.assertFalse(record_wake(None))
+
+
+class RecordWakeForConnTest(unittest.TestCase):
+    def test_the_nudge_lands_next_to_the_file_the_connection_writes(self):
+        db = tmp_db_path()
+        conn = sqlite3.connect(db)
+        try:
+            self.assertTrue(record_wake_for_conn(conn))
+        finally:
+            conn.close()
+        self.assertTrue(Path(wake_path(db)).exists())
+
+    def test_row_factory_does_not_break_the_pragma_read(self):
+        db = tmp_db_path()
+        conn = sqlite3.connect(db)
+        conn.row_factory = sqlite3.Row  # what kanban_db.connect() sets
+        try:
+            self.assertTrue(record_wake_for_conn(conn))
+        finally:
+            conn.close()
+        self.assertTrue(Path(wake_path(db)).exists())
+
+    def test_an_in_memory_db_has_no_file_and_degrades(self):
+        conn = sqlite3.connect(":memory:")
+        try:
+            self.assertFalse(record_wake_for_conn(conn))
+        finally:
+            conn.close()
+
+    def test_a_closed_connection_degrades_instead_of_raising(self):
+        conn = sqlite3.connect(":memory:")
+        conn.close()
+        self.assertFalse(record_wake_for_conn(conn))
+
+    def test_a_non_connection_degrades_instead_of_raising(self):
+        self.assertFalse(record_wake_for_conn(object()))
+
+
+class WakeMonitorTest(unittest.TestCase):
+    def test_quiet_board_means_no_change(self):
+        db = tmp_db_path()
+        record_wake(db)
+        monitor = WakeMonitor(db)
+        self.assertFalse(monitor.changed())
+        self.assertFalse(monitor.changed())
+
+    def test_history_from_before_construction_is_not_replayed(self):
+        db = tmp_db_path()
+        record_wake(db)
+        self.assertFalse(WakeMonitor(db).changed())
+
+    def test_a_nudge_is_seen_exactly_once(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+        record_wake(db)
+        self.assertTrue(monitor.changed())
+        self.assertFalse(monitor.changed(), "the edge must be consumed")
+
+    def test_the_first_nudge_ever_creates_the_file_and_is_seen(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)  # wake file does not exist yet
+        record_wake(db)
+        self.assertTrue(monitor.changed())
+
+    def test_a_burst_of_nudges_costs_one_early_scan(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+        for _ in range(5):
+            record_wake(db)
+        self.assertTrue(monitor.changed())
+        self.assertFalse(monitor.changed())
+
+    def test_a_missing_wake_file_reads_as_quiet(self):
+        monitor = WakeMonitor(tmp_db_path())
+        self.assertFalse(monitor.changed())
+
+    def test_a_callable_path_is_resolved_lazily_and_fail_soft(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(lambda: db)
+        record_wake(db)
+        self.assertTrue(monitor.changed())
+
+    def test_a_raising_resolver_degrades_the_monitor_not_the_caller(self):
+        def resolver():
+            raise RuntimeError("board root unreadable")
+
+        with self.assertLogs(LOGGER_NAME, level=logging.WARNING):
+            monitor = WakeMonitor(resolver)
+        self.assertFalse(monitor.changed())
+        self.assertFalse(monitor.changed())
+
+    def test_a_monitor_born_inert_says_why(self):
+        # The one failure here worth a log line. A resolver that raises leaves
+        # this monitor dead for the lifetime of the watcher loop that built it,
+        # so wait_interval silently becomes the 5s sleep it replaced and the
+        # only symptom is the per-hop latency the patch removed. Without this
+        # line an operator sees the old numbers and no cause.
+        def resolver():
+            raise RuntimeError("HERMES_KANBAN_DB points at a missing volume")
+
+        with self.assertLogs(LOGGER_NAME, level=logging.WARNING) as captured:
+            WakeMonitor(resolver)
+        joined = "\n".join(captured.output)
+        self.assertIn("missing volume", joined, "the cause must survive")
+        self.assertIn("polling", joined, "the consequence must be stated")
+
+    def test_a_working_monitor_logs_nothing(self):
+        # Both watcher loops build one at startup; a warning on the healthy
+        # path would be noise on every gateway boot.
+        logging.getLogger(LOGGER_NAME).warning("probe")
+        with self.assertLogs(LOGGER_NAME, level=logging.WARNING) as captured:
+            logging.getLogger(LOGGER_NAME).warning("probe")
+            WakeMonitor(tmp_db_path())
+        self.assertEqual(len(captured.output), 1)
+
+    def test_an_unstattable_wake_file_stays_silent(self):
+        # Deliberately unlike the constructor: _stat runs once per 0.25s slice
+        # in both loops, so logging a missing wake file would cost eight lines
+        # a second forever. An absent file simply reads as quiet.
+        logging.getLogger(LOGGER_NAME).warning("probe")
+        monitor = WakeMonitor(tmp_db_path())
+        with self.assertLogs(LOGGER_NAME, level=logging.WARNING) as captured:
+            logging.getLogger(LOGGER_NAME).warning("probe")
+            for _ in range(10):
+                monitor.changed()
+        self.assertEqual(len(captured.output), 1)
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+class WaitIntervalTest(unittest.TestCase):
+    def test_a_nudge_breaks_the_wait_early(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+        record_wake(db)
+        start = time.monotonic()
+        self.assertTrue(run(wait_interval(monitor, 5.0)))
+        # <=0.25s reaction promised; allow slack for a slow CI box.
+        self.assertLess(time.monotonic() - start, 1.0)
+
+    def test_a_quiet_board_waits_the_full_interval(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+        start = time.monotonic()
+        self.assertTrue(run(wait_interval(monitor, 0.4)))
+        self.assertGreaterEqual(time.monotonic() - start, 0.35)
+
+    def test_shutdown_returns_false_immediately(self):
+        start = time.monotonic()
+        self.assertFalse(run(wait_interval(WakeMonitor(tmp_db_path()), 30.0, lambda: False)))
+        self.assertLess(time.monotonic() - start, 0.5)
+
+    def test_a_nudge_mid_wait_is_noticed_within_a_slice(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+
+        async def scenario():
+            async def nudge_later():
+                await asyncio.sleep(0.1)
+                record_wake(db)
+
+            task = asyncio.ensure_future(nudge_later())
+            start = time.monotonic()
+            woke = await wait_interval(monitor, 5.0)
+            await task
+            return woke, time.monotonic() - start
+
+        woke, elapsed = run(scenario())
+        self.assertTrue(woke)
+        self.assertLess(elapsed, 1.5)
+
+    def test_no_monitor_is_exactly_the_upstream_sleep(self):
+        start = time.monotonic()
+        self.assertTrue(run(wait_interval(None, 0.3)))
+        self.assertGreaterEqual(time.monotonic() - start, 0.25)
+
+    def test_a_raising_monitor_is_exactly_the_upstream_sleep(self):
+        class Broken:
+            def changed(self):
+                raise OSError("stat storm")
+
+        start = time.monotonic()
+        self.assertTrue(run(wait_interval(Broken(), 0.3)))
+        self.assertGreaterEqual(time.monotonic() - start, 0.25)
+
+    def test_a_garbage_interval_falls_back_rather_than_raising(self):
+        db = tmp_db_path()
+        monitor = WakeMonitor(db)
+        record_wake(db)
+        self.assertTrue(run(wait_interval(monitor, "not a number")))
+
+    def test_a_zero_interval_cannot_become_a_hot_loop(self):
+        start = time.monotonic()
+        self.assertTrue(run(wait_interval(WakeMonitor(tmp_db_path()), 0)))
+        self.assertGreaterEqual(time.monotonic() - start, 0.2)
+
+
+# The producers, reduced to the three regions the patch rewrites.
+UPSTREAM_DB = '''\
+def create_task(conn, **kwargs):
+    for attempt in range(2):
+        task_id = _new_task_id()
+        try:
+            with write_txn(conn):
+                do_inserts()
+                _inherit_notify_subs(conn, task_id, parents, created_at=now)
+            return task_id
+        except IntegrityError:
+            continue
+    raise RuntimeError("unreachable")
+
+
+def complete_task(conn, task_id):
+    _clear_failure_counter(conn, task_id)
+    # Recompute ready status for dependents (separate txn so children see done).
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    return True
+
+
+def unblock_task(conn, task_id):
+    with write_txn(conn):
+        cur = conn.execute("UPDATE tasks SET status = ?", ("ready",))
+        if cur.rowcount != 1:
+            return False
+        _append_event(
+            conn, task_id, "unblocked",
+            {"status": new_status} if new_status != "ready" else None,
+        )
+        return True
+'''
+
+# The consumers, reduced to the two loops the patch rewrites.
+UPSTREAM_WATCHERS = '''\
+class GatewayKanbanWatchersMixin:
+    async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
+        # Initial delay so the gateway can finish wiring adapters.
+        await asyncio.sleep(5)
+
+        while self._running:
+            try:
+                deliveries = await asyncio.to_thread(collect)
+            except Exception as exc:
+                logger.warning("kanban notifier tick failed: %s", exc)
+            # Sleep with cancellation checks.
+            for _ in range(int(max(1, interval))):
+                if not self._running:
+                    return
+                await asyncio.sleep(1)
+
+    async def _kanban_dispatcher_watcher(self) -> None:
+        logger.info(
+            "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval
+        )
+        while self._running:
+            try:
+                results = await asyncio.to_thread(tick)
+            except Exception:
+                logger.exception("kanban dispatcher: unexpected watcher error")
+
+            # Sleep in 1s slices so shutdown is snappy — otherwise a stop()
+            # waits up to `interval` seconds for the current sleep to finish.
+            slept = 0.0
+            while slept < interval and self._running:
+                await asyncio.sleep(min(1.0, interval - slept))
+                slept += 1.0
+
+        self._release_kanban_dispatcher_lock()
+'''
+
+
+def patch_tree(db_source=UPSTREAM_DB, watchers_source=UPSTREAM_WATCHERS):
+    """Write miniature sources under a temp root, patch, and return the texts."""
+    root = Path(tempfile.mkdtemp())
+    db_target = root / DB_RELATIVE
+    db_target.parent.mkdir(parents=True)
+    db_target.write_text(db_source)
+    watchers_target = root / WATCHERS_RELATIVE
+    watchers_target.parent.mkdir(parents=True)
+    watchers_target.write_text(watchers_source)
+    apply(root)
+    return db_target.read_text(), watchers_target.read_text()
+
+
+class ApplyTest(unittest.TestCase):
+    def test_every_anchor_matches_the_miniature_upstream_exactly_once(self):
+        for anchor in (CREATE_ANCHOR, UNBLOCK_ANCHOR):
+            self.assertEqual(UPSTREAM_DB.count(anchor), 1, anchor)
+        for anchor in (NOTIFIER_SLEEP_ANCHOR, DISPATCHER_SLEEP_ANCHOR):
+            self.assertEqual(UPSTREAM_WATCHERS.count(anchor), 1, anchor)
+
+    def test_all_three_producers_gain_a_nudge(self):
+        db, _ = patch_tree()
+        self.assertEqual(db.count("_kanban_record_wake(conn)"), 3)
+
+    def test_the_unblock_nudge_lands_after_the_commit(self):
+        # The dedent is the point of that edit: a wake recorded inside the
+        # txn fires before the commit is visible and burns the edge. At
+        # function level the nudge runs after write_txn's __exit__ committed.
+        db, _ = patch_tree()
+        lines = db.splitlines()
+        exits = [
+            i
+            for i, line in enumerate(lines[:-1])
+            if line == "    _kanban_record_wake(conn)"
+            and lines[i + 1] == "    return True"
+        ]
+        self.assertEqual(
+            len(exits), 1, "the unblock nudge must sit at function level, pre-return"
+        )
+        self.assertNotIn(
+            "        _kanban_record_wake(conn)\n        return True",
+            db,
+            "the nudge must not remain inside the unblock write txn",
+        )
+
+    def test_both_watcher_loops_get_a_monitor_and_a_wake_aware_wait(self):
+        _, watchers = patch_tree()
+        self.assertEqual(
+            watchers.count("_wake_monitor = _KanbanWakeMonitor(_kb.kanban_db_path)"), 2
+        )
+        self.assertEqual(watchers.count("await _kanban_wait_interval("), 2)
+        # The notifier's shutdown `return` must survive the swap.
+        self.assertIn("            ):\n                return", watchers)
+
+    def test_the_import_trailers_are_appended(self):
+        db, watchers = patch_tree()
+        self.assertIn(
+            "from hermes_cli.kanban_wake_nudge import (  # noqa: E402", db
+        )
+        self.assertIn("record_wake_for_conn as _kanban_record_wake", db)
+        self.assertIn("WakeMonitor as _KanbanWakeMonitor", watchers)
+        self.assertIn("wait_interval as _kanban_wait_interval", watchers)
+
+    def test_both_patched_files_still_parse(self):
+        db, watchers = patch_tree()
+        ast.parse(db)
+        ast.parse(watchers)
+
+    def test_a_drifted_anchor_fails_loudly_and_names_the_edit(self):
+        drifted = UPSTREAM_WATCHERS.replace("await asyncio.sleep(1)", "await asyncio.sleep(2)")
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(watchers_source=drifted)
+        self.assertIn("notifier sleep", str(ctx.exception))
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_applying_twice_fails_rather_than_silently_no_opping(self):
+        root = Path(tempfile.mkdtemp())
+        (root / DB_RELATIVE).parent.mkdir(parents=True)
+        (root / DB_RELATIVE).write_text(UPSTREAM_DB)
+        (root / WATCHERS_RELATIVE).parent.mkdir(parents=True)
+        (root / WATCHERS_RELATIVE).write_text(UPSTREAM_WATCHERS)
+        apply(root)
+        with self.assertRaises(SystemExit):
+            apply(root)
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            apply(Path(tempfile.mkdtemp()))
+        self.assertIn("does not exist", str(ctx.exception))
+
+
+class PatchedProducerBehaviourTest(unittest.TestCase):
+    """Execute the patched miniature producers against a real sqlite file.
+
+    The build-time gate (verify_kanban_wake_nudge.py) drives the real engine;
+    this asserts the same wiring holds host-side with no Hermes install: the
+    nudge lands next to the DB the connection wrote, only after the commit.
+    """
+
+    def _load_patched_db_module(self):
+        db_text, _ = patch_tree()
+        # Strip the real trailer import and inject the local module instead —
+        # hermes_cli does not exist host-side.
+        db_text = db_text.split("\n\n# kube-agents patch:")[0]
+        namespace = {
+            "_kanban_record_wake": record_wake_for_conn,
+            "_new_task_id": lambda: "t_test",
+            "_inherit_notify_subs": lambda *a, **k: None,
+            "_clear_failure_counter": lambda *a, **k: None,
+            "_cleanup_workspace": lambda *a, **k: None,
+            "recompute_ready": lambda conn: None,
+            "_append_event": lambda *a, **k: None,
+            "do_inserts": lambda: None,
+            "IntegrityError": sqlite3.IntegrityError,
+            "parents": (),
+            "now": 0,
+            "new_status": "ready",
+        }
+        import contextlib
+
+        @contextlib.contextmanager
+        def write_txn(conn):
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield conn
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+            else:
+                conn.execute("COMMIT")
+
+        namespace["write_txn"] = write_txn
+        exec(compile(db_text, "patched_kanban_db_miniature", "exec"), namespace)
+        return namespace
+
+    def _conn(self, db):
+        conn = sqlite3.connect(db)
+        conn.isolation_level = None  # autocommit + explicit BEGIN, as upstream
+        conn.execute("CREATE TABLE tasks (status TEXT)")
+        conn.execute("INSERT INTO tasks VALUES ('blocked')")
+        return conn
+
+    def test_create_complete_and_unblock_each_record_a_wake(self):
+        ns = self._load_patched_db_module()
+        db = tmp_db_path()
+        conn = self._conn(db)
+        try:
+            monitor = WakeMonitor(db)
+            self.assertEqual(ns["create_task"](conn), "t_test")
+            self.assertTrue(monitor.changed(), "create_task must nudge")
+            self.assertTrue(ns["complete_task"](conn, "t_test"))
+            self.assertTrue(monitor.changed(), "complete_task must nudge")
+            self.assertTrue(ns["unblock_task"](conn, "t_test"))
+            self.assertTrue(monitor.changed(), "unblock_task must nudge")
+        finally:
+            conn.close()
+
+    def test_a_failed_unblock_does_not_nudge(self):
+        ns = self._load_patched_db_module()
+        db = tmp_db_path()
+        conn = self._conn(db)
+        conn.execute("DELETE FROM tasks")  # rowcount will be 0
+        try:
+            monitor = WakeMonitor(db)
+            self.assertFalse(ns["unblock_task"](conn, "t_test"))
+            self.assertFalse(monitor.changed(), "a no-op unblock must stay quiet")
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_kanban_worker_tools.py
+++ b/deploy/docker/patches/test_kanban_worker_tools.py
@@ -1,0 +1,362 @@
+"""Unit tests for the worker-only kanban gate installed by deploy/docker/Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import ast
+import importlib
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from apply_kanban_worker_tools import (
+    HANDLERS,
+    IMPORT_AFTER,
+    RELATIVE,
+    UPSTREAM_CHECK_FN,
+    apply,
+    check_handler_mapping,
+)
+from kanban_worker_tools import WORKER_ONLY_TOOLS, check_kanban_worker_mode
+
+# Tools an orchestrator profile keeps — the surface agents/chat/SOUL.md §1.5
+# permits the front door: create, read, route, comment, unblock.
+ORCHESTRATOR_TOOLS = (
+    "kanban_show",
+    "kanban_comment",
+    "kanban_create",
+)
+
+# Reproduces the shape of upstream tools/kanban_tools.py closely enough that the
+# anchors have to be right: the two gate functions, then the registrations.
+GATES = '''\
+import os
+
+
+def _profile_has_kanban_toolset() -> bool:
+    return False
+
+
+def _check_kanban_mode() -> bool:
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return True
+    return _profile_has_kanban_toolset()
+
+
+def _check_kanban_orchestrator_mode() -> bool:
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return False
+    return _profile_has_kanban_toolset()
+'''
+
+
+def registration(tool, check_fn, handler=None):
+    handler = handler or HANDLERS.get(tool, f"_handle_{tool[len('kanban_'):]}")
+    return (
+        "\n\nregistry.register(\n"
+        f'    name="{tool}",\n'
+        '    toolset="kanban",\n'
+        f"    schema={tool.upper()}_SCHEMA,\n"
+        f"    handler={handler},\n"
+        f"    check_fn={check_fn},\n"
+        '    emoji="x",\n'
+        ")\n"
+    )
+
+
+def upstream_source():
+    src = GATES
+    src += registration("kanban_list", "_check_kanban_orchestrator_mode")
+    src += registration("kanban_unblock", "_check_kanban_orchestrator_mode")
+    for tool in ORCHESTRATOR_TOOLS:
+        src += registration(tool, "_check_kanban_mode")
+    for tool in WORKER_ONLY_TOOLS:
+        src += registration(tool, "_check_kanban_mode")
+    return src
+
+
+def patch_tree(source):
+    """Write ``source`` as tools/kanban_tools.py under a temp root and patch it."""
+    root = Path(tempfile.mkdtemp())
+    target = root / RELATIVE
+    target.parent.mkdir(parents=True)
+    target.write_text(source)
+    apply(root)
+    return target.read_text()
+
+
+class CheckWorkerModeTest(unittest.TestCase):
+    def test_true_only_inside_a_dispatched_run(self):
+        with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_c31a1f00"}):
+            self.assertTrue(check_kanban_worker_mode())
+
+    def test_false_for_an_orchestrator_profile(self):
+        env = {k: v for k, v in os.environ.items() if k != "HERMES_KANBAN_TASK"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertFalse(check_kanban_worker_mode())
+
+    def test_an_empty_task_id_is_not_a_worker(self):
+        with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": ""}):
+            self.assertFalse(check_kanban_worker_mode())
+
+    def test_the_forbidden_four_are_all_covered(self):
+        # The four agents/chat/SOUL.md §1.5 names explicitly. If a future edit
+        # trims WORKER_ONLY_TOOLS, the prose and the schema set diverge again.
+        for tool in ("kanban_complete", "kanban_block", "kanban_heartbeat", "kanban_link"):
+            self.assertIn(tool, WORKER_ONLY_TOOLS)
+
+
+def with_delegation_context(reader):
+    """Patch a fake ``agent.delegation_context`` whose reader is *reader*.
+
+    ``kanban_ownership`` imports it lazily per call, so a fake in ``sys.modules``
+    is enough to exercise the branch on a host with no Hermes. The polarities
+    themselves live in test_kanban_ownership.py; what is asserted here is that
+    this gate asks for the right one.
+    """
+    fake = types.ModuleType("agent.delegation_context")
+    fake.is_delegated_child_context = reader
+    agent_pkg = types.ModuleType("agent")
+    agent_pkg.delegation_context = fake
+    return mock.patch.dict(
+        sys.modules, {"agent": agent_pkg, "agent.delegation_context": fake}
+    )
+
+
+class DelegatedChildTest(unittest.TestCase):
+    """A delegate_task child inherits ``HERMES_KANBAN_TASK`` and owns no card.
+
+    The child runs ``run_conversation`` in the parent's own process, so the env
+    var this gate keys off is the parent's and proves nothing about the child.
+    Upstream's own two gates, ``_check_kanban_mode`` and
+    ``_check_kanban_orchestrator_mode``, both open with the same short-circuit;
+    without it this was the only kanban gate in the file that said *True* for a
+    child, which would have offered it the seven worker-only tools and none of
+    the five an orchestrator keeps.
+    """
+
+    def test_a_delegated_child_is_not_a_worker(self):
+        with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_c31a1f00"}):
+            with with_delegation_context(lambda: True):
+                self.assertFalse(check_kanban_worker_mode())
+
+    def test_the_parent_worker_still_keeps_its_tools(self):
+        with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_c31a1f00"}):
+            with with_delegation_context(lambda: False):
+                self.assertTrue(check_kanban_worker_mode())
+
+    def test_it_consults_the_real_delegation_context(self):
+        """The gate takes no argument, so the module import is the only seam.
+
+        ``check_fn`` is called with no arguments by ``tools/registry.py``, which
+        means a short-circuit that did not reach ``agent.delegation_context``
+        itself would be inert in the only place it matters.
+        """
+        module = importlib.import_module("kanban_worker_tools")
+        with with_delegation_context(lambda: True):
+            self.assertTrue(module.is_delegated_child(on_unknown=False))
+
+    def test_a_host_without_hermes_is_not_a_delegated_child(self):
+        """The import fails outside the image; that is not evidence of a child.
+
+        Answering True there would hide ``kanban_complete`` and ``kanban_block``
+        from every dispatcher-spawned worker in the image at once, and a worker
+        with no terminal tool cannot end its run.
+        """
+        module = importlib.import_module("kanban_worker_tools")
+        with mock.patch.dict(sys.modules, {"agent.delegation_context": None}):
+            self.assertFalse(module.is_delegated_child(on_unknown=False))
+            with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_c31a1f00"}):
+                self.assertTrue(check_kanban_worker_mode())
+
+    def test_a_raising_reader_leaves_the_worker_its_tools(self):
+        """Uncertainty must not strand a card.
+
+        This gate asks ``kanban_ownership.is_delegated_child`` with
+        ``on_unknown=False``, the opposite of what
+        ``kanban_guardrail_exit.should_record_missing_terminal`` asks for, whose
+        wrong answer writes to the board. This one only chooses which schemas
+        ship, and ``_reject_delegated_child_mutation`` still refuses a child's
+        mutations.
+        """
+        module = importlib.import_module("kanban_worker_tools")
+
+        def boom():
+            raise RuntimeError("no delegation context")
+
+        with with_delegation_context(boom):
+            self.assertFalse(module.is_delegated_child(on_unknown=False))
+            with mock.patch.dict(os.environ, {"HERMES_KANBAN_TASK": "t_c31a1f00"}):
+                self.assertTrue(check_kanban_worker_mode())
+
+    def test_a_child_of_an_orchestrator_is_not_a_worker_either(self):
+        # No HERMES_KANBAN_TASK at all: the Chat Agent delegating to a
+        # specialist. The gate was already False here; the short-circuit must
+        # not have turned it into a way in.
+        env = {k: v for k, v in os.environ.items() if k != "HERMES_KANBAN_TASK"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with with_delegation_context(lambda: True):
+                self.assertFalse(check_kanban_worker_mode())
+
+
+class ApplyTest(unittest.TestCase):
+    def test_worker_only_tools_are_regated(self):
+        patched = patch_tree(upstream_source())
+        for tool in WORKER_ONLY_TOOLS:
+            self.assertIn(
+                registration(tool, "_check_kanban_worker_mode"),
+                patched,
+                f"{tool} was not re-gated",
+            )
+
+    def test_orchestrator_tools_are_left_alone(self):
+        patched = patch_tree(upstream_source())
+        for tool in ORCHESTRATOR_TOOLS:
+            self.assertIn(registration(tool, "_check_kanban_mode"), patched)
+        for tool in ("kanban_list", "kanban_unblock"):
+            self.assertIn(registration(tool, "_check_kanban_orchestrator_mode"), patched)
+
+    def test_the_import_lands_above_the_registrations(self):
+        patched = patch_tree(upstream_source())
+        import_at = patched.index("from tools.kanban_worker_tools import")
+        first_use = patched.index("check_fn=_check_kanban_worker_mode")
+        # check_fn= is evaluated at import time, so a trailing import would
+        # NameError at module load rather than at first tool call.
+        self.assertLess(import_at, first_use)
+
+    def test_the_patched_module_still_parses(self):
+        ast.parse(patch_tree(upstream_source()))
+
+    def test_reformatting_the_registration_no_longer_breaks_the_build(self):
+        """The point of locating by AST: layout is not the contract.
+
+        The five-line slice this applier used to anchor on would have found
+        nothing here, and eight anchors would have failed at once over
+        whitespace that changes no behaviour.
+        """
+        reflowed = upstream_source().replace(
+            '    name="kanban_complete",\n    toolset="kanban",\n',
+            '    name="kanban_complete",\n\n    # a comment upstream added\n'
+            '    toolset="kanban",\n',
+        )
+        patched = patch_tree(reflowed)
+        self.assertIn("check_fn=_check_kanban_worker_mode", patched)
+        self.assertEqual(
+            patched.count("check_fn=_check_kanban_worker_mode"),
+            len(WORKER_ONLY_TOOLS),
+        )
+
+    def test_applying_twice_fails_rather_than_silently_no_opping(self):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        target.write_text(upstream_source())
+        apply(root)
+        with self.assertRaises(SystemExit) as ctx:
+            apply(root)
+        # The second run gets as far as the registration and finds the gate
+        # already swapped, which is the loud version of "already patched".
+        self.assertIn(f"where {UPSTREAM_CHECK_FN} was expected", str(ctx.exception))
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            apply(Path(tempfile.mkdtemp()))
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_every_worker_only_tool_has_a_handler_mapping(self):
+        self.assertEqual(set(WORKER_ONLY_TOOLS) - set(HANDLERS), set())
+        check_handler_mapping()
+
+
+class LocatorFailureTest(unittest.TestCase):
+    """An AST locator that matched the wrong node would be worse than an anchor.
+
+    A literal anchor fails loudly by construction — the text is either there or
+    it is not. A locator has to be *made* to fail loudly, so each way upstream
+    could move a registration out from under this patch gets a test.
+    """
+
+    def assert_refuses(self, source, *expected):
+        with self.assertRaises(SystemExit) as ctx:
+            patch_tree(source)
+        for fragment in expected:
+            self.assertIn(fragment, str(ctx.exception))
+        return str(ctx.exception)
+
+    def test_an_absent_registration_fails_loudly(self):
+        source = upstream_source().replace(
+            registration("kanban_link", "_check_kanban_mode"), ""
+        )
+        self.assert_refuses(source, "kanban_link registration", "found 0")
+
+    def test_a_duplicated_registration_fails_loudly(self):
+        """Two calls registering the same tool: which one is the patch for?"""
+        source = upstream_source() + registration("kanban_link", "_check_kanban_mode")
+        self.assert_refuses(source, "kanban_link registration", "found 2")
+
+    def test_a_renamed_tool_fails_loudly(self):
+        source = upstream_source().replace('name="kanban_attach"', 'name="kanban_file"')
+        self.assert_refuses(source, "kanban_attach registration", "found 0")
+
+    def test_a_renamed_handler_fails_loudly(self):
+        """Found the call, but it is no longer wired to what we expected."""
+        source = upstream_source().replace(
+            registration("kanban_complete", "_check_kanban_mode"),
+            registration("kanban_complete", "_check_kanban_mode", handler="_handle_finish"),
+        )
+        self.assert_refuses(
+            source, "kanban_complete registration", "_handle_finish", "_handle_complete"
+        )
+
+    def test_a_renamed_gate_fails_loudly(self):
+        """The check_fn upstream ships is asserted, not merely overwritten."""
+        source = upstream_source().replace(
+            registration("kanban_block", "_check_kanban_mode"),
+            registration("kanban_block", "_check_kanban_task_mode"),
+        )
+        self.assert_refuses(
+            source, "kanban_block registration", "_check_kanban_task_mode"
+        )
+
+    def test_a_registration_moved_out_of_module_scope_fails_loudly(self):
+        """Wrapped in a `def register_all()`, the call is no longer ours to find."""
+        source = upstream_source().replace(
+            registration("kanban_heartbeat", "_check_kanban_mode"),
+            "\n\ndef _register_late():\n"
+            + "\n".join(
+                "    " + line
+                for line in registration(
+                    "kanban_heartbeat", "_check_kanban_mode"
+                ).strip("\n").split("\n")
+            )
+            + "\n",
+        )
+        self.assert_refuses(source, "kanban_heartbeat registration", "found 0")
+
+    def test_an_absent_import_site_fails_loudly(self):
+        source = upstream_source().replace(f"def {IMPORT_AFTER}()", "def _check_other()")
+        self.assert_refuses(source, "worker-gate import site", "found 0")
+
+    def test_a_duplicated_import_site_fails_loudly(self):
+        source = upstream_source() + (
+            f"\n\ndef {IMPORT_AFTER}() -> bool:\n    return False\n"
+        )
+        self.assert_refuses(source, "worker-gate import site", "found 2")
+
+    def test_nothing_is_written_when_a_locator_refuses(self):
+        root = Path(tempfile.mkdtemp())
+        target = root / RELATIVE
+        target.parent.mkdir(parents=True)
+        source = upstream_source().replace('name="kanban_attach"', 'name="kanban_file"')
+        target.write_text(source)
+        with self.assertRaises(SystemExit):
+            apply(root)
+        self.assertEqual(target.read_text(), source, "a refused run must not write")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/test_patchlib.py
+++ b/deploy/docker/patches/test_patchlib.py
@@ -1,0 +1,425 @@
+"""Unit tests for patchlib, the shared machinery behind every apply_*.py here.
+
+These appliers only protect the image because they fail loudly, and every one of
+them now delegates that failure to this module. The negative cases below are
+therefore the point of the file: an anchor that matches nothing, an anchor that
+matches twice, and a replacement that produces source Python cannot parse must
+all end in a non-zero exit with the file named, and must leave the target on
+disk exactly as upstream shipped it.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+"""
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "tools/kanban_tools.py"
+
+SOURCE = '''\
+import os
+
+
+def _check_kanban_mode() -> bool:
+    return bool(os.environ.get("HERMES_KANBAN_TASK"))
+
+
+registry.register(
+    name="kanban_complete",
+    toolset="kanban",
+    schema=KANBAN_COMPLETE_SCHEMA,
+    handler=_handle_complete,
+    check_fn=_check_kanban_mode,
+    emoji="✔",
+)
+
+
+registry.register(
+    name="kanban_show",
+    toolset="kanban",
+    schema=KANBAN_SHOW_SCHEMA,
+    handler=_handle_show,
+    check_fn=_check_kanban_mode,
+    emoji="\U0001f4cb",
+)
+'''
+
+
+def tree(source=SOURCE, relative=RELATIVE):
+    """Write *source* under a fresh temp root and return (root, target path)."""
+    root = Path(tempfile.mkdtemp())
+    target = root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(source)
+    return root, target
+
+
+def patch(source=SOURCE, **kwargs):
+    root, target = tree(source)
+    kwargs.setdefault("prefix", "test")
+    return patchlib.Patch(root, RELATIVE, **kwargs), target
+
+
+class ConstructionTest(unittest.TestCase):
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit) as ctx:
+            patchlib.Patch(Path(tempfile.mkdtemp()), RELATIVE, prefix="test")
+        self.assertIn("does not exist", str(ctx.exception))
+        self.assertIn(RELATIVE, str(ctx.exception))
+
+    def test_a_directory_is_not_a_file(self):
+        root = Path(tempfile.mkdtemp())
+        (root / RELATIVE).mkdir(parents=True)
+        with self.assertRaises(SystemExit) as ctx:
+            patchlib.Patch(root, RELATIVE, prefix="test")
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_every_failure_names_the_file(self):
+        # A Docker build log is the only place these are ever read, and the
+        # reader has thirteen appliers to choose from.
+        p, _ = patch()
+        self.assertIn(RELATIVE, str(p._fail("something")))
+        self.assertIn("test patch:", str(p._fail("something")))
+
+
+class SubstituteTest(unittest.TestCase):
+    def test_an_anchor_found_once_is_replaced(self):
+        p, target = patch()
+        p.substitute("import os\n", "import os\nimport sys\n")
+        p.commit("1 anchor")
+        self.assertIn("import sys", target.read_text())
+
+    def test_an_absent_anchor_fails_loudly(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute("import json\n", "")
+        message = str(ctx.exception)
+        self.assertIn("found 0", message)
+        self.assertIn("expected 1 occurrence(s)", message)
+        self.assertIn(RELATIVE, message)
+        # The anchor itself is echoed: "found 0" without it says nothing about
+        # which of an applier's fourteen anchors moved.
+        self.assertIn("--- anchor ---\nimport json", message)
+
+    def test_a_duplicated_anchor_fails_loudly(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute('    toolset="kanban",\n', "")
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_an_expected_count_above_one_is_honoured(self):
+        p, target = patch()
+        p.substitute('    toolset="kanban",\n', '    toolset="kb",\n', expected=2)
+        p.commit("2 anchors")
+        self.assertEqual(target.read_text().count('toolset="kb"'), 2)
+
+    def test_an_expected_count_above_one_still_fails_on_a_short_count(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute("import os\n", "", expected=2)
+        self.assertIn("expected 2 occurrence(s)", str(ctx.exception))
+        self.assertIn("found 1", str(ctx.exception))
+
+    def test_a_label_names_which_anchor_moved(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute("import json\n", "", label="stdlib import")
+        self.assertIn("occurrence(s) of the stdlib import anchor", str(ctx.exception))
+
+    def test_the_drift_note_tells_the_reader_what_to_do(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute("import json\n", "")
+        self.assertIn("re-derive the anchor", str(ctx.exception))
+
+    def test_the_drift_note_is_overridable(self):
+        # apply_mcp_remote_forward_errors.py patches a TypeScript file, where
+        # "bump the base image" is the wrong advice.
+        p, _ = patch(note="mcp-remote changed.")
+        with self.assertRaises(SystemExit) as ctx:
+            p.substitute("import json\n", "")
+        self.assertIn("mcp-remote changed.", str(ctx.exception))
+        self.assertNotIn("base image", str(ctx.exception))
+
+
+class RefuseIfPatchedTest(unittest.TestCase):
+    def test_a_present_marker_refuses(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.refuse_if_patched("_handle_complete")
+        self.assertIn("already patched", str(ctx.exception))
+        self.assertIn("'_handle_complete' is present", str(ctx.exception))
+
+    def test_an_absent_marker_is_a_no_op(self):
+        p, _ = patch()
+        p.refuse_if_patched("_kube_agents_marker")
+
+    def test_any_one_of_several_markers_refuses(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.refuse_if_patched("_kube_agents_marker", "_handle_show")
+        self.assertIn("_handle_show", str(ctx.exception))
+
+
+class CommitTest(unittest.TestCase):
+    def test_nothing_is_written_before_commit(self):
+        p, target = patch()
+        p.substitute("import os\n", "import sys\n")
+        self.assertEqual(target.read_text(), SOURCE, "commit is the only write")
+
+    def test_a_replacement_that_breaks_the_parse_fails_loudly(self):
+        p, target = patch()
+        p.substitute("import os\n", "import os\ndef (:\n")
+        with self.assertRaises(SystemExit) as ctx:
+            p.commit("1 anchor")
+        self.assertIn("no longer parses", str(ctx.exception))
+        self.assertIn(RELATIVE, str(ctx.exception))
+        self.assertEqual(
+            target.read_text(), SOURCE, "a file that does not parse must not be written"
+        )
+
+    def test_parse_false_writes_a_non_python_target(self):
+        # The one non-Python target in this directory is TypeScript; `npm run
+        # build` is its parse gate.
+        p, target = patch(source="const x = 1\n")
+        p.substitute("const x = 1\n", "const x = 2\n")
+        p.commit("1 anchor", parse=False)
+        self.assertEqual(target.read_text(), "const x = 2\n")
+
+    def test_the_summary_is_reported_on_stdout(self):
+        p, _ = patch()
+        p.substitute("import os\n", "import sys\n")
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            p.commit("1 anchor")
+        self.assertIn(f"test patch: {RELATIVE} (1 anchor)", printed.getvalue())
+
+
+class AppendTest(unittest.TestCase):
+    def test_a_trailer_lands_at_the_end(self):
+        p, target = patch()
+        p.append("\n\nimport late\n")
+        p.commit("trailer")
+        self.assertTrue(target.read_text().endswith("\n\nimport late\n"))
+
+
+class FindDefTest(unittest.TestCase):
+    def test_a_def_is_located_by_name(self):
+        p, _ = patch()
+        site = p.find_def("_check_kanban_mode", label="gate")
+        self.assertEqual(
+            p.source[site.start : site.end].splitlines()[0],
+            "def _check_kanban_mode() -> bool:",
+        )
+
+    def test_after_is_the_line_following_the_def(self):
+        p, target = patch()
+        site = p.find_def("_check_kanban_mode", label="gate")
+        p.insert(site.after, "\n\nimport sys\n")
+        p.commit("insert")
+        self.assertIn(
+            'return bool(os.environ.get("HERMES_KANBAN_TASK"))\n\n\nimport sys\n',
+            target.read_text(),
+        )
+
+    def test_an_absent_def_fails_loudly(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_def("_check_kanban_worker_mode", label="gate")
+        self.assertIn("expected 1 module-level def", str(ctx.exception))
+        self.assertIn("found 0", str(ctx.exception))
+        self.assertIn("for the gate", str(ctx.exception))
+
+    def test_a_duplicated_def_fails_loudly(self):
+        p, _ = patch(source=SOURCE + "\n\ndef _check_kanban_mode() -> bool:\n    x = 1\n")
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_def("_check_kanban_mode", label="gate")
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_a_nested_def_is_not_module_level(self):
+        # An insert placed after a method would land inside the class body.
+        p, _ = patch(source="class Gate:\n    def _check_kanban_mode(self):\n        pass\n")
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_def("_check_kanban_mode", label="gate")
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_an_async_def_counts(self):
+        p, _ = patch(source="async def _run() -> None:\n    pass\n")
+        self.assertIsInstance(p.find_def("_run", label="runner"), patchlib.Definition)
+
+    def test_a_file_that_does_not_parse_fails_loudly(self):
+        p, _ = patch(source="def (:\n")
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_def("_run", label="runner")
+        self.assertIn("does not parse", str(ctx.exception))
+
+
+class FindCallTest(unittest.TestCase):
+    def test_a_call_is_located_by_a_keyword_argument(self):
+        p, _ = patch()
+        site = p.find_call(
+            "registry.register", label="complete registration", name="kanban_complete"
+        )
+        self.assertIn("KANBAN_COMPLETE_SCHEMA", p.source[site.start : site.end])
+        self.assertNotIn("KANBAN_SHOW_SCHEMA", p.source[site.start : site.end])
+
+    def test_the_span_covers_the_whole_statement(self):
+        p, _ = patch()
+        site = p.find_call("registry.register", label="show", name="kanban_show")
+        segment = p.source[site.start : site.end]
+        self.assertTrue(segment.startswith("registry.register("))
+        self.assertTrue(segment.endswith(")"))
+
+    def test_an_absent_call_fails_loudly(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_call("registry.register", label="block", name="kanban_block")
+        message = str(ctx.exception)
+        self.assertIn("expected 1 module-level registry.register", message)
+        self.assertIn("name='kanban_block'", message)
+        self.assertIn("found 0", message)
+
+    def test_a_duplicated_call_fails_loudly(self):
+        p, _ = patch(
+            source=SOURCE + '\n\nregistry.register(\n    name="kanban_show",\n)\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_call("registry.register", label="show", name="kanban_show")
+        self.assertIn("found 2", str(ctx.exception))
+
+    def test_a_renamed_callee_fails_loudly(self):
+        p, _ = patch()
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_call("registry.add", label="show", name="kanban_show")
+        self.assertIn("registry.add", str(ctx.exception))
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_a_call_that_is_not_a_bare_statement_is_not_matched(self):
+        # `x = registry.register(...)` is a different thing to splice into.
+        p, _ = patch(source='x = registry.register(\n    name="kanban_show",\n)\n')
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_call("registry.register", label="show", name="kanban_show")
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_a_string_selector_does_not_match_a_bare_name(self):
+        p, _ = patch(source="registry.register(\n    name=kanban_show,\n)\n")
+        with self.assertRaises(SystemExit) as ctx:
+            p.find_call("registry.register", label="show", name="kanban_show")
+        self.assertIn("found 0", str(ctx.exception))
+
+    def test_an_ident_selector_matches_a_bare_name(self):
+        p, _ = patch(source="registry.register(\n    name=kanban_show,\n)\n")
+        site = p.find_call(
+            "registry.register", label="show", name=patchlib.Ident("kanban_show")
+        )
+        self.assertIsInstance(site, patchlib.CallSite)
+
+
+class ExpectTest(unittest.TestCase):
+    def site(self, source=SOURCE):
+        p, _ = patch(source=source)
+        return p, p.find_call(
+            "registry.register", label="complete registration", name="kanban_complete"
+        )
+
+    def test_matching_arguments_pass(self):
+        _, site = self.site()
+        site.expect(
+            toolset="kanban",
+            schema=patchlib.Ident("KANBAN_COMPLETE_SCHEMA"),
+            handler=patchlib.Ident("_handle_complete"),
+        )
+
+    def test_a_rewired_argument_fails_loudly(self):
+        _, site = self.site()
+        with self.assertRaises(SystemExit) as ctx:
+            site.expect(handler=patchlib.Ident("_handle_finish"))
+        message = str(ctx.exception)
+        self.assertIn("the complete registration sets handler=_handle_complete", message)
+        self.assertIn("where _handle_finish was expected", message)
+
+    def test_a_string_where_a_name_was_expected_fails(self):
+        # check_fn="_check_kanban_mode" would be a different program: a string
+        # is not the callable the registry is about to hold onto.
+        _, site = self.site(
+            'registry.register(\n'
+            '    name="kanban_complete",\n'
+            '    check_fn="_check_kanban_mode",\n'
+            ')\n'
+        )
+        with self.assertRaises(SystemExit) as ctx:
+            site.expect(check_fn=patchlib.Ident("_check_kanban_mode"))
+        self.assertIn("where _check_kanban_mode was expected", str(ctx.exception))
+
+    def test_a_missing_argument_fails_loudly(self):
+        _, site = self.site()
+        with self.assertRaises(SystemExit) as ctx:
+            site.expect(deprecated=True)
+        self.assertIn("sets no deprecated= argument", str(ctx.exception))
+
+
+class KeywordSpanTest(unittest.TestCase):
+    def test_the_span_covers_only_the_value(self):
+        p, _ = patch()
+        site = p.find_call("registry.register", label="complete", name="kanban_complete")
+        start, end = site.keyword_span("check_fn")
+        self.assertEqual(p.source[start:end], "_check_kanban_mode")
+
+    def test_a_splice_replaces_only_that_value(self):
+        p, target = patch()
+        site = p.find_call("registry.register", label="complete", name="kanban_complete")
+        start, end = site.keyword_span("check_fn")
+        p.splice(start, end, "_check_kanban_worker_mode")
+        p.commit("1 registration")
+        patched = target.read_text()
+        self.assertIn("check_fn=_check_kanban_worker_mode,", patched)
+        # The sibling registration is untouched.
+        self.assertEqual(patched.count("check_fn=_check_kanban_mode,"), 1)
+
+    def test_a_missing_argument_fails_loudly(self):
+        p, _ = patch()
+        site = p.find_call("registry.register", label="complete", name="kanban_complete")
+        with self.assertRaises(SystemExit) as ctx:
+            site.keyword_span("gate_fn")
+        self.assertIn("sets no gate_fn= argument", str(ctx.exception))
+
+
+class ByteColumnTest(unittest.TestCase):
+    """``ast`` reports columns in UTF-8 bytes; the source being spliced is a str.
+
+    No span the current locators return lands on a non-ASCII line, so this is a
+    trap that has not sprung yet — but every registration in
+    ``tools/kanban_tools.py`` carries an ``emoji=`` argument, and a byte column
+    read as a character index does not raise, it splices three characters off
+    target. These tests fail if ``_offset`` is ever simplified away.
+    """
+
+    def test_a_span_after_an_emoji_line_is_still_exact(self):
+        p, _ = patch()
+        site = p.find_call("registry.register", label="show", name="kanban_show")
+        # kanban_show's registration follows kanban_complete's "✔" line.
+        start, end = site.keyword_span("schema")
+        self.assertEqual(p.source[start:end], "KANBAN_SHOW_SCHEMA")
+
+    def test_a_span_on_a_line_containing_an_emoji_is_still_exact(self):
+        source = 'registry.register(\n    emoji="\U0001f4cb", name="kanban_show",\n)\n'
+        p, _ = patch(source=source)
+        site = p.find_call("registry.register", label="show", name="kanban_show")
+        start, end = site.keyword_span("name")
+        self.assertEqual(p.source[start:end], '"kanban_show"')
+
+    def test_a_def_after_an_emoji_is_located_exactly(self):
+        body = "def _gate() -> bool:\n    return True"
+        source = 'X = "\U0001f4cb\U0001f4cb\U0001f4cb"\n\n\n' + body + "\n"
+        p, _ = patch(source=source)
+        site = p.find_def("_gate", label="gate")
+        self.assertEqual(p.source[site.start : site.end], body)
+        self.assertEqual(site.after, len(source))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/verify_cron_run_scope.py
+++ b/deploy/docker/patches/verify_cron_run_scope.py
@@ -45,7 +45,7 @@ def main() -> int:
 
     import tools.cronjob_tools as ct
     import tools.kanban_tools as kt
-    from tools.cron_run_scope import cron_run_scope
+    from tools.cron_run_scope import cron_run_scope, current_cron_job
 
     # --- outside a cron run: the worker keeps its ambient card --------------
     check("worker default task", kt._default_task_id(None), CALLER_CARD)
@@ -96,7 +96,7 @@ def main() -> int:
             outcome["response"] = f"Audit complete. Ledger updated at {LEDGER_URL}"
             outcome["output_file"] = OUTPUT_FILE
             outcome["delivery_error"] = "platform 'slack' not configured/enabled"
-        seen["inside_scope"] = bool(os.environ.get("HERMES_KANBAN_CRON_RUN"))
+        seen["inside_scope"] = current_cron_job()
         return True
 
     sched.run_one_job = fake_run_one_job
@@ -104,7 +104,7 @@ def main() -> int:
     ct.get_job = lambda jid: {"id": jid, "last_status": "ok", "last_error": None}
 
     exec_result = ct._execute_job_now({"id": JOB_ID})
-    check("run_one_job ran inside the scope", seen.get("inside_scope"), True)
+    check("run_one_job ran inside the scope", seen.get("inside_scope"), JOB_ID)
     check(
         "report reached the caller",
         exec_result.get("response"),
@@ -112,7 +112,17 @@ def main() -> int:
     )
     check("output file reached the caller", bool(exec_result.get("output_file")), True)
     check("delivery error reached the caller", bool(exec_result.get("delivery_error")), True)
-    check("marker cleared after the run", os.environ.get("HERMES_KANBAN_CRON_RUN"), None)
+    check("marker cleared after the run", current_cron_job(), "")
+    # The scope holds the marker in a ContextVar only. os.environ is
+    # process-global and a cron run is not: writing it there bled into
+    # unrelated worker threads, was inherited for life by workers the
+    # dispatcher spawned mid-run, and leaked permanently when two runs
+    # overlapped without nesting. See tools/cron_run_scope.py.
+    check(
+        "and the scope never wrote it to the process environment",
+        os.environ.get("HERMES_KANBAN_CRON_RUN"),
+        None,
+    )
 
     # --- the run action still produces valid JSON ---------------------------
     # The regression: a Path here made json.dumps raise and the caller got an

--- a/deploy/docker/patches/verify_cron_skip_ledger.py
+++ b/deploy/docker/patches/verify_cron_skip_ledger.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+"""Build gate for the cron skip-ledger patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after
+``apply_cron_skip_ledger.py``. The applier proves fourteen anchors matched and
+that four files still parse; it proves nothing about whether a skip actually
+reaches the ledger, and this patch fails silently in both directions if it does
+not.
+
+Two properties make a build-time gate non-optional here.
+
+**The migration runs once, on a populated volume, in production.** The host
+suite exercises it against a synthesised legacy database, but not through the
+path that will invoke it: ``_initialize_schema``, inside ``_transaction``, with
+WAL applied by ``hermes_state`` and ``PRAGMA synchronous=FULL``, and with the
+two ``CREATE INDEX`` statements running after the table has been dropped and
+rebuilt underneath them. So checks 2 and 3 lay down a byte-for-byte copy of the
+schema the live boards carry and drive the real module over it.
+
+**Every skip is written from a guard clause that must not raise.**
+``record_skip`` swallows by design — a ledger write must never take a tick
+down — so a mis-wired call site fails exactly like the bug it was meant to fix:
+silently. Check 5 therefore drives ``tick`` and ``run_one_job`` themselves,
+once per reason, and reads the ledger back.
+
+The six checks:
+
+1. SHAPE, ON THE REAL TREE. The prune is per job; ``_ensure_skip_schema`` runs
+   before the indexes it invalidates; the ledger write in the in-process guard
+   is outside ``_running_lock``; the cross-process guard releases the running
+   slot before writing. Each is an ordering the applier's text match cannot see
+   and a behavioural check would only catch under contention.
+2. THE MIGRATION. Legacy DDL, rows in it, driven through ``list_executions``.
+   Rows preserved, CHECK widened and still enforced, indexes back, scratch
+   table gone, second pass a no-op.
+3. THE WRITE PATH. ``record_skipped_execution`` and ``skip_execution``, and
+   terminal-once still holding.
+4. TELEMETRY. ``project_execution_event`` must not launder ``skipped`` into
+   ``unknown`` — the state that means an owner process died mid-run.
+5. THE FIVE REASONS, END TO END. Three ``tick`` guards, ``run_one_job``'s
+   dispatch claim, and a genuinely stale job store through the real
+   ``cron.jobs.get_due_jobs``.
+6. RETENTION. A flood of one job's rows must not evict another job's, which is
+   the live failure this half of the patch exists to fix.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_cron_skip_ledger.py
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+HERMES = Path(os.environ.get("HERMES_ROOT", "/opt/hermes"))
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+# Must precede every Hermes import: cron/executions.py resolves EXECUTIONS_FILE
+# from get_hermes_home() at module scope, so a HERMES_HOME set afterwards would
+# point these checks at the image's real ledger.
+HOME = Path(tempfile.mkdtemp(prefix="skip-ledger-verify-"))
+os.environ["HERMES_HOME"] = str(HOME)
+(HOME / "cron").mkdir(parents=True, exist_ok=True)
+LEDGER = HOME / "cron" / "executions.db"
+
+# The exact CREATE TABLE both live boards carry, read out of sqlite_master on
+# 2026-08-08. Not a paraphrase: the migration derives the rebuilt table from
+# this text by regex, so a tidied-up fixture would test a different migration
+# than the one that ships.
+LEGACY_DDL = """CREATE TABLE executions (
+             id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             source TEXT NOT NULL,
+             process_id TEXT NOT NULL,
+             pid INTEGER NOT NULL,
+             process_started_at INTEGER,
+             status TEXT NOT NULL CHECK(status IN
+               ('claimed','running','completed','failed','unknown')),
+             claimed_at TEXT NOT NULL,
+             started_at TEXT,
+             finished_at TEXT,
+             error TEXT
+           )"""
+
+CHATTY_JOB = "profile-cron-tick"
+QUIET_JOB = "compliance-audit"
+LEGACY_ROWS = 40
+
+FAILURES: list = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+# --- 1. shape, on the real tree ---------------------------------------------
+
+
+def function_named(path: Path, name: str):
+    return next(
+        (
+            n
+            for n in ast.walk(ast.parse(path.read_text()))
+            if isinstance(n, ast.FunctionDef) and n.name == name
+        ),
+        None,
+    )
+
+
+def check_shape() -> None:
+    print("patched shape (orderings a text match cannot see):")
+
+    executions = HERMES / "cron" / "executions.py"
+    prune = function_named(executions, "_prune_unlocked")
+    check("_prune_unlocked still exists", prune is not None)
+    if prune is not None:
+        src = ast.unparse(prune)
+        check(
+            "the prune is per job",
+            "_prune_terminal_executions(conn)" in src,
+            f"body is still {src!r} — the global cap survived, so the busiest "
+            "job goes on evicting every other job's evidence",
+        )
+        check(
+            "the global DELETE is gone",
+            "LIMIT -1 OFFSET" not in src,
+            "the upstream statement is still there alongside the new one",
+        )
+
+    init = function_named(executions, "_initialize_schema")
+    check("_initialize_schema still exists", init is not None)
+    if init is not None:
+        src = ast.unparse(init)
+        migrate = src.find("_ensure_skip_schema(conn)")
+        index = src.find("idx_executions_job_claimed")
+        check("the migration is invoked from schema init", migrate >= 0)
+        check(
+            "it runs before the indexes are recreated",
+            0 <= migrate < index,
+            "the rebuild drops both indexes with the old table; recreating "
+            "them first leaves the ledger unindexed until the next restart",
+        )
+
+    scheduler = HERMES / "cron" / "scheduler.py"
+    guard = function_named(scheduler, "_submit_with_guard")
+    check("_submit_with_guard still wraps the dispatch", guard is not None)
+    if guard is not None:
+        under_lock = [
+            ast.unparse(n)
+            for n in ast.walk(guard)
+            if isinstance(n, ast.With)
+            and "_running_lock" in ast.unparse(n.items[0].context_expr)
+        ]
+        check(
+            "no ledger write happens under _running_lock",
+            not any("record_skip" in w for w in under_lock),
+            "every dispatching thread in the tick takes that lock; a SQLite "
+            "write behind a 5s busy timeout inside it serialises the whole "
+            "dispatch pass",
+        )
+        src = ast.unparse(guard)
+        released = src.find("_running_job_ids.discard(job_id)")
+        recorded = src.find("SKIP_ALREADY_RUNNING_ELSEWHERE")
+        check(
+            "the running slot is released before the cross-process skip is written",
+            0 <= released < recorded,
+            "a slow ledger write would leave the job wedged in the running "
+            "set, suppressing it on the next tick as well",
+        )
+
+
+# --- 2 + 3. the migration and the write path --------------------------------
+
+
+def seed_legacy_ledger() -> None:
+    """A pre-patch ledger with rows in it, the way a live volume has one."""
+    conn = sqlite3.connect(LEDGER)
+    try:
+        conn.execute(LEGACY_DDL)
+        conn.execute(
+            "CREATE INDEX idx_executions_job_claimed "
+            "ON executions(job_id, claimed_at DESC, id DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX idx_executions_status_claimed "
+            "ON executions(status, claimed_at DESC, id DESC)"
+        )
+        for i in range(LEGACY_ROWS):
+            stamp = f"2026-08-07T{i // 60:02d}:{i % 60:02d}:00+00:00"
+            conn.execute(
+                "INSERT INTO executions (id, job_id, source, process_id, pid, "
+                "status, claimed_at, finished_at) VALUES (?,?,?,?,?,?,?,?)",
+                (
+                    uuid.uuid4().hex,
+                    CHATTY_JOB if i % 4 else QUIET_JOB,
+                    "builtin",
+                    "legacy",
+                    4242,
+                    "completed",
+                    stamp,
+                    stamp,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def ledger_sql() -> str:
+    conn = sqlite3.connect(f"file:{LEDGER}?mode=ro", uri=True)
+    try:
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='executions'"
+        ).fetchone()
+        return str(row[0]) if row else ""
+    finally:
+        conn.close()
+
+
+def ledger_objects(kind: str) -> set:
+    conn = sqlite3.connect(f"file:{LEDGER}?mode=ro", uri=True)
+    try:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type=? "
+                "AND name NOT LIKE 'sqlite_%'",
+                (kind,),
+            )
+        }
+    finally:
+        conn.close()
+
+
+def skips_for(reason: str) -> list:
+    conn = sqlite3.connect(f"file:{LEDGER}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        return [
+            dict(r)
+            for r in conn.execute(
+                "SELECT * FROM executions WHERE status='skipped' AND skip_reason=?",
+                (reason,),
+            )
+        ]
+    finally:
+        conn.close()
+
+
+def check_migration(ex) -> None:
+    print("migration (a populated pre-patch ledger, through the real module):")
+    before = ex.list_executions(limit=500)
+    check(
+        "every legacy row survived the rebuild",
+        len(before) == LEGACY_ROWS,
+        f"{len(before)} of {LEGACY_ROWS} rows",
+    )
+    sql = ledger_sql()
+    check("the CHECK now admits skipped", "'skipped'" in sql, sql)
+    check("the four upstream statuses are still constrained", "'unknown'" in sql, sql)
+    check("the skip_reason column exists", "skip_reason" in sql, sql)
+    check(
+        "both indexes were recreated after the drop",
+        ledger_objects("index")
+        == {"idx_executions_job_claimed", "idx_executions_status_claimed"},
+        f"found {sorted(ledger_objects('index'))} — the rebuild dropped them "
+        "with the old table and nothing put them back",
+    )
+    check(
+        "the scratch table was not left behind",
+        "executions_kubeagents_migrating" not in ledger_objects("table"),
+        f"found {sorted(ledger_objects('table'))}",
+    )
+
+    sql_after_first = ledger_sql()
+    ex.list_executions(limit=1)
+    check(
+        "a second pass is a no-op",
+        ledger_sql() == sql_after_first,
+        "the migration is not idempotent, so every connection rebuilds the "
+        "table — on a 1000-row ledger, on every tick",
+    )
+    check(
+        "and did not disturb the rows",
+        len(ex.list_executions(limit=500)) == LEGACY_ROWS,
+    )
+
+    conn = sqlite3.connect(LEDGER)
+    refused = False
+    try:
+        conn.execute(
+            "INSERT INTO executions (id, job_id, source, process_id, pid, "
+            "status, claimed_at) VALUES ('x','j','builtin','p',1,'bogus','t')"
+        )
+    except sqlite3.IntegrityError:
+        refused = True
+    finally:
+        conn.close()
+    check(
+        "the rebuilt CHECK still refuses an unknown status",
+        refused,
+        "the rebuild widened the constraint into uselessness",
+    )
+
+
+def check_write_path(ex, reasons):
+    print("write path (cron/executions.py):")
+    record = ex.record_skipped_execution(
+        QUIET_JOB, source="builtin", reason=reasons.SKIP_ALREADY_RUNNING, detail="d"
+    )
+    check(
+        "a skip row was written",
+        (record or {}).get("status") == "skipped",
+        repr(record),
+    )
+    check(
+        "with its reason",
+        (record or {}).get("skip_reason") == reasons.SKIP_ALREADY_RUNNING,
+        repr(record),
+    )
+    check(
+        "and nothing pretending to be a runtime",
+        (record or {}).get("started_at") is None,
+        "started_at is set, so cron_health will report a duration for a run "
+        "that never started",
+    )
+    check("and a finish time", bool((record or {}).get("finished_at")))
+
+    claimed = ex.create_execution(QUIET_JOB, source="direct")
+    closed = ex.skip_execution(
+        claimed["id"], reason=reasons.SKIP_DISPATCH_CLAIM_REJECTED
+    )
+    check(
+        "a claimed attempt closes as skipped",
+        (closed or {}).get("status") == "skipped",
+        repr(closed),
+    )
+    check(
+        "a terminal attempt cannot be rewritten",
+        ex.skip_execution(claimed["id"], reason=reasons.SKIP_ALREADY_RUNNING) is None,
+        "terminal-once no longer holds, so a finished attempt can be relabelled",
+    )
+    return record
+
+
+# --- 4. telemetry ------------------------------------------------------------
+
+
+def check_telemetry(record, reasons) -> None:
+    print("telemetry (agent/monitoring/cron_health.py):")
+    from agent.monitoring.cron_health import project_execution_event
+
+    event = project_execution_event(record)
+    check(
+        "the status is not laundered into unknown",
+        event.status == "skipped",
+        f"status={event.status!r} — 'unknown' means an owner process died "
+        "mid-run, so coercing to it corrupts a real signal too",
+    )
+    check(
+        "the reason is projected",
+        event.error_class == reasons.SKIP_ALREADY_RUNNING,
+        f"error_class={event.error_class!r}",
+    )
+    check(
+        "no runtime is invented",
+        event.duration_ms == 0,
+        f"duration_ms={event.duration_ms!r}",
+    )
+
+
+# --- 5. the five reasons, end to end -----------------------------------------
+
+
+def check_tick_guards(sched, reasons) -> None:
+    print("the tick guards (driven, then read back out of the ledger):")
+    job = {"id": CHATTY_JOB, "name": "Named-Profile Cron Ticker"}
+    sched.get_due_jobs = lambda: [dict(job)]
+    sched.advance_next_runs = lambda ids: None
+
+    sched._running_job_ids.add(CHATTY_JOB)
+    try:
+        sched.tick(verbose=False, sync=True)
+    finally:
+        sched._running_job_ids.discard(CHATTY_JOB)
+    rows = skips_for(reasons.SKIP_ALREADY_RUNNING)
+    check(
+        "an in-process overlap is recorded",
+        any(r["job_id"] == CHATTY_JOB for r in rows),
+        "next_run_at was already advanced for the whole due set, so this "
+        "occurrence is gone and nothing records it",
+    )
+
+    class RefusingLocks:
+        def claim(self, job_id):
+            return None
+
+    real_locks = sched._job_locks
+    sched._job_locks = RefusingLocks()
+    try:
+        sched.tick(verbose=False, sync=True)
+    finally:
+        sched._job_locks = real_locks
+    check(
+        "a cross-process overlap is recorded",
+        bool(skips_for(reasons.SKIP_ALREADY_RUNNING_ELSEWHERE)),
+        "two tickers racing for the same profile leave no trace",
+    )
+    check(
+        "and the job is not left wedged in the running set",
+        CHATTY_JOB not in sched.get_running_job_ids(),
+    )
+
+    real_shutting_down = sched._interpreter_shutting_down
+    sched._interpreter_shutting_down = lambda *a, **k: True
+    try:
+        sched.tick(verbose=False, sync=True)
+    finally:
+        sched._interpreter_shutting_down = real_shutting_down
+    check(
+        "a dispatch dropped to interpreter shutdown is recorded",
+        bool(skips_for(reasons.SKIP_INTERPRETER_SHUTDOWN)),
+        "a rollout silently eats the occurrences that were mid-dispatch",
+    )
+
+    real_claim_dispatch = sched.claim_dispatch
+    sched.claim_dispatch = lambda job_id: False
+    try:
+        processed = sched.run_one_job({"id": QUIET_JOB, "name": "Compliance Audit"})
+    finally:
+        sched.claim_dispatch = real_claim_dispatch
+    check("run_one_job still reports the occurrence handled", processed is True)
+    check(
+        "a spent one-shot budget is recorded as skipped, not failed",
+        len(skips_for(reasons.SKIP_DISPATCH_CLAIM_REJECTED)) >= 2,
+        "an at-most-once guarantee working as designed is still inflating the "
+        "failure rate cron_health derives",
+    )
+
+
+def check_missed_window(reasons) -> None:
+    print("the outage that hides itself (cron/jobs.py::get_due_jobs):")
+    from hermes_time import now as hermes_now
+
+    import cron.jobs as cj
+
+    now = hermes_now()
+    stale = (now - timedelta(hours=5)).isoformat()  # a daily job's grace is 7200s
+    (HOME / "cron" / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": QUIET_JOB,
+                        "name": "Security & RBAC Posture Audit",
+                        "schedule": {"kind": "cron", "expr": "20 6 * * *"},
+                        "prompt": "",
+                        "enabled": True,
+                        "deliver": "local",
+                        "next_run_at": stale,
+                        "state": "scheduled",
+                    }
+                ],
+                "updated_at": now.isoformat(),
+            }
+        )
+    )
+    due = cj.get_due_jobs()
+    check(
+        "the stale job still fires exactly once",
+        len(due) == 1,
+        f"{len(due)} due — the catch-up behaviour changed, which is not this "
+        "patch's business to change",
+    )
+    missed = skips_for(reasons.SKIP_MISSED_WINDOW)
+    check(
+        "the collapsed window is recorded",
+        len(missed) == 1,
+        f"{len(missed)} rows — one row per gap, not per lost occurrence, and "
+        "not zero: upstream's only trace is a profile-wide integer in a file",
+    )
+    if missed:
+        check("against the job it belongs to", missed[0]["job_id"] == QUIET_JOB)
+        check(
+            "with a count rather than a shrug",
+            "unknown number" not in (missed[0]["error"] or ""),
+            f"detail={missed[0]['error']!r} — croniter could not walk the "
+            "expression, so the row cannot say how much was lost",
+        )
+
+
+# --- 6. retention -------------------------------------------------------------
+
+
+def check_retention() -> None:
+    print("retention (a chatty job must not evict a quiet one):")
+    from tools.cron_skip_ledger import (
+        MAX_TERMINAL_EXECUTIONS_PER_JOB,
+        prune_terminal_executions,
+    )
+
+    conn = sqlite3.connect(LEDGER)
+    try:
+        conn.execute("PRAGMA busy_timeout=5000")
+        quiet_before = conn.execute(
+            "SELECT count(*) FROM executions WHERE job_id=?", (QUIET_JOB,)
+        ).fetchone()[0]
+        overflow = MAX_TERMINAL_EXECUTIONS_PER_JOB + 500
+        conn.executemany(
+            "INSERT INTO executions (id, job_id, source, process_id, pid, "
+            "status, claimed_at, finished_at) VALUES (?,?,?,?,?,?,?,?)",
+            [
+                (
+                    uuid.uuid4().hex,
+                    CHATTY_JOB,
+                    "builtin",
+                    "flood",
+                    1,
+                    "completed",
+                    # Newer than every quiet-job row, which is the point: under
+                    # the global cap these are exactly what evicted them.
+                    "2026-08-09T{:02d}:{:02d}:{:02d}+00:00".format(
+                        i // 3600 % 24, i // 60 % 60, i % 60
+                    ),
+                    "2026-08-09T00:00:00+00:00",
+                )
+                for i in range(overflow)
+            ],
+        )
+        conn.commit()
+        prune_terminal_executions(conn)
+        conn.commit()
+        chatty_after = conn.execute(
+            "SELECT count(*) FROM executions WHERE job_id=?", (CHATTY_JOB,)
+        ).fetchone()[0]
+        quiet_after = conn.execute(
+            "SELECT count(*) FROM executions WHERE job_id=?", (QUIET_JOB,)
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    check(
+        "the chatty job is capped at its own limit",
+        chatty_after == MAX_TERMINAL_EXECUTIONS_PER_JOB,
+        f"{chatty_after} rows, cap {MAX_TERMINAL_EXECUTIONS_PER_JOB}",
+    )
+    check(
+        "and the quiet job kept every row it had",
+        quiet_after == quiet_before,
+        f"{quiet_after} of {quiet_before} rows survived — the flood still "
+        "evicted the evidence, which is the whole defect",
+    )
+
+
+if __name__ == "__main__":
+    print("verify_cron_skip_ledger")
+    check_shape()
+
+    seed_legacy_ledger()
+    check(
+        "the fixture really is a pre-patch ledger",
+        "'skipped'" not in ledger_sql(),
+        "the fixture already admits skipped, so the migration is untested",
+    )
+
+    import cron.executions as executions_module
+    import cron.scheduler as scheduler_module
+    import tools.cron_skip_ledger as skip_reasons
+
+    check_migration(executions_module)
+    skip_record = check_write_path(executions_module, skip_reasons)
+    check_telemetry(skip_record, skip_reasons)
+    check_tick_guards(scheduler_module, skip_reasons)
+    check_missed_window(skip_reasons)
+    check_retention()
+
+    print()
+    if FAILURES:
+        print(f"verify_cron_skip_ledger: {len(FAILURES)} FAILED")
+        for failure in FAILURES:
+            print(f"  - {failure}")
+        raise SystemExit(1)
+    print("verify_cron_skip_ledger: all checks passed")

--- a/deploy/docker/patches/verify_cron_tick_lock_scope.py
+++ b/deploy/docker/patches/verify_cron_tick_lock_scope.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Build gate for the cron tick-lock-scope patch.
+
+Run by deploy/docker/Dockerfile from /opt/hermes after
+apply_cron_tick_lock_scope.py. The applier only proves eleven anchors matched;
+it proves nothing about WHERE the release landed, and a release placed one
+statement too early would silently break at-most-once.
+
+Six checks, each a way the patch could match its anchors and still be wrong or
+harmful:
+
+1. RELEASE PLACEMENT. Parse the patched ``cron/scheduler.py::tick`` and assert
+   the ``_tick_lock.release()`` statement sits inside the ``try``, strictly
+   AFTER the ``advance_next_runs(...)`` call and after the last
+   ``_submit_with_guard`` call, and strictly BEFORE the ``if sync:`` node.
+   Releasing before the advance or before dispatch would reintroduce
+   double-firing. The ``finally`` is also asserted to be the idempotent
+   backstop and nothing else -- if it still touches ``lock_fd`` directly, the
+   old wide-scope unlock survived alongside the new one.
+
+2. THE CLAIM IS CARRIED, NOT LOOKED UP. Assert the dispatch guard binds
+   ``_job_lock`` from ``_job_locks.claim(...)``, hands that object to
+   ``_run_and_release`` as a default argument, releases through it, and that
+   ``_job_locks.release(`` appears nowhere. Releasing by job id meant
+   recomputing the lock path on a worker thread whose context can no longer
+   resolve the profile -- see the "caller owns its claim" section of
+   ``cron_tick_lock_scope.py``. The binding is also what keeps the lock object
+   alive for the run's duration.
+
+3. THE DISPATCH PATH CLAIMS BEFORE THE CAS. Assert
+   ``tools/cronjob_tools.py::_execute_job_now`` claims the per-job flock on a
+   line strictly before ``claim_job_for_fire`` -- after would leave
+   ``next_run_at`` advanced for a run that was then refused -- and releases in
+   a ``finally``, which is the only path out that a BaseException cannot skip.
+
+4. THE SPAWNED TICK SWEEPS FIRST. Assert ``hermes_cli/cron.py::cron_tick``
+   calls ``recover_interrupted_executions`` before ``tick``, and inside a
+   ``try`` -- a bookkeeping sweep that raises must never cost the profile its
+   tick.
+
+5. HEAD-OF-LINE IS GONE, AND THE GUARD IS ARMED. Against a throwaway
+   HERMES_HOME with one ``no_agent`` job whose script sleeps, run a real
+   ``tick(sync=True)`` in a child process; once the ledger shows the job
+   running, assert ``.tick.lock`` can be flock'd from this process (on the
+   unpatched image it cannot -- that is the defect, stated as an assertion)
+   and that ``.job-<id>.lock`` cannot. Then, with the child STILL ALIVE after
+   its tick returns, assert the per-job lock is free: that proves the patched
+   code released the claim rather than the kernel reaping it at exit, which is
+   the half a dying process would hide.
+
+6. A STUCK LEDGER ROW IS REAPED. Leave a ``running`` row behind from a child
+   that exits without finishing it -- the live platform profile had six of
+   these, the oldest a day old -- then run the patched ``cron_tick`` in another
+   child and assert the row became ``unknown``.
+
+Checks 5 and 6 are real cross-process exercises, not AST assertions: separate
+interpreters hold the locks and own the ledger rows, and this process is the
+second claimant. The kernel-releases-on-death property is pinned by the host
+suite instead (``test_cron_tick_lock_scope.py``), because it needs a SIGKILL
+that would make this file's child bookkeeping much harder to read.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_cron_tick_lock_scope.py
+"""
+
+from __future__ import annotations
+
+import ast
+import fcntl
+import json
+import os
+import subprocess
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERMES = Path(os.environ.get("HERMES_ROOT", "/opt/hermes"))
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+def function_named(path: Path, name: str):
+    """The named function node in ``path``, or None."""
+    tree = ast.parse(path.read_text())
+    fn = next((n for n in ast.walk(tree)
+               if isinstance(n, ast.FunctionDef) and n.name == name), None)
+    return tree, fn
+
+
+def call_linenos(node, pred) -> list[int]:
+    return [n.lineno for n in ast.walk(node) if isinstance(n, ast.Call) and pred(n)]
+
+
+def named_call(name: str):
+    """Matches ``name(...)`` however it is spelled -- bare or as an attribute."""
+    return lambda n: (getattr(n.func, "id", None) == name
+                      or getattr(n.func, "attr", None) == name)
+
+
+# --- 1 + 2. cron/scheduler.py -----------------------------------------------
+def check_release_placement() -> None:
+    print("release placement (cron/scheduler.py::tick):")
+    scheduler = HERMES / "cron" / "scheduler.py"
+    tree, fn = function_named(scheduler, "tick")
+    check("tick() is still a module-level function", fn is not None)
+    if fn is None:
+        return
+
+    # tick() has TWO top-level Try nodes: the acquire's try/except, and the
+    # try/finally that wraps the whole body. Only the second one is ours.
+    tries = [n for n in fn.body if isinstance(n, ast.Try) and n.finalbody]
+    check("tick() still has exactly one try/finally", len(tries) == 1,
+          f"found {len(tries)}")
+    if len(tries) != 1:
+        return
+    outer = tries[0]
+    body = outer.body
+
+    releases = [n.lineno for n in body
+                if isinstance(n, ast.Expr) and isinstance(n.value, ast.Call)
+                and getattr(n.value.func, "attr", None) == "release"
+                and getattr(getattr(n.value.func, "value", None), "id", None) == "_tick_lock"]
+    advances = call_linenos(outer, named_call("advance_next_runs"))
+    submits = call_linenos(outer, named_call("_submit_with_guard"))
+    syncs = [n.lineno for n in body
+             if isinstance(n, ast.If) and getattr(n.test, "id", None) == "sync"]
+
+    check("exactly one _tick_lock.release() in the try body", len(releases) == 1,
+          f"found {len(releases)}")
+    check("advance_next_runs still called under the lock", len(advances) == 1,
+          f"found {len(advances)}")
+    check("_submit_with_guard still called under the lock", len(submits) >= 1,
+          f"found {len(submits)}")
+    check("if sync: still in the try body", len(syncs) == 1, f"found {len(syncs)}")
+    if releases and advances and submits and syncs:
+        check("release is after advance_next_runs", releases[0] > advances[0],
+              f"release at {releases[0]}, advance at {advances[0]}")
+        check("release is after every dispatch", releases[0] > max(submits),
+              f"release at {releases[0]}, last submit at {max(submits)}")
+        check("release is before the sync wait", releases[0] < syncs[0],
+              f"release at {releases[0]}, if sync: at {syncs[0]}")
+
+    finally_src = "\n".join(ast.unparse(s) for s in outer.finalbody)
+    check("finally still releases as a backstop",
+          "_tick_lock.release()" in finally_src, f"finally body: {finally_src!r}")
+    check("the old wide-scope unlock is gone from the finally",
+          "lock_fd" not in finally_src,
+          "the finally still unlocks lock_fd directly, so the narrowing did "
+          f"not take: {finally_src!r}")
+
+    # The registry the guard depends on has to exist at module scope, and it
+    # must not reference a bare `msvcrt` -- that name is only bound inside the
+    # ImportError branch of the fcntl import, so on Unix it does not exist.
+    module_src = "\n".join(
+        ast.unparse(n) for n in tree.body if isinstance(n, ast.Assign)
+        and any(getattr(t, "id", None) == "_job_locks" for t in n.targets)
+    )
+    check("_job_locks is created at module scope", "JobLocks(" in module_src,
+          f"found {module_src!r}")
+    check("_job_locks does not reference a bare msvcrt",
+          "globals().get('msvcrt')" in module_src
+          or 'globals().get("msvcrt")' in module_src,
+          f"found {module_src!r}")
+
+
+def check_claim_is_carried() -> None:
+    print("claim ownership (cron/scheduler.py dispatch guard):")
+    scheduler = HERMES / "cron" / "scheduler.py"
+    source = scheduler.read_text()
+    _tree, fn = function_named(scheduler, "tick")
+    if fn is None:
+        check("tick() is still a module-level function", False)
+        return
+    src = ast.unparse(fn)
+
+    check("the guard binds the claim it took",
+          "_job_lock = _job_locks.claim(job_id)" in src,
+          "the claim is not held in a local, so nothing keeps the lock object "
+          "alive and the flock is dropped the moment it is garbage collected")
+    check("a lost claim skips the job", "if _job_lock is None:" in src)
+
+    # Scoped to the nested worker rather than searched for across tick(): the
+    # tick lock's own `_tick_lock.release()` would satisfy a loose substring
+    # match and the check would pass on an unpatched image.
+    worker = next((n for n in ast.walk(fn) if isinstance(n, ast.FunctionDef)
+                   and n.name == "_run_and_release"), None)
+    check("_run_and_release still wraps the dispatch", worker is not None)
+    if worker is not None:
+        params = [a.arg for a in worker.args.args]
+        defaults = [ast.unparse(d) for d in worker.args.defaults]
+        check("the claim travels into the worker as a default argument",
+              "lock" in params and "_job_lock" in defaults,
+              f"params={params}, defaults={defaults} — the worker cannot "
+              "resolve the store the claim was taken under, so it has to be "
+              "handed the object")
+        finals = "\n".join(ast.unparse(s) for t in worker.body
+                           if isinstance(t, ast.Try) for s in t.finalbody)
+        check("the worker releases through that object in its finally",
+              "lock.release()" in finals,
+              f"finally body: {finals!r}")
+
+    check("nothing releases a claim by job id", "_job_locks.release(" not in source,
+          "release-by-id recomputes the lock path from get_hermes_home(), whose "
+          "override is a ContextVar the worker thread does not have — the pop "
+          "misses and the job is suppressed for the gateway's whole life")
+
+
+# --- 3. tools/cronjob_tools.py ----------------------------------------------
+def check_dispatch_claims_before_the_cas() -> None:
+    print("dispatch gate (tools/cronjob_tools.py::_execute_job_now):")
+    path = HERMES / "tools" / "cronjob_tools.py"
+    _tree, fn = function_named(path, "_execute_job_now")
+    check("_execute_job_now still exists", fn is not None)
+    if fn is None:
+        return
+
+    claims = [n.lineno for n in ast.walk(fn) if isinstance(n, ast.Call)
+              and getattr(n.func, "attr", None) == "claim"
+              and getattr(getattr(n.func, "value", None), "id", None) == "_job_locks"]
+    cas = call_linenos(fn, named_call("claim_job_for_fire"))
+    check("it claims the per-job flock", len(claims) == 1, f"found {len(claims)}")
+    check("it still performs the store CAS", len(cas) == 1, f"found {len(cas)}")
+    if claims and cas:
+        check("the flock is claimed BEFORE the CAS", claims[0] < cas[0],
+              f"claim at {claims[0]}, claim_job_for_fire at {cas[0]} — a "
+              "refusal discovered after the CAS leaves next_run_at advanced "
+              "for a run that never happened")
+
+    tries = [n for n in fn.body if isinstance(n, ast.Try) and n.finalbody]
+    check("_execute_job_now has exactly one try/finally", len(tries) == 1,
+          f"found {len(tries)}")
+    if len(tries) == 1:
+        finally_src = "\n".join(ast.unparse(s) for s in tries[0].finalbody)
+        check("the claim is released in the finally",
+              "_run_lock.release()" in finally_src,
+              "a return or a BaseException would leak the claim, and a leaked "
+              f"claim silently suppresses the job: {finally_src!r}")
+
+
+# --- 4. hermes_cli/cron.py ---------------------------------------------------
+def check_spawned_tick_sweeps_first() -> None:
+    print("recovery sweep (hermes_cli/cron.py::cron_tick):")
+    path = HERMES / "hermes_cli" / "cron.py"
+    _tree, fn = function_named(path, "cron_tick")
+    check("cron_tick still exists", fn is not None)
+    if fn is None:
+        return
+
+    sweeps = call_linenos(fn, named_call("recover_interrupted_executions"))
+    ticks = call_linenos(fn, named_call("tick"))
+    check("it sweeps interrupted executions", len(sweeps) == 1,
+          f"found {len(sweeps)} — a spawned tick is this profile's entire "
+          "scheduler lifecycle, so nothing else will ever reap a stuck row")
+    check("it still ticks", len(ticks) == 1, f"found {len(ticks)}")
+    if sweeps and ticks:
+        check("the sweep runs before the tick", sweeps[0] < ticks[0],
+              f"sweep at {sweeps[0]}, tick at {ticks[0]}")
+
+    guarded = any(sweeps and t.lineno <= sweeps[0] <= (t.end_lineno or t.lineno)
+                  for t in ast.walk(fn) if isinstance(t, ast.Try))
+    check("the sweep is wrapped in a try", guarded,
+          "bookkeeping that raises would cost the profile its tick")
+
+
+# --- 5 + 6. behavioural ------------------------------------------------------
+SLOW_SCRIPT = "import time\ntime.sleep(12)\nprint('slow job done')\n"
+
+# The child stays alive after the tick returns on purpose: it lets the parent
+# tell "the patch released the per-job claim" from "the process died and the
+# kernel released it for us". Only the first is evidence the code is correct.
+CHILD = (
+    "import sys, time\n"
+    "sys.path.insert(0, {root!r})\n"
+    "from cron.scheduler import tick\n"
+    "tick(verbose=False)\n"
+    "print('TICK RETURNED', flush=True)\n"
+    "time.sleep(60)\n"
+)
+
+# Exits without a terminal ledger state, exactly as the kanban worker processes
+# that left six immortal `running` rows on the live platform profile did.
+GHOST = (
+    "import os, sys\n"
+    "sys.path.insert(0, {root!r})\n"
+    "from cron.executions import create_execution, mark_execution_running\n"
+    "row = create_execution('ghost-job', source='direct')\n"
+    "mark_execution_running(row['id'])\n"
+    "print(row['id'], flush=True)\n"
+    "os._exit(0)\n"
+)
+
+SWEEPER = (
+    "import sys\n"
+    "sys.path.insert(0, {root!r})\n"
+    "from hermes_cli.cron import cron_tick\n"
+    "cron_tick()\n"
+)
+
+
+def flockable(path: Path) -> bool:
+    """Whether an exclusive non-blocking flock on ``path`` succeeds right now."""
+    try:
+        fh = open(path, "w", encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        fcntl.flock(fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        fh.close()
+        return False
+    fcntl.flock(fh, fcntl.LOCK_UN)
+    fh.close()
+    return True
+
+
+def flockable_within(path: Path, seconds: float = 3.0) -> bool:
+    """``flockable``, retried — for the assertion that must eventually be true.
+
+    ``create_execution`` runs inside ``_submit_with_guard``, several statements
+    BEFORE ``_tick_lock.release()``. So the in-flight ledger row that wakes the
+    poller below legitimately exists for a short window during which the tick
+    lock is still held. A single shot that landed in that window would fail the
+    docker build with "one slow job still starves the whole profile" — a scary
+    and false diagnosis of a correctly patched image. Only this direction
+    needs the retry; "the per-job lock IS held" must be true the instant the
+    row appears, so that one stays a single shot.
+    """
+    deadline = time.monotonic() + seconds
+    while True:
+        if flockable(path):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.05)
+
+
+def write_job_store(home: Path, jobs: list) -> None:
+    (home / "cron").mkdir(parents=True, exist_ok=True)
+    (home / "cron" / "jobs.json").write_text(json.dumps({"jobs": jobs}))
+
+
+def wait_for_line(log: Path, needle: str, child, seconds: float) -> bool:
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if log.is_file() and needle in log.read_text(errors="replace"):
+            return True
+        if child.poll() is not None:
+            return log.is_file() and needle in log.read_text(errors="replace")
+        time.sleep(0.2)
+    return False
+
+
+def check_behaviour() -> None:
+    print("lock behaviour (a real second process holds the locks):")
+    with tempfile.TemporaryDirectory() as d:
+        home = Path(d)
+        (home / "scripts").mkdir(parents=True)
+        (home / "scripts" / "slow_job.py").write_text(SLOW_SCRIPT)
+        write_job_store(home, [{
+            "id": "slow-job", "name": "Slow Job",
+            "schedule": {"kind": "interval", "minutes": 1, "display": "every 1m"},
+            "prompt": "", "no_agent": True, "script": "slow_job.py", "skills": [],
+            "enabled": True, "deliver": "local",
+            "next_run_at": "2000-01-01T00:00:00+00:00", "state": "scheduled",
+        }])
+
+        env = dict(os.environ, HERMES_HOME=str(home))
+        # The child's output is kept, not discarded: if the throwaway
+        # HERMES_HOME fails to dispatch, this log is the only account of why,
+        # and an opaque build failure here is expensive to diagnose.
+        log = home / "child.log"
+        child_log = open(log, "w", encoding="utf-8")
+        child = subprocess.Popen(
+            [sys.executable, "-c", CHILD.format(root=str(HERMES))], env=env,
+            stdout=child_log, stderr=subprocess.STDOUT)
+        try:
+            ledger = home / "cron" / "executions.db"
+            deadline = time.monotonic() + 20
+            running = False
+            while time.monotonic() < deadline and not running:
+                if ledger.is_file():
+                    try:
+                        con = sqlite3.connect(f"file:{ledger}?mode=ro", uri=True)
+                        running = bool(list(con.execute(
+                            "SELECT 1 FROM executions WHERE job_id='slow-job' "
+                            "AND finished_at IS NULL")))
+                        con.close()
+                    except sqlite3.Error:
+                        pass
+                if not running:
+                    if child.poll() is not None:
+                        break  # the tick is over; no in-flight window to test
+                    time.sleep(0.2)
+            check("slow job reached the ledger as in-flight", running,
+                  "the throwaway HERMES_HOME never dispatched — the harness "
+                  "is broken, not the patch")
+            if not running:
+                child_log.close()
+                print("--- child output ---")
+                print(log.read_text()[-4000:] or "(empty)")
+                print("--- end child output ---")
+                return
+
+            check("tick lock is free while a job runs (the defect)",
+                  flockable_within(home / "cron" / ".tick.lock"),
+                  "tick() is still holding .tick.lock across the as_completed "
+                  "wait, so one slow job still starves the whole profile")
+            check("per-job lock is held while the job runs (the guard)",
+                  not flockable(home / "cron" / ".job-slow-job.lock"),
+                  "nothing replaced the cross-process in-flight guard the wide "
+                  "lock used to provide")
+
+            returned = wait_for_line(log, "TICK RETURNED", child, 60)
+            check("the child's tick returned", returned,
+                  "the slow job never finished, so the release cannot be "
+                  f"observed: {log.read_text()[-2000:]!r}")
+            check("the claim is released by the code, not by the child dying",
+                  returned and child.poll() is None
+                  and flockable_within(home / "cron" / ".job-slow-job.lock"),
+                  "the per-job claim outlived the run inside a process that is "
+                  "still alive — _run_and_release did not release it, which is "
+                  "the leak that suppresses the job on every later tick")
+        finally:
+            child.kill()
+            child.wait(timeout=30)
+            child_log.close()
+
+
+def check_recovery_sweep() -> None:
+    print("recovery sweep (a stuck row from a process that is gone):")
+    with tempfile.TemporaryDirectory() as d:
+        home = Path(d)
+        write_job_store(home, [])
+        env = dict(os.environ, HERMES_HOME=str(home))
+
+        ghost = subprocess.run(
+            [sys.executable, "-c", GHOST.format(root=str(HERMES))], env=env,
+            capture_output=True, text=True, timeout=60)
+        row_id = ghost.stdout.strip().splitlines()[-1] if ghost.stdout.strip() else ""
+        check("a running row was left behind", bool(row_id),
+              f"stdout={ghost.stdout!r} stderr={ghost.stderr[-2000:]!r}")
+        if not row_id:
+            return
+
+        ledger = home / "cron" / "executions.db"
+
+        def status() -> str:
+            con = sqlite3.connect(f"file:{ledger}?mode=ro", uri=True)
+            try:
+                found = list(con.execute(
+                    "SELECT status FROM executions WHERE id=?", (row_id,)))
+            finally:
+                con.close()
+            return found[0][0] if found else ""
+
+        check("the row starts out running", status() == "running",
+              f"status={status()!r}")
+
+        swept = subprocess.run(
+            [sys.executable, "-c", SWEEPER.format(root=str(HERMES))], env=env,
+            capture_output=True, text=True, timeout=120)
+        check("the row was reaped as unknown", status() == "unknown",
+              f"status={status()!r} — a spawned tick still never sweeps, so a "
+              "run whose process died stays in flight forever and its failure "
+              f"is invisible. sweeper stdout={swept.stdout[-2000:]!r} "
+              f"stderr={swept.stderr[-2000:]!r}")
+
+
+if __name__ == "__main__":
+    print("verify_cron_tick_lock_scope")
+    check_release_placement()
+    check_claim_is_carried()
+    check_dispatch_claims_before_the_cas()
+    check_spawned_tick_sweeps_first()
+    check_behaviour()
+    check_recovery_sweep()
+    print()
+    if FAILURES:
+        print(f"verify_cron_tick_lock_scope: {len(FAILURES)} FAILED")
+        for f in FAILURES:
+            print(f"  - {f}")
+        raise SystemExit(1)
+    print("verify_cron_tick_lock_scope: all checks passed")

--- a/deploy/docker/patches/verify_cron_tirith_scan.py
+++ b/deploy/docker/patches/verify_cron_tirith_scan.py
@@ -1,0 +1,236 @@
+"""Build-time behaviour gate for the cron Tirith-scan patch.
+
+Run by ``deploy/docker/Dockerfile`` against the patched ``/opt/hermes`` tree,
+immediately after ``apply_cron_tirith_scan.py``. The applier proves the anchor
+matched and ``tools/approval.py`` still parses; this proves the patched gate
+actually refuses a command it used to run.
+
+That distinction is the whole reason this file exists. Every way this patch can
+fail is silent: a moved anchor, a scan that never reaches the wire, a block
+result in the wrong shape, an import cycle that makes ``cron_tirith_block``
+raise and take the terminal tool down with it. None of them announce themselves
+— they look exactly like a cron run that had nothing to flag. So the checks
+below drive the real ``check_all_command_guards`` and assert on its return
+value, rather than grepping for the text the applier just inserted.
+
+The unit suite in ``test_cron_tirith_scan.py`` covers ``cron_tirith_scan.py`` in
+isolation and cannot cover any of this, because the edit lives inside Hermes'
+own module.
+
+What is faked, and why that is still a real test
+------------------------------------------------
+Tirith is not in the image at build time — it downloads to ``$HERMES_HOME/bin``
+on first use at runtime — so ``check_command_security`` is replaced with a stub
+that returns a fixed verdict. Everything between that stub and the caller is
+the shipped code: the real ``check_all_command_guards``, the real patched cron
+arm, the real ``cron_tirith_block``, the real ``_format_tirith_description``,
+the real config read. The session predicates are pinned so a build host's
+environment cannot decide which branch is under test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# Freeze this before tools.approval is imported: _YOLO_MODE_FROZEN is read at
+# module import time precisely so nothing can flip it later, so a build host
+# exporting it would silently turn every check below into a pass.
+os.environ.pop("HERMES_YOLO_MODE", None)
+os.environ.pop("HERMES_EXEC_ASK", None)
+
+# A command with a hostile-looking URL and no dangerous *pattern* at all. That
+# is the case the patch exists for: DANGEROUS_PATTERNS has nothing to say about
+# it, so if the block does not come from the content scan it does not come at
+# all.
+COMMAND = "kubectl apply -f https://raw.githubusercontent.example/x/manifest.yaml"
+
+FINDING_TITLE = "Lookalike TLD"
+FINDING_DESC = "the host uses a TLD easily confused with a legitimate one"
+BLOCK_RESULT = {
+    "action": "block",
+    "findings": [
+        {
+            "rule_id": "lookalike_tld",
+            "severity": "HIGH",
+            "title": FINDING_TITLE,
+            "description": FINDING_DESC,
+        }
+    ],
+    "summary": "lookalike tld",
+}
+ALLOW_RESULT = {"action": "allow", "findings": [], "summary": ""}
+
+failures: list[str] = []
+scan_calls: list[str] = []
+
+
+def check(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        failures.append(f"{label}: expected {expected!r}, got {actual!r}")
+    else:
+        print(f"  ok  {label}")
+
+
+def install_scanner(behaviour) -> None:
+    """Replace tools.tirith_security with a stub both import sites will find.
+
+    Both the patched arm (via ``cron_tirith_block``) and upstream's deny arm
+    import ``check_command_security`` lazily from inside a function, so seeding
+    ``sys.modules`` ahead of the first call is enough to intercept both — which
+    is the point: the deny arm must go on using the scanner exactly as before.
+    """
+    import tools
+
+    stub = types.ModuleType("tools.tirith_security")
+
+    def check_command_security(command: str) -> dict:
+        scan_calls.append(command)
+        if isinstance(behaviour, BaseException):
+            raise behaviour
+        return behaviour
+
+    stub.check_command_security = check_command_security
+    sys.modules["tools.tirith_security"] = stub
+    tools.tirith_security = stub
+
+
+def main() -> int:
+    import tools.approval as ap
+    import tools.cron_tirith_scan as cts
+
+    # The patch must be reachable by the name the wiring imports it under. A
+    # COPY to the wrong path fails here rather than at 06:20 on a Sunday.
+    if not callable(getattr(cts, "cron_tirith_block", None)):
+        failures.append("tools.cron_tirith_scan.cron_tirith_block is missing")
+        print("\nVERIFY FAILED:\n  " + failures[0])
+        return 1
+
+    state = {"cron": True, "mode": "approve"}
+
+    # Pin the session predicates. Each is upstream's own and is not what this
+    # patch changes; leaving them live would let a build host's environment
+    # pick the branch under test.
+    ap._is_interactive_cli = lambda: False
+    ap._is_gateway_approval_context = lambda: False
+    ap._is_cron_approval_context = lambda: state["cron"]
+    ap._get_cron_approval_mode = lambda: state["mode"]
+    # approvals.mode: "off" is a global bypass that returns before the cron arm
+    # is reached. Pin it away from "off" so the checks below test the cron arm
+    # and not the bypass.
+    ap._get_approval_mode = lambda: "smart"
+    ap._command_matches_permanent_allowlist = lambda command: False
+    ap._match_user_deny_rule = lambda command: None
+
+    # The premise of COMMAND: no pattern matches it, so any refusal below is
+    # attributable to the content scan and to nothing else. Assert it rather
+    # than assume it — a future DANGEROUS_PATTERNS entry could quietly make
+    # every check pass for the wrong reason.
+    is_dangerous, _key, _desc = ap.detect_dangerous_command(COMMAND)
+    check("the probe command matches no dangerous pattern", is_dangerous, False)
+    check("and is not hardline", ap.detect_hardline_command(COMMAND)[0], False)
+
+    # --- cron_mode: approve, scanner objects → blocked ----------------------
+    # This is the finding. Before the patch this returned approved with the
+    # scanner never consulted.
+    install_scanner(BLOCK_RESULT)
+    del scan_calls[:]
+    result = ap.check_all_command_guards(COMMAND, "local")
+    check("cron approve: scanner was consulted", len(scan_calls), 1)
+    check("cron approve: command refused", result.get("approved"), False)
+    message = result.get("message") or ""
+    check("refusal names the finding", FINDING_TITLE in message, True)
+    # The wiring passes Hermes' own _format_tirith_description in. That renderer
+    # includes the finding's description; cron_tirith_scan's local fallback does
+    # not. So this assertion is what proves the real one is wired, rather than
+    # the stand-in the unit suite uses.
+    check("refusal uses Hermes' own finding renderer", FINDING_DESC in message, True)
+    check("refusal says not to retry it", "Do not retry" in message, True)
+
+    # --- cron_mode: approve, scanner clean → runs ---------------------------
+    # The other half of the requirement: a watchdog that is not doing anything
+    # objectionable must not be slowed down or stopped.
+    install_scanner(ALLOW_RESULT)
+    del scan_calls[:]
+    result = ap.check_all_command_guards(COMMAND, "local")
+    check("cron approve: clean command scanned", len(scan_calls), 1)
+    check("cron approve: clean command allowed", result.get("approved"), True)
+    check("clean command carries no message", result.get("message"), None)
+
+    # --- cron_mode: deny is untouched ---------------------------------------
+    # Upstream already scans on this arm. The patch must not scan twice (a scan
+    # is a subprocess spawn) and must leave upstream's message alone.
+    state["mode"] = "deny"
+    install_scanner(BLOCK_RESULT)
+    del scan_calls[:]
+    result = ap.check_all_command_guards(COMMAND, "local")
+    check("cron deny: scanned exactly once", len(scan_calls), 1)
+    check("cron deny: still refused", result.get("approved"), False)
+    check(
+        "cron deny: still upstream's message",
+        "cron jobs run without a user present" in (result.get("message") or ""),
+        True,
+    )
+    state["mode"] = "approve"
+
+    # --- non-cron non-interactive is untouched ------------------------------
+    # The patch widens the scan to the cron approve path and to nothing else. A
+    # kanban worker's headless session keeps upstream's fall-through, for better
+    # or worse; changing that is a separate decision with a separate blast
+    # radius.
+    state["cron"] = False
+    install_scanner(BLOCK_RESULT)
+    del scan_calls[:]
+    result = ap.check_all_command_guards(COMMAND, "local")
+    check("non-cron headless: not scanned", len(scan_calls), 0)
+    check("non-cron headless: allowed as before", result.get("approved"), True)
+    state["cron"] = True
+
+    # --- a missing scanner honours security.tirith_fail_open ----------------
+    # Tirith genuinely is absent from the image at build time, so this is the
+    # state a first cron run hits before the background install lands. It must
+    # not brick the roster. The default (fail open) is checked against the real
+    # config read; the fail-closed variant pins the loader because the build
+    # image has no config.yaml to set it in.
+    install_scanner(ImportError("No module named 'tirith'"))
+    del scan_calls[:]
+    result = ap.check_all_command_guards(COMMAND, "local")
+    check("scanner absent, fail-open default: allowed", result.get("approved"), True)
+
+    real_loader = cts._load_config_readonly
+    try:
+        cts._load_config_readonly = lambda: {"security": {"tirith_fail_open": False}}
+        result = ap.check_all_command_guards(COMMAND, "local")
+        check("scanner absent, fail-closed: refused", result.get("approved"), False)
+        check(
+            "fail-closed refusal names the flag",
+            "tirith_fail_open" in (result.get("message") or ""),
+            True,
+        )
+
+        # --- the documented opt-out actually opts out -----------------------
+        # approvals.cron_scan: false is the escape hatch for a watchdog that
+        # trips the scanner for a reason the operator has examined. If it did
+        # not work, the only remaining lever would be turning Tirith off for
+        # interactive sessions too.
+        cts._load_config_readonly = lambda: {"approvals": {"cron_scan": False}}
+        install_scanner(BLOCK_RESULT)
+        del scan_calls[:]
+        result = ap.check_all_command_guards(COMMAND, "local")
+        check("cron_scan: false — not scanned", len(scan_calls), 0)
+        check("cron_scan: false — allowed", result.get("approved"), True)
+    finally:
+        cts._load_config_readonly = real_loader
+
+    if failures:
+        print("\nVERIFY FAILED:")
+        for f in failures:
+            print("  " + f)
+        return 1
+    print("\ncron_tirith_scan verify OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/docker/patches/verify_kanban_auto_subscribe.py
+++ b/deploy/docker/patches/verify_kanban_auto_subscribe.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban worker subscription-inheritance patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after the applier.
+The applier only proves the anchor matched. This replays the 2026-08-07
+incident shape through the *real patched* tool handler — the same
+``_handle_create`` a worker's ``kanban_create`` call reaches — against a real
+board: a subscribed coordinator card, a worker env
+(``HERMES_KANBAN_TASK``), and children created without the session context
+that ``_maybe_auto_subscribe`` needs. Before the patch those children were
+invisible to the notifier and the synthesizer's answer sat undelivered for
+91.3 seconds; after it, every hop inherits the chat thread.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_auto_subscribe.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+TMP = Path(tempfile.mkdtemp())
+DB = TMP / "kanban.db"
+# Pin the board the tool layer resolves — the same pin the dispatcher injects
+# into every worker it spawns.
+os.environ["HERMES_KANBAN_DB"] = str(DB)
+os.environ.pop("HERMES_KANBAN_TASK", None)
+# The TUI fallback in _maybe_auto_subscribe keys on HERMES_SESSION_KEY; the
+# incident's defining feature is that a worker has no session identity at all.
+os.environ.pop("HERMES_SESSION_KEY", None)
+
+from hermes_cli import kanban_db as K  # noqa: E402
+import tools.kanban_tools as kt  # noqa: E402
+
+conn = K.connect(DB)
+
+
+def subs(task_id):
+    return conn.execute(
+        "SELECT * FROM kanban_notify_subs WHERE task_id = ? "
+        "ORDER BY platform, chat_id",
+        (task_id,),
+    ).fetchall()
+
+
+def head(task_id):
+    return conn.execute(
+        "SELECT COALESCE(MAX(id), 0) FROM task_events WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()[0]
+
+
+# The kinds gateway/kanban_watchers.py claims for a subscriber; anything the
+# cursor is left behind is a message that lands in the user's chat thread.
+TERMINAL_KINDS = (
+    "completed", "blocked", "gave_up", "crashed", "timed_out",
+    "status", "archived", "unblocked", "block_loop_detected",
+)
+
+
+def would_replay(task_id):
+    """The events the notifier's next tick would post for ``task_id``."""
+    _, events = K.unseen_events_for_sub(
+        conn,
+        task_id=task_id,
+        platform="slack",
+        chat_id="C0PLATFORM",
+        thread_id="1723033132.001",
+        kinds=TERMINAL_KINDS,
+    )
+    return [e.kind for e in events]
+
+
+def tool_create(**args):
+    out = json.loads(kt._handle_create({"assignee": "platform", **args}))
+    if not out.get("ok"):
+        raise AssertionError(f"kanban_create failed: {out}")
+    return out
+
+
+check(
+    "the create handler resolved the inheritance import",
+    hasattr(kt, "_kanban_inherit_worker_subs"),
+    "the trailer import did not execute",
+)
+
+# --- The incident, replayed --------------------------------------------------
+print("worker-created cards:")
+# The coordinator card, subscribed the way the chat agent's session was.
+coordinator = K.create_task(conn, title="coordinator", assignee="platform")
+K.add_notify_sub(
+    conn,
+    task_id=coordinator,
+    platform="slack",
+    chat_id="C0PLATFORM",
+    thread_id="1723033132.001",
+    user_id="U0ADAM",
+    notifier_profile="default",
+)
+check("the coordinator card is subscribed", len(subs(coordinator)) == 1)
+
+# Now the coordinator runs as a dispatcher-spawned worker: HERMES_KANBAN_TASK
+# is pinned, session context vars are absent.
+os.environ["HERMES_KANBAN_TASK"] = coordinator
+
+sleeper = tool_create(title="sleep task 1")
+check(
+    "the worker's create has no session context to auto-subscribe with",
+    sleeper.get("subscribed") is False,
+    "session context leaked into the verify environment",
+)
+rows = subs(sleeper["task_id"])
+check("the worker's child card inherits the chat subscription", len(rows) == 1)
+if rows:
+    row = rows[0]
+    check(
+        "the inherited row targets the originating thread",
+        row["platform"] == "slack"
+        and row["chat_id"] == "C0PLATFORM"
+        and row["thread_id"] == "1723033132.001"
+        and row["user_id"] == "U0ADAM"
+        and row["notifier_profile"] == "default",
+    )
+    check(
+        "the child's cursor starts caught up with its own history",
+        row["last_event_id"] == head(sleeper["task_id"]),
+        f"last_event_id={row['last_event_id']}, head={head(sleeper['task_id'])}",
+    )
+    check(
+        "so the notifier's next tick has nothing to replay",
+        would_replay(sleeper["task_id"]) == [],
+        f"would post {would_replay(sleeper['task_id'])}",
+    )
+
+# A child that ALSO names the subscribed card as a graph parent hits both
+# upstream's _inherit_notify_subs and this patch — the primary key must
+# deduplicate them.
+synthesizer = tool_create(
+    title="synthesizer", parents=[sleeper["task_id"]]
+)
+check(
+    "overlap with upstream parent-edge inheritance stays single",
+    len(subs(synthesizer["task_id"])) == 1,
+    f"{len(subs(synthesizer['task_id']))} rows",
+)
+
+# The chain must survive a second hop: a worker running a child card fans out
+# again, and the grandchild still reaches the user's thread.
+os.environ["HERMES_KANBAN_TASK"] = synthesizer["task_id"]
+grandchild = tool_create(title="grandchild")
+check("a second fan-out hop still inherits", len(subs(grandchild["task_id"])) == 1)
+
+# A worker whose own card was never subscribed (no chat origin) propagates
+# nothing — and the create must still succeed.
+unsubscribed = K.create_task(conn, title="cron-born card", assignee="platform")
+os.environ["HERMES_KANBAN_TASK"] = unsubscribed
+orphan = tool_create(title="child of an unsubscribed card")
+check("an unsubscribed parent propagates nothing", len(subs(orphan["task_id"])) == 0)
+
+# --- The card an idempotent create hands back --------------------------------
+# create_task answers a repeat idempotency_key by returning the id of the
+# EXISTING card, before it opens write_txn. The tool handler cannot tell the
+# difference, so this patch's hook can land on a card with a full history —
+# and a cursor of 0 would post all of it into the user's thread.
+print("idempotent re-create of a finished card:")
+finished = K.create_task(
+    conn, title="nightly cost report", assignee="platform",
+    idempotency_key="nightly-cost-report",
+)
+# _append_event is the helper every kernel status/blocked/completed path calls;
+# the gate only needs the history to be there, not the runs that produced it.
+with K.write_txn(conn):
+    for kind in ("status", "blocked", "unblocked", "completed"):
+        K._append_event(conn, finished, kind, None)
+
+os.environ["HERMES_KANBAN_TASK"] = coordinator
+again = tool_create(
+    title="nightly cost report", idempotency_key="nightly-cost-report"
+)
+check(
+    "the repeat create returns the existing card",
+    again["task_id"] == finished,
+    f"got {again['task_id']}, expected {finished}",
+)
+check("that card is subscribed to the worker's thread", len(subs(finished)) == 1)
+check(
+    "and its closed history is NOT replayed into the thread",
+    would_replay(finished) == [],
+    f"would post {would_replay(finished)}",
+)
+
+# --- Non-worker creates are untouched -----------------------------------------
+print("non-worker creates:")
+os.environ.pop("HERMES_KANBAN_TASK", None)
+plain = tool_create(title="created outside any worker")
+check(
+    "a non-worker create writes no subscription",
+    len(subs(plain["task_id"])) == 0,
+    "the patch must not widen beyond dispatcher-spawned workers",
+)
+
+print()
+if FAILURES:
+    print(f"verify_kanban_auto_subscribe: {len(FAILURES)} FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_auto_subscribe: all checks passed")

--- a/deploy/docker/patches/verify_kanban_comment_status.py
+++ b/deploy/docker/patches/verify_kanban_comment_status.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban comment status patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after the applier. The
+applier only proves its one anchor matched. This drives the *real patched*
+handler — the same ``_handle_comment`` a ``kanban_comment`` tool call reaches —
+against a real board, and replays the 2026-08-08 shape that produced the
+incident: a card completed, its report delivered, its subscription torn down,
+and then a comment written to it.
+
+Not vacuous, and measured rather than asserted: run against the same image with
+the applier skipped, 17 of the 33 checks fail and the script exits 1, because
+upstream's ``_handle_comment`` returns ``{"ok", "task_id", "comment_id"}`` and
+nothing else. The checks that pass on an unpatched tree are the ones that are
+supposed to — they assert the patch did NOT change what upstream already
+returned, and a regression there would fail on the patched tree instead.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_comment_status.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+TMP = Path(tempfile.mkdtemp())
+DB = TMP / "kanban.db"
+# Pin the board the tool layer resolves, the way the dispatcher pins it into
+# every worker it spawns.
+os.environ["HERMES_KANBAN_DB"] = str(DB)
+# The handler derives the comment author from HERMES_PROFILE and refuses
+# mutations from a delegate_task child; neither should vary this run.
+os.environ["HERMES_PROFILE"] = "default"
+os.environ.pop("HERMES_KANBAN_TASK", None)
+
+from hermes_cli import kanban_db as K  # noqa: E402
+import tools.kanban_tools as kt  # noqa: E402
+
+try:
+    import tools.kanban_comment_status as kcs  # noqa: E402
+except ImportError:  # the module was never COPYd in
+    kcs = None
+
+conn = K.connect(DB)
+
+UPSTREAM_KEYS = {"ok", "task_id", "comment_id"}
+
+
+def comment(task_id: str, body: str = "a note on this card") -> dict:
+    """Call the real tool handler exactly as the model does."""
+    return json.loads(kt._handle_comment({"task_id": task_id, "body": body}))
+
+
+def card(title: str, status: str = "running") -> str:
+    """A card pinned to ``status``.
+
+    ``create_task``'s own default is not relied on: it lands a card in ``ready``
+    here, upstream's signature says ``running``, and the dispatcher moves cards
+    between the two. This patch's behaviour is a function of the status, so the
+    status is stated rather than inherited.
+    """
+    tid = K.create_task(conn, title=title, assignee="platform")
+    with K.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, tid))
+    return tid
+
+
+def subscribe(task_id: str) -> None:
+    K.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="slack",
+        chat_id="C0PLATFORM",
+        thread_id="1723033132.001",
+        user_id="U0ADAM",
+        notifier_profile="default",
+    )
+
+
+def sub_rows(task_id: str) -> int:
+    return conn.execute(
+        "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?", (task_id,),
+    ).fetchone()[0]
+
+
+def bodies(task_id: str) -> list:
+    return [c.body for c in K.list_comments(conn, task_id)]
+
+
+check(
+    "the handler resolved the delivery-fields import",
+    hasattr(kt, "_comment_delivery_fields"),
+    "the trailer import did not execute",
+)
+
+# --- 1. Upstream's contract is intact ----------------------------------------
+# The model parses these three. Adding fields is safe; changing them is not.
+print("upstream fields:")
+open_card = card("an open card", "running")
+out = comment(open_card, "still upstream's shape")
+check("ok is still True", out.get("ok") is True)
+check("task_id is still echoed back", out.get("task_id") == open_card)
+check(
+    "comment_id is still the integer rowid",
+    isinstance(out.get("comment_id"), int) and out["comment_id"] > 0,
+    f"got {out.get('comment_id')!r}",
+)
+check(
+    "no upstream field was dropped",
+    UPSTREAM_KEYS <= set(out),
+    f"missing {sorted(UPSTREAM_KEYS - set(out))}",
+)
+check("the comment landed on the card", "still upstream's shape" in bodies(open_card))
+
+# --- 2. A live card says so --------------------------------------------------
+print("open cards:")
+check(
+    "a running card reports its status",
+    out.get("task_status") == "running",
+    f"got {out.get('task_status')!r}",
+)
+check(
+    "and names the live worker as the reader",
+    out.get("comment_reaches") == "the worker running this card right now",
+    f"got {out.get('comment_reaches')!r}",
+)
+check(
+    "an unsubscribed card is honest that completing posts nowhere",
+    out.get("completion_posts_to_chat") is False,
+    f"got {out.get('completion_posts_to_chat')!r}",
+)
+
+subscribe(open_card)
+out = comment(open_card, "now with a thread behind it")
+check(
+    "a subscribed card reports that its completion reaches chat",
+    out.get("completion_posts_to_chat") is True,
+    f"got {out.get('completion_posts_to_chat')!r}",
+)
+check("no note is attached to a card that can still deliver", "note" not in out)
+
+queued = card("not started yet", "todo")
+out = comment(queued)
+check(
+    "a queued card points at the worker that will pick it up",
+    out.get("task_status") == "todo"
+    and out.get("comment_reaches") == "the next worker to run this card",
+    f"got {out.get('task_status')!r} / {out.get('comment_reaches')!r}",
+)
+
+# --- 3. The 2026-08-08 incident, replayed ------------------------------------
+# t_a8f58a2a completed at 19:09:43, its 6,191-char report reached the Slack
+# thread at 19:09:44, the notifier unsubscribed on the same tick, and at 19:11:30
+# the front door commented on the card and told the user the results would post
+# there when the agent finished.
+print("2026-08-08 incident replay:")
+incident = card("audit the fleet", "running")
+subscribe(incident)
+report = "FINDINGS\n" + ("cluster row " * 500)
+K.complete_task(
+    conn, incident, result=report, summary="Audited the fleet; 9 findings.",
+)
+# What gateway/kanban_watchers.py does on the tick that carries the terminal
+# event: task_terminal -> _kanban_unsub.
+K.remove_notify_sub(
+    conn,
+    task_id=incident,
+    platform="slack",
+    chat_id="C0PLATFORM",
+    thread_id="1723033132.001",
+)
+check("the card is done", K.get_task(conn, incident).status == "done")
+check("its subscription is gone", sub_rows(incident) == 0)
+
+out = comment(incident, "Any update on this? Posting results here when done.")
+check("the comment still succeeds", out.get("ok") is True)
+check(
+    "the comment is still stored",
+    "Any update on this? Posting results here when done." in bodies(incident),
+    "a terminal card must not swallow the annotation",
+)
+check(
+    "the result names the terminal status",
+    out.get("task_status") == "done",
+    f"got {out.get('task_status')!r}",
+)
+check(
+    "and says nobody will read the comment",
+    out.get("comment_reaches") == "nobody",
+    f"got {out.get('comment_reaches')!r}",
+)
+note = out.get("note") or ""
+check("a terminal card carries an explicit note", bool(note))
+check(
+    "the note forbids promising a delivery",
+    "Do NOT say that results will follow" in note,
+    f"got {note!r}",
+)
+check(
+    "the note points at where the answer already is",
+    "kanban_show" in note and incident in note,
+)
+check(
+    "nothing in the payload can be read as a pending delivery",
+    "completion_posts_to_chat" not in out,
+    "a terminal card must not advertise a delivery channel at all",
+)
+
+# --- 4. Status outranks the subscription row ---------------------------------
+# The unsub happens when the notifier PROCESSES the terminal event, so for up to
+# one tick a done card still has its rows. If the racy field could contradict
+# the durable one, the model would resolve it optimistically -- which is the bug.
+print("done-but-not-yet-unsubscribed:")
+racy = card("just completed", "running")
+subscribe(racy)
+K.complete_task(conn, racy, result="the answer", summary="done")
+check("the subscription row is still there", sub_rows(racy) == 1)
+out = comment(racy)
+check(
+    "the card is still reported as undeliverable",
+    out.get("comment_reaches") == "nobody" and out.get("task_status") == "done",
+    f"got {out.get('task_status')!r} / {out.get('comment_reaches')!r}",
+)
+check(
+    "the surviving subscription is not advertised",
+    "completion_posts_to_chat" not in out,
+    "status must outrank the row that is one tick from deletion",
+)
+
+print("archived cards:")
+gone = card("old card", "running")
+K.archive_task(conn, gone)
+out = comment(gone)
+check(
+    "an archived card is terminal too",
+    out.get("task_status") == "archived" and out.get("comment_reaches") == "nobody",
+    f"got {out.get('task_status')!r} / {out.get('comment_reaches')!r}",
+)
+
+# --- 5. The set this patch is coupled to -------------------------------------
+# TERMINAL_STATUSES exists to mirror the notifier's own terminal test. If
+# upstream widens that test, a card can lose its subscription while this patch
+# still calls it deliverable, and the incident comes back on the new status.
+print("coupling to the notifier:")
+watchers = Path("gateway/kanban_watchers.py").read_text()
+check(
+    "the notifier still unsubscribes on exactly {done, archived}",
+    'task.status in {"done", "archived"}' in watchers,
+    "gateway/kanban_watchers.py changed its terminal test — re-derive "
+    "TERMINAL_STATUSES in tools/kanban_comment_status.py",
+)
+check(
+    "and this patch's terminal set matches it",
+    kcs is not None and set(kcs.TERMINAL_STATUSES) == {"done", "archived"},
+    "tools/kanban_comment_status.py is missing" if kcs is None
+    else f"got {sorted(kcs.TERMINAL_STATUSES)}",
+)
+
+# --- 6. Fails toward upstream -------------------------------------------------
+# A comment that reaches the board must never be lost to the bookkeeping that
+# describes it. add_comment has already committed its own write_txn by the time
+# delivery_fields runs, so the only question is what the handler returns.
+print("fail-soft:")
+live = card("lookup will break", "running")
+
+
+def _boom(*a, **kw):
+    raise RuntimeError("simulated board failure")
+
+
+_real_get_task = K.get_task
+K.get_task = _boom
+try:
+    out = comment(live, "written while the status lookup is broken")
+finally:
+    K.get_task = _real_get_task
+
+check(
+    "a broken status lookup still returns success",
+    out.get("ok") is True and out.get("comment_id"),
+    f"got {out!r}",
+)
+check(
+    "and degrades to exactly upstream's fields",
+    set(out) == UPSTREAM_KEYS,
+    f"got {sorted(out)}",
+)
+check(
+    "and the comment is on the card",
+    "written while the status lookup is broken" in bodies(live),
+    "a status field is not worth a lost comment",
+)
+
+if kcs is None:
+    check("a broken subscription probe keeps the status", False,
+          "tools/kanban_comment_status.py is missing")
+else:
+    _real_probe = kcs._has_chat_subscriber
+    kcs._has_chat_subscriber = _boom
+    try:
+        out = comment(live, "subscription probe broken")
+    finally:
+        kcs._has_chat_subscriber = _real_probe
+
+    check(
+        "a broken subscription probe keeps the status",
+        out.get("task_status") == "running",
+        f"got {out.get('task_status')!r}",
+    )
+    check(
+        "and drops only the half that failed",
+        "completion_posts_to_chat" not in out,
+        f"got {sorted(out)}",
+    )
+
+# --- 7. The wiring itself -----------------------------------------------------
+print("wiring:")
+_src = Path("tools/kanban_tools.py").read_text()
+_calls = _src.count("**_comment_delivery_fields(kb, conn, tid)")
+check(
+    "the handler splats the delivery fields into upstream's _ok",
+    _calls >= 1,
+    "the applier did not run",
+)
+check(
+    "exactly one call site",
+    _calls == 1,
+    f"found {_calls} — the applier ran twice" if _calls > 1 else "found 0",
+)
+
+print()
+if FAILURES:
+    print(f"verify_kanban_comment_status: {len(FAILURES)} check(s) FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_comment_status: all checks passed")

--- a/deploy/docker/patches/verify_kanban_guardrail_exit.py
+++ b/deploy/docker/patches/verify_kanban_guardrail_exit.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban guardrail-exit patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after
+``apply_kanban_guardrail_exit.py``. The applier only proves its two anchors
+matched exactly once; that says nothing about whether the inserted code is
+reachable, whether it still composes with the upstream helpers it calls, or
+whether the board write it makes lands.
+
+Four things are checked, and each one is a way the patch could match its anchor
+and still be useless:
+
+1. **The nudge is reachable and terminal.** Parsed out of the *patched*
+   ``agent/conversation_loop.py``: the insert has to sit inside the
+   guardrail-halt branch, ahead of the ``break`` it is there to pre-empt, and it
+   has to clear ``agent._tool_guardrail_halt_decision`` before ``continue`` —
+   ``reset_for_turn`` clears that once per turn, not per iteration, so leaving it
+   set sends the next iteration straight back into the branch and out through the
+   same ``break``. Also asserted: the insert never touches
+   ``_turn_web_search_count``, which would hand the model another 50 searches.
+2. **It still composes with upstream.** ``guardrail_halt_nudge`` is driven
+   against the real ``agent.kanban_stop.build_kanban_stop_nudge`` — a signature
+   change there is silent, because the patch swallows exceptions and falls back
+   to the old exit path by design.
+3. **The backstop is inside the funnel.** The ``finalize_turn`` insert is checked
+   for placement within the function every ``break`` passes through.
+4. **The board write lands.** ``record_missing_terminal_call`` is driven against
+   a real kanban database through the real ``_record_task_failure``: claim
+   released, run closed, failure counted, exit reason legible in the event. Plus
+   the three cases that must *not* write — a card the board no longer shows as
+   ``running`` (compaction can drop a terminal tool call out of ``messages``,
+   the board cannot), a goal-mode worker between turns, and a dispatched cron
+   run, which is holding its *caller's* task id. The cron case is checked
+   against the real ``tools.cron_run_scope``: the unit tests can only reach that
+   module as a top-level sibling, so this is the only place the import the
+   exclusion actually defaults to is exercised.
+
+The per-turn ``max_web_searches`` ceiling that triggered all this is a config
+change, not a patch, and is gated where the template is built — see the
+``/opt/platform-template/config.yaml`` assertion in the Dockerfile.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_guardrail_exit.py
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+HERMES = Path(os.environ.get("HERMES_ROOT", "/opt/hermes"))
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+
+# --- 1. The nudge is reachable, and it is the exit it claims to be ----------
+print("guardrail-halt nudge (agent/conversation_loop.py):")
+
+loop_tree = ast.parse((HERMES / "agent" / "conversation_loop.py").read_text())
+
+HALT_TEST = "agent._tool_guardrail_halt_decision is not None"
+halt_ifs = [
+    node
+    for node in ast.walk(loop_tree)
+    if isinstance(node, ast.If) and ast.unparse(node.test) == HALT_TEST
+]
+check(
+    "the guardrail-halt branch is still a single branch",
+    len(halt_ifs) == 1,
+    f"found {len(halt_ifs)} — the anchor matched something that moved",
+)
+
+nudge_if = None
+halt_break = None
+if len(halt_ifs) == 1:
+    halt = halt_ifs[0]
+    nudge_ifs = [
+        s
+        for s in halt.body
+        if isinstance(s, ast.If) and ast.unparse(s.test) == "_kanban_halt_nudge"
+    ]
+    breaks = [s for s in halt.body if isinstance(s, ast.Break)]
+    check("the nudge sits inside the halt branch", len(nudge_ifs) == 1)
+    check("the halt branch still ends in a break", len(breaks) == 1)
+    if nudge_ifs:
+        nudge_if = nudge_ifs[0]
+    if breaks:
+        halt_break = breaks[0]
+
+if nudge_if is not None and halt_break is not None:
+    check(
+        "the nudge runs before the break it pre-empts",
+        nudge_if.lineno < halt_break.lineno,
+        f"nudge at {nudge_if.lineno}, break at {halt_break.lineno}",
+    )
+
+if nudge_if is not None:
+    body = nudge_if.body
+    assigns = {
+        ast.unparse(t): ast.unparse(s.value)
+        for s in body
+        if isinstance(s, ast.Assign)
+        for t in s.targets
+    }
+
+    check(
+        "the nudge path continues the loop rather than falling through",
+        isinstance(body[-1], ast.Continue),
+        f"last statement is {type(body[-1]).__name__}",
+    )
+    check(
+        "the halt decision is cleared before continuing",
+        assigns.get("agent._tool_guardrail_halt_decision") == "None",
+        "reset_for_turn clears it per turn, not per iteration — the next "
+        "iteration would re-enter this branch and break anyway",
+    )
+    check(
+        "the halt text is withheld as this turn's answer",
+        assigns.get("final_response") == "None"
+        and "_pending_verification_response" in assigns,
+        f"assignments: {sorted(assigns)}",
+    )
+    check(
+        "the exit reason is taken back off guardrail_halt",
+        assigns.get("_turn_exit_reason") == "'unknown'",
+        f"left as {assigns.get('_turn_exit_reason')!r}",
+    )
+
+    nudge_src = ast.unparse(nudge_if)
+    check(
+        "the synthetic turn is marked as one",
+        "_kanban_stop_synthetic" in nudge_src,
+        "unmarked synthetic turns are indistinguishable from the user's",
+    )
+    check(
+        "the nudge budget is spent, not just read",
+        "agent._kanban_stop_nudges" in nudge_src,
+        "without the increment the two-attempt bound never terminates",
+    )
+    check(
+        "the search counter is left alone",
+        "_turn_web_search_count" not in nudge_src,
+        "resetting it hands the model another full cap",
+    )
+
+
+# --- 2. It still composes with the upstream helper it borrows ---------------
+print("composition with agent.kanban_stop:")
+
+from agent.kanban_stop import build_kanban_stop_nudge  # noqa: E402
+from hermes_cli.kanban_guardrail_exit import (  # noqa: E402
+    DEFAULT_MAX_NUDGES,
+    DETECTOR,
+    OUTCOME,
+    guardrail_halt_nudge,
+    missing_terminal_error,
+    record_missing_terminal_call,
+    should_record_missing_terminal,
+    task_is_still_running,
+)
+
+
+class _Decision:
+    """The shape ``_guardrail_block_result`` records on the agent."""
+
+    tool_name = "web_search"
+    code = "loop_web_search_cap"
+
+
+DECISION = _Decision()
+TERMINAL_MESSAGES = [
+    {
+        "role": "assistant",
+        "tool_calls": [{"function": {"name": "kanban_complete"}}],
+    }
+]
+
+os.environ["HERMES_KANBAN_TASK"] = "t_verify"
+os.environ.pop("HERMES_KANBAN_GOAL_MODE", None)
+
+nudge = guardrail_halt_nudge(
+    build_kanban_stop_nudge, messages=[], attempts=0, decision=DECISION
+)
+check(
+    "a halted worker gets a nudge",
+    isinstance(nudge, str) and nudge,
+    "upstream's build_kanban_stop_nudge signature or gating changed — the "
+    "patch swallows that and silently reverts to the old exit",
+)
+if isinstance(nudge, str):
+    check(
+        "the nudge still carries upstream's terminal-call instruction",
+        "kanban_complete" in nudge and "kanban_block" in nudge,
+    )
+    check(
+        "it names the tool that is gone and why",
+        "web_search" in nudge and "loop_web_search_cap" in nudge,
+    )
+    check(
+        "it tells the model not to retry the exhausted tool",
+        "do not try again" in nudge,
+        "without this the model re-halts and burns the next nudge",
+    )
+
+check(
+    "the nudge budget is bounded",
+    guardrail_halt_nudge(
+        build_kanban_stop_nudge,
+        messages=[],
+        attempts=DEFAULT_MAX_NUDGES,
+        decision=DECISION,
+    )
+    is None,
+    "an unbounded nudge loop is worse than the exit it replaces",
+)
+check(
+    "a worker that already closed its card is not nudged",
+    guardrail_halt_nudge(
+        build_kanban_stop_nudge,
+        messages=TERMINAL_MESSAGES,
+        attempts=0,
+        decision=DECISION,
+    )
+    is None,
+)
+
+del os.environ["HERMES_KANBAN_TASK"]
+check(
+    "non-kanban sessions keep the stock halt behaviour",
+    guardrail_halt_nudge(
+        build_kanban_stop_nudge, messages=[], attempts=0, decision=DECISION
+    )
+    is None,
+    "the patch changed the exit for every interactive session too",
+)
+os.environ["HERMES_KANBAN_TASK"] = "t_verify"
+
+
+# --- 3. The backstop is inside the funnel every break passes through --------
+print("terminal-call backstop (agent/turn_finalizer.py):")
+
+finalizer_tree = ast.parse((HERMES / "agent" / "turn_finalizer.py").read_text())
+finalize = next(
+    (
+        n
+        for n in ast.walk(finalizer_tree)
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and n.name == "finalize_turn"
+    ),
+    None,
+)
+check("finalize_turn is still the funnel", finalize is not None)
+
+if finalize is not None:
+    calls = {
+        ast.unparse(n.func)
+        for n in ast.walk(finalize)
+        if isinstance(n, ast.Call) and isinstance(n.func, (ast.Name, ast.Attribute))
+    }
+    check(
+        "the leak check runs inside finalize_turn",
+        "_kanban_should_record_missing" in calls,
+        "an insert outside the funnel covers none of the seven exits",
+    )
+    check(
+        "the recorder runs inside finalize_turn",
+        "_kanban_record_missing_terminal" in calls,
+    )
+    check(
+        "the exit reason reaches the board",
+        "_turn_exit_reason" in ast.unparse(finalize),
+        "without it the failure is as unexplained as the protocol violation "
+        "it replaces",
+    )
+
+# The seven ways out of the loop that leak. Each has to be legible in the
+# failure text, because that text is the only account of what happened.
+EXIT_REASONS = (
+    "guardrail_halt",
+    "all_retries_exhausted_no_response",
+    "partial_stream_recovery",
+    "fallback_prior_turn_content",
+    "empty_response_exhausted",
+    "local_processing_error",
+    "error_near_max_iterations",
+)
+errors = {r: missing_terminal_error(r) for r in EXIT_REASONS}
+check(
+    "every exit reason names itself in the failure text",
+    all(r in errors[r] for r in EXIT_REASONS),
+)
+check(
+    "the seven exits stay distinguishable after truncation to 500 chars",
+    len({e[:500] for e in errors.values()}) == len(EXIT_REASONS),
+)
+
+
+def leaks(**over):
+    kwargs = dict(
+        task_id="t_verify",
+        interrupted=False,
+        failed=False,
+        iteration_limit_fallback=False,
+    )
+    kwargs.update(over)
+    return should_record_missing_terminal(**kwargs)
+
+
+check("a worker that never closed its card is a leak", leaks() is True)
+check(
+    "the transcript is not consulted — the board is",
+    "session_called_terminal"
+    not in inspect.signature(should_record_missing_terminal).parameters,
+    "a REJECTED kanban_complete still lands as a tool message named "
+    "kanban_complete, so the transcript check let one refusal from "
+    "kanban_result_required silence the backstop for the rest of the run",
+)
+check("an interrupt is not", leaks(interrupted=True) is False)
+check("an already-failed turn is not", leaks(failed=True) is False)
+check(
+    "the iteration-budget path is not double-counted",
+    leaks(iteration_limit_fallback=True) is False,
+)
+check("a non-worker session is not", leaks(task_id=None) is False)
+check(
+    "a goal-mode worker between turns is not",
+    leaks(goal_mode=True) is False,
+    "goal mode calls finalize_turn once per turn — recording on turn 1 of N "
+    "would release the claim underneath the loop",
+)
+
+os.environ["HERMES_KANBAN_GOAL_MODE"] = "1"
+check(
+    "goal mode is read from the environment the dispatcher sets",
+    leaks() is False,
+    "the exclusion only works if it defaults to the real env var",
+)
+del os.environ["HERMES_KANBAN_GOAL_MODE"]
+
+check("a dispatched cron run is not a leak", leaks(cron_run=True) is False)
+
+# The unit tests can only reach cron_run_scope as a top-level sibling. In the
+# image it is tools.cron_run_scope, and that import is the one that decides
+# whether the exclusion defaults on at all — get it wrong and _in_cron_run
+# silently degrades to the process-wide env var, losing the per-thread
+# precision that makes it safe under dispatch_in_gateway.
+from tools.cron_run_scope import cron_run_scope  # noqa: E402
+
+with cron_run_scope("verify-fleet-audit"):
+    check(
+        "the exclusion defaults to tools.cron_run_scope's context variable",
+        leaks() is False,
+        "a cron run would charge its caller a timed_out and release the claim "
+        "the caller is still blocked on",
+    )
+check(
+    "and the scope hands the marker back on the way out",
+    leaks() is True,
+    "a leaked marker disables the backstop for every worker after it",
+)
+
+check(
+    "a delegate_task child is not a leak", leaks(delegated_child=True) is False
+)
+
+# Both defaults come from tools/kanban_ownership.py, shared with
+# tools/kanban_worker_tools.py, which asks the same two questions with
+# on_unknown=False. verify_kanban_worker_tools.py proves the polarity argument
+# is honoured; what has to be true here is that this module reached the shipped
+# copy at all rather than falling through to a top-level sibling that happens to
+# be importable.
+_ownership = sys.modules.get("tools.kanban_ownership")
+check(
+    "the exclusions read tools/kanban_ownership.py",
+    _ownership is not None
+    and Path(_ownership.__file__).resolve()
+    == (HERMES / "tools" / "kanban_ownership.py").resolve(),
+    f"resolved to {getattr(_ownership, '__file__', None)!r}",
+)
+
+# Same argument as the cron scope above, against the module the runtime really
+# reads. A child runs in the parent's process with the parent's
+# HERMES_KANBAN_TASK still set, so a default that did not consult this would
+# charge the PARENT a timed_out and release its claim mid-run.
+from agent.delegation_context import (  # noqa: E402
+    delegated_child_context,
+    is_delegated_child_context,
+)
+
+check(
+    "outside a delegation the real context says 'not a child'",
+    is_delegated_child_context() is False,
+)
+with delegated_child_context():
+    check(
+        "the exclusion defaults to agent.delegation_context",
+        leaks() is False,
+        "upstream refuses every board mutation from a delegate_task child for "
+        "the same reason: an inherited HERMES_KANBAN_TASK is not ownership",
+    )
+check(
+    "and the delegation context hands control back on the way out",
+    leaks() is True,
+)
+
+
+# --- 4. The board write lands -----------------------------------------------
+print("board write:")
+
+from hermes_cli import kanban_db as K  # noqa: E402
+
+TMP = Path(tempfile.mkdtemp())
+DB = TMP / "kanban.db"
+
+
+def board():
+    return K.connect(DB)
+
+
+def row(conn, tid):
+    return conn.execute(
+        "SELECT status, claim_lock, consecutive_failures, last_failure_error "
+        "FROM tasks WHERE id = ?",
+        (tid,),
+    ).fetchone()
+
+
+def events(conn, tid):
+    return [
+        (r["kind"], r["payload"])
+        for r in conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        )
+    ]
+
+
+def open_runs(conn, tid):
+    return conn.execute(
+        "SELECT COUNT(*) AS n FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+        (tid,),
+    ).fetchone()["n"]
+
+
+conn = board()
+card = K.create_task(
+    conn, title="Evaluate Config Connector Setup Patterns", assignee="platform"
+)
+K.recompute_ready(conn)
+check("the card is claimed the way the dispatcher claims it", K.claim_task(conn, card))
+check("the run is open before the leak", open_runs(conn, card) == 1)
+
+recorded = record_missing_terminal_call(
+    task_id=card,
+    turn_exit_reason="guardrail_halt",
+    connect=board,
+    record_failure=K._record_task_failure,
+)
+check("the leak is recorded", recorded is True)
+
+conn = board()
+after = row(conn, card)
+check(
+    "the claim is handed back",
+    after["claim_lock"] is None and after["status"] != "running",
+    f"status={after['status']!r} lock={after['claim_lock']!r}",
+)
+check("the run is closed", open_runs(conn, card) == 0)
+check("the failure is counted", after["consecutive_failures"] == 1)
+check(
+    "the exit reason survives to the board",
+    "turn_exit_reason=guardrail_halt" in (after["last_failure_error"] or ""),
+    f"last_failure_error={after['last_failure_error']!r}",
+)
+kinds = [k for k, _ in events(conn, card)]
+check(
+    f"the failure is classified {OUTCOME}",
+    OUTCOME in kinds,
+    f"events: {kinds}",
+)
+check(
+    "the reason is legible in the event payload too",
+    any(
+        k == OUTCOME and "turn_exit_reason=guardrail_halt" in (p or "")
+        for k, p in events(conn, card)
+    ),
+)
+
+# Nothing to hand back twice. This is the guard that makes a false positive
+# impossible rather than merely unlikely: the transcript can lie about a
+# terminal call after compaction, the board cannot.
+check("the card is no longer running", not task_is_still_running(conn, card))
+before = len(events(conn, card))
+check(
+    "a card the board has already moved is left alone",
+    record_missing_terminal_call(
+        task_id=card,
+        turn_exit_reason="guardrail_halt",
+        connect=board,
+        record_failure=K._record_task_failure,
+    )
+    is False,
+)
+check(
+    "and nothing is written for it",
+    len(events(board(), card)) == before,
+)
+check(
+    "an unknown card is left alone",
+    record_missing_terminal_call(
+        task_id="t_does_not_exist",
+        turn_exit_reason="guardrail_halt",
+        connect=board,
+        record_failure=K._record_task_failure,
+    )
+    is False,
+)
+
+# Repeated leaks must reach the circuit breaker rather than looping forever,
+# and the breaker's event is the one place event_payload_extra lands.
+conn = board()
+for _ in range(6):
+    K.recompute_ready(conn)
+    if not K.claim_task(conn, card):
+        break
+    record_missing_terminal_call(
+        task_id=card,
+        turn_exit_reason="guardrail_halt",
+        connect=board,
+        record_failure=K._record_task_failure,
+    )
+    conn = board()
+
+gave_up = [p for k, p in events(conn, card) if k == "gave_up"]
+check(
+    "repeated leaks trip the circuit breaker",
+    gave_up,
+    "the card would retry indefinitely",
+)
+if gave_up:
+    check(
+        "the breaker's event says what detected this and how the turn ended",
+        DETECTOR in gave_up[-1] and "turn_exit_reason" in gave_up[-1],
+        f"payload: {gave_up[-1]}",
+    )
+check(
+    "the card ends up blocked for a human rather than in flight",
+    row(conn, card)["status"] == "blocked",
+    f"status={row(conn, card)['status']!r}",
+)
+
+
+print()
+if FAILURES:
+    print(f"verify_kanban_guardrail_exit: {len(FAILURES)} FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_guardrail_exit: all checks passed")

--- a/deploy/docker/patches/verify_kanban_notifier.py
+++ b/deploy/docker/patches/verify_kanban_notifier.py
@@ -1,0 +1,608 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban notifier patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after the applier. It
+replaces ``verify_kanban_wake_kinds.py`` and the delivery half of
+``verify_kanban_result.py`` (whose remaining sections still gate
+``tools/kanban_result_required.py``, a different patch against a different
+file), and it additionally covers the clip wiring, which previously had nothing
+behind it but two ``grep -q``\\ s in the Dockerfile.
+
+The applier only proves its two anchors matched, and a matched anchor is the
+weaker half of all four concerns here:
+
+* **Clip.** A textual grep proves ``_clip_handoff`` is called; it does not prove
+  the name resolves at runtime, and the whole patch exists because a URL arrived
+  severed. So the clip is driven, not read.
+* **Delivery.** The regression that motivated it was not a failed edit — it was
+  a field the model was told not to use — and the follow-on regression was a
+  hook that appended where it had to replace. Both are behavioural.
+* **Wake.** Every failure mode that costs anything is silent by construction:
+  ``resolve_wake_kinds`` fails *towards* upstream, so a ``hermes_cli.config``
+  that moved, a ``gateway.wake`` that moved, or a ``DEFAULT_WAKE_KINDS``
+  whitelist that fell behind the notifier all present identically to "the
+  operator never set ``kanban.wake_on_events``". The symptom is not an
+  exception, it is the 5.9 s / 32,460-token redundant turn from task
+  ``t_c31a1f00`` quietly coming back.
+* **Marker.** Worse again, because it writes into gateway session state that
+  nothing else in the build reads back. A note parked on a session *id* instead
+  of a session key, a store that dropped ``lookup_by_session_id``, a ``run.py``
+  that stopped draining ``sidecar_notes`` — each is a silent no-op producing
+  precisely what the unpatched gateway produced, which is the 9m46s of dead wait
+  on task ``t_a8f58a2a``.
+
+So this drives the *patched* runtime rather than reading it: the real
+``hermes_cli.config.load_config``, the real ``gateway.wake.adapter_supports_push``,
+the real ``APIServerAdapter`` whose ``supports_async_delivery = False`` is the
+reason the narrowing is scoped to the push path at all, the real
+``_clip_handoff`` / ``_kanban_handoff_with_result`` / ``_wake_kinds_for`` names
+the notifier loop resolved, and — for the marker — a real ``SessionStore`` with
+a real ``SessionEntry`` in it, the real ``GatewayRunner`` sidecar-note methods
+and the real ``consume_gateway_turn_context_notes`` the next turn calls.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_notifier.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+import gateway.kanban_watchers as watchers  # noqa: E402
+from gateway.kanban_notifier import (  # noqa: E402
+    CONFIG_KEY,
+    DEFAULT_LIMIT,
+    DEFAULT_WAKE_KINDS,
+    RESULT_LIMIT,
+    _adapter_can_push,
+    _load_kanban_config,
+    clip_handoff,
+    resolve_wake_kinds,
+    result_block,
+    wake_kinds_for,
+)
+
+NOTIFIER_SOURCE = open("gateway/kanban_watchers.py").read()
+
+FAILURE_ONLY = {"wake_on_events": ["gave_up", "crashed", "timed_out", "blocked"]}
+
+
+def cfg(kanban):
+    return lambda: {"kanban": kanban}
+
+
+class Event:
+    def __init__(self, kind):
+        self.kind = kind
+
+
+# --- 1. The wiring resolved ---------------------------------------------------
+# All three names are appended in one import trailer, so one of them failing to
+# resolve means none of them did — but they are checked separately because the
+# failure that matters is per-symbol: a rename in kanban_notifier.py breaks
+# exactly one, and the notifier would then raise on the delivery path.
+print("import wiring:")
+check(
+    "the notifier resolved the clip import",
+    hasattr(watchers, "_clip_handoff"),
+    "the trailer import did not execute",
+)
+check(
+    "the notifier resolved the delivery import",
+    hasattr(watchers, "_kanban_handoff_with_result"),
+    "the trailer import did not execute",
+)
+check(
+    "the notifier resolved the wake-kinds import",
+    hasattr(watchers, "_wake_kinds_for"),
+    "the trailer import did not execute",
+)
+check(
+    "the notifier names exactly one kube-agents notifier module",
+    NOTIFIER_SOURCE.count("from gateway.kanban_notifier import") == 1,
+    "the merged trailer was applied twice, or a retired module is still wired in",
+)
+check(
+    "the retired modules are no longer referenced",
+    "gateway.kanban_wake_kinds" not in NOTIFIER_SOURCE
+    and "gateway.kanban_result_delivery" not in NOTIFIER_SOURCE,
+)
+
+# --- 2. The clip -------------------------------------------------------------
+# Upstream hard-sliced the handoff at a fixed width, which on 2026-08-03 turned
+# a published ledger link into ".../is" — the delivered message was exactly 200
+# characters and `/issues/30` had been cut down to `/is`. Both slices are
+# rewritten; the greps prove the text landed, the drive proves the behaviour.
+print("handoff clip:")
+check(
+    "the summary branch clips on a token boundary",
+    "h = _clip_handoff(payload_summary)" in NOTIFIER_SOURCE,
+)
+check(
+    "the no-summary branch clips on a token boundary",
+    "r = _clip_handoff(task.result)" in NOTIFIER_SOURCE,
+)
+check(
+    "neither of upstream's hard slices survived",
+    "lines[0][:200]" not in NOTIFIER_SOURCE and "lines[0][:160]" not in NOTIFIER_SOURCE,
+    "a surviving slice still severs the URL this patch exists to protect",
+)
+
+LEDGER_URL = "https://github.com/gke-agentic/adamparco-infra/issues/30"
+PRODUCTION_SUMMARY = (
+    "Workload Reliability Audit executed successfully: 44 findings (0 critical, "
+    "28 major, 16 minor) across 3 clusters. The audit ledger has been updated at "
+    + LEDGER_URL
+)
+check(
+    "the production summary that broke now survives whole",
+    watchers._clip_handoff(PRODUCTION_SUMMARY) == PRODUCTION_SUMMARY
+    and LEDGER_URL in watchers._clip_handoff(PRODUCTION_SUMMARY),
+)
+check(
+    "a URL is dropped rather than severed when the clip does bite",
+    "https://" not in watchers._clip_handoff(PRODUCTION_SUMMARY, 200)
+    and len(watchers._clip_handoff(PRODUCTION_SUMMARY, 200)) <= 200,
+    "a truncated link is a dead link; the whole token has to go",
+)
+check(
+    "lines after the first are no longer discarded",
+    watchers._clip_handoff("First line.\nSecond line.\nThird line.").count("\n") == 2,
+)
+
+# --- 3. Delivery --------------------------------------------------------------
+print("result delivery:")
+check(
+    "the completion message's tail is built by the patch",
+    "handoff = _kanban_handoff_with_result(handoff, task)" in NOTIFIER_SOURCE,
+    "an appending hook cannot drop the clip the notifier already built",
+)
+
+catalogue = "\n".join(f"{i}. cron-job-{i} — 0 {i} * * *" for i in range(1, 10))
+block = result_block("Cataloged all 9 cron jobs.", catalogue)
+check("a multi-line result survives whole", block.count("\n") >= 9)
+check("the last line is delivered", "cron-job-9" in block)
+check(
+    "a result already shown in the status line is not repeated",
+    result_block(catalogue, catalogue) == "",
+)
+check("an empty result adds nothing", result_block("status", None) == "")
+
+huge = " ".join(f"token{i}" for i in range(20000))
+clipped = result_block("status", huge)
+check(
+    "a runaway result is clipped and says so",
+    len(clipped) <= RESULT_LIMIT + 200 and "clipped" in clipped.lower(),
+)
+check(
+    "clipping never severs a URL",
+    "https://" not in result_block("s", huge + " https://example.invalid/issues/27", limit=200),
+)
+check(
+    "a dead task row leaves the status line the notifier already built",
+    watchers._kanban_handoff_with_result("\nstatus", None) == "\nstatus",
+)
+
+# The branch that has no event summary: kanban_watchers.py builds the status
+# line out of a clip of task.result, so the message used to carry the opening
+# of the report and then the report. On the 60-line catalogue below, jobs 1 to
+# 19 arrived twice.
+long_catalogue = "\n".join(
+    f"{i}. cron-job-{i} — schedule `0 {i} * * *` — enabled" for i in range(1, 61)
+)
+
+
+class _ClippedTask:
+    result = long_catalogue
+
+
+check(
+    "the fixture is over the status line's budget",
+    len(long_catalogue) > DEFAULT_LIMIT,
+)
+no_summary_tail = watchers._kanban_handoff_with_result(
+    "\n" + clip_handoff(long_catalogue), _ClippedTask()
+)
+check(
+    "an over-budget report is delivered once rather than clipped and repeated",
+    no_summary_tail.count("1. cron-job-1 ") == 1,
+    "the clipped status line was kept above the full report",
+)
+check(
+    "the report the reader gets is the whole one",
+    "60. cron-job-60" in no_summary_tail,
+)
+check(
+    "no clip marker is left promising text that is already there",
+    "[…]" not in no_summary_tail,
+)
+check(
+    "a status line that is not the report is kept",
+    "Cataloged all 9" in watchers._kanban_handoff_with_result(
+        "\nCataloged all 9 cron jobs.", _ClippedTask()
+    ),
+)
+
+# --- 4. The whitelist still covers every kind the notifier knows about --------
+# `resolve_wake_kinds` treats DEFAULT_WAKE_KINDS as a whitelist so a typo in
+# config cannot be mistaken for a real kind. The cost of that is drift: if a
+# base-image bump teaches the notifier a sixth terminal kind, the whitelist
+# silently filters it out and an operator listing it gets a warning about an
+# "unknown" kind their gateway plainly understands. The notifier enumerates the
+# kinds it can describe in its own `_parts` block, so that block is the source
+# of truth to compare against.
+print("whitelist drift:")
+check(
+    "the notifier calls the helper with the adapter",
+    '_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)' in NOTIFIER_SOURCE,
+)
+check(
+    "upstream's hardcoded tuple is gone",
+    "_WAKE_KINDS = (" not in NOTIFIER_SOURCE and "in _WAKE_KINDS}" not in NOTIFIER_SOURCE,
+    "a second definition would shadow the configurable one",
+)
+notifier_kinds = set(re.findall(r'if "(\w+)" in _wake_kinds', NOTIFIER_SOURCE))
+check(
+    "the notifier's own kind list was located",
+    notifier_kinds,
+    "the `if \"<kind>\" in _wake_kinds` block moved; re-derive this check",
+)
+check(
+    "every kind the notifier can describe is in DEFAULT_WAKE_KINDS",
+    notifier_kinds <= set(DEFAULT_WAKE_KINDS),
+    f"notifier knows {sorted(notifier_kinds - set(DEFAULT_WAKE_KINDS))}, "
+    f"which the whitelist would drop as a typo",
+)
+check(
+    "DEFAULT_WAKE_KINDS claims nothing the notifier cannot describe",
+    set(DEFAULT_WAKE_KINDS) <= notifier_kinds,
+    f"whitelist has {sorted(set(DEFAULT_WAKE_KINDS) - notifier_kinds)} extra",
+)
+
+# --- 5. The real config loader is reachable ----------------------------------
+# The exact silent no-op this patch is most exposed to. `_load_kanban_config`
+# returns None when `hermes_cli.config` cannot be imported or read, and None
+# means DEFAULT_WAKE_KINDS on every single delivery — the key stops working and
+# nothing distinguishes that from an operator who never set it.
+print("real config path:")
+subtree = _load_kanban_config(None)
+check(
+    "hermes_cli.config.load_config is importable and readable",
+    isinstance(subtree, dict),
+    "the module falls back to upstream on every call; kanban."
+    f"{CONFIG_KEY} would be dead config",
+)
+check(
+    "the no-argument path returns a usable set",
+    isinstance(resolve_wake_kinds(), tuple)
+    and set(resolve_wake_kinds()) <= set(DEFAULT_WAKE_KINDS),
+)
+
+# --- 6. The real push-capability probe ---------------------------------------
+# `_adapter_can_push` prefers `gateway.wake.adapter_supports_push` and only
+# falls back to re-stating its one-line contract when that import fails —
+# which is the host-side test condition, not an in-image one. Drive it with the
+# two real adapter classes so a `gateway.wake` that moved is caught here rather
+# than by a completed card that never gets announced.
+print("push capability:")
+from gateway.platforms.api_server import APIServerAdapter  # noqa: E402
+from gateway.platforms.base import BasePlatformAdapter  # noqa: E402
+from gateway.wake import adapter_supports_push  # noqa: E402
+
+check(
+    "the api_server adapter is still the non-push one",
+    adapter_supports_push(APIServerAdapter) is False,
+    "the whole non-push carve-out is predicated on this adapter existing",
+)
+check("_adapter_can_push agrees on api_server", _adapter_can_push(APIServerAdapter) is False)
+check("_adapter_can_push agrees on the base adapter", _adapter_can_push(BasePlatformAdapter) is True)
+check(
+    "an adapter that does not declare the flag counts as push",
+    _adapter_can_push(object()) is True,
+    "reading it as non-push restores the redundant turn on every Slack card",
+)
+
+# --- 7. The decision the notifier actually makes ------------------------------
+print("wake decision:")
+completed = [Event("completed"), Event("commented")]
+mixed = [Event("completed"), Event("crashed")]
+
+check(
+    "an unset key behaves exactly like upstream",
+    wake_kinds_for(completed, cfg({}), adapter=BasePlatformAdapter) == {"completed"},
+)
+check(
+    "a delivered completion costs no turn on a push adapter",
+    wake_kinds_for(completed, cfg(FAILURE_ONLY), adapter=BasePlatformAdapter) == set(),
+    "this is the 5.9s / 32,460-token hop the patch exists to remove",
+)
+check(
+    "a failure in the same batch still wakes the creator",
+    wake_kinds_for(mixed, cfg(FAILURE_ONLY), adapter=BasePlatformAdapter) == {"crashed"},
+)
+check(
+    "a non-push adapter still wakes on completion",
+    wake_kinds_for(completed, cfg(FAILURE_ONLY), adapter=APIServerAdapter) == {"completed"},
+    "on api_server the wake self-post IS the delivery; narrowing loses the answer",
+)
+check(
+    "even an explicit empty list cannot silence the non-push path",
+    wake_kinds_for(completed, cfg({"wake_on_events": []}), adapter=APIServerAdapter)
+    == {"completed"},
+)
+
+# --- 8. Failure posture -------------------------------------------------------
+print("fail-soft posture:")
+
+
+def raising():
+    raise RuntimeError("config unreadable")
+
+
+check(
+    "an unreadable config still wakes on a crash",
+    resolve_wake_kinds(raising) == DEFAULT_WAKE_KINDS,
+    "failing closed would mean a crashed card silently never escalating",
+)
+check(
+    "a config of the wrong shape still wakes on a crash",
+    resolve_wake_kinds(lambda: "not a mapping") == DEFAULT_WAKE_KINDS,
+)
+check(
+    "a value of the wrong shape still wakes on a crash",
+    resolve_wake_kinds(cfg({"wake_on_events": {"crashed": True}})) == DEFAULT_WAKE_KINDS,
+)
+check(
+    "an unknown kind is dropped rather than trusted",
+    resolve_wake_kinds(cfg({"wake_on_events": ["crashed", "compleeted"]})) == ("crashed",),
+)
+
+# --- 9. The suppressed completion is recorded on the creator's session --------
+# Section 7's narrowing is only safe because of this one, and this one is the
+# most silent thing in the patch: it writes into gateway state that nothing else
+# in the build reads back, so a marker parked on the wrong key, a session store
+# that no longer exposes the reverse lookup, or a run.py that stopped draining
+# the sidecar notes all produce *exactly* what the unpatched gateway produced —
+# a creator whose transcript never learns the card finished. That is the 9m46s
+# of dead wait on task t_a8f58a2a, and no exception is raised anywhere along the
+# way. So the whole chain is driven on real objects rather than described.
+print("suppressed-completion marker:")
+import threading  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+
+from gateway.kanban_notifier import (  # noqa: E402
+    NOTE_SIGNATURE,
+    completion_note,
+    note_suppressed_completion,
+    suppressed_kinds,
+)
+from gateway.run import GatewayRunner  # noqa: E402
+from gateway.session import SessionEntry, SessionStore  # noqa: E402
+from agent.turn_context import consume_gateway_turn_context_notes  # noqa: E402
+
+check(
+    "the notifier resolved the marker import",
+    hasattr(watchers, "_kanban_note_suppressed"),
+    "the trailer import did not execute",
+)
+check(
+    "the marker is called exactly once",
+    NOTIFIER_SOURCE.count("_kanban_note_suppressed(") == 1,
+    "a second call would announce the same card twice on one turn",
+)
+check(
+    "the marker is called with everything it names the card by",
+    'self, d["events"], _wake_kinds, task, sub, board_slug,' in NOTIFIER_SOURCE,
+)
+_wake_at = NOTIFIER_SOURCE.find('_wake_kinds = _wake_kinds_for(d["events"], adapter=adapter)')
+_note_at = NOTIFIER_SOURCE.find("_kanban_note_suppressed(")
+# `if task_terminal:` guards this delivery's unsub. It is the tail of the same
+# block the marker sits in, and unlike `self._kanban_unsub` — which upstream
+# also calls from two sibling branches earlier in the loop — it appears once.
+_terminal_at = NOTIFIER_SOURCE.find("if task_terminal:")
+check(
+    "the marker runs after the wake set it reports on",
+    0 <= _wake_at < _note_at,
+    "it subtracts the wake set from what upstream would have woken for",
+)
+check(
+    "the marker runs in the block that owns the terminal event",
+    0 <= _note_at < _terminal_at,
+    "the marker drifted past the unsub; re-derive the wake anchor",
+)
+
+# The reverse lookup. task.session_id is a persisted session *id*; per-turn
+# state is keyed by the session *key*. Writing to the id would be a no-op that
+# nothing anywhere reports.
+check(
+    "the session store still exposes the id→key lookup",
+    callable(getattr(SessionStore, "lookup_by_session_id", None)),
+    "without it the marker cannot find the creator and silently writes nothing",
+)
+check(
+    "SessionEntry still carries the session key",
+    "session_key" in getattr(SessionEntry, "__dataclass_fields__", {}),
+)
+for _name in (
+    "_set_pending_turn_sidecar_notes",
+    "_consume_pending_turn_sidecar_notes",
+    "_peek_session_state",
+):
+    check(
+        f"the gateway still has {_name}",
+        callable(getattr(GatewayRunner, _name, None)),
+    )
+
+# The two links between the note being staged and the model seeing it. Neither
+# is reachable from here without booting a turn, and either one going away turns
+# the marker into a write nobody reads.
+RUN_SOURCE = open("gateway/run.py").read()
+TURN_CONTEXT_SOURCE = open("agent/turn_context.py").read()
+check(
+    "run.py still drains the staged notes onto the agent",
+    "_gateway_turn_context_notes = " in RUN_SOURCE
+    and "self._runner._consume_pending_turn_sidecar_notes(ctx.session_key)" in RUN_SOURCE,
+    "staged notes would accumulate on the session and never reach a turn",
+)
+check(
+    "turn_context.py still delivers them on the user message",
+    "consume_gateway_turn_context_notes(agent)" in TURN_CONTEXT_SOURCE,
+    "the agent-side copy would be set and never read",
+)
+
+# --- the round trip, on the real classes -------------------------------------
+# Bare instances: GatewayRunner._sessions_map is explicitly written to support
+# runners built via object.__new__, and SessionStore.lookup_by_session_id needs
+# only the lock and the entries dict once _loaded short-circuits the disk read.
+CREATOR_ID = "20260808_190725_6714054d"
+CREATOR_KEY = "agent:main:slack:dm:T0BLH2UB516:D0BKGRBM6RH:1786216044.637229"
+NOW = datetime.now(timezone.utc)
+
+store = object.__new__(SessionStore)
+store._lock = threading.Lock()  # what SessionStore.__init__ builds
+store._loaded = True  # short-circuits _ensure_loaded_locked's disk read
+store._entries = {
+    CREATOR_KEY: SessionEntry(
+        session_key=CREATOR_KEY, session_id=CREATOR_ID, created_at=NOW, updated_at=NOW,
+    )
+}
+runner = object.__new__(GatewayRunner)
+runner.session_store = store
+
+
+class _Card:
+    id = "t_a8f58a2a"
+    session_id = CREATOR_ID
+    title = "List configured cron jobs"
+    status = "done"
+
+
+SUB = {"task_id": "t_a8f58a2a", "chat_id": "D0BKGRBM6RH"}
+COMPLETED = [Event("completed")]
+
+check(
+    "the completion the narrowing dropped is the one recorded",
+    suppressed_kinds(COMPLETED, wake_kinds_for(COMPLETED, cfg(FAILURE_ONLY),
+                                               adapter=BasePlatformAdapter)) == {"completed"},
+)
+check(
+    "a card whose wake still fires is not double-announced",
+    suppressed_kinds(COMPLETED, wake_kinds_for(COMPLETED, cfg({}),
+                                               adapter=BasePlatformAdapter)) == set(),
+)
+check(
+    "the marker was staged on the creator's session",
+    note_suppressed_completion(runner, COMPLETED, set(), _Card(), SUB, "") is True,
+    "the report reached the user and nothing told the agent",
+)
+check(
+    "it landed on the session key, not the session id",
+    runner._peek_session_state(CREATOR_KEY) is not None
+    and runner._peek_session_state(CREATOR_ID) is None,
+)
+
+# Exactly what gateway/run.py does at the top of the creator's next turn.
+staged = runner._consume_pending_turn_sidecar_notes(CREATOR_KEY)
+check("the next turn reads back one note", len(staged) == 1, f"got {staged!r}")
+check(
+    "the note names the card and contradicts 'still running'",
+    staged and "t_a8f58a2a" in staged[0] and "NOT still running" in staged[0],
+    staged[0] if staged else "nothing was staged",
+)
+check(
+    "the note does not ask the agent to re-post what the user can see",
+    staged and "already delivered" in staged[0],
+)
+check(
+    "the marker is one-shot at the session",
+    runner._consume_pending_turn_sidecar_notes(CREATOR_KEY) == [],
+    "a note replayed every turn would re-announce a card the agent reported",
+)
+
+
+class _Agent:
+    pass
+
+
+note_suppressed_completion(runner, COMPLETED, set(), _Card(), SUB, "")
+agent = _Agent()
+agent._gateway_turn_context_notes = "\n\n".join(
+    runner._consume_pending_turn_sidecar_notes(CREATOR_KEY)
+)
+delivered = consume_gateway_turn_context_notes(agent)
+check(
+    "the note survives into the turn's user-message sidecar",
+    "t_a8f58a2a" in delivered,
+    "the real consume_gateway_turn_context_notes dropped it",
+)
+check(
+    "and is one-shot there too",
+    consume_gateway_turn_context_notes(agent) == "",
+)
+
+# --- the marker's failure posture --------------------------------------------
+# Everything here is layered on top of a delivery that already succeeded, so
+# every failure has to degrade to today's behaviour rather than raise into a
+# loop that would rewind the claim and re-send the report.
+class _Exploding:
+    id = "t_a8f58a2a"
+    title = "boom"
+    status = "done"
+
+    @property
+    def session_id(self):
+        raise RuntimeError("session row unreadable")
+
+
+check(
+    "a card the marker cannot read does not break the delivery",
+    note_suppressed_completion(runner, COMPLETED, set(), _Exploding(), SUB, "") is False,
+)
+check(
+    "a card with no creator session records nothing",
+    note_suppressed_completion(runner, COMPLETED, set(), object(), SUB, "") is False,
+    "cron and CLI cards have no gateway session to tell",
+)
+check(
+    "a runner with no session store records nothing",
+    note_suppressed_completion(object(), COMPLETED, set(), _Card(), SUB, "") is False,
+)
+
+# Upstream's own notes share the list, and one of them tells the agent its
+# history was reset. A blind assignment would drop it.
+RESET = "[System note: The user's previous session expired due to inactivity.]"
+runner._set_pending_turn_sidecar_notes(CREATOR_KEY, [RESET])
+note_suppressed_completion(runner, COMPLETED, set(), _Card(), SUB, "")
+both = runner._consume_pending_turn_sidecar_notes(CREATOR_KEY)
+check(
+    "an upstream note staged in the same instant is not clobbered",
+    RESET in both and any(n.startswith(NOTE_SIGNATURE) for n in both),
+    f"got {both!r}",
+)
+check(
+    "the note is small enough to be cheaper than the wake it replaces",
+    len(completion_note("t_a8f58a2a", title=_Card.title, status="done",
+                        kinds={"completed"})) < 600,
+    "the wake it replaces cost 32,460 input tokens; this must stay trivial",
+)
+
+print()
+if FAILURES:
+    print(f"verify_kanban_notifier: {len(FAILURES)} check(s) FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_notifier: all checks passed")

--- a/deploy/docker/patches/verify_kanban_notifier.py
+++ b/deploy/docker/patches/verify_kanban_notifier.py
@@ -75,7 +75,8 @@ from gateway.kanban_notifier import (  # noqa: E402
     wake_kinds_for,
 )
 
-NOTIFIER_SOURCE = open("gateway/kanban_watchers.py").read()
+with open("gateway/kanban_watchers.py", encoding="utf-8") as _notifier_src:
+    NOTIFIER_SOURCE = _notifier_src.read()
 
 FAILURE_ONLY = {"wake_on_events": ["gave_up", "crashed", "timed_out", "blocked"]}
 

--- a/deploy/docker/patches/verify_kanban_result.py
+++ b/deploy/docker/patches/verify_kanban_result.py
@@ -116,7 +116,8 @@ check(
 )
 krr._refused_at.clear()
 
-_kanban_tools_src = open("tools/kanban_tools.py").read()
+with open("tools/kanban_tools.py", encoding="utf-8") as _kanban_tools_file:
+    _kanban_tools_src = _kanban_tools_file.read()
 check(
     "the gate is wired into the completion handler",
     "_require_result(tid, summary, result)" in _kanban_tools_src,

--- a/deploy/docker/patches/verify_kanban_result.py
+++ b/deploy/docker/patches/verify_kanban_result.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban result capture patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after
+``apply_kanban_result_required.py``. The applier only proves its anchors
+matched; this exercises the patched code in the image the way a worker actually
+reaches it.
+
+It is deliberately behavioural rather than textual. The regression that
+motivated the whole change was not a failed edit — it was a field the model was
+told not to use, so the check that matters is "does a worker get refused when it
+drops the answer".
+
+The other half of that question — "does the answer then reach the message" —
+belongs to ``gateway/kanban_notifier.py`` and is gated by
+``verify_kanban_notifier.py``, which runs earlier in the build. What stays here
+is the seam between the two: the incident replay below drives a real refusal
+through the real gate and then hands what the gate stored to the real delivery
+path, which is the only assertion in either file that neither patch can make on
+its own.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_result.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+# --- 1. The tool schema a worker actually reads -----------------------------
+print("kanban_complete schema:")
+from tools.kanban_tools import KANBAN_COMPLETE_SCHEMA as SCHEMA  # noqa: E402
+
+props = SCHEMA["parameters"]["properties"]
+blob = repr(SCHEMA)
+
+check("result is a required parameter", "result" in SCHEMA["parameters"]["required"])
+check(
+    "result is described as REQUIRED",
+    "REQUIRED" in props["result"]["description"],
+)
+check(
+    "result no longer described as a legacy log line",
+    "legacy field" not in blob,
+    "upstream's discouraging wording survived the patch",
+)
+check(
+    "summary no longer invites a 1-3 sentence report",
+    "1-3 sentence" not in blob,
+)
+check(
+    "summary states the real 400-character single-line cut",
+    "400" in props["summary"]["description"]
+    and "FIRST LINE" in props["summary"]["description"],
+)
+check(
+    "the tool description's tail is preserved",
+    "created_cards" in SCHEMA["description"] and "artifacts" in SCHEMA["description"],
+    "the description was replaced wholesale instead of having its head swapped",
+)
+
+# --- 2. The gate ------------------------------------------------------------
+print("require_result gate:")
+import tools.kanban_result_required as krr  # noqa: E402
+
+krr._refused_at.clear()
+err, out = krr.require_result("t_verify", "a status line", None)
+check("a completion with no result is refused", err is not None)
+check("the refusal names the field", err and "result" in err)
+err2, out2 = krr.require_result("t_verify", "a status line", "the answer")
+check("the retry carrying a result is accepted", err2 is None and out2 == "the answer")
+check(
+    "the answered refusal is forgotten",
+    krr._refused_at == {},
+    "the gate keeps a ledger of every card it ever refused, so a card reopened "
+    "and retried in this process would be closed empty in silence",
+)
+err2b, _ = krr.require_result("t_verify", "a status line", None)
+check("a card reopened after a refusal is nudged again", err2b is not None)
+
+krr._refused_at.clear()
+krr.require_result("t_wedge", "a status line", None)
+err3, out3 = krr.require_result("t_wedge", "a status line", None)
+check(
+    "a card is never wedged shut by the gate",
+    err3 is None,
+    "a second empty completion was still refused",
+)
+check("summary is promoted so the card carries something", out3 == "a status line")
+
+krr._refused_at.clear()
+err4, _ = krr.require_result("t_ok", "s", "  \n ")
+check("a whitespace-only result counts as empty", err4 is not None)
+
+krr._refused_at.clear()
+krr.require_result("t_blank", None, "  \n ")
+_, blank_out = krr.require_result("t_blank", None, "  \n ")
+check(
+    "a blank result is never handed back as the value to store",
+    blank_out is None,
+    "complete_task indexes line zero of the stripped value inside write_txn, so "
+    "whitespace rolls the completion back with IndexError and the card, whose "
+    "nudge is already spent, fails the same way on every retry",
+)
+krr._refused_at.clear()
+
+_kanban_tools_src = open("tools/kanban_tools.py").read()
+check(
+    "the gate is wired into the completion handler",
+    "_require_result(tid, summary, result)" in _kanban_tools_src,
+)
+check(
+    "the handler's own summary is folded before it reaches complete_task",
+    "summary = _blank_to_none(summary)" in _kanban_tools_src,
+    "a whitespace-only summary still wedges the card however good the result is",
+)
+
+# --- 3. The incident, replayed ----------------------------------------------
+# The seam between the two patches, and the only thing here that needs both:
+# what the gate stores on the retry is what the notifier has to deliver. Every
+# other delivery assertion lives in verify_kanban_notifier.py.
+print("2026-08-07 incident replay:")
+from gateway.kanban_notifier import result_block  # noqa: E402
+
+catalogue = "\n".join(f"{i}. cron-job-{i} — 0 {i} * * *" for i in range(1, 10))
+
+krr._refused_at.clear()
+incident_summary = (
+    "Successfully inspected and cataloged all 9 active platform-agent-level and "
+    "system-wide cron jobs. Compiled their detailed purposes, schedules, and "
+    "active configurations."
+)
+err, _ = krr.require_result("t_8d1cf5cf", incident_summary, None)
+check("the completion that lost the catalogue is refused", err is not None)
+_, stored = krr.require_result("t_8d1cf5cf", incident_summary, catalogue)
+
+delivered = result_block("\n" + incident_summary, stored)
+check("the retry's catalogue reaches the message", "cron-job-1" in delivered)
+check("every job in the catalogue is delivered", all(f"cron-job-{i}" in delivered for i in range(1, 10)))
+krr._refused_at.clear()
+
+# --- Result -----------------------------------------------------------------
+if FAILURES:
+    print(f"\nverify_kanban_result: {len(FAILURES)} check(s) FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("\nverify_kanban_result: all checks passed")

--- a/deploy/docker/patches/verify_kanban_scheduling.py
+++ b/deploy/docker/patches/verify_kanban_scheduling.py
@@ -1,0 +1,1028 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban scheduling patches.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after
+``apply_kanban_scheduling.py``. The applier only proves six anchors matched
+exactly once. That says nothing about whether the engine those six edits produce
+actually schedules correctly, and all three faults they fix were emergent
+scheduling behaviour rather than a bad string — so every case below is driven
+against the real patched ``hermes_cli.kanban_db`` on a real board, through the
+real ``create_task`` / ``claim_task`` / ``block_task`` / ``detect_crashed_workers``
+/ ``_record_task_failure`` / ``recompute_ready``, in the order ``dispatch_once``
+calls them.
+
+  A. Dependency deadlock. A card creates work with ``parents=[<itself>]`` and
+     then blocks on it. Before the patch the children were permanently
+     unclaimable and the parent respawned every few seconds; after it, the
+     children dispatch and the parent waits on them for real. The three
+     negative cases are the ones the first version of the patch got wrong.
+  B. Claim fencing. A gateway process goes away. Its successor must not
+     adjudicate the dead process's worker PIDs, must hand those cards straight
+     back instead of leaving them dark for the 900-second claim TTL, and must
+     charge exactly the releases that are faults — an in-place death, yes; a
+     pod Kubernetes replaced, no.
+  C. Failure fingerprints. The systemic-crash heuristic the fence stops
+     misfiring must still fire when it should.
+  D. Breaker counter. Nine scenarios, the same nine that were executed against
+     the live image before the breaker edits were written:
+
+       1. protocol ``force_trip`` (limit 3)          FIXED    -- was reverted in-tick
+       2. systemic ``failure_limit=1``               FIXED    -- was reverted in-tick
+       3. an ordinary two-failure trip               UNCHANGED - no inflation
+       4. ``assign_task`` recovery                   PRESERVED - the rejected fix broke this
+       4b. ``assign_task`` to the SAME profile       CHANGED   -- no longer recovers
+       5. ``unblock_task`` recovery                  PRESERVED
+       6. parent-gated card, never tripped           PRESERVED
+       7. ``max_retries=5`` override                 FIXED    -- honours the override
+       8. worker ``kanban_block`` stickiness         UNCHANGED
+       9. spawn path (``release_claim``) at limit 1  FIXED    -- the second patched bind
+
+     4, 5, 6 and 8 are preservation tests. They are not decoration: they are
+     exactly the cases the rejected event-reader fix broke, and they are the
+     reason that fix keeps ``consecutive_failures`` as the single arbiter. That
+     rejected version passed every anchor check and silently pinned reassigned
+     cards in ``blocked`` forever. 4b is the one case the patch deliberately
+     DOES change, pinned here so it stays a decision rather than a surprise.
+
+Sections B and D overlap on purpose: the fence decides which cards reach the
+breaker and the charge loop is a caller of the very function D exercises, so a
+regression in either is only visible when both run against the same engine.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_scheduling.py
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import socket
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERMES = Path(os.environ.get("HERMES_ROOT", "/opt/hermes"))
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+from hermes_cli import kanban_db as K  # noqa: E402
+
+# Imported under its own name as well as through the trailer, so this gate fails
+# if the module did not land at ``hermes_cli/kanban_scheduling.py`` — and so the
+# discriminator's constants can be asserted by name rather than by string.
+from hermes_cli import kanban_scheduling as KS  # noqa: E402
+
+TMP = Path(tempfile.mkdtemp())
+_BOARDS = itertools.count()
+
+
+def fresh():
+    """A real board, created through the engine's own schema path.
+
+    The name comes from a counter. Deriving it from ``len(list(TMP.iterdir()))``
+    looks equivalent and is not, and the way it fails is silent: ``K.connect``
+    opens the board in WAL mode, so each one owns a ``-wal`` and a ``-shm`` as
+    well as the ``.db`` and an ``.init.lock``. Rebinding ``conn = fresh()``
+    drops the last reference to the previous connection, CPython closes it, and
+    SQLite *deletes* that board's ``-wal`` and ``-shm``. Files therefore leave
+    the directory as well as arrive; the count is not monotonic, it reaches a
+    fixed point, and from there every "fresh" board reopens one file that
+    already holds every card the sections before it left running.
+
+    That is invisible to a check which only asserts on its own card -- which is
+    most of them -- and fatal to one that asserts on the whole of a sweep's
+    result. It cost a Cloud Build failure that read exactly like a defect in
+    ``release_dead_foreign_claims``: a third card, left ``running`` by an
+    earlier section, was swept alongside the two this board had put there.
+
+    The emptiness assertion is not paranoia, it is the gate that turns the next
+    recurrence into one obvious line instead of a day of reading the sweep. It
+    raises rather than calling ``check`` because a board that is not fresh
+    invalidates every check after it, so there is nothing to be gained by
+    carrying on and counting failures.
+    """
+    conn = K.connect(TMP / f"kanban{next(_BOARDS)}.db")
+    leftovers = conn.execute("SELECT count(*) FROM tasks").fetchone()[0]
+    if leftovers:
+        raise SystemExit(
+            "verify_kanban_scheduling: fixture defect — a 'fresh' board opened "
+            f"with {leftovers} card(s) already on it. Every check from here on "
+            "would be adjudicating another section's leftovers."
+        )
+    return conn
+
+
+def status(conn, tid):
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    return row["status"] if row else None
+
+
+def failures(conn, tid):
+    row = conn.execute(
+        "SELECT consecutive_failures FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    return int(row["consecutive_failures"] or 0) if row else None
+
+
+def kinds(conn, tid):
+    return [
+        r["kind"]
+        for r in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id", (tid,)
+        )
+    ]
+
+
+def last_event(conn, tid, kind):
+    row = conn.execute(
+        "SELECT payload FROM task_events WHERE task_id = ? AND kind = ? "
+        "ORDER BY id DESC LIMIT 1",
+        (tid, kind),
+    ).fetchone()
+    return json.loads(row["payload"]) if row and row["payload"] else {}
+
+
+def new_card(conn, title, parents=()):
+    task = K.create_task(
+        conn, title=title, assignee="platform", parents=tuple(parents)
+    )
+    return task.id if hasattr(task, "id") else str(task)
+
+
+# --- A. The self-parenting deadlock -----------------------------------------
+print("dependency deadlock repair:")
+conn = fresh()
+
+parent = new_card(conn, "Fleet-wide Security Baseline Assessment")
+K.recompute_ready(conn)
+claimed = K.claim_task(conn, parent)
+check("the orchestrator card claims normally", claimed is not None)
+
+kids = [new_card(conn, f"Audit cluster {n}", parents=[parent]) for n in (1, 2, 3)]
+K.recompute_ready(conn)
+check(
+    "children parented to a running card start unclaimable",
+    all(K.claim_task(conn, k) is None for k in kids),
+    "the invariant this patch exists to work around has changed upstream",
+)
+
+blocked = K.block_task(
+    conn, parent, reason="waiting on the three cluster audits", kind="dependency"
+)
+check("the dependency block is accepted", blocked is True)
+check("the repair event is recorded", "dependency_repaired" in kinds(conn, parent))
+
+K.recompute_ready(conn)
+claimed_kids = [k for k in kids if K.claim_task(conn, k) is not None]
+check(
+    "every child dispatches after the block",
+    len(claimed_kids) == 3,
+    f"only {len(claimed_kids)}/3 became claimable",
+)
+check(
+    "the blocking card now waits instead of respawning",
+    K.claim_task(conn, parent) is None,
+    "the parent is claimable while its prerequisites are unfinished",
+)
+
+for k in kids:
+    conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (k,))
+conn.commit()
+K.recompute_ready(conn)
+check(
+    "the wait resolves once the children finish",
+    K.claim_task(conn, parent) is not None,
+    f"parent stuck in {status(conn, parent)!r}",
+)
+
+# A real fan-in must survive one of its inputs blocking. The sink was planned
+# before a was ever claimed, so it is nobody's fan-out, and releasing a would be
+# pointless anyway while b is unfinished. (The first version of this patch
+# failed exactly here, inverting a -> sink.)
+conn = fresh()
+a = new_card(conn, "researcher a")
+b = new_card(conn, "researcher b")
+sink = new_card(conn, "synthesizer", parents=[a, b])
+K.recompute_ready(conn)
+K.claim_task(conn, a)
+K.block_task(conn, a, reason="waiting on an external approval", kind="dependency")
+check(
+    "a correct fan-in is left alone",
+    "dependency_repaired" not in kinds(conn, a),
+    "the repair fired on a graph that was already correct",
+)
+K.recompute_ready(conn)
+check("the fan-in sink still waits for its inputs", K.claim_task(conn, sink) is None)
+check(
+    "the blocked input is still an input, not a successor",
+    conn.execute(
+        "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?", (a, sink)
+    ).fetchone()
+    is not None,
+    "the pipeline was turned around",
+)
+
+# An ordinary pipeline stage that blocks for a reason of its own. This is the
+# scenario the patch shipped broken: by the time `mid` runs its prerequisite is
+# `done`, so the parent-set test that used to guard the repair could not tell it
+# apart from the t_ab112f5b deadlock and inverted mid -> tail, dispatching the
+# final stage ahead of the middle one. Driven through claim_task rather than a
+# raw UPDATE precisely because that is what makes the parents settled.
+conn = fresh()
+upstream = new_card(conn, "prerequisite")
+mid = new_card(conn, "middle stage", parents=[upstream])
+tail = new_card(conn, "final stage", parents=[mid])
+conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (upstream,))
+conn.commit()
+K.recompute_ready(conn)
+check(
+    "the middle stage claims once its prerequisite is done",
+    K.claim_task(conn, mid) is not None,
+    f"mid stuck in {status(conn, mid)!r}",
+)
+K.block_task(conn, mid, reason="waiting on an external approval", kind="dependency")
+check(
+    "a pipeline stage that blocks is left alone",
+    "dependency_repaired" not in kinds(conn, mid),
+    "the repair rewrote a pipeline it had no hand in creating",
+)
+check(
+    "the pipeline keeps its direction",
+    conn.execute(
+        "SELECT 1 FROM task_links WHERE parent_id = ? AND child_id = ?", (mid, tail)
+    ).fetchone()
+    is not None,
+)
+K.recompute_ready(conn)
+check(
+    "the final stage still waits its turn",
+    K.claim_task(conn, tail) is None,
+    "the successor was dispatched ahead of the stage it follows",
+)
+
+# --- B. Claim fencing across a container restart ----------------------------
+print("claim fencing:")
+conn = fresh()
+
+DEAD_PID = 4_194_303  # above every plausible pid_max, so _pid_alive is False
+check("the probe pid really is dead", not K._pid_alive(DEAD_PID))
+
+pod = socket.gethostname()
+predecessor = f"{pod}:4"  # same pod name, the process that died
+check(
+    "the predecessor's token would have passed upstream's host-prefix test",
+    predecessor.startswith(f"{pod.split(':')[0]}:"),
+)
+
+orphan = new_card(conn, "card in flight when the gateway crashed")
+K.recompute_ready(conn)
+K.claim_task(conn, orphan, claimer=predecessor)
+conn.execute(
+    "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (DEAD_PID, orphan)
+)
+conn.commit()
+check("the card is running under the old claim", status(conn, orphan) == "running")
+
+crashed = K.detect_crashed_workers(conn)
+check(
+    "the successor does not report its predecessor's worker as a crash",
+    orphan not in crashed,
+    "a recycled PID namespace was adjudicated as if it were still ours",
+)
+check(
+    "the card is handed back rather than left for the 900s TTL",
+    status(conn, orphan) == "ready",
+    f"left in {status(conn, orphan)!r}",
+)
+events = kinds(conn, orphan)
+check("the release is recorded as reclaimed", "reclaimed" in events)
+check(
+    "one gateway crash costs the card one retry, not the card",
+    "gave_up" not in events and "crashed" not in events,
+    f"events: {events}",
+)
+check(
+    "and that retry is actually spent",
+    failures(conn, orphan) == 1,
+    f"consecutive_failures is {failures(conn, orphan)}, so nothing bounds a reclaim loop",
+)
+check(
+    "the release says why it was charged",
+    last_event(conn, orphan, "reclaimed").get("owner_fate")
+    == KS.PROCESS_DIED_IN_PLACE
+    and last_event(conn, orphan, "reclaimed").get("charged") is True,
+    f"reclaimed payload: {last_event(conn, orphan, 'reclaimed')}",
+)
+
+
+def reclaim_cycle(conn, tid, cycle):
+    """One turn of claim -> the dispatcher dies -> the successor sweeps."""
+    K.claim_task(conn, tid, claimer=f"{pod}:{900 + cycle}")
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (DEAD_PID, tid)
+    )
+    conn.commit()
+    K.detect_crashed_workers(conn)
+    K.recompute_ready(conn)
+
+
+# A card that kills the dispatcher gets reclaimed by whatever comes up next.
+# Uncharged that is a closed loop — claim, restart, reclaim, promote, forever —
+# so the breaker has to be on this path, at its own threshold.
+conn = fresh()
+poison = new_card(conn, "card whose work takes the gateway down with it")
+K.recompute_ready(conn)
+for cycle in range(K.DEFAULT_FAILURE_LIMIT + 2):
+    if status(conn, poison) == "blocked":
+        break
+    reclaim_cycle(conn, poison, cycle)
+check(
+    "a card that keeps killing its dispatcher is parked instead of cycling",
+    status(conn, poison) == "blocked",
+    f"still {status(conn, poison)!r} with {failures(conn, poison)} failures after "
+    f"{K.DEFAULT_FAILURE_LIMIT + 2} reclaims",
+)
+check(
+    "the breaker used its own budget rather than a second one",
+    failures(conn, poison) >= K.DEFAULT_FAILURE_LIMIT,
+    f"parked at {failures(conn, poison)} of {K.DEFAULT_FAILURE_LIMIT}",
+)
+check("parking the poison card is announced", "gave_up" in kinds(conn, poison))
+check(
+    "a parked card stays parked",
+    K.claim_task(conn, poison) is None,
+    "recompute_ready promoted a card the breaker had given up on",
+)
+
+# The founding property of this patch: one infrastructure event must never
+# abandon every card that happened to be in flight. Six identical reclaim
+# messages must not read as one systemic fault. The claims here carry this pod's
+# own name, so they are the charged arm — which is the arm where the property
+# has to hold, since a forgiven release never reaches _record_task_failure at
+# all.
+conn = fresh()
+fleet = [new_card(conn, f"card {n} in flight when the container died") for n in range(6)]
+K.recompute_ready(conn)
+for n, tid in enumerate(fleet):
+    K.claim_task(conn, tid, claimer=f"{pod}:{800 + n}")
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (DEAD_PID, tid)
+    )
+conn.commit()
+K.detect_crashed_workers(conn)
+check(
+    "a container restart hands every in-flight card back at once",
+    all(status(conn, t) == "ready" for t in fleet),
+    f"statuses: {[status(conn, t) for t in fleet]}",
+)
+check(
+    "and abandons none of them",
+    all(failures(conn, t) == 1 for t in fleet),
+    f"failures: {[failures(conn, t) for t in fleet]}",
+)
+
+# Our own dead worker must still be adjudicated — the fence narrows the check,
+# it must not disable it.
+conn = fresh()
+mine = new_card(conn, "card whose worker really did die")
+K.recompute_ready(conn)
+K.claim_task(conn, mine)
+conn.execute(
+    "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (DEAD_PID, mine)
+)
+conn.commit()
+check(
+    "our own dead worker is still detected",
+    mine in K.detect_crashed_workers(conn),
+    "the fence disabled crash detection instead of narrowing it",
+)
+
+# A live foreign worker is never taken away.
+conn = fresh()
+
+live = new_card(conn, "card held by a live process elsewhere")
+K.recompute_ready(conn)
+K.claim_task(conn, live, claimer="some-other-pod:7")
+conn.execute(
+    "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (os.getpid(), live)
+)
+conn.commit()
+K.detect_crashed_workers(conn)
+check(
+    "a live foreign worker keeps its claim",
+    status(conn, live) == "running",
+    "the sweep reclaimed a card from a process that is still running it",
+)
+
+# --- B2. The discriminator: a rollout is not a retry ------------------------
+#
+# Everything above charges, because everything above happens inside this pod.
+# The boundary the discriminator draws is between that and a pod Kubernetes
+# took away, and it is drawn with two facts: a different pod name, and a claim
+# older than this process. Both branches are driven through the engine below,
+# because the whole point is what ``detect_crashed_workers`` does with them.
+print("reclaim discriminator:")
+
+# Inside the image this is Linux and the /proc reader is the one that must
+# answer; on a developer's machine it is absent and the import-time fallback
+# must. Asserting the equivalence rather than the Linux answer keeps the script
+# runnable on both without going vacuous on either.
+HAVE_PROC = Path("/proc/self/stat").exists()
+check(
+    "the /proc reader answers exactly when /proc is there",
+    (KS.read_proc_start_time() is not None) == HAVE_PROC,
+    "on Linux the fallback is in use, so the boundary is import time rather "
+    "than process start — see kanban_scheduling.process_start_time"
+    if HAVE_PROC
+    else "the reader returned a value with no /proc to read",
+)
+PROCESS_START = KS.process_start_time()
+check(
+    "and it is a plausible wall-clock instant",
+    0 <= time.time() - PROCESS_START < 3600,
+    f"process_start_time() is {PROCESS_START}, now is {time.time()}",
+)
+check(
+    "the boundary does not move between sweeps",
+    KS.process_start_time() == PROCESS_START,
+    "a boundary that drifts reclassifies the same claim differently each tick",
+)
+
+PRE_BOOT = int(PROCESS_START) - 600
+OTHER_POD = "platform-agent-gateway-75b5f6ddf6-7dkd7"
+
+
+def backdate_claim(conn, tid, when):
+    """Move the *current run's* start, which is what the sweep reads.
+
+    ``tasks.started_at`` is left alone deliberately: it is
+    ``COALESCE(started_at, ?)``, the first start the card ever had, and the
+    sweep uses it only for the launch-window grace check.
+    """
+    conn.execute(
+        "UPDATE task_runs SET started_at = ? WHERE id = "
+        "(SELECT current_run_id FROM tasks WHERE id = ?)",
+        (int(when), tid),
+    )
+
+
+def dead_foreign_claim(conn, tid, claimer, claimed_at=None, drop_run=False):
+    """Put ``tid`` into the state a departed owner leaves behind."""
+    K.claim_task(conn, tid, claimer=claimer)
+    if claimed_at is not None:
+        backdate_claim(conn, tid, claimed_at)
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?",
+        (DEAD_PID, tid),
+    )
+    if drop_run:
+        conn.execute("UPDATE tasks SET current_run_id = NULL WHERE id = ?", (tid,))
+    conn.commit()
+
+
+conn = fresh()
+rolled = new_card(conn, "card in flight when the pod was replaced")
+K.recompute_ready(conn)
+dead_foreign_claim(conn, rolled, f"{OTHER_POD}:4", claimed_at=PRE_BOOT)
+K.detect_crashed_workers(conn)
+check(
+    "a pre-boot claim from a replaced pod is handed straight back",
+    status(conn, rolled) == "ready",
+    f"left in {status(conn, rolled)!r}",
+)
+check(
+    "and costs the card nothing",
+    failures(conn, rolled) == 0,
+    f"consecutive_failures is {failures(conn, rolled)} — a rollout charged a retry",
+)
+check(
+    "and says on the board that it was forgiven",
+    last_event(conn, rolled, "reclaimed").get("owner_fate") == KS.POD_REPLACED
+    and last_event(conn, rolled, "reclaimed").get("charged") is False,
+    f"reclaimed payload: {last_event(conn, rolled, 'reclaimed')}",
+)
+
+# The same foreign pod, but the claim was made while this process was already
+# running: the owner was alive alongside us and went away on its own. A fault,
+# and charged, or a CLI in another pod would hand out free retries forever.
+conn = fresh()
+concurrent = new_card(conn, "card claimed by another pod after we started")
+K.recompute_ready(conn)
+dead_foreign_claim(conn, concurrent, f"{OTHER_POD}:5", claimed_at=int(time.time()))
+K.detect_crashed_workers(conn)
+check(
+    "a claim made after this process started is still handed back",
+    status(conn, concurrent) == "ready",
+    f"left in {status(conn, concurrent)!r}",
+)
+check(
+    "but it is charged, because we watched that owner die",
+    failures(conn, concurrent) == 1
+    and last_event(conn, concurrent, "reclaimed").get("owner_fate")
+    == KS.CONCURRENT_OWNER,
+    f"failures {failures(conn, concurrent)}, payload "
+    f"{last_event(conn, concurrent, 'reclaimed')}",
+)
+
+# No run row to read the claim instant from. An unknown is not a provable
+# replacement, so it is charged.
+conn = fresh()
+runless = new_card(conn, "card whose run row is gone")
+K.recompute_ready(conn)
+dead_foreign_claim(conn, runless, f"{OTHER_POD}:6", drop_run=True)
+K.detect_crashed_workers(conn)
+check(
+    "an unreadable claim time is charged rather than forgiven",
+    failures(conn, runless) == 1
+    and last_event(conn, runless, "reclaimed").get("owner_fate")
+    == KS.CLAIM_TIME_UNKNOWN,
+    f"failures {failures(conn, runless)}, payload "
+    f"{last_event(conn, runless, 'reclaimed')}",
+)
+
+# The arithmetic this whole section exists for. DEFAULT_FAILURE_LIMIT is 2 and
+# nothing overrides it, so before the discriminator the second deploy a
+# long-lived card sat through parked it in ``blocked`` behind a
+# ``hermes kanban unblock``. Four replacements here, twice the limit.
+conn = fresh()
+survivor = new_card(conn, "long-running card that sits through several deploys")
+K.recompute_ready(conn)
+for cycle in range(K.DEFAULT_FAILURE_LIMIT + 2):
+    dead_foreign_claim(
+        conn,
+        survivor,
+        f"platform-agent-gateway-{cycle}-{cycle:05d}:{7 + cycle}",
+        claimed_at=PRE_BOOT,
+    )
+    K.detect_crashed_workers(conn)
+    K.recompute_ready(conn)
+check(
+    f"{K.DEFAULT_FAILURE_LIMIT + 2} pod replacements never park the card",
+    status(conn, survivor) == "ready" and failures(conn, survivor) == 0,
+    f"{status(conn, survivor)!r} with {failures(conn, survivor)} failures — the "
+    "discriminator is not forgiving replacements",
+)
+check(
+    "and none of them was recorded as a fault",
+    "gave_up" not in kinds(conn, survivor) and "crashed" not in kinds(conn, survivor),
+    f"events: {kinds(conn, survivor)}",
+)
+
+# The split itself, called directly: the sweep has to report the forgiven
+# releases as well as the charged ones, or a free reclaim is indistinguishable
+# from a sweep that did nothing.
+conn = fresh()
+gone_pod = new_card(conn, "held by a pod that was replaced")
+died_here = new_card(conn, "held by a process that died in place")
+K.recompute_ready(conn)
+K.claim_task(conn, gone_pod, claimer=f"{OTHER_POD}:8")
+backdate_claim(conn, gone_pod, PRE_BOOT)
+K.claim_task(conn, died_here, claimer=f"{pod}:9")
+backdate_claim(conn, died_here, PRE_BOOT)
+conn.execute("UPDATE tasks SET worker_pid = ?, started_at = 1", (DEAD_PID,))
+conn.commit()
+with K.write_txn(conn):
+    swept = KS.release_dead_foreign_claims(
+        conn, K._claimer_id(), K._pid_alive, None, PROCESS_START
+    )
+check(
+    "the sweep reports its releases split by fault",
+    isinstance(swept, KS.Reclaimed),
+    f"returned {type(swept).__name__}",
+)
+check(
+    "the replaced pod's card is in the forgiven half",
+    list(swept.forgiven) == [gone_pod],
+    f"forgiven: {list(swept.forgiven)}",
+)
+check(
+    "the in-place death is in the chargeable half",
+    list(swept.chargeable) == [died_here],
+    f"chargeable: {list(swept.chargeable)}",
+)
+check(
+    "both are back at ready either way",
+    status(conn, gone_pod) == "ready" and status(conn, died_here) == "ready",
+    f"{status(conn, gone_pod)!r} / {status(conn, died_here)!r}",
+)
+
+# --- C. A burst of identical crashes must still look systemic ---------------
+#
+# ``_error_fingerprint`` is reachable from exactly two call sites, both inside
+# ``detect_crashed_workers``, and every message that path builds carries a pid.
+# So the ``pid N`` substitution is not cosmetic: without it no two concurrent
+# workers can share a bucket, ``_fp_counts`` never reaches 3, and the heuristic
+# that halts a board where everything is failing the same way is dead code.
+# This patch leaves the substitution alone — the fence above is what keeps a
+# predecessor's workers out of the bucket in the first place.
+print("failure fingerprints:")
+for template in ("pid {} not alive", "pid {} exited with code 137"):
+    prints = {K._error_fingerprint(template.format(p)) for p in range(1044, 1050)}
+    check(
+        f"six workers felled by one event share a fingerprint ({template})",
+        len(prints) == 1,
+        f"split into {len(prints)} — the systemic heuristic can never reach 3",
+    )
+check(
+    "distinct faults keep distinct fingerprints",
+    K._error_fingerprint("pid 1044 exited with code 137")
+    != K._error_fingerprint("pid 1044 killed by signal 9"),
+)
+
+# And the detector it feeds must actually fire, through the real engine.
+DEAD_PIDS = [DEAD_PID - n for n in range(4)]
+check("the probe pids really are dead", not any(K._pid_alive(p) for p in DEAD_PIDS))
+
+conn = fresh()
+burst = [new_card(conn, f"card {n} whose worker was OOM-killed") for n in range(4)]
+K.recompute_ready(conn)
+for tid, p in zip(burst, DEAD_PIDS):
+    K.claim_task(conn, tid)
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (p, tid)
+    )
+conn.commit()
+K.detect_crashed_workers(conn)
+check(
+    "four of our own workers dying the same way in one tick reads as systemic",
+    all(status(conn, t) == "blocked" for t in burst),
+    f"statuses: {[status(conn, t) for t in burst]} — is_systemic never fired",
+)
+
+# Below the heuristic's threshold nothing is systemic: two crashes are two
+# crashes, and each card keeps the rest of its budget.
+conn = fresh()
+pair = [new_card(conn, f"card {n} whose worker died alone") for n in range(2)]
+K.recompute_ready(conn)
+for tid, p in zip(pair, DEAD_PIDS):
+    K.claim_task(conn, tid)
+    conn.execute(
+        "UPDATE tasks SET worker_pid = ?, started_at = 1 WHERE id = ?", (p, tid)
+    )
+conn.commit()
+K.detect_crashed_workers(conn)
+check(
+    "two crashes in a tick are just two crashes",
+    all(status(conn, t) == "ready" for t in pair),
+    f"statuses: {[status(conn, t) for t in pair]} — the heuristic fired below 3",
+)
+
+# --- D. The breaker counter --------------------------------------------------
+#
+# Driven on an in-memory board rather than through ``fresh()``: the subject here
+# is two SQL binds and a threshold, and ``claim_task`` would drag
+# ``get_current_board`` and the ``$HERMES_HOME`` layout into a test that has no
+# use for either.
+
+# What ``dispatch_once`` passes to ``recompute_ready`` under the shipped
+# configuration (``kanban.failure_limit`` unset on every profile).
+DISPATCHER_LIMIT = K.DEFAULT_SPAWN_FAILURE_LIMIT
+PROTOCOL_LIMIT = K._PROTOCOL_VIOLATION_FAILURE_LIMIT
+# The constant the patch itself floors against. It is a distinct name from
+# ``DEFAULT_SPAWN_FAILURE_LIMIT`` above, currently aliased to it in kanban_db.py
+# (``DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT``). Referencing both
+# separately means the day they diverge this gate fails rather than passing on a
+# coincidence.
+FLOOR = K.DEFAULT_FAILURE_LIMIT
+
+
+def board() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(K.SCHEMA_SQL)
+    return conn
+
+
+def make(conn, tid, *, status="ready", max_retries=None):
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at, "
+        "consecutive_failures, max_retries) VALUES (?, ?, ?, ?, 0, ?)",
+        (tid, tid, status, int(time.time()), max_retries),
+    )
+    conn.commit()
+
+
+def claim(conn, tid):
+    """Put ``tid`` into the state ``claim_task`` leaves behind.
+
+    Open-coded for the reason given above; the columns below are exactly what
+    its UPDATE plus ``_start_run`` write.
+    """
+    now = int(time.time())
+    cur = conn.execute(
+        "INSERT INTO task_runs (task_id, status, claim_lock, worker_pid, "
+        "started_at) VALUES (?, 'running', ?, ?, ?)",
+        (tid, f"verify-{tid}", 4242, now),
+    )
+    conn.execute(
+        "UPDATE tasks SET status = 'running', claim_lock = ?, "
+        "claim_expires = ?, worker_pid = ?, started_at = ?, "
+        "current_run_id = ? WHERE id = ?",
+        (f"verify-{tid}", now + 900, 4242, now, cur.lastrowid, tid),
+    )
+    conn.commit()
+
+
+def state(conn, tid):
+    row = conn.execute(
+        "SELECT status, consecutive_failures FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    return row["status"], int(row["consecutive_failures"])
+
+
+def gave_up_payload(conn, tid):
+    return last_event(conn, tid, "gave_up")
+
+
+def stored_from_payload(payload):
+    """Reconstruct ``consecutive_failures`` from the untouched ``gave_up`` row.
+
+    Two arms, because the floor the patch applies is INVISIBLE in the payload:
+    it only fires when there is no per-task override, and the payload records
+    that as ``limit_source``, not as a number. ``max(failures,
+    effective_limit)`` alone is right for the ``task`` arm and wrong for the
+    systemic one, which stores 2 while its payload reads
+    ``{"failures": 1, "effective_limit": 1}``. The audit trail is the only
+    account of why a card is blocked, so a formula that is right for three of
+    four arms is not good enough to document.
+    """
+    stored = max(payload.get("failures", 0), payload.get("effective_limit", 0))
+    if payload.get("limit_source") != "task":
+        stored = max(stored, FLOOR)
+    return stored
+
+
+print(f"breaker counter (dispatcher limit {DISPATCHER_LIMIT}):")
+
+# --- 1, 2, 7, 9: the arms that used to be reverted in the same tick ---------
+conn = board()
+
+# 1. Protocol violation. detect_crashed_workers adjudicates its own streak and
+#    passes force_trip=True, so the raw counter lands at 1 -- below the
+#    dispatcher's 2, which is what let recompute_ready undo the trip.
+make(conn, "proto")
+K._record_task_failure(
+    conn,
+    "proto",
+    error="clean exit without a terminal kanban call",
+    outcome="crashed",
+    failure_limit=PROTOCOL_LIMIT,
+    force_trip=True,
+)
+check(
+    "1. protocol force_trip stores the threshold it was decided against",
+    state(conn, "proto") == ("blocked", PROTOCOL_LIMIT),
+    f"got {state(conn, 'proto')}, want ('blocked', {PROTOCOL_LIMIT})",
+)
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "1. protocol trip survives recompute_ready",
+    state(conn, "proto")[0] == "blocked" and promoted == 0,
+    f"state {state(conn, 'proto')}, promoted {promoted}",
+)
+
+# 2. Systemic same-error crash. The caller lowers the limit to 1.
+make(conn, "systemic")
+K._record_task_failure(
+    conn, "systemic", error="container OOMKilled", outcome="crashed",
+    failure_limit=1,
+)
+check(
+    "2. systemic trip is floored at the dispatcher default",
+    state(conn, "systemic") == ("blocked", DISPATCHER_LIMIT),
+    f"got {state(conn, 'systemic')}, want ('blocked', {DISPATCHER_LIMIT})",
+)
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "2. systemic trip survives recompute_ready",
+    state(conn, "systemic")[0] == "blocked" and promoted == 0,
+    f"state {state(conn, 'systemic')}, promoted {promoted}",
+)
+
+# 7. A per-task max_retries override must be honoured, not flattened to the
+#    module default -- recompute_ready resolves against max_retries first.
+make(conn, "override", max_retries=5)
+K._record_task_failure(
+    conn, "override", error="clean exit without a terminal kanban call",
+    outcome="crashed", failure_limit=5, force_trip=True,
+)
+check(
+    "7. max_retries override is stored, not the default floor",
+    state(conn, "override") == ("blocked", 5),
+    f"got {state(conn, 'override')}, want ('blocked', 5)",
+)
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "7. override trip survives recompute_ready",
+    state(conn, "override")[0] == "blocked" and promoted == 0,
+    f"state {state(conn, 'override')}, promoted {promoted}",
+)
+
+# 9. The spawn-failure path takes the OTHER patched UPDATE (release_claim=True,
+#    the one whose WHERE clause is ('running', 'ready')). Without its own case
+#    that bind could be left unpatched and everything above would still pass.
+make(conn, "spawn")
+claim(conn, "spawn")
+K._record_task_failure(
+    conn, "spawn", error="failed to spawn worker", outcome="spawn_failed",
+    failure_limit=1, release_claim=True, end_run=True,
+)
+check(
+    "9. spawn-path trip is floored too",
+    state(conn, "spawn") == ("blocked", DISPATCHER_LIMIT),
+    f"got {state(conn, 'spawn')}, want ('blocked', {DISPATCHER_LIMIT})",
+)
+spawn_row = conn.execute(
+    "SELECT claim_lock, worker_pid, current_run_id FROM tasks WHERE id = 'spawn'"
+).fetchone()
+check(
+    "9. the spawn-path claim is still released and the run closed",
+    spawn_row["claim_lock"] is None
+    and spawn_row["worker_pid"] is None
+    and spawn_row["current_run_id"] is None,
+    f"claim_lock={spawn_row['claim_lock']!r} pid={spawn_row['worker_pid']!r} "
+    f"run={spawn_row['current_run_id']!r}",
+)
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "9. spawn-path trip survives recompute_ready",
+    state(conn, "spawn")[0] == "blocked" and promoted == 0,
+    f"state {state(conn, 'spawn')}, promoted {promoted}",
+)
+
+# --- 3: no inflation on the ordinary path -----------------------------------
+make(conn, "normal")
+K._record_task_failure(
+    conn, "normal", error="boom 1", outcome="crashed",
+    failure_limit=DISPATCHER_LIMIT,
+)
+check(
+    "3. the first ordinary failure neither blocks nor inflates",
+    state(conn, "normal") == ("ready", 1),
+    f"got {state(conn, 'normal')}, want ('ready', 1)",
+)
+K._record_task_failure(
+    conn, "normal", error="boom 2", outcome="crashed",
+    failure_limit=DISPATCHER_LIMIT,
+)
+check(
+    "3. the ordinary trip stores the true count",
+    state(conn, "normal") == ("blocked", DISPATCHER_LIMIT),
+    f"got {state(conn, 'normal')}, want ('blocked', {DISPATCHER_LIMIT})",
+)
+
+# --- the audit trail must not change meaning --------------------------------
+payload = gave_up_payload(conn, "proto")
+check(
+    "the gave_up payload still reports the true attempt count",
+    payload.get("failures") == 1,
+    f"payload: {payload}",
+)
+check(
+    "the gave_up payload still reports the deciding threshold",
+    payload.get("effective_limit") == PROTOCOL_LIMIT,
+    f"payload: {payload}",
+)
+
+# Every arm, not just the one where the floor happens not to bite. Asserting
+# recoverability on ``proto`` alone is vacuous: its effective_limit (3) already
+# exceeds the floor, so the two formulas agree there and the systemic arm --
+# the one that motivated this patch -- goes unchecked.
+for tid in ("proto", "systemic", "override", "spawn"):
+    payload = gave_up_payload(conn, tid)
+    stored = state(conn, tid)[1]
+    check(
+        f"the stored counter is recoverable from {tid}'s untouched payload",
+        stored_from_payload(payload) == stored,
+        f"payload {payload} reconstructs to {stored_from_payload(payload)}, "
+        f"column holds {stored}",
+    )
+check(
+    "the systemic arm is the one that needs the two-arm formula",
+    max(gave_up_payload(conn, "systemic").get("failures", 0),
+        gave_up_payload(conn, "systemic").get("effective_limit", 0))
+    != state(conn, "systemic")[1],
+    "the naive one-line formula now agrees on the systemic arm, so the "
+    "docstring's two-arm caveat has gone stale — re-derive it before trusting "
+    "the simpler form",
+)
+conn.close()
+
+# --- 4, 5, 6, 8: preservation. This is what the rejected fix broke. ---------
+conn = board()
+
+# 4. assign_task zeroes the counter on a profile change and calls that "an
+#    explicit recovery action". It emits kind 'assigned', not 'unblocked', and
+#    does not change status -- so any fix that reads the gave_up EVENT instead
+#    of the counter pins this card in blocked forever.
+make(conn, "reassigned")
+K._record_task_failure(
+    conn, "reassigned", error="pv", outcome="crashed",
+    failure_limit=PROTOCOL_LIMIT, force_trip=True,
+)
+check(
+    "4. the reassigned card starts out tripped",
+    state(conn, "reassigned")[0] == "blocked",
+)
+K.assign_task(conn, "reassigned", "platform")
+check(
+    "4. assign_task still zeroes the counter",
+    state(conn, "reassigned")[1] == 0,
+    f"state {state(conn, 'reassigned')}",
+)
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "4. assign_task still recovers a force-tripped card",
+    state(conn, "reassigned") == ("ready", 0) and promoted == 1,
+    f"state {state(conn, 'reassigned')}, promoted {promoted}",
+)
+
+# 4b. The behaviour change operators have to know about, asserted rather than
+#     only written down. assign_task only zeroes the counter when the assignee
+#     actually CHANGES; to the same profile it just rewrites the column. That
+#     was survivable before this patch because a systemic trip stored 1, below
+#     the dispatcher's 2, so recompute_ready promoted the card whatever
+#     assign_task did. Now the stored count is the exhausted budget and the
+#     no-op assign no longer frees it. Reassign elsewhere, or unblock.
+K._record_task_failure(
+    conn, "reassigned", error="container OOMKilled", outcome="crashed",
+    failure_limit=1,
+)
+check(
+    "4b. the card is tripped again before the same-profile assign",
+    state(conn, "reassigned") == ("blocked", DISPATCHER_LIMIT),
+    f"got {state(conn, 'reassigned')}, want ('blocked', {DISPATCHER_LIMIT})",
+)
+K.assign_task(conn, "reassigned", "platform")  # same profile: a no-op reassign
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "4b. assign_task to the SAME profile no longer frees a tripped card",
+    state(conn, "reassigned") == ("blocked", DISPATCHER_LIMIT) and promoted == 0,
+    f"state {state(conn, 'reassigned')}, promoted {promoted} — if this now "
+    "recovers, the counter stopped being the arbiter and the docstring's "
+    "recovery-path list needs redoing",
+)
+
+# 5. unblock_task is the operator's exit.
+make(conn, "unblocked")
+K._record_task_failure(
+    conn, "unblocked", error="pv", outcome="crashed",
+    failure_limit=PROTOCOL_LIMIT, force_trip=True,
+)
+K.unblock_task(conn, "unblocked")
+check(
+    "5. unblock_task still recovers a force-tripped card",
+    state(conn, "unblocked") == ("ready", 0),
+    f"got {state(conn, 'unblocked')}, want ('ready', 0)",
+)
+
+# 6. A card gated only by a parent never trips, so it must still auto-promote.
+make(conn, "parent", status="done")
+make(conn, "child", status="todo")
+conn.execute(
+    "INSERT INTO task_links (parent_id, child_id) VALUES ('parent', 'child')"
+)
+conn.commit()
+K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "6. a parent-gated card with no trip still auto-promotes",
+    state(conn, "child") == ("ready", 0),
+    f"got {state(conn, 'child')}, want ('ready', 0)",
+)
+
+# 8. A worker/operator kanban_block stays sticky, as before. Note the counter
+#    is 0 here, so only _has_sticky_block can hold this card.
+make(conn, "sticky", status="blocked")
+with K.write_txn(conn):
+    K._append_event(conn, "sticky", "blocked", {"reason": "review-required"})
+promoted = K.recompute_ready(conn, failure_limit=DISPATCHER_LIMIT)
+check(
+    "8. a worker kanban_block is still sticky",
+    state(conn, "sticky")[0] == "blocked",
+    f"state {state(conn, 'sticky')}, promoted {promoted}",
+)
+
+conn.close()
+
+print()
+if FAILURES:
+    print(f"verify_kanban_scheduling: {len(FAILURES)} FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_scheduling: all checks passed")

--- a/deploy/docker/patches/verify_kanban_wake_nudge.py
+++ b/deploy/docker/patches/verify_kanban_wake_nudge.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Build gate for the kanban wake-nudge patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after the applier.
+The applier only proves the anchors matched. This drives the *patched* engine
+against a real board — real ``create_task`` / ``claim_task`` /
+``complete_task`` / ``unblock_task`` — because the property that matters is
+behavioural: the exact mutations that give a watcher work must nudge, the
+mutations a dispatcher tick performs must NOT (that would be a self-waking
+busy loop), and a board whose wake file cannot be written must degrade to
+plain polling rather than fail the write.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_wake_nudge.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import tempfile
+import time
+from pathlib import Path
+from unittest import mock
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+from hermes_cli import kanban_db as K  # noqa: E402
+from hermes_cli.kanban_wake_nudge import (  # noqa: E402
+    WakeMonitor,
+    record_wake,
+    wait_interval,
+    wake_path,
+)
+
+TMP = Path(tempfile.mkdtemp())
+
+
+def fresh():
+    db = TMP / f"kanban{len(list(TMP.iterdir()))}.db"
+    return db, K.connect(db)
+
+
+def status(conn, tid):
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (tid,)).fetchone()
+    return row["status"] if row else None
+
+
+# --- 1. The wiring resolved --------------------------------------------------
+print("import wiring:")
+import gateway.kanban_watchers as watchers  # noqa: E402
+
+check(
+    "the watchers resolved the monitor import",
+    hasattr(watchers, "_KanbanWakeMonitor") and hasattr(watchers, "_kanban_wait_interval"),
+    "the trailer import did not execute",
+)
+check(
+    "kanban_db resolved the producer import",
+    hasattr(K, "_kanban_record_wake"),
+)
+
+# --- 2. Producers nudge, dispatcher writes stay quiet ------------------------
+print("producer nudges:")
+db, conn = fresh()
+monitor = WakeMonitor(db)
+
+parent = K.create_task(conn, title="coordinator", assignee="platform")
+check("create_task writes the wake file next to the board", Path(wake_path(db)).exists())
+check("create_task nudges", monitor.changed())
+
+K.recompute_ready(conn)
+claimed = K.claim_task(conn, parent)
+check("the card claims normally", claimed is not None)
+check(
+    "a dispatcher's own writes do not nudge",
+    not monitor.changed(),
+    "claim/recompute nudging would wake the dispatcher into a busy loop",
+)
+
+child = K.create_task(conn, title="synthesizer", assignee="platform", parents=(parent,))
+monitor.changed()  # consume the create nudge; the completion is what's under test
+check("the dependent child waits on its parent", status(conn, child) == "todo")
+done = K.complete_task(conn, parent, result="the answer", summary="done")
+check("complete_task succeeds", done is True)
+check("complete_task nudges", monitor.changed())
+check(
+    "the completion nudge covers the promoted child",
+    status(conn, child) == "ready",
+    f"child left in {status(conn, child)!r}",
+)
+
+blocked = K.create_task(
+    conn, title="parked for ops review", assignee="platform", initial_status="blocked"
+)
+monitor.changed()  # consume the create nudge
+check("unblock_task returns the card", K.unblock_task(conn, blocked) is True)
+check("unblock_task nudges", monitor.changed())
+check(
+    "a no-op unblock stays quiet",
+    K.unblock_task(conn, blocked) is False and not monitor.changed(),
+)
+
+# --- 3. Reaction time through the real wait ----------------------------------
+print("reaction time:")
+
+
+async def race():
+    db2, conn2 = fresh()
+    conn2.close()
+    m = WakeMonitor(db2)
+
+    def create_on_thread():
+        # A worker is another process with its own connection; the nearest
+        # in-process equivalent is another thread with its own connection
+        # (kanban connections are thread-bound).
+        c = K.connect(db2)
+        try:
+            K.create_task(c, title="mid-wait card", assignee="platform")
+        finally:
+            c.close()
+
+    async def create_later():
+        await asyncio.sleep(0.1)
+        await asyncio.to_thread(create_on_thread)
+
+    task = asyncio.ensure_future(create_later())
+    start = time.monotonic()
+    woke = await wait_interval(m, 5.0)
+    await task
+    return woke, time.monotonic() - start
+
+
+woke, elapsed = asyncio.run(race())
+check("a mid-wait create breaks the wait early", woke and elapsed < 1.5, f"{elapsed:.2f}s")
+check(
+    "the wait would have cost the full 5s tick upstream",
+    elapsed < 2.5,  # avg upstream penalty per hop measured 2026-08-07
+    f"{elapsed:.2f}s",
+)
+
+# --- 4. Degradation is exactly upstream polling -------------------------------
+print("fail-soft degradation:")
+db3, conn3 = fresh()
+with mock.patch("hermes_cli.kanban_wake_nudge.os.utime", side_effect=OSError("read-only fs")):
+    check("record_wake fails soft", record_wake(db3) is False)
+    tid = K.create_task(conn3, title="card on a read-only wake path", assignee="platform")
+    check("the board write itself still succeeds", status(conn3, tid) == "ready")
+
+quiet = WakeMonitor(TMP / "never-created.db")
+start = time.monotonic()
+full = asyncio.run(wait_interval(quiet, 0.4))
+check(
+    "an absent wake file degrades to the full-interval poll",
+    full is True and time.monotonic() - start >= 0.3,
+)
+check("shutdown still interrupts the wait", asyncio.run(wait_interval(quiet, 30.0, lambda: False)) is False)
+
+print()
+if FAILURES:
+    print(f"verify_kanban_wake_nudge: {len(FAILURES)} FAILED")
+    for f in FAILURES:
+        print(f"  - {f}")
+    sys.exit(1)
+print("verify_kanban_wake_nudge: all checks passed")

--- a/deploy/docker/patches/verify_kanban_worker_tools.py
+++ b/deploy/docker/patches/verify_kanban_worker_tools.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Build gate for the worker-only kanban tool patch.
+
+Run by ``deploy/docker/Dockerfile`` from ``/opt/hermes`` after
+``apply_kanban_worker_tools.py``. The applier proves only that eight anchors
+matched exactly once, and the Dockerfile's ``grep -c`` proves only that the
+string ``check_fn=_check_kanban_worker_mode`` appears seven times. Neither says
+anything about which function that name is bound to at import time, nor about
+what it answers, and the gate has two answers to get right:
+
+1. **A dispatcher-spawned worker keeps everything.** This patch exists to shrink
+   the Chat Agent's prompt, and a version of it that also shrank a worker's tool
+   surface would strand cards rather than save tokens: without
+   ``kanban_complete`` or ``kanban_block`` a worker cannot end its run, exits
+   rc=0, and is reaped as a ``protocol_violation``.
+2. **A ``delegate_task`` child is not a worker.** The child runs
+   ``run_conversation`` in the parent's own process and inherits its
+   ``HERMES_KANBAN_TASK``, so an env-var read alone answers True for it. That is
+   asserted here against the real ``agent.delegation_context``, because the unit
+   tests can only reach that module through a fake in ``sys.modules`` — this is
+   the only place the import the gate actually performs is exercised. Upstream's
+   own two gates are measured alongside it: all three must agree that a child is
+   neither a worker nor an orchestrator.
+3. **The shared predicate is the shipped one, and it still takes its polarity
+   from the caller.** ``tools/kanban_ownership.py`` answers this question for
+   ``hermes_cli/kanban_guardrail_exit.py`` too, with the opposite ``on_unknown``.
+   Checked here that the import resolved to the file in the image rather than a
+   stray top-level copy, that a raising reader really does produce two different
+   answers, and that an *absent* module produces ``False`` either way — the two
+   failure modes have to stay distinct.
+
+The last section drives the whole assembly path, ``model_tools`` through
+``tools/registry.py``, because that is the only check that proves a schema
+really disappears rather than a boolean flipping in isolation.
+
+Usage::
+
+    cd /opt/hermes && python3 verify_kanban_worker_tools.py
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+FAILURES: list[str] = []
+
+
+def check(label: str, condition: object, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {label}")
+        return
+    FAILURES.append(f"{label}{': ' + detail if detail else ''}")
+    print(f"  FAIL {label}{': ' + detail if detail else ''}")
+
+
+HERMES = Path(os.environ.get("HERMES_ROOT", "/opt/hermes"))
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+from tools.kanban_worker_tools import (  # noqa: E402
+    WORKER_ONLY_TOOLS,
+    check_kanban_worker_mode,
+)
+
+# The surface agents/chat/SOUL.md §1.5 leaves an orchestrator, and the gate
+# upstream registers each one with. Asserted so that a future anchor edit cannot
+# quietly re-gate the tools the front door still needs.
+ORCHESTRATOR_GATES = {
+    "kanban_show": "_check_kanban_mode",
+    "kanban_comment": "_check_kanban_mode",
+    "kanban_create": "_check_kanban_mode",
+    "kanban_list": "_check_kanban_orchestrator_mode",
+    "kanban_unblock": "_check_kanban_orchestrator_mode",
+}
+
+
+# --- 1. Every registration names the gate it should -------------------------
+print("registrations (tools/kanban_tools.py):")
+
+tree = ast.parse((HERMES / "tools" / "kanban_tools.py").read_text())
+
+gates: dict[str, str] = {}
+for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+        continue
+    kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+    name = kwargs.get("name")
+    if not isinstance(name, ast.Constant) or not isinstance(name.value, str):
+        continue
+    if "check_fn" not in kwargs:
+        continue
+    gates[name.value] = ast.unparse(kwargs["check_fn"])
+
+for tool in WORKER_ONLY_TOOLS:
+    check(
+        f"{tool} is gated on the worker check",
+        gates.get(tool) == "_check_kanban_worker_mode",
+        f"registered with {gates.get(tool)!r}",
+    )
+
+for tool, gate in ORCHESTRATOR_GATES.items():
+    check(
+        f"{tool} still uses upstream's {gate}",
+        gates.get(tool) == gate,
+        f"registered with {gates.get(tool)!r}",
+    )
+
+
+# --- 2. The name resolves to this module's function -------------------------
+# An import that landed below the registrations would raise NameError at module
+# load; one that landed anywhere and shadowed the wrong callable would not. The
+# live registry is the only place that distinction is visible.
+print("live registry:")
+
+import tools.kanban_tools as kanban_tools  # noqa: E402
+from tools.registry import invalidate_check_fn_cache, registry  # noqa: E402
+
+for tool in WORKER_ONLY_TOOLS:
+    entry = registry.get_entry(tool)
+    check(
+        f"{tool} is registered with this module's gate",
+        entry is not None and entry.check_fn is check_kanban_worker_mode,
+        "missing from the registry" if entry is None else f"check_fn={entry.check_fn!r}",
+    )
+
+
+# --- 3. What the gate answers -----------------------------------------------
+print("the gate:")
+
+os.environ.pop("HERMES_KANBAN_TASK", None)
+check("an orchestrator profile is not a worker", check_kanban_worker_mode() is False)
+
+os.environ["HERMES_KANBAN_TASK"] = "t_c31a1f00"
+check("a dispatcher-spawned worker is", check_kanban_worker_mode() is True)
+
+from agent.delegation_context import (  # noqa: E402
+    delegated_child_context,
+    is_delegated_child_context,
+)
+
+check(
+    "outside a delegation the real context says 'not a child'",
+    is_delegated_child_context() is False,
+)
+with delegated_child_context():
+    # The parent's HERMES_KANBAN_TASK is deliberately still set here: that is
+    # the whole hazard, and scrubbing it would test nothing.
+    check(
+        "a delegate_task child is not a worker",
+        check_kanban_worker_mode() is False,
+        "the child inherits HERMES_KANBAN_TASK from the parent's process and "
+        "owns no card; tools/kanban_tools.py refuses its board mutations for "
+        "the same reason",
+    )
+    check(
+        "and upstream's own two gates say the same",
+        (
+            kanban_tools._check_kanban_mode() is False
+            and kanban_tools._check_kanban_orchestrator_mode() is False
+        ),
+        "upstream's own gates changed shape — re-derive this patch",
+    )
+check(
+    "the delegation context hands the worker its tools back on the way out",
+    check_kanban_worker_mode() is True,
+)
+
+# The predicate lives in tools/kanban_ownership.py, shared with
+# hermes_cli/kanban_guardrail_exit.py, which asks the same question with the
+# opposite ``on_unknown``. Two things can go wrong that the booleans above do
+# not see: the shared file never landed and a stray top-level copy answered
+# instead, or the polarity argument stopped being honoured and both callers
+# silently converged on one answer.
+ownership = sys.modules.get("tools.kanban_ownership")
+check(
+    "the gate reads tools/kanban_ownership.py",
+    ownership is not None
+    and Path(ownership.__file__).resolve()
+    == (HERMES / "tools" / "kanban_ownership.py").resolve(),
+    f"resolved to {getattr(ownership, '__file__', None)!r}",
+)
+
+if ownership is not None:
+    import agent.delegation_context as _delegation  # noqa: E402
+
+    def _boom() -> bool:
+        raise RuntimeError("delegation context unreadable")
+
+    _real_reader = _delegation.is_delegated_child_context
+    _delegation.is_delegated_child_context = _boom
+    try:
+        check(
+            "a reader that raises is uncertainty, and the caller picks the answer",
+            ownership.is_delegated_child(on_unknown=True) is True
+            and ownership.is_delegated_child(on_unknown=False) is False,
+            "on_unknown stopped being honoured — the two callers need opposite "
+            "answers here and would now share one",
+        )
+        check(
+            "this gate keeps its tools when the reader raises",
+            check_kanban_worker_mode() is True,
+            "a worker with no kanban_complete cannot end its run: it exits rc=0 "
+            "and the reaper stamps a protocol_violation",
+        )
+    finally:
+        _delegation.is_delegated_child_context = _real_reader
+
+    # A None entry in sys.modules is how the interpreter reports "not there",
+    # which is the other failure mode and must NOT consult on_unknown.
+    sys.modules["agent.delegation_context"] = None
+    try:
+        check(
+            "an absent module is a structural fact, not uncertainty",
+            ownership.is_delegated_child(on_unknown=True) is False,
+            "on_unknown must cover a reader that raises, not one that is not "
+            "there — otherwise both callers flip on any host without Hermes",
+        )
+    finally:
+        sys.modules["agent.delegation_context"] = _delegation
+
+
+# --- 4. The schemas really disappear ----------------------------------------
+# The booleans above are only worth what the assembly does with them, and the
+# assembly caches: tools/registry.py memoizes check_fn results for 30s keyed on
+# (fn, profile), which is blind to the delegated-child ContextVar. Invalidate
+# between measurements or the second one reads the first one's answer.
+print("assembled tool definitions:")
+
+import model_tools  # noqa: E402
+
+
+def kanban_tool_names() -> set[str]:
+    invalidate_check_fn_cache()
+    defs = model_tools.get_tool_definitions(
+        enabled_toolsets=["kanban"],
+        disabled_toolsets=[],
+        quiet_mode=True,
+        skip_tool_search_assembly=True,
+    )
+    return {
+        (d.get("function") or {}).get("name")
+        for d in (defs or [])
+        if (d.get("function") or {}).get("name", "").startswith("kanban_")
+    }
+
+
+worker_tools = kanban_tool_names()
+check(
+    "a worker is offered every worker-only tool",
+    set(WORKER_ONLY_TOOLS) <= worker_tools,
+    f"missing {sorted(set(WORKER_ONLY_TOOLS) - worker_tools)}",
+)
+
+with delegated_child_context():
+    child_tools = kanban_tool_names()
+check(
+    "a delegate_task child is offered none of them",
+    not (set(WORKER_ONLY_TOOLS) & child_tools),
+    f"leaked {sorted(set(WORKER_ONLY_TOOLS) & child_tools)}",
+)
+
+invalidate_check_fn_cache()
+
+
+if FAILURES:
+    print("\nkanban_worker_tools verification FAILED:")
+    for failure in FAILURES:
+        print(f"  - {failure}")
+    sys.exit(1)
+print("\nkanban_worker_tools verification passed")


### PR DESCRIPTION
# Pull Request

**Stacked PR 2 of 5.** Base: `ap-build-ci`. Review that PR first — this diff shows only this PR's own work.

> **How this stack works upstream.** GitHub cannot base a cross-fork pull request on a branch that lives in the fork, so the five base branches (`ap-build-ci`, `ap-image-patch-surface`, `ap-agent-runtime`, `ap-governance-cron-2`, `ap-agent-prose`) have been pushed to this repository solely to serve as targets. `ap-governance-cron-2` mirrors the head of the fourth pull request; it replaced an earlier `ap-governance-cron` that branch protection would not let us update in place, so that leftover should be deleted too. These branches carry no work beyond the pull request that proposes them and should all be deleted once the stack lands. **As each pull request merges, retarget the next one at `main`.**

## Why This Change

The image patches the vendored Hermes tree at build time. Each patch was a standalone script carrying its own copy of "find this source region and rewrite it" string surgery, with no shared failure mode. Critically, **a patch whose anchor no longer matched simply did nothing** — a Hermes bump could silently drop a behaviour and still produce a green build and a working-looking image. Adding a patch meant copying several hundred lines.

That fragility was not theoretical. Writing tests against the patched modules surfaced a cluster of real correctness bugs in unattended (cron- and kanban-driven) runs, all of which are fixed here.

## What Changed

**Files:**

- `deploy/docker/patches/patchlib.py` (new — the shared patching primitives)
- `deploy/docker/patches/{apply,verify,test}_*.py` (the restructured patch surface, 55 files)
- `deploy/docker/Dockerfile` (patch-wiring hunks only; the image-layout hunks land in PR 3)

**Added/Changed/Fixed:**

- Added `patchlib.py` and restructured every patch as an `apply_*`/`verify_*`/`test_*` triple:
  - `apply_*` performs the edit and **fails loudly when its anchor is absent**, so a Hermes bump breaks the build rather than shipping an image that quietly lost a behaviour.
  - `verify_*` re-reads the patched tree and asserts the invariant the patch was meant to establish.
  - `test_*` exercises the patched module directly, off the image, so the logic is testable in CI without a Docker build.
- Wired apply-then-verify for each patch into the Dockerfile.
- Fixed: a card's answer now reaches the person who asked, instead of only being written to the board.
- Fixed: broke the self-parenting deadlock and fenced stale claims, so a worker that dies mid-card no longer holds it forever.
- Fixed: a worker can no longer exit rc=0 without ever touching the board — the guardrail exit records a result.
- Fixed: the leaked-exit backstop treats the board as the only authority, and excludes dispatched cron runs, which were being reaped as if they had leaked.
- Fixed: platform cron no longer runs at half speed; a tripped breaker stays tripped; the cron-run marker lives in a `ContextVar` rather than process-global state; stuck runs are reaped and dispatched runs fenced.
- Fixed: a failed remote MCP call surfaces its error instead of hanging for the full deadline.
- Changed: dispatch is event-driven with inherited subscriptions and lazy MCP startup, cutting per-card latency.

## Why This Matters

- The build now fails on a stale patch instead of silently shipping degraded behaviour — this is the single most valuable property in the change.
- The patched logic is unit-testable without a Docker build, so the correctness bugs above are regression-guarded.
- The kanban and cron fixes are all failure modes of *unattended* operation, which is exactly where nobody is watching.

## Context

Squashes: `a1baac6`, `555e40b`, `c519dc7`, `0a66ff2`, `a1fced8`, `6b9ba99`, `2fc3a6c`, `a33b249`, `1f2b53e`, `dc5ed39`, `f642c2a`, `041956f`, `c64a9cf` (patch-surface portions).

`deploy/docker/Dockerfile` is deliberately split across this PR and PR 3: the patch-wiring hunks are here, and the image-layout and boot hunks are in `ap-agent-runtime`, so both PRs stay coherent. The file is complete only at the top of the stack.

Stack: `ap-build-ci` → **`ap-image-patch-surface`** → `ap-agent-runtime` → `ap-governance-cron` → `ap-agent-prose`.

## Testing

- `make test-python` — pass (the new `deploy/docker/patches/test_*.py` suites are the bulk of the added coverage).
- `make docs-check` — pass.
- `prettier --check` — no in-scope files.
- Not run: an actual `docker build` of the intermediate Dockerfile state. The patch-wiring hunks were verified to apply cleanly, but the split image is only build-tested at the top of the stack.

---

Large diff, but the great majority is new test and verify code. Runtime risk is concentrated in the kanban/cron behaviour changes, which are the fixes themselves; rollout is via the agent image.
