### PR TITLE
feat(hack): count Hermes coupling and ratchet it downward

### DIFF
--- a/.github/workflows/hermes-coupling-metric.yml
+++ b/.github/workflows/hermes-coupling-metric.yml
@@ -1,0 +1,42 @@
+name: Hermes Coupling Metric
+
+# Advisory only. This job reports how tightly the build is still coupled to
+# Hermes internals and never fails a pull request on the number alone -- the
+# ratchet is enforced locally by `make patch-metric` and in review, not by
+# blocking a branch whose author may have had a good reason. The point is that
+# the trend is visible on every pull request as the harness-v2 work moves
+# cron, kanban, chat, and approvals out of Hermes.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  patch-metric:
+    name: Report Hermes coupling
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Count Hermes touchpoints
+        run: |
+          {
+            echo "## Hermes coupling metric"
+            echo ""
+            bash hack/patch-metric.sh --summary-only
+            echo ""
+            echo "Lower is better. \`make patch-metric\` runs the same check locally and"
+            echo "fails on a regression; \`hack/patch-metric.sh --update\` lowers the"
+            echo "baseline once a milestone has earned it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Run again for the job log, and surface a regression as a notice so it
+          # is visible in the checks list without turning the pull request red.
+          if ! bash hack/patch-metric.sh; then
+            echo "::notice title=Hermes coupling grew::A patch set or Dockerfile patch reference was added. See the job summary; implementation.md section 0.4 says a milestone needing a new patch set is mis-designed."
+          fi

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPO ?= $(eval REPO := $(LOCATION)-docker.pkg.dev/$(shell gcloud config get core
 
 BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
 
-.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write test-python test-python-deps validate docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map chart-sync chart-check
+.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent status prettier-check prettier-write test-python test-python-deps patch-metric validate docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map chart-sync chart-check
 
 # The agent images this repository builds -- one per `--target` stage in
 # deploy/docker/Dockerfile, which is not the same thing as one per directory
@@ -181,6 +181,9 @@ chart-sync: ## Sync the Helm chart's CRD copies and operator ClusterRole rules f
 
 chart-check: ## Verify the chart's CRD/RBAC copies match k8s-operator/config (CI runs this).
 	@./hack/sync-chart-manifests.sh --check
+
+patch-metric: ## Report the Hermes coupling counts and fail if any grew (--update lowers the baseline).
+	@./hack/patch-metric.sh
 
 validate: ## Fail if any skill sits under agents/*/defaults/skills/.
 	@if [ -n "$(BAD_SKILLS)" ]; then \

--- a/hack/patch-metric-baseline.env
+++ b/hack/patch-metric-baseline.env
@@ -1,0 +1,6 @@
+# Baselines for hack/patch-metric.sh. Lowered by --update as coupling is
+# removed; never raised. See that script's header for what each number is and
+# why it exists.
+BASELINE_APPLY_SETS=13
+BASELINE_VERIFY_SETS=12
+BASELINE_DOCKERFILE_PATCH_REFS=39

--- a/hack/patch-metric.sh
+++ b/hack/patch-metric.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# 📉 Hermes coupling metric - a ratchet that may only turn one way
+# ==============================================================================
+# This repository consumes upstream `nousresearch/hermes-agent` as an image and
+# then rewrites its internals at build time: 13 `apply_*.py` patch sets, each
+# anchored to source text in files we do not own. That is a fork maintained
+# inside a Dockerfile, and every upstream bump is a bet that the anchors still
+# hold.
+#
+# The harness-v2 direction is to move the responsibilities we patch hardest
+# (cron, kanban, chat adapters, approvals) out of Hermes, so the patch count
+# falls to zero. "Coupling is shrinking" is only a claim until something counts
+# it, so this script counts it, and CI prints the number on every pull request.
+#
+# The ratchet: a count may never exceed its checked-in baseline. Going *under*
+# the baseline is the point of the exercise -- when that happens the script says
+# so and `--update` writes the lower number back. `--update` refuses to raise
+# any baseline, which is what makes this a ratchet rather than a thermometer.
+#
+# Portable to bash 3.2 (macOS) as well as CI. Fails loudly rather than skipping
+# a check it cannot run: a metric that silently reports 0 because a path moved
+# would read as total success at the exact moment it stopped working.
+# ==============================================================================
+
+set -uo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+
+BASELINE_FILE="hack/patch-metric-baseline.env"
+PATCH_DIR="deploy/docker/patches"
+DOCKERFILE="deploy/docker/Dockerfile"
+
+UPDATE=0
+SUMMARY_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --update) UPDATE=1 ;;
+    --summary-only) SUMMARY_ONLY=1 ;;
+    -h | --help)
+      sed -n '2,22p' "${BASH_SOURCE[0]}"
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown argument '$arg' (want --update, --summary-only)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in "$PATCH_DIR" "$DOCKERFILE" "$BASELINE_FILE"; do
+  if [ ! -e "$required" ]; then
+    echo "ERROR: '$required' does not exist - the metric cannot run." >&2
+    echo "       If it moved, update this script; do not let the count silently drop." >&2
+    exit 1
+  fi
+done
+
+# ------------------------------------------------------------------------------
+# Measurement
+# ------------------------------------------------------------------------------
+# Each metric is deliberately the crudest thing that cannot be gamed by
+# reformatting. `dockerfile_patch_refs` counts *lines* mentioning a patch
+# script, comments included, exactly as `grep -c apply_` does; it is a coarse
+# proxy for "how much of the Dockerfile is patch machinery" and its absolute
+# value means nothing. Only the direction of travel does.
+
+count_files() { # <glob-prefix> -> number of matching files in PATCH_DIR
+  # shellcheck disable=SC2012 # names here are known-safe; ls is enough
+  ls "$PATCH_DIR"/"$1"*.py 2>/dev/null | wc -l | tr -d ' '
+}
+
+apply_sets=$(count_files "apply_")
+verify_sets=$(count_files "verify_")
+dockerfile_patch_refs=$(grep -c "apply_" "$DOCKERFILE" | tr -d ' ')
+
+if [ "$apply_sets" -eq 0 ]; then
+  echo "ERROR: found zero apply_*.py under $PATCH_DIR." >&2
+  echo "       Either the patches all went away (celebrate, then run --update)," >&2
+  echo "       or the glob is stale. Refusing to report a zero it cannot justify." >&2
+  exit 1
+fi
+
+# Every apply_*.py is expected to have a verify_*.py beside it, because the
+# verifier is what proves at build time that the anchors still matched. Two
+# appliers legitimately break the naming rule; they are listed here with their
+# reason so that this check stays quiet in the steady state and only speaks up
+# when a *new* patch set arrives without a verifier. A warning that is always
+# on is a warning nobody reads.
+#
+#   kanban_result_required -> verified by verify_kanban_result.py. Deliberate:
+#       the Dockerfile comment at the COPY explains that the notifier patch took
+#       the longer name and this verifier kept the shorter one.
+#   mcp_remote_forward_errors -> no build-time verifier, and it is the one
+#       applier that does not patch Hermes at all: it rewrites /opt/mcp-remote.
+#       Covered instead by test_apply_mcp_remote_forward_errors.py in the
+#       `make test-python` suite.
+UNPAIRED_EXPECTED="kanban_result_required mcp_remote_forward_errors"
+
+unpaired=""
+for applier in "$PATCH_DIR"/apply_*.py; do
+  stem=$(basename "$applier" .py)
+  stem=${stem#apply_}
+  [ -f "$PATCH_DIR/verify_${stem}.py" ] && continue
+  case " $UNPAIRED_EXPECTED " in
+    *" $stem "*) continue ;;
+  esac
+  unpaired="${unpaired}${unpaired:+, }${stem}"
+done
+
+# ------------------------------------------------------------------------------
+# Comparison against the baseline
+# ------------------------------------------------------------------------------
+# shellcheck source=hack/patch-metric-baseline.env
+. "./$BASELINE_FILE"
+
+REGRESSED=0
+IMPROVED=0
+REPORT=""
+
+compare() { # <label> <actual> <baseline>
+  local label="$1" actual="$2" baseline="$3" mark
+  if [ "$actual" -gt "$baseline" ]; then
+    mark="🔴 up from $baseline - coupling grew"
+    REGRESSED=1
+  elif [ "$actual" -lt "$baseline" ]; then
+    mark="🟢 down from $baseline - ratchet me"
+    IMPROVED=1
+  else
+    mark="⚪️ at baseline"
+  fi
+  REPORT="${REPORT}| ${label} | ${actual} | ${baseline} | ${mark} |
+"
+}
+
+REPORT="| Metric | Now | Baseline | |
+| --- | --- | --- | --- |
+"
+compare "Hermes patch sets (apply_\*.py)" "$apply_sets" "$BASELINE_APPLY_SETS"
+compare "Patch verifiers (verify_\*.py)" "$verify_sets" "$BASELINE_VERIFY_SETS"
+compare "Dockerfile patch references" "$dockerfile_patch_refs" "$BASELINE_DOCKERFILE_PATCH_REFS"
+
+printf '%s' "$REPORT"
+
+if [ -n "$unpaired" ]; then
+  echo
+  echo "⚠️  New apply_*.py with no verify_*.py beside it: $unpaired"
+  echo "    Add a verifier, or record the exception in UNPAIRED_EXPECTED with a reason."
+  REGRESSED=1
+fi
+
+# ------------------------------------------------------------------------------
+# --update: lower the baseline, never raise it
+# ------------------------------------------------------------------------------
+if [ "$UPDATE" -eq 1 ]; then
+  if [ "$REGRESSED" -eq 1 ]; then
+    echo
+    echo "ERROR: --update refuses to raise a baseline. That is the whole point of" >&2
+    echo "       the ratchet: a milestone that adds a patch set is mis-designed" >&2
+    echo "       (implementation.md section 0.4). Stop and re-plan instead." >&2
+    exit 1
+  fi
+  if [ "$IMPROVED" -eq 0 ]; then
+    echo
+    echo "Nothing to update: every count is already at its baseline."
+    exit 0
+  fi
+  cat > "$BASELINE_FILE" <<EOF
+# Baselines for hack/patch-metric.sh. Lowered by --update as coupling is
+# removed; never raised. See that script's header for what each number is and
+# why it exists.
+BASELINE_APPLY_SETS=$apply_sets
+BASELINE_VERIFY_SETS=$verify_sets
+BASELINE_DOCKERFILE_PATCH_REFS=$dockerfile_patch_refs
+EOF
+  echo
+  echo "✅ Baseline lowered. Commit $BASELINE_FILE with the change that earned it."
+  exit 0
+fi
+
+# ------------------------------------------------------------------------------
+# Exit status
+# ------------------------------------------------------------------------------
+# --summary-only is for the advisory CI job, which reports the number without
+# turning a coupling regression into a red pull request. Locally the exit code
+# is the useful part.
+if [ "$SUMMARY_ONLY" -eq 1 ]; then
+  exit 0
+fi
+
+if [ "$REGRESSED" -eq 1 ]; then
+  echo
+  echo "FAIL: Hermes coupling grew. A milestone that needs a new patch set is" >&2
+  echo "      mis-designed - see implementation.md section 0.4/0.5." >&2
+  exit 1
+fi
+
+if [ "$IMPROVED" -eq 1 ]; then
+  echo
+  echo "Coupling fell below the baseline. Run 'bash hack/patch-metric.sh --update'"
+  echo "and commit the result so the ratchet holds."
+fi
+
+exit 0


### PR DESCRIPTION
# Pull Request

## Why This Change

The image build rewrites upstream Hermes internals at build time: 13 `apply_*.py` patch sets
anchored to source text in files this repository does not own. That is a fork maintained inside a
Dockerfile. "The coupling is shrinking" is a claim the repository makes in several places and
nothing counts it, so nothing can contradict it.

## What Changed

**Files:**

- `hack/patch-metric.sh`
- `hack/patch-metric-baseline.env`
- `.github/workflows/hermes-coupling-metric.yml`
- `Makefile`

**Added/Changed/Fixed:**

- `make patch-metric` counts the patch sets, their verifiers, and the Dockerfile's patch
  references, and compares each against a checked-in baseline.
- A count may never exceed its baseline. `--update` writes a lower one and **refuses** to write a
  higher one — that is what makes it a ratchet rather than a thermometer.
- Flags a new `apply_*.py` arriving without a `verify_*.py` beside it. The two existing exceptions
  are listed in the script with the reason each is legitimate, so the check stays silent until
  something actually regresses.
- CI job is advisory: writes the counts to the step summary and downgrades a regression to a
  `::notice`, following the existing `docs-freshness-check.yml` pattern.

## Why This Matters

- The number becomes visible on every pull request as cron, kanban, chat, and approvals move out
  of Hermes. Blocking the branch is deliberately not the job — a hard gate on a number that must
  fall slowly gets switched off.
- Baseline is **13**, not 14. A naive `grep -c 'apply_.*\.py'` also matches
  `test_apply_mcp_remote_forward_errors.py`; the script counts the patch sets themselves.

## Context

First mechanical milestone of a harness-decoupling track. A follow-up branch extends the same
ratchet to the coupling the patch glob cannot see (`sitecustomize` monkey patches, plugin imports
of Hermes internals); it is held until this merges.

## Testing

- `make patch-metric` — passes, reports 13/13/13 against baseline.
- Ratchet behaviour exercised by hand: `--update` accepts a lower count and refuses a higher one.
- `make docs-check` — green. `prettier --check` — green.
- **Not run:** `actionlint` on the new workflow. It is a Go binary and this machine's endpoint
  security agent (Santa, Lockdown mode) kills freshly-installed binaries, so the workflow's syntax
  is unverified here and worth a reviewer's eye. It is SHA-pinned per `AGENTS.md`.

---

Low risk: adds a new advisory CI job and a `make` target; changes no runtime code or image
content. This PR was generated with the help of Claude.
