### PR TITLE
fix(deps): bump nanoid to 3.3.18 in docs site lockfile

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -5280,9 +5280,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
# Pull Request

## Why This Change

Dependabot alert [#11](https://github.com/gke-labs/kube-agents/security/dependabot/11) — **GHSA-2v37-7h3g-55p8** (high): `nanoid` before 3.3.17 contains an infinite loop in `customAlphabet` and `customRandom`. When either is called with a `size` of 0, the internal generation loop never satisfies its exit condition and spins indefinitely, hanging the calling thread.

`nanoid` reaches us transitively in the docs site: `astro` → `postcss` → `nanoid@^3.3.16`, resolved to 3.3.16 in `docs/site/package-lock.json`.

## What Changed

**Files:**

- `docs/site/package-lock.json`

**Added/Changed/Fixed:**

- Bumped the resolved `nanoid` from 3.3.16 to 3.3.18 (latest 3.x; first patched is 3.3.17). This satisfies `postcss`'s existing `^3.3.16` range, so no `package.json` change is needed and no other dependency moves.

The entry was hand-edited rather than regenerated with `npm update nanoid --package-lock-only`. The local npm (10.9.8) is older than the one that produced the lockfile, and regenerating strips the `libc` fields from sharp's and rollup's optional platform packages — 48 lines of unrelated churn that would weaken platform selection on musl/glibc hosts. The diff here is the three lines that actually matter.

## Why This Matters

- Clears the only open high-severity Dependabot alert on the repository.
- The docs site is a static build, so the practical exposure is limited to build time and no code here passes an attacker-controlled `size` to `customAlphabet`/`customRandom` — but the alert stays open and noisy until the resolved version moves.

## Context

- Advisory: [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)
- Vulnerable range `< 3.3.17`; first patched 3.3.17.

## Testing

- `npm ci` in `docs/site/` — clean install against the edited lockfile, integrity verified, `node_modules/nanoid` resolves to 3.3.18.
- `npm run build` — docs site builds, 43 pages, Pagefind index generated, no errors.
- `npm audit` — 0 vulnerabilities.

---

Lockfile-only change to a dev/docs dependency; no runtime or agent behaviour is affected. Low risk, and revertable by restoring the three lines.

<sub>This PR was generated with the help of Claude.</sub>