### PR TITLE
fix(ci): fork the devops-bench gke cluster module and reap orphaned eval infrastructure before provisioning

### DIFF
--- a/bench/tf/modules/cluster/gke/main.tf
+++ b/bench/tf/modules/cluster/gke/main.tf
@@ -1,0 +1,279 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0.0"
+    }
+  }
+}
+
+# account_id is capped at 30 chars, so we can't fit a long cluster name. Truncating
+# the name alone is unsafe: names that share a prefix but differ only in a suffix past
+# the cutoff (e.g. "<base>-east" vs "<base>-west" when <base> is long) would collapse to
+# the same account_id and collide. Append a short hash of the *full* cluster name so the
+# id stays unique per cluster regardless of where the readable part is truncated.
+locals {
+  # A GCP IAM account_id must be lowercase letters, digits, and hyphens. Lowercase
+  # the cluster name and collapse any other characters (uppercase, underscores,
+  # dots) into hyphens before slicing so the readable part is always valid. The
+  # md5 hash below is over the *original* name, so distinct names still differ.
+  gke_nodes_name_slug = trim(substr(replace(lower(var.cluster_name), "/[^a-z0-9]+/", "-"), 0, 9), "-")
+
+  # Named once so the account and the reap below cannot disagree about what to
+  # look for.
+  gke_nodes_account_id = "gke-nodes-${local.gke_nodes_name_slug}-${substr(md5(var.cluster_name), 0, 6)}"
+}
+
+# kube-agents fork: a run killed before its teardown leaves this module's
+# resources behind with no state file to destroy them from, and the next apply
+# then dies on "409 Already Exists" before the evaluation can start. Reap them
+# first, so an aborted run costs the next one time rather than blocking it.
+#
+# This is safe only because the smoke test runs at max_concurrency 1: nothing
+# else can own a cluster with this name. That assumption is load-bearing -- if
+# the job is ever allowed to run concurrently, this deletes a live run's cluster.
+#
+# devops-bench hands each run a fresh scratch dir with empty state, so this is
+# created every time and the reap always runs.
+resource "terraform_data" "reap_orphans" {
+  triggers_replace = [var.cluster_name, var.location, var.project_id]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      # The cluster goes first: its nodes authenticate as the service account
+      # below, so deleting that account first would strand them.
+      if gcloud container clusters describe "${var.cluster_name}" \
+           --location "${var.location}" --project "${var.project_id}" >/dev/null 2>&1; then
+        echo "reaping orphaned cluster ${var.cluster_name} left by a previous run"
+        gcloud container clusters delete "${var.cluster_name}" \
+          --location "${var.location}" --project "${var.project_id}" --quiet
+      fi
+
+      sa="${local.gke_nodes_account_id}@${var.project_id}.iam.gserviceaccount.com"
+
+      # Strip the account's project bindings before deleting the account itself.
+      # Deleting it first leaves each binding behind as an inert
+      # "deleted:serviceAccount:<email>?uid=..." member that nothing later
+      # removes, and the recreated account gets a new uid, so its fresh bindings
+      # are separate entries -- every aborted run would add five more.
+      #
+      # The filter matches the tombstones as well as the live member, so this
+      # also clears whatever earlier reaps left behind. It runs outside the
+      # existence check below because those tombstones outlive the account.
+      #
+      # Roles are read back from the live policy rather than listed here, so
+      # this cannot drift from the google_project_iam_member resources above.
+      # Filtering on this account's email also keeps it away from
+      # agent_container_admin, which binds a long-lived external account.
+      while read -r role member; do
+        [[ -n "$role" && -n "$member" ]] || continue
+        echo "removing stale binding $role for $member"
+        gcloud projects remove-iam-policy-binding "${var.project_id}" \
+          --member "$member" --role "$role" --condition=None --quiet >/dev/null || true
+      done < <(gcloud projects get-iam-policy "${var.project_id}" \
+                 --flatten="bindings[].members" \
+                 --filter="bindings.members:$sa" \
+                 --format="value(bindings.role,bindings.members)")
+
+      if gcloud iam service-accounts describe "$sa" --project "${var.project_id}" >/dev/null 2>&1; then
+        echo "reaping orphaned service account $sa"
+        gcloud iam service-accounts delete "$sa" --project "${var.project_id}" --quiet
+      fi
+    EOT
+  }
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = local.gke_nodes_account_id
+  display_name = "GKE Node Service Account for ${var.cluster_name}"
+
+  depends_on = [terraform_data.reap_orphans]
+}
+
+resource "google_project_iam_member" "gke_nodes_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metric_writer" {
+  project = var.project_id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_monitoring_viewer" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_metadata_writer" {
+  project = var.project_id
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "gke_nodes_artifact_registry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.gke_nodes.email}"
+}
+
+resource "google_project_iam_member" "agent_container_admin" {
+  count   = var.agent_service_account != "" ? 1 : 0
+  project = var.project_id
+  role    = "roles/container.admin"
+  member  = "serviceAccount:${var.agent_service_account}"
+}
+
+resource "google_compute_firewall" "allow_iap_ssh" {
+  count   = var.enable_iap_ssh ? 1 : 0
+  name    = "allow-iap-ssh-${var.cluster_name}"
+  network = "default"
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges           = ["35.235.240.0/20"]
+  target_service_accounts = [google_service_account.gke_nodes.email]
+}
+
+# kube-agents fork: everything this module creates is disposable evaluation
+# infrastructure, and a run killed before its teardown leaves it behind with no
+# state file left to destroy it from. This label is the marker the orphan sweep
+# matches on, so it is fixed here rather than passed in -- a caller cannot
+# forget it, and it is identical on every run.
+locals {
+  bench_labels = {
+    "managed-by" = "kube-agents-bench"
+  }
+}
+
+resource "google_container_cluster" "primary" {
+  name     = var.cluster_name
+  location = var.location
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  deletion_protection      = false
+  min_master_version       = var.kubernetes_version
+  resource_labels          = local.bench_labels
+
+  dynamic "workload_identity_config" {
+    for_each = var.enable_workload_identity ? [1] : []
+    content {
+      workload_pool = "${var.project_id}.svc.id.goog"
+    }
+  }
+
+  depends_on = [terraform_data.reap_orphans]
+}
+
+locals {
+  # Map abstract types to GKE native guest accelerator strings
+  abstract_gpu_map = {
+    "l4"   = "nvidia-l4"
+    "a100" = "nvidia-tesla-a100"
+    "t4"   = "nvidia-tesla-t4"
+  }
+
+  # Map machine family prefix to GKE native guest accelerator strings
+  machine_family_gpu_map = {
+    "g2" = "nvidia-l4"
+    "a2" = "nvidia-tesla-a100"
+  }
+
+  is_g2 = startswith(var.machine_type, "g2-")
+  is_a2 = startswith(var.machine_type, "a2-")
+
+  # Determine final GPU attachment parameters
+  enable_gpu = var.gpu_type != "" || local.is_g2 || local.is_a2
+
+  # Extract machine family (e.g. "g2" from "g2-standard-4")
+  machine_family = split("-", var.machine_type)[0]
+
+  # Deduce GPU type from machine family if not explicitly set but GPU is enabled.
+  # This will fail at plan time if machine_family is not in machine_family_gpu_map.
+  deduced_gpu_type = var.gpu_type == "" && local.enable_gpu ? local.machine_family_gpu_map[local.machine_family] : ""
+
+  gpu_type = var.gpu_type != "" ? lookup(local.abstract_gpu_map, var.gpu_type) : local.deduced_gpu_type
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "primary-node-pool"
+  location   = var.location
+  cluster    = google_container_cluster.primary.name
+  node_count = var.node_count
+  version    = var.kubernetes_version
+
+  node_config {
+    preemptible     = false
+    machine_type    = var.machine_type
+    service_account = google_service_account.gke_nodes.email
+
+    # The node pool itself is not a labelable GCP resource, but this puts the
+    # marker on the Compute Engine instances it creates, so nodes outliving a
+    # deleted cluster are still identifiable.
+    resource_labels = local.bench_labels
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    dynamic "guest_accelerator" {
+      for_each = local.enable_gpu ? [1] : []
+      content {
+        type  = local.gpu_type
+        count = var.gpu_count
+        gpu_driver_installation_config {
+          gpu_driver_version = "DEFAULT"
+        }
+      }
+    }
+
+    dynamic "workload_metadata_config" {
+      for_each = var.enable_workload_identity ? [1] : []
+      content {
+        mode = "GKE_METADATA"
+      }
+    }
+  }
+}
+
+output "cluster_name" {
+  value = google_container_cluster.primary.name
+}
+
+output "cluster_location" {
+  value = google_container_cluster.primary.location
+}
+
+output "endpoint" {
+  value = google_container_cluster.primary.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+}
+

--- a/bench/tf/modules/cluster/gke/main.tf
+++ b/bench/tf/modules/cluster/gke/main.tf
@@ -47,8 +47,10 @@ locals {
 # else can own a cluster with this name. That assumption is load-bearing -- if
 # the job is ever allowed to run concurrently, this deletes a live run's cluster.
 #
-# devops-bench hands each run a fresh scratch dir with empty state, so this is
-# created every time and the reap always runs.
+# In CI each run gets a fresh pod and checkout, so there is never prior state
+# here and this resource is created, and the reap runs every time. Locally,
+# state persists under bench/tf, so after the first apply this only re-runs if
+# cluster_name, location or project_id change.
 resource "terraform_data" "reap_orphans" {
   triggers_replace = [var.cluster_name, var.location, var.project_id]
 
@@ -82,15 +84,17 @@ resource "terraform_data" "reap_orphans" {
       # this cannot drift from the google_project_iam_member resources above.
       # Filtering on this account's email also keeps it away from
       # agent_container_admin, which binds a long-lived external account.
+      policy=$(gcloud projects get-iam-policy "${var.project_id}" \
+                 --flatten="bindings[].members" \
+                 --filter="bindings.members:$sa" \
+                 --format="value(bindings.role,bindings.members)")
+
       while read -r role member; do
         [[ -n "$role" && -n "$member" ]] || continue
         echo "removing stale binding $role for $member"
         gcloud projects remove-iam-policy-binding "${var.project_id}" \
           --member "$member" --role "$role" --condition=None --quiet >/dev/null || true
-      done < <(gcloud projects get-iam-policy "${var.project_id}" \
-                 --flatten="bindings[].members" \
-                 --filter="bindings.members:$sa" \
-                 --format="value(bindings.role,bindings.members)")
+      done <<< "$policy"
 
       if gcloud iam service-accounts describe "$sa" --project "${var.project_id}" >/dev/null 2>&1; then
         echo "reaping orphaned service account $sa"

--- a/bench/tf/modules/cluster/gke/main.tf
+++ b/bench/tf/modules/cluster/gke/main.tf
@@ -77,8 +77,10 @@ resource "terraform_data" "reap_orphans" {
       # are separate entries -- every aborted run would add five more.
       #
       # The filter matches the tombstones as well as the live member, so this
-      # also clears whatever earlier reaps left behind. It runs outside the
-      # existence check below because those tombstones outlive the account.
+      # also clears what earlier runs left behind. It reaps only the resources
+      # this module deploys for the evaluation, nothing else in the project. It
+      # runs outside the existence check below because those tombstones outlive
+      # the account.
       #
       # Roles are read back from the live policy rather than listed here, so
       # this cannot drift from the google_project_iam_member resources above.
@@ -89,12 +91,27 @@ resource "terraform_data" "reap_orphans" {
                  --filter="bindings.members:$sa" \
                  --format="value(bindings.role,bindings.members)")
 
+      # Reported after the attempt rather than before it: this stays
+      # best-effort so one stuck binding cannot block the run, but a reap where
+      # every removal failed must not read identically to one where they all
+      # succeeded. Whatever is left behind is matched again by the next reap.
+      failed=0
       while read -r role member; do
         [[ -n "$role" && -n "$member" ]] || continue
-        echo "removing stale binding $role for $member"
-        gcloud projects remove-iam-policy-binding "${var.project_id}" \
-          --member "$member" --role "$role" --condition=None --quiet >/dev/null || true
+        if gcloud projects remove-iam-policy-binding "${var.project_id}" \
+             --member "$member" --role "$role" --condition=None --quiet >/dev/null; then
+          echo "removed stale binding $role for $member"
+        else
+          failed=$((failed + 1))
+          echo "WARNING: could not remove stale binding $role for $member"
+        fi
       done <<< "$policy"
+
+      # One line to grep for: the per-binding warnings above are easy to lose in
+      # a Prow log thousands of lines long.
+      if [ "$failed" -gt 0 ]; then
+        echo "WARNING: $failed stale binding(s) survived the reap; the next run retries them"
+      fi
 
       if gcloud iam service-accounts describe "$sa" --project "${var.project_id}" >/dev/null 2>&1; then
         echo "reaping orphaned service account $sa"
@@ -280,4 +297,3 @@ output "endpoint" {
 output "cluster_ca_certificate" {
   value = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
 }
-

--- a/bench/tf/modules/cluster/gke/variables.tf
+++ b/bench/tf/modules/cluster/gke/variables.tf
@@ -1,0 +1,83 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "location" {
+  description = "The GCP zone or region"
+  type        = string
+  default     = "us-central1-a"
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes in the standard pool"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Machine type for the nodes"
+  type        = string
+  default     = "e2-standard-2"
+}
+
+variable "enable_workload_identity" {
+  description = "Enable GKE Workload Identity"
+  type        = bool
+  default     = false
+}
+
+variable "kubernetes_version" {
+  description = "The Kubernetes version for the GKE cluster"
+  type        = string
+  default     = null
+}
+
+variable "agent_service_account" {
+  description = "The service account email of the agent"
+  type        = string
+  default     = ""
+}
+
+variable "enable_iap_ssh" {
+  description = "Enable IAP SSH firewall rule for the cluster"
+  type        = bool
+  default     = false
+}
+
+variable "gpu_type" {
+  description = "Abstract GPU family: 'l4', 'a100', 't4', or '' for no GPU"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = contains(["", "l4", "a100", "t4"], var.gpu_type)
+    error_message = "gpu_type must be one of: '', 'l4', 'a100', 't4'."
+  }
+}
+
+variable "gpu_count" {
+  description = "Quantity of GPUs to attach per node"
+  type        = number
+  default     = 1
+}
+

--- a/bench/tf/modules/cluster/main.tf
+++ b/bench/tf/modules/cluster/main.tf
@@ -1,0 +1,50 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This dispatch module instantiates only one concrete cluster sub-module and
+# declares no concrete-provider requirements of its own: each sub-module owns
+# its provider (google in ./gke, tehcyx/kind in ./kind), so a KinD-only run does
+# not pull in the GCP provider plugin.
+
+module "gke" {
+  source                   = "./gke"
+  count                    = var.infra_provider == "gcp" ? 1 : 0
+  project_id               = var.project_id
+  location                 = var.location != "" ? var.location : "us-central1-a"
+  cluster_name             = var.cluster_name
+  node_count               = var.node_count
+  machine_type             = var.machine_type != "" ? var.machine_type : "e2-standard-2"
+  kubernetes_version       = var.kubernetes_version
+  enable_workload_identity = var.enable_workload_identity
+  agent_service_account    = var.agent_service_account
+  enable_iap_ssh           = var.enable_iap_ssh
+  gpu_type                 = var.gpu_type
+  gpu_count                = var.gpu_count
+}
+
+# Only the gke sub-module is vendored: it carries kube-agents changes (resource
+# labels, orphan reaping) that cannot be expressed from the caller side. This
+# one has no local changes, so it stays upstream rather than becoming a copy
+# nobody maintains and nobody notices drifting.
+module "kind" {
+  source          = "git::https://github.com/kubernetes-sigs/devops-bench.git//tf/modules/cluster/kind?ref=4670d76dcc497e8f515d51c2bb6bad6ced7100b6"
+  count           = var.infra_provider == "kind" ? 1 : 0
+  cluster_name    = var.cluster_name
+  kubeconfig_path = var.kubeconfig_path
+  node_image      = var.node_image
+  project_id      = var.project_id
+  location        = var.location != "" ? var.location : "local"
+  node_count      = var.node_count
+}
+

--- a/bench/tf/modules/cluster/outputs.tf
+++ b/bench/tf/modules/cluster/outputs.tf
@@ -1,0 +1,49 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_name, "") : try(module.kind[0].cluster_name, "")
+  description = "The finalized name of the created cluster"
+}
+
+output "location" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_location, "") : try(module.kind[0].cluster_location, "")
+  description = "The region/zone or 'local'"
+}
+
+output "endpoint" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].endpoint, "") : try(module.kind[0].endpoint, "")
+  description = "Cluster control plane endpoint"
+}
+
+output "cluster_ca_certificate" {
+  value       = var.infra_provider == "gcp" ? try(module.gke[0].cluster_ca_certificate, "") : try(module.kind[0].cluster_ca_certificate, "")
+  description = "Cluster CA certificate"
+}
+
+output "client_certificate" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].client_certificate, "") : ""
+  description = "Client certificate for KinD"
+}
+
+output "client_key" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].client_key, "") : ""
+  description = "Client key for KinD"
+}
+
+output "kubeconfig_path" {
+  value       = var.infra_provider == "kind" ? try(module.kind[0].kubeconfig_path, "") : ""
+  description = "Local path to the kubeconfig file"
+}
+

--- a/bench/tf/modules/cluster/variables.tf
+++ b/bench/tf/modules/cluster/variables.tf
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The deployer scans this directory's *.tf only and never descends into the
-# module, so every variable that has to reach it is re-declared here.
-
 variable "infra_provider" {
   type        = string
   description = "The target cloud provider (gcp, kind)"
+
+  validation {
+    condition     = contains(["gcp", "kind"], var.infra_provider)
+    error_message = "infra_provider must be one of: 'gcp', 'kind'."
+  }
 }
 
 variable "cluster_name" {
@@ -34,40 +36,71 @@ variable "location" {
 variable "node_count" {
   type        = number
   description = "Number of worker nodes"
-  default     = 1
+  default     = 3
 }
 
 variable "machine_type" {
   type        = string
   description = "VM instance type"
-  default     = "g2-standard-4"
+  default     = ""
+}
+
+variable "gpu_type" {
+  type        = string
+  description = "Abstract GPU family: 'l4', 'a100', 't4', or ''"
+  default     = ""
+
+  validation {
+    condition     = contains(["", "l4", "a100", "t4"], var.gpu_type)
+    error_message = "gpu_type must be one of: '', 'l4', 'a100', 't4'."
+  }
+}
+
+variable "gpu_count" {
+  type        = number
+  description = "Quantity of GPUs to attach per node"
+  default     = 1
 }
 
 variable "project_id" {
   type        = string
-  description = "GCP Project ID"
+  description = "GCP Project ID (GCP-only)"
   default     = ""
 }
 
-# Relative to the directory tofu runs in. See tf/prebuilt/kind/variables.tf for
-# why this is not ~/.kube/config.
 variable "kubeconfig_path" {
   type        = string
   description = "Target path to write kubeconfig (KinD-only)"
-  default     = "./kind-kubeconfig.yaml"
+  default     = "~/.kube/config"
 }
 
-# Identify the CI run that created this infra so a janitor can find what a run
-# killed before teardown left behind. tofu reads these from TF_VAR_* in the
-# environment; both are empty outside CI.
-variable "prow_build_id" {
+variable "kubernetes_version" {
   type        = string
-  description = "Prow BUILD_ID of the run creating this infra"
+  description = "The Kubernetes version for the cluster"
+  default     = null
+}
+
+variable "enable_workload_identity" {
+  type        = bool
+  description = "Enable GKE Workload Identity (GCP-only)"
+  default     = false
+}
+
+variable "agent_service_account" {
+  type        = string
+  description = "The service account email of the agent (GCP-only)"
   default     = ""
 }
 
-variable "prow_pull_number" {
-  type        = string
-  description = "Pull request number the run belongs to"
-  default     = ""
+variable "enable_iap_ssh" {
+  type        = bool
+  description = "Enable IAP SSH firewall rule (GCP-only)"
+  default     = false
 }
+
+variable "node_image" {
+  type        = string
+  description = "The kind node image to use (KinD-only)"
+  default     = "kindest/node:v1.29.2"
+}
+

--- a/bench/tf/prebuilt/gpu-stress-test/main.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/main.tf
@@ -30,15 +30,29 @@ terraform {
   }
 }
 
+# GCP label values accept lowercase letters, digits, '-' and '_' only, so the
+# Prow ids go in verbatim.
+locals {
+  ci_labels = {
+    "managed-by"  = "kube-agents-bench"
+    "build-id"    = var.prow_build_id != "" ? var.prow_build_id : "local"
+    "pull-number" = var.prow_pull_number != "" ? var.prow_pull_number : "none"
+  }
+}
+
 provider "google" {
   project = var.project_id != "" ? var.project_id : null
   region  = var.location != "" && var.location != "local" ? var.location : null
+
+  # module.cluster declares no provider of its own and so inherits this one:
+  # the labels reach the cluster it creates without forking that module.
+  default_labels = local.ci_labels
 }
 
 provider "kind" {}
 
 module "cluster" {
-  source = "git::https://github.com/kubernetes-sigs/devops-bench.git//tf/modules/cluster?ref=4670d76dcc497e8f515d51c2bb6bad6ced7100b6"
+  source = "../../modules/cluster"
 
   infra_provider  = var.infra_provider
   cluster_name    = var.cluster_name

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -40,6 +40,13 @@ export CLUSTER_NAME="test-cluster"
 export TF_VAR_cluster_name="test-cluster"
 export GCP_LOCATION="us-west4-a" # set to different zone due to resource availability stockouts in us-central1
 
+# Stamp the run onto every labelable GCP resource the stacks create, alongside
+# the fixed managed-by label the cluster module applies. These say *which* run
+# left an orphan behind; managed-by is what the sweep matches on. Both are set
+# by Prow and empty when running locally, where the stacks fall back to "local".
+export TF_VAR_prow_build_id="${BUILD_ID:-}"
+export TF_VAR_prow_pull_number="${PULL_NUMBER:-}"
+
 # 4. Token & Model Configuration
 # Dynamically fetches API_SERVER_KEY from GKE secret and locks down Gemini 3.1
 export PLATFORM_AGENT_TOKEN="$(kubectl get secret platform-agent-secrets -n "${TARGET_NAMESPACE}" -o jsonpath='{.data.API_SERVER_KEY}' | base64 --decode)"


### PR DESCRIPTION
# Pull Request

## Why This Change
`pull-kube-agents-smoke-test` gets aborted routinely — a PR merges, a run is superseded, someone cancels. Prow sends SIGKILL after the grace period, which skips the devops-bench harness's teardown and the job's `trap ... EXIT` alike. Every in-pod cleanup mechanism is best-effort by construction, so the GKE cluster and its node service account survive with no state file left to destroy them from.

The next run then fails its `tofu apply` on `409 Already Exists` before the evaluation starts, and stays broken until someone deletes the leftovers by hand. Because the job runs at `max_concurrency: 1` against a fixed cluster name, one abort blocks the smoke test for every subsequent PR.

## What Changed

**Files:**
- `bench/tf/modules/cluster/**` — forked from `kubernetes-sigs/devops-bench@4670d76`
- `bench/tf/prebuilt/gpu-stress-test/main.tf`
- `bench/tf/prebuilt/gpu-stress-test/variables.tf`
- `hack/ci-eval-pr.sh`

**Added/Changed/Fixed:**
- **Forked the `cluster` module into `bench/tf/modules/`.** The stacks previously sourced it over `git::` pinned at `4670d76`, which made it read-only for us. Resource labels and recovery behaviour cannot be expressed from the caller side, so the module had to be ours. Only the `gke` sub-module is forked; `kind` has no local changes and still points at the upstream `git::` URL rather than becoming a copy nobody maintains.
- **Added `terraform_data.reap_orphans`**, which deletes a leftover cluster and node service account before anything else is created. Both `google_container_cluster.primary` and `google_service_account.gke_nodes` now `depends_on` it. devops-bench hands each run a fresh scratch dir with empty state, so the resource is always created and the check always runs.
- **The reap strips the account's project IAM bindings before deleting the account.** Deleting the account first leaves each binding behind as an inert `deleted:serviceAccount:...?uid=` member; the recreated account gets a new uid, so its fresh bindings do not replace them and every aborted run would add five more. Roles are read back from the live policy rather than hardcoded, so they cannot drift from the `google_project_iam_member` resources, and the same lookup clears tombstones left by earlier runs.
- **Labelled the infrastructure.** The stack sets `managed-by`, `build-id`, and `pull-number` as provider `default_labels`, which the module inherits; the module additionally sets `managed-by` in `node_config.resource_labels`, since a node pool is not itself a labelable resource and its instances can outlive a deleted cluster. `hack/ci-eval-pr.sh` passes Prow's `BUILD_ID` and `PULL_NUMBER` through as `TF_VAR_*`, defaulting to `local`/`none` outside CI.

## Why This Matters
- One aborted run currently blocks the smoke test for every PR that follows, until someone intervenes manually. After this change an abort costs the next run time (a cluster delete) rather than blocking it.
- Leaked resources were previously indistinguishable from anything else in the project. The labels make them findable without knowing what the stacks create.
- Recovery happens at the start of the apply that needs it, not on a schedule. There is no janitor cronjob to own, no grace period to tune, and nothing that can delete resources a run is still using.

## Context
- Job config lives in `GoogleCloudPlatform/oss-test-infra`: `prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml`.
- **The reap is safe only at `max_concurrency: 1`**, where nothing else can own a cluster with this name. That assumption is load-bearing and is stated in a comment above the resource: allowing the job to run concurrently would make this delete a live run's cluster.

## Testing
### Live validation
#### Manual
**Orphans were created deliberately, then observed being reaped.** 
- A `test-cluster` and a `gke-nodes-test-clus-9750e4@hangdng-gkedemos.iam.gserviceaccount.com` service account were created by hand before the run, so the reap had something real to find rather than matching a coincidence:
  - `module.cluster.module.gke[0].terraform_data.reap_orphans` appeared in the plan and ran first, ahead of the cluster and service account, confirming the `depends_on` edges.
  - It logged `reaping orphaned cluster test-cluster left by a previous run` and deleted it, then `reaping orphaned service account gke-nodes-test-clus-9750e4@…` and deleted that. 6m34s total.
  - The module then recreated the service account with the identical `account_id` 16 seconds later, with no collision against GCP's 30-day soft-delete tombstone. This was the specific failure mode the design risked, and it is the reason the test was run.
  - Cluster created in 11m10s, node pool in 2m43s, `guest_accelerator nvidia-l4` attached.
  - Teardown destroyed all 10 resources cleanly; the eval passed at 100% (OutcomeValidity [GEval] 1.00). No test artifacts left behind — the hand-made cluster and account were consumed by the reap, and everything the run created was destroyed.

**Labels verified on the live resources:**
- Cluster `effective_labels`: `build-id=local`, `pull-number=none`, `managed-by=kube-agents-bench`, plus Google's `goog-terraform-provisioned=true` — confirming `default_labels` reaches the module through provider inheritance.
- Cluster `resource_labels`: `managed-by=kube-agents-bench`.
- Node pool `node_config.resource_labels`: `managed-by=kube-agents-bench` alongside GKE's own


#### Prow Smoke Test
Prow presubmit `pull-kube-agents-smoke-test`, build [`2087552474192809984`](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/652/pull-kube-agents-smoke-test/2087552474192809984) on PR #652. Build cluster `kube-agents-prow`; infrastructure created in `kube-agents-evals`, zone `us-west4-a`. Job result SUCCESS in 56m05s, evaluation `OutcomeValidity` 1.00.

**The reap fired against a real leak**
  `terraform_data.reap_orphans` completed in 36s having removed ten stale bindings: 
```
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/artifactregistry.reader for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=105133120633823066254
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/artifactregistry.reader for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=115247132972129865670
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/logging.logWriter for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=105133120633823066254
module.cluster.module.gke[0].terraform_data.reap_orphans: Still creating... [10s elapsed]
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/logging.logWriter for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=115247132972129865670
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/monitoring.metricWriter for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=105133120633823066254
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/monitoring.metricWriter for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=115247132972129865670
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/monitoring.viewer for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=105133120633823066254
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/monitoring.viewer for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=115247132972129865670
module.cluster.module.gke[0].terraform_data.reap_orphans: Still creating... [20s elapsed]
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/stackdriver.resourceMetadata.writer for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=105133120633823066254
module.cluster.module.gke[0].terraform_data.reap_orphans: Still creating... [30s elapsed]
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): removing stale binding roles/stackdriver.resourceMetadata.writer for deleted:serviceAccount:gke-nodes-test-clus-9750e4@kube-agents-evals.iam.gserviceaccount.com?uid=115247132972129865670
module.cluster.module.gke[0].terraform_data.reap_orphans (local-exec): Updated IAM policy for project [kube-agents-evals].
module.cluster.module.gke[0].terraform_data.reap_orphans: Creation complete after 36s [id=3db57514-4bce-b2c4-89fe-fcc5ff44b470]
```
Five roles across **two distinct uids**, two separate aborted runs had each left a full set of tombstones behind in the shared CI project. Neither `reaping orphaned cluster` nor `reaping orphaned service account` appeared, so there was no live resource to delete; only the dead bindings the old code left behind remained. That is exactly the failure mode this change targets, observed in production rather than manufactured.

  **Labels verified at the API** 
On `google_container_cluster.primary`:
```

  resource_labels  = { "managed-by" = "kube-agents-bench" }
  effective_labels = { "build-id"                   = "2087552474192809984"
                       "goog-terraform-provisioned" = "true"
                       "managed-by"                 = "kube-agents-bench"
                       "pull-number"                = "652" }
```
  and on the node pool's `node_config`, `resource_labels = { "managed-by" =
  "kube-agents-bench" }`, merged by GKE with its own `goog-gke-accelerator-type =
  nvidia-l4` and `goog-gke-node-pool-provisioning-model = on-demand`.

  `build-id` matches the Prow build ID exactly and `pull-number` matches the PR, so
  the `TF_VAR_prow_build_id` / `TF_VAR_prow_pull_number` exports in
  `hack/ci-eval-pr.sh` reach the provider's `default_labels` end to end. The teardown
  plan later shows the same labels being *read back off the live resources* before
  destroying them — proof they were applied to GCP rather than only planned.

---

#### Risk and rollout
Contained to bench/ evaluation infrastructure and the CI eval script; no operator, chart, or agent behaviour changes. The one real risk is the max_concurrency: 1 assumption — if that is ever relaxed on the Prow job, this reap would delete a concurrent run's cluster; adding a build-id guard would lift the constraint if concurrency is ever wanted. Reverts cleanly, since each run provisions from an empty state file and the fork leaves nothing behind.
