### PR TITLE
feat(runner): add the runner contract, null runner, and conformance suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
 - `k8s-operator/`: Go/Kubebuilder operator reconciling `PlatformAgent` Custom Resources, plus provisioning scripts.
 - `examples/`: Example integrations (LiteLLM provider configs, vLLM serving, inference replay).
 - `bench/`: Evaluation harness that runs [kubernetes-sigs/devops-bench](https://github.com/kubernetes-sigs/devops-bench) against the Platform Agent as a pip-installed library.
+- `runner/`: The runner contract — request/event JSON Schemas, a stdlib conformance suite, and a null runner. No production runner implements it yet; see `docs/architecture/09-runner-contract.md`.
 - `INSTALL.md`: Installation guide.
 - `README.md`: Project overview.
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ PYTHON_TEST_DIRS := $(sort $(dir \
 	$(wildcard agents/*/defaults/plugins/*/test_*.py) \
 	$(wildcard deploy/docker/test_*.py) \
 	$(wildcard deploy/docker/patches/test_*.py) \
+	$(wildcard runner/test_*.py) \
 	$(wildcard scripts/test_*.py)))
 
 # The same packages as `import` names rather than distribution names, because
@@ -109,7 +110,7 @@ test-python-deps: ## Install the third-party imports `make test-python` needs.
 
 test-python: ## Run the Python unit tests outside k8s-operator/.
 	@if [ -z "$(PYTHON_TEST_DIRS)" ]; then \
-		echo "Error: no test_*.py files found under agents/, deploy/docker or scripts/."; \
+		echo "Error: no test_*.py files found under agents/, deploy/docker, runner/ or scripts/."; \
 		echo "Either the tests moved or the globs are stale -- failing rather than reporting success."; \
 		exit 1; \
 	fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -141,7 +141,7 @@ identifier appears, add its source here.
 Not every document describes the same thing. When checking a doc against the
 code, first check which era it belongs to:
 
-- **`docs/architecture/` (01–08 + README) describes the END-STATE target, not
+- **`docs/architecture/` (01–09 + README) describes the END-STATE target, not
   what ships.** Each file carries the banner "Specifies the end state, not
   current behaviour." Do not treat mismatches between these specs and the code
   as doc bugs — the delta is the roadmap (`07-implementation-roadmap.md`).
@@ -292,7 +292,7 @@ only what the title does not say.
 | `examples/litellm-gemini/README.md`               | Example  | LiteLLM proxy configured for Gemini models: secret, manifests, metric verification.                                                                                                                                                                                                                                                            | API-key secret, PodMonitoring                           | Cluster operators                                  |
 | `examples/vllm-gemma/README.md`                   | Example  | Serving Gemma models with vLLM on GPU nodes, based on the official GKE tutorial.                                                                                                                                                                                                                                                               | GPU serving, vLLM metrics                               | Self-hosted inference                              |
 
-### `charts/`, `terraform/`, `k8s-operator/`, and `tests/`
+### `charts/`, `runner/`, `terraform/`, `k8s-operator/`, and `tests/`
 
 | Path                                                | Category         | Purpose and summary                                                                                                                                                                                                 | Key topics                                    | Audience / notes                                                                          |
 | --------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ editing any doc.
 
 ## 1. Directory overview
 
-The repository tracks **203** `.md`/`.mdx` documents outside the root-level
+The repository tracks **205** `.md`/`.mdx` documents outside the root-level
 dot-directories — `docs-check-map` verifies this total against `git ls-files`
 and fails CI when it drifts. Dot-directories at the repository root
 (`.agents/`, `.github/`, `.claude/`) hold tooling — review skills, PR
@@ -47,7 +47,7 @@ kube-agents/
 ├── charts/                                        canonical Helm charts (kube-agents)
 ├── docs/                                          human documentation
 │   ├── README.md                                  this map
-│   ├── architecture/                              END-STATE spec set 01–08 + README
+│   ├── architecture/                              END-STATE spec set 01–09 + README
 │   ├── designs/                                   per-feature design documents
 │   ├── contributing.md, security-requirements.md,
 │   │   credential-isolation-design.md             standalone docs
@@ -57,6 +57,8 @@ kube-agents/
 │                                                  integration READMEs
 ├── k8s-operator/                                  operator, event watcher, Minty,
 │                                                  provisioning-scripts READMEs
+├── runner/                                        the runner contract, its schemas,
+│                                                  and the conformance suite README
 ├── scripts/release/                               Release Candidate automation scripts README
 ├── terraform/                                     companion Terraform modules +
 │                                                  the full-install composition
@@ -216,6 +218,7 @@ row's glob matches. Paths are repository-root-relative.
 | `docs/architecture/06-api-and-data-contracts.md`     | End-state spec    | Exact interfaces to implement: tier-discriminated `Agent` CRD, pre-created read-only identity contract, GitOps repo layout, OKF schema, review-gate contract.                                                | CR shape, cardinality, identity contract, naming conventions                 | End-state; the CR shape is labeled illustrative                               |
 | `docs/architecture/07-implementation-roadmap.md`     | End-state spec    | Phased sequence from the current state (direct-mutation agents, `PlatformAgent` only) to the three read-only personas, with acceptance criteria per phase.                                                   | Delta table, phases, definition of done                                      | End-state; sequencing only                                                    |
 | `docs/architecture/08-agent-runtime-and-identity.md` | End-state spec    | Simplest v1 runtime: a thin controller reconciles the `Agent` CRD into one isolated Hermes pod per agent bound to one pre-created read-only service account.                                                 | Runtime, identity referencing (never minting), deferred hardening            | End-state; deliberately simplicity-over-defense-in-depth                      |
+| `docs/architecture/09-runner-contract.md`            | End-state spec    | The one interface every agent execution goes through: `run(principal, profile, task, workspace, budget)` returning an event stream, plus the schemas, conformance suite, and null runner in `runner/`.       | Request and event schemas, conformance rules, null runner, open questions    | End-state; the null runner is the only conforming implementation today        |
 | `docs/designs/agent-communication.md`                | Feature design    | How the Platform Agent and per-cluster subagents exchange information: a file-based typed handover channel plus optional kanban delegation.                                                                  | Blackboard model, record envelope, `write_handover` tool                     | Design of record; NOT yet implemented (banner in file)                        |
 | `docs/designs/audit-logging-user-attribution.md`     | Feature design    | Closes the gap where audit logs identify the agent SA but not the requesting human, by carrying requester and trace/session IDs through existing telemetry.                                                  | Attribution contract per plane, correlation recipes, trust model             | Draft, P0; per-plane implemented-vs-planned split declared inline             |
 | `docs/designs/fleet-audit-issue-ledger.md`           | Feature design    | Replaces the audit's PR-as-report with one ledger issue per stream plus narrow per-finding remediation PRs; hybrid auto/pull-based gating and a first-class `recommendation` field.                          | Ledger issue, remediation PR lifecycle, promotion gating, migration          | Design of record; implemented (banner in file)                                |
@@ -301,6 +304,7 @@ only what the title does not say.
 | `k8s-operator/scripts/README.md`                    | Component README | **Canonical** description of every provisioning/teardown script and the shared `vars.sh` state model. The step tables are a **generated region** sourced from each script's comment banner.                         | Script inventory, state model                 | Do not hand-edit the tables; `make docs-generate`                                         |
 | `k8s-operator/scripts/dev/README.md`                | Component README | The script automating GCP Workload Identity Federation so GitHub Actions can deploy keylessly.                                                                                                                      | WIF/OIDC CI auth                              | Repo maintainers                                                                          |
 | `k8s-operator/testing/staging_workloads/README.md`  | Component README | Terraform PoC that stamps out multi-cluster GKE staging fleets with realistic workload bundles and traffic simulators.                                                                                              | Cluster maps, workload bundle, load shapes    | Developers building staging fleets                                                        |
+| `runner/README.md`                                  | Component README | The runner contract directory: what each file is, how to run the stdlib-only suite, how to conform a new runner, and the rules for editing the schemas.                                                             | Layout, conformance mixin, editing rules      | Runner developers; `docs/architecture/09-runner-contract.md` is the rationale             |
 | `scripts/release/README.md`                         | Component README | Overview of Release Candidate (RC) pipeline scripts: candidate tag creation (Step 1), environment provisioning (Step 2), GKE readiness & E2E test execution (Step 3), and validated tag promotion (Step 4).         | Release Candidate scripts, RC automation      | CI maintainers and release operators                                                      |
 | `terraform/examples/full-install/README.md`         | Component README | Single-apply root composition of all four modules plus a helm_release of the canonical chart — the IaC counterpart of `./provision.sh`; covers image-tag overrides, Chat/GitHub integration wiring, teardown order. | One-command IaC install, composed values      | Infrastructure engineers                                                                  |
 | `terraform/modules/gke-cluster/README.md`           | Component README | Reusable Terraform module for provisioning a regional GKE Autopilot cluster configured for Kube-Agents workloads.                                                                                                   | GKE Autopilot, Workload Identity, regional    | Infrastructure engineers                                                                  |

--- a/docs/architecture/01-vision-scope.md
+++ b/docs/architecture/01-vision-scope.md
@@ -192,6 +192,6 @@ per-phase acceptance ([07](07-implementation-roadmap.md) §2)._
 ## 8. Verification
 
 The §7 success criteria are the top-level acceptance. Each is made concrete and machine-checkable in
-the relevant spec's **Verification** section (02 §10, 03 §11, 04 §9, 05 §8, 06 §10, 08 §7) and the
-per-phase acceptance + **verification loop** in [07-implementation-roadmap.md](07-implementation-roadmap.md)
+the relevant spec's **Verification** section (02 §10, 03 §11, 04 §9, 05 §8, 06 §10, 08 §7, 09 §7)
+and the per-phase acceptance + **verification loop** in [07-implementation-roadmap.md](07-implementation-roadmap.md)
 §2/§5. A build is "working" only when all of those checks pass.

--- a/docs/architecture/07-implementation-roadmap.md
+++ b/docs/architecture/07-implementation-roadmap.md
@@ -251,8 +251,8 @@ Built end-to-end means all of these pass — the concrete form of [01](01-vision
 ## 5. Verification loop (how the harness iterates to "done")
 
 Every spec carries a **Verification** section of concrete, mostly-runnable checks — 02 §10, 03 §11,
-04 §9, 05 §8, 06 §10, 08 §7 — and every phase in §2 has **acceptance criteria**. Build by phase and,
-after each phase, run:
+04 §9, 05 §8, 06 §10, 08 §7, 09 §7 — and every phase in §2 has **acceptance criteria**. Build by
+phase and, after each phase, run:
 
 1. the **phase acceptance** for the current phase (§2),
 2. the **Verification** checks of every spec whose surface that phase touched, and

--- a/docs/architecture/09-runner-contract.md
+++ b/docs/architecture/09-runner-contract.md
@@ -68,7 +68,7 @@ or how a run is authorised ([03](03-security-model.md)). Those sit on either sid
   long before it is judged good.
 - **Transport.** JSON dicts in, JSON dicts out. Whether they cross a process boundary as SSE, a
   gRPC stream, or newline-delimited JSON is a deployment decision.
-- **Multi-runner scheduling.** Choosing *which* runner serves a request is the control plane's
+- **Multi-runner scheduling.** Choosing _which_ runner serves a request is the control plane's
   problem and is out of scope here.
 
 ## 3. The request
@@ -82,7 +82,7 @@ silently-ignored intent.
 | ------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `contract_version` | const `v1alpha1`                                                         | A runner that meets an unknown version must refuse, not guess (§5).                                                              |
 | `run_id`           | string                                                                   | Correlates every event to its run. Without it no valid event envelope can be built at all.                                       |
-| `principal`        | `subject`, `issuer`, optional `display_name`, `attributes`               | *Who this run is for*, carried explicitly rather than inferred from ambient credentials. The prerequisite for per-user scoping.  |
+| `principal`        | `subject`, `issuer`, optional `display_name`, `attributes`               | _Who this run is for_, carried explicitly rather than inferred from ambient credentials. The prerequisite for per-user scoping.  |
 | `profile`          | `name`, optional `revision`                                              | Which persona and skill set. `revision` lets a run pin what it ran against.                                                      |
 | `task`             | `input`, optional `conversation`, `attachments`                          | The work. `conversation` is the continuity handle for a stateful runner.                                                         |
 | `workspace`        | `mode` (`none` / `read-only` / `read-write`), optional `path`, `lease`   | Filesystem authority stated up front instead of discovered when a write fails.                                                   |
@@ -115,7 +115,7 @@ ceiling you set" apart from "the agent broke".
    silent non-zero exit does not. The contract makes the producer say. The heuristic still exists,
    quarantined in `runner/responses_adapter.py` as `sniff_failure()`, named so no reader mistakes
    it for something the producer reported.
-2. **`arguments` is an object.** On the wire it is a JSON *string*; every consumer therefore
+2. **`arguments` is an object.** On the wire it is a JSON _string_; every consumer therefore
    re-implements the decode, including the failure case.
 3. **`seq` is dense and starts at zero.** Gap-free ordering is checkable; wall-clock timestamps
    from a distributed producer are not.
@@ -163,7 +163,7 @@ interpreter and no install step, and a validator that silently ignores a keyword
 implement would report unenforced schemas as satisfied. Raising is what makes the omission safe —
 the schemas cannot grow a keyword without someone teaching the validator first.
 
-`responses_adapter.py` is **not** the Hermes runner. It translates a *recorded* payload, and it
+`responses_adapter.py` is **not** the Hermes runner. It translates a _recorded_ payload, and it
 earns its place by keeping §4 honest: the claim that the event shapes are modelled on what
 `/v1/responses` already emits is either demonstrated by a working translation or it is an
 assertion.
@@ -176,9 +176,9 @@ assertion.
   runners and asserts each fails **the specific test that names its defect** — plus a control that
   runs the same test names against the conforming null runner, so a typo'd name or a broken dynamic
   subclass cannot make the teeth pass vacuously.
-- The suite's teeth have been confirmed by mutation: weakening
-  `test_run_finished_occurs_exactly_once` to a tautology makes the corresponding teeth-test fail by
-  name.
+- Adding a rule to `conformance.py` means adding a broken runner that the new rule catches. A rule
+  nothing can fail is a comment, and the teeth tests are only as good as their coverage of the
+  suite.
 - `runner/test_schema.py` checks the schemas parse, use only keywords the validator enforces, and
   that the Python constants match the schema (every declared event type has a branch; the terminal
   status set matches the enum).
@@ -203,5 +203,6 @@ strong: **nothing in the shipping path implements this yet.** The Hermes runner 
 implementation of `run()` that this suite is pointed at, with today's build-time patches,
 `sitecustomize` monkey patches, and plugin-API reach-ins collapsed behind it — is a later
 milestone. Until it lands, the honest summary is that kube-agents has a runner contract and one
-null implementation of it, and the Hermes coupling audit under `docs/designs/` still describes how
-agents actually execute.
+null implementation of it, and how agents actually execute is what
+[08](08-agent-runtime-and-identity.md) and the Hermes patch sets under `deploy/docker/patches/`
+describe.

--- a/docs/architecture/09-runner-contract.md
+++ b/docs/architecture/09-runner-contract.md
@@ -1,0 +1,207 @@
+# Design 09: The Runner Contract
+
+**Status:** ✅ Agreed
+
+> **Specifies the end state, not current behaviour.** The contract, its schemas, the null runner
+> and the conformance suite exist today under `runner/`. **No production runner implements it
+> yet** — making Hermes pass the conformance suite is a separate, later milestone, and until it
+> lands the only conforming implementation is the null runner. See [README.md](README.md) for the
+> delta against what ships today.
+
+**Overview:** [README.md](README.md) · **Depends on:** [05](05-system-architecture.md),
+[06](06-api-and-data-contracts.md), [08](08-agent-runtime-and-identity.md) ·
+**Tier:** Buildable (bridging)
+
+---
+
+## TL;DR
+
+Every agent execution in kube-agents goes through **one interface**:
+
+```
+run(principal, profile, task, workspace, budget) -> stream of events
+```
+
+A **runner** is anything that implements it. Hermes becomes the first runner rather than the
+substrate everything else is written against, which is what makes a second runner — a different
+harness, a hosted API, a shell script for a fixture — possible without rewriting the control plane.
+
+The contract is **data, not Python**: two JSON Schemas in `runner/contract/`, a request and an
+event. A runner in another language conforms by being wrapped in a subprocess or HTTP shim, not by
+being ported. The **conformance suite** (`runner/conformance.py`) is a `unittest` mixin over those
+schemas that any candidate runner must pass, and the **null runner** (`runner/null_runner.py`)
+exists to prove the suite is satisfiable and to give the control plane something to test against
+that never talks to a model.
+
+The event vocabulary is deliberately close to what `/v1/responses` already emits — `tool_call`,
+`tool_result`, `message` mirror `function_call`, `function_call_output`, `message` — so the first
+adapter is a translation and not a redesign. Where it departs, it departs on purpose, and §4 says
+where and why.
+
+---
+
+## 1. What this doc decides
+
+The boundary between the **control plane** (what decides a run should happen, who it is for, and
+what it is allowed to spend) and the **execution plane** (what actually runs the agent turn). It
+decides the shape of the request across that boundary, the shape of the event stream back, and the
+rules a runner must obey to be called conformant.
+
+It does **not** decide which harness runs, how a profile is packaged ([08](08-agent-runtime-and-identity.md)),
+or how a run is authorised ([03](03-security-model.md)). Those sit on either side of this line.
+
+## 2. Goals / Non-goals
+
+**Goals**
+
+- One interface for every execution path — chat turn, cron run, delegated sub-task, bench case.
+- A contract expressible on a wire, so the runner need not be in-process or in Python.
+- Enough structure that the control plane can render progress, enforce a budget, and attribute a
+  failure without parsing prose.
+- A conformance suite with teeth: a runner that violates the contract must fail a test that names
+  the violation.
+
+**Non-goals**
+
+- **Answer quality.** A runner that replies "no" to everything conforms, and should. Quality is the
+  bench's job (`bench/`), and the separation is the point: a second runner can be judged conformant
+  long before it is judged good.
+- **Transport.** JSON dicts in, JSON dicts out. Whether they cross a process boundary as SSE, a
+  gRPC stream, or newline-delimited JSON is a deployment decision.
+- **Multi-runner scheduling.** Choosing *which* runner serves a request is the control plane's
+  problem and is out of scope here.
+
+## 3. The request
+
+`runner/contract/run_request.schema.json`. Seven top-level fields, **all required** — an optional
+field here is a field the runner has to guess at, and guessing is what this contract exists to end.
+`additionalProperties: false` throughout, so an unrecognised field is a rejection rather than a
+silently-ignored intent.
+
+| Field              | Shape                                                                    | Why it is in the contract                                                                                                        |
+| ------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `contract_version` | const `v1alpha1`                                                         | A runner that meets an unknown version must refuse, not guess (§5).                                                              |
+| `run_id`           | string                                                                   | Correlates every event to its run. Without it no valid event envelope can be built at all.                                       |
+| `principal`        | `subject`, `issuer`, optional `display_name`, `attributes`               | *Who this run is for*, carried explicitly rather than inferred from ambient credentials. The prerequisite for per-user scoping.  |
+| `profile`          | `name`, optional `revision`                                              | Which persona and skill set. `revision` lets a run pin what it ran against.                                                      |
+| `task`             | `input`, optional `conversation`, `attachments`                          | The work. `conversation` is the continuity handle for a stateful runner.                                                         |
+| `workspace`        | `mode` (`none` / `read-only` / `read-write`), optional `path`, `lease`   | Filesystem authority stated up front instead of discovered when a write fails.                                                   |
+| `budget`           | optional `max_tokens`, `max_tool_calls`, `max_turns`, `deadline_seconds` | The object is required; every limit inside it is optional. A caller must decide it has no limits, rather than omit the question. |
+
+## 4. The event stream
+
+`runner/contract/run_event.schema.json`. A `oneOf` over seven event types, each carrying the same
+envelope: `contract_version`, `run_id`, `seq`, `type`.
+
+| Event          | Carries                                                        |
+| -------------- | -------------------------------------------------------------- |
+| `run.started`  | optional `profile` as the runner resolved it                   |
+| `checklist`    | `items` — the plan, so progress is renderable without guessing |
+| `tool_call`    | `call_id`, `name`, `arguments` (an object, already decoded)    |
+| `tool_result`  | `call_id`, `status` (`completed` / `error`), `output`          |
+| `message`      | `role`, `text`                                                 |
+| `artifact`     | `kind`, `ref`, optional `media_type`, `description`            |
+| `run.finished` | `status`, optional `error`, `usage`                            |
+
+`run.finished.status` is one of `completed`, `failed`, `cancelled`, `budget_exceeded`, `refused`.
+Distinguishing the last three from `failed` is what lets the control plane tell "the agent hit the
+ceiling you set" apart from "the agent broke".
+
+**Where this departs from the Responses shape, and why.**
+
+1. **`tool_result.status` is explicit.** A Responses `function_call_output` carries no status, so
+   today `bench/kube_agents_bench/parsing.py` infers failure by scanning the output text. That
+   heuristic is wrong in both directions — a grep hit containing "error" reads as a failure, a
+   silent non-zero exit does not. The contract makes the producer say. The heuristic still exists,
+   quarantined in `runner/responses_adapter.py` as `sniff_failure()`, named so no reader mistakes
+   it for something the producer reported.
+2. **`arguments` is an object.** On the wire it is a JSON *string*; every consumer therefore
+   re-implements the decode, including the failure case.
+3. **`seq` is dense and starts at zero.** Gap-free ordering is checkable; wall-clock timestamps
+   from a distributed producer are not.
+4. **`checklist` has no Responses equivalent.** Progress is currently reconstructed by pattern-
+   matching tool names. A plan the runner states is not a plan a consumer has to infer.
+
+## 5. The rules a runner must obey
+
+Encoded as tests in `runner/conformance.py`; this section is the prose, that file is the authority.
+
+1. Every event validates against the event schema.
+2. The stream is non-empty; it opens with exactly one `run.started` and closes with exactly one
+   `run.finished`. Nothing follows the terminal event. **Two terminal events tell the control plane
+   two different things about the same run**, so the count is exact, not a minimum.
+3. `seq` is `0, 1, 2, …` with no gaps; every event carries the request's `run_id` and the
+   contract version.
+4. Every `tool_result` answers an earlier `tool_call` with the same `call_id`, and `call_id`s are
+   unique within a run. A result the runner cannot attribute must not be emitted — an orphan is
+   what forces the recovery code this contract removes.
+5. Every event is JSON-serialisable. In every real deployment the stream crosses a process
+   boundary, so an event holding a live object passes in-process and fails on the wire.
+6. A terminal status other than `completed` carries an `error` explaining it. A bare failure is the
+   defect this contract exists to prevent.
+7. An unknown `contract_version` is **refused**, not attempted.
+8. A malformed request is refused, not crashed — and a refused run does no work: no `tool_call` may
+   appear in its stream.
+9. Two runs off one runner instance do not share state. A sequence counter hoisted to instance
+   scope is the easy version of this bug, and it only shows up on the second run.
+10. `run()` is lazy. A runner that returns a fully-materialised list cannot stream progress, and
+    every consumer written against it hangs the first time it meets one that does.
+
+## 6. What exists today
+
+| Path                            | What it is                                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `runner/contract/*.schema.json` | The contract itself. Machine-readable, language-neutral.                                       |
+| `runner/schema.py`              | Constants, validation helpers, a `new_request()` builder.                                      |
+| `runner/jsonschema_mini.py`     | A stdlib validator for exactly the keywords the schemas use — **raises** on any other keyword. |
+| `runner/conformance.py`         | The suite, as a mixin. Pair with `unittest.TestCase` and implement `make_runner()`.            |
+| `runner/null_runner.py`         | Echo and scripted modes. The first conforming runner.                                          |
+| `runner/responses_adapter.py`   | Recorded Responses payload → contract events. Evidence the shapes are derivable, not invented. |
+
+`jsonschema_mini` is a deliberate choice: the suite must run on any machine with a Python 3
+interpreter and no install step, and a validator that silently ignores a keyword it does not
+implement would report unenforced schemas as satisfied. Raising is what makes the omission safe —
+the schemas cannot grow a keyword without someone teaching the validator first.
+
+`responses_adapter.py` is **not** the Hermes runner. It translates a *recorded* payload, and it
+earns its place by keeping §4 honest: the claim that the event shapes are modelled on what
+`/v1/responses` already emits is either demonstrated by a working translation or it is an
+assertion.
+
+## 7. Verification
+
+- `make test-python` runs the suite (`runner/` is in `PYTHON_TEST_DIRS`). The null runner passes
+  the conformance suite in both echo and scripted modes.
+- `runner/test_conformance_null_runner.py::ConformanceSuiteHasTeeth` runs nine deliberately-broken
+  runners and asserts each fails **the specific test that names its defect** — plus a control that
+  runs the same test names against the conforming null runner, so a typo'd name or a broken dynamic
+  subclass cannot make the teeth pass vacuously.
+- The suite's teeth have been confirmed by mutation: weakening
+  `test_run_finished_occurs_exactly_once` to a tautology makes the corresponding teeth-test fail by
+  name.
+- `runner/test_schema.py` checks the schemas parse, use only keywords the validator enforces, and
+  that the Python constants match the schema (every declared event type has a branch; the terminal
+  status set matches the enum).
+
+## 8. Open at v1alpha1
+
+1. **Cancellation** has a terminal status but no inbound channel. A runner cannot currently be told
+   to stop; it can only report that it did.
+2. **Budget enforcement is unlocated.** The contract carries the numbers and a
+   `budget_exceeded` status, but does not say whether the runner or the control plane counts.
+3. **`workspace.lease`** is a string with no lifecycle attached — reserved for the leasing model,
+   not yet spent.
+4. **Nested runs.** Delegation is a `tool_call` today. Whether a sub-run gets its own `run_id` and
+   stream, or stays opaque inside the parent's tool result, is undecided.
+5. **`artifact.ref`** is unqualified. Whether it is a workspace-relative path, a URI, or a content
+   hash is left to the first real producer.
+
+## 9. Hermes conformance is not part of this
+
+Stated plainly because the temptation to read a contract as a description of the running system is
+strong: **nothing in the shipping path implements this yet.** The Hermes runner — a real
+implementation of `run()` that this suite is pointed at, with today's build-time patches,
+`sitecustomize` monkey patches, and plugin-API reach-ins collapsed behind it — is a later
+milestone. Until it lands, the honest summary is that kube-agents has a runner contract and one
+null implementation of it, and the Hermes coupling audit under `docs/designs/` still describes how
+agents actually execute.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -46,10 +46,10 @@ The security model (03) makes these enforceable; the roadmap (07) proves them wi
 
 ## The design set
 
-Two tiers, meant to be read in order **01 → 08**:
+Two tiers, meant to be read in order **01 → 09**:
 
 - **Foundational (north star) — 01–04:** _what_ we are building and _why_.
-- **Buildable (bridging) — 05–08:** _how_ it is assembled.
+- **Buildable (bridging) — 05–09:** _how_ it is assembled.
 
 | #   | Document                                                       | Covers                                                                                                                                                                                                                                           |
 | --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -62,6 +62,7 @@ Two tiers, meant to be read in order **01 → 08**:
 | 06  | [API & data contracts](06-api-and-data-contracts.md)           | The per-persona `Agent` CRD, the pre-created read-only identity contract, GitOps repo layout & IaC conventions (KCC or Terraform via customer CI/CD), OKF schema, the ChatOps routing contract, the review-gate contract, MCP tool changes       |
 | 07  | [Implementation roadmap](07-implementation-roadmap.md)         | The phased build (current → end state), per-phase acceptance criteria, the verification loop, the definition of done, and risks                                                                                                                  |
 | 08  | [Agent runtime & identity](08-agent-runtime-and-identity.md)   | The thin kube-agents controller (the extended `k8s-operator/`) reconciling each `Agent` CR (Hermes harness) into an isolated pod with a per-pod read-only Workload-Identity SA, on Scion's per-pod model; what is deferred as hardening, and why |
+| 09  | [The runner contract](09-runner-contract.md)                   | The one interface every agent execution goes through — request and event-stream schemas, the rules a runner must obey, the conformance suite and null runner, and why Hermes conformance is a later milestone                                    |
 
 Each document opens with a **TL;DR** and carries a **Goals / Non-goals** section and a
 **Verification** section of concrete, mostly-runnable checks.
@@ -72,15 +73,16 @@ Each document opens with a **TL;DR** and carries a **Goals / Non-goals** section
 
 To build kube-agents end-to-end from this design set:
 
-1. **Read 01 → 08 in order.** 01–04 give the intent and the invariants above; 05 the system to
-   assemble; 06 the exact contracts; 07 the build sequence; 08 the runtime and identity model.
+1. **Read 01 → 09 in order.** 01–04 give the intent and the invariants above; 05 the system to
+   assemble; 06 the exact contracts; 07 the build sequence; 08 the runtime and identity model; 09
+   the interface every agent execution goes through.
 2. **Build by phase, verify, iterate.** Follow [07](07-implementation-roadmap.md) §2. After each
    phase, run its **acceptance criteria** _and_ the **Verification** checks of every spec the phase
-   touched (02 §10, 03 §11, 04 §9, 05 §8, 06 §10, 08 §7). Do not advance a phase — or open the final
+   touched (02 §10, 03 §11, 04 §9, 05 §8, 06 §10, 08 §7, 09 §7). Do not advance a phase — or open the final
    PR — until its checks pass. The verification loop is defined in
    [07](07-implementation-roadmap.md) §5.
 3. **Decisions are already made — don't re-litigate.** Every decision is stated in its home spec
-   (01–06 and 08). If you hit something genuinely unspecified, pick the simplest option consistent
+   (01–06, 08 and 09). If you hit something genuinely unspecified, pick the simplest option consistent
    with the invariants, implement it, and flag it in your PR.
 4. **Honor the invariants even when they contradict current code** (the code is mid-migration). They
    are listed above and detailed in [03](03-security-model.md).

--- a/runner/README.md
+++ b/runner/README.md
@@ -1,0 +1,58 @@
+# `runner/` — the runner contract
+
+One interface for every agent execution:
+
+```
+run(principal, profile, task, workspace, budget) -> stream of events
+```
+
+The design rationale, the field-by-field breakdown, and the open questions live in
+[`docs/architecture/09-runner-contract.md`](../docs/architecture/09-runner-contract.md). This file
+is the short version for someone about to edit this directory.
+
+**No production runner implements the contract yet.** The null runner is the only conforming
+implementation; pointing the suite at Hermes is a later milestone.
+
+## Layout
+
+| File                               | What it is                                                                                      |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `contract/run_request.schema.json` | The request. Seven required top-level fields, `additionalProperties: false`.                    |
+| `contract/run_event.schema.json`   | A `oneOf` over seven event types sharing one envelope.                                          |
+| `schema.py`                        | Constants, `request_errors` / `event_errors`, `check_*` raisers, a `new_request()` builder.     |
+| `jsonschema_mini.py`               | Stdlib validator for the keywords the schemas use. Raises on any keyword it does not implement. |
+| `conformance.py`                   | The suite, as a mixin.                                                                          |
+| `null_runner.py`                   | Echo and scripted modes.                                                                        |
+| `responses_adapter.py`             | Recorded `/v1/responses` payload → contract events.                                             |
+
+## Running the tests
+
+`make test-python` from the repository root, or from here:
+
+```bash
+python3 -m unittest discover -p "test_*.py"
+```
+
+Stdlib only — no install step, and deliberately so.
+
+## Conforming a new runner
+
+```python
+class MyRunnerConformance(RunnerConformanceTests, unittest.TestCase):
+    def make_runner(self):
+        return MyRunner()
+```
+
+The suite speaks plain JSON dicts, so a runner in another language conforms by being wrapped in a
+subprocess or HTTP shim rather than rewritten in Python.
+
+## Editing here
+
+- **Changing a schema means changing `contract_version`.** The current version is `v1alpha1`, and a
+  runner meeting a version it does not know must refuse rather than guess — so a silent shape change
+  is the one failure mode the contract cannot detect.
+- **A new schema keyword needs `jsonschema_mini.py` taught first.** It raises rather than ignoring,
+  which is what keeps "validated" from meaning "partly validated".
+- **A new contract rule is a new test in `conformance.py`, plus a broken runner in
+  `test_conformance_null_runner.py::ConformanceSuiteHasTeeth` that the new test catches.** A rule
+  nothing can fail is a comment.

--- a/runner/conformance.py
+++ b/runner/conformance.py
@@ -1,0 +1,177 @@
+"""The conformance suite every runner must pass.
+
+Subclass ``RunnerConformanceTests`` alongside ``unittest.TestCase`` and
+implement ``make_runner()``. The suite is transport-agnostic and speaks plain
+JSON dicts, so a runner in another language passes by being wrapped in a
+subprocess or HTTP shim rather than by being rewritten in Python.
+
+What the suite deliberately does not test: anything about the *content* of a
+run. A runner that answers every question with "no" passes, and should -- the
+contract is about the shape of the exchange. Answer quality is the bench's job
+(``bench/``), and that separation is the point: a second runner can be judged
+conformant long before it is judged good.
+
+Hermes does not run this suite yet. Making it pass is M4.1, and until then the
+contract's only conforming implementation is the null runner.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import schema
+
+
+class RunnerConformanceTests:
+    """Mixin of contract requirements. Pair with ``unittest.TestCase``."""
+
+    # ---- what a subclass provides ------------------------------------------
+
+    def make_runner(self) -> Any:
+        """Return an object with ``run(request) -> iterable of event dicts``."""
+        raise NotImplementedError
+
+    def make_request(self, **overrides: Any) -> dict[str, Any]:
+        """A valid request. Override to pin a profile the runner can resolve."""
+        request = schema.new_request(
+            run_id="conformance-run",
+            subject="user:conformance@example.com",
+            issuer="system",
+            profile="default",
+            input_text="Reply with anything.",
+        )
+        request.update(overrides)
+        return request
+
+    # ---- helpers -----------------------------------------------------------
+
+    def collect(self, request: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        request = self.make_request() if request is None else request
+        return list(self.make_runner().run(request))
+
+    # ---- the contract ------------------------------------------------------
+
+    def test_every_event_validates_against_the_schema(self) -> None:
+        for event in self.collect():
+            errors = schema.event_errors(event)
+            self.assertEqual([], errors, f"event {event!r} violates the schema")
+
+    def test_the_stream_is_not_empty(self) -> None:
+        self.assertTrue(self.collect(), "a runner must always account for a run it accepted")
+
+    def test_the_first_event_is_run_started(self) -> None:
+        self.assertEqual(schema.RUN_STARTED, self.collect()[0]["type"])
+
+    def test_run_started_occurs_exactly_once(self) -> None:
+        types = [event["type"] for event in self.collect()]
+        self.assertEqual(1, types.count(schema.RUN_STARTED))
+
+    def test_the_last_event_is_run_finished(self) -> None:
+        self.assertEqual(schema.RUN_FINISHED, self.collect()[-1]["type"])
+
+    def test_run_finished_occurs_exactly_once(self) -> None:
+        # A run that reports a terminal state twice has told the control plane
+        # two different things about the same run.
+        types = [event["type"] for event in self.collect()]
+        self.assertEqual(1, types.count(schema.RUN_FINISHED))
+
+    def test_no_events_follow_run_finished(self) -> None:
+        types = [event["type"] for event in self.collect()]
+        self.assertEqual(len(types) - 1, types.index(schema.RUN_FINISHED))
+
+    def test_seq_starts_at_zero_and_increments_by_one(self) -> None:
+        seqs = [event["seq"] for event in self.collect()]
+        self.assertEqual(list(range(len(seqs))), seqs)
+
+    def test_every_event_carries_the_requests_run_id(self) -> None:
+        request = self.make_request(run_id="a-distinctive-run-id")
+        for event in self.collect(request):
+            self.assertEqual("a-distinctive-run-id", event["run_id"])
+
+    def test_every_event_declares_the_contract_version(self) -> None:
+        for event in self.collect():
+            self.assertEqual(schema.CONTRACT_VERSION, event["contract_version"])
+
+    def test_every_tool_result_answers_an_earlier_tool_call(self) -> None:
+        """An unmatched result is the shape parsing.py has to call an orphan.
+
+        The contract removes the need for that recovery: a runner that cannot
+        attribute a result must not emit one.
+        """
+        open_calls: set[str] = set()
+        for event in self.collect():
+            if event["type"] == schema.TOOL_CALL:
+                self.assertNotIn(
+                    event["call_id"], open_calls, "call_id reused before its result arrived"
+                )
+                open_calls.add(event["call_id"])
+            elif event["type"] == schema.TOOL_RESULT:
+                self.assertIn(
+                    event["call_id"],
+                    open_calls,
+                    "tool_result with no preceding tool_call of that call_id",
+                )
+                open_calls.discard(event["call_id"])
+
+    def test_call_ids_are_unique_within_a_run(self) -> None:
+        ids = [e["call_id"] for e in self.collect() if e["type"] == schema.TOOL_CALL]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_every_event_is_json_serialisable(self) -> None:
+        # The stream crosses a process boundary in every real deployment, so an
+        # event holding a live object passes in-process and fails on the wire.
+        for event in self.collect():
+            round_tripped = json.loads(json.dumps(event))
+            self.assertEqual(event, round_tripped)
+
+    def test_a_failure_status_carries_an_explanation(self) -> None:
+        final = self.collect()[-1]
+        if final["status"] != "completed":
+            self.assertTrue(
+                final.get("error", "").strip(),
+                "a non-completed run must say why; a bare terminal event is the defect "
+                "this contract exists to prevent",
+            )
+
+    def test_an_unknown_contract_version_is_refused_not_guessed(self) -> None:
+        request = self.make_request(contract_version="v9-from-the-future")
+        events = self.collect(request)
+        self.assertEqual(schema.RUN_FINISHED, events[-1]["type"])
+        self.assertEqual("refused", events[-1]["status"])
+
+    def test_a_malformed_request_is_refused_not_crashed(self) -> None:
+        request = self.make_request()
+        del request["principal"]
+        events = self.collect(request)
+        self.assertEqual("refused", events[-1]["status"])
+
+    def test_a_refused_run_does_no_work(self) -> None:
+        request = self.make_request()
+        del request["principal"]
+        types = [event["type"] for event in self.collect(request)]
+        self.assertNotIn(schema.TOOL_CALL, types, "a refused request must not reach the tool plane")
+
+    def test_the_run_is_repeatable_without_cross_contamination(self) -> None:
+        """Two runs off one runner instance must not share sequence state.
+
+        A counter hoisted to instance scope is the easy version of this bug, and
+        it only shows up on the second run.
+        """
+        runner = self.make_runner()
+        first = [e["seq"] for e in runner.run(self.make_request())]
+        second = [e["seq"] for e in runner.run(self.make_request())]
+        self.assertEqual(first, second)
+
+    def test_the_stream_is_lazy(self) -> None:
+        """Calling run() must not do the whole run.
+
+        A runner that returns a fully-built list cannot stream progress, and a
+        consumer written against it will hang the first time it meets one that
+        does stream.
+        """
+        stream = self.make_runner().run(self.make_request())
+        self.assertFalse(
+            isinstance(stream, (list, tuple)),
+            "run() must return an iterator, not a materialised sequence",
+        )

--- a/runner/contract/run_event.schema.json
+++ b/runner/contract/run_event.schema.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kubeagents.x-k8s.io/schemas/runner/v1alpha1/run-event.json",
+  "title": "RunEvent",
+  "description": "One event from Runner.run(). Every event repeats the same four-field envelope (contract_version, run_id, seq, type) so a consumer can route without knowing the variant. The tool_call / tool_result / message shapes deliberately mirror the function_call / function_call_output / message items of a Responses-style payload, which is what bench/kube_agents_bench/parsing.py already reads.",
+  "oneOf": [
+    {
+      "title": "run.started",
+      "description": "Exactly one, first. A stream that emits anything before this is malformed.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "run.started" },
+        "profile": {
+          "description": "The resolved profile name. Echoed so a recorded stream is interpretable without its request.",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "checklist",
+      "description": "The run's plan, whole, each time it changes. Not a delta: the latest checklist event supersedes every earlier one, so a consumer that joins late is never wrong.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "items"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "checklist" },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "title", "status"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "title": { "type": "string", "minLength": 1 },
+              "status": { "enum": ["pending", "active", "done", "skipped", "failed"] }
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "tool_call",
+      "description": "Mirrors a Responses function_call item.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "call_id", "name", "arguments"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "tool_call" },
+        "call_id": {
+          "description": "Unique within the run. The tool_result that answers this call repeats it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "arguments": {
+          "description": "Decoded arguments. A Responses payload carries these as a JSON string; the runner decodes before emitting, so a consumer never parses twice.",
+          "type": "object"
+        }
+      }
+    },
+    {
+      "title": "tool_result",
+      "description": "Mirrors a Responses function_call_output item. Carries an explicit status, which the Responses shape does not: parsing.py has to sniff failure out of the output text, and a contract should not require that.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "call_id", "status", "output"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "tool_result" },
+        "call_id": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["completed", "error"] },
+        "output": {
+          "description": "Flattened result text. Structured results are JSON-encoded into it, matching what parsing.py reads today.",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "message",
+      "description": "Assistant prose. Mirrors a Responses message item whose content blocks are output_text, already flattened.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "role", "text"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "message" },
+        "role": { "const": "assistant" },
+        "text": { "type": "string" }
+      }
+    },
+    {
+      "title": "artifact",
+      "description": "Something durable the run produced. A reference, never bytes: the event stream is not a file transport.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "kind", "ref"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "artifact" },
+        "kind": {
+          "description": "'file' means ref is a path inside the request's workspace; 'url' means ref is an absolute URL.",
+          "enum": ["file", "url"]
+        },
+        "ref": { "type": "string", "minLength": 1 },
+        "media_type": { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+    {
+      "title": "run.finished",
+      "description": "Exactly one, last. A stream that ends without it is a failed run, not an empty one -- which is the distinction the kanban_guardrail_exit patch exists to restore inside Hermes.",
+      "type": "object",
+      "required": ["contract_version", "run_id", "seq", "type", "status"],
+      "additionalProperties": false,
+      "properties": {
+        "contract_version": { "const": "v1alpha1" },
+        "run_id": { "type": "string", "minLength": 1 },
+        "seq": { "type": "integer", "minimum": 0 },
+        "type": { "const": "run.finished" },
+        "status": {
+          "description": "'refused' is for a request the runner declined before doing any work (unknown contract_version, unresolvable profile, a budget it will not accept). 'budget_exceeded' is for one it started and stopped.",
+          "enum": ["completed", "failed", "cancelled", "budget_exceeded", "refused"]
+        },
+        "error": {
+          "description": "Required in spirit whenever status is not 'completed': a terminal event with no explanation is the failure mode this contract is trying to remove.",
+          "type": "string"
+        },
+        "usage": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "input_tokens": { "type": "integer", "minimum": 0 },
+            "output_tokens": { "type": "integer", "minimum": 0 },
+            "total_tokens": { "type": "integer", "minimum": 0 },
+            "tool_calls": { "type": "integer", "minimum": 0 }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/runner/contract/run_request.schema.json
+++ b/runner/contract/run_request.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kubeagents.x-k8s.io/schemas/runner/v1alpha1/run-request.json",
+  "title": "RunRequest",
+  "description": "The single argument to Runner.run(). Five fields, each answering a question the control plane must not leave to the runner: who is asking (principal), what persona answers (profile), what is being asked (task), what it may touch (workspace), and what it may spend (budget).",
+  "type": "object",
+  "required": ["contract_version", "run_id", "principal", "profile", "task", "workspace", "budget"],
+  "additionalProperties": false,
+  "properties": {
+    "contract_version": {
+      "description": "The contract revision this request is written against. A runner that does not recognise the value must refuse the run rather than guess.",
+      "const": "v1alpha1"
+    },
+    "run_id": {
+      "description": "Control-plane-assigned identifier, unique per run. Every event the run emits repeats it, so events from concurrent runs can share a transport.",
+      "type": "string",
+      "minLength": 1
+    },
+    "principal": {
+      "description": "Who the run acts for. Never inferred by the runner from the task text.",
+      "type": "object",
+      "required": ["subject", "issuer"],
+      "additionalProperties": false,
+      "properties": {
+        "subject": {
+          "description": "Stable identifier of the requesting human or system, opaque to the runner.",
+          "type": "string",
+          "minLength": 1
+        },
+        "issuer": {
+          "description": "Which authority vouched for the subject: a chat platform, an OIDC issuer, or 'system' for control-plane-initiated runs.",
+          "type": "string",
+          "minLength": 1
+        },
+        "display_name": {
+          "description": "Human-readable name, for prose only. Never an authorization input.",
+          "type": "string"
+        },
+        "attributes": {
+          "description": "Issuer-specific claims the tool plane may consult (groups, tenant). Opaque to the runner, which must forward rather than interpret them.",
+          "type": "object"
+        }
+      }
+    },
+    "profile": {
+      "description": "Which persona answers. A reference, not the persona itself: the runner resolves it, so profile content is never on the wire.",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "revision": {
+          "description": "Pins a specific version of the profile. Omitted means whatever the runner currently has, which is only acceptable for interactive runs.",
+          "type": "string"
+        }
+      }
+    },
+    "task": {
+      "description": "What is being asked.",
+      "type": "object",
+      "required": ["input"],
+      "additionalProperties": false,
+      "properties": {
+        "input": {
+          "description": "The instruction text. Maps to the 'input' field of a /v1/responses request.",
+          "type": "string"
+        },
+        "conversation": {
+          "description": "Opaque prior-context handle. Two requests carrying the same value continue one conversation; omitted means a fresh one. The control plane owns the value, so a runner may not invent one.",
+          "type": "string"
+        },
+        "attachments": {
+          "description": "Workspace-relative paths the task refers to. Paths, never bytes.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "workspace": {
+      "description": "What the run may touch on disk.",
+      "type": "object",
+      "required": ["mode"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "description": "'none' denies filesystem work outright; 'read-only' permits reads; 'read-write' permits writes inside path and nowhere else.",
+          "enum": ["none", "read-only", "read-write"]
+        },
+        "path": {
+          "description": "Absolute path of the run's private tree. Required unless mode is 'none'; a runner must reject a request that omits it otherwise.",
+          "type": "string",
+          "minLength": 1
+        },
+        "lease": {
+          "description": "Identifier of the lease that granted the path, for the reaper to match against. See docs/designs/gitops-workspace-leases.md.",
+          "type": "string"
+        }
+      }
+    },
+    "budget": {
+      "description": "What the run may spend. An empty object means the control plane set no ceiling, which a runner may still refuse.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "max_tokens": {
+          "description": "Total model tokens across the run, input and output.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_tool_calls": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_turns": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "deadline_seconds": {
+          "description": "Wall-clock ceiling measured from the first event.",
+          "type": "number",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/runner/jsonschema_mini.py
+++ b/runner/jsonschema_mini.py
@@ -1,0 +1,143 @@
+"""A JSON Schema validator covering exactly the keywords `runner/contract/` uses.
+
+Why not `jsonschema`: the conformance suite has to run wherever `make test-python`
+runs, and every third-party import in that suite is one more way for a
+contributor's first test run to fail for a reason that has nothing to do with
+their change. The two schemas here are small and deliberately written against a
+small keyword set, so a validator for that set is cheaper than a dependency.
+
+The one property that makes this safe: an unrecognised keyword **raises**. A
+validator that silently ignores what it does not understand reports success on a
+schema it never checked, which is worse than having no validator -- the schema
+would look enforced while enforcing nothing. If a schema starts using `$ref`,
+`allOf`, or `patternProperties`, this file must grow first and the failure says
+so by name.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Keywords that carry no constraint. Listed rather than pattern-matched on a
+# leading "$" so that a genuine "$ref" cannot slip through as an annotation.
+_ANNOTATIONS = frozenset(
+    {"$schema", "$id", "$comment", "title", "description", "examples", "default"}
+)
+
+_CONSTRAINTS = frozenset(
+    {
+        "type",
+        "enum",
+        "const",
+        "required",
+        "properties",
+        "additionalProperties",
+        "items",
+        "oneOf",
+        "minimum",
+        "minLength",
+        "minItems",
+    }
+)
+
+_TYPES: dict[str, Any] = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "boolean": bool,
+    "null": type(None),
+}
+
+
+class UnsupportedSchemaError(Exception):
+    """A schema used a keyword this validator does not implement."""
+
+
+def _type_matches(value: Any, expected: str) -> bool:
+    # bool is a subclass of int in Python and is not a JSON number, so the
+    # numeric branches exclude it explicitly. Without that, `true` validates
+    # against {"type": "integer"}.
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    known = _TYPES.get(expected)
+    if known is None:
+        raise UnsupportedSchemaError(f"unknown type name {expected!r}")
+    return isinstance(value, known)
+
+
+def validate(instance: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    """Return every way ``instance`` violates ``schema``; empty means valid.
+
+    Errors accumulate rather than short-circuit, because a conformance failure
+    is more useful as "these four fields are wrong" than as the first one.
+    """
+    unknown = set(schema) - _ANNOTATIONS - _CONSTRAINTS
+    if unknown:
+        raise UnsupportedSchemaError(
+            f"{path}: schema uses unimplemented keyword(s) {sorted(unknown)}. "
+            "Add support to runner/jsonschema_mini.py before using them."
+        )
+
+    errors: list[str] = []
+
+    if "oneOf" in schema:
+        branches = schema["oneOf"]
+        matched = [b for b in branches if not validate(instance, b, path)]
+        if len(matched) != 1:
+            titles = [b.get("title", "<untitled>") for b in branches]
+            errors.append(
+                f"{path}: matched {len(matched)} of {len(branches)} oneOf branches "
+                f"(expected exactly 1); branches are {titles}"
+            )
+        # A oneOf schema in these files carries nothing beside oneOf, and
+        # reporting a failed branch's inner errors here would be noise: the
+        # instance is not meant to satisfy the other six.
+        return errors
+
+    if "const" in schema and instance != schema["const"]:
+        errors.append(f"{path}: expected {schema['const']!r}, got {instance!r}")
+
+    if "enum" in schema and instance not in schema["enum"]:
+        errors.append(f"{path}: {instance!r} is not one of {schema['enum']}")
+
+    if "type" in schema:
+        expected = schema["type"]
+        names = expected if isinstance(expected, list) else [expected]
+        if not any(_type_matches(instance, name) for name in names):
+            got = type(instance).__name__
+            errors.append(f"{path}: expected type {expected!r}, got {got}")
+            # Every remaining keyword assumes the type held, so stop here rather
+            # than emit a cascade of consequences of the one real error.
+            return errors
+
+    if isinstance(instance, dict):
+        for name in schema.get("required", []):
+            if name not in instance:
+                errors.append(f"{path}: missing required property {name!r}")
+        properties = schema.get("properties", {})
+        for name, value in instance.items():
+            if name in properties:
+                errors.extend(validate(value, properties[name], f"{path}.{name}"))
+            elif schema.get("additionalProperties") is False:
+                errors.append(f"{path}: unexpected property {name!r}")
+
+    if isinstance(instance, list):
+        if "items" in schema:
+            for index, value in enumerate(instance):
+                errors.extend(validate(value, schema["items"], f"{path}[{index}]"))
+        if "minItems" in schema and len(instance) < schema["minItems"]:
+            errors.append(f"{path}: needs at least {schema['minItems']} item(s)")
+
+    if isinstance(instance, str) and "minLength" in schema:
+        if len(instance) < schema["minLength"]:
+            errors.append(f"{path}: shorter than minLength {schema['minLength']}")
+
+    if "minimum" in schema and isinstance(instance, (int, float)):
+        if not isinstance(instance, bool) and instance < schema["minimum"]:
+            errors.append(f"{path}: {instance} is below minimum {schema['minimum']}")
+
+    return errors

--- a/runner/null_runner.py
+++ b/runner/null_runner.py
@@ -1,0 +1,110 @@
+"""A runner that does no work, so the contract can be tested without a model.
+
+Two jobs. It is the reference implementation -- the shortest thing that passes
+the conformance suite, which is what makes the suite's difficulty honest. And it
+is a fixture generator: `scripted()` replays a canned sequence, so a consumer of
+the event stream (a dispatcher, a chat gateway, a bench client) can be tested
+against a run that is deterministic and does not need a cluster.
+
+It is not a mock in the usual sense. It validates its input and refuses bad
+requests exactly as a real runner must, because "the null runner accepted it"
+should mean the request was well formed.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any, Iterable, Iterator
+
+import schema
+
+
+class NullRunner:
+    """Emits a deterministic, contract-valid stream for any valid request."""
+
+    def __init__(self, script: Iterable[dict[str, Any]] | None = None) -> None:
+        """``script`` is a sequence of partial events -- type and its own
+        fields, with the envelope left off. ``run()`` stamps
+        ``contract_version``, ``run_id`` and ``seq`` onto each. Omit it for the
+        default echo behaviour.
+        """
+        self._script = list(script) if script is not None else None
+
+    @classmethod
+    def scripted(cls, *events: dict[str, Any]) -> NullRunner:
+        """``NullRunner.scripted({"type": "message", ...}, ...)``."""
+        return cls(events)
+
+    def run(self, request: dict[str, Any]) -> Iterator[dict[str, Any]]:
+        """The contract's single method: a request in, an event stream out.
+
+        Lazy on purpose. A runner that builds the whole stream before yielding
+        cannot report progress, and a consumer written against an eager stub
+        would deadlock against a real one.
+        """
+        run_id = request.get("run_id") if isinstance(request, dict) else None
+        if not isinstance(run_id, str) or not run_id:
+            # No envelope can be built without it, so there is no valid stream
+            # in which to report the problem.
+            raise ValueError("request has no usable 'run_id'; cannot emit a contract-valid stream")
+
+        counter = itertools.count()
+
+        def emit(body: dict[str, Any]) -> dict[str, Any]:
+            event = {
+                "contract_version": schema.CONTRACT_VERSION,
+                "run_id": run_id,
+                "seq": next(counter),
+                **body,
+            }
+            # Self-check rather than trust: the reference implementation
+            # emitting an invalid event would make every conformance run a
+            # false negative somewhere else.
+            schema.check_event(event)
+            return event
+
+        errors = schema.request_errors(request)
+        if errors:
+            yield emit({"type": schema.RUN_STARTED})
+            yield emit(
+                {
+                    "type": schema.RUN_FINISHED,
+                    "status": "refused",
+                    "error": "invalid RunRequest: " + "; ".join(errors),
+                }
+            )
+            return
+
+        yield emit({"type": schema.RUN_STARTED, "profile": request["profile"]["name"]})
+
+        if self._script is not None:
+            saw_terminal = False
+            for body in self._script:
+                if body.get("type") == schema.RUN_STARTED:
+                    raise ValueError("a script must not contain its own run.started event")
+                saw_terminal = body.get("type") == schema.RUN_FINISHED
+                yield emit(dict(body))
+            if not saw_terminal:
+                yield emit({"type": schema.RUN_FINISHED, "status": "completed"})
+            return
+
+        yield emit(
+            {
+                "type": schema.CHECKLIST,
+                "items": [{"id": "echo", "title": "Echo the task input", "status": "active"}],
+            }
+        )
+        yield emit({"type": schema.MESSAGE, "role": "assistant", "text": request["task"]["input"]})
+        yield emit(
+            {
+                "type": schema.CHECKLIST,
+                "items": [{"id": "echo", "title": "Echo the task input", "status": "done"}],
+            }
+        )
+        yield emit(
+            {
+                "type": schema.RUN_FINISHED,
+                "status": "completed",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "tool_calls": 0},
+            }
+        )

--- a/runner/responses_adapter.py
+++ b/runner/responses_adapter.py
@@ -1,0 +1,215 @@
+"""Translate a Responses-style payload into a contract event stream.
+
+This is not M4.1. Making Hermes pass the conformance suite is a separate
+milestone with a live runner behind it. What this module does is keep the
+contract honest at design time: the event shapes claim to be modelled on what
+`/v1/responses` already emits, and a translator that runs over a recorded
+payload is the difference between that being true and it being asserted.
+
+It is also where the legacy sniffing goes to be quarantined. A Responses
+``function_call_output`` carries no status, so ``bench/kube_agents_bench/parsing.py``
+has to infer failure from the output text. The contract's ``tool_result`` has an
+explicit ``status`` precisely so nothing downstream repeats that guess -- and the
+guess has to live somewhere until the producer is fixed, so it lives here, at the
+boundary, with a name that says what it is.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Iterator
+
+import schema
+
+_TOOL_ERROR_PREFIX = "Error executing tool"
+
+# The producer replaces a re-emitted output with this notice when an identical
+# one appears later in the same payload. Emitting it as a tool_result would
+# publish the placeholder as though it were the tool's answer.
+_ELIDED_OUTPUT = re.compile(r"^\[Duplicate tool output\b.*\]$", re.DOTALL)
+
+
+def _flatten_output(output: Any) -> str:
+    """Collapse a ``function_call_output.output`` to text.
+
+    Streaming and non-streaming builders wrap the same payload differently, so
+    both the bare string and the list-of-blocks shape are accepted.
+    """
+    if isinstance(output, str):
+        return output
+    if output is None:
+        return ""
+    if isinstance(output, list):
+        parts = []
+        for block in output:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return "".join(parts)
+    return json.dumps(output, default=str)
+
+
+def _flatten_message(item: dict[str, Any]) -> str:
+    content = item.get("content")
+    if not isinstance(content, list):
+        return ""
+    return "".join(
+        block["text"]
+        for block in content
+        if isinstance(block, dict)
+        and block.get("type") == "output_text"
+        and isinstance(block.get("text"), str)
+    )
+
+
+def _decode_arguments(raw: Any) -> dict[str, Any]:
+    """``function_call.arguments`` is a JSON *string* on the wire."""
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return {"raw": raw}
+    if isinstance(raw, dict):
+        return raw
+    return {} if raw is None else {"raw": raw}
+
+
+def sniff_failure(text: str) -> bool:
+    """Guess whether a status-less tool output represents a failure.
+
+    Deliberately conservative: free text is never scanned for the word "error",
+    because tool output legitimately contains it (a grep hit, a test log). Only
+    the structured shapes count.
+
+    Named ``sniff_`` so no reader mistakes it for a fact the producer reported.
+    A conforming runner sets ``status`` and never calls this.
+    """
+    if text.startswith(_TOOL_ERROR_PREFIX):
+        return True
+    try:
+        data = json.loads(text.strip())
+    except ValueError:
+        return False
+    if not isinstance(data, dict):
+        return False
+    if data.get("success") is False or data.get("ok") is False:
+        return True
+    exit_code = data.get("exit_code", data.get("returncode"))
+    if isinstance(exit_code, int) and exit_code != 0:
+        return True
+    # An error reported beside a real payload is a diagnostic, not a failure.
+    return bool(data.get("error")) and not (
+        data.get("content") or data.get("result") or data.get("structuredContent")
+    )
+
+
+def events_from_responses(
+    payload: dict[str, Any],
+    *,
+    run_id: str,
+    profile: str | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield contract events for one Responses payload.
+
+    Three things the translation has to handle, all of them consequences of the
+    endpoint being stateful and replaying earlier turns:
+
+    - A ``function_call`` repeating a ``call_id`` already seen is a replay, not
+      a second call, and is dropped -- emitting it would break the contract's
+      uniqueness requirement and read downstream as a tool loop.
+    - A ``function_call_output`` whose ``call_id`` matches no call in this
+      payload cannot be attributed, and the contract forbids an unattributable
+      ``tool_result``. It is dropped rather than orphaned.
+    - An elided duplicate output is dropped, leaving its call unanswered, which
+      is the truth: this payload does not carry that result.
+    """
+    seq = 0
+
+    def emit(body: dict[str, Any]) -> dict[str, Any]:
+        nonlocal seq
+        event = {
+            "contract_version": schema.CONTRACT_VERSION,
+            "run_id": run_id,
+            "seq": seq,
+            **body,
+        }
+        seq += 1
+        return event
+
+    started: dict[str, Any] = {"type": schema.RUN_STARTED}
+    if profile is not None:
+        started["profile"] = profile
+    yield emit(started)
+
+    items = payload.get("output")
+    items = items if isinstance(items, list) else []
+    seen_calls: set[str] = set()
+    answered: set[str] = set()
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        kind = item.get("type")
+
+        if kind == "message" and item.get("role") == "assistant":
+            text = _flatten_message(item)
+            if text:
+                yield emit({"type": schema.MESSAGE, "role": "assistant", "text": text})
+
+        elif kind == "function_call":
+            call_id = item.get("call_id")
+            if not call_id:
+                # The contract requires a correlatable id and the payload has
+                # none to offer, so this call cannot be represented.
+                continue
+            call_id = str(call_id)
+            if call_id in seen_calls:
+                continue
+            seen_calls.add(call_id)
+            yield emit(
+                {
+                    "type": schema.TOOL_CALL,
+                    "call_id": call_id,
+                    "name": str(item.get("name") or "unknown"),
+                    "arguments": _decode_arguments(item.get("arguments")),
+                }
+            )
+
+        elif kind == "function_call_output":
+            call_id = item.get("call_id")
+            if not call_id:
+                continue
+            call_id = str(call_id)
+            if call_id not in seen_calls or call_id in answered:
+                continue
+            text = _flatten_output(item.get("output"))
+            if _ELIDED_OUTPUT.match(text.strip()):
+                continue
+            answered.add(call_id)
+            yield emit(
+                {
+                    "type": schema.TOOL_RESULT,
+                    "call_id": call_id,
+                    "status": "error" if sniff_failure(text) else "completed",
+                    "output": text,
+                }
+            )
+
+    finished: dict[str, Any] = {
+        "type": schema.RUN_FINISHED,
+        "status": "completed" if payload.get("status") in (None, "completed") else "failed",
+    }
+    if finished["status"] == "failed":
+        finished["error"] = f"upstream response status {payload.get('status')!r}"
+    usage = payload.get("usage")
+    if isinstance(usage, dict):
+        buckets = {
+            key: usage[key]
+            for key in ("input_tokens", "output_tokens", "total_tokens")
+            if isinstance(usage.get(key), int)
+        }
+        if buckets:
+            finished["usage"] = buckets
+    yield emit(finished)

--- a/runner/schema.py
+++ b/runner/schema.py
@@ -1,0 +1,115 @@
+"""Load `runner/contract/*.schema.json` and validate against them.
+
+The JSON files are the contract; this module is the only thing that reads them,
+so a runner written in another language can ignore it entirely and validate the
+same files with its own tooling.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema_mini import validate
+
+CONTRACT_VERSION = "v1alpha1"
+
+CONTRACT_DIR = Path(__file__).resolve().parent / "contract"
+
+# Event type names, so a typo is an AttributeError at import rather than a
+# silently unmatched string at runtime.
+RUN_STARTED = "run.started"
+CHECKLIST = "checklist"
+TOOL_CALL = "tool_call"
+TOOL_RESULT = "tool_result"
+MESSAGE = "message"
+ARTIFACT = "artifact"
+RUN_FINISHED = "run.finished"
+
+EVENT_TYPES = frozenset(
+    {RUN_STARTED, CHECKLIST, TOOL_CALL, TOOL_RESULT, MESSAGE, ARTIFACT, RUN_FINISHED}
+)
+
+TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled", "budget_exceeded", "refused"})
+
+
+class ContractViolation(Exception):
+    """A request or event does not satisfy the contract."""
+
+
+@lru_cache(maxsize=None)
+def _schema(name: str) -> dict[str, Any]:
+    path = CONTRACT_DIR / f"{name}.schema.json"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"contract schema {path} is missing -- runner/contract/ is the source of truth "
+            "and this module cannot validate without it"
+        )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def request_schema() -> dict[str, Any]:
+    return _schema("run_request")
+
+
+def event_schema() -> dict[str, Any]:
+    return _schema("run_event")
+
+
+def request_errors(request: Any) -> list[str]:
+    return validate(request, request_schema())
+
+
+def event_errors(event: Any) -> list[str]:
+    return validate(event, event_schema())
+
+
+def check_request(request: Any) -> None:
+    """Raise ``ContractViolation`` if ``request`` is not a valid RunRequest."""
+    errors = request_errors(request)
+    if errors:
+        raise ContractViolation("invalid RunRequest:\n  " + "\n  ".join(errors))
+
+
+def check_event(event: Any) -> None:
+    """Raise ``ContractViolation`` if ``event`` is not a valid RunEvent."""
+    errors = event_errors(event)
+    if errors:
+        raise ContractViolation("invalid RunEvent:\n  " + "\n  ".join(errors))
+
+
+def new_request(
+    *,
+    run_id: str,
+    subject: str,
+    issuer: str,
+    profile: str,
+    input_text: str,
+    workspace_mode: str = "none",
+    workspace_path: str | None = None,
+    conversation: str | None = None,
+    budget: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal valid RunRequest.
+
+    A convenience for tests and for control-plane code that would otherwise
+    hand-assemble the same nested literal; the contract is the schema, not this
+    signature.
+    """
+    workspace: dict[str, Any] = {"mode": workspace_mode}
+    if workspace_path is not None:
+        workspace["path"] = workspace_path
+    task: dict[str, Any] = {"input": input_text}
+    if conversation is not None:
+        task["conversation"] = conversation
+    return {
+        "contract_version": CONTRACT_VERSION,
+        "run_id": run_id,
+        "principal": {"subject": subject, "issuer": issuer},
+        "profile": {"name": profile},
+        "task": task,
+        "workspace": workspace,
+        "budget": dict(budget) if budget else {},
+    }

--- a/runner/test_conformance_null_runner.py
+++ b/runner/test_conformance_null_runner.py
@@ -1,0 +1,245 @@
+"""The null runner against the conformance suite, plus the suite's own teeth.
+
+Two halves. The first runs `RunnerConformanceTests` against `NullRunner`, in
+both its echo and scripted modes -- that is the milestone's exit criterion. The
+second checks that the suite *fails* runners that violate the contract, because
+a conformance suite nothing can fail is decoration.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import schema
+from conformance import RunnerConformanceTests
+from null_runner import NullRunner
+
+
+class NullRunnerConformance(RunnerConformanceTests, unittest.TestCase):
+    def make_runner(self):
+        return NullRunner()
+
+
+class ScriptedNullRunnerConformance(RunnerConformanceTests, unittest.TestCase):
+    """The same suite over a stream that actually uses the tool events."""
+
+    def make_runner(self):
+        return NullRunner.scripted(
+            {
+                "type": schema.CHECKLIST,
+                "items": [{"id": "1", "title": "List the nodes", "status": "active"}],
+            },
+            {
+                "type": schema.TOOL_CALL,
+                "call_id": "call-1",
+                "name": "kubectl",
+                "arguments": {"argv": ["get", "nodes"]},
+            },
+            {
+                "type": schema.TOOL_RESULT,
+                "call_id": "call-1",
+                "status": "completed",
+                "output": "node-1  Ready",
+            },
+            {"type": schema.ARTIFACT, "kind": "file", "ref": "report.md"},
+            {"type": schema.MESSAGE, "role": "assistant", "text": "One node, ready."},
+            {
+                "type": schema.CHECKLIST,
+                "items": [{"id": "1", "title": "List the nodes", "status": "done"}],
+            },
+        )
+
+
+class NullRunnerBehaviour(unittest.TestCase):
+    def test_the_echo_run_returns_the_task_input(self):
+        request = schema.new_request(
+            run_id="r1",
+            subject="user:a",
+            issuer="system",
+            profile="platform",
+            input_text="how many nodes?",
+        )
+        messages = [e for e in NullRunner().run(request) if e["type"] == schema.MESSAGE]
+        self.assertEqual(["how many nodes?"], [m["text"] for m in messages])
+
+    def test_run_started_echoes_the_resolved_profile(self):
+        request = schema.new_request(
+            run_id="r1", subject="user:a", issuer="system", profile="platform", input_text="hi"
+        )
+        first = next(iter(NullRunner().run(request)))
+        self.assertEqual("platform", first["profile"])
+
+    def test_a_script_may_not_supply_its_own_run_started(self):
+        runner = NullRunner.scripted({"type": schema.RUN_STARTED})
+        request = schema.new_request(
+            run_id="r1", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        with self.assertRaises(ValueError):
+            list(runner.run(request))
+
+    def test_a_script_may_supply_its_own_terminal_event(self):
+        runner = NullRunner.scripted(
+            {"type": schema.RUN_FINISHED, "status": "failed", "error": "the cluster was gone"}
+        )
+        request = schema.new_request(
+            run_id="r1", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        events = list(runner.run(request))
+        self.assertEqual(1, [e["type"] for e in events].count(schema.RUN_FINISHED))
+        self.assertEqual("failed", events[-1]["status"])
+
+    def test_a_request_without_a_run_id_cannot_produce_a_stream(self):
+        # Distinct from a refusal: a refusal is itself a stream, and a stream
+        # needs a run_id in every envelope.
+        with self.assertRaises(ValueError):
+            list(NullRunner().run({"contract_version": schema.CONTRACT_VERSION}))
+
+    def test_a_refusal_names_the_schema_violation(self):
+        request = schema.new_request(
+            run_id="r1", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        del request["budget"]
+        final = list(NullRunner().run(request))[-1]
+        self.assertEqual("refused", final["status"])
+        self.assertIn("budget", final["error"])
+
+
+class _BadRunner:
+    """Base for the deliberately-broken runners below."""
+
+    def __init__(self, events):
+        self._events = events
+
+    def run(self, request):
+        return iter(self._events)
+
+
+def _envelope(seq, **body):
+    return {"contract_version": schema.CONTRACT_VERSION, "run_id": "conformance-run", "seq": seq, **body}
+
+
+class ConformanceSuiteHasTeeth(unittest.TestCase):
+    """Each broken runner must fail the specific test that names its defect."""
+
+    def _run_one(self, runner, test_name):
+        case = type(
+            "Case",
+            (RunnerConformanceTests, unittest.TestCase),
+            {"make_runner": lambda _self: runner},
+        )(test_name)
+        return unittest.TestResult(), case
+
+    def assert_fails(self, events, test_name):
+        result, case = self._run_one(_BadRunner(events), test_name)
+        case.run(result)
+        self.assertTrue(
+            result.failures or result.errors,
+            f"{test_name} passed a runner that should have failed it",
+        )
+
+    def test_the_harness_itself_is_not_the_thing_failing(self):
+        """Control for every assert_fails above.
+
+        Each of those asserts only that *something* went wrong, so a typo in a
+        test name or a broken dynamic subclass would satisfy all of them while
+        checking nothing. Running the same names against the conforming null
+        runner is what distinguishes "the contract caught it" from "the harness
+        is broken".
+        """
+        names = [n for n in dir(RunnerConformanceTests) if n.startswith("test_")]
+        self.assertGreater(len(names), 10, "the suite should have more than a handful of tests")
+        for name in names:
+            with self.subTest(name):
+                result, case = self._run_one(NullRunner(), name)
+                case.run(result)
+                self.assertEqual(
+                    ([], []),
+                    (result.failures, result.errors),
+                    f"the null runner should pass {name}: {result.failures or result.errors}",
+                )
+
+    def test_catches_a_missing_terminal_event(self):
+        self.assert_fails(
+            [_envelope(0, type=schema.RUN_STARTED)],
+            "test_the_last_event_is_run_finished",
+        )
+
+    def test_catches_two_terminal_events(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.RUN_FINISHED, status="completed"),
+                _envelope(2, type=schema.RUN_FINISHED, status="failed", error="again"),
+            ],
+            "test_run_finished_occurs_exactly_once",
+        )
+
+    def test_catches_a_gap_in_the_sequence(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(7, type=schema.RUN_FINISHED, status="completed"),
+            ],
+            "test_seq_starts_at_zero_and_increments_by_one",
+        )
+
+    def test_catches_an_orphaned_tool_result(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.TOOL_RESULT, call_id="ghost", status="completed", output=""),
+                _envelope(2, type=schema.RUN_FINISHED, status="completed"),
+            ],
+            "test_every_tool_result_answers_an_earlier_tool_call",
+        )
+
+    def test_catches_a_reused_call_id(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.TOOL_CALL, call_id="c", name="kubectl", arguments={}),
+                _envelope(2, type=schema.TOOL_CALL, call_id="c", name="kubectl", arguments={}),
+                _envelope(3, type=schema.RUN_FINISHED, status="completed"),
+            ],
+            "test_call_ids_are_unique_within_a_run",
+        )
+
+    def test_catches_a_silent_failure(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.RUN_FINISHED, status="failed"),
+            ],
+            "test_a_failure_status_carries_an_explanation",
+        )
+
+    def test_catches_an_invalid_event(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.RUN_FINISHED, status="exploded"),
+            ],
+            "test_every_event_validates_against_the_schema",
+        )
+
+    def test_catches_a_runner_that_guesses_at_an_unknown_contract_version(self):
+        self.assert_fails(
+            [
+                _envelope(0, type=schema.RUN_STARTED),
+                _envelope(1, type=schema.RUN_FINISHED, status="completed"),
+            ],
+            "test_an_unknown_contract_version_is_refused_not_guessed",
+        )
+
+    def test_catches_an_eager_stream(self):
+        class Eager:
+            def run(self, request):
+                return [_envelope(0, type=schema.RUN_STARTED)]
+
+        result, case = self._run_one(Eager(), "test_the_stream_is_lazy")
+        case.run(result)
+        self.assertTrue(result.failures or result.errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runner/test_responses_adapter.py
+++ b/runner/test_responses_adapter.py
@@ -1,0 +1,132 @@
+"""The Responses -> contract translation, over payloads shaped like real ones."""
+
+from __future__ import annotations
+
+import unittest
+
+import schema
+from responses_adapter import events_from_responses, sniff_failure
+
+
+def translate(payload, run_id="r1", profile=None):
+    return list(events_from_responses(payload, run_id=run_id, profile=profile))
+
+
+def _message(text):
+    return {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": text}]}
+
+
+def _call(call_id, name="kubectl", arguments='{"argv": ["get", "nodes"]}'):
+    return {"type": "function_call", "call_id": call_id, "name": name, "arguments": arguments}
+
+
+def _output(call_id, output):
+    return {"type": "function_call_output", "call_id": call_id, "output": output}
+
+
+class Translation(unittest.TestCase):
+    def test_an_empty_payload_still_frames_a_run(self):
+        events = translate({})
+        self.assertEqual([schema.RUN_STARTED, schema.RUN_FINISHED], [e["type"] for e in events])
+
+    def test_every_translated_event_satisfies_the_contract(self):
+        payload = {
+            "status": "completed",
+            "usage": {"input_tokens": 10, "output_tokens": 4, "total_tokens": 14},
+            "output": [
+                _call("c1"),
+                _output("c1", "node-1 Ready"),
+                _message("One node."),
+            ],
+        }
+        for event in translate(payload, profile="platform"):
+            self.assertEqual([], schema.event_errors(event), f"invalid: {event!r}")
+
+    def test_the_stream_passes_the_contracts_ordering_rules(self):
+        payload = {"output": [_call("c1"), _output("c1", "ok"), _message("done")]}
+        events = translate(payload)
+        self.assertEqual(schema.RUN_STARTED, events[0]["type"])
+        self.assertEqual(schema.RUN_FINISHED, events[-1]["type"])
+        self.assertEqual(list(range(len(events))), [e["seq"] for e in events])
+
+    def test_arguments_are_decoded_from_their_json_string(self):
+        call = next(e for e in translate({"output": [_call("c1")]}) if e["type"] == schema.TOOL_CALL)
+        self.assertEqual({"argv": ["get", "nodes"]}, call["arguments"])
+
+    def test_unparseable_arguments_are_preserved_rather_than_dropped(self):
+        payload = {"output": [_call("c1", arguments="{not json")]}
+        call = next(e for e in translate(payload) if e["type"] == schema.TOOL_CALL)
+        self.assertEqual({"raw": "{not json"}, call["arguments"])
+
+    def test_a_replayed_call_id_is_not_emitted_twice(self):
+        # The endpoint is stateful and re-sends earlier turns' items; a second
+        # emission would read downstream as a tool loop the agent never ran.
+        payload = {"output": [_call("c1"), _output("c1", "ok"), _call("c1")]}
+        calls = [e for e in translate(payload) if e["type"] == schema.TOOL_CALL]
+        self.assertEqual(1, len(calls))
+
+    def test_an_output_with_no_matching_call_is_dropped(self):
+        payload = {"output": [_output("ghost", "ok")]}
+        self.assertEqual([], [e for e in translate(payload) if e["type"] == schema.TOOL_RESULT])
+
+    def test_an_elided_duplicate_output_leaves_the_call_unanswered(self):
+        payload = {"output": [_call("c1"), _output("c1", "[Duplicate tool output for c1]")]}
+        types = [e["type"] for e in translate(payload)]
+        self.assertIn(schema.TOOL_CALL, types)
+        self.assertNotIn(schema.TOOL_RESULT, types)
+
+    def test_block_wrapped_output_is_flattened(self):
+        payload = {"output": [_call("c1"), _output("c1", [{"text": "a"}, {"text": "b"}])]}
+        result = next(e for e in translate(payload) if e["type"] == schema.TOOL_RESULT)
+        self.assertEqual("ab", result["output"])
+
+    def test_a_failed_tool_output_becomes_an_error_status(self):
+        payload = {"output": [_call("c1"), _output("c1", "Error executing tool kubectl: denied")]}
+        result = next(e for e in translate(payload) if e["type"] == schema.TOOL_RESULT)
+        self.assertEqual("error", result["status"])
+
+    def test_an_upstream_failure_status_is_carried_with_a_reason(self):
+        final = translate({"status": "incomplete"})[-1]
+        self.assertEqual("failed", final["status"])
+        self.assertIn("incomplete", final["error"])
+
+    def test_usage_is_carried_into_the_terminal_event(self):
+        payload = {"usage": {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8}}
+        self.assertEqual(
+            {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8},
+            translate(payload)[-1]["usage"],
+        )
+
+    def test_a_message_with_no_text_is_not_emitted(self):
+        payload = {"output": [{"type": "message", "role": "assistant", "content": []}]}
+        self.assertEqual([], [e for e in translate(payload) if e["type"] == schema.MESSAGE])
+
+    def test_a_user_message_is_not_translated(self):
+        payload = {"output": [dict(_message("hi"), role="user")]}
+        self.assertEqual([], [e for e in translate(payload) if e["type"] == schema.MESSAGE])
+
+    def test_a_non_list_output_field_degrades_rather_than_raises(self):
+        self.assertEqual(2, len(translate({"output": "unexpected"})))
+
+
+class FailureSniffing(unittest.TestCase):
+    """The guess the contract exists to make unnecessary."""
+
+    def test_prose_containing_the_word_error_is_not_a_failure(self):
+        self.assertFalse(sniff_failure("2 errors found in the log, both benign"))
+
+    def test_a_structured_failure_flag_is(self):
+        self.assertTrue(sniff_failure('{"success": false}'))
+        self.assertTrue(sniff_failure('{"ok": false}'))
+
+    def test_a_nonzero_exit_code_is(self):
+        self.assertTrue(sniff_failure('{"exit_code": 1}'))
+        self.assertFalse(sniff_failure('{"exit_code": 0}'))
+
+    def test_an_error_beside_a_real_payload_is_a_diagnostic_not_a_failure(self):
+        self.assertFalse(sniff_failure('{"error": "warn", "result": "the answer"}'))
+        self.assertTrue(sniff_failure('{"error": "it broke"}'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runner/test_schema.py
+++ b/runner/test_schema.py
@@ -1,0 +1,141 @@
+"""The schemas and the validator that reads them."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import schema
+from jsonschema_mini import UnsupportedSchemaError, validate
+
+
+class MiniValidator(unittest.TestCase):
+    def test_an_unimplemented_keyword_raises_rather_than_passing(self):
+        # The property the whole file rests on: a schema this validator cannot
+        # enforce must never be reported as satisfied.
+        with self.assertRaises(UnsupportedSchemaError) as caught:
+            validate({}, {"type": "object", "patternProperties": {"^x": {}}})
+        self.assertIn("patternProperties", str(caught.exception))
+
+    def test_booleans_are_not_integers(self):
+        # bool subclasses int in Python, so the naive check accepts `true` for
+        # an integer field.
+        self.assertTrue(validate(True, {"type": "integer"}))
+        self.assertEqual([], validate(1, {"type": "integer"}))
+
+    def test_booleans_are_not_numbers(self):
+        self.assertTrue(validate(False, {"type": "number"}))
+
+    def test_additional_properties_false_is_enforced(self):
+        errors = validate({"a": 1, "b": 2}, {"type": "object", "properties": {"a": {}}, "additionalProperties": False})
+        self.assertEqual(1, len(errors))
+        self.assertIn("'b'", errors[0])
+
+    def test_required_properties_are_reported_by_name(self):
+        errors = validate({}, {"type": "object", "required": ["x", "y"]})
+        self.assertEqual(2, len(errors))
+
+    def test_a_wrong_type_does_not_cascade(self):
+        # One error, not one per unchecked constraint underneath it.
+        errors = validate("nope", {"type": "object", "required": ["a", "b", "c"]})
+        self.assertEqual(1, len(errors))
+
+    def test_one_of_requires_exactly_one_match(self):
+        one_of = {"oneOf": [{"const": "a"}, {"const": "b"}]}
+        self.assertEqual([], validate("a", one_of))
+        self.assertTrue(validate("c", one_of))
+
+    def test_nested_errors_name_their_path(self):
+        errors = validate(
+            {"outer": {"inner": 1}},
+            {"type": "object", "properties": {"outer": {"type": "object", "properties": {"inner": {"type": "string"}}}}},
+        )
+        self.assertEqual(1, len(errors))
+        self.assertIn("$.outer.inner", errors[0])
+
+    def test_min_length_and_minimum_and_min_items(self):
+        self.assertTrue(validate("", {"type": "string", "minLength": 1}))
+        self.assertTrue(validate(0, {"type": "integer", "minimum": 1}))
+        self.assertTrue(validate([], {"type": "array", "minItems": 1}))
+
+
+class ContractSchemas(unittest.TestCase):
+    def test_both_schemas_parse_and_use_only_supported_keywords(self):
+        # validate() raises on an unimplemented keyword, so running it over a
+        # trivial instance is a structural check of the schema itself.
+        for loaded in (schema.request_schema(), schema.event_schema()):
+            try:
+                validate({"unlikely": True}, loaded)
+            except UnsupportedSchemaError as exc:
+                self.fail(f"contract schema uses an unsupported keyword: {exc}")
+
+    def test_new_request_builds_a_valid_request(self):
+        request = schema.new_request(
+            run_id="r", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        self.assertEqual([], schema.request_errors(request))
+
+    def test_new_request_with_a_workspace_and_budget_is_valid(self):
+        request = schema.new_request(
+            run_id="r",
+            subject="user:a",
+            issuer="google-chat",
+            profile="platform",
+            input_text="hi",
+            workspace_mode="read-write",
+            workspace_path="/workspace/lease-1",
+            conversation="conv-9",
+            budget={"max_tokens": 64000, "max_tool_calls": 40, "deadline_seconds": 900},
+        )
+        self.assertEqual([], schema.request_errors(request))
+
+    def test_an_unknown_top_level_field_is_rejected(self):
+        request = schema.new_request(
+            run_id="r", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        request["tenant"] = "acme"
+        self.assertTrue(schema.request_errors(request))
+
+    def test_a_bad_workspace_mode_is_rejected(self):
+        request = schema.new_request(
+            run_id="r", subject="user:a", issuer="system", profile="p", input_text="hi"
+        )
+        request["workspace"]["mode"] = "read-write-and-then-some"
+        self.assertTrue(schema.request_errors(request))
+
+    def test_check_request_raises_with_the_reasons_in_the_message(self):
+        with self.assertRaises(schema.ContractViolation) as caught:
+            schema.check_request({"contract_version": schema.CONTRACT_VERSION})
+        self.assertIn("run_id", str(caught.exception))
+
+    def test_every_declared_event_type_has_a_schema_branch(self):
+        titles = {branch["title"] for branch in schema.event_schema()["oneOf"]}
+        self.assertEqual(schema.EVENT_TYPES, titles)
+
+    def test_the_terminal_status_constant_matches_the_schema(self):
+        branch = next(
+            b for b in schema.event_schema()["oneOf"] if b["title"] == schema.RUN_FINISHED
+        )
+        self.assertEqual(schema.TERMINAL_STATUSES, set(branch["properties"]["status"]["enum"]))
+
+    def test_an_event_of_two_minds_matches_no_branch(self):
+        # oneOf, not anyOf: mixing two variants' fields must not validate.
+        event = {
+            "contract_version": schema.CONTRACT_VERSION,
+            "run_id": "r",
+            "seq": 0,
+            "type": "message",
+            "role": "assistant",
+            "text": "hi",
+            "call_id": "c",
+        }
+        self.assertTrue(schema.event_errors(event))
+
+    def test_the_schemas_are_valid_json_on_disk(self):
+        for name in ("run_request", "run_event"):
+            path = schema.CONTRACT_DIR / f"{name}.schema.json"
+            json.loads(path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Pull Request

## Why This Change

Every agent execution in kube-agents goes through Hermes today, which makes Hermes the substrate
rather than an implementation choice. There is no interface to write a second runner against, so
"Hermes is replaceable" cannot be tested.

## What Changed

**Files:**

- `docs/architecture/09-runner-contract.md` (new spec)
- `runner/contract/run_request.schema.json`, `runner/contract/run_event.schema.json`
- `runner/conformance.py`, `runner/null_runner.py`, `runner/schema.py`,
  `runner/jsonschema_mini.py`, `runner/responses_adapter.py`
- `runner/README.md`, four test modules
- `Makefile`, `AGENTS.md`, `docs/README.md`, `docs/architecture/{README,01,07}.md`

**Added/Changed/Fixed:**

- The interface: `run(principal, profile, task, workspace, budget) -> stream of events`.
- The contract is **data, not Python** — two JSON Schemas. A runner in another language conforms by
  being wrapped in a subprocess or HTTP shim, not by being ported.
- `conformance.py` is the suite as a `unittest` mixin: 19 rules covering ordering, sequence
  density, tool-call/result correlation, refusal of an unknown contract version, per-run state
  isolation, and laziness.
- `null_runner.py` is the first conforming implementation (echo and scripted modes) — it proves the
  suite is satisfiable and gives the control plane something to test against that never calls a
  model.
- `jsonschema_mini.py` validates exactly the keywords the schemas use and _raises_ on any other, so
  the suite needs no third-party install and a schema cannot quietly outgrow its validator.
- `responses_adapter.py` translates a recorded `/v1/responses` payload into contract events.

## Why This Matters

- `ConformanceSuiteHasTeeth` runs nine deliberately-broken runners and asserts each fails the
  specific test naming its defect, with a control that runs the same test names against the null
  runner — so the teeth cannot pass vacuously. A conformance suite nobody has tried to fail is a
  document.
- The adapter is what keeps "the event shapes are modelled on what Hermes already emits" from being
  merely asserted. It also quarantines the failure-sniffing heuristic `bench/` needs today because
  `function_call_output` carries no status; the contract's `tool_result.status` is why nothing
  downstream should repeat that guess.
- **Hermes does not run this suite.** Pointing it at a real runner is a separate, later milestone,
  and until then the null runner is the only conforming implementation — stated in the contract
  doc, the README, and the suite's own docstring.

## Context

Adding a `09` to a spec set that describes itself as `01–08` leaves the count stated in more places
than the obvious ones; the second commit fixes four such spots found by
`.agents/skills/review-docs-drift`. It also replaces a §7 note recording a one-off mutation
experiment with the maintenance rule it was evidence for — a new conformance rule needs a broken
runner that catches it. The experiment is not repeatable by a reader, so as prose it could only rot.

## Testing

- `make test-python` — green, 92 tests (`runner/` joins `PYTHON_TEST_DIRS`).
- `make docs-check` — green. `prettier --check` — green. Docs-site `npm run build` — exit 0.

---

Additive: new directory, new spec, no change to any existing runtime path. This PR was generated
with the help of Claude.
