### PR TITLE
fix(ci): export GCP and GKE env vars in rc provision script

### DIFF
--- a/scripts/release/provision_rc_environment.sh
+++ b/scripts/release/provision_rc_environment.sh
@@ -2,5 +2,10 @@
 # Executes environment teardown and provisioning for release candidate deployment.
 set -euo pipefail
 
+export PROJECT_ID="${GCP_PROJECT_ID}"
+export REGION="${GCP_REGION}"
+export CLUSTER_NAME="${GKE_CLUSTER_NAME}"
+export PROJECT_NUMBER="${GCP_PROJECT_NUMBER:-}"
+
 ./k8s-operator/scripts/teardown.sh --no-confirm
 ./k8s-operator/scripts/provision.sh --no-confirm


### PR DESCRIPTION
# Pull Request

## Why This Change

The twice-daily Release Candidate (RC) pipeline began failing on Step 3 (`wait_for_gke_readiness.sh`) with a `404 Not Found` error:
```
Could not find [platform-agent-host] in [us-east4].
Did you mean [platform-agent-host] in [us-central1]?
```

### Root Cause & Why It Worked Previously
1. **Variable Name Drift & Hidden Fallback Masking**:
   - A variable naming drift existed between GitHub Actions environment variables (`GCP_PROJECT_ID`, `GCP_REGION`, `GKE_CLUSTER_NAME`, `GCP_PROJECT_NUMBER`) and the provisioning scripts expected variables (`PROJECT_ID`, `REGION`, `CLUSTER_NAME`, `PROJECT_NUMBER`).
   - Previously, `provision_01_gcp_cluster.sh` had a hardcoded default `"us-east4"`. Because this hardcoded fallback happened to match the exact value configured in the GitHub `rc` environment (`GCP_REGION="us-east4"`), the script appeared to work as expected, hiding the underlying variable name mismatch.
2. **Recent Changes Exposed the Bug**:
   - In PR #631 (commit `87b64997`), all script defaults were cleaned up and unified to use `DEFAULT_REGION="us-central1"`.
   - Once the fallback changed to `us-central1`, `provision.sh` started deploying the GKE cluster to `us-central1` because `REGION` was not set (only `GCP_REGION` existed in the environment).
3. **Provision vs Teardown Asymmetry**:
   - Unlike `provision.sh` (which only inspected `${REGION:-}`), `teardown.sh` via `ensure_teardown_state()` in `common.sh` was already reading `${GCP_REGION}` directly (`export REGION="${REGION:-${GCP_REGION:-$DEFAULT_REGION}}"`).
   - This asymmetry caused `teardown.sh` to successfully find and delete the cluster in `us-east4`, while `provision.sh` provisioned a new cluster in `us-central1`. Step 3 (`wait_for_gke_readiness.sh`) then failed looking for the cluster in `us-east4`.

## What Changed

**Files:**

- `scripts/release/provision_rc_environment.sh`

**Added/Changed/Fixed:**

- Explicitly mapped and exported the incoming GitHub environment variables (`GCP_PROJECT_ID`, `GCP_REGION`, `GKE_CLUSTER_NAME`, `GCP_PROJECT_NUMBER`) to the standard variables (`PROJECT_ID`, `REGION`, `CLUSTER_NAME`, `PROJECT_NUMBER`) at the RC pipeline entry point before invoking `teardown.sh` and `provision.sh`.

## Why This Matters

- Ensures the RC pipeline provisions the GKE cluster in the intended environment region (`us-east4`) rather than silently falling back to the script default (`us-central1`).
- Unblocks the Release Candidate E2E validation pipeline and automated release tagging.

## Context

- Related to PR #631 (commit `87b64997`), which unified script default values and exposed the latent variable drift.

## Testing

- `make docs-check`: Passed (relative links, terminology, doc map inventory).
- Python test suite: Passed (`python3 -m unittest discover -s tests`).
- Go operator tests: Passed (`cd k8s-operator && go test ./...`).

### Live validation

- **Dry-run validation with distinct custom variables**:
  - Invoked `provision_rc_environment.sh` in dry-run mode with `GCP_PROJECT_ID="custom-test-proj-999"`, `GCP_REGION="europe-west4"`, `GKE_CLUSTER_NAME="custom-cluster-xyz"`, and `GCP_PROJECT_NUMBER="999888777666"`.
  - Confirmed all sub-scripts (`provision_01_gcp_cluster.sh`, `provision_02_gvisor_nodepool.sh`, `provision_05_gcp_gchat.sh`) properly received and applied the custom region, project ID, cluster name, and project number throughout execution.
- **Observed failure replay**:
  - Verified against historical CI run logs (Runs 31537099435 and 31582820122) confirming the exact failure mechanism where `teardown.sh` removed `us-east4` and `provision.sh` created `us-central1`.

---

## Follow-up Activities

1. **Trigger / Monitor Next RC Run**: Once merged, trigger the RC pipeline via `workflow_dispatch` or wait for the next scheduled run to verify end-to-end GKE readiness in `us-east4`.
2. **Align Variable Naming Across Scripts & Workflows**: Standardize variable names across all workflows and scripts to prevent naming drift in the future.
3. **Align Provisioning and Teardown State Handling**: Update `load_state()` in `k8s-operator/scripts/common.sh` to match `ensure_teardown_state()` so both provisioning and teardown handle `GCP_*` / `GKE_*` aliases symmetrically.
4. **GCP Project Cleanup**: Clean up the orphaned `platform-agent-host` cluster in `us-central1` inside project `kube-agents-rc` created during previous failing runs.
