### PR TITLE
fix(release): address code review feedback on rc pipeline, tags, and local execution

### DIFF
--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -2,7 +2,7 @@ name: RC Release E2E Pipeline
 
 on:
   schedule:
-    - cron: "0 */3 * * *"
+    - cron: "17 */3 * * *"
   workflow_dispatch:
     inputs:
       commit_sha:

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -7,7 +7,7 @@ This directory contains executable scripts supporting the Release Candidate (RC)
 - `common.sh`: Centralized registry/repository helpers (`DEFAULT_REGISTRY_PREFIX`, `DEFAULT_RELEASE_REPO`, `REQUIRED_RELEASE_IMAGES`), commit discovery (`find_latest_built_commit`), validation check (`is_commit_already_validated`), and automated bot tagging (`ensure_git_tag`).
 - `resolve_rc_tag.sh`: Validates candidate commit SHAs, resolves input tags/commit inputs, discovers the latest built commit on `main` during scheduled runs, checks for existing `*_validated` tags to skip redundant runs, and sets workflow step outputs.
 - `verify_candidate_images.sh`: Verifies that prebuilt container images (`k8s-operator`, `platform-agent`) exist in GHCR/registry for the target candidate SHA.
-- `create_release_tag.sh`: Creates and pushes candidate release tags (`rc_YYMMDDHHMM_<short_sha>`) safely and idempotently.
+- `create_release_tag.sh`: Creates and pushes candidate release tags (`rc_YYMMDDHHMM_<short_sha>`, derived from commit timestamp) safely and idempotently. When executed locally outside CI, runs in dry-run mode (creates tag locally and skips remote push).
 - `validate_and_log_deploy_summary.sh`: Validates required environment variables and secrets, then logs a formatted deployment matrix and GCP cluster target overview for auditing before provisioning.
 - `provision_rc_environment.sh`: Orchestrates cluster teardown and fresh provisioning against the dedicated RC GCP project.
 - `tag_validated_release.sh`: Attaches the `*_validated` tag to a candidate commit upon 100% test pass.
@@ -16,9 +16,10 @@ This directory contains executable scripts supporting the Release Candidate (RC)
 
 The end-to-end pipeline (`.github/workflows/rc-release-pipeline.yml`) runs on a recurring schedule and can also be triggered manually:
 
-- **Scheduled Cadence (every 3 hours `0 */3 * * *`)**:
+- **Scheduled Cadence (every 3 hours `17 */3 * * *`, best-effort)**:
   - Automatically scans recent commits on `main` (`FETCH_HEAD`) for published container images in GHCR.
-  - **Redundant Run Skipping**: If the latest candidate commit already carries a `*_validated` tag from a previous successful run, the pipeline skips subsequent provisioning and E2E test execution (`skip_rc=true`), finishing in seconds.
+  - **Redundant Run Skipping**: If the latest candidate commit already carries a `*_validated` tag or was previously attempted, the pipeline skips subsequent provisioning and E2E test execution (`skip_rc=true`), finishing in seconds.
+  - _Note_: Scheduled runs are scheduled at minute `17` to avoid GitHub Actions peak top-of-the-hour queue congestion; actual start times are best-effort based on GitHub scheduler availability.
 - **Manual Trigger (`workflow_dispatch`)**:
   - Requires an explicit `commit_sha` input to rigorously test a specific target commit.
 

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -109,7 +109,8 @@ find_latest_built_commit() {
 
   local fetch_ok="false"
   if [ -n "${target_repo}" ]; then
-    if git fetch "https://github.com/${target_repo}.git" main --tags "${depth_arg[@]}" >/dev/null 2>&1; then
+    # bash 3.2 compatibility: guard empty array expansion under set -u
+    if git fetch "https://github.com/${target_repo}.git" main --tags ${depth_arg[@]+"${depth_arg[@]}"} >/dev/null 2>&1; then
       fetch_ok="true"
     else
       echo "⚠️ Warning: Failed to fetch from target_repo (${target_repo}), falling back to origin..." >&2
@@ -117,7 +118,8 @@ find_latest_built_commit() {
   fi
 
   if [ "${fetch_ok}" != "true" ]; then
-    if git fetch origin main --tags "${depth_arg[@]}" >/dev/null 2>&1; then
+    # bash 3.2 compatibility: guard empty array expansion under set -u
+    if git fetch origin main --tags ${depth_arg[@]+"${depth_arg[@]}"} >/dev/null 2>&1; then
       fetch_ok="true"
     else
       echo "⚠️ Warning: Failed to fetch from origin remote, checking available local refs..." >&2

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -7,6 +7,25 @@ DEFAULT_REGISTRY_PREFIX="ghcr.io/gke-labs/kube-agents"
 DEFAULT_RELEASE_REPO="gke-labs/kube-agents"
 REQUIRED_RELEASE_IMAGES=("k8s-operator" "platform-agent")
 
+# ─── Boolean Parsing ──────────────────────────────────────────────────────────
+# Interpret a value as a boolean toggle. Returns 0 (success) for common
+# affirmative spellings and 1 otherwise. Matching is case-insensitive and
+# surrounding whitespace is ignored, so all of the following are truthy:
+#   true, yes, y, 1, on  (in any letter case, e.g. "True", "YES", "On")
+# Everything else — including false, no, n, 0, off, and empty/unset — is falsy.
+is_truthy() {
+  local val="${1:-}"
+  val="${val//[[:space:]]/}"
+  case "$val" in
+    [Tt][Rr][Uu][Ee] | [Yy][Ee][Ss] | [Yy] | 1 | [Oo][Nn]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_ci_pipeline() {
+  is_truthy "${CI:-}"
+}
+
 # Resolves target GitHub repository (e.g. gke-labs/kube-agents)
 get_target_repo() {
   if [ -n "${GH_ORG:-}" ] && [ -n "${GH_REPO:-}" ]; then
@@ -50,6 +69,20 @@ check_commit_images_exist() {
   return 0
 }
 
+# Finds an existing rc_* tag for a commit SHA (excluding *_validated tags)
+get_existing_rc_tag() {
+  local sha="$1"
+  git tag --points-at "${sha}" "rc_*" 2>/dev/null | grep -v '_validated$' | head -n 1 || echo ""
+}
+
+# Checks if a commit SHA has already been attempted in a previous RC run (rc_* tag exists)
+is_commit_already_attempted() {
+  local sha="$1"
+  local rc_tag
+  rc_tag=$(get_existing_rc_tag "${sha}")
+  [ -n "${rc_tag}" ]
+}
+
 # Checks if a commit SHA has already been validated in a previous RC run (*_validated tag)
 is_commit_already_validated() {
   local sha="$1"
@@ -67,10 +100,28 @@ find_latest_built_commit() {
 
   echo "🔍 [Schedule / Auto-resolve] Scanning recent commits on main for prebuilt container images (${registry_prefix})..." >&2
 
+  local is_shallow
+  is_shallow="$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")"
+  local depth_arg=()
+  if [ "${is_shallow}" = "true" ]; then
+    depth_arg=("--depth=30")
+  fi
+
+  local fetch_ok="false"
   if [ -n "${target_repo}" ]; then
-    git fetch "https://github.com/${target_repo}.git" main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || git fetch origin main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || true
-  else
-    git fetch origin main +refs/tags/*:refs/tags/* --depth=30 >/dev/null 2>&1 || true
+    if git fetch "https://github.com/${target_repo}.git" main --tags "${depth_arg[@]}" >/dev/null 2>&1; then
+      fetch_ok="true"
+    else
+      echo "⚠️ Warning: Failed to fetch from target_repo (${target_repo}), falling back to origin..." >&2
+    fi
+  fi
+
+  if [ "${fetch_ok}" != "true" ]; then
+    if git fetch origin main --tags "${depth_arg[@]}" >/dev/null 2>&1; then
+      fetch_ok="true"
+    else
+      echo "⚠️ Warning: Failed to fetch from origin remote, checking available local refs..." >&2
+    fi
   fi
 
   local candidate_commits
@@ -97,8 +148,10 @@ find_latest_built_commit() {
 
 # Configures Git bot user identity for automated tagging
 setup_git_bot_user() {
-  git config user.name "github-actions[bot]"
-  git config user.email "github-actions[bot]@users.noreply.github.com"
+  if is_ci_pipeline; then
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+  fi
 }
 
 # Ensures a Git tag exists for a given commit SHA idempotently and pushes to origin.
@@ -118,7 +171,7 @@ ensure_git_tag() {
 
   # Fetch remote tags to ensure local view is updated
   if [ -n "${target_repo}" ]; then
-    git fetch "https://github.com/${target_repo}.git" +refs/tags/*:refs/tags/* >/dev/null 2>&1 || git fetch origin --tags >/dev/null 2>&1 || true
+    git fetch "https://github.com/${target_repo}.git" --tags >/dev/null 2>&1 || git fetch origin --tags >/dev/null 2>&1 || true
   else
     git fetch origin --tags >/dev/null 2>&1 || true
   fi
@@ -138,6 +191,12 @@ ensure_git_tag() {
 
   setup_git_bot_user
   git tag -a "${rc_tag}" "${commit_sha}" -m "${tag_message}"
+
+  # Safety Guard: Remote push executes exclusively inside CI
+  if ! is_ci_pipeline; then
+    echo "⚠️ [Local Execution] Dry-run: Git tag '${rc_tag}' created locally. Remote push skipped (runs only in CI)."
+    return 0
+  fi
 
   local push_err
   if push_err=$(git push "https://github.com/${target_repo}.git" "${rc_tag}" 2>&1); then

--- a/scripts/release/resolve_rc_tag.sh
+++ b/scripts/release/resolve_rc_tag.sh
@@ -21,7 +21,7 @@ elif [ -n "${RC_TAG}" ]; then
   target_repo="$(get_target_repo)"
 
   if [ -n "${target_repo}" ]; then
-    git fetch "https://github.com/${target_repo}.git" +refs/tags/*:refs/tags/* >/dev/null 2>&1 || true
+    git fetch "https://github.com/${target_repo}.git" --tags >/dev/null 2>&1 || true
   else
     git fetch --tags >/dev/null 2>&1 || true
   fi
@@ -39,6 +39,9 @@ elif [ "${IS_SCHEDULED}" = "true" ]; then
   if is_commit_already_validated "${COMMIT_SHA}"; then
     echo "ℹ️ Latest built commit ${COMMIT_SHA:0:7} is already validated (*_validated). Skipping redundant RC run." >&2
     SKIP_RC="true"
+  elif is_commit_already_attempted "${COMMIT_SHA}"; then
+    echo "ℹ️ Latest built commit ${COMMIT_SHA:0:7} has already been evaluated in a previous RC pipeline run. Skipping redundant RC run." >&2
+    SKIP_RC="true"
   else
     SKIP_RC="false"
   fi
@@ -47,10 +50,16 @@ else
   exit 1
 fi
 
-# Resolve Release Tag Name (User input > auto-generated fallback with short SHA)
+# Resolve Release Tag Name (User input > existing candidate tag > deterministic rc_YYMMDDHHMM_<short_sha>)
 if [ -z "${RC_TAG}" ]; then
-  SHORT_SHA="${COMMIT_SHA:0:7}"
-  RC_TAG="rc_$(date -u +'%y%m%d%H%M')_${SHORT_SHA}"
+  existing_rc_tag="$(get_existing_rc_tag "${COMMIT_SHA}")"
+  if [ -n "${existing_rc_tag}" ]; then
+    RC_TAG="${existing_rc_tag}"
+  else
+    SHORT_SHA="${COMMIT_SHA:0:7}"
+    COMMIT_DATE="$(TZ=UTC0 git show -s --date=format-local:'%y%m%d%H%M' --format='%cd' "${COMMIT_SHA}")"
+    RC_TAG="rc_${COMMIT_DATE}_${SHORT_SHA}"
+  fi
 fi
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses review feedback on the Release Candidate (RC) automation pipeline from [#611](https://github.com/gke-labs/kube-agents/pull/611):
1. **Unbounded Retries**: A candidate commit failing E2E tests was re-tested repeatedly on every 3-hour cron tick without backoff or suppression.
2. **Tag Inconsistency**: Auto-generated candidate tags embedded runner execution wall-clock time, creating duplicate timestamped tags for the same commit across repeated runs.
3. **Local Clone Mutation**: Running `find_latest_built_commit` locally silently converted full git clones to shallow clones via `--depth=30` and force-overwrote local tags with `+refs/tags/*:refs/tags/*`.
4. **Accidental Upstream Push**: Running tag creation locally pushed test tags upstream to `gke-labs/kube-agents` by default.
5. **Scheduler Contention**: The cron schedule ran at `0 */3 * * *`, sitting in GitHub Actions' most heavily congested top-of-the-hour queue slot.

## What Changed

**Files:**
- `scripts/release/common.sh`
- `scripts/release/resolve_rc_tag.sh`
- `scripts/release/README.md`
- `.github/workflows/rc-release-pipeline.yml`

**Added/Changed/Fixed:**
- **Deterministic Tag Resolution**: Candidate tags (`rc_YYMMDDHHMM_<short_sha>`) are now derived from the commit's UTC author timestamp using Git's native formatter (`TZ=UTC0 git show -s --date=format-local:'%y%m%d%H%M' --format='%cd'`), ensuring 100% deterministic tag names across all platforms and runs.
- **Retry Suppression on Attempted Commits**: Added `get_existing_rc_tag()` and `is_commit_already_attempted()`. In scheduled mode (`IS_SCHEDULED=true`), if a commit already has an `rc_*` candidate tag from a previous attempt, redundant cluster teardown/rebuilds are skipped (`skip_rc=true`). Manual `workflow_dispatch` runs continue to allow intentional re-runs.
- **Topology-Aware Fetching**: `find_latest_built_commit` now checks `git rev-parse --is-shallow-repository` before applying `--depth=30`, preserving full git history on developer workstations. Replaced destructive `+refs/tags/*:refs/tags/*` with safe `--tags`.
- **Local Push Safety Guard**: Added `is_truthy()` and `is_ci_pipeline()` helpers to `scripts/release/common.sh` (matching `k8s-operator/scripts/common.sh`). `ensure_git_tag()` creates tags locally and skips remote pushes unless running inside CI.
- **Off-Peak Cron Schedule**: Shifted cron schedule from `0 */3 * * *` to `17 */3 * * *` to avoid top-of-the-hour queue delays, and documented the best-effort nature of scheduled runs in `scripts/release/README.md`.

## Why This Matters

- **Pipeline Stability**: Eliminates redundant GKE cluster teardowns and rebuilds over weekends when a commit fails E2E tests.
- **Developer Safety**: Protects developer workstations from clone shallowing, tag clobbering, and accidental remote tag pushes to upstream.
- **Tag Hygiene**: Guarantees deterministic, 1-to-1 tag naming per commit.
- **Reliable Scheduling**: Mitigates GitHub Actions scheduler delays by avoiding peak contention slots.

## Context

Follow-up to [PR #611](https://github.com/gke-labs/kube-agents/pull/611) addressing code review findings.

## Testing

- **Syntax Check**: `bash -n scripts/release/*.sh` passed with 0 errors.
- **Local Dry-Run Testing**: Verified `ensure_git_tag` creates tags locally and skips remote pushes when run outside CI.
- **Parameter Combinations**: Tested `resolve_rc_tag.sh` with explicit commit SHAs, custom tag names, positional arguments, scheduled discovery mode, and invalid inputs.
- **Clone Depth Preservation**: Verified `git rev-parse --is-shallow-repository` remains `false` after running `find_latest_built_commit`.
- **Operator Tests**: Ran `cd k8s-operator && go test ./...` — all tests passed.
- **Documentation Verification**: Ran `make docs-check` — all 230 markdown files and doc maps validated clean.
