### PR TITLE
refactor(kanban): put board storage behind an adapter

### DIFF
--- a/agents/platform/scripts/kanban_notify_propagate.py
+++ b/agents/platform/scripts/kanban_notify_propagate.py
@@ -57,11 +57,13 @@ def propagate(db_path: str, parent_id: str, child_id: str) -> int:
     wrapper below turns those into a fail-soft exit.
 
     Refuses to write for a child card that is not on the board, because such a
-    row can never be cleaned up: the notifier unsubscribes only when a task turns
-    terminal, and `delete_task` opens with `DELETE FROM tasks WHERE id = ?` and
-    returns early when that matches nothing, so its cascade never reaches the
-    subscription table. A typo'd `--to` would therefore leave a row scanned on
-    every notifier tick for the life of the board.
+    row can never be cleaned up. The reason is in Hermes' code, not this file's:
+    the notifier unsubscribes only when a task turns terminal, and Hermes'
+    `delete_task` opens with `DELETE FROM tasks WHERE id = ?` and returns early
+    when that matches nothing, so its cascade never reaches the subscription
+    table. A typo'd `--to` would therefore leave a row scanned on every notifier
+    tick for the life of the board. `KanbanStore.card_exists` is what this file
+    asks; the SQL behind it is the store's business.
     """
     if not child_id:
         raise ValueError("child id (--to) is required")

--- a/agents/platform/scripts/kanban_notify_propagate.py
+++ b/agents/platform/scripts/kanban_notify_propagate.py
@@ -4,12 +4,12 @@
 #
 # Why this exists
 # ---------------
-# The gateway kanban notifier delivers thread updates by iterating rows in the
-# `kanban_notify_subs` table: a card with no subscription row is invisible to it
-# (no line posted, no agent woken). Subscriptions are written by
-# `_maybe_auto_subscribe` at `kanban_create` time, which reads the originating
-# chat identity (`HERMES_SESSION_CHAT_ID` / `_THREAD_ID` / `_PLATFORM`) from the
-# session context. Those context vars are set ONLY on inbound user messages.
+# The gateway kanban notifier delivers thread updates by iterating a card's
+# subscriptions: a card with none is invisible to it (no line posted, no agent
+# woken). Subscriptions are written by `_maybe_auto_subscribe` at `kanban_create`
+# time, which reads the originating chat identity (`HERMES_SESSION_CHAT_ID` /
+# `_THREAD_ID` / `_PLATFORM`) from the session context. Those context vars are set
+# ONLY on inbound user messages.
 #
 # A specialist agent that is running as a dispatcher-spawned kanban worker has no
 # such session context, so the child cards it creates to stage its work are NOT
@@ -22,68 +22,45 @@
 #   python3 /opt/data/scripts/kanban_notify_propagate.py --to <child_id> [--from <parent_id>]
 #
 # `--from` defaults to $HERMES_KANBAN_TASK (the worker's current card). The board
-# DB is read from $HERMES_KANBAN_DB (pinned into every worker by the dispatcher).
+# is read from $HERMES_KANBAN_DB (pinned into every worker by the dispatcher).
 #
-# Idempotent (INSERT OR IGNORE on the subscription primary key) and fail-soft: any
-# operational problem is logged to stderr and exits 0 so it can never break the
-# specialist's flow. It couples only to the stable `kanban_notify_subs` columns,
-# plus a soft read of `tasks` to confirm the child card is real before writing a
-# subscription row that nothing would ever clean up (see `propagate`).
+# Idempotent and fail-soft: any operational problem is logged to stderr and exits
+# 0 so it can never break the specialist's flow.
+#
+# What this file is NOT
+# ---------------------
+# It is not where the board's storage lives. Every table name, column list, and
+# connection setting belongs to `kanban_store.KanbanStore`; this file is the
+# policy on top -- which cards, in which direction, and what to do when it fails.
+# Adding SQL here would put the coupling back where it was.
 
 import argparse
 import os
-import sqlite3
 import sys
-import time
+from pathlib import Path
 
-# The subscription columns we copy from parent -> child. `task_id` is rewritten
-# to the child id; `created_at` is re-stamped; `last_event_id` resets to 0 so the
-# child's own events are delivered from the start. Pinned here so a schema drift
-# in Hermes surfaces as a clear error (and a failing unit test) rather than
-# silently copying the wrong shape.
-_COPY_COLUMNS = ("platform", "chat_id", "thread_id", "user_id", "notifier_profile")
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+
+from kanban_store import BoardUnavailable, KanbanStore  # noqa: E402
 
 
 def log(msg: str) -> None:
     print(f"[KANBAN-PROPAGATE] {msg}", file=sys.stderr)
 
 
-def _connect(db_path: str) -> sqlite3.Connection:
-    # `timeout=` IS the busy timeout (Python calls sqlite3_busy_timeout with it), so
-    # it is the only knob set here — a `PRAGMA busy_timeout` would silently override
-    # it and leave two different values in the source. Waiting matters: the gateway
-    # and CLI write this same board, and a propagation lost to a busy DB costs the
-    # user progress updates for that sub-step, which is the whole point of the
-    # script. Deliberately no `PRAGMA journal_mode` — cooperate with the WAL store
-    # the gateway/CLI already set up; never force it.
-    conn = sqlite3.connect(db_path, timeout=10)
-    conn.row_factory = sqlite3.Row
-    return conn
-
-
-def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
-    return (
-        conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-            (table,),
-        ).fetchone()
-        is not None
-    )
-
-
 def propagate(db_path: str, parent_id: str, child_id: str) -> int:
-    """Copy every kanban_notify_subs row from parent_id to child_id.
+    """Copy every subscription from parent_id to child_id.
 
-    Returns the number of subscription rows written to the child. Idempotent:
-    re-running is a no-op once the child rows exist. Raises on a genuinely broken
-    DB / missing table / bad args so callers (and tests) can see real failures;
-    the CLI wrapper turns those into a fail-soft exit.
+    Returns the number of subscriptions the child ends up with. Idempotent:
+    re-running is a no-op once they exist. Raises on a genuinely broken board /
+    missing card / bad args so callers (and tests) can see real failures; the CLI
+    wrapper below turns those into a fail-soft exit.
 
     Refuses to write for a child card that is not on the board, because such a
     row can never be cleaned up: the notifier unsubscribes only when a task turns
     terminal, and `delete_task` opens with `DELETE FROM tasks WHERE id = ?` and
-    returns early when that matches nothing, so its cascade never reaches
-    `kanban_notify_subs`. A typo'd `--to` would therefore leave a row scanned on
+    returns early when that matches nothing, so its cascade never reaches the
+    subscription table. A typo'd `--to` would therefore leave a row scanned on
     every notifier tick for the life of the board.
     """
     if not child_id:
@@ -93,56 +70,31 @@ def propagate(db_path: str, parent_id: str, child_id: str) -> int:
     if parent_id == child_id:
         log(f"parent and child are the same card ({child_id}); nothing to do")
         return 0
-    if not os.path.exists(db_path):
-        raise FileNotFoundError(f"kanban DB not found at {db_path!r}")
 
-    conn = _connect(db_path)
-    try:
-        # Soft coupling on purpose. This module's contract is that it depends only
-        # on `kanban_notify_subs`; a board that somehow lacks `tasks` gets the old
-        # unguarded behaviour rather than losing propagation entirely, because
-        # failing every propagation would be a worse bug than the orphan row this
-        # prevents. On a real board `tasks` is always there and the guard is live.
-        if _table_exists(conn, "tasks"):
-            if not conn.execute(
-                "SELECT 1 FROM tasks WHERE id = ?", (child_id,)
-            ).fetchone():
-                raise ValueError(f"child card {child_id!r} not found on this board")
-        else:
-            log("board has no `tasks` table; skipping the child-card existence check")
+    store = KanbanStore(db_path)
 
-        cols = ", ".join(_COPY_COLUMNS)
-        rows = conn.execute(
-            f"SELECT {cols} FROM kanban_notify_subs WHERE task_id = ?",
-            (parent_id,),
-        ).fetchall()
-        if not rows:
-            log(
-                f"parent card {parent_id} has no chat subscription; nothing to "
-                f"propagate to {child_id} (the request may not have come from chat)"
-            )
-            return 0
+    # Tri-state on purpose: `None` means the board has no card table to check
+    # against. Treating that as "card missing" would refuse every propagation on a
+    # board this helper does not recognise, which is a worse failure than the
+    # orphan row the check prevents. On a real board the check is live.
+    exists = store.card_exists(child_id)
+    if exists is False:
+        raise ValueError(f"child card {child_id!r} not found on this board")
+    if exists is None:
+        log("board has no card table; skipping the child-card existence check")
 
-        now = int(time.time())
-        placeholders = ", ".join(["?"] * (len(_COPY_COLUMNS) + 3))
-        insert_cols = "task_id, " + cols + ", created_at, last_event_id"
-        with conn:  # single transaction; commits on success, rolls back on error
-            conn.executemany(
-                f"INSERT OR IGNORE INTO kanban_notify_subs ({insert_cols}) "
-                f"VALUES ({placeholders})",
-                [(child_id, *[r[c] for c in _COPY_COLUMNS], now, 0) for r in rows],
-            )
-        # Report the child's resulting subscription count (idempotent: a re-run
-        # leaves this unchanged rather than double-counting).
-        written = conn.execute(
-            "SELECT COUNT(*) FROM kanban_notify_subs WHERE task_id = ?",
-            (child_id,),
-        ).fetchone()[0]
-        log(f"propagated subscription(s) from {parent_id} -> {child_id} "
-            f"(child now has {written} row(s))")
-        return written
-    finally:
-        conn.close()
+    identities = store.subscriptions_for(parent_id)
+    if not identities:
+        log(
+            f"parent card {parent_id} has no chat subscription; nothing to "
+            f"propagate to {child_id} (the request may not have come from chat)"
+        )
+        return 0
+
+    written = store.add_subscriptions(child_id, identities)
+    log(f"propagated subscription(s) from {parent_id} -> {child_id} "
+        f"(child now has {written} row(s))")
+    return written
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -155,16 +107,18 @@ def main(argv: list[str] | None = None) -> int:
         help="parent task id (defaults to $HERMES_KANBAN_TASK)",
     )
     parser.add_argument(
-        "--db", dest="db", default=os.environ.get("HERMES_KANBAN_DB", ""),
-        help="board DB path (defaults to $HERMES_KANBAN_DB)",
+        "--db", dest="db", default="",
+        help="board path (defaults to the store's configured board)",
     )
     args = parser.parse_args(argv)
 
-    if not args.db:
-        log("no board DB configured ($HERMES_KANBAN_DB unset); skipping (fail-soft)")
+    try:
+        db_path = KanbanStore.from_env(args.db).db_path
+    except BoardUnavailable as e:
+        log(f"{e}; skipping (fail-soft)")
         return 0
     try:
-        propagate(args.db, args.parent, args.child)
+        propagate(db_path, args.parent, args.child)
     except Exception as e:  # noqa: BLE001 - fail-soft: never break the worker's flow
         log(f"propagation failed (continuing): {e}")
     return 0

--- a/agents/platform/scripts/kanban_store.py
+++ b/agents/platform/scripts/kanban_store.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
-# kanban_store.py - the one module in this repository that talks to the kanban
-# board's storage.
+# kanban_store.py - the one module outside deploy/docker/patches/ that talks to
+# the kanban board's storage.
+#
+# The qualifier is load-bearing, and `test_kanban_store.py` enforces exactly it:
+# several patch modules under deploy/docker/patches/ also open the board with raw
+# SQL. Those ship *into* /opt/hermes as part of a patch set and are Hermes' own
+# code by the time they run, so they are exempt here and die with the patch set
+# that installs them.
 #
 # Why this exists
 # ---------------

--- a/agents/platform/scripts/kanban_store.py
+++ b/agents/platform/scripts/kanban_store.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+# kanban_store.py - the one module in this repository that talks to the kanban
+# board's storage.
+#
+# Why this exists
+# ---------------
+# The board is Hermes' SQLite file. Repository-owned code that opens it directly
+# is coupled to three things at once: that the board is SQLite at all, where the
+# file lives, and what Hermes calls its tables and columns. Spread across several
+# callers, that coupling has to be found before it can be changed.
+#
+# So it lives here instead. Everything a caller needs to know is a method on
+# `KanbanStore`; everything Hermes-specific -- the `HERMES_KANBAN_DB` env var, the
+# `kanban_notify_subs` and `tasks` table names, the busy-timeout policy -- is a
+# constant in this file. When the board stops being a SQLite file in a Hermes pod,
+# this module is what changes, and callers keep their code.
+#
+# What this module deliberately does not do
+# -----------------------------------------
+# No logging, no `sys.exit`, no fail-soft. It raises and returns facts. Whether a
+# failed board write should stop the caller is the caller's decision, and the
+# helper that decides it fail-soft (`kanban_notify_propagate.py`) is a different
+# file for exactly that reason.
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from typing import Any, Iterable, Sequence
+
+# --- what Hermes calls things -------------------------------------------------
+#
+# Pinned as constants rather than inlined in each query so a Hermes schema change
+# is one edit here and a small number of failing tests, instead of a grep.
+
+BOARD_PATH_ENV = "HERMES_KANBAN_DB"
+NOTIFY_SUBS_TABLE = "kanban_notify_subs"
+TASKS_TABLE = "tasks"
+
+# The chat-identity columns of a subscription: the part that identifies *where* a
+# notification goes. `task_id`, `created_at` and `last_event_id` are excluded
+# because they are per-subscription bookkeeping the store manages itself.
+SUBSCRIPTION_IDENTITY_COLUMNS: tuple[str, ...] = (
+    "platform",
+    "chat_id",
+    "thread_id",
+    "user_id",
+    "notifier_profile",
+)
+
+# `timeout=` IS the busy timeout (Python passes it to sqlite3_busy_timeout), so it
+# is the only knob set -- a `PRAGMA busy_timeout` would silently override it and
+# leave two different values in the source. Waiting matters: the gateway and the
+# CLI write this same board, and work lost to a busy DB is work the user never
+# hears about. Deliberately no `PRAGMA journal_mode`: cooperate with the WAL store
+# the gateway already set up, never force it.
+BUSY_TIMEOUT_SECONDS = 10
+
+
+class KanbanStoreError(Exception):
+    """Base for every error this module raises."""
+
+
+class BoardUnavailable(KanbanStoreError, FileNotFoundError):
+    """The board file is not where it was expected.
+
+    Also a `FileNotFoundError` because that is what callers written against the
+    raw SQLite path already catch.
+    """
+
+
+class UnknownCard(KanbanStoreError, ValueError):
+    """A task id that is not on the board."""
+
+
+class KanbanStore:
+    """Board access, scoped to one SQLite file.
+
+    Construct with an explicit path, or with `from_env()` to take the path the
+    dispatcher pins into every worker.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+
+    # ---- construction --------------------------------------------------------
+
+    @classmethod
+    def from_env(cls, db_path: str | None = None, env: dict[str, str] | None = None) -> "KanbanStore":
+        """Resolve the board path, preferring an explicit one.
+
+        Raises `BoardUnavailable` when neither is set, rather than defaulting to a
+        guessed path: a store pointed at the wrong file writes rows nothing reads,
+        which is harder to notice than a refusal.
+        """
+        environ = os.environ if env is None else env
+        path = db_path or environ.get(BOARD_PATH_ENV, "")
+        if not path:
+            raise BoardUnavailable(
+                f"no board configured: pass a path or set ${BOARD_PATH_ENV}"
+            )
+        return cls(path)
+
+    # ---- connection ----------------------------------------------------------
+
+    def connect(self) -> sqlite3.Connection:
+        """Open the board. Callers outside this module should not need this."""
+        if not os.path.exists(self.db_path):
+            raise BoardUnavailable(f"kanban DB not found at {self.db_path!r}")
+        conn = sqlite3.connect(self.db_path, timeout=BUSY_TIMEOUT_SECONDS)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _has_table(self, conn: sqlite3.Connection, table: str) -> bool:
+        return (
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+                (table,),
+            ).fetchone()
+            is not None
+        )
+
+    # ---- reads ---------------------------------------------------------------
+
+    def card_exists(self, task_id: str) -> bool | None:
+        """Is this card on the board?
+
+        Three answers, not two: `None` means the board cannot say, because it has
+        no `tasks` table. Callers decide what to do with that -- collapsing it into
+        `False` would turn a board this module does not recognise into a board on
+        which every card is missing.
+        """
+        conn = self.connect()
+        try:
+            if not self._has_table(conn, TASKS_TABLE):
+                return None
+            row = conn.execute(
+                f"SELECT 1 FROM {TASKS_TABLE} WHERE id = ?", (task_id,)
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+
+    def subscriptions_for(self, task_id: str) -> list[dict[str, Any]]:
+        """The chat identities subscribed to this card, newest schema fields only."""
+        cols = ", ".join(SUBSCRIPTION_IDENTITY_COLUMNS)
+        conn = self.connect()
+        try:
+            rows = conn.execute(
+                f"SELECT {cols} FROM {NOTIFY_SUBS_TABLE} WHERE task_id = ?",
+                (task_id,),
+            ).fetchall()
+            return [{c: row[c] for c in SUBSCRIPTION_IDENTITY_COLUMNS} for row in rows]
+        finally:
+            conn.close()
+
+    def subscription_count(self, task_id: str) -> int:
+        conn = self.connect()
+        try:
+            return conn.execute(
+                f"SELECT COUNT(*) FROM {NOTIFY_SUBS_TABLE} WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    # ---- writes --------------------------------------------------------------
+
+    def add_subscriptions(
+        self,
+        task_id: str,
+        identities: Sequence[dict[str, Any]],
+        *,
+        now: int | None = None,
+    ) -> int:
+        """Subscribe these chat identities to this card. Returns the resulting count.
+
+        Idempotent: the subscription primary key is
+        `(task_id, platform, chat_id, thread_id)`, so re-adding an identity is a
+        no-op rather than a duplicate. `last_event_id` starts at 0 so the card's
+        events are delivered from the beginning.
+
+        `INSERT OR IGNORE` is what buys that idempotency, and it does not
+        distinguish "already subscribed" from "violates a constraint" -- both are
+        skipped without an error. The returned count is therefore the fact to
+        trust, not the number of identities passed in.
+        """
+        if not identities:
+            return self.subscription_count(task_id)
+
+        stamp = int(time.time()) if now is None else now
+        cols = ", ".join(SUBSCRIPTION_IDENTITY_COLUMNS)
+        insert_cols = f"task_id, {cols}, created_at, last_event_id"
+        placeholders = ", ".join(["?"] * (len(SUBSCRIPTION_IDENTITY_COLUMNS) + 3))
+        values = [
+            (task_id, *[identity.get(c) for c in SUBSCRIPTION_IDENTITY_COLUMNS], stamp, 0)
+            for identity in identities
+        ]
+
+        conn = self.connect()
+        try:
+            with conn:  # one transaction; commits on success, rolls back on error
+                conn.executemany(
+                    f"INSERT OR IGNORE INTO {NOTIFY_SUBS_TABLE} ({insert_cols}) "
+                    f"VALUES ({placeholders})",
+                    values,
+                )
+            return conn.execute(
+                f"SELECT COUNT(*) FROM {NOTIFY_SUBS_TABLE} WHERE task_id = ?",
+                (task_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    def copy_subscriptions(self, from_task: str, to_task: str) -> int:
+        """Copy every subscription on one card onto another. Returns the target's count.
+
+        A board operation rather than two calls in a caller, because the pair is
+        what has meaning: the child card should reach the same chat thread the
+        parent does.
+        """
+        identities = self.subscriptions_for(from_task)
+        if not identities:
+            return 0
+        return self.add_subscriptions(to_task, identities)
+
+    # ---- introspection -------------------------------------------------------
+
+    def missing_columns(self, table: str, columns: Iterable[str]) -> list[str]:
+        """Columns this module expects that the board does not have.
+
+        Exists so a caller can assert its assumptions against a real board and get
+        a named list back, rather than an `OperationalError` mid-transaction.
+        """
+        conn = self.connect()
+        try:
+            present = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+            return [c for c in columns if c not in present]
+        finally:
+            conn.close()

--- a/agents/platform/scripts/test_kanban_notify_propagate.py
+++ b/agents/platform/scripts/test_kanban_notify_propagate.py
@@ -118,10 +118,12 @@ class TestPropagate(unittest.TestCase):
             self.assertEqual(len(_rows(db, "child-typo")), 0)
 
     def test_board_without_tasks_table_still_propagates(self):
-        # Documented degradation. This module's contract is a dependency on
-        # kanban_notify_subs alone; if Hermes ever renames or drops `tasks`,
-        # losing every propagation would be a worse bug than the orphan row the
-        # guard prevents, so the check is skipped rather than fatal.
+        # Documented degradation, and it is the store's tri-state card_exists
+        # that makes it expressible: `None` means the board cannot answer, which
+        # this module treats differently from `False`. If Hermes ever renames or
+        # drops the card table, losing every propagation would be a worse bug
+        # than the orphan row the guard prevents, so the check is skipped rather
+        # than fatal.
         with TemporaryDirectory() as tmp:
             db = str(Path(tmp) / "kanban.db")
             _make_db(db, with_tasks=False)

--- a/agents/platform/scripts/test_kanban_notify_propagate.py
+++ b/agents/platform/scripts/test_kanban_notify_propagate.py
@@ -1,5 +1,11 @@
+"""The propagation policy: which cards, in which direction, and failing soft.
+
+Board storage itself is `test_kanban_store.py`'s subject; the schema fixtures are
+imported from there so this repository writes down what it believes Hermes' board
+looks like exactly once.
+"""
+
 import importlib
-import sqlite3
 import sys
 import unittest
 from pathlib import Path
@@ -9,76 +15,12 @@ from tempfile import TemporaryDirectory
 sys.path.insert(0, str(Path(__file__).parent.absolute()))
 prop = importlib.import_module("kanban_notify_propagate")
 
-
-# Mirror the production kanban_notify_subs schema (hermes_cli/kanban_db.py). If
-# Hermes drifts the columns the helper copies, this fixture + the module's
-# _COPY_COLUMNS assertion below will catch it.
-_SCHEMA = """
-CREATE TABLE kanban_notify_subs (
-    task_id       TEXT NOT NULL,
-    platform      TEXT NOT NULL,
-    chat_id       TEXT NOT NULL,
-    thread_id     TEXT NOT NULL DEFAULT '',
-    user_id       TEXT,
-    notifier_profile TEXT,
-    created_at    INTEGER NOT NULL,
-    last_event_id INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (task_id, platform, chat_id, thread_id)
-);
-"""
-
-# The board's card table. Only the primary key matters here — the helper reads
-# nothing else from it — but a real board always has this table, so the fixture
-# must too, or the tests would exercise the no-`tasks` degradation path instead
-# of the production one.
-_TASKS_SCHEMA = """
-CREATE TABLE tasks (
-    id     TEXT PRIMARY KEY,
-    title  TEXT,
-    status TEXT
-);
-"""
-
-
-def _make_db(path: str, with_tasks: bool = True) -> None:
-    conn = sqlite3.connect(path)
-    conn.executescript(_SCHEMA)
-    if with_tasks:
-        conn.executescript(_TASKS_SCHEMA)
-    conn.close()
-
-
-def _add_card(path: str, *task_ids: str) -> None:
-    conn = sqlite3.connect(path)
-    conn.executemany(
-        "INSERT OR IGNORE INTO tasks (id, title, status) VALUES (?, ?, 'todo')",
-        [(t, f"card {t}") for t in task_ids],
-    )
-    conn.commit()
-    conn.close()
-
-
-def _add_sub(path, task_id, platform="google_chat", chat_id="spaces/AAA",
-             thread_id="spaces/AAA/threads/T1", user_id="users/u1",
-             notifier_profile="default", last_event_id=42):
-    conn = sqlite3.connect(path)
-    conn.execute(
-        "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, thread_id, "
-        "user_id, notifier_profile, created_at, last_event_id) VALUES (?,?,?,?,?,?,?,?)",
-        (task_id, platform, chat_id, thread_id, user_id, notifier_profile, 1000, last_event_id),
-    )
-    conn.commit()
-    conn.close()
-
-
-def _rows(path, task_id):
-    conn = sqlite3.connect(path)
-    conn.row_factory = sqlite3.Row
-    rows = conn.execute(
-        "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,)
-    ).fetchall()
-    conn.close()
-    return rows
+from test_kanban_store import (  # noqa: E402
+    add_card as _add_card,
+    add_sub as _add_sub,
+    make_board as _make_db,
+    rows_for as _rows,
+)
 
 
 class TestPropagate(unittest.TestCase):
@@ -198,36 +140,6 @@ class TestPropagate(unittest.TestCase):
             db = str(Path(tmp) / "kanban.db")  # does not exist
             rc = prop.main(["--to", "child-1", "--from", "parent-1", "--db", db])
             self.assertEqual(rc, 0)
-
-    def test_copy_columns_match_schema(self):
-        # Guardrail: every column the helper copies must exist in the table.
-        with TemporaryDirectory() as tmp:
-            db = str(Path(tmp) / "kanban.db")
-            _make_db(db)
-            conn = sqlite3.connect(db)
-            cols = {r[1] for r in conn.execute("PRAGMA table_info(kanban_notify_subs)")}
-            conn.close()
-            for c in prop._COPY_COLUMNS:
-                self.assertIn(c, cols)
-
-    def test_connect_sets_one_unambiguous_busy_timeout(self):
-        # The busy timeout must come from exactly one place. Setting `timeout=` on
-        # connect() AND a `PRAGMA busy_timeout` silently resolves to whichever ran
-        # last, so the source can advertise a wait the connection does not honor.
-        with TemporaryDirectory() as tmp:
-            db = str(Path(tmp) / "kanban.db")
-            _make_db(db)
-            conn = prop._connect(db)
-            try:
-                self.assertEqual(
-                    conn.execute("PRAGMA busy_timeout").fetchone()[0], 10_000
-                )
-                # journal_mode is the gateway's to choose; this helper must not force it.
-                self.assertEqual(
-                    conn.execute("PRAGMA journal_mode").fetchone()[0], "delete"
-                )
-            finally:
-                conn.close()
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/test_kanban_store.py
+++ b/agents/platform/scripts/test_kanban_store.py
@@ -1,0 +1,320 @@
+"""The kanban store, plus the guard that keeps it the only board-storage caller.
+
+The fixture helpers here are public on purpose: `test_kanban_notify_propagate.py`
+imports them, so the schema this repository believes Hermes has is written down
+once. A second copy would drift, and a drifted fixture makes both suites pass
+against a board that no longer exists.
+"""
+
+import importlib
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+store_mod = importlib.import_module("kanban_store")
+
+# Mirrors the production kanban_notify_subs schema (hermes_cli/kanban_db.py).
+NOTIFY_SUBS_SCHEMA = """
+CREATE TABLE kanban_notify_subs (
+    task_id       TEXT NOT NULL,
+    platform      TEXT NOT NULL,
+    chat_id       TEXT NOT NULL,
+    thread_id     TEXT NOT NULL DEFAULT '',
+    user_id       TEXT,
+    notifier_profile TEXT,
+    created_at    INTEGER NOT NULL,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (task_id, platform, chat_id, thread_id)
+);
+"""
+
+# The board's card table. Only the primary key matters to this repository, but a
+# real board always has it, so the fixture must too -- otherwise every test would
+# silently exercise the no-card-table degradation path instead of the real one.
+TASKS_SCHEMA = """
+CREATE TABLE tasks (
+    id     TEXT PRIMARY KEY,
+    title  TEXT,
+    status TEXT
+);
+"""
+
+
+def make_board(path: str, with_tasks: bool = True) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(NOTIFY_SUBS_SCHEMA)
+    if with_tasks:
+        conn.executescript(TASKS_SCHEMA)
+    conn.close()
+
+
+def add_card(path: str, *task_ids: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.executemany(
+        "INSERT OR IGNORE INTO tasks (id, title, status) VALUES (?, ?, 'todo')",
+        [(t, f"card {t}") for t in task_ids],
+    )
+    conn.commit()
+    conn.close()
+
+
+def add_sub(path, task_id, platform="google_chat", chat_id="spaces/AAA",
+            thread_id="spaces/AAA/threads/T1", user_id="users/u1",
+            notifier_profile="default", last_event_id=42):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "INSERT INTO kanban_notify_subs (task_id, platform, chat_id, thread_id, "
+        "user_id, notifier_profile, created_at, last_event_id) VALUES (?,?,?,?,?,?,?,?)",
+        (task_id, platform, chat_id, thread_id, user_id, notifier_profile, 1000, last_event_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def rows_for(path, task_id):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM kanban_notify_subs WHERE task_id = ?", (task_id,)
+    ).fetchall()
+    conn.close()
+    return rows
+
+
+class BoardResolution(unittest.TestCase):
+    def test_an_explicit_path_wins_over_the_environment(self):
+        s = store_mod.KanbanStore.from_env("/explicit.db", env={"HERMES_KANBAN_DB": "/env.db"})
+        self.assertEqual("/explicit.db", s.db_path)
+
+    def test_the_environment_supplies_the_path_when_none_is_given(self):
+        s = store_mod.KanbanStore.from_env(env={"HERMES_KANBAN_DB": "/env.db"})
+        self.assertEqual("/env.db", s.db_path)
+
+    def test_no_path_anywhere_refuses_rather_than_guessing(self):
+        # A store pointed at a guessed path writes rows nothing reads, which is
+        # harder to notice than a refusal.
+        with self.assertRaises(store_mod.BoardUnavailable):
+            store_mod.KanbanStore.from_env(env={})
+
+    def test_board_unavailable_is_still_a_file_not_found_error(self):
+        # Callers written against the raw path catch FileNotFoundError.
+        self.assertTrue(issubclass(store_mod.BoardUnavailable, FileNotFoundError))
+
+    def test_unknown_card_is_still_a_value_error(self):
+        self.assertTrue(issubclass(store_mod.UnknownCard, ValueError))
+
+
+class Reads(unittest.TestCase):
+    def test_card_exists_answers_true_and_false(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            add_card(db, "here")
+            s = store_mod.KanbanStore(db)
+            self.assertIs(True, s.card_exists("here"))
+            self.assertIs(False, s.card_exists("elsewhere"))
+
+    def test_a_board_with_no_card_table_answers_none_not_false(self):
+        # Tri-state. Collapsing "cannot say" into "missing" would turn an
+        # unrecognised board into one where every card is absent.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db, with_tasks=False)
+            self.assertIsNone(store_mod.KanbanStore(db).card_exists("anything"))
+
+    def test_subscriptions_for_returns_only_the_identity_columns(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            add_sub(db, "p")
+            identities = store_mod.KanbanStore(db).subscriptions_for("p")
+            self.assertEqual(1, len(identities))
+            self.assertEqual(
+                set(store_mod.SUBSCRIPTION_IDENTITY_COLUMNS), set(identities[0])
+            )
+            self.assertNotIn("last_event_id", identities[0])
+
+    def test_a_card_with_no_subscriptions_reads_as_empty(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            self.assertEqual([], store_mod.KanbanStore(db).subscriptions_for("p"))
+
+    def test_a_missing_board_raises_rather_than_reading_empty(self):
+        with self.assertRaises(store_mod.BoardUnavailable):
+            store_mod.KanbanStore("/nonexistent/kanban.db").subscriptions_for("p")
+
+
+class Writes(unittest.TestCase):
+    def test_added_subscriptions_start_their_event_cursor_at_zero(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            s = store_mod.KanbanStore(db)
+            s.add_subscriptions("c", [{"platform": "google_chat", "chat_id": "spaces/A",
+                                       "thread_id": "t", "user_id": "u",
+                                       "notifier_profile": "default"}])
+            self.assertEqual(0, rows_for(db, "c")[0]["last_event_id"])
+
+    def test_adding_the_same_identity_twice_is_a_no_op(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            s = store_mod.KanbanStore(db)
+            identity = [{"platform": "google_chat", "chat_id": "spaces/A",
+                         "thread_id": "t", "user_id": "u", "notifier_profile": "default"}]
+            self.assertEqual(1, s.add_subscriptions("c", identity))
+            self.assertEqual(1, s.add_subscriptions("c", identity))
+
+    def test_adding_nothing_reports_the_existing_count_without_writing(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            add_sub(db, "c")
+            self.assertEqual(1, store_mod.KanbanStore(db).add_subscriptions("c", []))
+
+    def test_copy_subscriptions_moves_every_identity(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            add_sub(db, "p", chat_id="spaces/A", thread_id="t1")
+            add_sub(db, "p", chat_id="spaces/B", thread_id="t2")
+            self.assertEqual(2, store_mod.KanbanStore(db).copy_subscriptions("p", "c"))
+            self.assertEqual(2, len(rows_for(db, "c")))
+
+    def test_copying_from_an_unsubscribed_card_writes_nothing(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            self.assertEqual(0, store_mod.KanbanStore(db).copy_subscriptions("p", "c"))
+            self.assertEqual([], rows_for(db, "c"))
+
+    def test_a_constraint_violating_identity_is_skipped_not_raised(self):
+        # `INSERT OR IGNORE` is what makes re-subscribing idempotent, and it does
+        # not distinguish "already there" from "violates NOT NULL": both are
+        # skipped silently. Documented rather than changed -- this is the
+        # behaviour that shipped, and the returned count still tells the caller
+        # the truth about what the card ended up with.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            good = {"platform": "google_chat", "chat_id": "spaces/A",
+                    "thread_id": "t", "user_id": "u", "notifier_profile": "default"}
+            bad = dict(good, chat_id=None, thread_id="t2")  # chat_id is NOT NULL
+            written = store_mod.KanbanStore(db).add_subscriptions("c", [good, bad])
+            self.assertEqual(1, written)
+            self.assertEqual(1, len(rows_for(db, "c")))
+
+
+class SchemaAssumptions(unittest.TestCase):
+    def test_every_column_the_store_names_exists_on_a_real_board(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            missing = store_mod.KanbanStore(db).missing_columns(
+                store_mod.NOTIFY_SUBS_TABLE, store_mod.SUBSCRIPTION_IDENTITY_COLUMNS
+            )
+            self.assertEqual([], missing)
+
+    def test_missing_columns_names_what_is_absent(self):
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            self.assertEqual(
+                ["invented"],
+                store_mod.KanbanStore(db).missing_columns(
+                    store_mod.NOTIFY_SUBS_TABLE, ["platform", "invented"]
+                ),
+            )
+
+    def test_the_busy_timeout_comes_from_exactly_one_place(self):
+        # Setting `timeout=` on connect() AND a `PRAGMA busy_timeout` silently
+        # resolves to whichever ran last, so the source can advertise a wait the
+        # connection does not honour.
+        with TemporaryDirectory() as tmp:
+            db = str(Path(tmp) / "kanban.db")
+            make_board(db)
+            conn = store_mod.KanbanStore(db).connect()
+            try:
+                self.assertEqual(
+                    store_mod.BUSY_TIMEOUT_SECONDS * 1000,
+                    conn.execute("PRAGMA busy_timeout").fetchone()[0],
+                )
+                # journal_mode is the gateway's to choose; this store must not force it.
+                self.assertEqual(
+                    "delete", conn.execute("PRAGMA journal_mode").fetchone()[0]
+                )
+            finally:
+                conn.close()
+
+
+class NoDirectBoardAccessOutsideTheStore(unittest.TestCase):
+    """The ratchet this milestone exists to set.
+
+    "Direct SQLite writes: 0" is only true for as long as nobody adds the next
+    one, and the next one will look reasonable in review. This makes it fail a
+    test instead.
+    """
+
+    # Ships *inside* /opt/hermes as part of a patch set, so it is Hermes' own code
+    # by the time it runs and dies with the patch set it belongs to. Excluded here
+    # rather than allowlisted per-file so a new patch does not have to edit this.
+    EXEMPT_DIRS = ("deploy/docker/patches",)
+
+    # This module and its own test necessarily do both.
+    EXEMPT_FILES = (
+        "agents/platform/scripts/kanban_store.py",
+        "agents/platform/scripts/test_kanban_store.py",
+        "agents/platform/scripts/test_kanban_notify_propagate.py",
+    )
+
+    BOARD_TABLES = ("kanban_notify_subs",)
+
+    def _repo_root(self) -> Path:
+        root = Path(__file__).resolve().parents[3]
+        self.assertTrue(
+            (root / "AGENTS.md").is_file(),
+            f"expected the repository root at {root}; the scan would silently cover nothing",
+        )
+        return root
+
+    def test_no_other_python_file_opens_the_board_itself(self):
+        root = self._repo_root()
+        offenders = []
+        for path in sorted(root.rglob("*.py")):
+            rel = path.relative_to(root).as_posix()
+            if rel.startswith(self.EXEMPT_DIRS) or rel in self.EXEMPT_FILES:
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            if "sqlite3" not in text:
+                continue
+            if any(table in text for table in self.BOARD_TABLES):
+                offenders.append(rel)
+        self.assertEqual(
+            [],
+            offenders,
+            "these files reach into the kanban board's storage directly; "
+            "call agents/platform/scripts/kanban_store.KanbanStore instead",
+        )
+
+    def test_the_scan_would_actually_catch_one(self):
+        # Without this, a scan that walks the wrong root or matches nothing passes
+        # identically to a clean repository.
+        root = self._repo_root()
+        candidates = [
+            p for p in root.rglob("*.py")
+            if "sqlite3" in p.read_text(encoding="utf-8", errors="replace")
+            and any(t in p.read_text(encoding="utf-8", errors="replace")
+                    for t in self.BOARD_TABLES)
+        ]
+        self.assertTrue(
+            candidates,
+            "the scan matched no files at all -- the pattern or the root is wrong",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -533,8 +533,9 @@ RUN /opt/hermes/.venv/bin/python3 /tmp/apply_kanban_guardrail_exit.py /opt/herme
 # (gateway.log: zero Slack sends 12:59:02-13:02:15) until the user asked. The
 # manual remedy (scripts/kanban_notify_propagate.py) relies on the worker
 # remembering to run it; it didn't. Same column set and INSERT OR IGNORE
-# idempotency as that script, so keeping it around as a back-fill tool
-# double-writes harmlessly. verify_kanban_auto_subscribe.py replays the
+# idempotency as that script's storage layer (scripts/kanban_store.py, which
+# owns both), so keeping it around as a back-fill tool double-writes
+# harmlessly. verify_kanban_auto_subscribe.py replays the
 # incident through the real patched create handler on a real board.
 # See the module docstring in deploy/docker/patches/kanban_auto_subscribe.py.
 #

--- a/deploy/docker/patches/kanban_auto_subscribe.py
+++ b/deploy/docker/patches/kanban_auto_subscribe.py
@@ -48,6 +48,13 @@ subscription primary key makes it idempotent — the script remains in place
 as a manual/back-fill tool and double-writes are harmless — and
 ``created_at`` is re-stamped.
 
+That column list is owned by ``kanban_store.SUBSCRIPTION_IDENTITY_COLUMNS``
+in ``agents/platform/scripts/``; the copy above is a second, unlinked one.
+It has to be: this module is patched into ``/opt/hermes`` and cannot import
+from the agent's script directory, which is also why the repository-wide
+guard test in ``test_kanban_store.py`` exempts ``deploy/docker/patches/``.
+Nothing keeps the two in sync automatically, so change them together.
+
 The cursor starts caught up
 ---------------------------
 ``last_event_id`` is seeded at the child's current ``MAX(task_events.id)``


### PR DESCRIPTION
# Pull Request

## Why This Change

`kanban_notify_propagate.py` opened Hermes' kanban SQLite file and wrote `kanban_notify_subs`
itself. That coupled one helper to three separate facts — that the board is SQLite, where the file
lives, and what Hermes calls its tables and columns — and nothing stopped the next caller from
coupling to them again.

## What Changed

**Files:**

- `agents/platform/scripts/kanban_store.py` (new)
- `agents/platform/scripts/kanban_notify_propagate.py`
- `agents/platform/scripts/test_kanban_store.py` (new),
  `agents/platform/scripts/test_kanban_notify_propagate.py`
- `deploy/docker/Dockerfile`, `deploy/docker/patches/kanban_auto_subscribe.py` (comments)

**Added/Changed/Fixed:**

- `kanban_store.KanbanStore` owns all of it: the `HERMES_KANBAN_DB` env var, the table and column
  names, the busy-timeout policy, and the deliberate absence of a `journal_mode` pragma. When the
  board stops being a SQLite file in a Hermes pod, this is the module that changes.
- Same behaviour, one indirection. The propagation helper keeps its CLI, its idempotency, and its
  fail-soft exit; what it loses is the SQL.
- `NoDirectBoardAccessOutsideTheStore` is the ratchet: it scans every Python file in the repository
  for one that both imports `sqlite3` and names a board table, exempting only the store, its tests,
  and `deploy/docker/patches/` (which ships inside `/opt/hermes` and dies with the patch sets it
  belongs to). A second test asserts the scan matches something, so a walk of the wrong directory
  cannot pass as a clean repository.

## Why This Matters

Two behaviours are worth a reviewer's attention because they look like bugs and are not:

- `card_exists()` returns `True`/`False`/`None` rather than a bool. `None` means the board has no
  card table to check against; collapsing it into `False` would refuse every propagation on a board
  this helper does not recognise — a worse failure than the orphan row the check prevents.
- `add_subscriptions()` uses `INSERT OR IGNORE`, which is what makes re-subscribing idempotent and
  also means a constraint-violating identity is skipped rather than raised. That is the behaviour
  that shipped; it is now documented and pinned by a test rather than implied.

## Context

The second commit fixes four prose claims the refactor made stale — none wrong about behaviour,
each pointing a reader at a file where the claim can no longer be checked. Notably `kanban_store.py`
called itself "the one module in this repository" that opens the board, which its own guard test
contradicts by exempting `deploy/docker/patches/`; the header now carries the qualifier the test
actually enforces, and the reason for the exemption.

## Testing

- `make test-python` — green, including the new `test_kanban_store.py` and the guard tests.
- No Markdown/YAML in this branch, so `prettier` has nothing to check; `make docs-check` — green.
- **Not run:** `docker build`. No container runtime is available on this machine, so the
  Dockerfile comment change is unbuilt here. It is a comment-only edit to that file.

---

Behaviour-preserving refactor plus a repository-wide guard test. The riskiest surface is the
propagation helper's fail-soft path, which is covered by the retained tests. This PR was generated
with the help of Claude.
