### PR TITLE
fix(chat): use a non-credential base64 payload in the basic-auth redaction test

### DIFF
--- a/agents/chat/defaults/plugins/common/test_redactor.py
+++ b/agents/chat/defaults/plugins/common/test_redactor.py
@@ -53,10 +53,14 @@ class TestRedactText(unittest.TestCase):
         self.assertIn("Bearer [REDACTED_SECRET]", result)
 
     def test_basic_auth_keeps_the_scheme(self):
-        # base64 of `admin:hunter2`, i.e. the credential shape a `curl -u` in a
-        # tool argument leaves behind.
+        # The header a `curl -u` in a tool argument leaves behind. Deliberately
+        # not a `user:pass` base64 payload — it decodes to
+        # "not-a-real-credential" — so secret scanners do not flag the fixture.
+        # The redactor keys off the `Basic` prefix and the base64 alphabet,
+        # never the payload's contents.
         result = self.assertRedacted(
-            "Authorization: Basic YWRtaW46aHVudGVyMg==", "YWRtaW46aHVudGVyMg"
+            "Authorization: Basic bm90LWEtcmVhbC1jcmVkZW50aWFs",
+            "bm90LWEtcmVhbC1jcmVkZW50aWFs",
         )
         self.assertIn("Basic [REDACTED_SECRET]", result)
 


### PR DESCRIPTION
# Pull Request

## Why This Change

GitHub secret scanning [alert #2](https://github.com/gke-labs/kube-agents/security/secret-scanning/2)
(`http_basic_authentication_header`) fires on the shared audit redactor's test suite. The fixture
pasted base64 of `admin:hunter2` into an `Authorization: Basic` header — a decodable `user:pass`
pair, which is exactly the shape the detector looks for.

Nothing needs rotating: the value is a well-known fake. But a permanently open alert trains readers
to skip the secret-scanning page, and the test loses nothing by carrying a payload that is not a
credential.

## What Changed

**Files:**

- `agents/chat/defaults/plugins/common/test_redactor.py`

**Added/Changed/Fixed:**

- `test_basic_auth_keeps_the_scheme` now uses `bm90LWEtcmVhbC1jcmVkZW50aWFs` (base64 of
  `not-a-real-credential`) instead of base64 of `admin:hunter2`, with a comment saying why the
  payload is deliberately not a `user:pass` pair.

## Why This Matters

- `AuditRedactor.BEARER_TOKEN_PATTERN` matches on the `bearer|basic` scheme and the base64
  alphabet (`{12,}`), never on what the payload decodes to — so the assertion is unchanged in
  strength, only the literal differs.
- This was the last occurrence in the tree: `grep -rn "Basic [A-Za-z0-9+/=]\{12,\}"` now returns
  only the already-fixed fleet-audit fixture.

## Context

- Resolves secret-scanning alert #2.
- Uses the same replacement payload and rationale as #535, which fixed the identical fixture in
  `agents/platform/skills/fleet-audit/scripts/test_audit_report.py`.
- Removing the literal from `main` does not by itself close the alert — secret scanning also sees
  the blob in history. A maintainer with security-alert write access still needs to resolve #2 as
  **used in tests**; this PR is what makes that resolution honest going forward.
- Generated with the help of Claude.

## Testing

- `python3 -m pytest common/test_redactor.py` from `agents/chat/defaults/plugins` — 40 passed.
- `make docs-check` — clean (generated regions current, 236 files link-checked, terminology and map
  inventory pass).
- No Markdown/JSON/YAML changed, so `prettier` is not implicated.

### Live validation

Install: `kube-agents-cluster` (`bhoekstra-gkedemos`, `us-central1`), operator and agent images at
tag `dns-endpoint-7dac349`, pod `platform-agent-gateway-568f95dcf6-c7k8f` in `kubeagents-system`.

This file ships in the image — it is present at `/opt/defaults/plugins/common/test_redactor.py`
inside the running `platform-agent` container — so the branch version was exercised there rather
than only on a laptop:

1. Copied the shipped `common/` package to `/tmp/livetest/` in the pod and overwrote only
   `test_redactor.py` with this branch's version, leaving the image's `redactor.py` as-is.
2. `python3 -m unittest common.test_redactor` in the pod: **Ran 40 tests … OK**, against the
   redactor the pod actually runs.
3. Direct call in the pod: `AuditRedactor.redact_text("Authorization: Basic bm90LWEt…")` returns
   `Authorization: Basic [REDACTED_SECRET]`.

Proving the mechanism rather than a coincidence — a green test could just mean the new payload no
longer reaches the `Basic` branch and the assertion passes vacuously. Negative control: in the pod's
scratch copy, `sed`-ing `(bearer|basic)` down to `(bearer)` in `redactor.py` makes precisely this
test fail —

```
AssertionError: 'bm90LWEtcmVhbC1jcmVkZW50aWFs' unexpectedly found in
'Authorization: Basic bm90LWEtcmVhbC1jcmVkZW50aWFs'
```

— so the new fixture still exercises the branch it is meant to cover: the same scratch copy was
green in step 2 and is red only once the `Basic` branch is disabled.

Not covered: the alert's own state. Closing #2 needs security-alert write access on
`gke-labs/kube-agents`, which I cannot exercise from a PR.

Cleanup: `/tmp/livetest` removed from the pod; the shipped `/opt/defaults/...` tree was never
written to and still carries the old literal (it will change when the image is next built).

---

Test-fixture only — no runtime code path changes, so the functional risk is nil. The image does not
need rebuilding for correctness; the next routine build picks the fixture up.
