### PR TITLE
Update waw-leads owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,6 @@
 aliases:
   waw-leads:
+    - AntonTyb
     - fatoshoti
     - mateuszklinowski
     - mplakhtiy


### PR DESCRIPTION
# Pull Request

## Why This Change

`AntonTyb` is a lead on the Warsaw team but was not a member of the `waw-leads` alias, so he could
not `/approve` pull requests in this repository. Every approval had to route through one of the
other three alias members or a top-level repository owner, which slows review turnaround and puts
an artificial single-point dependency on the rest of the team whenever they are out.

## What Changed

**Files:**

- `OWNERS_ALIASES`

**Added/Changed/Fixed:**

- Added `AntonTyb` to the `waw-leads` alias, keeping the list alphabetically ordered.

`waw-leads` is referenced from the root `OWNERS` `approvers` list, so this grants `AntonTyb`
repository-wide approval rights through Prow — the same rights the other three alias members
already hold. No other permission surface changes.

## Why This Matters

- Unblocks a fourth approver, reducing review latency and the bus factor on approvals for the
  Warsaw team.
- Brings the alias in line with the team's actual composition, so the OWNERS file reflects who is
  genuinely accountable for the code.

## Context

- The `waw-leads` group in `.github/auto_request_review.yml` is a **separate** list used only for
  automatic reviewer *assignment*, and is intentionally left untouched here. This PR is scoped to
  approval rights; adding `AntonTyb` to the auto-assignment rotation is a separate decision and can
  follow in its own PR if the team wants it.
- No follow-up work is required for this change to take effect — Prow reads `OWNERS_ALIASES` from
  `main` on the next PR after merge.

## Testing

- All CI checks pass on `0632bdb2`, including `validate` (which parses the OWNERS files) and
  `prettier`.
- `tide` currently reports `Not mergeable. Needs lgtm label.` — the PR already carries `approved`
  and is waiting only on `lgtm`.

---

Zero functional impact on the operator, charts, or agent configuration: this is a repository
governance change only. It is trivially revertible by dropping the single added line.

_This description was generated with the help of Claude._
