### PR TITLE
fix(ci): default ALLOW_UNENCRYPTED_SECRETS to false in ci-deploy

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -37,10 +37,9 @@ export IMAGE_TAG="${TAG}"
 
 export MODEL_PROVIDER="gemini"
 export MODEL_DEFAULT_NAME="gemini-3.1-pro-preview"
-# Allow deployments on pre-existing CI evaluation clusters (e.g. in kube-agents-evals)
-# that were created without Cloud KMS etcd database encryption (CMEK), while keeping
-# strict CMEK enforcement enabled by default for production installations.
-export ALLOW_UNENCRYPTED_SECRETS="${ALLOW_UNENCRYPTED_SECRETS:-true}"
+# Default to enforcing CMEK database encryption on CI evaluation clusters.
+# Set ALLOW_UNENCRYPTED_SECRETS=true to bypass CMEK checks on unencrypted test clusters.
+export ALLOW_UNENCRYPTED_SECRETS="${ALLOW_UNENCRYPTED_SECRETS:-false}"
 
 export KSA_NAME="kubeagents-platform-agent"
 export GSA_NAME="kubeagents-platform-gsa"


### PR DESCRIPTION
# Pull Request

## Why This Change

Revert the temporary `ALLOW_UNENCRYPTED_SECRETS` flag in `hack/ci-deploy.sh` back to its default value (`false`). After adding CMEK support (#495) and rerunning cluster provisioning (step 1), the CI host cluster is now CMEK-encrypted, making the temporary bypass unnecessary.

## What Changed

**Files:**

- `hack/ci-deploy.sh`

**Added/Changed/Fixed:**

- Reverted `ALLOW_UNENCRYPTED_SECRETS` default to `false`.

## Why This Matters

- Enforces CMEK database encryption by default in CI deployments, matching production.

## Context

- Follow-up to CMEK database encryption (#495).

## Testing

- `make docs-check`

### Live validation

- Verified CI host cluster state with `gcloud container clusters list --project kube-agents-evals --format="table(name,location,databaseEncryption.state,databaseEncryption.keyName)"`, confirming `platform-agent-host` in `us-central1` is `ALL_OBJECTS_ENCRYPTION_ENABLED` with the KMS key configured.
