### PR TITLE
fix(install): require gcloud 576.0.0 before provisioning a cluster

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -117,15 +117,15 @@ The Kubernetes Agentic Harness manages Kubernetes operations via an autonomous *
 
 Before beginning installation, ensure your environment meets the following requirements:
 
-| CLI Tool / Utility              | Required Version                                | Verification Command       | Description                                                                                        |
-| :------------------------------ | :---------------------------------------------- | :------------------------- | :------------------------------------------------------------------------------------------------- |
-| **Go**                          | `1.25+`                                         | `go version`               | Required for building operator binaries and running tests.                                         |
-| **Docker / Podman**             | `20.10+`                                        | `docker --version`         | Required to build container images for the operator.                                               |
-| **kubectl**                     | `1.28+`                                         | `kubectl version --client` | Communicates with your target Kubernetes or GKE cluster.                                           |
-| **Kubernetes Cluster**          | `1.28+` (`1.35+` for `AgentPlugin` OCI volumes) | `kubectl version`          | Target Kubernetes or GKE cluster (`AgentPlugin` OCI volumes require K8s 1.35+ `ImageVolume` gate). |
-| **Google Cloud SDK (`gcloud`)** | Latest                                          | `gcloud version`           | Needed for GKE cluster access, IAM, and Artifact Registry.                                         |
-| **Helm**                        | `3.10+`                                         | `helm version`             | Used for installing cluster dependencies like `cert-manager`.                                      |
-| **gettext (`envsubst`)**        | Standard                                        | `envsubst --version`       | Used by Makefile deployment targets for template substitution.                                     |
+| CLI Tool / Utility              | Required Version                                | Verification Command       | Description                                                                                           |
+| :------------------------------ | :---------------------------------------------- | :------------------------- | :---------------------------------------------------------------------------------------------------- |
+| **Go**                          | `1.25+`                                         | `go version`               | Required for building operator binaries and running tests.                                            |
+| **Docker / Podman**             | `20.10+`                                        | `docker --version`         | Required to build container images for the operator.                                                  |
+| **kubectl**                     | `1.28+`                                         | `kubectl version --client` | Communicates with your target Kubernetes or GKE cluster.                                              |
+| **Kubernetes Cluster**          | `1.28+` (`1.35+` for `AgentPlugin` OCI volumes) | `kubectl version`          | Target Kubernetes or GKE cluster (`AgentPlugin` OCI volumes require K8s 1.35+ `ImageVolume` gate).    |
+| **Google Cloud SDK (`gcloud`)** | `576.0.0+`                                      | `gcloud version`           | GKE cluster access, IAM, and Artifact Registry. `576.0.0` is where `--managed-otel-scope` reached GA. |
+| **Helm**                        | `3.10+`                                         | `helm version`             | Used for installing cluster dependencies like `cert-manager`.                                         |
+| **gettext (`envsubst`)**        | Standard                                        | `envsubst --version`       | Used by Makefile deployment targets for template substitution.                                        |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,7 @@ identifier appears, add its source here.
 | --- | --- |
 | Service-account names, namespace, permission-set defaults | `k8s-operator/scripts/common.sh` |
 | Go toolchain version | `k8s-operator/go.mod` |
+| Minimum supported tool versions (`gcloud`) | `k8s-operator/scripts/min_versions.sh` |
 | Toolsets, plugins, and MCP servers of an agent profile | that profile's `config.yaml` (`agents/platform/`, `agents/chat/`, `agents/cluster/`) |
 | Cron job rosters and schedules | `agents/chat/defaults/cron/jobs.json` and `agents/platform/cron/jobs.json` |
 | Persona rules and `§N` section numbering | the profile's `SOUL.md` |

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -7,7 +7,7 @@ The shipping install path targets GKE. You'll need one working GCP project plus 
 
 ## Local tooling
 
-- **Google Cloud SDK** (`gcloud`) — [install](https://cloud.google.com/sdk/docs/install), authenticated: `gcloud auth login && gcloud auth application-default login`.
+- **Google Cloud SDK** (`gcloud`) — **576.0.0 or newer**, [install](https://cloud.google.com/sdk/docs/install), authenticated: `gcloud auth login && gcloud auth application-default login`. Cluster creation enables Managed OpenTelemetry with `--managed-otel-scope`, which reached GA in gcloud 576.0.0 (2026-07-14); on an older SDK the flag exists only on the alpha and beta tracks and cluster creation fails. The installer checks this before it touches any cloud resource — `gcloud components update` if it complains.
 - **`kubectl`** — [install](https://kubernetes.io/docs/tasks/tools/). The provisioner points it at the GKE cluster it creates.
 - **Docker or Podman** — required by the operator dev workflow (`make docker-build`) if you rebuild images locally. Not required for a stock install.
 - **Bash 4+** — the provisioning scripts are bash.

--- a/install.sh
+++ b/install.sh
@@ -197,6 +197,20 @@ define_print_helpers() {
 }
 define_print_helpers
 
+# Minimum tool versions, shared with the provisioning scripts so the numbers
+# live in exactly one place. This installer is also downloaded and run on its
+# own, before any checkout exists, so the source is guarded: in that case the
+# workspace step clones the repository and provision_01 enforces the same
+# minimum a few steps later.
+_min_versions="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/k8s-operator/scripts/min_versions.sh"
+if [ -r "$_min_versions" ]; then
+  # shellcheck source=k8s-operator/scripts/min_versions.sh
+  source "$_min_versions"
+else
+  require_min_gcloud_version() { return 0; }
+fi
+unset _min_versions
+
 validate_immutable_ref() {
   local ref="${1:-}"
   if [ -z "$ref" ]; then
@@ -980,6 +994,7 @@ main() {
       auto_install_tool "$tool"
     fi
   done
+  require_min_gcloud_version || exit 1
 
   # 3. Provisioning Sources & Shared Defaults
   print_step "2. Setting up Workspace Repository"

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,9 @@ define_print_helpers
 # minimum a few steps later.
 _min_versions="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/k8s-operator/scripts/min_versions.sh"
 if [ -r "$_min_versions" ]; then
-  # shellcheck source=k8s-operator/scripts/min_versions.sh
+  # CI runs shellcheck without -x, so the source= hint alone still raises
+  # SC1091 for a file it was not handed as input.
+  # shellcheck source=k8s-operator/scripts/min_versions.sh disable=SC1091
   source "$_min_versions"
 else
   require_min_gcloud_version() { return 0; }

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -13,6 +13,11 @@ fi
 # load_state then creates empty — silently blanking IMAGE_TAG and AGENT_IMAGE.
 VARS_FILE="${VARS_FILE:-${SCRIPT_DIR}/vars.sh}"
 
+# Minimum tool versions. Sourced from the helper's own directory rather than
+# SCRIPT_DIR, which callers under scripts/dev/ override to point at themselves.
+# shellcheck source=k8s-operator/scripts/min_versions.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/min_versions.sh"
+
 # ─── ANSI Colors ──────────────────────────────────────────────────────────────
 # Empty unless stdout is a terminal and NO_COLOR is unset. This pipeline's output
 # is routinely redirected — install.sh tees it to a log, CI captures it — and

--- a/k8s-operator/scripts/min_versions.sh
+++ b/k8s-operator/scripts/min_versions.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Minimum Supported Tool Versions
+# ==============================================================================
+# The single home for every "you need at least version X" number in the
+# provisioning pipeline. Kept free of side effects — no state loading, no
+# argument parsing, no output at source time — because both the standalone
+# installer (install.sh, which does not source common.sh) and the provisioning
+# scripts (which do, via common.sh) need these numbers. Sourcing this file must
+# be safe from either.
+#
+# Print/exit behaviour lives in the callers; the helpers here only compare.
+# ==============================================================================
+
+# gcloud 576.0.0 (2026-07-14) promoted --managed-otel-scope to GA on
+# `container clusters create`, `create-auto`, and `update`. Earlier releases
+# expose it on the alpha/beta tracks only, so provision_01_gcp_cluster.sh — which
+# passes the flag on the GA surface — fails argument parsing before it issues a
+# single API call. That failure arrives *after* the APIs and the Cloud KMS key
+# have been provisioned, which is why the check runs up front rather than being
+# left to gcloud.
+MIN_GCLOUD_VERSION="576.0.0"
+
+# Compare two dotted version strings. Returns 0 when $1 is strictly older than
+# $2. Uses sort -V rather than a field-by-field loop so that the many shapes
+# gcloud has shipped over the years (450.0.0, 2026.05.08) all order sanely.
+version_lt() {
+  local lhs="$1" rhs="$2"
+  [ "$lhs" = "$rhs" ] && return 1
+  [ "$(printf '%s\n%s\n' "$lhs" "$rhs" | sort -V | head -n1)" = "$lhs" ]
+}
+
+# Echo the core Google Cloud SDK version, e.g. "576.0.0".
+#
+# `gcloud version` prints one component per line and the alpha/beta components
+# carry date-style versions ("alpha 2026.05.08"). Only the "Google Cloud SDK"
+# line is the release number the release notes are keyed on, so it is matched
+# by name instead of by position.
+gcloud_core_version() {
+  gcloud version 2>/dev/null | sed -n 's/^Google Cloud SDK \([0-9][0-9.]*\).*/\1/p' | head -n1
+}
+
+# Fail unless the installed gcloud is at least MIN_GCLOUD_VERSION.
+#
+# An unreadable version is a warning, not an error: gcloud has changed the
+# output of `gcloud version` before, and refusing to install because a regex
+# missed would be a worse failure than letting the flag error out downstream.
+require_min_gcloud_version() {
+  local found
+  found="$(gcloud_core_version)"
+
+  if [ -z "$found" ]; then
+    print_warning "Could not determine the Google Cloud SDK version; skipping the >= ${MIN_GCLOUD_VERSION} check."
+    return 0
+  fi
+
+  if version_lt "$found" "$MIN_GCLOUD_VERSION"; then
+    print_error "Google Cloud SDK ${found} is too old; ${MIN_GCLOUD_VERSION} or newer is required."
+    print_info "Cluster creation passes --managed-otel-scope on the GA surface, which arrived in gcloud ${MIN_GCLOUD_VERSION} (2026-07-14)."
+    print_info "Upgrade with 'gcloud components update', or reinstall the SDK if it was installed from a package manager."
+    return 1
+  fi
+
+  print_success "Google Cloud SDK ${found} meets the minimum of ${MIN_GCLOUD_VERSION}."
+  return 0
+}

--- a/k8s-operator/scripts/provision_01_gcp_cluster.sh
+++ b/k8s-operator/scripts/provision_01_gcp_cluster.sh
@@ -23,6 +23,10 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 # ─── Prerequisites Check ──────────────────────────────────────────────────────
 print_step "Checking Local Prerequisites"
 check_prereqs "gcloud" "kubectl"
+# Before enabling APIs or cutting a KMS key: execute_cluster passes
+# --managed-otel-scope on the GA surface, and an older gcloud rejects it during
+# argument parsing, stranding those resources behind a failed run.
+require_min_gcloud_version || exit 1
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
 print_step "Setting up Configuration State"


### PR DESCRIPTION
# Pull Request

## Why This Change

`provision_01_gcp_cluster.sh` creates the GKE cluster with
`--managed-otel-scope=COLLECTION_AND_INSTRUMENTATION_COMPONENTS`. That flag reached
the GA `gcloud container clusters create` surface in Google Cloud SDK **576.0.0
(2026-07-14)**; before that it existed only under `gcloud beta`.

On an older SDK the flag is rejected during argument parsing, so the run dies at
step 3 — but only *after* steps 1 and 2 have enabled three APIs and cut a Cloud KMS
keyring and key. The operator is left paying for a KMS key with no cluster, and the
error message (`unrecognized arguments`) points at a flag rather than at the real
cause, which is the SDK version. This was hit on a real install with gcloud 568.0.0.

Nothing in the repo declared a minimum gcloud version: `INSTALL.md` said "Latest",
and the prerequisites page said only "install and authenticate".

## What Changed

**Files:**

- `k8s-operator/scripts/min_versions.sh` (new)
- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/provision_01_gcp_cluster.sh`
- `install.sh`
- `INSTALL.md`
- `docs/site/src/content/docs/install/prerequisites.md`
- `docs/README.md`

**Added/Changed/Fixed:**

- New `min_versions.sh` holds `MIN_GCLOUD_VERSION=576.0.0` plus `version_lt`,
  `gcloud_core_version`, and `require_min_gcloud_version`. It is deliberately
  side-effect-free — no `set -e`, no state loading, no output at source time — so
  both `common.sh` and the standalone `install.sh` can source it.
- `common.sh` sources it from the helper's *own* directory rather than `SCRIPT_DIR`,
  which callers under `scripts/dev/` override to point at themselves.
- `provision_01` calls the check immediately after `check_prereqs`, i.e. before the
  API-enable and KMS steps, so a too-old SDK fails without stranding cloud resources.
- `install.sh` sources the helper defensively (`[ -r ... ]`, falling back to a no-op
  stub) because it can run standalone from a curl before a full checkout exists; that
  path is still covered later by `provision_01`.
- An SDK whose version cannot be parsed **warns and continues** rather than blocking.
  A version string we don't recognise is not evidence of an old SDK, and hard-failing
  there would break installs over a `sed` mismatch.
- Docs now state 576.0.0+ and why, in the two places a user checks before installing.

## Why This Matters

- Turns a confusing mid-run `unrecognized arguments` failure that leaves billable
  resources behind into a clear precondition failure that costs nothing.
- Gives the repo a single home for minimum tool versions; the next version floor is
  a one-line change plus a docs edit, not a new grep across the scripts.
- `docs/README.md` now registers `min_versions.sh` as the source of truth for the
  number, so `make docs-check` catches the docs drifting from the script.

## Context

- `--managed-otel-scope` GA promotion: Google Cloud SDK 576.0.0 release notes
  (2026-07-14).
- Found while running a full `install.sh` against a fresh project on gcloud 568.0.0.
- No behaviour change for anyone already on a current SDK — the check passes and
  prints one success line.
- This PR was generated with the help of Claude.

## Testing

- `bash -n` on all four changed/added shell scripts.
- Ran `require_min_gcloud_version` against the local gcloud 568.0.0: fails with
  `✗ Google Cloud SDK 568.0.0 is too old; 576.0.0 or newer is required.` plus the
  upgrade hint. Simulated 576.0.0 and 580.1.0: both pass.
- `version_lt` spot-checked on the multi-digit cases plain string comparison gets
  wrong (`9.0.0` vs `576.0.0`, `576.0.0` vs `576.0.0`).
- `prettier --check` clean on the changed Markdown.
- `make docs-check` clean (it failed first on the missing identifier-sources row,
  which is why `docs/README.md` is in this PR).
- Ran the `review-docs-drift` skill over the branch diff; its one Blocking finding
  was the `docs/README.md` row, now addressed.

---

Low risk and no runtime path: the check runs only in the installer and in
provisioning step 1, before any cloud mutation. Worst case for an unusual SDK build
is a warning line and today's behaviour.
