### PR TITLE
fix(teardown): skip GKE backup plan teardown if feature disabled

### DIFF
--- a/k8s-operator/scripts/teardown_12_gke_backup_plan.sh
+++ b/k8s-operator/scripts/teardown_12_gke_backup_plan.sh
@@ -15,6 +15,13 @@ source "${SCRIPT_DIR}/common.sh" "$@"
 
 ensure_teardown_state
 
+# Do not prompt in teardown. If the value is explicitly false, skip.
+# If missing, we assume true to attempt a safe cleanup of any potential orphaned resources.
+if [ -n "${ENABLE_GKE_BACKUP_PLAN:-}" ] && ! is_truthy "$ENABLE_GKE_BACKUP_PLAN"; then
+  echo -e "  ${C_YELLOW}ℹ Skipping GKE Backup Plan teardown (ENABLE_GKE_BACKUP_PLAN=${ENABLE_GKE_BACKUP_PLAN}).${C_RESET}"
+  exit 0
+fi
+
 if [ "${DRY_RUN:-0}" -ne 1 ] && ! gcloud beta --help &>/dev/null; then
   print_info "The 'gcloud beta' component is not installed. Skipping GKE Backup Plan teardown."
   exit 0


### PR DESCRIPTION
# Pull Request

## Why This Change

Addresses a `PERMISSION_DENIED` error in the RC pipeline teardown step (`Step 2 - Provision RC Environment / deploy-rc`). 
The provisioning step correctly skipped creating a GKE backup plan if `ENABLE_GKE_BACKUP_PLAN` was false, but the teardown script unconditionally attempted to query the Backup Plan API. Since the WIF Service Account lacks `gkebackup.admin` permission (as the feature isn't actively enabled in RC), this unconditionally triggered an API permission error.

## What Changed

Added an early exit condition in the teardown script to check if the feature is disabled.

**Files:**

- `k8s-operator/scripts/teardown_12_gke_backup_plan.sh`

**Added/Changed/Fixed:**

- Fixed `teardown_12_gke_backup_plan.sh` to check `ENABLE_GKE_BACKUP_PLAN` and exit with 0 if it's explicitly falsy, mimicking the provisioning script's behavior.

## Why This Matters

- Prevents unnecessary API calls when the feature is disabled.
- Fixes the asymmetry between how `provision_12` and `teardown_12` scripts handle the feature toggle.

## Context

**Why was this error ignored earlier, and why do we still ignore it?**
The CI teardown orchestrator script (`k8s-operator/scripts/teardown.sh`) executes this particular step with an appended `|| true`. This means that even if the `gcloud describe` command threw a `PERMISSION_DENIED` error and the script exited with a non-zero exit code, the master script ignored the failure and proceeded to tear down other resources. This acts as a safeguard so one cleanup failure doesn't halt the rest.

We intentionally chose to keep this behavior. If the state file is missing, the script assumes `true` and attempts cleanup to ensure no orphaned resources are left behind. As a result, CI (which doesn't have this variable set) will still attempt the teardown and log the `PERMISSION_DENIED` error, but it will continue to be safely ignored without breaking the pipeline.

## Testing

- ✅ Verified locally that when `ENABLE_GKE_BACKUP_PLAN=false`, running `./k8s-operator/scripts/teardown_12_gke_backup_plan.sh` cleanly outputs `ℹ Skipping GKE Backup Plan teardown...` and exits gracefully.
- ✅ Verified locally by the user that when `ENABLE_GKE_BACKUP_PLAN=true` (or is unset), the script correctly issues a deletion request and waits for operation completion without errors (if properly authenticated).

---
