### PR TITLE
fix(entrypoint): remove the inert hermes_otel enable step

### DIFF
--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -153,9 +153,14 @@ fi
 
 # 2a. Force-sync the image-managed default-profile files so they ALWAYS track the
 # image, not the persistent PVC. The update-only copy above (cp -u) can skip
-# config.yaml: step 3 below rewrites config.yaml on every start (to enable otel),
-# bumping its mtime, so on the next image roll cp -u sees the PVC copy as "newer"
-# and never overwrites it — leaving a stale toolset/persona config live. These
+# config.yaml, and on a long-lived volume it eventually always does. `cp` without
+# -p stamps the destination with the time of the copy, so the moment step 2 lands
+# config.yaml the PVC copy is NEWER than the image file it came from, and every
+# subsequent boot's cp -u declines to overwrite it — leaving a stale
+# toolset/persona config live across the image roll that was supposed to replace
+# it. Step 2a-bis re-stamps it again on every operator-managed start. (Rollback to
+# an older image and builds with deterministic file timestamps get there by the
+# other direction; step 2b describes that pair for the shared scripts.) These
 # files are image-owned (not runtime state), so overwrite them unconditionally.
 if [ -d "/opt/defaults" ]; then
     for f in config.yaml SOUL.md AGENTS.md CAPABILITIES.md; do
@@ -302,10 +307,10 @@ fi
 #   - The platform config.yaml is entirely image-owned — built at image build
 #     time by merging the shared defaults with the platform overlay. `hermes
 #     profile create` emits no config.yaml, and nothing writes to
-#     profiles/platform/config.yaml at runtime (step 3's otel injection targets
-#     only the default profile; the platform template already enables
-#     hermes_otel). Without syncing it, an image that changes the platform's
-#     toolsets or plugins has no effect on any existing deployment.
+#     profiles/platform/config.yaml at runtime — step 2.7's overlay merge is the
+#     one exception, and it runs after this on purpose. Without syncing it, an
+#     image that changes the platform's toolsets or plugins has no effect on any
+#     existing deployment.
 #   - A cluster config.yaml is identity-stamped at scaffold time with that
 #     cluster's `cluster_identity` block (project/cluster/location), so it is
 #     runtime state. Overwriting it from the template would strip the record
@@ -616,10 +621,28 @@ if [ -f "$OVERLAY_SCRIPT" ]; then
     done
 fi
 
-# 3. Enable OpenTelemetry plugin in active config.yaml (if writable)
-if [ -f "$TARGET_DIR/config.yaml" ] && [ -w "$TARGET_DIR/config.yaml" ]; then
-    "$INSTALL_DIR/.venv/bin/python3" -c "import sys, yaml, pathlib; p = pathlib.Path(sys.argv[1]); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; enabled = c.setdefault('plugins', {}).setdefault('enabled', []); 'hermes_otel' not in enabled and enabled.append('hermes_otel'); p.write_text(yaml.safe_dump(c))" "$TARGET_DIR/config.yaml" 2>/dev/null || true
-fi
+# 3. (removed) Enabling hermes_otel in the default profile's config.yaml.
+#
+# The step appended `hermes_otel` to plugins.enabled if it was missing, guarded on the file
+# being writable. It could not fire, and had nothing to do if it did:
+#
+#   - Under the operator that path is a ConfigMap subPath mount, and ConfigMap volumes are
+#     mounted read-only whatever the mount's readOnly field says, so `[ -w ]` was false in
+#     both the gateway and the dashboard. The mode is 0400/0755 on root-owned files against
+#     RunAsUser 10000 besides (buildDefaultVolumeMounts and the volume's DefaultMode in
+#     platformagent_manifests.go), so it fails the ownership test as well as the mount one.
+#   - The content was already there either way. `hermes_otel` heads plugins.enabled in
+#     agents/chat/config.yaml, which the image installs as /opt/defaults/config.yaml, and it
+#     is in the operator's DefaultBuiltInPlugins, so it is in the rendered ConfigMap too.
+#
+# Where the guard DID pass — compose, `docker run`, or the fresh-PVC boot where the subPath
+# fails to establish and step 2a-bis leaves a plain file behind — the step found the plugin
+# already enabled, appended nothing, and rewrote the file anyway: yaml.safe_dump round-trips
+# it, so it sorted the keys and dropped every comment in a config people read.
+#
+# Do not restore it as a "belt and braces" measure. If a profile ever needs a plugin the
+# image does not ship enabled, the operator overlay in step 2.7 is the mechanism, and it is
+# one that works on the path this ran on.
 
 # 4. Inject dynamic OpenTelemetry service name (if writable)
 if [ -f "$TARGET_DIR/plugins/hermes_otel/config.yaml" ] && [ -w "$TARGET_DIR/plugins/hermes_otel/config.yaml" ]; then

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -2028,7 +2028,10 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 				// nothing puts one on the PVC for this container to find. In the gateway
 				// this exact path is a ConfigMap mount, and ConfigMap volumes are always
 				// read-only, so the entrypoint's copy from /opt/defaults cannot land a
-				// config.yaml on the volume underneath it (hence step 3's `[ -w ]` guard).
+				// config.yaml on the volume underneath it. Anything in the entrypoint that
+				// wants to EDIT this file is therefore inert under the operator; the step
+				// that used to try was deleted rather than left to look load-bearing (see
+				// the step 3 note in deploy/shared/docker-entrypoint.sh).
 				// The dashboard used to write one itself, as a side effect of running a
 				// setup pass it must no longer run; on a fresh PVC that leaves `hermes
 				// dashboard` starting against a HERMES_HOME with no config at all. An


### PR DESCRIPTION
# Pull Request

## Why This Change

Step 3 of `docker-entrypoint.sh` appended `hermes_otel` to the default profile's
`plugins.enabled` if it was missing, guarded on the config file being writable. It is dead
code: it cannot fire on the deployed path, and it has nothing to do on the paths where it
can.

**The guard is always false under the operator.** `$TARGET_DIR/config.yaml` is a ConfigMap
`subPath` mount in both the gateway and the dashboard (`buildDefaultVolumeMounts`, and the
dashboard mount in `buildBaseContainers`). ConfigMap volumes are mounted read-only whatever
the mount's `readOnly` field says, and the files are root-owned at the volume's
`DefaultMode` against `RunAsUser: 10000` — so it fails the ownership test as well as the
mount one.

**The content is already there regardless.** `hermes_otel` heads `plugins.enabled` in
`agents/chat/config.yaml`, which the image installs as `/opt/defaults/config.yaml`, and it
is in the operator's `DefaultBuiltInPlugins`, so it is in the rendered ConfigMap too.

**Where the guard did pass it was worse than a no-op.** On compose, `docker run`, or the
fresh-PVC boot where the `subPath` fails to establish and step 2a-bis leaves a plain file
behind, the step found the plugin already enabled, appended nothing, and rewrote the file
anyway — `yaml.safe_dump` round-trips it, sorting the keys and dropping every comment in a
config people read.

The operator's own comment already documented the read-only mount and named step 3's
`[ -w ]` guard as the reason it was harmless. Harmless and load-bearing look identical from
the outside, which is what this PR fixes.

## What Changed

**Files:**

- `deploy/shared/docker-entrypoint.sh`
- `k8s-operator/internal/controller/platformagent_manifests.go`

**Added/Changed/Fixed:**

- Removed step 3. The only executable change in this PR is that three-line `if` block;
  everything else is comments.
- Replaced it with a note recording why it could not fire, what it did on the paths where
  it could, and to reach for the step 2.7 operator overlay instead of restoring it as a
  "belt and braces" measure.
- Corrected two comments that cited step 3 as load-bearing, rather than deleting them:
  - **Step 2a** justified its force-sync by saying step 3 bumped `config.yaml`'s mtime. The
    force-sync is still needed, for a reason that outlives step 3: `cp` without `-p` stamps
    the destination with the time of the copy, so the PVC copy is newer than the image file
    it came from from the moment step 2 lands it, and every later `cp -u` declines to
    overwrite.
  - **Step 2.6** cited step 3 as the reason nothing writes `profiles/platform/config.yaml`
    at runtime. The real exception is step 2.7's overlay merge, which is ordered after it
    on purpose.
- `platformagent_manifests.go`: the dashboard mount comment no longer points at a guard
  that no longer exists; it states the general rule, so the next person reaching for a
  config edit in the entrypoint learns it is inert before writing it.

Step numbering is deliberately left alone (4, 5, 5.5, 6). `entrypoint_gate_check.sh` and
`docs/site/src/content/docs/deploy/docker-images.md` both reference entrypoint steps by
number; renumbering would invalidate those for no gain.

## Why This Matters

- Dead code guarding a real invariant reads as the thing enforcing it. Anyone auditing why
  `hermes_otel` is enabled finds this step first and concludes the entrypoint is
  responsible, when the image default and the operator-rendered ConfigMap are.
- On the non-operator paths it actively damaged the file it touched, stripping comments out
  of a config that is meant to be read.
- Its presence invites the same mistake again — the next plugin that "just needs enabling"
  gets appended here, where it will silently never apply under the operator.

## Context

Found while reading `docker-entrypoint.sh`; no linked issue. The mechanism is the same
family as the `cp -u` mtime trap that steps 2a/2a-bis/2b already work around.

Related: `AGENTS.md` instructs contributors to run `make docs-check` before pushing, but no
such target exists in the `Makefile`. Out of scope here, worth a follow-up.

## Testing

Local:

- `sh -n deploy/shared/docker-entrypoint.sh` clean.
- `tests/test_docker_entrypoint.py` — 25/25 pass.
- `gofmt` clean; `go build ./...` and `go test ./internal/controller/...` pass.
- No Markdown/YAML/JSON changed, so prettier does not apply.
- `review-docs-drift` run against the branch diff: no Blocking findings. No doc claims
  start-up enables `hermes_otel`; the pages that mention it say it is enabled in every
  profile config. `docker-images.md` cites entrypoint steps 4 and 5, both still correct.

Live cluster (`toshiowang-gkedemos` / `platform-agent-host`), deployed via
`make dev-rebuild-agent`:

- Confirmed the premise before the change: `/opt/data/config.yaml` is `-rwxr-xr-x
  root:hermes`, the process runs as uid 10000, `[ -w ]` is false, and the path is a mount
  point. Step 3 could never have fired.
- After: `config.yaml` is **byte-identical** to the pre-change baseline (same sha256), with
  `hermes_otel` still in `plugins.enabled`.
- `hermes-otel` plugin live — connected to `gke-managed-otel`, `Registered 13 hooks`.
- Step 4 intact: `$HOME/.hermes/...` compat symlink resolves, `service.name` injected.
- `PlatformAgent` reconciled `Ready`; 4/4 containers, 0 restarts; metrics endpoint 200.
- Ported `entrypoint_gate_check.sh` into the live pod: 15/16 pass. The one failure is the
  check's own known race reaping scratch Session KV servers against pod-wide port 8699
  (its header documents this); all spawned PIDs had already exited.

Note: `entrypoint-gate-check` ships only in the `entrypoint-gate-test` build stage, not in
`platform`, despite its header saying it is safe to run in a live pod. Pre-existing; not
touched here.

---

Comment-only apart from a three-line deletion on a path proven inert on the deployed
configuration, and verified byte-identical against a live agent. Rollback is reverting the
commit.

Generated with the help of Claude.
