### PR TITLE
fix(model): default Anthropic installs to claude-opus-5

### DIFF
--- a/charts/kube-agents/templates/litellm.yaml
+++ b/charts/kube-agents/templates/litellm.yaml
@@ -4,7 +4,7 @@
 {{- fail "litellm.modelProvider 'chatgpt' is not supported by the chart: it needs the OAuth-token PVC from the kustomize overlay (k8s-operator/config/integrations/litellm/overlays/chatgpt). Use the provisioning-script path for chatgpt mode." }}
 {{- end }}
 {{- /* Per-provider default model names mirror k8s-operator/scripts/common.sh. */}}
-{{- $defaultModels := dict "gemini" "gemini-3.5-flash" "anthropic" "claude-sonnet-4-5-20250929" "openai" "gpt-5.4" "vertex_ai" "gemini-3.5-flash" }}
+{{- $defaultModels := dict "gemini" "gemini-3.5-flash" "anthropic" "claude-opus-5" "openai" "gpt-5.4" "vertex_ai" "gemini-3.5-flash" }}
 {{- if not (hasKey $defaultModels $provider) }}
 {{- fail (printf "litellm.modelProvider %q is not one of gemini, anthropic, openai, vertex_ai — a typo here would otherwise fail only at runtime" $provider) }}
 {{- end }}

--- a/docs/site/src/content/docs/concepts/inference-gateway.md
+++ b/docs/site/src/content/docs/concepts/inference-gateway.md
@@ -47,7 +47,7 @@ The two substituted values come from provisioning (`MODEL_PROVIDER` and `MODEL_D
 | `MODEL_PROVIDER`   | Default `MODEL_DEFAULT_NAME` | Notes                                      |
 | ------------------ | ---------------------------- | ------------------------------------------ |
 | `gemini` (default) | `gemini-3.5-flash`           | Uses `GEMINI_API_KEY`.                     |
-| `anthropic`        | `claude-sonnet-4-5-20250929` | Uses `ANTHROPIC_API_KEY`.                  |
+| `anthropic`        | `claude-opus-5`              | Uses `ANTHROPIC_API_KEY`.                  |
 | `openai`           | `gpt-5.4`                    | Uses `OPENAI_API_KEY`.                     |
 | `chatgpt`          | `gpt-5.4`                    | Personal ChatGPT subscription (OAuth).     |
 | `vertex_ai`        | `gemini-3.5-flash`           | No API key — Workload Identity. See below. |

--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -209,7 +209,7 @@ DEFAULT_MODEL_PROVIDER="gemini"
 default_model_for_provider() {
   case "${1:-}" in
     chatgpt | openai) echo "gpt-5.4" ;;
-    anthropic) echo "claude-sonnet-4-5-20250929" ;;
+    anthropic) echo "claude-opus-5" ;;
     *) echo "gemini-3.5-flash" ;;
   esac
 }


### PR DESCRIPTION
# Pull Request

## Why This Change

Choosing `anthropic` at install time produces an agent that cannot complete a single LLM call.

Hermes's `custom` provider — which every kube-agents config selects in order to reach LiteLLM (`deploy/shared/defaults/config.yaml:2`, `agents/chat/config.yaml:58`, `agents/cluster/config.yaml:20`, and `renderConfigYAML` at `k8s-operator/internal/controller/platformagent_manifests.go:728`) — sends a hardcoded `default_max_tokens=65536`. Nothing in this repository overrides it: the operator's model struct (`platformagent_manifests.go:736-741`) carries only `Default`, `Provider`, `Model`, `BaseURL`, and `APIKey`, and the only `max_tokens` strings anywhere in the tree are the memory plugin's recall budget and the reranker's env names — neither reaches the harness's model config.

Anthropic caps output for `claude-sonnet-4-5-20250929` at 64000. So every request returns HTTP 400:

```
max_tokens: 65536 > 64000, which is the maximum allowed number of output
tokens for claude-sonnet-4-5-20250929
```

The agent's conversation loop classifies any 400 as context overflow, so this does not surface as a `max_tokens` problem. It compresses the conversation 10,427 → 347 → 25 tokens, hits the identical 400 each time, and reports:

```
Context length exceeded (25 tokens). Cannot compress further.
```

The 25 is how far the conversation had been compressed while retrying, not any real limit. That error message is why this went undiagnosed.

## What Changed

`claude-opus-5` accepts the 65536 the harness actually sends, so it becomes the Anthropic default.

**Files:**

- `k8s-operator/scripts/common.sh`
- `charts/kube-agents/templates/litellm.yaml`
- `docs/site/src/content/docs/concepts/inference-gateway.md`

**Added/Changed/Fixed:**

- **`common.sh:212`** — the `anthropic` arm of `default_model_for_provider`. This is the value the provisioning scripts offer and `envsubst` bakes into the LiteLLM `ConfigMap`.
- **`charts/kube-agents/templates/litellm.yaml:7`** — the `$defaultModels` dict, whose comment states it mirrors `common.sh`. That invariant is restored, not broken, by this change. The `vertex_ai` entry #644 added to the same line is carried through untouched.
- **`inference-gateway.md:50`** — the shipping-defaults table. The `Default MODEL_DEFAULT_NAME` column is sized by its header, so this is a one-line diff with no table reflow.
- **No `install.sh` change is needed**, though an earlier revision of this PR edited five literals there. `install.sh` now derives every menu label and every assignment from `default_model_for_provider` (`:790`, `:873`–`:898`, `:1264`–`:1293`), so the one-line `common.sh` change covers all five sites on its own.

## Why This Matters

- **The default is the broken path.** A user who selects Anthropic and accepts the offered model gets an install that looks healthy — pods Running, `.status` populated, LiteLLM serving `/v1/models` — and fails on first contact with the agent.
- **The error message actively misleads.** "Context length exceeded" sends you looking at conversation size, compaction settings, and context windows. None of them are involved. Anyone debugging this from the message alone is searching the wrong subsystem.
- **This is a one-line fix to a total outage**, and it is worth landing ahead of the real fix below rather than behind it.

## Context

- **This does not fix the underlying gap.** There is still no supported way to set `max_tokens` — not via the CRD (no model-tuning section exists), not via chart values, and not by editing the file in the pod: the platform profile's `config.yaml` is image-owned and force-synced on every start (`deploy/shared/docker-entrypoint.sh:541`, step 2.6), and the default profile's is rebuilt from the image template plus the operator's overlay (step 2d, `:326`). Any future Anthropic model with an output cap below 65536 breaks identically. The durable fix is a `max_tokens` field on the operator's model struct plus a CRD field; a cheaper gateway-side clamp would be `max_tokens` under `litellm_params` in the LiteLLM base config. Happy to follow up with either — I did not bundle it here because it is a design decision, not a typo.
- **Vertex AI now reaches the same trap by another road.** #644 landed `vertex_ai` as a first-class provider after this PR was opened. Its default is `gemini-3.5-flash` and this PR does not change it, but Model Garden's Claude models carry the same 64000 output cap, so pointing `MODEL_DEFAULT_NAME` at `claude-sonnet-4-5@20250929` produces the identical 400 until `max_tokens` is settable. Another argument for the durable fix rather than more default-swapping.
- **Scope is Anthropic-only as far as I have proven.** The `gemini` (overall default) and `openai`/`chatgpt` branches keep their current ids; I have not verified whether `gemini-3.5-flash` or `gpt-5.4` sit above the 65536 floor. That the most-travelled default may happen to clear it is plausibly why this survived.
- **Related finding, not fixed here:** the LiteLLM `ConfigMap` name is fixed rather than content-hashed, so changing the model updates the `ConfigMap` while `kubectl` reports the Deployment `unchanged` — LiteLLM keeps serving the old config until a manual `kubectl rollout restart deploy/litellm`. `provision_09` does not do this. Worth its own issue. (The chart path does not have this problem: its Deployment carries a `checksum/config` annotation over provider, model, and callbacks.)
- **Rebased onto current `main`** to clear conflicts with #644 (Vertex AI) and #676, both of which had touched the two lines this PR changes. The resolution kept `main`'s version of each line and reapplied only the anthropic value; the diff is unchanged in intent and is now three files rather than four.

## Testing

- `bash -n k8s-operator/scripts/common.sh` — clean.
- `default_model_for_provider` exercised directly rather than trusting the literal: `anthropic → claude-opus-5`, `gemini → gemini-3.5-flash`, `openai` and `chatgpt → gpt-5.4`, `vertex_ai → gemini-3.5-flash`, unknown → `gemini-3.5-flash`.
- `helm template` for every provider, post-rebase: `anthropic` renders `model: anthropic/claude-opus-5`; `gemini`, `openai`, `vertex_ai`, and the no-provider default render `gemini/gemini-3.5-flash`, `openai/gpt-5.4`, `vertex_ai/gemini-3.5-flash`, and `gemini/gemini-3.5-flash` respectively — no blast radius beyond the intended branch. A misspelled provider still fails with #644's four-name error, confirming the conflict resolution kept that validation intact.
- `make docs-check` — clean (generated regions, 240 files link-checked, terminology, 213-doc map inventory).
- `prettier@3.9.6 --check` on the changed Markdown and YAML — clean. The rewritten table row was checked byte-for-byte against the other rows: all six are the same width, so nothing else in the table moved.
- `review-docs-drift` against the branch diff: no Blocking findings. Swept `docs/`, `README.md`, `INSTALL.md`, and `charts/kube-agents/README.md` for any other prose naming an Anthropic model id — the table at `inference-gateway.md:50` was the only one; every other hit names the provider, not a model. That skill run predates the rebase; re-checked afterwards by grep, the only surviving `claude-sonnet-4-5` string in the tree is #644's Model Garden publisher-ID example, which is a different identifier in a different role and correctly left alone.

### Live validation

Run against a real install: GCP project `bhoekstra-gkedemos`, cluster `kube-agents-cluster` (regional `us-central1`, 3 nodes), namespace `kubeagents-system`, image tag `79dc1d1a7cb8b90e990d80bb13d7ed2ea7f790c5`, stood up by the provisioning scripts with `MODEL_PROVIDER=anthropic`.

**The failure reproduced first, on the shipping default.** With `claude-sonnet-4-5-20250929` the gateway pod logged the 400 quoted at the top of this PR, followed by the compression cascade and `Context length exceeded: 25 tokens`. Last occurrence `19:15:05Z`.

**Then the change.** Set `MODEL_DEFAULT_NAME=claude-opus-5`, ran `provision_09_deploy_litellm.sh`, plus a `kubectl rollout restart deploy/litellm` for the non-hashed-`ConfigMap` reason above. Both replicas up at `19:24:09Z`. Observed at each layer:

- **`ConfigMap` `litellm-config-k4b9ht22c7`** — all three aliases (`model-default`, `hermes-agent`, and the literal name) render `model: anthropic/claude-opus-5`.
- **From inside the agent pod** — `GET /v1/models` returns 200 listing `model-default`, `hermes-agent`, `claude-opus-5`.
- **The actual failing request** — two completions through LiteLLM differing only in `max_tokens`. `65536` now returns **HTTP 200** where it previously returned 400; `64000` returns 200 as before.
- **Gateway log** — zero occurrences of `max_tokens: 65536` or `Cannot compress further` in the 12 minutes since the rollout, against a steady stream of them before it.

**Mechanism, not coincidence:** the before and after differ on the identical request — the same `max_tokens=65536` that returned 400 against the old default returns 200 against the new one. The isolation test varies one parameter and nothing else.

**What I could not cover:** a full Chat round-trip through the agent (the LiteLLM layer is proven; the end-to-end conversation is not); the Helm path, which I verified only by `helm template`, not by applying it to a cluster; and `install.sh`'s interactive menus, which I read but did not drive interactively — and which this revision no longer edits at all.

**Not re-run after the rebase.** The cluster validation above was performed on the pre-rebase revision. The rebase changed no line of the three-file diff other than preserving #644's `vertex_ai` dict entry beside the new anthropic value, and the automated checks under Testing were all re-run against the rebased tree; the cluster exercise was not repeated. Nothing in #644 or #676 touches the anthropic code path.

**Cleanup:** nothing to revert. This install is the standing test bed and is deliberately left on `claude-opus-5`, which is now what this PR makes the default anyway; `vars.sh` was backed up before the edit. No other cluster state was touched.

---

Functionally this is a one-line change repeated in three files, and reverting it is a `sed`. The real consideration is not risk but **cost**: Opus 5 is materially more expensive per token than Sonnet 4.5, and this silently raises the bill for anyone who takes the Anthropic default. If the project would rather keep a cheaper default, the alternative is to pick a Sonnet-class model and land the `max_tokens` fix from **Context** instead — that solves the outage without the price change, at the cost of being a larger diff. I went with the one-liner because the current default is broken today, but I would defer to a maintainer on which of the two ships.

This PR was generated with the help of Claude.
