### PR TITLE
fix(operator): cap kanban dispatch concurrency by default

### DIFF
--- a/agentplugins/gke-stockout-investigator/tuning.yaml
+++ b/agentplugins/gke-stockout-investigator/tuning.yaml
@@ -10,10 +10,11 @@
 # feeds this patch.
 #
 # None of these are kube-agents defaults, and that is deliberate. A vanilla deployment
-# runs on Hermes' own values (3 retries, 90 iterations, uncapped dispatch), which suit
-# interactive and short-horizon work. Stockout remediation is neither: it is a
-# long-running, quota-hungry background task, and every value below is raised for that
-# workload specifically. A fleet doing something else should not inherit them.
+# runs on Hermes' own per-run values (3 retries, 90 iterations) and on the operator's
+# dispatch cap of 2, which suit interactive and short-horizon work. Stockout
+# remediation is neither: it is a long-running, quota-hungry background task, and every
+# value below is raised for that workload specifically. A fleet doing something else
+# should not inherit them.
 #
 # All three failures these prevent look identical from the outside — the worker stops
 # without calling a terminal kanban tool, and the dispatcher reports a "protocol
@@ -29,7 +30,8 @@ spec:
       # saturates it — a single day of uncapped running produced 2226 HTTP 429s. A
       # worker whose retries are exhausted exits without completing its card, so quota
       # pressure surfaces as a fake worker bug and each retry hits the same saturated
-      # backend. Some cap is therefore necessary.
+      # backend. Some cap is therefore necessary; the operator now renders 2 by default,
+      # and this raises it by one for a workload that runs long enough to want the room.
       #
       # Three rather than one. Serialising avoids 429s most decisively, but it makes a
       # single stuck worker everyone's problem: it holds the only slot, and a claim

--- a/agents/chat/config.yaml
+++ b/agents/chat/config.yaml
@@ -165,6 +165,17 @@ kanban:
     - crashed
     - timed_out
     - blocked
+  # Board-wide worker cap. Upstream leaves this unbounded, and a worker is a full
+  # agent process holding a few hundred MiB for the length of its task — so a burst
+  # of cards spawns processes until the cgroup OOM killer takes them, which kills a
+  # child rather than the container and so produces no restart and no event.
+  #
+  # On an operator-managed install this line is overwritten: the operator renders
+  # the same value into its config ConfigMap and the entrypoint force-syncs that
+  # over this file. It is here for the install that runs the image without the
+  # operator, which would otherwise be the only one left uncapped. The operator's
+  # defaultKanbanMaxInProgress is authoritative; keep the two the same.
+  max_in_progress: 2
 
 # Denylist applied last for every platform key — the authoritative guarantee that
 # the front door cannot touch the system. Everything except the delegation

--- a/charts/kube-agents/crds/kubeagents.x-k8s.io_platformagents.yaml
+++ b/charts/kube-agents/crds/kubeagents.x-k8s.io_platformagents.yaml
@@ -8348,21 +8348,30 @@ spec:
                             every worker it spawns — platform and cluster alike — draws on the same model
                             quota. Setting it to 1 serialises all delegated work.
 
-                            Unset leaves Hermes' own behaviour, which does not cap concurrency. Cap it when
-                            a deployment's model quota cannot absorb parallel fan-out: workers that exhaust
-                            their retry budget exit without calling a terminal kanban tool, which the
-                            dispatcher then reports as a "protocol violation" rather than as the quota
-                            exhaustion it actually is. Capping costs throughput — one long-running worker
-                            holds the only slot — so it is a trade, not a default.
+                            Unset means 2, the operator's default — not Hermes' own behaviour, which does not
+                            cap concurrency at all. The default exists because a worker is a full agent process
+                            holding a few hundred MiB for the length of the task: unbounded dispatch lets a
+                            burst of queued cards spawn workers until the cgroup OOM killer takes them, and
+                            that kills a child process rather than the container, so it produces no Kubernetes
+                            event and no restart while the dispatcher strands the card instead of retrying it.
 
-                            Do NOT reach for it as a latency fix. An uncapped fan-out does spawn every
-                            sandboxed worker at once and they contend during startup, but a slot is held
-                            for a worker's entire run, so a cap serialises minutes of model work to save
-                            seconds of boot. Measured against real fan-outs on a live cluster, capping at
-                            2 roughly doubled the time for the batch to finish. What the workers contend
-                            for is not established either — CPU limit, memory ceiling and gVisor I/O all
-                            fit the evidence, and gVisor hides the cgroup throttle counters that would
-                            settle it — so raising resources is not a guaranteed fix; measure it.
+                            The cap is bought at a real price, so raise it deliberately rather than leaving it
+                            alone by default. A slot is held for a worker's entire run, so capping serialises
+                            minutes of model work: measured against real fan-outs on a live cluster, capping at
+                            2 roughly doubled the time for a batch to finish. Do NOT reach for a lower value as
+                            a latency fix — an uncapped fan-out does spawn every sandboxed worker at once and
+                            they contend during startup, but a cap trades minutes of model work for seconds of
+                            boot. What the workers contend for is not established either — CPU limit, memory
+                            ceiling and gVisor I/O all fit the evidence, and gVisor hides the cgroup throttle
+                            counters that would settle it — so raising resources is not a guaranteed fix;
+                            measure it.
+
+                            Set it higher once a deployment has measured its own worker footprint and model
+                            quota — a fleet with headroom is throttled by 2. Set it to 1 to serialise all
+                            delegated work. When quota rather than memory binds, note the related failure mode:
+                            workers that exhaust their retry budget exit without calling a terminal kanban
+                            tool, and the dispatcher reports that as a "protocol violation" rather than as the
+                            quota exhaustion it actually is.
                           minimum: 1
                           type: integer
                         platform:

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -54,7 +54,7 @@ the agent a usable kubectl context) when it has the complete triple; with one mi
 | `memory.userProfileEnabled`                    | bool   | Toggle per-user memory profiling. Default `false`.                                                                                                           |
 | `tuning.<persona>.apiMaxRetries`               | int    | Model-call retries before a run gives up. Unset = Hermes default `3`.                                                                                        |
 | `tuning.<persona>.maxTurns`                    | int    | Iterations allowed in a single turn. Unset = Hermes default `90`, except `platform` (see below).                                                             |
-| `tuning.maxInProgress`                         | int    | Board-wide cap on concurrent kanban workers. Unset = uncapped (upstream).                                                                                    |
+| `tuning.maxInProgress`                         | int    | Board-wide cap on concurrent kanban workers. Unset = operator default `2`.                                                                                   |
 
 `sessionKVApiKeySecretRef` is optional in the API but not in practice, and the `503` above is the
 milder half of what its absence costs. The `k8s-event-watcher` in the credential sidecar
@@ -69,22 +69,26 @@ Execution limits per agent persona, where `<persona>` is one of `default` (the C
 door), `platform` (the Platform Agent), or `cluster` (**every** Cluster Agent), plus the board-wide
 `maxInProgress`.
 
-**Everything here is opt-in.** The operator pins nothing of its own: what a fleet needs depends on
-its model quota and on what its agents actually do, so a deployment doing short interactive work
-should not inherit limits raised for long-running batch work. Unset therefore means whatever the
-profile's own `config.yaml` carries, and the `default` and `cluster` configs set no execution limit
-of their own — Hermes' defaults apply there, 3 retries, 90 iterations, uncapped dispatch. The
+**The per-run limits are opt-in.** The operator pins nothing of its own there: what a fleet needs
+depends on its model quota and on what its agents actually do, so a deployment doing short
+interactive work should not inherit limits raised for long-running batch work. Unset therefore means
+whatever the profile's own `config.yaml` carries, and the `default` and `cluster` configs set no
+execution limit of their own — Hermes' defaults apply there, 3 retries and 90 iterations. The
 `platform` profile is the exception: the image ships `agent.max_turns: 250` in
 `agents/platform/config.yaml` because the fleet audits outgrow 90, and
 [Config reference](/kube-agents/reference/config/#agent) is canonical for why. Setting
 `tuning.platform.maxTurns` here still wins — the overlay is merged after the image force-sync — and
 removing it restores the image's value rather than Hermes'.
 
+**`maxInProgress` is not.** Unset renders `2`, because the untuned case is the one that cannot
+absorb the alternative — see [Why dispatch is capped by default](#why-dispatch-is-capped-by-default)
+below. Set it on the CR to raise or lower that.
+
 ```yaml
 spec:
   harness:
     tuning:
-      maxInProgress: 1 # board-wide: serialise all kanban workers
+      maxInProgress: 4 # board-wide; raises the operator's default of 2
       platform:
         apiMaxRetries: 8
         maxTurns: 200
@@ -121,9 +125,27 @@ Sizing notes: `maxTurns` is consumed mostly by repository exploration, so scale 
 the agent has to read rather than how complex the request is. `apiMaxRetries` exists because
 Hermes' default of `3` assumes an interactive session where a human retries; a background worker
 has nobody to retry it, so a transient burst of upstream 429s or 503s simply ends the run. Raising
-`maxTurns` interacts with `maxInProgress`: under a serial dispatcher, one long-running worker
-holds the only slot and blocks every other profile, so raising one is a reason to reconsider the
-other.
+`maxTurns` interacts with `maxInProgress`: a long-running worker holds its slot for the whole task
+and there are only `maxInProgress` of them, so raising one is a reason to reconsider the other.
+
+#### Why dispatch is capped by default
+
+A kanban worker is not a coroutine. It is a full `hermes … kanban task` process — a few hundred MiB
+resident once its MCP proxies are up, and alive for as long as the task takes, which for an incident
+triage is minutes rather than seconds. Uncapped, the dispatcher starts one per queued card, and a
+burst of cluster events queues them faster than they retire.
+
+What follows is invisible in the places you would look. The cgroup OOM killer takes a worker, not
+PID 1, so there is no container restart and no Kubernetes event; the pod stays `Running` and the
+only trace is `pid not alive` in the kanban ledger. The dispatcher's retry budget is 1, so the card
+is stranded rather than re-dispatched, and the work it stood for is never done — a triage report
+that simply never arrives, with nothing anywhere reporting a failure.
+
+`2` is a floor for a deployment that has not measured itself, not a recommendation. It is chosen to
+hold on the smallest pod anyone runs, and because the cost of being wrong is asymmetric: too low
+delays a delegated task, too high loses it silently. Raise it once you know your worker footprint
+and your model quota — that quota is the other shared resource, and for most deployments it binds
+before memory does.
 
 ## `spec.deployment`
 

--- a/k8s-operator/api/v1alpha1/common_types.go
+++ b/k8s-operator/api/v1alpha1/common_types.go
@@ -133,21 +133,30 @@ type TuningSpec struct {
 	// every worker it spawns — platform and cluster alike — draws on the same model
 	// quota. Setting it to 1 serialises all delegated work.
 	//
-	// Unset leaves Hermes' own behaviour, which does not cap concurrency. Cap it when
-	// a deployment's model quota cannot absorb parallel fan-out: workers that exhaust
-	// their retry budget exit without calling a terminal kanban tool, which the
-	// dispatcher then reports as a "protocol violation" rather than as the quota
-	// exhaustion it actually is. Capping costs throughput — one long-running worker
-	// holds the only slot — so it is a trade, not a default.
+	// Unset means 2, the operator's default — not Hermes' own behaviour, which does not
+	// cap concurrency at all. The default exists because a worker is a full agent process
+	// holding a few hundred MiB for the length of the task: unbounded dispatch lets a
+	// burst of queued cards spawn workers until the cgroup OOM killer takes them, and
+	// that kills a child process rather than the container, so it produces no Kubernetes
+	// event and no restart while the dispatcher strands the card instead of retrying it.
 	//
-	// Do NOT reach for it as a latency fix. An uncapped fan-out does spawn every
-	// sandboxed worker at once and they contend during startup, but a slot is held
-	// for a worker's entire run, so a cap serialises minutes of model work to save
-	// seconds of boot. Measured against real fan-outs on a live cluster, capping at
-	// 2 roughly doubled the time for the batch to finish. What the workers contend
-	// for is not established either — CPU limit, memory ceiling and gVisor I/O all
-	// fit the evidence, and gVisor hides the cgroup throttle counters that would
-	// settle it — so raising resources is not a guaranteed fix; measure it.
+	// The cap is bought at a real price, so raise it deliberately rather than leaving it
+	// alone by default. A slot is held for a worker's entire run, so capping serialises
+	// minutes of model work: measured against real fan-outs on a live cluster, capping at
+	// 2 roughly doubled the time for a batch to finish. Do NOT reach for a lower value as
+	// a latency fix — an uncapped fan-out does spawn every sandboxed worker at once and
+	// they contend during startup, but a cap trades minutes of model work for seconds of
+	// boot. What the workers contend for is not established either — CPU limit, memory
+	// ceiling and gVisor I/O all fit the evidence, and gVisor hides the cgroup throttle
+	// counters that would settle it — so raising resources is not a guaranteed fix;
+	// measure it.
+	//
+	// Set it higher once a deployment has measured its own worker footprint and model
+	// quota — a fleet with headroom is throttled by 2. Set it to 1 to serialise all
+	// delegated work. When quota rather than memory binds, note the related failure mode:
+	// workers that exhaust their retry budget exit without calling a terminal kanban
+	// tool, and the dispatcher reports that as a "protocol violation" rather than as the
+	// quota exhaustion it actually is.
 	// +kubebuilder:validation:Minimum=1
 	// +optional
 	MaxInProgress *int `json:"maxInProgress,omitempty"`

--- a/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
+++ b/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
@@ -8348,21 +8348,30 @@ spec:
                             every worker it spawns — platform and cluster alike — draws on the same model
                             quota. Setting it to 1 serialises all delegated work.
 
-                            Unset leaves Hermes' own behaviour, which does not cap concurrency. Cap it when
-                            a deployment's model quota cannot absorb parallel fan-out: workers that exhaust
-                            their retry budget exit without calling a terminal kanban tool, which the
-                            dispatcher then reports as a "protocol violation" rather than as the quota
-                            exhaustion it actually is. Capping costs throughput — one long-running worker
-                            holds the only slot — so it is a trade, not a default.
+                            Unset means 2, the operator's default — not Hermes' own behaviour, which does not
+                            cap concurrency at all. The default exists because a worker is a full agent process
+                            holding a few hundred MiB for the length of the task: unbounded dispatch lets a
+                            burst of queued cards spawn workers until the cgroup OOM killer takes them, and
+                            that kills a child process rather than the container, so it produces no Kubernetes
+                            event and no restart while the dispatcher strands the card instead of retrying it.
 
-                            Do NOT reach for it as a latency fix. An uncapped fan-out does spawn every
-                            sandboxed worker at once and they contend during startup, but a slot is held
-                            for a worker's entire run, so a cap serialises minutes of model work to save
-                            seconds of boot. Measured against real fan-outs on a live cluster, capping at
-                            2 roughly doubled the time for the batch to finish. What the workers contend
-                            for is not established either — CPU limit, memory ceiling and gVisor I/O all
-                            fit the evidence, and gVisor hides the cgroup throttle counters that would
-                            settle it — so raising resources is not a guaranteed fix; measure it.
+                            The cap is bought at a real price, so raise it deliberately rather than leaving it
+                            alone by default. A slot is held for a worker's entire run, so capping serialises
+                            minutes of model work: measured against real fan-outs on a live cluster, capping at
+                            2 roughly doubled the time for a batch to finish. Do NOT reach for a lower value as
+                            a latency fix — an uncapped fan-out does spawn every sandboxed worker at once and
+                            they contend during startup, but a cap trades minutes of model work for seconds of
+                            boot. What the workers contend for is not established either — CPU limit, memory
+                            ceiling and gVisor I/O all fit the evidence, and gVisor hides the cgroup throttle
+                            counters that would settle it — so raising resources is not a guaranteed fix;
+                            measure it.
+
+                            Set it higher once a deployment has measured its own worker footprint and model
+                            quota — a fleet with headroom is throttled by 2. Set it to 1 to serialise all
+                            delegated work. When quota rather than memory binds, note the related failure mode:
+                            workers that exhaust their retry budget exit without calling a terminal kanban
+                            tool, and the dispatcher reports that as a "protocol violation" rather than as the
+                            quota exhaustion it actually is.
                           minimum: 1
                           type: integer
                         platform:

--- a/k8s-operator/examples/platformagent.yaml
+++ b/k8s-operator/examples/platformagent.yaml
@@ -34,13 +34,15 @@ spec:
       apiServerSecretRef:
         name: "platformagent-secrets"
         key: "api-key"
-    # Tuning bounds what the harness may consume. Left unset on purpose: every
-    # field under it is a deployment trade, not a default the operator can pick
-    # for you. See the field docs on TuningSpec in
+    # Tuning bounds what the harness may consume. Left unset on purpose: the per-run
+    # fields under it are a deployment trade, not a default the operator can pick for
+    # you. `maxInProgress` is the exception — unset renders the operator's cap of 2,
+    # because uncapped dispatch loses cards silently rather than merely running them
+    # unbounded. See the field docs on TuningSpec in
     # api/v1alpha1/common_types.go (`kubectl explain platformagent.spec.harness.tuning`).
     # +optional
     # tuning:
-    #   maxInProgress: 2
+    #   maxInProgress: 4 # raises the operator's default of 2
   # Deployment abstracts the Kubernetes Pod/Deployment configuration,
   # decoupling the compute payload from the agent's application logic.
   # +optional

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -379,6 +379,18 @@ const platformProfileName = "platform"
 // takes its config through the same `profile-<name>.overlay.yaml` key as the rest.
 const defaultProfileName = "default"
 
+// defaultKanbanMaxInProgress bounds concurrent kanban workers when the CR does not.
+//
+// Two, not more, because the number has to hold on the smallest pod anyone runs, and
+// the cost of being wrong is asymmetric: too low delays a delegated task, too high
+// loses it silently to the OOM killer. Two keeps a second card moving while the first
+// is mid-triage, which is what unbounded dispatch was buying in practice.
+//
+// Raise it on spec.harness.tuning.maxInProgress once a deployment has measured its own
+// worker footprint and model quota. This is a floor for the untuned case, not a
+// recommendation.
+const defaultKanbanMaxInProgress = 2
+
 // clusterProfileClassKey is the ConfigMap key holding the overlay applied to EVERY
 // cluster-* profile.
 //
@@ -670,10 +682,12 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent, agentPlugins []*agentv
 			AutoSubscribeOnCreate   bool `json:"auto_subscribe_on_create"`
 			DispatchIntervalSeconds int  `json:"dispatch_interval_seconds"`
 			// Live concurrency cap across the whole board (not a per-tick
-			// spawn budget). Every worker shares one LiteLLM/Vertex quota.
-			// omitempty matters: without tuning this stays 0, and emitting
-			// `max_in_progress: 0` would be both meaningless (Hermes ignores
-			// anything below 1) and misleading to anyone reading the ConfigMap.
+			// spawn budget). Every worker shares one LiteLLM/Vertex quota and
+			// one container memory limit, so this is always rendered — see
+			// defaultKanbanMaxInProgress. omitempty is retained only as a guard
+			// against a future zero value reaching the ConfigMap: Hermes ignores
+			// anything below 1, so `max_in_progress: 0` would read as a serial
+			// board while behaving as an unbounded one.
 			MaxInProgress int `json:"max_in_progress,omitempty"`
 			// Terminal event kinds that wake the card's creator for a follow-up
 			// turn. Read by the image patch in
@@ -833,12 +847,26 @@ func renderConfigYAML(agent *agentv1alpha1.PlatformAgent, agentPlugins []*agentv
 	// The failure kinds stay: those deliver a bare status line, and the front
 	// door has to decide whether to retry, escalate, or explain.
 	cfg.Kanban.WakeOnEvents = []string{"gave_up", "crashed", "timed_out", "blocked"}
-	// Dispatch concurrency is NOT pinned here. Upstream leaves it unbounded, and that
-	// suits a fleet with headroom; capping it is a deployment decision, because every
-	// worker draws on the same model quota and the right number depends on how much
-	// quota this deployment has. spec.harness.tuning.maxInProgress sets it when a
-	// deployment needs the cap — see the stockout example in
-	// k8s-operator/examples/. Left unset, Hermes' own default applies.
+	// Dispatch concurrency defaults to a cap rather than to upstream's unbounded
+	// behaviour. A kanban worker here is not a coroutine: it is a full
+	// `hermes -p <profile> ... kanban task` process — measured at ~340 Mi resident once
+	// its MCP proxies are up, and alive for the 8-14 minutes an incident triage took on
+	// the deployment where this was diagnosed. Unbounded
+	// dispatch therefore spawns one such process per queued card, and a burst of
+	// cluster events queues them faster than they retire.
+	//
+	// The failure that follows is silent by construction. The cgroup OOM killer takes
+	// a child process, not PID 1, so there is no container restart, no Kubernetes
+	// event, and no non-zero exit anywhere the operator can see — only `pid not alive`
+	// in the kanban ledger. The dispatcher's own retry budget is 1, so the card is then
+	// stranded rather than re-dispatched, and the work it stood for is simply never
+	// done.
+	//
+	// The cap is deliberately below what memory alone would allow. Model quota is the
+	// other shared resource and it binds first for most deployments, so the default is
+	// chosen to be safe on a small pod rather than optimal on a large one — a fleet
+	// with headroom raises it on the CR, which still wins outright below.
+	cfg.Kanban.MaxInProgress = defaultKanbanMaxInProgress
 	if limits := agentTuning(agent); limits != nil && limits.MaxInProgress != nil {
 		cfg.Kanban.MaxInProgress = *limits.MaxInProgress
 	}

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -3573,9 +3573,11 @@ func TestRenderConfigYAMLAppliesDefaultTuning(t *testing.T) {
 	}
 }
 
-// Unset tuning must leave Hermes' own defaults alone. The operator pins no execution
-// limits of its own: what a fleet needs depends on its model quota and on what its
-// agents do, so an untuned deployment gets vanilla Hermes behaviour.
+// Unset tuning must leave Hermes' own per-run limits alone. The operator pins no
+// execution limits of its own: what a fleet needs depends on its model quota and on
+// what its agents do, so an untuned deployment gets vanilla Hermes behaviour.
+//
+// Dispatch concurrency is the exception and is asserted separately below.
 func TestRenderConfigYAMLNoTuningLeavesHermesDefaults(t *testing.T) {
 	var parsed map[string]any
 	if err := yaml.Unmarshal([]byte(renderConfigYAML(newTestPlatformAgent(), nil)), &parsed); err != nil {
@@ -3587,15 +3589,39 @@ func TestRenderConfigYAMLNoTuningLeavesHermesDefaults(t *testing.T) {
 			t.Errorf("%s must be omitted without tuning so Hermes' default applies, got %v", key, v)
 		}
 	}
+}
+
+// Dispatch concurrency is capped even without tuning. Upstream leaves it unbounded,
+// which lets a burst of queued cards spawn one full agent process per card until the
+// cgroup OOM killer takes them — a failure that produces no container restart and no
+// Kubernetes event, only a stranded card. The untuned deployment must not be exposed
+// to that, so the render always carries a number.
+func TestRenderConfigYAMLDefaultsMaxInProgress(t *testing.T) {
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(renderConfigYAML(newTestPlatformAgent(), nil)), &parsed); err != nil {
+		t.Fatalf("unmarshal rendered YAML: %v", err)
+	}
 	kanban, _ := parsed["kanban"].(map[string]any)
-	if v, ok := kanban["max_in_progress"]; ok {
-		t.Errorf("max_in_progress must be omitted without tuning (uncapped is upstream behaviour), got %v", v)
+	got, ok := kanban["max_in_progress"]
+	if !ok {
+		t.Fatalf("max_in_progress must be rendered without tuning, got kanban block %v", kanban)
+	}
+	if fmt.Sprint(got) != fmt.Sprint(defaultKanbanMaxInProgress) {
+		t.Errorf("max_in_progress = %v, want %d", got, defaultKanbanMaxInProgress)
+	}
+	// A rendered 0 would be worse than no key at all: Hermes ignores anything below 1,
+	// so the ConfigMap would read as a capped board while behaving as an unbounded one.
+	if fmt.Sprint(got) == "0" {
+		t.Error("max_in_progress must never render as 0 — Hermes ignores it and the board runs uncapped")
 	}
 }
 
-// ...and setting it opts the deployment in.
+// ...and the CR overrides the operator's default outright.
 func TestRenderConfigYAMLMaxInProgressFromTuning(t *testing.T) {
 	one := 1
+	if one == defaultKanbanMaxInProgress {
+		t.Fatalf("test value %d must differ from the default to prove the override", one)
+	}
 	agent := agentWithTuning(&agentv1alpha1.TuningSpec{MaxInProgress: &one})
 
 	var parsed map[string]any
@@ -3647,6 +3673,23 @@ func TestDefaultProfileWakesOnFailuresOnly(t *testing.T) {
 			t.Error("wake_on_events must not contain `completed`: the notifier has " +
 				"already delivered that summary, so the woken turn is pure overhead")
 		}
+	}
+}
+
+// Raising the cap must work too — the default is a floor for the untuned case, not a
+// ceiling. A one-sided override test would pass even if the render silently took the
+// minimum of the two.
+func TestRenderConfigYAMLMaxInProgressRaisedAboveDefault(t *testing.T) {
+	eight := 8
+	agent := agentWithTuning(&agentv1alpha1.TuningSpec{MaxInProgress: &eight})
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(renderConfigYAML(agent, nil)), &parsed); err != nil {
+		t.Fatalf("unmarshal rendered YAML: %v", err)
+	}
+	kanban, _ := parsed["kanban"].(map[string]any)
+	if fmt.Sprint(kanban["max_in_progress"]) != "8" {
+		t.Errorf("max_in_progress = %v, want 8", kanban["max_in_progress"])
 	}
 }
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -353,6 +353,7 @@ data:
       auto_subscribe_on_create: true
       dispatch_in_gateway: true
       dispatch_interval_seconds: 5
+      max_in_progress: 2
       wake_on_events:
       - gave_up
       - crashed
@@ -583,7 +584,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 83a2d5b06243868e8cd1f4f33427817e65156eccbe98d62ef795d4b5b991b86b
+        kubeagents.x-k8s.io/config-hash: 550310a3ab2c9e35816fa1a8be64e68cc87377afc9609c0aa8a604e2b778c341
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -325,6 +325,7 @@ data:
       auto_subscribe_on_create: true
       dispatch_in_gateway: true
       dispatch_interval_seconds: 5
+      max_in_progress: 2
       wake_on_events:
       - gave_up
       - crashed
@@ -554,7 +555,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: a5953dc0d2580201d97c24eaf3c98774971ebe23f1320cf7bd3599d73a3c0310
+        kubeagents.x-k8s.io/config-hash: fff685f46be77b2e136806220db6dff17c663aee1077db530ad287ff9a158c14
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -353,6 +353,7 @@ data:
       auto_subscribe_on_create: true
       dispatch_in_gateway: true
       dispatch_interval_seconds: 5
+      max_in_progress: 2
       wake_on_events:
       - gave_up
       - crashed
@@ -583,7 +584,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubeagents.x-k8s.io/config-hash: 83a2d5b06243868e8cd1f4f33427817e65156eccbe98d62ef795d4b5b991b86b
+        kubeagents.x-k8s.io/config-hash: 550310a3ab2c9e35816fa1a8be64e68cc87377afc9609c0aa8a604e2b778c341
         kubeagents.x-k8s.io/fluent-bit-config-hash: 50923ab88e1741b0729c37837bc1c3869161e3161402494a4ee64cda3a2cfab3
         kubeagents.x-k8s.io/proxy-policy-hash: db64678068cfed7481ee3b503145c688a2b49257e8e534565333c172185a750d
         kubeagents.x-k8s.io/settings-config-hash: 9db5b5cb5fb8ec46b1a0572ef34ef27e0ed44dc1f787a4a76bdd75f43934c8b9

--- a/tests/e2e/operator/agentplugins_e2e_test.py
+++ b/tests/e2e/operator/agentplugins_e2e_test.py
@@ -1201,7 +1201,11 @@ spec:
         assert rejected.returncode != 0, 'targetProfile "default" must be rejected by the CRD'
         log('Verified targetProfile "default" is rejected.')
 
-        # tuning is opt-in: present means overlays, absent means Hermes' own defaults.
+        # Per-run tuning is opt-in: present means overlays, absent means Hermes' own
+        # defaults. maxInProgress is the exception — absent means the operator's cap,
+        # which is asserted after the removal below. 1 is chosen here precisely because
+        # it differs from that cap, so the assertion proves the override rather than
+        # matching what would be rendered anyway.
         run_kubectl([
             "patch", "platformagent", "platform-agent", "-n", NAMESPACE, "--type=merge",
             "-p", '{"spec":{"harness":{"tuning":{"maxInProgress":1,'
@@ -1234,10 +1238,14 @@ spec:
         assert "profileclass-cluster" not in keys, (
             f"removing tuning must drop the cluster class overlay, got keys:\n{keys}"
         )
-        assert "max_in_progress" not in get_platform_configmap_yaml(), (
-            "removing tuning must leave Hermes' own dispatch default, not a pinned value"
+        # Dispatch concurrency does NOT revert to Hermes' uncapped behaviour: withdrawing
+        # tuning falls back to the operator's own cap. Uncapped is the state that lets a
+        # burst of cards spawn a worker process each until the OOM killer takes them, and
+        # a removed CR field must not be a way back into it.
+        assert "max_in_progress: 2" in get_platform_configmap_yaml(), (
+            "removing tuning must fall back to the operator's dispatch cap, not to uncapped"
         )
-        log("Verified tuning removal drops the overlays and restores Hermes defaults.")
+        log("Verified tuning removal drops the overlays and falls back to the operator's dispatch cap.")
 
         # Withdrawing the plugin has to undo both halves. A stale link would leave a
         # dangling entry in the profile's plugins dir, and a stale plugins.enabled entry


### PR DESCRIPTION

# Pull Request

## Why This Change

  The operator rendered no `kanban.max_in_progress`, so an untuned install ran the board
  uncapped. That is not a tuning gap; it is a silent data-loss path.

  A kanban worker is not a coroutine — it is a full `hermes … kanban task` process, a few
  hundred MiB resident once its MCP proxies are up, alive for the length of the task
  (8–14 minutes for an incident triage). Uncapped, the dispatcher starts one per queued
  card, so a burst of cluster events queues workers faster than they retire.

  What follows is invisible everywhere you would look. The memory kill takes a worker, not
  PID 1: no container restart, no Kubernetes event, no non-zero exit code. The pod stays
  `Running`. The only trace is `pid not alive` in the kanban ledger, and because the
  dispatcher's retry budget is 1, the card is stranded in `ready` permanently. The symptom a
  user sees is an incident that never gets its 📋 triage report, with a healthy pod and a
  clean event stream.

  This was observed on a live install: nine concurrent workers at 3303Mi, workers dying as
  child processes, cards stranded.
## What Changed

<!-- Summarize the important files, behavior, or workflow changes. -->

**Files:**

  The operator now renders `kanban.max_in_progress: 2` when the CR does not set it.
  `spec.harness.tuning.maxInProgress` still overrides it in both directions.

  **Files:**

  - `k8s-operator/internal/controller/platformagent_manifests.go` — `defaultKanbanMaxInProgress = 2`; the render site now seeds the default and lets tuning
  override it
  - `k8s-operator/api/v1alpha1/common_types.go` — `MaxInProgress` doc comment: unset now means 2, not Hermes' uncapped behaviour
  - `k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml`, `charts/kube-agents/crds/kubeagents.x-k8s.io_platformagents.yaml` — regenerated
  description
  - `agents/chat/config.yaml` — same cap for the image-baked `default` profile, so an install running the image without the operator is not the one left
  uncapped
  - `k8s-operator/internal/controller/platformagent_manifests_test.go` — default is rendered, is never `0`, and is overridable upward and downward
  - `k8s-operator/internal/testing/testdata/platform/expected/platformagent{,-tagged,-telemetry}.yaml` — goldens
  - `tests/e2e/operator/agentplugins_e2e_test.py` — withdrawing tuning now asserts fallback to the cap, not to uncapped
  - `docs/site/src/content/docs/operator/platformagent-crd.md` — `maxInProgress` is no longer opt-in; adds "Why dispatch is capped by default"
  - `agentplugins/gke-stockout-investigator/tuning.yaml` — its `maxInProgress: 3` now raises the operator default rather than capping an uncapped board



**Added/Changed/Fixed:**

  - Added a board-wide default of 2 concurrent kanban workers
  - Fixed cards being stranded indefinitely when dispatch outruns pod memory
  - Changed `maxInProgress` from "unset = Hermes' behaviour" to "unset = 2"

## Why This Matters

  **Why 2.** The number has to hold on the smallest pod anyone runs, and the cost of being
  wrong is asymmetric: too low delays a delegated task, too high loses it silently. Two
  keeps a second card moving while the first is mid-triage, which is what unbounded
  dispatch was buying in practice. It is a floor for the untuned case, not a
  recommendation — a deployment that has measured its own worker footprint and model quota
  should raise it.

## Testing

<!-- Automated checks: unit tests, builds, `make docs-check`, `prettier --check`. -->

  - `go build ./...` and `go vet ./...` clean in `k8s-operator/`
  - `make docs-check` passes — generated regions current, 232 files' links resolve, terminology clean, 206 tracked docs mapped
  - `make manifests` produces no diff and `make chart-check` passes, confirming the CRD descriptions match the Go source
  - Unit tests: `TestRenderConfigYAMLDefaultsMaxInProgress` (default rendered, equals the constant, never `0`),
  `TestRenderConfigYAMLMaxInProgressFromTuning` (override to 1, guarded to differ from the default), `TestRenderConfigYAMLMaxInProgressRaisedAboveDefault`
  (override to 8 — a one-sided test would pass if the render took the min), plus `TestAgentsGolden` across all three fixtures
  - The e2e assertion that withdrawing tuning leaves no cap was inverted to assert the fallback


### Live validation

 **Install.** GKE cluster `platform-agent-host` / `us-east4`, project `stalhaali-gkedemos`.
  Agent image `platform-agent:dev-20260811-194344`. `PlatformAgent/platform-agent` in
  `kubeagents-system`. The install normally runs the upstream operator
  `ghcr.io/gke-labs/kube-agents/k8s-operator:latest`; for this test the manager image was
  swapped to a Cloud Build of this branch (commit `828cd29`),
  `us-east4-docker.pkg.dev/stalhaali-gkedemos/kube-agents/k8s-operator:dev-maxinprogress-20260812-0229`,
  and reverted afterwards.

 Then spammed the cluster with alerts: eight pods with unresolvable images. Workers held at
  2 with the rest queued in `ready`, and **every card completed with its incident triage
  report** — nothing stranded. That is the failure this fixes; previously a burst spawned
  workers until they were killed, and a killed worker left its card in `ready` forever.


-

---

<!-- Close with a short note on functional impact, risk, or rollout. -->
