### PR TITLE
feat(ci): add 3-hour cron schedule and smart commit resolution to RC pipeline

### DIFF
--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -30,6 +30,8 @@ on:
         value: ${{ jobs.create-tag.outputs.commit_sha }}
       rc_tag:
         value: ${{ jobs.create-tag.outputs.rc_tag }}
+      skip_rc:
+        value: ${{ jobs.create-tag.outputs.skip_rc }}
 
 jobs:
   create-tag:
@@ -40,6 +42,7 @@ jobs:
     outputs:
       commit_sha: ${{ steps.resolve_target.outputs.commit_sha }}
       rc_tag: ${{ steps.resolve_target.outputs.rc_tag }}
+      skip_rc: ${{ steps.resolve_target.outputs.skip_rc }}
 
     steps:
       - name: Checkout repository
@@ -59,12 +62,14 @@ jobs:
         run: ./scripts/release/resolve_rc_tag.sh
 
       - name: Verify Prebuilt Container Images Exist in Registry
+        if: steps.resolve_target.outputs.skip_rc != 'true'
         env:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX }}
         run: ./scripts/release/verify_candidate_images.sh
 
       - name: Create Git Tag & Push
+        if: steps.resolve_target.outputs.skip_rc != 'true'
         env:
           COMMIT_SHA: ${{ steps.resolve_target.outputs.commit_sha }}
           RC_TAG: ${{ steps.resolve_target.outputs.rc_tag }}

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -21,6 +21,11 @@ on:
         description: "Release Candidate Tag (Optional, Default: Auto-generated rc_YYMMDDHHMM)"
         required: false
         type: string
+      is_scheduled:
+        description: "Flag indicating whether run was triggered by automated cron schedule"
+        required: false
+        type: boolean
+        default: false
     secrets:
       RELEASE_BOT_TOKEN:
         description: "Release Bot PAT Token"
@@ -56,6 +61,7 @@ jobs:
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
           RC_TAG: ${{ inputs.rc_tag }}
+          IS_SCHEDULED: ${{ inputs.is_scheduled }}
           GH_ORG: ${{ vars.GH_ORG }}
           GH_REPO: ${{ vars.GH_REPO }}
           REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX }}

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -14,8 +14,8 @@ on:
   workflow_call:
     inputs:
       commit_sha:
-        description: "Target Commit SHA to tag (Mandatory)"
-        required: true
+        description: "Target Commit SHA to tag (Optional for automated schedule, Mandatory for manual runs)"
+        required: false
         type: string
       rc_tag:
         description: "Release Candidate Tag (Optional, Default: Auto-generated rc_YYMMDDHHMM)"
@@ -53,6 +53,9 @@ jobs:
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
           RC_TAG: ${{ inputs.rc_tag }}
+          GH_ORG: ${{ vars.GH_ORG }}
+          GH_REPO: ${{ vars.GH_REPO }}
+          REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX }}
         run: ./scripts/release/resolve_rc_tag.sh
 
       - name: Verify Prebuilt Container Images Exist in Registry

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -27,6 +27,7 @@ jobs:
     with:
       commit_sha: ${{ inputs.commit_sha }}
       rc_tag: ${{ inputs.rc_tag }}
+      is_scheduled: ${{ github.event_name == 'schedule' }}
     secrets:
       RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
 

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -1,6 +1,8 @@
 name: RC Release E2E Pipeline
 
 on:
+  schedule:
+    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -33,6 +33,7 @@ jobs:
   step-2-deploy-env:
     name: Step 2 - Provision RC Environment
     needs: step-1-create-tag
+    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
     uses: ./.github/workflows/rc-deploy-environment.yml
     permissions:
       contents: read
@@ -45,6 +46,7 @@ jobs:
   step-3-run-e2e-tests:
     name: Step 3 - Run E2E Tests
     needs: [step-1-create-tag, step-2-deploy-env]
+    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
     runs-on: ubuntu-latest
     environment: rc
     concurrency:
@@ -103,6 +105,7 @@ jobs:
   step-4-tag-validated:
     name: Step 4 - Tag Validated Release
     needs: [step-1-create-tag, step-3-run-e2e-tests]
+    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
     uses: ./.github/workflows/rc-tag-validated.yml
     permissions:
       contents: write

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -4,13 +4,23 @@ This directory contains executable scripts supporting the Release Candidate (RC)
 
 ## Overview of Scripts
 
-- `common.sh`: Shared helper functions for Git operations and automated bot tagging (`ensure_git_tag`).
-- `resolve_rc_tag.sh`: Validates candidate commit SHAs, resolves input tags/commit inputs, and sets workflow step outputs.
-- `verify_candidate_images.sh`: Verifies that prebuilt container images (`k8s-operator`, `platform-agent`) exist in GHCR for the target candidate SHA.
+- `common.sh`: Centralized registry/repository helpers (`DEFAULT_REGISTRY_PREFIX`, `DEFAULT_RELEASE_REPO`, `REQUIRED_RELEASE_IMAGES`), commit discovery (`find_latest_built_commit`), validation check (`is_commit_already_validated`), and automated bot tagging (`ensure_git_tag`).
+- `resolve_rc_tag.sh`: Validates candidate commit SHAs, resolves input tags/commit inputs, discovers the latest built commit on `main` during scheduled runs, checks for existing `*_validated` tags to skip redundant runs, and sets workflow step outputs.
+- `verify_candidate_images.sh`: Verifies that prebuilt container images (`k8s-operator`, `platform-agent`) exist in GHCR/registry for the target candidate SHA.
 - `create_release_tag.sh`: Creates and pushes candidate release tags (`rc_YYMMDDHHMM_<short_sha>`) safely and idempotently.
 - `validate_and_log_deploy_summary.sh`: Validates required environment variables and secrets, then logs a formatted deployment matrix and GCP cluster target overview for auditing before provisioning.
 - `provision_rc_environment.sh`: Orchestrates cluster teardown and fresh provisioning against the dedicated RC GCP project.
 - `tag_validated_release.sh`: Attaches the `*_validated` tag to a candidate commit upon 100% test pass.
+
+## Pipeline Cadence & Execution Flow
+
+The end-to-end pipeline (`.github/workflows/rc-release-pipeline.yml`) runs on a recurring schedule and can also be triggered manually:
+
+- **Scheduled Cadence (every 3 hours `0 */3 * * *`)**:
+  - Automatically scans recent commits on `main` (`FETCH_HEAD`) for published container images in GHCR.
+  - **Redundant Run Skipping**: If the latest candidate commit already carries a `*_validated` tag from a previous successful run, the pipeline skips subsequent provisioning and E2E test execution (`skip_rc=true`), finishing in seconds.
+- **Manual Trigger (`workflow_dispatch`)**:
+  - Requires an explicit `commit_sha` input to rigorously test a specific target commit.
 
 ## Workflow Mapping
 

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -83,12 +83,6 @@ find_latest_built_commit() {
 
   for sha in $candidate_commits; do
     if check_commit_images_exist "${sha}"; then
-      if is_commit_already_validated "${sha}"; then
-        echo "ℹ️ Latest built commit ${sha:0:7} is already validated (*_validated). Skipping redundant RC run." >&2
-        echo "SKIPPED_ALREADY_VALIDATED:${sha}"
-        return 0
-      fi
-
       echo "✅ Found latest commit with verified container images: ${sha}" >&2
       echo "$sha"
       return 0

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -2,6 +2,91 @@
 # Common helper functions for Release Candidate CI/CD automation scripts.
 set -euo pipefail
 
+# Centralized definition of required container images and registry defaults
+DEFAULT_REGISTRY_PREFIX="ghcr.io/gke-labs/kube-agents"
+DEFAULT_RELEASE_REPO="gke-labs/kube-agents"
+REQUIRED_RELEASE_IMAGES=("k8s-operator" "platform-agent")
+
+# Resolves target GitHub repository (e.g. gke-labs/kube-agents)
+get_target_repo() {
+  if [ -n "${GH_ORG:-}" ] && [ -n "${GH_REPO:-}" ]; then
+    echo "${GH_ORG}/${GH_REPO}"
+  elif [ -n "${GITHUB_REPOSITORY:-}" ]; then
+    echo "${GITHUB_REPOSITORY}"
+  else
+    echo "${DEFAULT_RELEASE_REPO}"
+  fi
+}
+
+# Resolves registry prefix (e.g. ghcr.io/gke-labs/kube-agents)
+get_registry_prefix() {
+  if [ -n "${REGISTRY_PREFIX:-}" ]; then
+    echo "${REGISTRY_PREFIX}"
+  else
+    local target_repo
+    target_repo="$(get_target_repo)"
+    if [ "$target_repo" = "$DEFAULT_RELEASE_REPO" ]; then
+      echo "$DEFAULT_REGISTRY_PREFIX"
+    else
+      local repo_downcased
+      repo_downcased="$(echo "$target_repo" | tr '[:upper:]' '[:lower:]')"
+      echo "ghcr.io/${repo_downcased}"
+    fi
+  fi
+}
+
+# Checks if all required candidate container images exist in GHCR for a specific commit SHA
+check_commit_images_exist() {
+  local sha="$1"
+  local registry_prefix
+  registry_prefix="$(get_registry_prefix)"
+
+  for img in "${REQUIRED_RELEASE_IMAGES[@]}"; do
+    local target_img="${registry_prefix}/${img}:${sha}"
+    if ! docker manifest inspect "${target_img}" >/dev/null 2>&1; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Finds the latest commit on main whose required container images are already built in the registry
+find_latest_built_commit() {
+  local target_repo
+  target_repo="$(get_target_repo)"
+  local registry_prefix
+  registry_prefix="$(get_registry_prefix)"
+
+  echo "🔍 [Schedule / Auto-resolve] Scanning recent commits on main for prebuilt container images (${registry_prefix})..." >&2
+
+  if [ -n "${target_repo}" ]; then
+    git fetch "https://github.com/${target_repo}.git" main --depth=30 >/dev/null 2>&1 || git fetch origin main --depth=30 >/dev/null 2>&1 || true
+  else
+    git fetch origin main --depth=30 >/dev/null 2>&1 || true
+  fi
+
+  local candidate_commits
+  candidate_commits=$(git log -n 30 --format="%H" FETCH_HEAD 2>/dev/null || git log -n 30 --format="%H" origin/main 2>/dev/null || git log -n 30 --format="%H" HEAD 2>/dev/null || echo "")
+
+  if [ -z "${candidate_commits}" ]; then
+    echo "❌ ERROR: Cannot retrieve commit history from git repository!" >&2
+    return 1
+  fi
+
+  for sha in $candidate_commits; do
+    if check_commit_images_exist "${sha}"; then
+      echo "✅ Found latest commit with verified container images: ${sha}" >&2
+      echo "$sha"
+      return 0
+    else
+      echo "  ⏳ Images not ready yet in GHCR for commit ${sha:0:7}, checking previous commit..." >&2
+    fi
+  done
+
+  echo "❌ ERROR: Could not find any commit in the last 30 commits on main with published images in GHCR (${registry_prefix})!" >&2
+  return 1
+}
+
 # Configures Git bot user identity for automated tagging
 setup_git_bot_user() {
   git config user.name "github-actions[bot]"

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -50,6 +50,14 @@ check_commit_images_exist() {
   return 0
 }
 
+# Checks if a commit SHA has already been validated in a previous RC run (*_validated tag)
+is_commit_already_validated() {
+  local sha="$1"
+  local validated_tags
+  validated_tags=$(git tag --points-at "${sha}" "*_validated" 2>/dev/null || echo "")
+  [ -n "${validated_tags}" ]
+}
+
 # Finds the latest commit on main whose required container images are already built in the registry
 find_latest_built_commit() {
   local target_repo
@@ -60,7 +68,7 @@ find_latest_built_commit() {
   echo "🔍 [Schedule / Auto-resolve] Scanning recent commits on main for prebuilt container images (${registry_prefix})..." >&2
 
   if [ -n "${target_repo}" ]; then
-    git fetch "https://github.com/${target_repo}.git" main --depth=30 >/dev/null 2>&1 || git fetch origin main --depth=30 >/dev/null 2>&1 || true
+    git fetch "https://github.com/${target_repo}.git" main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || git fetch origin main --depth=30 >/dev/null 2>&1 || true
   else
     git fetch origin main --depth=30 >/dev/null 2>&1 || true
   fi
@@ -75,6 +83,12 @@ find_latest_built_commit() {
 
   for sha in $candidate_commits; do
     if check_commit_images_exist "${sha}"; then
+      if is_commit_already_validated "${sha}"; then
+        echo "ℹ️ Latest built commit ${sha:0:7} is already validated (*_validated). Skipping redundant RC run." >&2
+        echo "SKIPPED_ALREADY_VALIDATED:${sha}"
+        return 0
+      fi
+
       echo "✅ Found latest commit with verified container images: ${sha}" >&2
       echo "$sha"
       return 0

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -68,9 +68,9 @@ find_latest_built_commit() {
   echo "🔍 [Schedule / Auto-resolve] Scanning recent commits on main for prebuilt container images (${registry_prefix})..." >&2
 
   if [ -n "${target_repo}" ]; then
-    git fetch "https://github.com/${target_repo}.git" main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || git fetch origin main --depth=30 >/dev/null 2>&1 || true
+    git fetch "https://github.com/${target_repo}.git" main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || git fetch origin main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || true
   else
-    git fetch origin main --depth=30 >/dev/null 2>&1 || true
+    git fetch origin main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || true
   fi
 
   local candidate_commits
@@ -113,9 +113,14 @@ ensure_git_tag() {
     return 1
   fi
 
+  local target_repo
+  target_repo="$(get_target_repo)"
+
   # Fetch remote tags to ensure local view is updated
-  if ! git fetch origin --tags >/dev/null 2>&1; then
-    echo "⚠️ Warning: Could not fetch tags from origin repository." >&2
+  if [ -n "${target_repo}" ]; then
+    git fetch "https://github.com/${target_repo}.git" +refs/tags/*:refs/tags/* >/dev/null 2>&1 || git fetch origin --tags >/dev/null 2>&1 || true
+  else
+    git fetch origin --tags >/dev/null 2>&1 || true
   fi
 
   # Check if tag already exists in Git
@@ -133,13 +138,6 @@ ensure_git_tag() {
 
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
-
-  local target_repo
-  if [ -n "${GH_ORG:-}" ] && [ -n "${GH_REPO:-}" ]; then
-    target_repo="${GH_ORG}/${GH_REPO}"
-  else
-    target_repo="${GITHUB_REPOSITORY:-}"
-  fi
 
   local push_err
   if push_err=$(git push "https://github.com/${target_repo}.git" "${rc_tag}" 2>&1); then

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -30,16 +30,15 @@ elif [ -n "${RC_TAG}" ]; then
     exit 1
   fi
 elif [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
-  RESOLVED_TARGET=$(find_latest_built_commit)
-  if [ -z "${RESOLVED_TARGET}" ]; then
+  COMMIT_SHA=$(find_latest_built_commit)
+  if [ -z "${COMMIT_SHA}" ]; then
     exit 1
   fi
 
-  if [[ "${RESOLVED_TARGET}" == SKIPPED_ALREADY_VALIDATED:* ]]; then
-    COMMIT_SHA="${RESOLVED_TARGET#SKIPPED_ALREADY_VALIDATED:}"
+  if is_commit_already_validated "${COMMIT_SHA}"; then
+    echo "ℹ️ Latest built commit ${COMMIT_SHA:0:7} is already validated (*_validated). Skipping redundant RC run." >&2
     SKIP_RC="true"
   else
-    COMMIT_SHA="${RESOLVED_TARGET}"
     SKIP_RC="false"
   fi
 else

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -8,6 +8,8 @@ source "${SCRIPT_DIR}/common.sh"
 RC_TAG="${1:-${RC_TAG:-}}"
 COMMIT_INPUT="${2:-${COMMIT_SHA:-}}"
 
+SKIP_RC="false"
+
 # Strict Target Commit SHA resolution
 if [ -n "${COMMIT_INPUT}" ]; then
   if ! COMMIT_SHA=$(git rev-parse --verify "${COMMIT_INPUT}^{commit}" 2>/dev/null); then
@@ -28,9 +30,17 @@ elif [ -n "${RC_TAG}" ]; then
     exit 1
   fi
 elif [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
-  COMMIT_SHA=$(find_latest_built_commit)
-  if [ -z "${COMMIT_SHA}" ]; then
+  RESOLVED_TARGET=$(find_latest_built_commit)
+  if [ -z "${RESOLVED_TARGET}" ]; then
     exit 1
+  fi
+
+  if [[ "${RESOLVED_TARGET}" == SKIPPED_ALREADY_VALIDATED:* ]]; then
+    COMMIT_SHA="${RESOLVED_TARGET#SKIPPED_ALREADY_VALIDATED:}"
+    SKIP_RC="true"
+  else
+    COMMIT_SHA="${RESOLVED_TARGET}"
+    SKIP_RC="false"
   fi
 else
   echo "❌ ERROR: Neither COMMIT_SHA nor RC_TAG input was provided (mandatory for manual runs)!" >&2
@@ -46,10 +56,12 @@ fi
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
   echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+  echo "skip_rc=${SKIP_RC}" >> "$GITHUB_OUTPUT"
 fi
 
 echo "======================================================================"
 echo "🏷️ RESOLVED RELEASE CANDIDATE TARGET"
-echo "Target Commit SHA: ${COMMIT_SHA}"
-echo "Release Tag:      ${RC_TAG}"
+echo "Target Commit SHA:            ${COMMIT_SHA}"
+echo "Release Tag:                  ${RC_TAG}"
+echo "Skip (RC Already Validated):  ${SKIP_RC}"
 echo "======================================================================"

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -2,6 +2,9 @@
 # Resolves candidate commit SHA and release tag, setting GITHUB_OUTPUT.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 RC_TAG="${1:-${RC_TAG:-}}"
 COMMIT_INPUT="${2:-${COMMIT_SHA:-}}"
 
@@ -12,12 +15,7 @@ if [ -n "${COMMIT_INPUT}" ]; then
     exit 1
   fi
 elif [ -n "${RC_TAG}" ]; then
-  target_repo=""
-  if [ -n "${GH_ORG:-}" ] && [ -n "${GH_REPO:-}" ]; then
-    target_repo="${GH_ORG}/${GH_REPO}"
-  elif [ -n "${GITHUB_REPOSITORY:-}" ]; then
-    target_repo="${GITHUB_REPOSITORY}"
-  fi
+  target_repo="$(get_target_repo)"
 
   if [ -n "${target_repo}" ]; then
     git fetch "https://github.com/${target_repo}.git" +refs/tags/*:refs/tags/* >/dev/null 2>&1 || true
@@ -29,10 +27,13 @@ elif [ -n "${RC_TAG}" ]; then
     echo "❌ ERROR: Cannot resolve valid Git commit SHA from release tag '${RC_TAG}'!" >&2
     exit 1
   fi
-elif [ -n "${GITHUB_SHA:-}" ]; then
-  COMMIT_SHA="${GITHUB_SHA}"
+elif [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
+  COMMIT_SHA=$(find_latest_built_commit)
+  if [ -z "${COMMIT_SHA}" ]; then
+    exit 1
+  fi
 else
-  echo "❌ ERROR: Neither COMMIT_SHA nor RC_TAG input was provided!" >&2
+  echo "❌ ERROR: Neither COMMIT_SHA nor RC_TAG input was provided (mandatory for manual runs)!" >&2
   exit 1
 fi
 

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -7,6 +7,7 @@ source "${SCRIPT_DIR}/common.sh"
 
 RC_TAG="${1:-${RC_TAG:-}}"
 COMMIT_INPUT="${2:-${COMMIT_SHA:-}}"
+IS_SCHEDULED="${IS_SCHEDULED:-false}"
 
 SKIP_RC="false"
 
@@ -29,7 +30,7 @@ elif [ -n "${RC_TAG}" ]; then
     echo "❌ ERROR: Cannot resolve valid Git commit SHA from release tag '${RC_TAG}'!" >&2
     exit 1
   fi
-elif [ "${GITHUB_EVENT_NAME:-}" = "schedule" ]; then
+elif [ "${IS_SCHEDULED}" = "true" ]; then
   COMMIT_SHA=$(find_latest_built_commit)
   if [ -z "${COMMIT_SHA}" ]; then
     exit 1

--- a/scripts/release/verify_candidate_images.sh
+++ b/scripts/release/verify_candidate_images.sh
@@ -2,6 +2,9 @@
 # Verifies that prebuilt container images exist in GHCR for a candidate commit SHA.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/common.sh"
+
 COMMIT_SHA="${1:-${COMMIT_SHA:-}}"
 
 if [ -z "${COMMIT_SHA}" ]; then
@@ -9,16 +12,11 @@ if [ -z "${COMMIT_SHA}" ]; then
   exit 1
 fi
 
-DEFAULT_REPO="gke-labs/kube-agents"
-REPO_FULL="${GITHUB_REPOSITORY:-$DEFAULT_REPO}"
-REPO_DOWNCASED=$(echo "$REPO_FULL" | tr '[:upper:]' '[:lower:]')
-REGISTRY_PREFIX="${REGISTRY_PREFIX:-ghcr.io/${REPO_DOWNCASED}}"
-REQUIRED_IMAGES=("k8s-operator" "platform-agent")
+registry_prefix="$(get_registry_prefix)"
+echo "🔍 Checking candidate container images in GHCR for commit ${COMMIT_SHA} (${registry_prefix})..."
 
-echo "🔍 Checking candidate container images in GHCR for commit ${COMMIT_SHA}..."
-
-for img_name in "${REQUIRED_IMAGES[@]}"; do
-  target_img="${REGISTRY_PREFIX}/${img_name}:${COMMIT_SHA}"
+for img_name in "${REQUIRED_RELEASE_IMAGES[@]}"; do
+  target_img="${registry_prefix}/${img_name}:${COMMIT_SHA}"
 
   echo "Checking image '${target_img}'..."
 


### PR DESCRIPTION
# Pull Request

## Why This Change

- Automates the end-to-end Release Candidate (RC) testing and validation pipeline on a 3-hour cron schedule.
- Prevents spurious CI failures when commits are rapidly merged to `main` by dynamically resolving the latest commit that already has prebuilt images in GHCR, rather than blindly taking `HEAD`.
- Automatically skips redundant 30-minute deployment and E2E test runs during cron triggers if the latest commit on `main` is already marked with a `*_validated` tag.
- Preserves mandatory `commit_sha` input for manual `workflow_dispatch` runs.
- Eliminates duplicate image names and registry URL construction by centralizing release helpers in `scripts/release/common.sh`.

## What Changed

**Files:**

- `.github/workflows/rc-release-pipeline.yml`
- `.github/workflows/rc-create-tag.yml`
- `scripts/release/common.sh`
- `scripts/release/resolve_rc_tag.sh`
- `scripts/release/verify_candidate_images.sh`
- `scripts/release/README.md`

**Added/Changed/Fixed:**

- Added `schedule: - cron: "0 */3 * * *"` to `.github/workflows/rc-release-pipeline.yml`.
- Added auto-skip logic (`is_commit_already_validated()` and `skip_rc` output) so recurring cron runs skip deployment and E2E tests if the latest candidate commit was already validated in a previous RC run.
- Added `if: needs.step-1-create-tag.outputs.skip_rc != 'true'` to steps 2, 3, and 4 in `rc-release-pipeline.yml` and tagging steps in `rc-create-tag.yml`.
- Kept `commit_sha` mandatory (`required: true`) for manual runs; set `required: false` on `workflow_call` for automated schedule runs.
- Centralized `DEFAULT_REGISTRY_PREFIX`, `DEFAULT_RELEASE_REPO`, `REQUIRED_RELEASE_IMAGES`, and helper functions in `scripts/release/common.sh`.
- Added `find_latest_built_commit()` to scan recent commits on `main` (`FETCH_HEAD`) and return the newest commit with verified container images (`k8s-operator`, `platform-agent`).
- Refactored `verify_candidate_images.sh` and `resolve_rc_tag.sh` to source `common.sh`.
- Documented 3-hour cron cadence, smart resolution, and redundant run skip behavior in `scripts/release/README.md`.

## Why This Matters

- Ensures automated, continuous RC validation without manual triggering.
- Saves significant cloud resources and execution time by skipping redundant test runs on unchanged/already validated commits.
- Avoids race conditions with active image build workflows.
- Keeps release scripts clean, modular, and DRY.

## Context

Follow-up to Release Candidate CI/CD automation pipeline.

## Testing

Locally validated across all key scenarios:
- **Cron Auto-resolve & Skip Validation**: Successfully scans fetched upstream `main`, resolves newest commit with published GHCR images (`ebc956b8`), and correctly flags `skip_rc: true` when marked with `*_validated`.
- **Manual Runs**: Successfully accepts explicit valid commit SHAs (`HEAD`, full SHA) and fails with clear error messages on missing or invalid inputs.
- **Image Verification**: Validated manifest checks against GHCR and custom Google Artifact Registry (GAR) endpoints.
- **Repository Health**: `make docs-check` passes cleanly.

---