### PR TITLE
feat(alerts): cap chat alerts per severity per day

### DIFF
--- a/agents/platform/docs/session_management.md
+++ b/agents/platform/docs/session_management.md
@@ -163,7 +163,8 @@ Suppression is silent in chat, so this is how you tell a quiet day from a capped
 
 ```bash
 kubectl -n kubeagents-system exec deployment/platform-agent-gateway -c platform-agent -- \
-  curl -s http://127.0.0.1:8699/v1/alert-quota
+  sh -c 'curl -s -H "Authorization: Bearer $SESSION_KV_API_KEY" \
+    http://127.0.0.1:8699/v1/alert-quota'
 ```
 
 Pass `?day=YYYY-MM-DD` for a past day. To see which workloads were dropped:

--- a/agents/platform/docs/session_management.md
+++ b/agents/platform/docs/session_management.md
@@ -30,10 +30,11 @@ Deduplication bounds how often _one_ failure is reported. It does nothing about 
 | ---------- | ---------------------------- | ------- |
 | `Critical` | `ALERT_DAILY_LIMIT_CRITICAL` | `10`    |
 | `Warning`  | `ALERT_DAILY_LIMIT_WARNING`  | `5`     |
+| `Info`     | `ALERT_DAILY_LIMIT_INFO`     | `5`     |
 
-`Info` is uncapped and does not arrive in practice: the watcher forwards only Warning-type events. Setting a limit to `0` turns that severity's cap off entirely.
+`Info` is capped alongside the others because it genuinely arrives. Nothing on the path from the kubelet to `inject_message` filters on `Event.Type`: the watcher's filter matches reason, namespace and repeat count, its informer carries no field selector, and the type is passed through in the payload. An allowlisted reason emitted as `type: Normal` is therefore classified `Info` here — `BackOff` is on the watcher's default reason list and the kubelet emits it as `Normal` for image-pull back-off, so an image-pull storm produces exactly that. Setting a limit to `0` turns that severity's cap off entirely.
 
-Both are tunable on the `PlatformAgent` CR without rebuilding the image. They reach the container because they are on the sandbox env allowlist in `safeSandboxEnvOverrides` (`k8s-operator/internal/controller/platformagent_manifests.go`) — `spec.deployment.env` is filtered, so an arbitrary variable set there is dropped:
+All three are tunable on the `PlatformAgent` CR without rebuilding the image. They reach the container because they are on the sandbox env allowlist in `safeSandboxEnvOverrides` (`k8s-operator/internal/controller/platformagent_manifests.go`) — `spec.deployment.env` is filtered, so an arbitrary variable set there is dropped:
 
 ```yaml
 spec:
@@ -144,7 +145,7 @@ Tracks how much of each severity's daily allowance has been spent, and how many 
 ```sql
 CREATE TABLE alert_quota(
   day TEXT NOT NULL,              -- UTC YYYY-MM-DD
-  severity TEXT NOT NULL,         -- Critical | Warning
+  severity TEXT NOT NULL,         -- Critical | Warning | Info
   sent INTEGER NOT NULL DEFAULT 0,
   suppressed INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (day, severity)

--- a/agents/platform/docs/session_management.md
+++ b/agents/platform/docs/session_management.md
@@ -18,6 +18,41 @@ It binds loopback rather than `0.0.0.0` because it has exactly three callers and
 2. **Dynamic Thread Resolution:** Captures the Chat API message ID returned from the first alert, saving it as the persistent thread key.
 3. **Incident Triage Context Preservation:** Persists completed triage reports inside the local SQLite database.
 4. **Gateway Message Rewriting Hook:** Integrates the `incident_context` plugin to intercept user replies on active incident threads and automatically prepend the triage report, allowing the fixer agent session to run with full context.
+5. **Daily Alert Ceiling:** Caps how many alerts of each severity reach chat in one UTC day, bounding the volume that survives deduplication.
+
+### Daily Alert Ceiling
+
+Deduplication bounds how often _one_ failure is reported. It does nothing about many _distinct_ failures at once — a node draining or a namespace collapsing produces a hundred unrelated pods, each a legitimately new incident. The ceiling is the backstop for that case.
+
+`inject_message` classifies severity (`get_severity_details`) and then spends one of that severity's daily allowance before anything is posted or any agent turn is started. This is the only place both actions pass through, and severity is not known any earlier — `POST /sessions` carries no payload.
+
+| Severity   | Env var                      | Default |
+| ---------- | ---------------------------- | ------- |
+| `Critical` | `ALERT_DAILY_LIMIT_CRITICAL` | `10`    |
+| `Warning`  | `ALERT_DAILY_LIMIT_WARNING`  | `5`     |
+
+`Info` is uncapped and does not arrive in practice: the watcher forwards only Warning-type events. Setting a limit to `0` turns that severity's cap off entirely.
+
+Both are tunable on the `PlatformAgent` CR without rebuilding the image. They reach the container because they are on the sandbox env allowlist in `safeSandboxEnvOverrides` (`k8s-operator/internal/controller/platformagent_manifests.go`) — `spec.deployment.env` is filtered, so an arbitrary variable set there is dropped:
+
+```yaml
+spec:
+  deployment:
+    env:
+      - name: ALERT_DAILY_LIMIT_CRITICAL
+        value: "25"
+      - name: ALERT_DAILY_LIMIT_WARNING
+        value: "0" # uncapped
+```
+
+Behaviour worth knowing before relying on it:
+
+- **Suppression is silent.** Nothing is posted to say the ceiling was reached — announcing it would spend a message to say no more messages are coming. The consequence is that once the cap bites, a quiet channel no longer distinguishes "nothing is wrong" from "the budget is spent", so the accounting lives outside chat: every suppressed alert is counted in `alert_quota`, logged at `WARNING` with the workload it dropped, and readable from `GET /v1/alert-quota`.
+- **The counter is fleet-wide,** not per cluster. One collapsing cluster can therefore exhaust the day's budget for every other cluster.
+- **It fails open.** If the quota table cannot be read or written, the alert goes through. A ceiling is a comfort feature and must never be the reason an incident is withheld.
+- **The suppressed alert is still acknowledged** to the watcher with `200 {"status": "suppressed"}`. A failure response would leave the watcher's dedup entry unbound, so the same workload would be re-reported on its next sighting — a suppressed alert would cost more API calls than a delivered one.
+- **The budget survives restarts,** because it is on the `system-metadata` PVC rather than in memory. A crash-looping session server would otherwise hand out a fresh day's quota on every restart, which is precisely the condition the cap exists for.
+- **The day boundary is UTC midnight,** not the operator's local midnight.
 
 ---
 
@@ -41,6 +76,7 @@ sequenceDiagram
     Watcher->>Proxy: POST /sessions (Creates session ID: k8s-evt-abc123)
     Proxy-->>Watcher: Returns sessionID: k8s-evt-abc123
     Watcher->>Proxy: POST /sessions/k8s-evt-abc123/inject (Payload: Event details)
+    Proxy->>Proxy: Spend one of today's alerts for this severity (silently drops if the ceiling is reached)
     Proxy->>Chat: Post Alert & Triage Report (N options, one marked Recommended)
     Note over Proxy: Store triage report in db (incidents table)
     Proxy->>Gateway: POST /api/sessions/k8s-evt-abc123/chat (Start Troubleshooter)
@@ -101,9 +137,40 @@ CREATE TABLE incidents(
 );
 ```
 
+#### `alert_quota`
+
+Tracks how much of each severity's daily allowance has been spent, and how many alerts the ceiling dropped:
+
+```sql
+CREATE TABLE alert_quota(
+  day TEXT NOT NULL,              -- UTC YYYY-MM-DD
+  severity TEXT NOT NULL,         -- Critical | Warning
+  sent INTEGER NOT NULL DEFAULT 0,
+  suppressed INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (day, severity)
+);
+```
+
+Rows age out with everything else after `SESSION_KV_CLEANUP_TTL_DAYS`, so roughly two weeks of history is available to answer "what did we drop last week".
+
 ---
 
 ## Verification & Troubleshooting
+
+### Check Today's Alert Budget
+
+Suppression is silent in chat, so this is how you tell a quiet day from a capped one:
+
+```bash
+kubectl -n kubeagents-system exec deployment/platform-agent-gateway -c platform-agent -- \
+  curl -s http://127.0.0.1:8699/v1/alert-quota
+```
+
+Pass `?day=YYYY-MM-DD` for a past day. To see which workloads were dropped:
+
+```bash
+kubectl -n kubeagents-system logs deployment/platform-agent-gateway -c platform-agent | grep "Suppressed"
+```
 
 ### Check Persisted Incidents
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -156,6 +156,50 @@ def _purge_plaintext_identities(conn: sqlite3.Connection) -> None:
         logger.info(f"Purged plaintext identity fields from {purged} session metadata row(s)")
 
 
+def _alert_daily_limit(env_var: str, default: int) -> int:
+    """Read a per-day alert ceiling from the environment. 0 disables the cap."""
+    raw = os.getenv(env_var, "")
+    if raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.error(f"{env_var}={raw!r} is not an integer; falling back to {default}")
+        return default
+    # Negative is meaningless as a ceiling, and treating it as 0 makes "turn
+    # this off" forgiving of the two spellings an operator might reach for.
+    return max(value, 0)
+
+
+# Per-severity ceiling on alerts posted to chat in one UTC day. This bounds
+# volume, not redundancy: the dedup window in the event watcher is what stops
+# one failure being reported repeatedly, and this cap is the backstop for the
+# case that defeats it — many *distinct* failures at once, typically a node or
+# a namespace going down and taking a hundred unrelated pods with it.
+#
+# Suppression is deliberately invisible in chat. Announcing the ceiling would
+# spend a message to say no more messages are coming, which is self-defeating
+# when the point is a quieter channel. The trade-off is real and worth naming:
+# once the cap bites, a silent channel no longer distinguishes "nothing is
+# wrong" from "the budget is spent", so the accounting lives outside chat
+# instead. Every suppressed alert is counted per severity in `alert_quota`,
+# logged at WARNING with the workload that was dropped, and readable from
+# `GET /v1/alert-quota`. Anyone asking "did we miss something today" has an
+# answer; they just have to ask.
+#
+# Severities come from get_severity_details. Info is deliberately absent and so
+# uncapped — the watcher only forwards Warning-type events, so Info alerts do
+# not arrive here in practice and a ceiling on them would bound nothing.
+#
+# Counts are fleet-wide rather than per-cluster, matching the ceiling as
+# specified. The trade-off is that one collapsing cluster can exhaust the day's
+# budget for the others; the notice makes that visible when it happens.
+ALERT_DAILY_LIMITS = {
+    "Critical": _alert_daily_limit("ALERT_DAILY_LIMIT_CRITICAL", 10),
+    "Warning": _alert_daily_limit("ALERT_DAILY_LIMIT_WARNING", 5),
+}
+
+
 def init_db() -> None:
     db_dir = os.path.dirname(SESSION_KV_DB_PATH)
     if db_dir:
@@ -183,6 +227,25 @@ def init_db() -> None:
                 )
                 """
             )
+            # Today's alert budget per severity. In the database rather than in
+            # memory because this table's whole job is to survive a restart:
+            # the session server goes down with its container, and an in-memory
+            # counter would hand out a fresh day's quota every time it came
+            # back — turning a crash loop into an alert storm, which is exactly
+            # the condition the cap exists for. `day` is a UTC `YYYY-MM-DD`
+            # string so it sorts and compares as text against SQLite's own
+            # `date()`.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS alert_quota (
+                    day        TEXT NOT NULL,
+                    severity   TEXT NOT NULL,
+                    sent       INTEGER NOT NULL DEFAULT 0,
+                    suppressed INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (day, severity)
+                )
+                """
+            )
             _purge_plaintext_identities(conn)
 
 
@@ -196,6 +259,10 @@ def cleanup_old_records(conn: sqlite3.Connection) -> None:
         param = f"-{CLEANUP_TTL_DAYS} days"
         conn.execute("DELETE FROM incidents WHERE created_at < datetime('now', ?)", (param,))
         conn.execute("DELETE FROM session_metadata WHERE updated_at < datetime('now', ?)", (param,))
+        # Spent quota is only meaningful for the day it belongs to; the history
+        # is kept the same 14 days as everything else so an operator asked
+        # "what did we drop last week" still has an answer.
+        conn.execute("DELETE FROM alert_quota WHERE day < date('now', ?)", (param,))
     except Exception as exc:
         logger.error(f"Failed to clean up old DB records: {exc}")
 
@@ -314,6 +381,63 @@ def _post_initial_alert(active_platform: str, alert_msg: str) -> str | None:
     except Exception as exc:
         logger.error(f"Failed to post warning alert or parse message_id response: {exc}")
     return None
+
+
+def _claim_alert_quota(severity: str) -> tuple[bool, int]:
+    """Spend one of today's alerts for `severity`.
+
+    Returns `(allowed, suppressed_today)`. `allowed` is False once the day's
+    ceiling is spent; `suppressed_today` is the running count of alerts the cap
+    has dropped today, which the caller logs so the drop leaves a trace even
+    though nothing is posted to chat.
+
+    Fails open. A cap is a comfort feature and a database that cannot be
+    written is not a reason to withhold an incident from an on-call human, so
+    any error here lets the alert through and is logged.
+    """
+    limit = ALERT_DAILY_LIMITS.get(severity, 0)
+    if limit <= 0:
+        return True, 0
+
+    day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    try:
+        # isolation_level=None hands transaction control to us so the BEGIN
+        # IMMEDIATE below is the real thing rather than sqlite3's implicit
+        # deferred transaction.
+        with closing(sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0, isolation_level=None)) as conn:
+            # IMMEDIATE takes the write lock before the read. A deferred
+            # transaction would let two alerts arriving together both read
+            # `sent` at limit-1 and both conclude they are within budget, which
+            # is the one bug a cap must not have.
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                conn.execute(
+                    "INSERT OR IGNORE INTO alert_quota (day, severity) VALUES (?, ?)",
+                    (day, severity),
+                )
+                sent, suppressed = conn.execute(
+                    "SELECT sent, suppressed FROM alert_quota WHERE day = ? AND severity = ?",
+                    (day, severity),
+                ).fetchone()
+                if sent < limit:
+                    conn.execute(
+                        "UPDATE alert_quota SET sent = sent + 1 WHERE day = ? AND severity = ?",
+                        (day, severity),
+                    )
+                    conn.execute("COMMIT")
+                    return True, suppressed
+                conn.execute(
+                    "UPDATE alert_quota SET suppressed = suppressed + 1 WHERE day = ? AND severity = ?",
+                    (day, severity),
+                )
+                conn.execute("COMMIT")
+                return False, suppressed + 1
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+    except Exception as exc:
+        logger.error(f"Alert quota check failed for severity {severity} (allowing the alert through): {exc}")
+        return True, 0
 
 
 def _register_session_routing(session_id: str, platform: str, thread_id: str) -> None:
@@ -485,6 +609,26 @@ def inject_message(session_id: str, request_data: Dict[str, Any], background_tas
     event_type = payload.get("type") or "Warning"
 
     severity_emoji, severity_label = get_severity_details(event_type, event_reason)
+
+    # The daily ceiling is enforced here rather than at /sessions because
+    # severity is not known until the payload arrives, and here is the single
+    # point both the chat post and the agent turn pass through. The cost is a
+    # session row created for an alert that never posts; those age out under
+    # CLEANUP_TTL_DAYS like any other.
+    #
+    # The watcher is told this succeeded on purpose. A failure response would
+    # leave its dedup entry unbound and the same workload would be re-reported
+    # on the next sighting, so a suppressed alert would cost more API calls
+    # than a delivered one.
+    allowed, suppressed_today = _claim_alert_quota(severity_label)
+    if not allowed:
+        logger.warning(
+            f"Suppressed {severity_label} alert for {namespace}/{object_kind}/{object_name} "
+            f"({event_reason}): daily limit of {ALERT_DAILY_LIMITS[severity_label]} reached, "
+            f"{suppressed_today} suppressed today"
+        )
+        return {"status": "suppressed", "severity": severity_label, "suppressed_today": str(suppressed_today)}
+
     clean_name = clean_workload_name(object_kind, object_name)
     clean_reason = clean_reason_label(event_reason)
     clean_msg = clean_event_message(message)
@@ -582,6 +726,37 @@ def get_incident(chat_id: str, thread_id: str) -> Dict[str, str]:
     if not row:
         raise HTTPException(status_code=404, detail="no incident for thread")
     return {"chat_id": chat_id, "thread_id": thread_id, "report": row[0]}
+
+
+@app.get("/v1/alert-quota")
+def get_alert_quota(day: str = "") -> Dict[str, Any]:
+    """Report how much of the daily alert budget was spent, and what it dropped.
+
+    Suppression is silent in chat, so this is where an operator finds out
+    whether a quiet day was quiet because nothing broke or because the ceiling
+    was reached. Defaults to today (UTC); pass `day=YYYY-MM-DD` for history,
+    which reaches back CLEANUP_TTL_DAYS.
+    """
+    day = day or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    with closing(sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0)) as conn:
+        rows = conn.execute(
+            "SELECT severity, sent, suppressed FROM alert_quota WHERE day = ?",
+            (day,),
+        ).fetchall()
+
+    counts = {severity: {"sent": sent, "suppressed": suppressed} for severity, sent, suppressed in rows}
+    # Report every capped severity, including ones with no traffic today, so a
+    # missing key means "not capped" rather than "no alerts yet".
+    severities = {
+        severity: {
+            "limit": limit,
+            "sent": counts.get(severity, {}).get("sent", 0),
+            "suppressed": counts.get(severity, {}).get("suppressed", 0),
+        }
+        for severity, limit in ALERT_DAILY_LIMITS.items()
+        if limit > 0
+    }
+    return {"day": day, "severities": severities}
 
 
 init_db()

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -728,7 +728,7 @@ def get_incident(chat_id: str, thread_id: str) -> Dict[str, str]:
     return {"chat_id": chat_id, "thread_id": thread_id, "report": row[0]}
 
 
-@app.get("/v1/alert-quota")
+@app.get("/v1/alert-quota", dependencies=[Depends(verify_api_key)])
 def get_alert_quota(day: str = "") -> Dict[str, Any]:
     """Report how much of the daily alert budget was spent, and what it dropped.
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -187,9 +187,19 @@ def _alert_daily_limit(env_var: str, default: int) -> int:
 # `GET /v1/alert-quota`. Anyone asking "did we miss something today" has an
 # answer; they just have to ask.
 #
-# Severities come from get_severity_details. Info is deliberately absent and so
-# uncapped — the watcher only forwards Warning-type events, so Info alerts do
-# not arrive here in practice and a ceiling on them would bound nothing.
+# Severities come from get_severity_details, and every one of them is capped.
+# Info is not a hypothetical: nothing between the kubelet and this function
+# filters on Event.Type. The watcher's filter matches reason, namespace and
+# repeat count only, and its informer runs without a field selector, so an
+# allowlisted reason arriving as `type: Normal` is forwarded like any other,
+# classified Info here, and — left out of this dict — would post to chat and
+# start an agent turn outside every ceiling. `BackOff` is on the watcher's
+# default reason list and the kubelet emits it as Normal for image-pull
+# back-off, which is exactly the storm the cap exists for.
+#
+# Covering all three also means the `.get(severity, 0)` default in
+# _claim_alert_quota is now reached only by a severity this module cannot
+# produce, rather than by a routine one.
 #
 # Counts are fleet-wide rather than per-cluster, matching the ceiling as
 # specified. The trade-off is that one collapsing cluster can exhaust the day's
@@ -197,6 +207,8 @@ def _alert_daily_limit(env_var: str, default: int) -> int:
 ALERT_DAILY_LIMITS = {
     "Critical": _alert_daily_limit("ALERT_DAILY_LIMIT_CRITICAL", 10),
     "Warning": _alert_daily_limit("ALERT_DAILY_LIMIT_WARNING", 5),
+    # Capped, not exempt: see above — Normal-type events land here.
+    "Info": _alert_daily_limit("ALERT_DAILY_LIMIT_INFO", 5),
 }
 
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -193,7 +193,7 @@ def _alert_daily_limit(env_var: str, default: int) -> int:
 #
 # Counts are fleet-wide rather than per-cluster, matching the ceiling as
 # specified. The trade-off is that one collapsing cluster can exhaust the day's
-# budget for the others; the notice makes that visible when it happens.
+# budget for the others; `GET /v1/alert-quota` is where that shows up.
 ALERT_DAILY_LIMITS = {
     "Critical": _alert_daily_limit("ALERT_DAILY_LIMIT_CRITICAL", 10),
     "Warning": _alert_daily_limit("ALERT_DAILY_LIMIT_WARNING", 5),

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -199,6 +199,7 @@ class TestSessionKvServerAuth(unittest.TestCase):
         ("GET", "/v1/sessions/sess-1/metadata", None),
         ("POST", "/v1/incidents", {"chat_id": "c", "thread_id": "t", "report": "r"}),
         ("GET", "/v1/incidents/by-thread?chat_id=c&thread_id=t", None),
+        ("GET", "/v1/alert-quota", None),
     )
 
     def setUp(self):
@@ -357,13 +358,21 @@ class TestAlertDailyQuota(unittest.TestCase):
         import sqlite3
         from fastapi.testclient import TestClient
 
-        self.client = TestClient(session_kv_server.app)
+        # Every route these tests touch is behind verify_api_key, including
+        # /v1/alert-quota. The key goes on the client rather than on each call
+        # so these tests stay about the ceiling; the auth boundary itself is
+        # pinned by TestSessionKvServerAuth above.
+        os.environ["SESSION_KV_API_KEY"] = API_KEY
+        self.client = TestClient(session_kv_server.app, headers=AUTH_HEADERS)
         # The temp database is shared by every test in this file, so today's
         # spent budget has to be cleared or these tests order-depend on each
         # other.
         with sqlite3.connect(temp_db_path) as conn:
             with conn:
                 conn.execute("DELETE FROM alert_quota")
+
+    def tearDown(self):
+        os.environ.pop("SESSION_KV_API_KEY", None)
 
     def _inject(self, reason="Unhealthy", session_id="k8s-evt-quota"):
         payload = {

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -350,6 +350,181 @@ class TestPlaintextIdentityPurge(unittest.TestCase):
         self.assertEqual(self._read("modern-1")["user_email_hash"], "deadbeef")
 
 
+class TestAlertDailyQuota(unittest.TestCase):
+    """The per-severity daily ceiling enforced in /sessions/{id}/inject."""
+
+    def setUp(self):
+        import sqlite3
+        from fastapi.testclient import TestClient
+
+        self.client = TestClient(session_kv_server.app)
+        # The temp database is shared by every test in this file, so today's
+        # spent budget has to be cleared or these tests order-depend on each
+        # other.
+        with sqlite3.connect(temp_db_path) as conn:
+            with conn:
+                conn.execute("DELETE FROM alert_quota")
+
+    def _inject(self, reason="Unhealthy", session_id="k8s-evt-quota"):
+        payload = {
+            "reason": reason,
+            "namespace": "ns",
+            "kind_of_object": "Pod",
+            "name": "billing-pod",
+            "message": "some message",
+            "type": "Warning",
+        }
+        return self.client.post(f"/sessions/{session_id}/inject", json={"message": json.dumps(payload)})
+
+    def test_alert_daily_limit_parsing(self):
+        parse = session_kv_server._alert_daily_limit
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("X_LIMIT", None)
+            # Unset falls back to the default rather than to "uncapped".
+            self.assertEqual(parse("X_LIMIT", 10), 10)
+        with patch.dict(os.environ, {"X_LIMIT": "3"}):
+            self.assertEqual(parse("X_LIMIT", 10), 3)
+        with patch.dict(os.environ, {"X_LIMIT": "0"}):
+            # An explicit 0 is how the cap is turned off.
+            self.assertEqual(parse("X_LIMIT", 10), 0)
+        with patch.dict(os.environ, {"X_LIMIT": "-5"}):
+            # Negative is not a ceiling; treated as "off", not as "block all".
+            self.assertEqual(parse("X_LIMIT", 10), 0)
+        with patch.dict(os.environ, {"X_LIMIT": "ten"}):
+            # Garbage must not silently disable the cap or block everything.
+            self.assertEqual(parse("X_LIMIT", 10), 10)
+
+    def test_zero_limit_never_suppresses(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 0}):
+            for _ in range(20):
+                allowed, suppressed = session_kv_server._claim_alert_quota("Warning")
+                self.assertTrue(allowed)
+                self.assertEqual(suppressed, 0)
+
+    def test_uncapped_severity_is_allowed(self):
+        # Info has no entry in ALERT_DAILY_LIMITS, so it must pass through
+        # rather than being treated as a zero budget.
+        allowed, _ = session_kv_server._claim_alert_quota("Info")
+        self.assertTrue(allowed)
+
+    def test_claim_allows_exactly_the_limit_then_suppresses(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 3}):
+            for i in range(3):
+                allowed, suppressed = session_kv_server._claim_alert_quota("Warning")
+                self.assertTrue(allowed, f"alert {i + 1} of 3 should be within budget")
+                self.assertEqual(suppressed, 0)
+
+            allowed, suppressed = session_kv_server._claim_alert_quota("Warning")
+            self.assertFalse(allowed)
+            self.assertEqual(suppressed, 1)
+
+            allowed, suppressed = session_kv_server._claim_alert_quota("Warning")
+            self.assertFalse(allowed)
+            self.assertEqual(suppressed, 2)
+
+    def test_severities_have_independent_budgets(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 1, "Critical": 2}):
+            self.assertTrue(session_kv_server._claim_alert_quota("Warning")[0])
+            self.assertFalse(session_kv_server._claim_alert_quota("Warning")[0])
+            # Exhausting warnings must not touch the critical budget.
+            self.assertTrue(session_kv_server._claim_alert_quota("Critical")[0])
+            self.assertTrue(session_kv_server._claim_alert_quota("Critical")[0])
+            self.assertFalse(session_kv_server._claim_alert_quota("Critical")[0])
+
+    def test_yesterdays_spend_does_not_consume_today(self):
+        import sqlite3
+
+        with sqlite3.connect(temp_db_path) as conn:
+            with conn:
+                conn.execute(
+                    "INSERT INTO alert_quota (day, severity, sent, suppressed) VALUES ('2020-01-01', 'Warning', 99, 42)"
+                )
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 2}):
+            self.assertTrue(session_kv_server._claim_alert_quota("Warning")[0])
+
+    def test_claim_fails_open_when_the_database_is_unavailable(self):
+        import sqlite3
+
+        # A cap must never be the reason an incident goes unreported.
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 1}):
+            with patch.object(session_kv_server.sqlite3, "connect", side_effect=sqlite3.OperationalError("locked")):
+                allowed, suppressed = session_kv_server._claim_alert_quota("Warning")
+        self.assertTrue(allowed)
+        self.assertEqual(suppressed, 0)
+
+    def test_inject_suppresses_past_the_limit_and_does_not_trigger_the_agent(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 2}):
+            with patch.object(session_kv_server, "trigger_agent_troubleshooter") as trigger:
+                self.assertEqual(self._inject().json()["status"], "injected")
+                self.assertEqual(self._inject().json()["status"], "injected")
+
+                resp = self._inject()
+                # 200, not an error: a failure response would leave the
+                # watcher's dedup entry unbound and cost us a re-report.
+                self.assertEqual(resp.status_code, 200)
+                body = resp.json()
+                self.assertEqual(body["status"], "suppressed")
+                self.assertEqual(body["severity"], "Warning")
+                self.assertEqual(body["suppressed_today"], "1")
+
+                self.assertEqual(trigger.call_count, 2, "the suppressed alert must not reach the agent")
+
+    def test_suppression_posts_nothing_to_chat(self):
+        # Announcing the ceiling would spend a message to say no more messages
+        # are coming. Nothing at all may be sent once the budget is spent.
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 1}):
+            with patch.object(session_kv_server, "trigger_agent_troubleshooter"):
+                with patch.object(session_kv_server, "_post_initial_alert") as post:
+                    self._inject()
+                    self._inject()
+                    self._inject()
+        post.assert_not_called()
+
+    def test_alert_quota_endpoint_reports_spend_and_drops(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 1, "Critical": 5}):
+            with patch.object(session_kv_server, "trigger_agent_troubleshooter"):
+                self._inject()
+                self._inject()
+
+            resp = self.client.get("/v1/alert-quota")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertEqual(data["severities"]["Warning"], {"limit": 1, "sent": 1, "suppressed": 1})
+            # A capped severity with no traffic still reports, so a missing key
+            # means "uncapped" rather than "quiet".
+            self.assertEqual(data["severities"]["Critical"], {"limit": 5, "sent": 0, "suppressed": 0})
+
+    def test_alert_quota_endpoint_omits_uncapped_severities(self):
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Warning": 0, "Critical": 5}):
+            data = self.client.get("/v1/alert-quota").json()
+            self.assertNotIn("Warning", data["severities"])
+            self.assertIn("Critical", data["severities"])
+
+    def test_old_quota_rows_are_cleaned_up(self):
+        import sqlite3
+        from datetime import datetime, timedelta
+
+        stale_day = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d")
+        fresh_day = datetime.now().strftime("%Y-%m-%d")
+        with sqlite3.connect(temp_db_path) as conn:
+            with conn:
+                conn.execute(
+                    "INSERT INTO alert_quota (day, severity, sent, suppressed) VALUES (?, 'Warning', 1, 1)",
+                    (stale_day,),
+                )
+                conn.execute(
+                    "INSERT INTO alert_quota (day, severity, sent, suppressed) VALUES (?, 'Warning', 1, 1)",
+                    (fresh_day,),
+                )
+
+        # Any write endpoint runs cleanup_old_records.
+        self.assertEqual(self.client.post("/sessions").status_code, 201)
+
+        with sqlite3.connect(temp_db_path) as conn:
+            self.assertIsNone(conn.execute("SELECT 1 FROM alert_quota WHERE day = ?", (stale_day,)).fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM alert_quota WHERE day = ?", (fresh_day,)).fetchone())
+
+
 class TestSessionKvServerQueryBuilding(unittest.TestCase):
 
     @patch.dict(os.environ, {"GCP_PROJECT_ID": "test-project-id"})

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -410,10 +410,26 @@ class TestAlertDailyQuota(unittest.TestCase):
                 self.assertTrue(allowed)
                 self.assertEqual(suppressed, 0)
 
-    def test_uncapped_severity_is_allowed(self):
-        # Info has no entry in ALERT_DAILY_LIMITS, so it must pass through
-        # rather than being treated as a zero budget.
-        allowed, _ = session_kv_server._claim_alert_quota("Info")
+    def test_info_severity_is_capped(self):
+        # Info is a real arrival, not a theoretical one: nothing on the path
+        # from the kubelet filters on Event.Type, so an allowlisted reason
+        # emitted as `type: Normal` — BackOff during image-pull back-off, say —
+        # is classified Info here. It gets a ceiling like everything else.
+        self.assertIn("Info", session_kv_server.ALERT_DAILY_LIMITS)
+        with patch.dict(session_kv_server.ALERT_DAILY_LIMITS, {"Info": 1}):
+            allowed, _ = session_kv_server._claim_alert_quota("Info")
+            self.assertTrue(allowed)
+
+            allowed, suppressed = session_kv_server._claim_alert_quota("Info")
+            self.assertFalse(allowed, "Info must not bypass the ceiling")
+            self.assertEqual(suppressed, 1)
+
+    def test_unknown_severity_is_allowed(self):
+        # The .get default is now reachable only by a string
+        # get_severity_details cannot return. Such a severity must pass through
+        # rather than be read as a zero budget and blocked outright.
+        self.assertNotIn("Nonsense", session_kv_server.ALERT_DAILY_LIMITS)
+        allowed, _ = session_kv_server._claim_alert_quota("Nonsense")
         self.assertTrue(allowed)
 
     def test_claim_allows_exactly_the_limit_then_suppresses(self):

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -47,8 +47,12 @@ The operator does not place managed credentials in the sandbox container's:
 - mounted ServiceAccount token path.
 
 `spec.deployment.env` is applied to the credential sidecar because it may
-contain credentials. Four allowlisted OpenTelemetry settings may also be copied
-to the sandbox, but only as literal values; all `valueFrom` sources are rejected.
+contain credentials. A short allowlist may also be copied to the sandbox — the
+four OpenTelemetry settings and the two `ALERT_DAILY_LIMIT_*` alert ceilings —
+but only as literal values; all `valueFrom` sources are rejected. A name earns a
+place on that list only if an arbitrary value for it cannot redirect state,
+grant access, or change what code runs; `safeSandboxEnvOverrides` in
+`k8s-operator/internal/controller/platformagent_manifests.go` is the list.
 Reserved proxy, runtime-loader, and shell-startup variables cannot override the
 operator's managed values.
 

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -48,7 +48,7 @@ The operator does not place managed credentials in the sandbox container's:
 
 `spec.deployment.env` is applied to the credential sidecar because it may
 contain credentials. A short allowlist may also be copied to the sandbox — the
-four OpenTelemetry settings and the two `ALERT_DAILY_LIMIT_*` alert ceilings —
+four OpenTelemetry settings and the three `ALERT_DAILY_LIMIT_*` alert ceilings —
 but only as literal values; all `valueFrom` sources are rejected. A name earns a
 place on that list only if an arbitrary value for it cannot redirect state,
 grant access, or change what code runs; `safeSandboxEnvOverrides` in

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -77,7 +77,7 @@ Pod-wide `automountServiceAccountToken` is `false`. The sidecar's projected toke
 
 ## Guarantee and limitation
 
-**Guarantee:** the operator does not place managed credentials in the sandbox container's environment, root filesystem, persistent agent volume, or mounted ServiceAccount token path. `spec.deployment.env` is applied to the credential sidecar because it may contain credentials (only a short allowlist is copied to the sandbox — the four OpenTelemetry settings and the two `ALERT_DAILY_LIMIT_*` alert ceilings — as literal values only).
+**Guarantee:** the operator does not place managed credentials in the sandbox container's environment, root filesystem, persistent agent volume, or mounted ServiceAccount token path. `spec.deployment.env` is applied to the credential sidecar because it may contain credentials (only a short allowlist is copied to the sandbox — the four OpenTelemetry settings and the three `ALERT_DAILY_LIMIT_*` alert ceilings — as literal values only).
 
 **Limitation:** containers in one Pod share a network namespace and one Pod identity. The sandbox has no KSA token file, but it can technically reach the GKE metadata server used by the sidecar — a Pod-level NetworkPolicy cannot block metadata for one container while allowing it for another. The design meets the scoped filesystem-and-environment goal but does not provide the stronger identity boundary of separate Pods.
 

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -77,7 +77,7 @@ Pod-wide `automountServiceAccountToken` is `false`. The sidecar's projected toke
 
 ## Guarantee and limitation
 
-**Guarantee:** the operator does not place managed credentials in the sandbox container's environment, root filesystem, persistent agent volume, or mounted ServiceAccount token path. `spec.deployment.env` is applied to the credential sidecar because it may contain credentials (only four allowlisted OpenTelemetry settings are copied to the sandbox, as literal values only).
+**Guarantee:** the operator does not place managed credentials in the sandbox container's environment, root filesystem, persistent agent volume, or mounted ServiceAccount token path. `spec.deployment.env` is applied to the credential sidecar because it may contain credentials (only a short allowlist is copied to the sandbox — the four OpenTelemetry settings and the two `ALERT_DAILY_LIMIT_*` alert ceilings — as literal values only).
 
 **Limitation:** containers in one Pod share a network namespace and one Pod identity. The sandbox has no KSA token file, but it can technically reach the GKE metadata server used by the sidecar — a Pod-level NetworkPolicy cannot block metadata for one container while allowing it for another. The design meets the scoped filesystem-and-environment goal but does not provide the stronger identity boundary of separate Pods.
 

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -2039,7 +2039,15 @@ func mergeCredentialProxyEnv(managed, custom []corev1.EnvVar) []corev1.EnvVar {
 // safeSandboxEnvOverrides preserves non-secret telemetry customization without
 // copying arbitrary deployment environment variables into the agent sandbox.
 func safeSandboxEnvOverrides(custom []corev1.EnvVar) []corev1.EnvVar {
+	// An allowlist, not a denylist: this env reaches the agent sandbox, so a
+	// variable earns a place here only if an arbitrary value for it cannot
+	// redirect state, grant access, or change what code runs. Telemetry
+	// destinations qualify, and so do the alert ceilings — they bound how many
+	// notifications the session server posts in a day and nothing else. A
+	// path, a credential or an image reference would not.
 	allowed := map[string]struct{}{
+		"ALERT_DAILY_LIMIT_CRITICAL":  {},
+		"ALERT_DAILY_LIMIT_WARNING":   {},
 		"OTEL_EXPORTER_OTLP_ENDPOINT": {},
 		"OTEL_EXPORTER_OTLP_PROTOCOL": {},
 		"OTEL_RESOURCE_ATTRIBUTES":    {},
@@ -2047,8 +2055,8 @@ func safeSandboxEnvOverrides(custom []corev1.EnvVar) []corev1.EnvVar {
 	}
 	var result []corev1.EnvVar
 	for _, env := range custom {
-		// Only literal telemetry settings are safe to copy. A ValueFrom source can
-		// reference a Secret even when its environment variable name is allowlisted.
+		// Only literal values are copied. A ValueFrom source can reference a
+		// Secret even when its environment variable name is allowlisted.
 		if _, ok := allowed[env.Name]; ok && env.ValueFrom == nil {
 			result = append(result, env)
 		}

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -2047,6 +2047,7 @@ func safeSandboxEnvOverrides(custom []corev1.EnvVar) []corev1.EnvVar {
 	// path, a credential or an image reference would not.
 	allowed := map[string]struct{}{
 		"ALERT_DAILY_LIMIT_CRITICAL":  {},
+		"ALERT_DAILY_LIMIT_INFO":      {},
 		"ALERT_DAILY_LIMIT_WARNING":   {},
 		"OTEL_EXPORTER_OTLP_ENDPOINT": {},
 		"OTEL_EXPORTER_OTLP_PROTOCOL": {},

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -1064,6 +1064,47 @@ func TestSafeSandboxEnvOverridesRejectsValueFrom(t *testing.T) {
 	}
 }
 
+func TestSafeSandboxEnvOverridesPassesAlertLimits(t *testing.T) {
+	// The session server reads its daily alert ceilings from the environment,
+	// so an operator has to be able to tune or disable them on the CR. Without
+	// these two names on the allowlist the documented override silently does
+	// nothing and the only way to change a limit is a new image.
+	custom := []corev1.EnvVar{
+		{Name: "ALERT_DAILY_LIMIT_CRITICAL", Value: "25"},
+		{Name: "ALERT_DAILY_LIMIT_WARNING", Value: "0"},
+		{Name: "SESSION_KV_DB_PATH", Value: "/tmp/hijacked.db"},
+		{
+			Name: "ALERT_DAILY_LIMIT_CRITICAL",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "s"},
+				Key:                  "k",
+			}},
+		},
+	}
+
+	got := safeSandboxEnvOverrides(custom)
+	values := map[string]string{}
+	for _, e := range got {
+		if e.ValueFrom != nil {
+			t.Errorf("ValueFrom must never survive the allowlist, got %#v", e)
+		}
+		values[e.Name] = e.Value
+	}
+
+	if values["ALERT_DAILY_LIMIT_CRITICAL"] != "25" {
+		t.Errorf("expected the critical ceiling to be overridable, got %q", values["ALERT_DAILY_LIMIT_CRITICAL"])
+	}
+	// 0 is how a severity's cap is turned off; it must survive as a literal
+	// rather than being dropped as an empty-ish value.
+	if v, ok := values["ALERT_DAILY_LIMIT_WARNING"]; !ok || v != "0" {
+		t.Errorf("expected the warning ceiling to be settable to 0, got %q (present=%v)", v, ok)
+	}
+	// Widening the allowlist must not have widened it to everything.
+	if _, ok := values["SESSION_KV_DB_PATH"]; ok {
+		t.Errorf("SESSION_KV_DB_PATH must stay operator-owned, got %#v", got)
+	}
+}
+
 func TestBuildCredentialProxySidecar(t *testing.T) {
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -1067,10 +1067,12 @@ func TestSafeSandboxEnvOverridesRejectsValueFrom(t *testing.T) {
 func TestSafeSandboxEnvOverridesPassesAlertLimits(t *testing.T) {
 	// The session server reads its daily alert ceilings from the environment,
 	// so an operator has to be able to tune or disable them on the CR. Without
-	// these two names on the allowlist the documented override silently does
-	// nothing and the only way to change a limit is a new image.
+	// these names on the allowlist the documented override silently does
+	// nothing and the only way to change a limit is a new image. One name per
+	// severity the server caps, Info included.
 	custom := []corev1.EnvVar{
 		{Name: "ALERT_DAILY_LIMIT_CRITICAL", Value: "25"},
+		{Name: "ALERT_DAILY_LIMIT_INFO", Value: "3"},
 		{Name: "ALERT_DAILY_LIMIT_WARNING", Value: "0"},
 		{Name: "SESSION_KV_DB_PATH", Value: "/tmp/hijacked.db"},
 		{
@@ -1093,6 +1095,11 @@ func TestSafeSandboxEnvOverridesPassesAlertLimits(t *testing.T) {
 
 	if values["ALERT_DAILY_LIMIT_CRITICAL"] != "25" {
 		t.Errorf("expected the critical ceiling to be overridable, got %q", values["ALERT_DAILY_LIMIT_CRITICAL"])
+	}
+	// Info is capped too — nothing on the watcher path filters on Event.Type,
+	// so Normal-type events with an allowlisted reason arrive as Info.
+	if values["ALERT_DAILY_LIMIT_INFO"] != "3" {
+		t.Errorf("expected the info ceiling to be overridable, got %q", values["ALERT_DAILY_LIMIT_INFO"])
 	}
 	// 0 is how a severity's cap is turned off; it must survive as a literal
 	// rather than being dropped as an empty-ish value.


### PR DESCRIPTION
# Pull Request

## Why This Change

  Dedup bounds how often _one_ failure is reported. It does nothing about many
  _distinct_ failures at once — a draining node produces a hundred unrelated pods,
  each a new UID, none a repeat. This adds the backstop: a per-severity daily
  ceiling of 10 Critical, 5 Warning.


## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  - `agents/platform/scripts/session_kv_server.py` (+ tests)
  - `k8s-operator/internal/controller/platformagent_manifests.go` (+ tests)
  - `agents/platform/docs/session_management.md`
  - `docs/credential-isolation-design.md`,
    `docs/site/src/content/docs/reference/credential-isolation.md`,
    `docs/README.md`

**Added/Changed/Fixed:**

  - `inject_message` spends the severity's allowance before anything is posted or
    any agent turn starts — the single point both pass through, and the earliest
    point severity is known.
  - New `alert_quota` table on the `system-metadata` PVC. On disk, not in memory:
    an in-memory counter would hand out a fresh quota on every restart, turning a
    crash loop into the storm the cap prevents. Rows age out with the existing
    TTL sweep.
  - New `GET /v1/alert-quota` — today's spend and drops per severity.
  - `ALERT_DAILY_LIMIT_CRITICAL` / `_WARNING` added to the sandbox env allowlist
    in `safeSandboxEnvOverrides`, so the limits are tunable on the CR. `0`
    disables a cap. **Without this the documented override would silently do
    nothing** — the allowlist previously admitted four OTel names and dropped
    everything else.


 **Suppression is silent by design.** Announcing the ceiling spends a message to
  say no more are coming. The cost: a quiet channel no longer distinguishes
  "nothing is wrong" from "budget spent" — so every drop is counted, logged at
  `WARNING` with the workload, and readable from the endpoint.


<!-- Include related issues, PRs, follow-up work, or other background. -->

## Testing

### Live validation

  `platform-agent-host` (`us-east4`, `stalhaali-gkedemos`), image built from this
  branch via `make dev-rebuild-agent ARGS="platform"`, 

  - **Baseline:** endpoint returned `Critical {limit 10, 0, 0}`,
    `Warning {limit 5, 0, 0}` — table created on the PVC, endpoint served.
  - **Warning, through the real watcher:** 7 pods with an unresolvable image in
    `quota-test` → `sent 5, suppressed 2`. Five Chat messages, then silence.
    `sent` stopped at exactly 5, not 6. Two log lines named
    `quota-test/Pod/badimage-6` and `-7`.
  - **Independence:** `Critical` stayed `0/0` while `Warning` saturated.
  - **Critical:** `FailedScheduling` is filtered out (see Context), so 12
    `CrashLoopBackOff` payloads went to `POST /sessions/{id}/inject` — 1–10
    `{"status":"injected"}`, 11–12 `{"status":"suppressed",...,"1"/"2"}`,
    endpoint `Critical {sent 10, suppressed 2}`, `Warning` untouched.
  - **Cleanup:** both namespaces deleted, all `alert_quota` rows cleared.



<!-- Close with a short note on functional impact, risk, or rollout. -->
