### PR TITLE
feat(security): enforce a read-only root filesystem on the agent containers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -47,10 +47,10 @@ jobs:
       # deploy to amd64 GKE nodes, and the multi-arch bases otherwise resolve to
       # whatever the runner is (#560). Redundant on today's amd64 runners; load-bearing
       # the day the runner label changes.
-      # load: true, unlike the other builds here, so the layer-budget step below
-      # has an image to inspect. It costs a transfer from the buildx cache into
-      # the daemon; nothing else needs the image, which is why the others do
-      # without.
+      # load: true, so the layer-budget step below has an image to inspect. It costs
+      # a transfer from the buildx cache into the daemon, which is why only this
+      # build and the gate-test build below -- the two whose output a later step
+      # runs or inspects -- pay for it.
       - name: Build Platform Agent
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -89,8 +89,33 @@ jobs:
           target: entrypoint-gate-test
           platforms: linux/amd64
           push: false
+          # load, unlike before: the step below re-runs this stage's check as a
+          # container rather than as a build RUN, and needs the image in the daemon.
+          load: true
+          tags: entrypoint-gate-test:latest
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+
+      # The same check again, against the rootfs the operator actually gives the pod.
+      # The RUN above cannot cover this: a build layer is writable by definition, so it
+      # proves the entrypoint works but says nothing about whether it needs the write.
+      # readOnlyRootFilesystem turns any such write into EROFS at container start, and
+      # the entrypoint runs a script this repo does not own (upstream's stage2-hook.sh),
+      # so "it only writes under $HERMES_HOME and /tmp" has to be tested rather than read
+      # off the source. Cheap, because the image is already in the daemon from the load.
+      #
+      # --tmpfs stands in for the two writable mounts the Deployment provides: the data
+      # PVC at $PLATFORM_AGENT_HOME, which the check already relocates under /tmp, and the
+      # tmp-scratch emptyDir. size=2g matches that volume's sizeLimit, so a case that
+      # outgrows the real volume fails here too; exec because the check's HA-handoff case
+      # runs a wrapper script from the scratch tree, and Docker's default tmpfs is noexec.
+      - name: Verify entrypoint under a read-only root filesystem
+        run: |
+          docker run --rm \
+            --read-only \
+            --tmpfs /tmp:rw,exec,mode=1777,size=2g \
+            --entrypoint /usr/local/bin/entrypoint-gate-check \
+            entrypoint-gate-test:latest
 
       # No load: true. This shares only agent-base with the build above, so it is
       # the shorter chain of the two and not the one the budget is measured

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -104,11 +104,15 @@ jobs:
       # so "it only writes under $HERMES_HOME and /tmp" has to be tested rather than read
       # off the source. Cheap, because the image is already in the daemon from the load.
       #
-      # --tmpfs stands in for the two writable mounts the Deployment provides: the data
-      # PVC at $PLATFORM_AGENT_HOME, which the check already relocates under /tmp, and the
-      # tmp-scratch emptyDir. size=2g matches that volume's sizeLimit, so a case that
-      # outgrows the real volume fails here too; exec because the check's HA-handoff case
-      # runs a wrapper script from the scratch tree, and Docker's default tmpfs is noexec.
+      # One --tmpfs stands in for two writable mounts the Deployment provides separately:
+      # the data PVC at $PLATFORM_AGENT_HOME, which the check already relocates under /tmp,
+      # and the tmp-scratch emptyDir. Those have independent budgets in the pod -- a
+      # multi-Gi PVC and a 2Gi emptyDir -- so size=2g is a ceiling on the two combined and
+      # not a model of either. It is there to keep a runaway case from filling the runner,
+      # not to predict which volume a real pod would outgrow; read a failure here as "this
+      # case writes more than we expect", not as "tmp-scratch is too small". exec, because
+      # the check's HA-handoff case runs a wrapper script from the scratch tree and
+      # Docker's default tmpfs is noexec.
       - name: Verify entrypoint under a read-only root filesystem
         run: |
           docker run --rm \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1464,6 +1464,9 @@ USER 10000:10000
 # --- ENTRYPOINT GATE TEST TARGET ---
 # Not shipped, and not a layer of anything that is. Built only by
 # `--target entrypoint-gate-test`, where the RUN either passes or fails the build.
+# `docker-build.yml` then loads the stage and runs the same check a second time as a
+# container under `--read-only`, because a build layer is writable by definition and so
+# the RUN cannot tell you whether the entrypoint needs the write.
 #
 # It exists because the unit tests structurally cannot cover this. They run the entrypoint
 # on a developer host, where every step below the shared-state gate is guarded on

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -324,8 +324,17 @@ only command output, never a mounted Git credential file.
   sidecar.
 - The sandbox and sidecar run non-root, drop all Linux capabilities, disallow
   privilege escalation, and use the runtime-default seccomp profile.
-- The credential sidecar root filesystem is read-only; writable state uses
-  bounded `emptyDir` volumes.
+- Every container the operator builds — the credential-cleanup init container,
+  sandbox, dashboard, sidecar, log shipper — has a read-only root filesystem;
+  writable state uses bounded `emptyDir` volumes. The sandbox and dashboard
+  share a 2Gi `/tmp` scratch volume: the entrypoint runs several hermes
+  invocations with `HOME=/tmp` before the agent starts, and those two
+  containers already share the data PVC, so the shared volume is not a new
+  channel between them. The log shipper gets no `/tmp`: it buffers in memory
+  and keeps its tail database on its own volume. Containers supplied through
+  `spec.deployment.sidecars`/`initContainers` are appended to the Pod as
+  written; the webhook does not require a read-only root of them, so a CR can
+  still add a writable container to this Pod.
 - A policy ConfigMap hash is placed on the Pod template to trigger rollout when
   command policy changes.
 - The operator reports Ready only when the combined Pod is ready.

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -330,7 +330,11 @@ only command output, never a mounted Git credential file.
   share a 2Gi `/tmp` scratch volume: the entrypoint runs several hermes
   invocations with `HOME=/tmp` before the agent starts, and those two
   containers already share the data PVC, so the shared volume is not a new
-  channel between them. The log shipper gets no `/tmp`: it buffers in memory
+  channel between them. Note the lifetime this changes: `/tmp` used to be each
+  container's own writable layer, discarded whenever that container restarted.
+  An `emptyDir` is scoped to the Pod, so its contents now survive a container
+  crash or restart and are visible to both containers' next boot. The log
+  shipper gets no `/tmp`: it buffers in memory
   and keeps its tail database on its own volume. Containers supplied through
   `spec.deployment.sidecars`/`initContainers` are appended to the Pod as
   written; the webhook does not require a read-only root of them, so a CR can

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -135,6 +135,8 @@ kubectl exec -i deploy/platform-agent-gateway -c platform-agent -- \
 
 Confining it takes more than a scratch `$PLATFORM_AGENT_HOME`, because two of the setup's effects are not derived from it. Step 4 points `$HOME/.hermes/plugins/hermes_otel/config.yaml` at the config it generates — `hermes-otel` resolves its config below `~/.hermes` whatever `HERMES_HOME` says — and `$HOME` in the gateway is `/opt/data/home`, on the data PVC. Step 5 starts the Session KV server on port 8699, which is pod-wide and scoped by nothing. So each case also gets a scratch `$HOME`, and the server it spawns is killed by its scratch path as the case returns. The run ends by asserting both: that the pod's real compat symlink is byte-for-byte what it was, and that no process from the run is still alive.
 
+CI then runs the same script a second time, as a container under `docker run --read-only --tmpfs /tmp`. The build stage above cannot cover that: a build layer is writable by definition, so it proves the entrypoint works and not that it works without writing to the root filesystem. The operator sets `readOnlyRootFilesystem` on every container it builds, which turns any such write into `EROFS`, and the entrypoint's first step runs a script this repository does not own — so the second run is what keeps an upstream change to `stage2-hook.sh` from reaching a cluster as a pod that will not start.
+
 ## Base image pin
 
 The Hermes base image tag is pinned in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) at the repo root:

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -2114,6 +2114,14 @@ func buildDefaultVolumeMounts(homeDir string) []corev1.VolumeMount {
 // would be a silent behaviour change on upgrade. If they mounted something read-only there
 // the agent will fail to start — but it would have failed the same way before this change,
 // since the entrypoint has always needed a writable /tmp.
+//
+// Narrow on purpose: it detects the collision by cleaned mountPath but removes the default
+// by volume name, and only ever for /tmp. The general form — drop every default whose
+// cleaned path a user mount claims — is the same amount of code and would cover the next
+// default the operator adds. It would also silently drop the data PVC mount if a CR set
+// homeDir to a path the defaults use, turning a Deployment the API server rejects outright
+// into an agent that comes up with no persistent home. A rejected Deployment is the better
+// failure of the two, so the generalisation waits for a second path that actually needs it.
 func dropTmpScratchIfClaimed(defaults, userMounts []corev1.VolumeMount) []corev1.VolumeMount {
 	claimed := false
 	for _, m := range userMounts {
@@ -3114,6 +3122,14 @@ func buildDefaultVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volume {
 			// alpha LocalStorageCapacityIsolationFSQuotaMonitoring gate, which GKE
 			// does not enable. 2Gi matches credential-proxy-tmp, the closest
 			// analogue.
+			//
+			// Declared unconditionally, while dropTmpScratchIfClaimed can remove the
+			// mount from both containers -- so a CR that claims /tmp itself leaves
+			// this volume in the pod with nothing mounting it. That is legal and
+			// inert: the kubelet creates an empty directory and no container sees it.
+			// Making the declaration conditional would mean deciding it here from
+			// state that lives in the mount builders, which buys a tidier pod spec
+			// for a coupling that is easier to get wrong than this is to explain.
 			Name: tmpScratchVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -2134,6 +2134,28 @@ func dropTmpScratchIfClaimed(defaults, userMounts []corev1.VolumeMount) []corev1
 	return kept
 }
 
+// hardenedSecurityContext is the container hardening every container the operator builds
+// carries: no privilege escalation, no capabilities, and a root filesystem the process
+// cannot write to.
+//
+// One helper rather than a literal per container, because the alternative has already
+// failed. The same three fields were written out five times, and three of the five had
+// silently drifted to two of them — the read-only root was on the credential sidecar and
+// the cleanup init container and on neither agent container nor the log shipper, which is
+// the gap this function was introduced to close (RUNTIME-007). Nothing failed while that
+// was true. A container added from here on gets the block by construction, and
+// TestEveryContainerHasAHardenedSecurityContext fails if one is built without it.
+//
+// Anything a container needs on top — a different user, a writable path — belongs on that
+// container, not here. This is the floor, not the whole context.
+func hardenedSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+	}
+}
+
 func buildSandboxCredentialCleanup(image string, pullPolicy corev1.PullPolicy) corev1.Container {
 	return corev1.Container{
 		Name:            "sandbox-credential-cleanup",
@@ -2154,12 +2176,8 @@ func buildSandboxCredentialCleanup(image string, pullPolicy corev1.PullPolicy) c
   /workspace/home/.netrc \
   /workspace/home/.npmrc \
   /workspace/home/.pypirc`},
-		VolumeMounts: []corev1.VolumeMount{{Name: "platform-agent-data-vol", MountPath: "/workspace"}},
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			ReadOnlyRootFilesystem:   ptr.To(true),
-			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-		},
+		VolumeMounts:    []corev1.VolumeMount{{Name: "platform-agent-data-vol", MountPath: "/workspace"}},
+		SecurityContext: hardenedSecurityContext(),
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("200m"),
@@ -2276,9 +2294,7 @@ func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir str
 			{Name: "event-watcher-ksa-token", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true},
 			{Name: "platform-agent-data-vol", MountPath: homeDir},
 		},
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false), ReadOnlyRootFilesystem: ptr.To(true), Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
-		},
+		SecurityContext: hardenedSecurityContext(),
 	}
 }
 
@@ -2765,15 +2781,9 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			// The bearer key is the non-secret loopback sentinel already in this
 			// container's env, and API_SERVER_ENABLED is unconditionally true above,
 			// so the probe is valid in every configuration.
-			StartupProbe:   agentAPIProbe(10, 60),
-			ReadinessProbe: agentAPIProbe(15, 3),
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: ptr.To(false),
-				ReadOnlyRootFilesystem:   ptr.To(true),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-			},
+			StartupProbe:    agentAPIProbe(10, 60),
+			ReadinessProbe:  agentAPIProbe(15, 3),
+			SecurityContext: hardenedSecurityContext(),
 		},
 	}
 
@@ -2950,13 +2960,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 				TimeoutSeconds:      5,
 				FailureThreshold:    3,
 			},
-			SecurityContext: &corev1.SecurityContext{
-				AllowPrivilegeEscalation: ptr.To(false),
-				ReadOnlyRootFilesystem:   ptr.To(true),
-				Capabilities: &corev1.Capabilities{
-					Drop: []corev1.Capability{"ALL"},
-				},
-			},
+			SecurityContext: hardenedSecurityContext(),
 		})
 	}
 
@@ -3002,18 +3006,12 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 				MountPath: "/fluent-bit/state",
 			},
 		},
-		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			// No /tmp for this one, deliberately. The config above buffers in memory
-			// (Mem_Buf_Limit, no storage.path), keeps its tail DB on the
-			// fluent-bit-state volume and outputs to stdout, so it writes nothing to
-			// the root filesystem. Handing it the agent's tmp-scratch would only give
-			// an LLM-driven container a path into the log shipper.
-			ReadOnlyRootFilesystem: ptr.To(true),
-			Capabilities: &corev1.Capabilities{
-				Drop: []corev1.Capability{"ALL"},
-			},
-		},
+		// Read-only root and no /tmp, the only container here with neither. The config
+		// above buffers in memory (Mem_Buf_Limit, no storage.path), keeps its tail DB on
+		// the fluent-bit-state volume and outputs to stdout, so it writes nothing to the
+		// root filesystem. Handing it the agent's tmp-scratch would only give an
+		// LLM-driven container a path into the log shipper.
+		SecurityContext: hardenedSecurityContext(),
 	})
 
 	// The k8s-event-watcher is not a container of its own. It runs inside

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -60,7 +60,8 @@ const (
 	// (see the readiness probe in buildBaseContainers), so the container port, the
 	// Service port, and the NetworkPolicy rule below all describe a listener that
 	// only kubelet's port-forward can reach.
-	dashboardPort = 9119
+	dashboardPort        = 9119
+	tmpScratchVolumeName = "tmp-scratch"
 )
 
 // Shared-state ownership. Step 1.5 of deploy/shared/docker-entrypoint.sh reads this
@@ -2086,7 +2087,51 @@ func buildDefaultVolumeMounts(homeDir string) []corev1.VolumeMount {
 			MountPath: path.Dir(sessionKVDBPath),
 			SubPath:   "session",
 		},
+		{
+			// The one writable path outside the PVC, and the reason
+			// readOnlyRootFilesystem is survivable here: docker-entrypoint.sh runs
+			// four hermes invocations with HOME=/tmp before the agent starts, and
+			// the image is otherwise root-owned against a runtime UID of 10000.
+			Name:      tmpScratchVolumeName,
+			MountPath: "/tmp",
+		},
 	}
+}
+
+// dropTmpScratchIfClaimed removes the operator's /tmp mount when the CR already mounts
+// something there via storages or extraVolumeMounts.
+//
+// Those are appended to the defaults without deduplication, and the API server rejects a
+// Pod spec with two mounts on one mountPath. So without this the /tmp mount added above
+// would not merely be redundant on such a CR, it would make the Deployment unappliable and
+// stop reconciliation dead — on an upgrade, for a field the user set before /tmp was a
+// path the operator had any opinion about. Mounting scratch space at /tmp is exactly what
+// someone would have done while the root filesystem was still writable and there was no
+// other writable path outside the PVC, which is what makes this worth handling rather than
+// rejecting.
+//
+// The user's mount wins, deliberately: it is the one that predates this, and overriding it
+// would be a silent behaviour change on upgrade. If they mounted something read-only there
+// the agent will fail to start — but it would have failed the same way before this change,
+// since the entrypoint has always needed a writable /tmp.
+func dropTmpScratchIfClaimed(defaults, userMounts []corev1.VolumeMount) []corev1.VolumeMount {
+	claimed := false
+	for _, m := range userMounts {
+		if path.Clean(m.MountPath) == "/tmp" {
+			claimed = true
+			break
+		}
+	}
+	if !claimed {
+		return defaults
+	}
+	kept := make([]corev1.VolumeMount, 0, len(defaults))
+	for _, m := range defaults {
+		if m.Name != tmpScratchVolumeName {
+			kept = append(kept, m)
+		}
+	}
+	return kept
 }
 
 func buildSandboxCredentialCleanup(image string, pullPolicy corev1.PullPolicy) corev1.Container {
@@ -2599,13 +2644,14 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 
 	resources := resolveResources(agent.Spec.Deployment)
 
-	volumeMounts := buildDefaultVolumeMounts(homeDir)
+	var userVolumeMounts []corev1.VolumeMount
 	if len(storages) > 0 {
-		volumeMounts = append(volumeMounts, buildCustomStorageVolumeMounts(storages)...)
+		userVolumeMounts = append(userVolumeMounts, buildCustomStorageVolumeMounts(storages)...)
 	}
 	if len(extraVolumeMounts) > 0 {
-		volumeMounts = append(volumeMounts, extraVolumeMounts...)
+		userVolumeMounts = append(userVolumeMounts, extraVolumeMounts...)
 	}
+	volumeMounts := append(dropTmpScratchIfClaimed(buildDefaultVolumeMounts(homeDir), userVolumeMounts), userVolumeMounts...)
 
 	// Args, never Command. Command replaces the image ENTRYPOINT
 	// (/usr/local/bin/agent-entrypoint), and that script is what makes $HERMES_HOME
@@ -2723,6 +2769,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			ReadinessProbe: agentAPIProbe(15, 3),
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
+				ReadOnlyRootFilesystem:   ptr.To(true),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
@@ -2813,6 +2860,13 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 				MountPath: path.Dir(sessionKVDBPath),
 				SubPath:   "session",
 			},
+			{
+				// Same emptyDir the gateway gets. Sharing it is not a new channel:
+				// these two containers already run the same image against the same
+				// data PVC, so they are one trust domain either way.
+				Name:      tmpScratchVolumeName,
+				MountPath: "/tmp",
+			},
 		}
 
 		// What keeps this container out of the shared tree is AGENT_SHARED_STATE_SETUP
@@ -2841,7 +2895,9 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 					corev1.ResourceMemory: resource.MustParse("2Gi"),
 				},
 			},
-			VolumeMounts: append(dashboardVolumeMounts, extraVolumeMounts...),
+			// Through the same guard as the gateway's list above. extraVolumeMounts
+			// reaches both containers, so a CR claiming /tmp collides here too.
+			VolumeMounts: append(dropTmpScratchIfClaimed(dashboardVolumeMounts, extraVolumeMounts), extraVolumeMounts...),
 			// What this buys is not what a probe on a serving container buys. The
 			// Service's :9119 endpoint is unreachable over the pod network either
 			// way (see dashboardPort), so nothing is being kept out of rotation.
@@ -2896,6 +2952,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			},
 			SecurityContext: &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.To(false),
+				ReadOnlyRootFilesystem:   ptr.To(true),
 				Capabilities: &corev1.Capabilities{
 					Drop: []corev1.Capability{"ALL"},
 				},
@@ -2947,6 +3004,12 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 		},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
+			// No /tmp for this one, deliberately. The config above buffers in memory
+			// (Mem_Buf_Limit, no storage.path), keeps its tail DB on the
+			// fluent-bit-state volume and outputs to stdout, so it writes nothing to
+			// the root filesystem. Handing it the agent's tmp-scratch would only give
+			// an LLM-driven container a path into the log shipper.
+			ReadOnlyRootFilesystem: ptr.To(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},
@@ -3040,6 +3103,23 @@ func buildDefaultVolumes(agent *agentv1alpha1.PlatformAgent) []corev1.Volume {
 						Name: agent.Name + "-settings",
 					},
 					DefaultMode: ptr.To(int32(0644)),
+				},
+			},
+		},
+		{
+			// Bounded, like every other scratch emptyDir here. Without a
+			// sizeLimit a runaway write fills the node's ephemeral storage and the
+			// kubelet evicts whoever it decides is the worst offender, which need
+			// not be this pod. With one, the eviction is this pod, for a stated
+			// reason, at a predictable threshold. Note that it is an eviction
+			// either way: enforcing the limit as an in-container ENOSPC needs the
+			// alpha LocalStorageCapacityIsolationFSQuotaMonitoring gate, which GKE
+			// does not enable. 2Gi matches credential-proxy-tmp, the closest
+			// analogue.
+			Name: tmpScratchVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					SizeLimit: ptr.To(resource.MustParse("2Gi")),
 				},
 			},
 		},

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -424,11 +425,14 @@ func TestBuildDeployment(t *testing.T) {
 		if dashboardC.ImagePullPolicy != corev1.PullAlways {
 			t.Errorf("expected dashboard container image pull policy Always, got %s", dashboardC.ImagePullPolicy)
 		}
-		if len(dashboardC.VolumeMounts) != 4 {
-			t.Errorf("expected 4 volume mounts on dashboard container (3 base + 1 extra), got %d", len(dashboardC.VolumeMounts))
+		if len(dashboardC.VolumeMounts) != 5 {
+			t.Errorf("expected 5 volume mounts on dashboard container (4 base + 1 extra), got %d", len(dashboardC.VolumeMounts))
 		}
 		if dashboardC.SecurityContext == nil || dashboardC.SecurityContext.AllowPrivilegeEscalation == nil || *dashboardC.SecurityContext.AllowPrivilegeEscalation {
 			t.Errorf("expected SecurityContext.AllowPrivilegeEscalation false on dashboard container")
+		}
+		if dashboardC.SecurityContext == nil || dashboardC.SecurityContext.ReadOnlyRootFilesystem == nil || !*dashboardC.SecurityContext.ReadOnlyRootFilesystem {
+			t.Errorf("expected SecurityContext.ReadOnlyRootFilesystem true on dashboard container")
 		}
 		if dashboardC.Resources.Requests.Cpu().String() != "256m" || dashboardC.Resources.Requests.Memory().String() != "512Mi" {
 			t.Errorf("expected CPU 256m and Mem 512Mi requests on dashboard container, got %v", dashboardC.Resources.Requests)
@@ -779,6 +783,19 @@ func TestBuildDeployment(t *testing.T) {
 		}
 	}
 
+	// The one writable path the read-only root filesystem leaves the agent. Without
+	// it the entrypoint's HOME=/tmp invocations fail before the gateway starts.
+	if _, ok := mountsMap["tmp-scratch"]; !ok {
+		t.Errorf("expected tmp-scratch mount on platform-agent, not found")
+	} else if mountsMap["tmp-scratch"].MountPath != "/tmp" {
+		t.Errorf("expected tmp-scratch mount path /tmp, got %s", mountsMap["tmp-scratch"].MountPath)
+	}
+
+	agentC := containerByName(t, dep.Spec.Template.Spec.Containers, "platform-agent")
+	if agentC.SecurityContext == nil || agentC.SecurityContext.ReadOnlyRootFilesystem == nil || !*agentC.SecurityContext.ReadOnlyRootFilesystem {
+		t.Errorf("expected SecurityContext.ReadOnlyRootFilesystem true on platform-agent container")
+	}
+
 	// Verify Fluent Bit container
 	fbContainer := containerByName(t, dep.Spec.Template.Spec.Containers, "fluent-bit")
 	if fbContainer.Name != "fluent-bit" {
@@ -787,11 +804,31 @@ func TestBuildDeployment(t *testing.T) {
 	if fbContainer.Image != "fluent/fluent-bit:5.1.0" {
 		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.1.0, got %s", fbContainer.Image)
 	}
+	if fbContainer.SecurityContext == nil || fbContainer.SecurityContext.ReadOnlyRootFilesystem == nil || !*fbContainer.SecurityContext.ReadOnlyRootFilesystem {
+		t.Errorf("expected SecurityContext.ReadOnlyRootFilesystem true on fluent-bit container")
+	}
+	// Deliberately no /tmp here: the shipper buffers in memory and must not share
+	// the agent's scratch volume.
+	for _, m := range fbContainer.VolumeMounts {
+		if m.Name == "tmp-scratch" {
+			t.Errorf("fluent-bit must not mount the agent's tmp-scratch volume")
+		}
+	}
 
 	// Verify volumes
 	volumesMap := make(map[string]corev1.Volume)
 	for _, vol := range dep.Spec.Template.Spec.Volumes {
 		volumesMap[vol.Name] = vol
+	}
+	if v, ok := volumesMap["tmp-scratch"]; !ok {
+		t.Errorf("expected tmp-scratch volume, not found")
+	} else if v.EmptyDir == nil {
+		t.Errorf("expected tmp-scratch to be an emptyDir")
+	} else if v.EmptyDir.SizeLimit == nil || v.EmptyDir.SizeLimit.String() != "2Gi" {
+		// Unbounded, this is the only writable path outside the PVC for the two
+		// agent containers, so a runaway write becomes node-level disk pressure
+		// and the kubelet picks an eviction victim that need not be this pod.
+		t.Errorf("expected tmp-scratch sizeLimit 2Gi, got %v", v.EmptyDir.SizeLimit)
 	}
 	if _, ok := volumesMap["fluent-bit-config"]; !ok {
 		t.Errorf("expected fluent-bit-config volume, not found")
@@ -4307,6 +4344,77 @@ func TestDeploymentEnvCannotOverrideTheEventWatcherSwitch(t *testing.T) {
 	}
 }
 
+// A CR that already mounts /tmp must not collide with the operator's tmp-scratch mount.
+// Two VolumeMounts on one mountPath make the Deployment unappliable, so the failure is not
+// a redundant mount but a reconcile that stops on an upgrade.
+func TestUserSuppliedTmpMountReplacesTmpScratch(t *testing.T) {
+	cases := []struct {
+		name      string
+		configure func(*agentv1alpha1.DeploymentSpec)
+		// Per container, because the two inputs do not reach the same set of them:
+		// extraVolumeMounts is appended to the gateway and the dashboard, storages
+		// only to the gateway.
+		wantTmpOwner map[string]string
+	}{
+		{
+			name: "extraVolumeMounts",
+			configure: func(d *agentv1alpha1.DeploymentSpec) {
+				d.ExtraVolumeMounts = []corev1.VolumeMount{{Name: "my-tmp", MountPath: "/tmp"}}
+			},
+			wantTmpOwner: map[string]string{"platform-agent": "my-tmp", "platform-agent-dashboard": "my-tmp"},
+		},
+		{
+			// Trailing slash included on purpose: it is the same path to the API
+			// server's uniqueness check, so a name comparison would miss it.
+			name: "extraVolumeMounts with a trailing slash",
+			configure: func(d *agentv1alpha1.DeploymentSpec) {
+				d.ExtraVolumeMounts = []corev1.VolumeMount{{Name: "my-tmp", MountPath: "/tmp/"}}
+			},
+			wantTmpOwner: map[string]string{"platform-agent": "my-tmp", "platform-agent-dashboard": "my-tmp"},
+		},
+		{
+			// The dashboard keeps tmp-scratch here, and that is correct rather than an
+			// oversight: storages never reach it, so there is nothing to collide with
+			// and no reason to take its scratch space away.
+			name: "storages",
+			configure: func(d *agentv1alpha1.DeploymentSpec) {
+				d.Storages = []agentv1alpha1.StorageSpec{{Name: "scratch", MountPath: "/tmp"}}
+			},
+			wantTmpOwner: map[string]string{"platform-agent": "scratch-vol", "platform-agent-dashboard": tmpScratchVolumeName},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := newTestPlatformAgent()
+			agent.Spec.Deployment = &agentv1alpha1.DeploymentSpec{}
+			tc.configure(agent.Spec.Deployment)
+
+			pod := buildPodTemplateSpec(agent, "h", "h", "h", "h", nil, renderOptions{})
+
+			// Every container, not the one the guard was written for. The API server
+			// applies its uniqueness check per container, so checking a single one
+			// passes while the Deployment it describes is still rejected.
+			all := append(append([]corev1.Container{}, pod.Spec.InitContainers...), pod.Spec.Containers...)
+			for _, c := range all {
+				seen := make(map[string]string)
+				for _, m := range c.VolumeMounts {
+					clean := path.Clean(m.MountPath)
+					if prev, dup := seen[clean]; dup {
+						t.Errorf("container %s: duplicate mountPath %q, from volumes %q and %q", c.Name, clean, prev, m.Name)
+					}
+					seen[clean] = m.Name
+				}
+				if want, checked := tc.wantTmpOwner[c.Name]; checked {
+					if got := seen["/tmp"]; got != want {
+						t.Errorf("container %s: /tmp served by volume %q, want %q", c.Name, got, want)
+					}
+				}
+			}
+		})
+	}
+}
+
 // The same hole, on the variable next to it. EVENT_WATCHER_CLUSTER_NAME is
 // appended after the same merge and was unreserved for as long as it has
 // existed; it is pinned here so the two cannot drift apart again.
@@ -4899,4 +5007,23 @@ func TestDeploymentEnvCannotDisableReadOnlyEnforcement(t *testing.T) {
 			}
 		})
 	}
+}
+
+// The mount stays put when the CR mounts elsewhere -- the case above must not be paid for
+// by every other CR losing its writable /tmp under a read-only root filesystem.
+func TestUnrelatedExtraMountKeepsTmpScratch(t *testing.T) {
+	agent := newTestPlatformAgent()
+	agent.Spec.Deployment = &agentv1alpha1.DeploymentSpec{
+		ExtraVolumeMounts: []corev1.VolumeMount{{Name: "extra-vol", MountPath: "/tmpfoo"}},
+	}
+
+	pod := buildPodTemplateSpec(agent, "h", "h", "h", "h", nil, renderOptions{})
+	c := containerByName(t, pod.Spec.Containers, "platform-agent")
+
+	for _, m := range c.VolumeMounts {
+		if m.Name == tmpScratchVolumeName && m.MountPath == "/tmp" {
+			return
+		}
+	}
+	t.Errorf("expected the tmp-scratch mount at /tmp, got %v", c.VolumeMounts)
 }

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -5027,3 +5027,116 @@ func TestUnrelatedExtraMountKeepsTmpScratch(t *testing.T) {
 	}
 	t.Errorf("expected the tmp-scratch mount at /tmp, got %v", c.VolumeMounts)
 }
+
+// operatorBuiltContainers is every container buildPodTemplateSpec constructs itself, as
+// opposed to the ones a CR hands it through spec.deployment.sidecars/initContainers. The
+// list is written out rather than derived so that adding a container to the Pod has to
+// touch this file: the test below fails on a name it does not know, and the fix is to add
+// it here and give it hardenedSecurityContext().
+var operatorBuiltContainers = []string{
+	"sandbox-credential-cleanup",
+	"envoy-credential-proxy",
+	"platform-agent",
+	"platform-agent-dashboard",
+	"fluent-bit",
+}
+
+// The invariant the read-only-root work exists to establish, asserted once over the whole
+// Pod instead of container by container.
+//
+// Three of the five containers went without a read-only root for as long as they existed
+// and every test stayed green, because the assertions named containers one at a time and
+// nobody wrote one for the containers that were missing it. The golden manifests did
+// capture the omission, but a golden is regenerated mechanically when a container is
+// added, so it records whatever was built rather than rejecting it.
+//
+// So this walks. The name check is the half that catches the next container: an addition
+// the author forgot to harden arrives as an unknown name, not as a silent pass.
+func TestEveryContainerHasAHardenedSecurityContext(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		agent *agentv1alpha1.PlatformAgent
+		// The dashboard is the one operator-built container a CR can switch off.
+		absent string
+	}{
+		{name: "default", agent: newTestPlatformAgent()},
+		{
+			name: "dashboard disabled",
+			agent: func() *agentv1alpha1.PlatformAgent {
+				a := newTestPlatformAgent()
+				a.Spec.Harness = &agentv1alpha1.HarnessSpec{
+					Hermes: &agentv1alpha1.HermesSpec{DashboardEnabled: ptr.To(false)},
+				}
+				return a
+			}(),
+			absent: "platform-agent-dashboard",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := buildPodTemplateSpec(tc.agent, "h", "h", "h", "h", nil, renderOptions{})
+
+			want := make(map[string]bool, len(operatorBuiltContainers))
+			for _, n := range operatorBuiltContainers {
+				if n != tc.absent {
+					want[n] = true
+				}
+			}
+
+			all := append(append([]corev1.Container{}, pod.Spec.InitContainers...), pod.Spec.Containers...)
+			for _, c := range all {
+				if !want[c.Name] {
+					t.Errorf("container %q is not in operatorBuiltContainers: if the operator "+
+						"grew a container, give it hardenedSecurityContext() and add it to that list",
+						c.Name)
+					continue
+				}
+				delete(want, c.Name)
+
+				sc := c.SecurityContext
+				if sc == nil {
+					t.Errorf("container %s: no SecurityContext; want hardenedSecurityContext()", c.Name)
+					continue
+				}
+				if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+					t.Errorf("container %s: ReadOnlyRootFilesystem is not true", c.Name)
+				}
+				if sc.AllowPrivilegeEscalation == nil || *sc.AllowPrivilegeEscalation {
+					t.Errorf("container %s: AllowPrivilegeEscalation is not false", c.Name)
+				}
+				if sc.Capabilities == nil || !slices.Contains(sc.Capabilities.Drop, corev1.Capability("ALL")) {
+					t.Errorf("container %s: capabilities do not drop ALL, got %v", c.Name, sc.Capabilities)
+				}
+			}
+			// Without this the walk passes vacuously the day a container stops being
+			// built at all -- which is a change worth noticing, whatever its reason.
+			for n := range want {
+				t.Errorf("expected container %q in the Pod, not found", n)
+			}
+		})
+	}
+}
+
+// The other side of the same invariant: it covers what the operator builds and stops
+// there. A CR can still add a writable container to this Pod, which
+// docs/credential-isolation-design.md states as the limit of the guarantee -- pinned here
+// so that the doc and the code cannot drift apart silently.
+func TestCRSuppliedSidecarsAreNotHardenedByTheOperator(t *testing.T) {
+	agent := newTestPlatformAgent()
+	agent.Spec.Deployment = &agentv1alpha1.DeploymentSpec{
+		Sidecars:       []corev1.Container{{Name: "user-sidecar", Image: "example.com/side:v1"}},
+		InitContainers: []corev1.Container{{Name: "user-init", Image: "example.com/init:v1"}},
+	}
+
+	pod := buildPodTemplateSpec(agent, "h", "h", "h", "h", nil, renderOptions{})
+
+	for _, c := range append(append([]corev1.Container{}, pod.Spec.InitContainers...), pod.Spec.Containers...) {
+		if c.Name != "user-sidecar" && c.Name != "user-init" {
+			continue
+		}
+		if c.SecurityContext != nil {
+			t.Errorf("container %s: the operator rewrote a CR-supplied SecurityContext (%+v); "+
+				"if that is now intended, docs/credential-isolation-design.md says otherwise",
+				c.Name, c.SecurityContext)
+		}
+	}
+}

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -623,6 +623,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           startupProbe:
             exec:
               command:
@@ -655,6 +656,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - hermes
             - dashboard
@@ -699,6 +702,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -708,6 +712,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
@@ -727,6 +733,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -934,6 +941,9 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: tmp-scratch
         - configMap:
             name: platformagent-credential-proxy-policy
           name: credential-proxy-policy

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -578,6 +578,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           startupProbe:
             exec:
               command:
@@ -610,6 +611,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - hermes
             - dashboard
@@ -654,6 +657,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -663,6 +667,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
@@ -682,6 +688,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -886,6 +893,9 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: tmp-scratch
         - configMap:
             name: platformagent-credential-proxy-policy
           name: credential-proxy-policy

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -623,6 +623,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           startupProbe:
             exec:
               command:
@@ -655,6 +656,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - hermes
             - dashboard
@@ -699,6 +702,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -708,6 +712,8 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /tmp
+              name: tmp-scratch
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
@@ -727,6 +733,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /opt/data
               name: platform-agent-data-vol
@@ -934,6 +941,9 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - emptyDir:
+            sizeLimit: 2Gi
+          name: tmp-scratch
         - configMap:
             name: platformagent-credential-proxy-policy
           name: credential-proxy-policy

--- a/scripts/check_image_layers.py
+++ b/scripts/check_image_layers.py
@@ -14,8 +14,11 @@ now builds from ``agent-base`` through a short ``proxy-tools`` stage instead, so
 Move ``DEFAULT_IMAGE`` if that ever stops being true -- a gate pointed at the
 shallower chain reports headroom that is not the headroom at risk. The one
 stage deeper than ``platform``, ``entrypoint-gate-test``, is out of scope on
-purpose: buildx alone builds it, buildx has no depth limit, and no daemon ever
-mounts it.
+purpose, but no longer because nothing mounts it: ``docker-build.yml`` loads
+that stage into the daemon and runs it under ``--read-only``. It is out of
+scope because it adds one ``COPY`` and one ``RUN`` on top of ``platform``, so
+the 8-layer gap between ``DEFAULT_MAX_LAYERS`` and ``OVERLAY2_MAX_DEPTH``
+covers it. Narrow that gap and the gate stage is what runs out of room first.
 
 Why a check rather than a comment: the limit belongs to the classic Docker
 daemon, not to the image format. BuildKit has no equivalent limit, so an image


### PR DESCRIPTION
## Summary

The operator builds five containers into the agent Pod, and three of them — the agent itself, the dashboard, and the log shipper — were running with a writable root filesystem. This sets `readOnlyRootFilesystem` on all five, gives the two agent containers a bounded 2Gi `emptyDir` at `/tmp` because the entrypoint genuinely needs one writable path, and guards against the mount-path collision that would otherwise break any install whose CR already claims `/tmp`. The hardening block itself is extracted into one helper and asserted by a test that walks every container, so the drift that caused this gap cannot recur silently.

## Why This Change

The `platform-agent`, `platform-agent-dashboard`, and `fluent-bit` containers run with a writable root filesystem. A compromised agent process — this is a workload that executes LLM-driven, prompt-influenced tasks — can therefore modify binaries in the image layer and persist that modification across a container restart. The credential proxy and the sandbox credential cleanup container already set `readOnlyRootFilesystem: true`; these three were the remaining gap in the Pod.

This addresses security finding **RUNTIME-007**.

## What Changed

**Files:**

- `k8s-operator/internal/controller/platformagent_manifests.go`
- `k8s-operator/internal/controller/platformagent_manifests_test.go`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml`
- `k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml`
- `.github/workflows/docker-build.yml`
- `deploy/docker/Dockerfile` (comment only)
- `scripts/check_image_layers.py` (comment only)
- `docs/credential-isolation-design.md`
- `docs/site/src/content/docs/deploy/docker-images.md`

**Added/Changed/Fixed:**

- Extracted `hardenedSecurityContext()` and called it from all five containers the operator builds. The three fields — `AllowPrivilegeEscalation: false`, `ReadOnlyRootFilesystem: true`, `Capabilities.Drop: ["ALL"]` — were previously written out five times, and three of the five had drifted to two of them. That drift *is* RUNTIME-007. One helper means the next container added gets the block by construction rather than by someone remembering.
- Added a `tmp-scratch` `emptyDir`, mounted at `/tmp` on the two agent containers. `deploy/shared/docker-entrypoint.sh` runs four hermes invocations with `HOME=/tmp` (lines 640, 690, 713, 873) before the gateway starts; those are the only writes that leave the PVC, so `/tmp` is the one path that must stay writable.
- Bounded that volume with a `sizeLimit` of `2Gi`, matching `credential-proxy-tmp` and the other scratch `emptyDir`s the operator creates.
- Dropped the operator's `/tmp` mount, on both agent containers, when the CR already claims that path through `spec.deployment.storages` or `extraVolumeMounts`. Those are appended to the default mounts without deduplication, and two mounts on one `mountPath` make the Deployment unappliable — so without the guard a CR that mounted its own scratch space at `/tmp`, which is exactly what someone would have done while the root filesystem was still writable, would stop reconciling on upgrade. The CR's mount wins.
- Left `fluent-bit` without a `/tmp` mount, deliberately — see below.
- Added a CI step running the existing in-image entrypoint gate check a second time, as a container under `docker run --read-only --tmpfs /tmp`.
- Corrected three comments the change invalidated, none of them in code it otherwise touches: `scripts/check_image_layers.py` and `deploy/docker/Dockerfile` both said the `entrypoint-gate-test` stage is never loaded by a daemon, which the new CI step makes false, and the new step's own `--tmpfs` comment treated one 2g ceiling as modelling two pod volumes that have separate budgets. Found by the adversarial pass — see Self-Review.
- Updated the "Kubernetes Details" bullet in `docs/credential-isolation-design.md`, which previously singled out the credential sidecar as the container with a read-only root, and the entrypoint-gate section of `docs/site/src/content/docs/deploy/docker-images.md` for the new CI step.

## Why This Matters

- Blocks runtime tampering with the image layer — binary modification and persistence — in the container that executes prompt-influenced work.
- The two agent containers share one scratch volume rather than getting one each. That is not a new channel between them: they already run the same image against the same data PVC, so they are one trust domain either way.
- `fluent-bit` gets no `/tmp` on purpose. Its config buffers in memory (`Mem_Buf_Limit`, no `storage.path`), keeps its tail database on the `fluent-bit-state` volume, and outputs to stdout, so it writes nothing to the root filesystem. Handing it the agent's scratch volume would only give an LLM-driven container a path into the log shipper. This was the riskiest claim in the PR and is now the one with direct evidence — see Live validation.
- The `sizeLimit` makes the failure attributable. Unbounded, this is now the *only* writable path outside the PVC for the agent containers, so all scratch traffic that used to spread across the container's writable layer concentrates here — and a runaway write becomes node-level ephemeral-storage pressure, where the kubelet picks a victim that need not be this pod. With the limit it is this pod, at a stated threshold, for a stated reason. It is a pod eviction either way: enforcing the limit as an in-container `ENOSPC` requires the alpha `LocalStorageCapacityIsolationFSQuotaMonitoring` feature gate, which GKE does not enable.
- The hardening is now an asserted invariant rather than a convention. `TestEveryContainerHasAHardenedSecurityContext` walks every init container and container in the built Pod, in both the dashboard-enabled and dashboard-disabled shapes, and fails on a container it does not recognise — so adding a sixth container without the block is a test failure, not a silent regression. This is @mplakhtiy's review finding from the first round, adopted.

## Context

Re-creation of the read-only-rootfs half of **#496** (Buganizer task 537148050), rebuilt on current `main` rather than rebased: that branch dated from July and its `platformagent_manifests.go` base had grown by roughly 900 lines. #496 has since been closed and retitled to its other half — defaulting gVisor on (RUNTIME-002) — so there is no longer a coordination question between the two.

Deliberately **not** included:

- **The `ENABLE_GVISOR` default flip (RUNTIME-002).** Carries its own confirmed High finding and now has its own issue.
- **RUNTIME-006**, which was a verification with no code change.

## Testing

- `go test ./...` in `k8s-operator/` — all packages pass, three consecutive `-count=1` runs.
- `go build ./...` and `go vet ./...` clean; `gofmt -l` reports nothing new (`manifest_helpers.go` is unformatted on `main` already and is untouched here).
- `TestEveryContainerHasAHardenedSecurityContext` — the invariant walk described above.
- `TestCRSuppliedSidecarsAreNotHardenedByTheOperator` — states the limit of that invariant explicitly: containers supplied through `spec.deployment.sidecars`/`initContainers` pass through as written. The webhook validates `privileged`, `allowPrivilegeEscalation`, `runAsUser=0` and `capabilities.add` on them, but not `readOnlyRootFilesystem`, so a CR can still add a writable container to this Pod. Documented rather than changed.
- Existing by-name assertions kept: `ReadOnlyRootFilesystem` on each of the three containers, the `/tmp` mount and its path, the `tmp-scratch` volume and its `2Gi` sizeLimit, and a negative assertion that `fluent-bit` does **not** mount the agent's scratch volume. The walk says "all of them"; these say which.
- Regression tests for the mount collision: a CR claiming `/tmp` through `extraVolumeMounts` (with and without a trailing slash) or through `storages` yields no duplicate `mountPath` in **any** container or initContainer, and the CR's own volume at `/tmp` on each container the input reaches; a CR mounting somewhere else keeps `tmp-scratch`. The uniqueness assertion walks every container rather than picking one by name, because the API server applies its check per container — a single-container assertion passes while the Deployment it describes is still rejected.
- **Each guard was checked by breaking it.** Reverting the dashboard `/tmp` guard fails with `duplicate mountPath "/tmp", from volumes "tmp-scratch" and "my-tmp"`; unhardening `fluent-bit` fails with `ReadOnlyRootFilesystem is not true` and `capabilities do not drop ALL, got nil`; adding an unrecognised container fails with `not in operatorBuiltContainers: if the operator grew a container, give it hardenedSecurityContext() and add it to that list`. A guard that cannot be seen to fail is not a guard.
- `make docs-check` passes — generated regions current, 260 links resolve, terminology matches, map inventory covers all 230 tracked docs. `make docs-generate` leaves the tree clean.
- Golden manifests were hand-edited rather than taken from `go test -update`. The `-update` writer emits raw Go YAML with non-indented sequences, which reformats all ~1400 lines of each golden and would fail the Prettier gate; the insertions were applied in the committed style instead, and the golden tests then pass against the generator.
- **`prettier --check` could not be run locally** — `npm install` and `npx` both fail in this environment behind an authenticated corporate mirror, and no `prettier` binary exists on the machine; AGENTS.md notes this as a known cause of the step being skipped. The insertions were kept byte-identical in style to the adjacent `credential-proxy-tmp` block and to the surrounding Markdown instead. **CI's `prettier` job passes on this branch**, so the gate is satisfied — just not before the push.
- **CI is green on this head** apart from `pull-kube-agents-smoke-test`, which is currently failing repository-wide and not caused by this change. That includes `build` (5m14s), which is the job carrying the new read-only Docker step, and `Run Controller Tests`.
- **Not a finding, recorded because it will be seen:** `go test ./internal/testing/... -race` reports a data race between parallel golden subtests sharing one `runtime.Scheme`, which the controller-runtime fake client mutates via `AddKnownTypeWithName`. It reproduces on unmodified `main` at `fe08297f` (3–10 reports per run) and occasionally surfaces without `-race` as a map-corruption panic in the golden suite. Pre-existing, in the test harness, unrelated to this change — flagging it rather than fixing it here.

### Live validation

Two runs, at different commits, covering different things. Neither supersedes the other.

**1. @bradhoekstra, 2026-08-13, at `4a3b628` (pre-rebase) — [full report](https://github.com/gke-labs/kube-agents/pull/674#issuecomment-5283865862).** The deeper of the two, on `kube-agents-cluster` (`bhoekstra-gkedemos`) with a live LLM: 67 skills loading, a tool sweep (`kubectl`, `gcloud`, `git`, `python3`, `node`, `npm`, `uv`, `yq`, `helm`) under a read-only root, and two end-to-end LLM-driven agent tasks including a deliberately write-heavy one. Peak `/tmp` usage was **28K** against the 2Gi ceiling. It also exercised the `/tmp` collision guard live through `extraVolumeMounts` with the dashboard enabled, and confirmed the un-guarded shape is rejected by the API server with `mountPath must be unique`. That run answers the two questions the original PR body left for a reviewer with a cluster, and it is the evidence for "no skill writes outside `/tmp` and the PVC" and "2Gi is a sane ceiling" — my run below does not re-cover either.

Its commit predates the rebase. What it establishes is structural and behavioural, and the refactor since is a pure extraction of three fields that were already there, so I did not re-run it; run 2 re-confirms the structure at the current head.

**One finding from it, still open:** when a CR claims `/tmp` *and* the dashboard is disabled, the `tmp-scratch` volume stays declared in the Pod spec with no container mounting it. Dangling but harmless — the kubelet does not fault on it. Left as-is for now; flagging rather than burying it.

**2. Mine, at the rebased head.** Narrower, and its purpose is to confirm the rebase did not drop a hunk and that `fluent-bit` — the container the first run covered structurally but not under sustained load — survives a read-only root.

Live-tested on **kagent1** (`atyb-kagent-01-sandbox-708646`, `us-central1`, sandbox tier), against install `PlatformAgent/platform-agent` in `kubeagents-system`, agent image tag `dev-feature_design-537148878`. There is no container runtime on the workstation, so the operator could not be built into an image; it was run out-of-cluster instead per `k8s-operator/README.md`, with the in-cluster `kubeagents-controller-manager` scaled to 0 so the two would not fight over the CR, and `DefaultPlatformAgentVersion` pinned to the deployed tag so the agent image would not roll as a side effect. The live-test lease was held for the duration.

**Before.** `readOnlyRootFilesystem` was `true` on `sandbox-credential-cleanup` and `envoy-credential-proxy` and unset on `platform-agent`, `platform-agent-dashboard` and `fluent-bit`; no `tmp-scratch` volume; pod `platform-agent-gateway-576dc64b76-mgn78` 5/5 Running; CR `Ready=True`.

**After reconciling with this branch.** All five containers came back with `readOnlyRootFilesystem=true`, `allowPrivilegeEscalation=false`, `capabilities.drop=[ALL]`. The `tmp-scratch` volume appeared as `{"emptyDir": {"sizeLimit": "2Gi"}}`, mounted at `/tmp` on `platform-agent` and `platform-agent-dashboard` and on neither `fluent-bit` nor the credential proxy, which keeps its own `credential-proxy-tmp`.

**The mechanism, not a coincidence.** Inside both agent containers:

```
$ touch /pr674-probe        → touch: cannot touch '/pr674-probe': Read-only file system
$ touch /etc/pr674-probe    → touch: cannot touch '/etc/pr674-probe': Read-only file system
$ echo hello > /tmp/pr674-probe && cat /tmp/pr674-probe   → hello
$ grep ' / '    /proc/mounts → overlay / overlay ro,relatime,...
$ grep ' /tmp ' /proc/mounts → /dev/sda1 /tmp ext4 rw,relatime,commit=30
```

Then the revert: the in-cluster operator was scaled back to 1, and it put the Deployment back to `readOnlyRootFilesystem` unset on those three containers with no `tmp-scratch`. The same `touch /` in the same container now fails with `Permission denied` rather than `Read-only file system` — ordinary non-root permissions — and `/proc/mounts` shows `/` as `rw`. Same command, different errno, filesystem flipped `ro` → `rw`.

**`fluent-bit`, watched hardest.** It is the one container getting a read-only root with no writable path, and the claim that it needs none was previously read off the generated ConfigMap rather than observed. It came up Running with **0 restarts**, shipped agent and MCP log lines continuously for the whole window, and its complete log contains zero matches for `read-only`, `EROFS`, `permission denied`, `cannot open` or `failed`. The claim holds.

**What this run did not cover.** The pod did not reach fully Ready: `envoy-credential-proxy` crashlooped with `exec: "/usr/local/bin/start-services": no such file or directory`, and the CR went `Degraded` for that reason. That is version skew, not this change — `start-services` was introduced on `main` at `fe08297f:2200` when the event watcher was folded into the credential sidecar, the string appears nowhere in this diff, and the newest `credential-proxy` image in the sandbox registry (`latest`, same digest as the pinned tag) was built 2026-07-30 and predates it. With no container runtime available there was no way to build an image that has it. So: the three containers this PR targets all ran green under a read-only root; the one that crashed is the one that already had a read-only root before this PR, for an unrelated missing binary.

Also uncovered: whether a *skill* or plugin executed at runtime writes outside `/tmp` and the PVC over a long session, and whether `2Gi` is a sane ceiling for real workloads. The failure mode if either is wrong is `EROFS` inside the agent container, or eviction for exceeding the volume's `sizeLimit`.

**Cleanup.** The in-cluster operator is back at 1 replica, the pod is 5/5 Running, the CR is `Ready=True`, and both the CR spec and the Deployment pod spec are byte-identical to the baselines captured before the run. The lease was released. The cluster's DNS control-plane endpoint, enabled to reach the private control plane, was disabled again (`allowExternalTraffic: false`). No test artifacts remain in the cluster.

## Self-Review

Two pre-PR passes, both against the rebased diff `fe08297f...HEAD`.

**`review-adversarial` — run in a subagent that did not write the change.** Handed the diff range and the skill only: not the plan, not the commit bodies, not this PR body, and told to derive the intent from the diff itself. It ran all ten angles and reported what it looked for under each: line-by-line with slice-aliasing and `path.Clean` edge cases; removed behaviour, including an audit for silenced tests and narrowed CI triggers; a cross-file trace of every symbol the diff newly references and every renderer of this Pod; operations and security, weighing the shared `emptyDir` as a channel and the lost `1777` sticky bit; reuse; simplification; altitude; conventions and doc-claim verification against source; scope and test coverage, checked red-then-green rather than by reading; and the 100 open sibling PRs. Four findings:

- **No CI or test evidence that the three newly-hardened containers survive a read-only root at _runtime_** (MEDIUM). The new `docker run --read-only` step execs `entrypoint-gate-check`, whose cases must all exec `/bin/echo`, so it covers the entrypoint's setup phase and never starts `hermes gateway run`, `hermes dashboard`, or `fluent-bit`. **Not fixed in code; answered by evidence.** This is exactly the gap Live validation exists to close, and both runs below name all three containers — @bradhoekstra's under a live LLM with real skills, mine watching `fluent-bit` under sustained load. Closing it in CI would need a PR-time cluster e2e, which this repository does not have and this PR is not the place to add.
- **The diff makes `scripts/check_image_layers.py`'s stated rationale false** (LOW). Its docstring says `entrypoint-gate-test` is out of scope because "no daemon ever mounts it"; the diff adds `load: true` and then `docker run`s it. `deploy/docker/Dockerfile` carried the same now-incomplete claim. Neither file is in the diff, so the contradiction would have merged silently. **Fixed** in `a5c23db`: the stage is still out of scope, but because it adds two layers on top of `platform` and the 8-layer gap between the 120 budget and overlay2's 128 covers them — narrow that gap and the gate stage runs out of room first.
- **The `--tmpfs … size=2g` justification conflates two volumes with separate budgets** (LOW). The comment had one tmpfs stand in for both the data PVC and the `tmp-scratch` `emptyDir`, then read `size=2g` as matching "that volume's sizeLimit". In the pod those are two volumes with independent budgets. **Fixed** in `a5c23db`: the comment now says 2g bounds their sum, predicts neither, and that a failure there means "this case writes more than we expect", not "`tmp-scratch` is too small".
- **`dropTmpScratchIfClaimed` special-cases `/tmp` where a general dedup is the same amount of code** (LOW, design judgement). **Deliberately not generalised.** A general "drop every default whose cleaned path a user mount claims" would silently drop the data PVC mount if a CR set `homeDir` to a default path — turning a Deployment the API server rejects outright into an agent that comes up with no persistent home, which is the worse of the two failures. The pass's own counter-argument was that this trade-off is stated nowhere; `a5c23db` states it in the helper's doc comment. The sibling collision it demonstrated (`agentHome: /tmp`) is **pre-existing**, not a regression: the pass rendered the same CR at `fe08297f` and it was already unappliable via the credential proxy's `credential-proxy-tmp`.

The pass also **refuted** several things worth recording as checked: no slice-aliasing bug in the two rebuilt `append` chains; no test removed, skipped, or silenced and no CI trigger narrowed; the shared `/tmp` crosses no trust boundary the data PVC does not already cross; the `emptyDir` is disk-backed so it does not consume the memory limit.

**One thing the pass got wrong, corrected here rather than left standing.** It reported that it could construct no stale-state failure from the new pod-lifetime `/tmp`, on the grounds that `HERMES_HOME` is set explicitly on all four `HOME=/tmp` invocations. That reasoning does not hold. `deploy/shared/docker-entrypoint.sh:1265-1267` gives as the reason its step-4a compat symlink exists that "hermes-otel resolves config below `~/.hermes` even when `HERMES_HOME` points elsewhere", and `agents/platform/scripts/profile_scaffold.py:79-85` has the scaffold force `HOME=/tmp` onto every `hermes` subprocess it spawns. Those subprocesses do consult `/tmp/.hermes`, and that directory is now restart-durable and visible to the dashboard container. So @mplakhtiy's thread-1 mechanism stands; what remains unproven is whether attacker-controlled content there changes what the scaffolding pass does, which is what they labelled plausible rather than certain. Disposition is in that thread: the fix belongs in the entrypoint behind its own gate-check case, not here.

**What it could not cover, in its own words:** it had no Docker daemon, so it could not build or run the new CI step — the step answers itself on this PR's run; `stage2-hook.sh` lives in the upstream Hermes image and is unreadable from here, which is the whole reason that step tests rather than reads; and anything needing a live cluster, which is what Live validation below is for. It also noted, without raising it as a finding, that a read-only root blocks an LLM-driven agent from `pip install`ing into `/opt/hermes/.venv` — it grepped `agents/` and `.agents/` and found no skill that does so, and neither live run hit it.

**`review-docs-drift` — run in this session, the one that wrote the change.** Weaker placement than the pass above, and stated as such. No Blocking findings. Every claim in the two edited docs was verified against source rather than against other docs: the five-container enumeration against `platformagent_manifests.go`, the four `HOME=/tmp` invocations against `docker-entrypoint.sh`, the shared data PVC against the mount list, and the "the webhook does not require a read-only root" sentence against `validateContainerSecurity` in `platformagent_webhook.go`. No new files, so the documentation map needs no edit. `docs/architecture/08` mentions a read-only rootfs for the future gVisor execution sandbox — a different thing, not contradicted.

**One reviewer finding, from @bradhoekstra's live run, disposed here rather than deferred.** When a CR claims `/tmp`, the `tmp-scratch` volume stays declared in the Pod spec with no container mounting it, because the guard removes the mount and nothing removes the volume. Verified: the declaration is unconditional. **Deliberately not fixed** — it is legal and inert, the kubelet creates an empty directory and no container sees it, and making the declaration conditional means deciding it from state that lives in the mount builders. Two reviewers have now had to derive that from the code, so `a5c23db` writes it down at the declaration.

## Risk & Rollout

Blast radius is every agent Pod the operator builds, on the next reconcile — this changes the Pod template, so merging it rolls the gateway Deployment wherever it lands. Risk is concentrated in one place: a runtime write path outside `/tmp` and the PVC that neither static reading nor either live run found. The failure mode is visible and local — a write failing with `EROFS` inside the agent container, or a pod eviction for exceeding the volume's `sizeLimit` — not silent corruption.

The one upgrade hazard is the `/tmp` collision, which is why the guard exists: an install whose CR already mounts something at `/tmp` would otherwise produce a Deployment the API server rejects outright. That path is unit-tested for both `extraVolumeMounts` and `storages`, and @bradhoekstra exercised the `extraVolumeMounts` variant live.

Rollback is reverting the commit; there is no data migration, no CR schema change, and nothing to undo outside the Pod template. Nothing has to happen at merge time. Functional impact for standard deployments should be nil — `/tmp` remains writable, just bounded and no longer part of the image layer.

_This PR was generated with the help of Claude._
