### PR TITLE
fix(platform): clear two CodeQL clear-text sensitive-data alerts

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -47,13 +47,19 @@ CLEANUP_TTL_DAYS = int(os.getenv("SESSION_KV_CLEANUP_TTL_DAYS", "14"))
 # Deliberately not API_SERVER_KEY. That value is the loopback sentinel
 # `cluster-internal-trusted` — a marker, not a secret — so reusing it here would
 # authenticate nothing. See docs/credential-isolation-design.md.
-SESSION_KV_API_KEY_ENV = "SESSION_KV_API_KEY"
+#
+# Named for what it holds — the *name* of an environment variable, never the
+# key itself. An identifier matching `api_key` turns every log line that
+# mentions it into a clear-text-logging finding
+# (CodeQL py/clear-text-logging-sensitive-data), and the error below has to
+# name the variable an operator is being told to set.
+SESSION_KV_AUTH_ENV = "SESSION_KV_API_KEY"
 
 
 def _expected_api_key() -> str:
     # Read per request rather than at import: the value arrives from the pod
     # environment, and tests set it around individual calls.
-    return (os.getenv(SESSION_KV_API_KEY_ENV) or "").strip()
+    return (os.getenv(SESSION_KV_AUTH_ENV) or "").strip()
 
 
 def _presented_api_key(authorization: str, x_api_key: str) -> str:
@@ -81,7 +87,7 @@ def verify_api_key(
         logger.error(
             "%s is not set — refusing every authenticated request. "
             "Re-run provisioning so the pod secret carries a session KV key.",
-            SESSION_KV_API_KEY_ENV,
+            SESSION_KV_AUTH_ENV,
         )
         raise HTTPException(status_code=503, detail="session KV authentication is not configured")
 

--- a/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
+++ b/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
@@ -3177,7 +3177,11 @@ class TestAiSecurityAuditStream(BaseTestCase):
         the case it used to wave through, because `HF_TOKEN` reads as ordinary
         output to a pattern anchored on the bare word `token`.
         """
-        secret = "9f8e7d6c5b4a3928170695"
+        # Not named `secret`, though that is what it stands in for: the name
+        # alone makes the temp-file write in `write_findings` a clear-text
+        # storage finding (CodeQL py/clear-text-storage-sensitive-data). The
+        # value is a made-up hex string that never leaves this test.
+        pasted_value = "9f8e7d6c5b4a3928170695"
         doc = make_doc(
             audit=self.STREAM,
             findings=[
@@ -3192,7 +3196,7 @@ class TestAiSecurityAuditStream(BaseTestCase):
                         "kubectl --context gke_acme_us-east1_prod-us-east -n serving "
                         "get deployment llama-serve -o json"
                     ),
-                    excerpt=f"        - name: HF_TOKEN\n          value: {secret}",
+                    excerpt=f"        - name: HF_TOKEN\n          value: {pasted_value}",
                     remediation={
                         "kind": "manual",
                         "note": "Rotate the token, then move it to a Secret.",
@@ -3206,8 +3210,8 @@ class TestAiSecurityAuditStream(BaseTestCase):
         self.assertEqual(
             self.run_finish(doc, argv_extra=("--dry-run",), audit=self.STREAM), 0, self.err
         )
-        self.assertNotIn(secret, self.out)
-        self.assertNotIn(secret, self.err)
+        self.assertNotIn(pasted_value, self.out)
+        self.assertNotIn(pasted_value, self.err)
         # The variable is the finding. Only its value goes.
         self.assertIn("HF_TOKEN", self.out)
         self.assertIn(audit_report.REDACTED, self.out)


### PR DESCRIPTION
# Pull Request

## Why This Change

Two open CodeQL alerts on `main`, both rated High:

- [#15](https://github.com/gke-labs/kube-agents/security/code-scanning/15) — `py/clear-text-storage-sensitive-data`, `test_audit_report.py:542`
- [#16](https://github.com/gke-labs/kube-agents/security/code-scanning/16) — `py/clear-text-logging-sensitive-data`, `session_kv_server.py:84`

Both are name-driven false positives — no credential is logged or stored in either
place — and both queries take their source from an identifier whose *name* reads as a
credential. So the fix is not to add a guard, it is to stop misnaming things that are
not credentials. (Same shape as #535 and c6313e3, which retired secret-scanning
fixtures rather than suppressing the alert.)

## What Changed

**Files:**

- `agents/platform/scripts/session_kv_server.py`
- `agents/platform/skills/fleet-audit/scripts/test_audit_report.py`

**Added/Changed/Fixed:**

- Alert #16: `SESSION_KV_API_KEY_ENV` → `SESSION_KV_AUTH_ENV`. The constant holds the
  *name* of an environment variable, never its value, but `api_key` in the identifier
  makes any log line mentioning it a finding — and the 503 branch has to name the
  variable the operator is being told to set. **The environment variable itself is
  untouched**: still `SESSION_KV_API_KEY`, which is what the chart, the CRD, the
  installer, `upgrade.sh` and `INSTALL.md` all name. The rename is internal to one
  file (three occurrences, no other module referenced it).
- Alert #15: a local named `secret` carried a made-up hex string into a finding
  excerpt, and `write_findings` puts the document in a temp file — which CodeQL reads
  as storing a secret in clear text. Renamed to `pasted_value`, which is also what it
  is: the value the model pasted, and the thing the test asserts never reaches the
  ledger.
- A comment at each site says why the name is what it is, so the next reader does not
  helpfully rename it back.

No behaviour changes: same environment variable, same log text, same assertions.

## Why This Matters

- Clears the repository's only two open code-scanning alerts, both High.
- A standing false positive is not free: it is the noise that a real clear-text-logging
  finding would arrive alongside.
- `SESSION_KV_API_KEY_ENV` was actively misleading — it never held a key.

## Context

Generated with the help of Claude. No follow-up work; these were the only two open
alerts (`gh api repos/gke-labs/kube-agents/code-scanning/alerts` returns nothing else
open). CodeQL runs here through GitHub default setup, not a workflow in the repository,
so the alerts are re-evaluated on this PR — that run is the real verification that both
close.

## Testing

- `make test-python`: `agents/platform/scripts/` 444 tests, `fleet-audit/scripts/` 503
  tests, both green (the session-KV suite covers the 503-when-unset branch and the
  401/200 paths). One unrelated pre-existing failure,
  `test_slack_relay_patch.RelayedSlackErrorTest.test_an_unreadable_body_is_not_a_rejection`
  (`TypeError: a bytes-like object is required, not 'str'` in `slack_relay_patch.py:49`),
  fails identically on a clean `main` — verified by stashing this branch's diff.
- `make docs-check`: passed (generated regions current, links resolve, terminology,
  map coverage).
- No Markdown/YAML/JSON changed, so `prettier` is not in scope.

### Live validation

Install: `bhoekstra-gkedemos` / `kube-agents-cluster` (regional `us-central1`),
namespace `kubeagents-system`, pod `platform-agent-gateway-568f95dcf6-c7k8f`, images
tagged `dns-endpoint-7dac349`.

This install happens to exercise the exact branch the change touches: its
`SESSION_KV_API_KEY` comes from an optional Secret key that is absent, so the variable
is not in the container environment at all (`env | grep -c SESSION_KV_API_KEY` → `0`)
and the deployed server answers `503` to every request. Baseline recorded before
touching anything.

I ran the **modified** `session_kv_server.py` inside that pod rather than rebuilding the
image — copied to `/tmp/livetest/scripts/`, started under the pod's own
`/opt/hermes/.venv` interpreter on spare ports, with its own scratch SQLite path. The
deployed server on `127.0.0.1:8699` was left running and untouched throughout.

Two instances, to prove the mechanism rather than a coincidence — the unset case alone
would pass even if the constant resolved to nothing:

| Instance                                     | Request                          | Result |
| -------------------------------------------- | -------------------------------- | ------ |
| A — `SESSION_KV_API_KEY` unset (`:8799`)     | no key                           | `503`  |
| B — `SESSION_KV_API_KEY=live-test-key-b31f` (`:8800`) | no key                  | `401`  |
| B                                            | `X-Api-Key: nope`                | `401`  |
| B                                            | `X-Api-Key: live-test-key-b31f`  | `200`  |
| B                                            | `Authorization: Bearer <same>`   | `200`  |

B returning `200` only for the matching value is what proves `SESSION_KV_AUTH_ENV`
still resolves to the string `SESSION_KV_API_KEY`: had the rename changed the value the
server reads, B would have behaved like A.

Instance A's log still names the variable an operator has to set — the line the alert
was raised against:

```
ERROR  SESSION_KV_API_KEY is not set — refusing every authenticated request.
       Re-run provisioning so the pod secret carries a session KV key.
```

And the key value never appears in instance B's log (`grep -c live-test-key-b31f` → `0`).

Not covered: CodeQL itself cannot be run locally (no `codeql` CLI, and scanning is
default setup rather than a repository workflow), so that both alerts actually close is
verified by the code-scanning run on this PR, not before it. The fleet-audit change is
test-only and has no runtime surface to exercise on a cluster.

Cleanup: both test processes killed, `/tmp/livetest` removed, and the pod confirmed back
to one `session_kv_server` process (pid 101, the deployed one) still answering `503` as
it did at baseline. Nothing left behind, no redeploy, no CR edit.

---

Zero functional impact and no operator-visible surface: same environment variable, same
log text, same HTTP behaviour. Risk is limited to the rename itself, which is contained
to one file.
