### PR TITLE
docs: declare AGENTS.md canonical for the live-validation contract

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,10 +33,10 @@
 ### Live validation
 
 <!--
-Required, and never left empty. Describe how this change was exercised against a real,
-running kube-agents installation — which install (cluster, image tag, operator version),
-what you did, and what you observed at each layer the change claims to touch: the CR
-`.status`, the Deployment env, the file or process inside the pod.
+Required: an empty section is not an answer. Describe how this change was exercised
+against a real, running kube-agents installation — which install (cluster, image tag,
+operator version), what you did, and what you observed at each layer the change claims to
+touch: the CR `.status`, the Deployment env, the file or process inside the pod.
 
 Prove the mechanism, not a coincidence: if the new behaviour happens to match the old
 default, set something distinctly different, then revert and confirm it goes back.
@@ -46,6 +46,8 @@ cleaned up.
 
 If the change cannot reach a running installation — docs-only, a CI workflow, a path
 that needs infrastructure you do not have — write "Not live-tested" and say why.
+
+Full contract: AGENTS.md, "Pull Request Hygiene".
 -->
 
 -

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,10 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   exercised against a real, running kube-agents installation — see [INSTALL.md](INSTALL.md) if
   you do not have one. Green unit tests and a clean `make docs-check` are necessary, not
   sufficient: they cannot tell you whether the operator reconciled the change or the agent pod
-  picked it up.
+  picked it up. This bullet is the canonical statement of the requirement; the site's
+  [contributing guide](docs/site/src/content/docs/contributing.md) and the comment in
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise it — change
+  this list first, then reconcile them to it.
   - **Name the install and what you observed.** Cluster, image tag, operator version; what you
     did; and the result at each layer the change claims to touch — the CR `.status`, the
     Deployment env, the file or process inside the pod.

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -74,15 +74,17 @@ Before pushing, run the checks CI enforces:
 
 The checks above tell you the code compiles, the docs resolve, and the unit tests agree with themselves. None of them tell you whether the operator reconciled your change or the agent pod picked it up — this project's failure mode is a green build that configures nothing. So every pull request fills in the template's **Testing → Live validation** section with how the change was exercised against a real, running kube-agents installation. If you don't have one, [INSTALL.md](https://github.com/gke-labs/kube-agents/blob/main/INSTALL.md) stands one up.
 
+[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement in full and is canonical; what follows summarises it, so trust it over this page if the two ever differ.
+
 What that section should say:
 
 - **Which install, and what you did.** Cluster, image tag, operator version, and the steps you ran.
-- **What you observed at each layer the change touches** — the `PlatformAgent` `.status`, the Deployment env, the file or process inside the pod. A change that claims to reach the pod is verified by reading it in the pod.
+- **What you observed at each layer the change touches** — the CR `.status`, the Deployment env, the file or process inside the pod. A change that claims to reach the pod is verified by reading it in the pod.
 - **Evidence the mechanism worked, not a coincidence.** If your new value happens to equal the previous default, observing it proves nothing. Set something distinctly different, confirm it lands, then revert and confirm it goes back.
 - **What you could not cover, and why.** An honest gap is more useful than an implied one.
 - **Cleanup.** Remove test artifacts, restore prior state, and note anything left behind.
 
-Some changes can't reach a running installation — docs-only edits, CI workflow changes, code paths that need infrastructure you don't have. Write "Not live-tested" and say why. Leaving the section blank is the only wrong answer.
+Some changes can't reach a running installation — docs-only edits, CI workflow changes, code paths that need infrastructure you don't have. Write "Not live-tested" and say why. An empty section is not an answer.
 
 ## Code review
 


### PR DESCRIPTION
# Pull Request

## Why This Change

Follow-up to review feedback on #642 ([comment](https://github.com/gke-labs/kube-agents/pull/642#issuecomment-5257780995)). That PR wrote the live-validation requirement out in full in three places — the PR template comment, `AGENTS.md`, and the site's `contributing.md` — without any of them saying which copy is canonical. `AGENTS.md`'s own documentation rules require exactly that ("If you must summarise, say which page is canonical"), and the copies had already started to drift.

## What Changed

**Files:**

- `AGENTS.md`
- `docs/site/src/content/docs/contributing.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

**Added/Changed/Fixed:**

- `AGENTS.md`'s **Pull Request Hygiene** bullet is now declared the canonical statement of the requirement, naming the two summaries and the order to update them in.
- `contributing.md` defers to `AGENTS.md` in the same shape its **Automated review** section already uses for the bot's own comment ("trust it over this page if the two ever differ").
- Aligned the drifted `.status` wording: `contributing.md` said the `PlatformAgent` `.status`, where `AGENTS.md` and the template say the CR `.status`. The CR phrasing is the correct one — `AgentPlugin` has a `.status` too (`k8s-operator/api/v1alpha1/agentplugin_types.go:127`), so a change reaching that CR is equally in scope.
- Aligned the empty-section rule on one sentence, `AGENTS.md`'s "An empty section is not an answer." It had been phrased three ways across the three copies.
- Added the non-blocking nit from the review: a one-line "Full contract: AGENTS.md, 'Pull Request Hygiene'." at the end of the template comment.

## Why This Matters

- Three self-contained copies of a rule with no named owner is the drift the `AGENTS.md` docs rules exist to prevent — and it drifted within one PR.
- The `PlatformAgent`-vs-CR wording was a real narrowing: read literally, it excused a contributor changing `AgentPlugin` reconciliation from checking the object their change actually touches.

## Context

- Follows #642, merged as 330783b.
- Review comment: https://github.com/gke-labs/kube-agents/pull/642#issuecomment-5257780995

## Testing

<!-- Automated checks: unit tests, builds, `make docs-check`, `prettier --check`. -->

- `make docs-check` — passes (generated regions current, 230 files' relative links resolve, terminology clean, map inventory covers all 204 tracked docs).
- `prettier --check` on the three changed files — clean.

### Live validation

- Not live-tested: docs-only. Nothing here reaches a running installation — no operator behaviour, chart, image, or workflow is touched. Verified instead against the tree: the two relative links added to `AGENTS.md` resolve (`make docs-check` enforces this), the `Pull Request Hygiene` heading the template now cites exists at `AGENTS.md:79`, and the `.status` claim was checked against both CRD types rather than against other docs.

---

Low risk: prose only, no behaviour change. The one substantive edit is the `.status` correction, which widens the requirement rather than narrowing it.

_This PR was generated with the help of Claude._
