### PR TITLE
fix(admin): streamline project and cluster connections

### DIFF
--- a/admin_console/CONNECTION_SECURITY.md
+++ b/admin_console/CONNECTION_SECURITY.md
@@ -1,0 +1,90 @@
+# Connection-state security
+
+This document is the security contract for the local Kube Agents Console's
+persisted connection lease. The implementation is
+[`connection_persistence.py`](connection_persistence.py); general console setup
+and behavior remain in [`README.md`](README.md).
+
+## What is persisted
+
+After an explicit Project and Cluster connection succeeds, the portal writes:
+
+```text
+~/.kube-agent/state/admin-portal-connection.json
+```
+
+`KUBE_AGENTS_ADMIN_CONNECTION_STATE` may override that path for a test or a
+deployment. The JSON document contains only:
+
+- a schema version;
+- the launcher-verified gcloud account identifier;
+- project ID, cluster name, location, and Kubernetes namespace;
+- whether the target came from host-label discovery or manual selection; and
+- the last successful verification time.
+
+The account identifier and infrastructure names may be sensitive organizational
+metadata. Treat the file as private even though it is not a credential.
+
+The file never contains access or refresh tokens, service-account keys, API
+keys, cookies, kubeconfig content, prompts, transcripts, logs, traces, or
+Kubernetes workload data. Google Cloud credentials remain under gcloud's own
+credential management. Kubernetes credentials are prepared in the portal
+process's private temporary kubeconfig and removed when that process exits.
+
+## Filesystem protections
+
+The portal creates the state directory with mode `0700` when it does not exist.
+It writes a temporary file in that directory, sets mode `0600`, flushes it,
+atomically replaces the destination, and enforces mode `0600` on the result.
+
+Loading fails closed when the file:
+
+- is a symbolic link;
+- is not owned by the portal process's effective user;
+- grants any group or other permissions;
+- exceeds the bounded state-file size;
+- is malformed or uses an unsupported schema version;
+- names an invalid project, cluster, location, or namespace; or
+- belongs to a different launcher-verified gcloud account.
+
+These controls protect against accidental disclosure and unsafe file
+substitution across local accounts. They do not defend against a process already
+running as the same Unix user; that process can also access the user's gcloud
+configuration and is outside the local portal's trust boundary.
+
+## Resume and revalidation
+
+An arbitrary URL, configured project, or provisioning-state target cannot create
+a connected session. Only a lease written after an explicit successful
+connection can resume.
+
+On browser reload or reopen, the portal resumes an exact account-bound lease and
+immediately starts bounded, read-only live revalidation. A successful result
+refreshes the timestamp. A failed result disconnects the cluster, deletes the
+lease, and reports the failed check, observed reason, and next action. An open
+session repeats revalidation periodically.
+
+Disconnecting the cluster or project deletes the lease. No credential is revoked
+because the lease contains no credential; gcloud authentication has its own
+lifecycle.
+
+## Local verification
+
+Inspect permissions without printing the metadata:
+
+```bash
+stat --format='mode=%a owner=%U size=%s path=%n' \
+  "$HOME/.kube-agent/state/admin-portal-connection.json"
+```
+
+The expected mode is `600`, and the owner must be the user running
+`scripts/admin_portal.sh`.
+
+Inspect only the stored field names:
+
+```bash
+jq -r 'keys[]' "$HOME/.kube-agent/state/admin-portal-connection.json"
+```
+
+Use the UI's **Disconnect** action to remove the lease through the normal
+lifecycle.

--- a/admin_console/CONNECTION_SECURITY.md
+++ b/admin_console/CONNECTION_SECURITY.md
@@ -20,7 +20,8 @@ deployment. The JSON document contains only:
 - the launcher-verified gcloud account identifier;
 - project ID, cluster name, location, and Kubernetes namespace;
 - whether the target came from host-label discovery or manual selection; and
-- the last successful verification time.
+- the last successful verification time; and
+- whether runtime use is verified or requires revalidation.
 
 The account identifier and infrastructure names may be sensitive organizational
 metadata. Treat the file as private even though it is not a credential.
@@ -60,9 +61,15 @@ connection can resume.
 
 On browser reload or reopen, the portal resumes an exact account-bound lease and
 immediately starts bounded, read-only live revalidation. A successful result
-refreshes the timestamp. A failed result disconnects the cluster, deletes the
-lease, and reports the failed check, observed reason, and next action. An open
-session repeats revalidation periodically.
+refreshes the timestamp and marks the lease verified. A failed result disconnects
+the cluster and marks the retained target as requiring revalidation, which makes
+both the Streamlit runtime pages and scoped API reject its use. A later portal
+session can retry that exact target without another manual selection. The UI
+reports the failed check, observed reason, and next action. An open session
+repeats revalidation periodically while keeping Disconnect available.
+Tabs with a persisted lease also reconcile its status and target. If another tab
+disconnects, suspends, or replaces the lease, a stale tab detaches its runtime
+state and cannot recreate the removed lease with a late background result.
 
 Disconnecting the cluster or project deletes the lease. No credential is revoked
 because the lease contains no credential; gcloud authentication has its own

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -262,9 +262,16 @@ Free-text search stays out of the URL because it may contain sensitive data.
 
 The Activity Explorer retains each Logging insert ID or Trace/span ID, provides
 a Google Cloud evidence link, and shows scrubbed, size-bounded evidence fields.
-Records with missing or inferred attribution are excluded from the causal
-Sankey. Source errors and result-limit truncation are displayed rather than
-silently treated as a complete result. Both activity pages show one loading
+The causal flow is intentionally narrower than the evidence ledger: it uses
+Cloud Trace parent/child lineage to show individual `api.*` LLM requests,
+LLM-child tool calls and approvals, and agent skill loads with trusted
+attribution. Aggregate `llm.*`/turn wrappers, gateway/chat lifecycle spans, and
+parallel Cloud Logging delivery records remain available in Timeline and the
+ledger but do not inflate the flow. Fluent Bit is treated as a log collector,
+not an agent; when an audit payload has no profile identity, the ledger labels
+the source `gateway-runtime` and retains `fluent-bit` as collector evidence.
+Source errors and result-limit truncation are displayed rather than silently
+treated as a complete result. Both activity pages show one loading
 indicator while the initial snapshot, refresh, or next source pages are read.
 Logging and Trace start with two bounded pages and retain their opaque
 continuation tokens only in the UI session; **Load more activity** appends the

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -264,12 +264,18 @@ The Activity Explorer retains each Logging insert ID or Trace/span ID, provides
 a Google Cloud evidence link, and shows scrubbed, size-bounded evidence fields.
 The causal flow is intentionally narrower than the evidence ledger: it uses
 Cloud Trace parent/child lineage to show individual `api.*` LLM requests,
-LLM-child tool calls and approvals, and agent skill loads with trusted
-attribution. Aggregate `llm.*`/turn wrappers, gateway/chat lifecycle spans, and
-parallel Cloud Logging delivery records remain available in Timeline and the
-ledger but do not inflate the flow. Fluent Bit is treated as a log collector,
-not an agent; when an audit payload has no profile identity, the ledger labels
-the source `gateway-runtime` and retains `fluent-bit` as collector evidence.
+LLM-child tool calls and approvals, and agent skill loads. A typed source
+normalizer groups by raw OTel `user.id`/`hermes.sender.id`, then
+`chat.platform`, cron job parsed from `session.id`, explicit trigger, or
+`hermes.session.kind`, falling back to the unmodified `session.id`. The node
+retains every available origin field and scope, the distinct-session count, and
+bounded raw-value samples; it
+never converts `k8s-watcher` into a generic Human or Event label. Aggregate
+`llm.*`/turn wrappers, gateway/chat lifecycle spans, and parallel Cloud Logging
+delivery records remain available in Timeline and the ledger but do not inflate
+the flow. Fluent Bit is treated as a log collector, not an agent; when an audit
+payload has no profile identity, the ledger labels the source `gateway-runtime`
+and retains `fluent-bit` as collector evidence.
 Source errors and result-limit truncation are displayed rather than silently
 treated as a complete result. Both activity pages show one loading
 indicator while the initial snapshot, refresh, or next source pages are read.

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -54,16 +54,19 @@ consistent levels. First, the **Project** card verifies the gcloud identity,
 project access, and GKE discovery. Then the **Cluster** card verifies the
 selected kube-agents runtime. Both steps use the same **Connect**,
 **Connecting**, and **Connected** states. The active connection level exposes
-the only **Disconnect** action; while work is pending, that level instead
-exposes the only **Abort** action. Abort immediately detaches the pending attempt
-and ignores any late result.
+the only **Disconnect** action; while an explicit Connect attempt is pending,
+that level instead exposes the only **Abort** action. Abort immediately detaches
+the pending attempt and ignores any late result. Periodic revalidation keeps the
+cluster Connected and leaves Disconnect available.
 
 One session-scoped connection controller owns both levels, their selection,
 pending check, report, failure, and verified target. Connection renders that
 controller; Chat and every Observability page read the same verified target
 through the shared gate. URL parameters and persisted metadata are projections
 of the controller and cannot independently make a page connected or
-disconnected.
+disconnected. Controller bootstrap is shared and idempotent, so a selected page
+that Streamlit resumes directly after a development-server rebuild reconstructs
+the same session state instead of depending on the application entry point.
 
 The project selector suggests the provisioned target, active gcloud
 configuration, saved connection, and URL selection with their source labels; it
@@ -90,10 +93,15 @@ the gcloud account, project, cluster, location, namespace, selection source, and
 last verification time. It never contains an access token, refresh token, API
 key, kubeconfig, prompt, transcript, or telemetry record. On browser reload or
 reopen under the same launcher-verified account, that explicit lease resumes and
-immediately starts live revalidation. A failed revalidation deletes the lease
-and disconnects the cluster. A target supplied only by URL, provisioning state,
-or project configuration remains disconnected until the user selects Connect.
-Disconnecting either persisted cluster or its project deletes the file.
+immediately starts live revalidation. A failed revalidation locks runtime access
+and marks the retained target as requiring revalidation, so a later successful
+probe can recover without another manual selection. A target supplied only by
+URL, provisioning state, or project configuration remains disconnected until
+the user selects Connect. Disconnecting either persisted cluster or its project
+deletes the file.
+Tabs backed by a persisted lease reconcile that shared file; a Disconnect or
+target change in one tab promptly locks stale tabs and cannot be undone by a
+late background result.
 The complete data inventory, filesystem checks, trust boundary, revalidation
 contract, and local verification commands live in
 [`CONNECTION_SECURITY.md`](CONNECTION_SECURITY.md).

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -49,38 +49,67 @@ inferring that asynchronous work succeeded.
 
 ## Connect to kube-agents
 
-Connection controls live at the top of Setup's **Connection** page. One editable
-project selector suggests the provisioned target, active gcloud configuration,
-saved connection, and URL selection with their source labels; it also accepts a
-manually entered project ID. **Connect** discovers
-the single GKE cluster labeled `kube-agents-host=true` and selects it
-automatically. If no labeled host or multiple labeled hosts are found, the
-portal shows a red detection error and a separate cluster picker with a
-**Select** action. Project and cluster selection are locked while connected.
-Connect and Disconnect are mutually exclusive, and Disconnect retains the
-selected URL scope for a quick reconnect.
+Connection controls live at the top of Setup's **Connection** page as two
+consistent levels. First, the **Project** card verifies the gcloud identity,
+project access, and GKE discovery. Then the **Cluster** card verifies the
+selected kube-agents runtime. Both steps use the same **Connect**,
+**Connecting**, and **Connected** states. The active connection level exposes
+the only **Disconnect** action; while work is pending, that level instead
+exposes the only **Abort** action. Abort immediately detaches the pending attempt
+and ignores any late result.
+
+One session-scoped connection controller owns both levels, their selection,
+pending check, report, failure, and verified target. Connection renders that
+controller; Chat and every Observability page read the same verified target
+through the shared gate. URL parameters and persisted metadata are projections
+of the controller and cannot independently make a page connected or
+disconnected.
+
+The project selector suggests the provisioned target, active gcloud
+configuration, saved connection, and URL selection with their source labels; it
+also accepts a manually entered project ID. Project connection loads the cluster
+picker but never connects a cluster automatically. A single
+`kube-agents-host=true` label preselects that cluster. Zero or multiple labels
+leave the user in control of the same picker with one concise caption. A cluster
+failure produces one actionable error naming the failed check, observed reason,
+and next action instead of a partial checklist. The full verification checklist
+appears only after both levels succeed. Disconnect unwinds one level at a time:
+Cluster Disconnect retains the connected project, then Project Disconnect
+becomes available.
+
+All Kubernetes-backed portal features use one shared GKE access component. It
+automatically obtains the selected cluster credentials in a process-private
+temporary kubeconfig, then supplies the same target and failure behavior to
+connection verification, observability, scheduled cron, and Chat. It does not
+modify the user's normal kubeconfig, and the temporary directory is removed
+when the portal process exits.
 
 A successful connection also persists its non-secret target metadata in
-`$XDG_STATE_HOME/kube-agents/admin-portal-connection.json` (or
-`~/.local/state/kube-agents/admin-portal-connection.json`). The owner-only file
-contains the gcloud account, project, cluster, location, namespace, selection
-source, and last verification time. It never contains an access token, refresh
-token, API key, kubeconfig, prompt, transcript, or telemetry record. On browser
-reload or reopen, the portal revalidates this target before enabling Chat or
-Observability. **Disconnect** deletes the file.
+`~/.kube-agent/state/admin-portal-connection.json`. The owner-only file contains
+the gcloud account, project, cluster, location, namespace, selection source, and
+last verification time. It never contains an access token, refresh token, API
+key, kubeconfig, prompt, transcript, or telemetry record. On browser reload or
+reopen under the same launcher-verified account, that explicit lease resumes and
+immediately starts live revalidation. A failed revalidation deletes the lease
+and disconnects the cluster. A target supplied only by URL, provisioning state,
+or project configuration remains disconnected until the user selects Connect.
+Disconnecting either persisted cluster or its project deletes the file.
+The complete data inventory, filesystem checks, trust boundary, revalidation
+contract, and local verification commands live in
+[`CONNECTION_SECURITY.md`](CONNECTION_SECURITY.md).
 
 While a browser tab remains open, the connection is revalidated every ten
-minutes. Navigation renders first; when restore or revalidation data is needed,
-the portal runs the read-only network checks outside Streamlit's render thread
-and shows their status in the sidebar. A lightweight UI fragment observes the
-job, but only the completed job result changes connection state; elapsed time is
-never treated as success. This timer is still a UI-session refresh, not an
-unattended daemon. A failed refresh immediately locks the provider-backed pages
-and requires reconnecting. Credential refresh remains owned by the Google Cloud
-CLI credential store; the portal mints short-lived tokens only for individual
-checks and discards them.
+minutes. Revalidation runs outside Streamlit's render thread and shows its status
+in the sidebar. A lightweight UI fragment observes the job, but only the
+completed job result changes connection state; elapsed time is never treated as
+success. This timer is still a UI-session refresh, not an unattended daemon. A
+failed refresh immediately locks the provider-backed pages and requires
+reconnecting. Credential refresh remains owned by the Google Cloud CLI
+credential store; the portal mints short-lived tokens only for individual checks
+and discards them.
 
-Select **Connect** to perform bounded, read-only checks for:
+Project **Connect**, followed by Cluster **Connect**, performs bounded,
+read-only checks for:
 
 - gcloud CLI and Application Default Credentials
 - selected-project access and required APIs
@@ -89,11 +118,14 @@ Select **Connect** to perform bounded, read-only checks for:
 - recent Cloud Trace data
 - persisted agent chat history through a fixed, read-only in-pod query
 
-The **Connection** page displays the resulting checklist, distinguishes
-permission, authentication, API, connectivity, and no-recent-data outcomes, and
-provides remediation guidance directly below the connection controls. The portal
-never grants IAM, enables APIs, changes Kubernetes resources, or retains access
-tokens.
+After a successful connection, the **Connection** page displays the resulting
+checklist and distinguishes permission, authentication, API, connectivity, and
+no-recent-data outcomes. Cluster connectivity depends on the identity, project,
+GKE, and agent-runtime checks; an unavailable Logging or Trace source remains a
+visible checklist failure but does not lock runtime-backed Chat, Task Kanban, or
+Scheduled Cron. A failed cluster connection shows one actionable error by the
+controls. The portal never grants IAM, enables APIs, changes Kubernetes
+resources, or retains access tokens.
 Observe and Chat pages are unavailable until the required checks pass for the
 selected project and cluster.
 
@@ -191,13 +223,16 @@ storage paths are not returned, and the page never claims, retries, comments
 on, or otherwise changes a task.
 
 Scheduled Cron reads every bounded Hermes profile cron store in the selected
-Agent. It shows active and recent executions, configured cadence and task,
-manual versus scheduled triggers, last and next runs, and a UTC calendar of
-recent activity plus every projected occurrence in the next 21 days.
-High-frequency occurrences are summarized by job and day. Scheduler health
-comes from each profile's ticker heartbeat. An enabled definition without a
-live ticker is reported as unable to run automatically instead of being
-presented as healthy.
+Agent. Its execution table aggregates the selected history into one row per job
+title with run and outcome counts, latest activity, and participating profiles.
+Each row expands in place to list every retained start time, trigger, duration,
+status, profile, and error—there is no separate detail table. The page also shows
+configured cadence and task, last and next runs, and a UTC calendar of recent
+activity plus every projected occurrence in the next 21 days. High-frequency
+calendar occurrences are summarized by job and day. Scheduler health comes
+from each profile's ticker heartbeat. An enabled definition without a live
+ticker is reported as unable to run automatically instead of being presented
+as healthy.
 
 ## Live activity
 

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -264,12 +264,22 @@ The Activity Explorer retains each Logging insert ID or Trace/span ID, provides
 a Google Cloud evidence link, and shows scrubbed, size-bounded evidence fields.
 Records with missing or inferred attribution are excluded from the causal
 Sankey. Source errors and result-limit truncation are displayed rather than
-silently treated as a complete result.
+silently treated as a complete result. Both activity pages show one loading
+indicator while the initial snapshot, refresh, or next source pages are read.
+Logging and Trace start with two bounded pages and retain their opaque
+continuation tokens only in the UI session; **Load more activity** appends the
+next pages without rereading earlier results. Logging uses 500-record pages, a
+60-second per-page timeout, and a shared 90-second load deadline. A later-page
+failure retains the earlier pages and is reported as partial data. Trace and
+each of Logging's two non-overlapping queries stop after ten pages; the UI asks
+the user to narrow the time window when a query reaches that ceiling. The
+forensic ledger separately paginates the loaded events at 50 rows per page so
+source completeness does not create an oversized browser table.
 
 The provider is a read model, not a perfect causal join. Older records without
 trusted interaction, user, task, or proxy request identifiers remain labeled
-as missing. Page-local search and ledger selections are not yet persisted in
-the URL.
+as missing. The ledger page and selected event are persisted in the URL;
+free-text and facet filters remain local to the browser session.
 
 ## Validate
 

--- a/admin_console/activity_scope.py
+++ b/admin_console/activity_scope.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import streamlit as st
 
 from admin_console.connection_gate import require_connection
-from admin_console.telemetry import MAX_TRACE_PAGES, CloudTelemetryProvider
+from admin_console.telemetry import CloudTelemetryProvider, TelemetrySnapshot
 
 WINDOW_OPTIONS = {
     "1h": ("Last hour", 1),
@@ -21,13 +21,6 @@ def _query_value(name: str, default: str = "") -> str:
     return str(st.query_params.get(name, default)).strip()
 
 
-def _trace_pages() -> int:
-    try:
-        return max(1, min(int(_query_value("trace_pages", "1")), MAX_TRACE_PAGES))
-    except ValueError:
-        return 1
-
-
 def render_activity_scope() -> CloudTelemetryProvider:
     """Render compact page-local scope controls and return the live provider."""
     target = require_connection()
@@ -38,8 +31,6 @@ def render_activity_scope() -> CloudTelemetryProvider:
     requested_cluster = _query_value("activity_cluster")
     if requested_cluster == "all":
         requested_cluster = ""
-    requested_trace_pages = _trace_pages()
-
     with st.container(border=True):
         columns = st.columns([1, 1, 1.5])
         selected_window = columns[0].selectbox(
@@ -75,33 +66,65 @@ def render_activity_scope() -> CloudTelemetryProvider:
     if _query_value("activity_cluster") != cluster_parameter:
         st.query_params["activity_cluster"] = cluster_parameter
     if scope_changed:
-        requested_trace_pages = 1
-        st.query_params.pop("trace_pages", None)
-    elif requested_trace_pages > 1:
-        if _query_value("trace_pages") != str(requested_trace_pages):
-            st.query_params["trace_pages"] = str(requested_trace_pages)
-    else:
-        st.query_params.pop("trace_pages", None)
+        st.query_params.pop("activity_page", None)
+        st.query_params.pop("activity_event", None)
+    st.query_params.pop("trace_pages", None)
     if refresh:
         st.session_state.telemetry_refresh = (
             st.session_state.get("telemetry_refresh", 0) + 1
         )
+        st.session_state.telemetry_load_reason = "refresh"
+        st.query_params.pop("activity_page", None)
+        st.query_params.pop("activity_event", None)
 
+    account = st.session_state.get("authenticated_user", "")
     provider_key = (
         target.project_id,
         selected_cluster,
+        target.namespace,
+        account,
         selected_window,
-        requested_trace_pages,
         st.session_state.get("telemetry_refresh", 0),
     )
     if st.session_state.get("telemetry_provider_key") != provider_key:
         st.session_state.telemetry_provider = CloudTelemetryProvider(
             target.project_id,
-            account=st.session_state.get("authenticated_user", ""),
+            account=account,
             cluster=selected_cluster,
             namespace=target.namespace,
             hours=WINDOW_OPTIONS[selected_window][1],
-            trace_pages=requested_trace_pages,
         )
         st.session_state.telemetry_provider_key = provider_key
     return st.session_state.telemetry_provider
+
+
+def load_activity_snapshot(provider: CloudTelemetryProvider) -> TelemetrySnapshot:
+    """Load one snapshot with consistent visible feedback on every page."""
+    if provider.loaded:
+        return provider.get_snapshot()
+    reason = st.session_state.pop("telemetry_load_reason", "initial")
+    label = (
+        "Refreshing activity from Cloud Logging and Cloud Trace…"
+        if reason == "refresh"
+        else "Loading activity from Cloud Logging and Cloud Trace…"
+    )
+    with st.spinner(label, show_time=True):
+        return provider.get_snapshot()
+
+
+def render_activity_load_more(provider: CloudTelemetryProvider) -> None:
+    """Append bounded source pages while keeping source cursors server-side."""
+    if not provider.can_load_more:
+        return
+    action, context = st.columns([1, 3], vertical_alignment="center")
+    if action.button(
+        "Load more activity",
+        icon=":material/add:",
+        width="stretch",
+    ):
+        with st.spinner("Loading more activity…", show_time=True):
+            provider.load_more()
+        st.query_params.pop("activity_page", None)
+        st.query_params.pop("activity_event", None)
+        st.rerun()
+    context.caption("Fetch the next bounded Logging and Trace pages.")

--- a/admin_console/agent_chat.py
+++ b/admin_console/agent_chat.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import json
-import os
 import re
-import subprocess
-import threading
 from dataclasses import dataclass
 from typing import Callable, Protocol, Sequence
 
+from admin_console.kube_access import (
+    GKEKubeAccess,
+    KubeCommandResult as ChatCommandResult,
+    kube_failure_guidance,
+)
 from admin_console.project_config import (
     DeploymentTarget,
     is_valid_cluster_name,
@@ -179,14 +181,6 @@ else:
 '''
 
 
-@dataclass(frozen=True)
-class ChatCommandResult:
-    returncode: int
-    stdout: str = ""
-    stderr: str = ""
-    timed_out: bool = False
-
-
 class ChatKubeRunner(Protocol):
     def run(
         self,
@@ -199,6 +193,16 @@ class ChatKubeRunner(Protocol):
 
 
 class KubectlChatRunner:
+    """Chat adapter over the portal's shared GKE access component."""
+
+    def __init__(
+        self,
+        target: DeploymentTarget,
+        *,
+        access: GKEKubeAccess | None = None,
+    ) -> None:
+        self.access = access or GKEKubeAccess(target)
+
     def run(
         self,
         arguments: list[str],
@@ -207,82 +211,11 @@ class KubectlChatRunner:
         timeout: int = 620,
         line_callback: Callable[[str], None] | None = None,
     ) -> ChatCommandResult:
-        environment = os.environ.copy()
-        account = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
-        if account:
-            environment["CLOUDSDK_CORE_ACCOUNT"] = account
-        if line_callback is None:
-            try:
-                completed = subprocess.run(
-                    ["kubectl", *arguments],
-                    input=input_text,
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    env=environment,
-                )
-            except subprocess.TimeoutExpired:
-                return ChatCommandResult(124, timed_out=True)
-            except OSError as exc:
-                return ChatCommandResult(127, stderr=type(exc).__name__)
-            return ChatCommandResult(
-                completed.returncode,
-                completed.stdout,
-                completed.stderr,
-            )
-
-        try:
-            process = subprocess.Popen(
-                ["kubectl", *arguments],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                env=environment,
-            )
-        except OSError as exc:
-            return ChatCommandResult(127, stderr=type(exc).__name__)
-
-        stdout_lines: list[str] = []
-        stderr_lines: list[str] = []
-
-        def drain_stdout() -> None:
-            assert process.stdout is not None
-            for line in process.stdout:
-                stdout_lines.append(line)
-                line_callback(line.rstrip("\r\n"))
-
-        def drain_stderr() -> None:
-            assert process.stderr is not None
-            stderr_lines.extend(process.stderr)
-
-        stdout_thread = threading.Thread(target=drain_stdout, daemon=True)
-        stderr_thread = threading.Thread(target=drain_stderr, daemon=True)
-        stdout_thread.start()
-        stderr_thread.start()
-        assert process.stdin is not None
-        try:
-            process.stdin.write(input_text)
-            process.stdin.close()
-            process.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait()
-            stdout_thread.join(timeout=1)
-            stderr_thread.join(timeout=1)
-            return ChatCommandResult(
-                124,
-                "".join(stdout_lines),
-                "".join(stderr_lines),
-                timed_out=True,
-            )
-        stdout_thread.join(timeout=1)
-        stderr_thread.join(timeout=1)
-        return ChatCommandResult(
-            process.returncode,
-            "".join(stdout_lines),
-            "".join(stderr_lines),
+        return self.access.run(
+            arguments,
+            input_text=input_text,
+            timeout=timeout,
+            line_callback=line_callback,
         )
 
 
@@ -322,7 +255,7 @@ class AgentChatProvider:
         ):
             raise ValueError("invalid agent chat target")
         self.target = target
-        self.runner = runner or KubectlChatRunner()
+        self.runner = runner or KubectlChatRunner(target)
         self.context = f"gke_{target.project_id}_{target.location}_{target.cluster_name}"
 
     def _base(self) -> list[str]:
@@ -361,12 +294,19 @@ class AgentChatProvider:
     @staticmethod
     def _json(result: ChatCommandResult, component: str) -> dict:
         if result.returncode != 0:
-            if result.timed_out:
-                guidance = "The run exceeded the portal timeout. Check Activity Explorer before retrying."
-            elif "forbidden" in result.stderr.lower():
-                guidance = "Request pods/exec access to the selected gateway namespace."
-            else:
-                guidance = "Check the selected gateway pod and agent API health."
+            guidance = kube_failure_guidance(result)
+            if not guidance:
+                if result.timed_out:
+                    guidance = (
+                        "The run exceeded the portal timeout. Check Activity Explorer "
+                        "before retrying."
+                    )
+                elif "forbidden" in result.stderr.lower():
+                    guidance = (
+                        "Request pods/exec access to the selected gateway namespace."
+                    )
+                else:
+                    guidance = "Check the selected gateway pod and agent API health."
             raise AgentChatError(f"{component} failed.", guidance)
         try:
             payload = json.loads(result.stdout)

--- a/admin_console/agent_runtime.py
+++ b/admin_console/agent_runtime.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
-import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Protocol
 
+from admin_console.kube_access import (
+    GKEKubeAccess,
+    KubeCommandResult,
+    kube_failure_guidance,
+)
 from admin_console.project_config import (
     DeploymentTarget,
     is_valid_cluster_name,
@@ -502,42 +505,23 @@ print(json.dumps(payload, ensure_ascii=False))
 '''
 
 
-@dataclass(frozen=True)
-class KubeCommandResult:
-    returncode: int
-    stdout: str = ""
-    stderr: str = ""
-    timed_out: bool = False
-
-
 class KubeRunner(Protocol):
     def run(self, arguments: list[str], *, timeout: int = 20) -> KubeCommandResult: ...
 
 
 class KubectlRunner:
+    """Runtime adapter over the portal's shared GKE access component."""
+
+    def __init__(
+        self,
+        target: DeploymentTarget,
+        *,
+        access: GKEKubeAccess | None = None,
+    ) -> None:
+        self.access = access or GKEKubeAccess(target)
+
     def run(self, arguments: list[str], *, timeout: int = 20) -> KubeCommandResult:
-        environment = os.environ.copy()
-        account = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
-        if account:
-            environment["CLOUDSDK_CORE_ACCOUNT"] = account
-        try:
-            completed = subprocess.run(
-                ["kubectl", *arguments],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=environment,
-            )
-        except subprocess.TimeoutExpired:
-            return KubeCommandResult(124, timed_out=True)
-        except OSError as exc:
-            return KubeCommandResult(127, stderr=type(exc).__name__)
-        return KubeCommandResult(
-            completed.returncode,
-            completed.stdout,
-            completed.stderr,
-        )
+        return self.access.run(arguments, timeout=timeout)
 
 
 class AgentRuntimeError(RuntimeError):
@@ -809,10 +793,10 @@ class AgentRuntimeProvider:
         ):
             raise ValueError("invalid agent runtime target")
         self.target = target
-        self.runner = runner or KubectlRunner()
         self.context = (
             f"gke_{target.project_id}_{target.location}_{target.cluster_name}"
         )
+        self.runner = runner or KubectlRunner(target)
 
     def _base(self) -> list[str]:
         return ["--context", self.context, "-n", self.target.namespace]
@@ -820,22 +804,24 @@ class AgentRuntimeProvider:
     def _json(self, result: KubeCommandResult, component: str) -> dict:
         if result.returncode != 0:
             error = result.stderr.lower()
-            if result.timed_out:
-                guidance = "Check cluster connectivity and retry."
-            elif "context" in error or "not found" in error:
-                guidance = (
-                    "Load the cluster context with `gcloud container clusters "
-                    f"get-credentials {self.target.cluster_name} "
-                    f"--location {self.target.location} "
-                    f"--project {self.target.project_id}`."
-                )
-            elif "forbidden" in error or "permission" in error:
-                guidance = (
-                    "Request read access to PlatformAgent resources and pods/exec "
-                    "in the selected namespace."
-                )
-            else:
-                guidance = "Confirm the cluster, namespace, gateway pod, and kubectl access."
+            guidance = kube_failure_guidance(result)
+            if not guidance:
+                if result.timed_out:
+                    guidance = "Check cluster connectivity, then retry."
+                elif "context" in error or "not found" in error:
+                    guidance = (
+                        "Confirm the selected project, cluster, and location, "
+                        "then retry."
+                    )
+                elif "forbidden" in error or "permission" in error:
+                    guidance = (
+                        "Request read access to PlatformAgent resources and pods/exec "
+                        "in the selected namespace."
+                    )
+                else:
+                    guidance = (
+                        "Confirm the cluster, namespace, gateway pod, and kubectl access."
+                    )
             raise AgentRuntimeError(f"{component} failed.", guidance)
         try:
             payload = json.loads(result.stdout)

--- a/admin_console/api/app.py
+++ b/admin_console/api/app.py
@@ -35,7 +35,7 @@ def _error(code: str, message: str, *, retryable: bool = False) -> dict:
 def _persisted_runtime_factory(account: str) -> RuntimeProviderFactory:
     def build() -> agent_runtime.AgentRuntimeProvider:
         connection = load_connection(account)
-        if connection is None:
+        if connection is None or not connection.usable:
             raise RuntimeError(
                 "No verified portal connection is available. Open Connection and connect "
                 "to a kube-agents host first."
@@ -91,7 +91,7 @@ def create_app(
                         },
                     )
                 connection = load_connection(account)
-                if connection is None:
+                if connection is None or not connection.usable:
                     return JSONResponse(
                         status_code=503,
                         content={

--- a/admin_console/app.py
+++ b/admin_console/app.py
@@ -15,10 +15,15 @@ PACKAGE_PARENT = Path(__file__).resolve().parents[1]
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
 
+from admin_console.connection_controller import (
+    CONNECTION_CONTROLLER_KEY,
+    ConnectionController,
+)
 from admin_console.connection_gate import current_connection
 from admin_console.connection_persistence import load_connection
-from admin_console.connection_sidebar import maintain_connection
+from admin_console.connection_sidebar import connection_executor, maintain_connection
 from admin_console.project_config import (
+    DeploymentTarget,
     build_project_candidates,
     is_valid_cluster_name,
     is_valid_location,
@@ -44,7 +49,6 @@ if not authenticated_user:
     st.stop()
 st.session_state.authenticated_user = authenticated_user
 persisted_connection = load_connection(authenticated_user)
-st.session_state.persisted_connection = persisted_connection
 
 with st.sidebar:
     st.markdown("## ◈ Kube Agents")
@@ -53,7 +57,6 @@ with st.sidebar:
 provisioned_target = load_provisioned_target(
     PACKAGE_PARENT / "k8s-operator" / "scripts" / "vars.sh"
 )
-st.session_state.provisioned_target = provisioned_target
 query_project = str(st.query_params.get("project", "")).strip()
 configured_project = os.environ.get("KUBE_AGENTS_GCLOUD_PROJECT", "").strip()
 persisted_project = (
@@ -66,51 +69,100 @@ project_candidates = build_project_candidates(
     persisted_project,
 )
 project_ids = [candidate.project_id for candidate in project_candidates]
-candidate_sources = {
-    candidate.project_id: candidate.source for candidate in project_candidates
-}
-st.session_state.project_candidates = project_candidates
-st.session_state.project_candidate_sources = candidate_sources
-
-# The Connection page owns project selection. A valid URL selection wins;
-# otherwise initialize once from the active gcloud/provisioned candidates.
-# Disconnect removes the saved connection while retaining its URL scope.
-if is_valid_project_id(query_project):
-    st.session_state.selected_project = query_project
-elif "selected_project" not in st.session_state:
-    st.session_state.selected_project = (
-        persisted_project or (project_ids[0] if project_ids else "")
-    )
-selected_project = st.session_state.get("selected_project", "")
-if selected_project and query_project != selected_project:
-    st.query_params["project"] = selected_project
 
 query_cluster = str(st.query_params.get("cluster", "")).strip()
 query_location = str(st.query_params.get("location", "")).strip()
-session_cluster = str(st.session_state.get("selected_cluster", "")).strip()
-session_location = str(st.session_state.get("selected_location", "")).strip()
-if is_valid_cluster_name(query_cluster) and is_valid_location(query_location):
-    st.session_state.selected_cluster = query_cluster
-    st.session_state.selected_location = query_location
-elif is_valid_cluster_name(session_cluster) and is_valid_location(session_location):
-    # Page navigation may clear query parameters. A verified session selection
-    # must survive.
-    st.session_state.selected_cluster = session_cluster
-    st.session_state.selected_location = session_location
-elif (
-    persisted_connection
-    and persisted_connection.target.project_id == selected_project
-):
-    st.session_state.selected_cluster = persisted_connection.target.cluster_name
-    st.session_state.selected_location = persisted_connection.target.location
 
-selected_cluster = st.session_state.get("selected_cluster", "")
-selected_location = st.session_state.get("selected_location", "")
-if is_valid_cluster_name(selected_cluster) and is_valid_location(selected_location):
-    if query_cluster != selected_cluster:
-        st.query_params["cluster"] = selected_cluster
-    if query_location != selected_location:
-        st.query_params["location"] = selected_location
+# The controller is the session's only connection state. URL and persisted
+# values initialize or project its selection; neither can silently reconnect.
+initial_project = (
+    query_project
+    if is_valid_project_id(query_project)
+    else persisted_project or (project_ids[0] if project_ids else "")
+)
+initial_target = None
+if is_valid_cluster_name(query_cluster) and is_valid_location(query_location):
+    namespace = (
+        provisioned_target.namespace
+        if provisioned_target
+        and provisioned_target.project_id == initial_project
+        and provisioned_target.cluster_name == query_cluster
+        and provisioned_target.location == query_location
+        else "kubeagents-system"
+    )
+    initial_target = DeploymentTarget(
+        initial_project,
+        query_cluster,
+        query_location,
+        namespace,
+        "manual selection",
+    )
+elif persisted_connection and persisted_connection.target.project_id == initial_project:
+    initial_target = persisted_connection.target
+
+controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
+if not isinstance(controller, ConnectionController):
+    persisted_scope_matches = bool(
+        persisted_connection
+        and initial_target
+        and (
+            initial_target.project_id,
+            initial_target.cluster_name,
+            initial_target.location,
+            initial_target.namespace,
+        )
+        == (
+            persisted_connection.target.project_id,
+            persisted_connection.target.cluster_name,
+            persisted_connection.target.location,
+            persisted_connection.target.namespace,
+        )
+    )
+    if persisted_connection and persisted_scope_matches:
+        controller = ConnectionController.restored(
+            authenticated_user,
+            persisted_connection.target,
+            persisted_connection.verified_at,
+        )
+        controller.provisioned_target = provisioned_target
+        controller.project_candidates = tuple(project_candidates)
+        controller.refresh(connection_executor())
+    else:
+        controller = ConnectionController(
+            account=authenticated_user,
+            project_id=initial_project,
+            selected_target=initial_target,
+            provisioned_target=provisioned_target,
+            project_candidates=tuple(project_candidates),
+        )
+    st.session_state[CONNECTION_CONTROLLER_KEY] = controller
+else:
+    controller.account = authenticated_user
+    controller.provisioned_target = provisioned_target
+    controller.project_candidates = tuple(project_candidates)
+    if not controller.connected_project and not controller.working:
+        requested_project = (
+            query_project
+            if is_valid_project_id(query_project)
+            else controller.project_id or initial_project
+        )
+        controller.select_project(requested_project)
+        explicit_target = (
+            initial_target
+            if is_valid_cluster_name(query_cluster)
+            and is_valid_location(query_location)
+            else None
+        )
+        if explicit_target and explicit_target.project_id == controller.project_id:
+            controller.selected_target = explicit_target
+        elif controller.selected_target is None and initial_target:
+            controller.selected_target = initial_target
+
+if controller.project_id:
+    st.query_params["project"] = controller.project_id
+if controller.selected_target:
+    st.query_params["cluster"] = controller.selected_target.cluster_name
+    st.query_params["location"] = controller.selected_target.location
 
 pages = {
     "Setup": [
@@ -161,6 +213,6 @@ with st.sidebar:
     maintain_connection()
     st.caption(f"Signed in as {authenticated_user}")
     if not connection_is_current:
-        st.caption("Connect to enable Observability")
+        st.caption("Connect a project and cluster to enable Observability")
 
 navigation.run()

--- a/admin_console/app.py
+++ b/admin_console/app.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 
@@ -12,24 +11,16 @@ import streamlit as st
 # than the repository root on sys.path. Add the package parent before importing
 # application modules so local, container, and proxied launches behave alike.
 PACKAGE_PARENT = Path(__file__).resolve().parents[1]
+APP_DIRECTORY = Path(__file__).resolve().parent
 if str(PACKAGE_PARENT) not in sys.path:
     sys.path.insert(0, str(PACKAGE_PARENT))
 
-from admin_console.connection_controller import (
-    CONNECTION_CONTROLLER_KEY,
-    ConnectionController,
-)
 from admin_console.connection_gate import current_connection
-from admin_console.connection_persistence import load_connection
-from admin_console.connection_sidebar import connection_executor, maintain_connection
-from admin_console.project_config import (
-    DeploymentTarget,
-    build_project_candidates,
-    is_valid_cluster_name,
-    is_valid_location,
-    is_valid_project_id,
-    load_provisioned_target,
+from admin_console.connection_session import (
+    APP_SHELL_ACTIVE_KEY,
+    initialize_connection_controller,
 )
+from admin_console.connection_sidebar import connection_executor, maintain_connection
 from admin_console.ui import apply_theme
 
 st.set_page_config(
@@ -40,134 +31,18 @@ st.set_page_config(
 )
 apply_theme()
 
-authenticated_user = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
-if not authenticated_user:
-    st.error(
-        "No verified local identity is available. Start the portal with "
-        "`scripts/admin_portal.sh` so the active gcloud login can be verified."
-    )
-    st.stop()
-st.session_state.authenticated_user = authenticated_user
-persisted_connection = load_connection(authenticated_user)
+controller = initialize_connection_controller(PACKAGE_PARENT, connection_executor())
+authenticated_user = controller.account
+st.session_state[APP_SHELL_ACTIVE_KEY] = True
 
 with st.sidebar:
     st.markdown("## ◈ Kube Agents")
     st.divider()
 
-provisioned_target = load_provisioned_target(
-    PACKAGE_PARENT / "k8s-operator" / "scripts" / "vars.sh"
-)
-query_project = str(st.query_params.get("project", "")).strip()
-configured_project = os.environ.get("KUBE_AGENTS_GCLOUD_PROJECT", "").strip()
-persisted_project = (
-    persisted_connection.target.project_id if persisted_connection else ""
-)
-project_candidates = build_project_candidates(
-    provisioned_target,
-    configured_project,
-    query_project,
-    persisted_project,
-)
-project_ids = [candidate.project_id for candidate in project_candidates]
-
-query_cluster = str(st.query_params.get("cluster", "")).strip()
-query_location = str(st.query_params.get("location", "")).strip()
-
-# The controller is the session's only connection state. URL and persisted
-# values initialize or project its selection; neither can silently reconnect.
-initial_project = (
-    query_project
-    if is_valid_project_id(query_project)
-    else persisted_project or (project_ids[0] if project_ids else "")
-)
-initial_target = None
-if is_valid_cluster_name(query_cluster) and is_valid_location(query_location):
-    namespace = (
-        provisioned_target.namespace
-        if provisioned_target
-        and provisioned_target.project_id == initial_project
-        and provisioned_target.cluster_name == query_cluster
-        and provisioned_target.location == query_location
-        else "kubeagents-system"
-    )
-    initial_target = DeploymentTarget(
-        initial_project,
-        query_cluster,
-        query_location,
-        namespace,
-        "manual selection",
-    )
-elif persisted_connection and persisted_connection.target.project_id == initial_project:
-    initial_target = persisted_connection.target
-
-controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
-if not isinstance(controller, ConnectionController):
-    persisted_scope_matches = bool(
-        persisted_connection
-        and initial_target
-        and (
-            initial_target.project_id,
-            initial_target.cluster_name,
-            initial_target.location,
-            initial_target.namespace,
-        )
-        == (
-            persisted_connection.target.project_id,
-            persisted_connection.target.cluster_name,
-            persisted_connection.target.location,
-            persisted_connection.target.namespace,
-        )
-    )
-    if persisted_connection and persisted_scope_matches:
-        controller = ConnectionController.restored(
-            authenticated_user,
-            persisted_connection.target,
-            persisted_connection.verified_at,
-        )
-        controller.provisioned_target = provisioned_target
-        controller.project_candidates = tuple(project_candidates)
-        controller.refresh(connection_executor())
-    else:
-        controller = ConnectionController(
-            account=authenticated_user,
-            project_id=initial_project,
-            selected_target=initial_target,
-            provisioned_target=provisioned_target,
-            project_candidates=tuple(project_candidates),
-        )
-    st.session_state[CONNECTION_CONTROLLER_KEY] = controller
-else:
-    controller.account = authenticated_user
-    controller.provisioned_target = provisioned_target
-    controller.project_candidates = tuple(project_candidates)
-    if not controller.connected_project and not controller.working:
-        requested_project = (
-            query_project
-            if is_valid_project_id(query_project)
-            else controller.project_id or initial_project
-        )
-        controller.select_project(requested_project)
-        explicit_target = (
-            initial_target
-            if is_valid_cluster_name(query_cluster)
-            and is_valid_location(query_location)
-            else None
-        )
-        if explicit_target and explicit_target.project_id == controller.project_id:
-            controller.selected_target = explicit_target
-        elif controller.selected_target is None and initial_target:
-            controller.selected_target = initial_target
-
-if controller.project_id:
-    st.query_params["project"] = controller.project_id
-if controller.selected_target:
-    st.query_params["cluster"] = controller.selected_target.cluster_name
-    st.query_params["location"] = controller.selected_target.location
-
 pages = {
     "Setup": [
         st.Page(
-            "pages/connections.py",
+            APP_DIRECTORY / "pages" / "connections.py",
             title="Connection",
             icon=":material/cable:",
             default=True,
@@ -175,29 +50,29 @@ pages = {
     ],
     "Agentic": [
         st.Page(
-            "pages/chat.py",
+            APP_DIRECTORY / "pages" / "chat.py",
             title="Chat",
             icon=":material/forum:",
         ),
     ],
     "Observability": [
         st.Page(
-            "pages/overview.py",
+            APP_DIRECTORY / "pages" / "overview.py",
             title="Overview",
             icon=":material/space_dashboard:",
         ),
         st.Page(
-            "pages/activity.py",
+            APP_DIRECTORY / "pages" / "activity.py",
             title="Activity Explorer",
             icon=":material/account_tree:",
         ),
         st.Page(
-            "pages/kanban.py",
+            APP_DIRECTORY / "pages" / "kanban.py",
             title="Task Kanban",
             icon=":material/view_kanban:",
         ),
         st.Page(
-            "pages/autonomous.py",
+            APP_DIRECTORY / "pages" / "autonomous.py",
             title="Scheduled Cron",
             icon=":material/autorenew:",
             url_path="scheduled-cron",

--- a/admin_console/causal_flow.py
+++ b/admin_console/causal_flow.py
@@ -1,0 +1,75 @@
+"""Semantic projection for the agent-work causal flow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from admin_console.domain import ActivityEvent, AttributionLevel
+
+_TRUSTED_ATTRIBUTION = {
+    AttributionLevel.EXPLICIT,
+    AttributionLevel.INHERITED,
+}
+
+
+@dataclass(frozen=True)
+class CausalFlowProjection:
+    """Canonical LLM work separated from raw telemetry evidence."""
+
+    events: tuple[ActivityEvent, ...]
+    llm_calls: int
+    tool_calls: int
+    approvals: int
+    skill_loads: int
+    hidden_evidence: int
+
+    @classmethod
+    def from_events(
+        cls, events: Iterable[ActivityEvent]
+    ) -> "CausalFlowProjection":
+        selected: list[ActivityEvent] = []
+        counts = {"model": 0, "tool": 0, "approval": 0, "skill": 0}
+        hidden = 0
+        for event in events:
+            source = event.details.get("source", "")
+            span_name = event.details.get("span_name", "")
+            parent_name = event.details.get("parent_span_name", "")
+            trusted = event.attribution in _TRUSTED_ATTRIBUTION
+
+            kind = ""
+            if source == "cloud_trace" and trusted:
+                if event.action_type == "model" and span_name.startswith("api."):
+                    kind = "model"
+                elif event.action_type in {"tool", "approval"} and parent_name.startswith(
+                    "llm."
+                ):
+                    kind = event.action_type
+                elif event.action_type == "skill":
+                    kind = "skill"
+
+            if not kind:
+                hidden += 1
+                continue
+            selected.append(event)
+            counts[kind] += 1
+
+        return cls(
+            tuple(selected),
+            counts["model"],
+            counts["tool"],
+            counts["approval"],
+            counts["skill"],
+            hidden,
+        )
+
+    @property
+    def summary(self) -> str:
+        shown = len(self.events)
+        return (
+            f"{shown} agent action(s): {self.llm_calls} LLM call(s), "
+            f"{self.tool_calls} LLM-produced tool call(s), "
+            f"{self.approvals} approval(s), and {self.skill_loads} skill load(s). "
+            f"{self.hidden_evidence} transport, lifecycle, duplicate, or "
+            "unattributed evidence record(s) hidden from this flow."
+        )

--- a/admin_console/causal_flow.py
+++ b/admin_console/causal_flow.py
@@ -2,15 +2,100 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Iterable
 
-from admin_console.domain import ActivityEvent, AttributionLevel
+from admin_console.domain import ActivityEvent
 
-_TRUSTED_ATTRIBUTION = {
-    AttributionLevel.EXPLICIT,
-    AttributionLevel.INHERITED,
-}
+
+@dataclass(frozen=True)
+class SourceEvidence:
+    """One raw OTel source attribute and where it was observed."""
+
+    field: str
+    value: str
+    scope: str
+
+
+@dataclass(frozen=True)
+class CausalSource:
+    """Stable aggregation identity plus all available OTel origin evidence."""
+
+    key: str
+    source_type: str
+    source_id: str
+    primary: SourceEvidence | None
+    evidence: tuple[SourceEvidence, ...]
+    session_id: str
+
+    @staticmethod
+    def _raw(
+        details: dict[str, str], attribute: str
+    ) -> SourceEvidence | None:
+        direct = str(details.get(f"otel.{attribute}", ""))
+        if direct:
+            return SourceEvidence(attribute, direct, "span")
+        inherited = str(details.get(f"otel.trace.{attribute}", ""))
+        if inherited:
+            return SourceEvidence(attribute, inherited, "trace")
+        return None
+
+    @staticmethod
+    def _cron_job(session_id: str) -> str:
+        match = re.fullmatch(r"cron_(.+)_\d{8}_\d{6}", session_id)
+        return match.group(1) if match else ""
+
+    @classmethod
+    def from_event(cls, event: ActivityEvent) -> "CausalSource":
+        details = event.details
+        attributes = (
+            "session.id",
+            "user.id",
+            "hermes.sender.id",
+            "chat.platform",
+            "trigger.kind",
+            "hermes.session.kind",
+        )
+        evidence = tuple(
+            item
+            for attribute in attributes
+            if (item := cls._raw(details, attribute)) is not None
+        )
+        by_field = {item.field: item for item in evidence}
+        session = by_field.get("session.id")
+        if session is None and event.session_id:
+            session = SourceEvidence("session.id", event.session_id, "event")
+            evidence = (session, *evidence)
+        session_id = session.value if session else ""
+        cron_job = cls._cron_job(session_id)
+
+        primary = by_field.get("user.id") or by_field.get("hermes.sender.id")
+        if primary:
+            source_type, source_id = "user", primary.value
+        elif primary := by_field.get("chat.platform"):
+            source_type, source_id = "platform", primary.value
+        elif cron_job:
+            source_type, source_id = "cron", cron_job
+            primary = session
+        elif primary := by_field.get("trigger.kind"):
+            source_type, source_id = "trigger", primary.value
+        elif primary := by_field.get("hermes.session.kind"):
+            source_type, source_id = "session_kind", primary.value
+        elif session:
+            source_type, source_id = "session", session.value
+            primary = session
+        else:
+            source_type, source_id = "unknown", "unknown"
+            primary = None
+        return cls(
+            key=f"{source_type}\0{source_id}",
+            source_type=source_type,
+            source_id=source_id,
+            primary=primary,
+            evidence=evidence,
+            session_id=session_id,
+        )
 
 
 @dataclass(frozen=True)
@@ -35,10 +120,8 @@ class CausalFlowProjection:
             source = event.details.get("source", "")
             span_name = event.details.get("span_name", "")
             parent_name = event.details.get("parent_span_name", "")
-            trusted = event.attribution in _TRUSTED_ATTRIBUTION
-
             kind = ""
-            if source == "cloud_trace" and trusted:
+            if source == "cloud_trace":
                 if event.action_type == "model" and span_name.startswith("api."):
                     kind = "model"
                 elif event.action_type in {"tool", "approval"} and parent_name.startswith(
@@ -71,5 +154,5 @@ class CausalFlowProjection:
             f"{self.tool_calls} LLM-produced tool call(s), "
             f"{self.approvals} approval(s), and {self.skill_loads} skill load(s). "
             f"{self.hidden_evidence} transport, lifecycle, duplicate, or "
-            "unattributed evidence record(s) hidden from this flow."
+            "non-work evidence record(s) hidden from this flow."
         )

--- a/admin_console/charts.py
+++ b/admin_console/charts.py
@@ -121,8 +121,17 @@ def causality_sankey(events: list[ActivityEvent]) -> go.Figure:
             event.user_id or event.trigger_kind.value.replace("_", " ").title()
         )
         trigger_color = TRIGGER_COLORS[event.trigger_kind]
-        action_label = event.tool_name or event.action_type.replace("_", " ").title()
-        outcome_label = event.status.title()
+        action_label = (
+            event.tool_name
+            or ("LLM call" if event.action_type == "model" else "")
+            or (
+                event.action_name
+                if event.action_type in {"skill", "approval"}
+                else ""
+            )
+            or event.action_type.replace("_", " ").title()
+        )
+        outcome_label = event.status.replace("_", " ").title()
 
         trigger = node("trigger", trigger_label, trigger_color)
         agent = node("agent", event.agent_name, "#7C9CFF")

--- a/admin_console/charts.py
+++ b/admin_console/charts.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+from html import escape
 
 import plotly.graph_objects as go
 
+from admin_console.causal_flow import CausalSource
 from admin_console.domain import ActivityEvent
 from admin_console.ui import ATTRIBUTION_COLORS, STATUS_COLORS, TRIGGER_COLORS
 
@@ -102,24 +104,67 @@ def attribution_donut(events: list[ActivityEvent]) -> go.Figure:
 
 
 def causality_sankey(events: list[ActivityEvent]) -> go.Figure:
-    """Aggregate trigger → agent → action → outcome edges."""
+    """Aggregate raw OTel origin → agent → action → outcome edges."""
     labels: list[str] = []
     colors: list[str] = []
+    node_details: list[str] = []
     index: dict[tuple[str, str], int] = {}
 
-    def node(stage: str, label: str, color: str) -> int:
-        key = (stage, label)
+    def node(
+        stage: str,
+        label: str,
+        color: str,
+        detail: str = "",
+        identity: str = "",
+    ) -> int:
+        key = (stage, identity or label)
         if key not in index:
             index[key] = len(labels)
             labels.append(label)
             colors.append(color)
+            node_details.append(detail or label)
         return index[key]
 
+    sources = [CausalSource.from_event(event) for event in events]
+    source_sessions: dict[str, set[str]] = defaultdict(set)
+    source_evidence: dict[str, dict[tuple[str, str], set[str]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    for source in sources:
+        if source.session_id:
+            source_sessions[source.key].add(source.session_id)
+        for evidence in source.evidence:
+            source_evidence[source.key][
+                (evidence.scope, evidence.field)
+            ].add(evidence.value)
+
     edge_counts: Counter[tuple[int, int]] = Counter()
-    for event in events:
-        trigger_label = (
-            event.user_id or event.trigger_kind.value.replace("_", " ").title()
+    for event, source in zip(events, sources, strict=True):
+        session_count = len(source_sessions[source.key])
+        session_label = "session" if session_count == 1 else "sessions"
+        source_descriptor = "cron"
+        if source.source_type != "cron":
+            source_descriptor = (
+                source.primary.field if source.primary else "source unavailable"
+            )
+        source_label = (
+            f"{escape(source.source_id)} ({source_descriptor} · "
+            f"{session_count} {session_label})"
         )
+        source_detail_parts = [
+            f"source.type={escape(source.source_type)}",
+            f"source.id={escape(source.source_id)}",
+        ]
+        source_detail_parts.append(f"distinct sessions={session_count}")
+        for (scope, field), raw_values in sorted(
+            source_evidence[source.key].items()
+        ):
+            values = sorted(raw_values)
+            sample = ", ".join(escape(value) for value in values[:5])
+            suffix = "" if len(values) <= 5 else f" (+{len(values) - 5} more)"
+            source_detail_parts.append(
+                f"raw {scope} {field}={sample}{suffix}"
+            )
         trigger_color = TRIGGER_COLORS[event.trigger_kind]
         action_label = (
             event.tool_name
@@ -133,7 +178,13 @@ def causality_sankey(events: list[ActivityEvent]) -> go.Figure:
         )
         outcome_label = event.status.replace("_", " ").title()
 
-        trigger = node("trigger", trigger_label, trigger_color)
+        trigger = node(
+            "trigger",
+            source_label,
+            trigger_color,
+            "<br>".join(source_detail_parts),
+            source.key,
+        )
         agent = node("agent", event.agent_name, "#7C9CFF")
         action = node("action", action_label, "#B58CFF")
         outcome = node(
@@ -155,9 +206,11 @@ def causality_sankey(events: list[ActivityEvent]) -> go.Figure:
             node={
                 "label": labels,
                 "color": colors,
+                "customdata": node_details,
                 "pad": 20,
                 "thickness": 14,
                 "line": {"color": "#26344c", "width": 1},
+                "hovertemplate": "%{customdata}<extra></extra>",
             },
             link={
                 "source": sources,

--- a/admin_console/chat/backend.py
+++ b/admin_console/chat/backend.py
@@ -74,7 +74,7 @@ def persisted_backend_factory(account: str) -> BackendFactory:
 
     def build() -> ChatBackend:
         connection = load_connection(account)
-        if connection is None:
+        if connection is None or not connection.usable:
             raise RuntimeError(
                 "No verified portal connection is available. Open Connection and connect "
                 "to a kube-agents host first."

--- a/admin_console/chat/store.py
+++ b/admin_console/chat/store.py
@@ -215,6 +215,28 @@ def _encode_interaction(interaction: Interaction) -> str:
     return json.dumps(payload, separators=(",", ":"), sort_keys=True)
 
 
+def _decode_task_projection(payload: dict) -> TaskProjection:
+    """Decode known task fields while tolerating additive stored metadata."""
+    return TaskProjection(
+        task_id=str(payload["task_id"]),
+        title=str(payload["title"]),
+        assignee=str(payload["assignee"]),
+        status=str(payload["status"]),
+        summary=str(payload.get("summary") or ""),
+        error=str(payload.get("error") or ""),
+        run_count=int(payload.get("run_count") or 0),
+    )
+
+
+def _decode_tool_call(payload: dict) -> ToolCallEvidence:
+    """Decode known tool fields while tolerating additive stored metadata."""
+    return ToolCallEvidence(
+        name=str(payload["name"]),
+        status=str(payload["status"]),
+        source=str(payload.get("source") or "root_run"),
+    )
+
+
 def _decode_interaction(raw: str) -> Interaction:
     payload = json.loads(raw)
     return Interaction(
@@ -231,9 +253,11 @@ def _decode_interaction(raw: str) -> Interaction:
         error=str(payload.get("error") or ""),
         diagnostics=tuple(str(item) for item in payload.get("diagnostics", [])),
         approval=payload.get("approval"),
-        tasks=tuple(TaskProjection(**task) for task in payload.get("tasks", [])),
+        tasks=tuple(
+            _decode_task_projection(task) for task in payload.get("tasks", [])
+        ),
         tool_calls=tuple(
-            ToolCallEvidence(**tool) for tool in payload.get("tool_calls", [])
+            _decode_tool_call(tool) for tool in payload.get("tool_calls", [])
         ),
     )
 

--- a/admin_console/connection_controller.py
+++ b/admin_console/connection_controller.py
@@ -1,0 +1,394 @@
+"""Single-source connection state machine shared by every portal page."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+
+from admin_console import connections
+from admin_console.connection_persistence import delete_connection, save_connection
+from admin_console.project_config import DeploymentTarget, ProjectCandidate
+
+CONNECTION_CONTROLLER_KEY = "connection_controller"
+CONNECTION_REFRESH_INTERVAL = timedelta(minutes=10)
+
+
+class ConnectionPhase(StrEnum):
+    """A level's complete UI lifecycle."""
+
+    DISCONNECTED = "disconnected"
+    CONNECTING = "connecting"
+    CONNECTED = "connected"
+
+
+class ConnectionAction(StrEnum):
+    PROJECT = "project"
+    CLUSTER = "cluster"
+    REFRESH = "refresh"
+
+
+@dataclass
+class ConnectionLevel:
+    phase: ConnectionPhase = ConnectionPhase.DISCONNECTED
+    report: connections.ConnectionReport | None = None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class ConnectionEvent:
+    action: ConnectionAction
+    outcome: str
+    message: str = ""
+
+
+@dataclass(frozen=True)
+class ConnectionJob:
+    action: ConnectionAction
+    project_id: str
+    target: DeploymentTarget | None
+    future: Future[connections.ConnectionReport]
+
+
+@dataclass
+class ConnectionController:
+    """Own connection selection, transitions, reports, and verified scope.
+
+    This object is the only connection value stored in Streamlit session state.
+    URL parameters and the persisted target are projections of this state, not
+    competing sources of connection truth.
+    """
+
+    account: str
+    project_id: str = ""
+    selected_target: DeploymentTarget | None = None
+    provisioned_target: DeploymentTarget | None = None
+    project_candidates: tuple[ProjectCandidate, ...] = ()
+    project: ConnectionLevel = field(default_factory=ConnectionLevel)
+    cluster: ConnectionLevel = field(default_factory=ConnectionLevel)
+    verified_target: DeploymentTarget | None = None
+    verified_at: datetime | None = None
+    job: ConnectionJob | None = None
+    persistence_error: str = ""
+
+    @property
+    def connected_project(self) -> str | None:
+        if self.project.phase is ConnectionPhase.CONNECTED:
+            return self.project_id
+        return None
+
+    @property
+    def connected_target(self) -> DeploymentTarget | None:
+        if self.cluster.phase is ConnectionPhase.CONNECTED:
+            return self.verified_target
+        return None
+
+    @property
+    def action(self) -> ConnectionAction | None:
+        return self.job.action if self.job is not None else None
+
+    @property
+    def working(self) -> bool:
+        return self.job is not None
+
+    def select_project(self, project_id: str) -> None:
+        """Change disconnected selection and clear all derived state."""
+        if project_id == self.project_id:
+            return
+        if self.connected_project or self.working:
+            return
+        self.project_id = project_id
+        self.selected_target = None
+        self.project = ConnectionLevel()
+        self.cluster = ConnectionLevel()
+        self.verified_target = None
+        self.verified_at = None
+
+    def select_target(self, target: DeploymentTarget | None) -> None:
+        """Change cluster selection without changing connection status."""
+        if not self.connected_project or self.connected_target or self.working:
+            return
+        if target is not None and target.project_id != self.project_id:
+            raise ValueError("cluster selection must belong to the selected project")
+        self.selected_target = target
+        self.cluster = ConnectionLevel()
+
+    def target_for_cluster(
+        self, cluster: connections.ClusterInfo
+    ) -> DeploymentTarget:
+        namespace = (
+            self.provisioned_target.namespace
+            if self.provisioned_target
+            and self.provisioned_target.project_id == self.project_id
+            and self.provisioned_target.cluster_name == cluster.name
+            and self.provisioned_target.location == cluster.location
+            else "kubeagents-system"
+        )
+        return DeploymentTarget(
+            self.project_id,
+            cluster.name,
+            cluster.location,
+            namespace=namespace,
+            source=(
+                "kube-agents-host label"
+                if cluster.is_kube_agents_host
+                else "manual selection"
+            ),
+        )
+
+    def _submit(
+        self,
+        executor: ThreadPoolExecutor,
+        action: ConnectionAction,
+        target: DeploymentTarget | None,
+    ) -> None:
+        if self.working:
+            return
+        future = executor.submit(
+            connections.run_connection_checks,
+            self.project_id,
+            expected_target=target,
+            include_agent_runtime_probe=action is not ConnectionAction.PROJECT,
+            include_telemetry_probes=action is not ConnectionAction.PROJECT,
+        )
+        self.job = ConnectionJob(action, self.project_id, target, future)
+
+    def connect_project(self, executor: ThreadPoolExecutor) -> None:
+        self.disconnect_cluster(delete_persisted=False)
+        self.project = ConnectionLevel(ConnectionPhase.CONNECTING)
+        self._submit(executor, ConnectionAction.PROJECT, None)
+
+    def connect_cluster(self, executor: ThreadPoolExecutor) -> None:
+        if not self.connected_project or self.selected_target is None:
+            return
+        self.cluster = ConnectionLevel(ConnectionPhase.CONNECTING)
+        self._submit(executor, ConnectionAction.CLUSTER, self.selected_target)
+
+    def refresh(self, executor: ThreadPoolExecutor) -> None:
+        if self.connected_target is None or self.working:
+            return
+        self._submit(executor, ConnectionAction.REFRESH, self.connected_target)
+
+    def abort(self) -> ConnectionAction | None:
+        """Detach a pending future; a late result is no longer observable."""
+        job = self.job
+        if job is None:
+            return None
+        self.job = None
+        job.future.cancel()
+        if job.action is ConnectionAction.PROJECT:
+            self.project = ConnectionLevel()
+            self.cluster = ConnectionLevel()
+            self.verified_target = None
+            self.verified_at = None
+        elif job.action is ConnectionAction.CLUSTER:
+            self.cluster = ConnectionLevel()
+            self.verified_target = None
+            self.verified_at = None
+        return job.action
+
+    def disconnect_cluster(self, *, delete_persisted: bool = True) -> None:
+        if self.job and self.job.action is not ConnectionAction.PROJECT:
+            self.abort()
+        self.cluster = ConnectionLevel()
+        self.verified_target = None
+        self.verified_at = None
+        self.persistence_error = ""
+        if delete_persisted:
+            delete_connection()
+
+    def disconnect_project(self) -> None:
+        if self.job:
+            self.abort()
+        self.disconnect_cluster(delete_persisted=False)
+        self.project = ConnectionLevel()
+        self.selected_target = None
+        delete_connection()
+
+    @staticmethod
+    def _failure(
+        report: connections.ConnectionReport,
+        scope: str,
+        keys: tuple[str, ...],
+    ) -> str:
+        checks = {check.key: check for check in report.checks}
+        check = next(
+            (
+                checks[key]
+                for key in keys
+                if key in checks
+                and checks[key].status is not connections.CheckStatus.PASS
+            ),
+            next(
+                (
+                    item
+                    for item in report.checks
+                    if item.status is connections.CheckStatus.FAIL
+                ),
+                None,
+            ),
+        )
+        if check is None:
+            return f"Could not connect to {scope}. Retry the connection."
+        summary = check.summary.strip().rstrip(".")
+        guidance = check.guidance.strip().rstrip(".")
+        detail = f"{check.label}: {summary}."
+        if guidance and guidance.casefold() != summary.casefold():
+            detail += f" {guidance}."
+        return f"Could not connect to {scope}. {detail}"
+
+    def _select_discovered_target(
+        self, report: connections.ConnectionReport
+    ) -> None:
+        current = self.selected_target
+        if current and any(
+            item.name == current.cluster_name and item.location == current.location
+            for item in report.clusters
+        ):
+            return
+        self.selected_target = (
+            self.target_for_cluster(report.kube_agents_hosts[0])
+            if len(report.kube_agents_hosts) == 1
+            else None
+        )
+
+    def _persist(self, target: DeploymentTarget, checked_at: datetime) -> None:
+        try:
+            save_connection(self.account, target, checked_at)
+            self.persistence_error = ""
+        except (OSError, ValueError) as exc:
+            self.persistence_error = (
+                "Connection is active for this browser session but could not be "
+                f"persisted ({type(exc).__name__})."
+            )
+
+    def poll(self) -> ConnectionEvent | None:
+        """Apply one completed job; only the currently attached job can win."""
+        job = self.job
+        if job is None or not job.future.done():
+            return None
+        self.job = None
+        try:
+            report = job.future.result()
+        except Exception as exc:
+            message = (
+                "Connection checks stopped unexpectedly "
+                f"({type(exc).__name__}). Retry Connect."
+            )
+            if job.action is ConnectionAction.PROJECT:
+                self.project = ConnectionLevel(error=message)
+                self.cluster = ConnectionLevel()
+            elif job.action is ConnectionAction.CLUSTER:
+                self.cluster = ConnectionLevel(error=message)
+            else:
+                self.disconnect_cluster()
+                self.cluster.error = "The cluster connection failed revalidation."
+            return ConnectionEvent(job.action, "failed", message)
+
+        if job.action is ConnectionAction.PROJECT:
+            self.project.report = report
+            if connections.project_connection_is_ready(report):
+                self.project.phase = ConnectionPhase.CONNECTED
+                self.project.error = ""
+                self._select_discovered_target(report)
+                return ConnectionEvent(
+                    job.action, "connected", f"Connected to project {job.project_id}."
+                )
+            self.project = ConnectionLevel(
+                report=report,
+                error=self._failure(
+                    report,
+                    f"project {job.project_id}",
+                    ("cli_auth", "project", "gke"),
+                ),
+            )
+            self.cluster = ConnectionLevel()
+            return ConnectionEvent(job.action, "failed", self.project.error)
+
+        target = job.target
+        if job.action is ConnectionAction.CLUSTER:
+            self.cluster.report = report
+            if target is not None and connections.connection_is_ready(report):
+                self.cluster.phase = ConnectionPhase.CONNECTED
+                self.cluster.error = ""
+                self.verified_target = target
+                self.verified_at = report.checked_at
+                self.selected_target = target
+                self._persist(target, report.checked_at)
+                return ConnectionEvent(
+                    job.action, "connected", f"Connected to cluster {target.cluster_name}."
+                )
+            self.cluster = ConnectionLevel(
+                report=report,
+                error=self._failure(
+                    report,
+                    f"cluster {target.cluster_name if target else 'cluster'}",
+                    ("gke", "agent_runtime"),
+                ),
+            )
+            self.verified_target = None
+            self.verified_at = None
+            return ConnectionEvent(job.action, "failed", self.cluster.error)
+
+        self.project.report = report
+        if target is not None and connections.connection_is_ready(report):
+            self.cluster.report = report
+            self.cluster.phase = ConnectionPhase.CONNECTED
+            self.cluster.error = ""
+            self.verified_target = target
+            self.verified_at = report.checked_at
+            self._persist(target, report.checked_at)
+            return ConnectionEvent(job.action, "connected")
+        self.disconnect_cluster()
+        self.cluster = ConnectionLevel(
+            report=report,
+            error=self._failure(
+                report,
+                f"cluster {target.cluster_name if target else 'cluster'}",
+                ("gke", "agent_runtime"),
+            ),
+        )
+        return ConnectionEvent(job.action, "failed", self.cluster.error)
+
+    def refresh_due(self, now: datetime | None = None) -> bool:
+        if self.connected_target is None or self.verified_at is None or self.working:
+            return False
+        now = now or datetime.now(timezone.utc)
+        return now - self.verified_at >= CONNECTION_REFRESH_INTERVAL
+
+    @classmethod
+    def restored(
+        cls,
+        account: str,
+        target: DeploymentTarget,
+        verified_at: datetime,
+    ) -> ConnectionController:
+        """Resume an account-bound disk lease pending immediate revalidation."""
+        return cls(
+            account=account,
+            project_id=target.project_id,
+            selected_target=target,
+            project=ConnectionLevel(ConnectionPhase.CONNECTED),
+            cluster=ConnectionLevel(ConnectionPhase.CONNECTED),
+            verified_target=target,
+            verified_at=verified_at,
+        )
+
+    @classmethod
+    def verified(
+        cls,
+        account: str,
+        target: DeploymentTarget,
+        report: connections.ConnectionReport,
+    ) -> ConnectionController:
+        """Construct verified state for trusted adapters and functional tests."""
+        return cls(
+            account=account,
+            project_id=target.project_id,
+            selected_target=target,
+            project=ConnectionLevel(ConnectionPhase.CONNECTED, report),
+            cluster=ConnectionLevel(ConnectionPhase.CONNECTED, report),
+            verified_target=target,
+            verified_at=report.checked_at,
+        )

--- a/admin_console/connection_controller.py
+++ b/admin_console/connection_controller.py
@@ -6,9 +6,14 @@ from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
+from threading import Event
 
 from admin_console import connections
-from admin_console.connection_persistence import delete_connection, save_connection
+from admin_console.connection_persistence import (
+    delete_connection,
+    load_connection,
+    save_connection,
+)
 from admin_console.project_config import DeploymentTarget, ProjectCandidate
 
 CONNECTION_CONTROLLER_KEY = "connection_controller"
@@ -49,6 +54,7 @@ class ConnectionJob:
     project_id: str
     target: DeploymentTarget | None
     future: Future[connections.ConnectionReport]
+    cancel_event: Event
 
 
 @dataclass
@@ -71,6 +77,7 @@ class ConnectionController:
     verified_at: datetime | None = None
     job: ConnectionJob | None = None
     persistence_error: str = ""
+    persisted_lease: bool = False
 
     @property
     def connected_project(self) -> str | None:
@@ -145,14 +152,18 @@ class ConnectionController:
     ) -> None:
         if self.working:
             return
+        cancel_event = Event()
         future = executor.submit(
             connections.run_connection_checks,
             self.project_id,
             expected_target=target,
             include_agent_runtime_probe=action is not ConnectionAction.PROJECT,
             include_telemetry_probes=action is not ConnectionAction.PROJECT,
+            cancel_event=cancel_event,
         )
-        self.job = ConnectionJob(action, self.project_id, target, future)
+        self.job = ConnectionJob(
+            action, self.project_id, target, future, cancel_event
+        )
 
     def connect_project(self, executor: ThreadPoolExecutor) -> None:
         self.disconnect_cluster(delete_persisted=False)
@@ -170,12 +181,19 @@ class ConnectionController:
             return
         self._submit(executor, ConnectionAction.REFRESH, self.connected_target)
 
+    def resume(self, executor: ThreadPoolExecutor) -> None:
+        """Revalidate a retained target that is not currently usable."""
+        if self.selected_target is None or self.working:
+            return
+        self._submit(executor, ConnectionAction.REFRESH, self.selected_target)
+
     def abort(self) -> ConnectionAction | None:
-        """Detach a pending future; a late result is no longer observable."""
+        """Detach an explicit connection attempt; refresh is not user-abortable."""
         job = self.job
-        if job is None:
+        if job is None or job.action is ConnectionAction.REFRESH:
             return None
         self.job = None
+        job.cancel_event.set()
         job.future.cancel()
         if job.action is ConnectionAction.PROJECT:
             self.project = ConnectionLevel()
@@ -188,15 +206,24 @@ class ConnectionController:
             self.verified_at = None
         return job.action
 
+    def _detach_non_project_job(self) -> None:
+        """Detach cluster work so an explicit disconnect cannot be undone."""
+        job = self.job
+        if job is None or job.action is ConnectionAction.PROJECT:
+            return
+        self.job = None
+        job.cancel_event.set()
+        job.future.cancel()
+
     def disconnect_cluster(self, *, delete_persisted: bool = True) -> None:
-        if self.job and self.job.action is not ConnectionAction.PROJECT:
-            self.abort()
+        self._detach_non_project_job()
         self.cluster = ConnectionLevel()
         self.verified_target = None
         self.verified_at = None
         self.persistence_error = ""
         if delete_persisted:
             delete_connection()
+        self.persisted_lease = False
 
     def disconnect_project(self) -> None:
         if self.job:
@@ -257,11 +284,59 @@ class ConnectionController:
         try:
             save_connection(self.account, target, checked_at)
             self.persistence_error = ""
+            self.persisted_lease = True
         except (OSError, ValueError) as exc:
+            self.persisted_lease = False
             self.persistence_error = (
                 "Connection is active for this browser session but could not be "
                 f"persisted ({type(exc).__name__})."
             )
+
+    def _require_revalidation(
+        self, target: DeploymentTarget, verified_at: datetime | None
+    ) -> None:
+        """Retain selection while preventing API use of a failed lease."""
+        try:
+            save_connection(
+                self.account,
+                target,
+                verified_at or datetime.now(timezone.utc),
+                usable=False,
+            )
+            self.persistence_error = ""
+            self.persisted_lease = True
+        except (OSError, ValueError) as exc:
+            try:
+                delete_connection()
+            except OSError:
+                pass
+            self.persistence_error = (
+                "The connection could not be marked for revalidation "
+                f"({type(exc).__name__}); its saved target was removed."
+            )
+            self.persisted_lease = False
+
+    def reconcile_persisted_lease(self) -> bool:
+        """Detach a stale tab after another tab changes the shared lease."""
+        if not self.persisted_lease:
+            return False
+        target = self.connected_target or self.selected_target
+        if target is None:
+            return False
+        expected_usable = self.connected_target is not None
+        persisted = load_connection(self.account)
+        if (
+            persisted
+            and persisted.usable is expected_usable
+            and persisted.target == target
+        ):
+            return False
+        self.disconnect_cluster(delete_persisted=False)
+        self.cluster.error = (
+            "The saved cluster connection changed in another portal tab. "
+            "Connect again."
+        )
+        return True
 
     def poll(self) -> ConnectionEvent | None:
         """Apply one completed job; only the currently attached job can win."""
@@ -282,8 +357,17 @@ class ConnectionController:
             elif job.action is ConnectionAction.CLUSTER:
                 self.cluster = ConnectionLevel(error=message)
             else:
-                self.disconnect_cluster()
-                self.cluster.error = "The cluster connection failed revalidation."
+                failed_target = job.target
+                failed_verified_at = self.verified_at
+                self.disconnect_cluster(delete_persisted=False)
+                if failed_target is not None:
+                    self._require_revalidation(
+                        failed_target, failed_verified_at
+                    )
+                self.cluster.error = (
+                    "Cluster revalidation stopped unexpectedly "
+                    f"({type(exc).__name__}). Connect again."
+                )
             return ConnectionEvent(job.action, "failed", message)
 
         if job.action is ConnectionAction.PROJECT:
@@ -340,7 +424,10 @@ class ConnectionController:
             self.verified_at = report.checked_at
             self._persist(target, report.checked_at)
             return ConnectionEvent(job.action, "connected")
-        self.disconnect_cluster()
+        failed_verified_at = self.verified_at
+        self.disconnect_cluster(delete_persisted=False)
+        if target is not None:
+            self._require_revalidation(target, failed_verified_at)
         self.cluster = ConnectionLevel(
             report=report,
             error=self._failure(
@@ -363,6 +450,8 @@ class ConnectionController:
         account: str,
         target: DeploymentTarget,
         verified_at: datetime,
+        *,
+        usable: bool = True,
     ) -> ConnectionController:
         """Resume an account-bound disk lease pending immediate revalidation."""
         return cls(
@@ -370,9 +459,14 @@ class ConnectionController:
             project_id=target.project_id,
             selected_target=target,
             project=ConnectionLevel(ConnectionPhase.CONNECTED),
-            cluster=ConnectionLevel(ConnectionPhase.CONNECTED),
-            verified_target=target,
+            cluster=ConnectionLevel(
+                ConnectionPhase.CONNECTED
+                if usable
+                else ConnectionPhase.DISCONNECTED
+            ),
+            verified_target=target if usable else None,
             verified_at=verified_at,
+            persisted_lease=True,
         )
 
     @classmethod

--- a/admin_console/connection_gate.py
+++ b/admin_console/connection_gate.py
@@ -4,28 +4,26 @@ from __future__ import annotations
 
 import streamlit as st
 
+from admin_console.connection_controller import (
+    CONNECTION_CONTROLLER_KEY,
+    ConnectionController,
+)
 from admin_console.project_config import DeploymentTarget
 
 
 def current_connection() -> DeploymentTarget | None:
-    """Return the verified connection only when it matches the current scope."""
-    target = st.session_state.get("connected_target")
-    if not isinstance(target, DeploymentTarget):
+    """Read the same verified target used by Connection's controls."""
+    controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
+    if not isinstance(controller, ConnectionController):
         return None
-    if (
-        target.project_id != st.session_state.get("selected_project", "")
-        or target.cluster_name != st.session_state.get("selected_cluster", "")
-        or target.location != st.session_state.get("selected_location", "")
-    ):
-        return None
-    return target
+    return controller.connected_target
 
 
 def require_connection() -> DeploymentTarget:
     """Stop a provider-backed page after rendering consistent connect guidance."""
     target = current_connection()
     if target is None:
-        st.info("Connect to kube-agents on Connection.")
+        st.info("Connect a project and cluster on Connection.")
         st.page_link(
             "pages/connections.py",
             label="Open Connection",

--- a/admin_console/connection_persistence.py
+++ b/admin_console/connection_persistence.py
@@ -18,7 +18,7 @@ from admin_console.project_config import (
     is_valid_project_id,
 )
 
-STATE_VERSION = 1
+STATE_VERSION = 2
 MAX_STATE_BYTES = 4096
 
 
@@ -27,6 +27,7 @@ class PersistedConnection:
     target: DeploymentTarget
     account: str
     verified_at: datetime
+    usable: bool
 
 
 def connection_state_path() -> Path:
@@ -52,7 +53,7 @@ def load_connection(account: str) -> PersistedConnection | None:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (FileNotFoundError, OSError, json.JSONDecodeError):
         return None
-    if not isinstance(payload, dict) or payload.get("version") != STATE_VERSION:
+    if not isinstance(payload, dict) or payload.get("version") not in {1, STATE_VERSION}:
         return None
     stored_account = str(payload.get("account", ""))
     if not account or stored_account != account:
@@ -85,10 +86,16 @@ def load_connection(account: str) -> PersistedConnection | None:
         "persisted selection",
     }:
         source = "persisted selection"
+    status = (
+        "verified" if payload.get("version") == 1 else payload.get("status")
+    )
+    if status not in {"verified", "revalidation_required"}:
+        return None
     return PersistedConnection(
         DeploymentTarget(project_id, cluster_name, location, namespace, source),
         stored_account,
         verified_at,
+        status == "verified",
     )
 
 
@@ -96,6 +103,8 @@ def save_connection(
     account: str,
     target: DeploymentTarget,
     verified_at: datetime,
+    *,
+    usable: bool = True,
 ) -> None:
     """Atomically persist connection metadata with owner-only permissions."""
     if not account:
@@ -123,6 +132,7 @@ def save_connection(
         "location": target.location,
         "namespace": target.namespace,
         "source": target.source,
+        "status": "verified" if usable else "revalidation_required",
         "verified_at": verified_at.astimezone(timezone.utc).isoformat(),
     }
     descriptor, temporary_name = tempfile.mkstemp(

--- a/admin_console/connection_persistence.py
+++ b/admin_console/connection_persistence.py
@@ -34,9 +34,7 @@ def connection_state_path() -> Path:
     override = os.environ.get("KUBE_AGENTS_ADMIN_CONNECTION_STATE", "").strip()
     if override:
         return Path(override).expanduser()
-    state_root = os.environ.get("XDG_STATE_HOME", "").strip()
-    root = Path(state_root).expanduser() if state_root else Path.home() / ".local/state"
-    return root / "kube-agents" / "admin-portal-connection.json"
+    return Path.home() / ".kube-agent" / "state" / "admin-portal-connection.json"
 
 
 def load_connection(account: str) -> PersistedConnection | None:

--- a/admin_console/connection_session.py
+++ b/admin_console/connection_session.py
@@ -1,0 +1,175 @@
+"""Idempotent Streamlit-session bootstrap for the shared connection controller."""
+
+from __future__ import annotations
+
+import os
+import runpy
+from concurrent.futures import Executor
+from pathlib import Path
+
+import streamlit as st
+
+from admin_console.connection_controller import (
+    CONNECTION_CONTROLLER_KEY,
+    ConnectionController,
+)
+from admin_console.connection_persistence import load_connection
+from admin_console.project_config import (
+    DeploymentTarget,
+    build_project_candidates,
+    is_valid_cluster_name,
+    is_valid_location,
+    is_valid_project_id,
+    load_provisioned_target,
+)
+
+APP_SHELL_ACTIVE_KEY = "connection_app_shell_active"
+
+
+def recover_app_shell() -> None:
+    """Render the normal shell when Streamlit resumes a page as its script."""
+    if st.session_state.get(APP_SHELL_ACTIVE_KEY, False):
+        return
+    # Execute rather than import so every browser session can recover even
+    # after the module was loaded by another session in this server process.
+    # Its navigation executes this page again with the shell marker set;
+    # stopping then prevents the outer copy from rendering a second time.
+    app_path = Path(__file__).resolve().with_name("app.py")
+    runpy.run_path(str(app_path), run_name="__kube_agents_portal_shell__")
+    st.stop()
+
+
+def initialize_connection_controller(
+    package_parent: Path,
+    executor: Executor,
+) -> ConnectionController:
+    """Return the session controller, creating it when a page loads directly.
+
+    Streamlit can resume a selected page without first executing ``app.py``
+    after a development-server rebuild. Keeping bootstrap here makes that path
+    equivalent to entering through the application shell.
+    """
+    authenticated_user = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
+    if not authenticated_user:
+        st.error(
+            "No verified local identity is available. Start the portal with "
+            "`scripts/admin_portal.sh` so the active gcloud login can be verified."
+        )
+        st.stop()
+    st.session_state.authenticated_user = authenticated_user
+    persisted_connection = load_connection(authenticated_user)
+
+    provisioned_target = load_provisioned_target(
+        package_parent / "k8s-operator" / "scripts" / "vars.sh"
+    )
+    query_project = str(st.query_params.get("project", "")).strip()
+    configured_project = os.environ.get("KUBE_AGENTS_GCLOUD_PROJECT", "").strip()
+    persisted_project = (
+        persisted_connection.target.project_id if persisted_connection else ""
+    )
+    project_candidates = build_project_candidates(
+        provisioned_target,
+        configured_project,
+        query_project,
+        persisted_project,
+    )
+    project_ids = [candidate.project_id for candidate in project_candidates]
+
+    query_cluster = str(st.query_params.get("cluster", "")).strip()
+    query_location = str(st.query_params.get("location", "")).strip()
+    initial_project = (
+        query_project
+        if is_valid_project_id(query_project)
+        else persisted_project or (project_ids[0] if project_ids else "")
+    )
+    initial_target = None
+    if is_valid_cluster_name(query_cluster) and is_valid_location(query_location):
+        namespace = (
+            provisioned_target.namespace
+            if provisioned_target
+            and provisioned_target.project_id == initial_project
+            and provisioned_target.cluster_name == query_cluster
+            and provisioned_target.location == query_location
+            else "kubeagents-system"
+        )
+        initial_target = DeploymentTarget(
+            initial_project,
+            query_cluster,
+            query_location,
+            namespace,
+            "manual selection",
+        )
+    elif (
+        persisted_connection
+        and persisted_connection.target.project_id == initial_project
+    ):
+        initial_target = persisted_connection.target
+
+    controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
+    if not isinstance(controller, ConnectionController):
+        persisted_scope_matches = bool(
+            persisted_connection
+            and initial_target
+            and (
+                initial_target.project_id,
+                initial_target.cluster_name,
+                initial_target.location,
+                initial_target.namespace,
+            )
+            == (
+                persisted_connection.target.project_id,
+                persisted_connection.target.cluster_name,
+                persisted_connection.target.location,
+                persisted_connection.target.namespace,
+            )
+        )
+        if persisted_connection and persisted_scope_matches:
+            controller = ConnectionController.restored(
+                authenticated_user,
+                persisted_connection.target,
+                persisted_connection.verified_at,
+                usable=persisted_connection.usable,
+            )
+            controller.provisioned_target = provisioned_target
+            controller.project_candidates = tuple(project_candidates)
+            if persisted_connection.usable:
+                controller.refresh(executor)
+            else:
+                controller.resume(executor)
+        else:
+            controller = ConnectionController(
+                account=authenticated_user,
+                project_id=initial_project,
+                selected_target=initial_target,
+                provisioned_target=provisioned_target,
+                project_candidates=tuple(project_candidates),
+            )
+        st.session_state[CONNECTION_CONTROLLER_KEY] = controller
+    else:
+        controller.account = authenticated_user
+        controller.provisioned_target = provisioned_target
+        controller.project_candidates = tuple(project_candidates)
+        if not controller.connected_project and not controller.working:
+            requested_project = (
+                query_project
+                if is_valid_project_id(query_project)
+                else controller.project_id or initial_project
+            )
+            controller.select_project(requested_project)
+            explicit_target = (
+                initial_target
+                if is_valid_cluster_name(query_cluster)
+                and is_valid_location(query_location)
+                else None
+            )
+            if explicit_target and explicit_target.project_id == controller.project_id:
+                controller.selected_target = explicit_target
+            elif controller.selected_target is None and initial_target:
+                controller.selected_target = initial_target
+
+    if controller.project_id:
+        st.query_params["project"] = controller.project_id
+    if controller.selected_target:
+        st.query_params["cluster"] = controller.selected_target.cluster_name
+        st.query_params["location"] = controller.selected_target.location
+    return controller

--- a/admin_console/connection_sidebar.py
+++ b/admin_console/connection_sidebar.py
@@ -1,313 +1,130 @@
-"""Connection lifecycle and Setup-page controls."""
+"""Connection page rendering over the shared connection controller."""
 
 from __future__ import annotations
 
-from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from concurrent.futures import ThreadPoolExecutor
 
 import streamlit as st
 
 from admin_console import connections
-from admin_console.connection_persistence import (
-    PersistedConnection,
-    delete_connection,
-    save_connection,
+from admin_console.connection_controller import (
+    CONNECTION_CONTROLLER_KEY,
+    ConnectionAction,
+    ConnectionController,
+    ConnectionPhase,
 )
-from admin_console.project_config import (
-    DeploymentTarget,
-    is_valid_cluster_name,
-    is_valid_location,
-    is_valid_project_id,
-)
-
-CONNECTION_REFRESH_INTERVAL = timedelta(minutes=10)
-CONNECTION_ACTION_KEY = "connection_action"
-CONNECTION_JOB_KEY = "connection_job"
-CONNECTION_ACTIONS = {"connect", "select", "restore", "refresh"}
-
-
-@dataclass(frozen=True)
-class ConnectionJob:
-    """One cloud verification running outside Streamlit's render thread."""
-
-    kind: str
-    project_id: str
-    expected_target: DeploymentTarget | None
-    future: Future[connections.ConnectionReport]
+from admin_console.project_config import is_valid_project_id
 
 
 @st.cache_resource
-def _connection_executor() -> ThreadPoolExecutor:
+def connection_executor() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=2, thread_name_prefix="kube-agents-connect")
 
 
-def clear_connected_state() -> None:
-    """Forget the verified target and its derived providers, but retain scope."""
-    for key in (
-        "connected_target",
-        "telemetry_provider",
-        "telemetry_provider_key",
-        "telemetry_refresh",
-        "connection_last_verified_at",
-    ):
-        st.session_state.pop(key, None)
-
-
-def _persist_connection(
-    target: DeploymentTarget,
-    verified_at: datetime,
-) -> None:
-    """Persist only non-secret target metadata for the verified local account."""
-    try:
-        save_connection(
-            str(st.session_state.get("authenticated_user", "")),
-            target,
-            verified_at,
-        )
-        st.session_state.persisted_connection = PersistedConnection(
-            target,
-            str(st.session_state.get("authenticated_user", "")),
-            verified_at,
-        )
-        st.session_state.pop("connection_persistence_error", None)
-    except (OSError, ValueError) as exc:
-        st.session_state.connection_persistence_error = (
-            f"Connection is active for this browser session but could not be "
-            f"persisted ({type(exc).__name__})."
-        )
-
-
-def _mark_connected(
-    target: DeploymentTarget,
-    report: connections.ConnectionReport,
-) -> None:
-    st.session_state.connected_target = target
-    st.session_state.connection_last_verified_at = report.checked_at
-    _persist_connection(target, report.checked_at)
-
-
-def _set_scope(project_id: str, cluster_name: str = "", location: str = "") -> None:
-    st.session_state.selected_project = project_id
-    st.query_params["project"] = project_id
-    if is_valid_cluster_name(cluster_name) and is_valid_location(location):
-        st.session_state.selected_cluster = cluster_name
-        st.session_state.selected_location = location
-        st.query_params["cluster"] = cluster_name
-        st.query_params["location"] = location
-    else:
-        st.session_state.pop("selected_cluster", None)
-        st.session_state.pop("selected_location", None)
-        st.query_params.pop("cluster", None)
-        st.query_params.pop("location", None)
-
-
-def _target_for_cluster(
-    project_id: str, cluster: connections.ClusterInfo
-) -> DeploymentTarget:
-    provisioned = st.session_state.get("provisioned_target")
-    namespace = (
-        provisioned.namespace
-        if provisioned
-        and provisioned.project_id == project_id
-        and provisioned.cluster_name == cluster.name
-        and provisioned.location == cluster.location
-        else "kubeagents-system"
-    )
-    return DeploymentTarget(
-        project_id,
-        cluster.name,
-        cluster.location,
-        namespace=namespace,
-        source=(
-            "kube-agents-host label"
-            if cluster.is_kube_agents_host
-            else "manual selection"
-        ),
-    )
-
-
-def _start_connection_job(
-    kind: str,
-    project_id: str,
-    expected_target: DeploymentTarget | None,
-) -> None:
-    """Submit a connection check without blocking the page render."""
-    future = _connection_executor().submit(
-        connections.run_connection_checks,
-        project_id,
-        expected_target=expected_target,
-        include_agent_runtime_probe=True,
-    )
-    st.session_state[CONNECTION_ACTION_KEY] = {
-        "kind": kind,
-        "project_id": project_id,
-        "target": expected_target,
-    }
-    st.session_state[CONNECTION_JOB_KEY] = ConnectionJob(
-        kind,
-        project_id,
-        expected_target,
-        future,
-    )
-
-
-def _finish_connection_job(job: ConnectionJob) -> None:
-    """Apply a completed background check on Streamlit's render thread."""
-    try:
-        report = job.future.result()
-        st.session_state[f"connection_report:{job.project_id}"] = report
-        target = job.expected_target
-        if job.kind == "connect":
-            if len(report.kube_agents_hosts) == 1:
-                target = _target_for_cluster(job.project_id, report.kube_agents_hosts[0])
-                _set_scope(job.project_id, target.cluster_name, target.location)
-            elif report.clusters:
-                _set_scope(job.project_id)
-
-        if connections.connection_is_ready(report) and target is not None:
-            _mark_connected(target, report)
-            _set_scope(target.project_id, target.cluster_name, target.location)
-            if job.kind in {"connect", "select"}:
-                st.toast(f"Connected to {target.cluster_name}.")
-        elif job.kind == "refresh":
-            clear_connected_state()
-            st.session_state.connection_refresh_failed = True
-        elif job.kind == "restore":
-            st.session_state.connection_action_error = (
-                "The saved connection failed verification. Retry Connect."
-            )
-    except Exception as exc:
-        if job.kind == "refresh":
-            clear_connected_state()
-            st.session_state.connection_refresh_failed = True
-        elif job.kind == "restore":
-            st.session_state.connection_action_error = (
-                "The saved connection could not be restored "
-                f"({type(exc).__name__}). Retry Connect."
-            )
-        else:
-            st.session_state.connection_action_error = (
-                "Connection checks stopped unexpectedly "
-                f"({type(exc).__name__}). Retry Connect."
-            )
-    finally:
-        st.session_state.pop(CONNECTION_ACTION_KEY, None)
-        st.session_state.pop(CONNECTION_JOB_KEY, None)
-    st.rerun(scope="app")
-
-
-def _job_status_label(kind: str) -> str:
-    return {
-        "connect": "Connecting to kube-agents…",
-        "select": "Verifying the selected cluster…",
-        "restore": "Restoring and verifying your saved connection…",
-        "refresh": "Revalidating your connection…",
-    }.get(kind, "Checking the connection…")
+def connection_controller() -> ConnectionController:
+    controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
+    if not isinstance(controller, ConnectionController):
+        raise RuntimeError("connection controller is not initialized")
+    return controller
 
 
 @st.fragment(run_every=1)
 def maintain_connection() -> None:
-    """Start and observe connection work without blocking the application UI."""
-    job = st.session_state.get(CONNECTION_JOB_KEY)
-    if isinstance(job, ConnectionJob):
-        status = st.status(
-            _job_status_label(job.kind),
-            state="running",
-            expanded=True,
-        )
-        status.caption("You can continue using the navigation while this finishes.")
-        if job.future.done():
-            _finish_connection_job(job)
-        return
-
-    pending_action = st.session_state.get(CONNECTION_ACTION_KEY)
-    if isinstance(pending_action, dict):
-        kind = str(pending_action.get("kind", ""))
-        project_id = str(pending_action.get("project_id", ""))
-        target = pending_action.get("target")
-        if (
-            kind in {"connect", "select"}
-            and is_valid_project_id(project_id)
-            and (target is None or isinstance(target, DeploymentTarget))
-        ):
-            _start_connection_job(kind, project_id, target)
-            st.rerun(scope="app")
-        st.session_state.pop(CONNECTION_ACTION_KEY, None)
-
-    active_target = st.session_state.get("connected_target")
-    is_connected = active_target is not None
-    current_project = str(st.session_state.get("selected_project", "")).strip()
-
-    persisted = st.session_state.get("persisted_connection")
-    restore_key = ""
-    if isinstance(persisted, PersistedConnection):
-        target = persisted.target
-        restore_key = f"{target.project_id}|{target.cluster_name}|{target.location}"
-        scope_matches = (
-            target.project_id == current_project
-            and target.cluster_name == st.session_state.get("selected_cluster", "")
-            and target.location == st.session_state.get("selected_location", "")
-        )
-        if (
-            not is_connected
-            and scope_matches
-            and st.session_state.get("connection_restore_attempted") != restore_key
-        ):
-            st.session_state.connection_restore_attempted = restore_key
-            _start_connection_job("restore", target.project_id, target)
-            st.rerun(scope="app")
-            return
-
-    last_verified = st.session_state.get("connection_last_verified_at")
-    existing_report = (
-        st.session_state.get(f"connection_report:{active_target.project_id}")
-        if is_connected
-        else None
-    )
-    if (
-        is_connected
-        and not isinstance(last_verified, datetime)
-        and isinstance(existing_report, connections.ConnectionReport)
-        and connections.connection_is_ready(existing_report)
-    ):
-        _mark_connected(active_target, existing_report)
-        last_verified = existing_report.checked_at
-    refresh_due = (
-        is_connected
-        and isinstance(last_verified, datetime)
-        and datetime.now(timezone.utc) - last_verified >= CONNECTION_REFRESH_INTERVAL
-    )
-    if refresh_due:
-        _start_connection_job("refresh", active_target.project_id, active_target)
+    """Poll the one session controller and schedule bounded revalidation."""
+    controller = connection_controller()
+    event = controller.poll()
+    if event is not None:
+        if event.outcome == "connected" and event.message:
+            st.toast(event.message)
         st.rerun(scope="app")
+
+    if controller.refresh_due():
+        controller.refresh(connection_executor())
+        st.rerun(scope="app")
+
+    job = controller.job
+    if job is None:
+        return
+    label = {
+        ConnectionAction.PROJECT: "Connecting to the selected project…",
+        ConnectionAction.CLUSTER: "Connecting to the selected cluster…",
+        ConnectionAction.REFRESH: "Revalidating the cluster connection…",
+    }[job.action]
+    status = st.status(label, state="running", expanded=True)
+    status.caption("You can continue using the navigation while this finishes.")
+
+
+def _render_connection_actions(
+    key: str,
+    *,
+    connected: bool,
+    connecting: bool,
+    blocked: bool = False,
+    connect_disabled: bool = False,
+    can_disconnect: bool = False,
+) -> tuple[bool, bool]:
+    """Render one primary action and only the currently relevant escape action."""
+    show_secondary = connecting or (connected and can_disconnect)
+    if show_secondary:
+        primary, secondary = st.columns(2)
+    else:
+        primary = st.container()
+        secondary = None
+    if connecting:
+        primary_label = "Connecting…"
+        primary_icon = ":material/progress_activity:"
+        state = "connecting"
+    elif connected:
+        primary_label = "Connected"
+        primary_icon = ":material/check_circle:"
+        state = "connected"
+    else:
+        primary_label = "Connect"
+        primary_icon = ":material/cable:"
+        state = "disconnected"
+    primary_clicked = primary.button(
+        primary_label,
+        type="primary",
+        icon=primary_icon,
+        width="stretch",
+        disabled=(connected or connecting or blocked or connect_disabled),
+        key=f"{key}_primary_{state}",
+    )
+    secondary_clicked = False
+    if secondary is not None:
+        secondary_clicked = secondary.button(
+            "Abort" if connecting else "Disconnect",
+            icon=(":material/cancel:" if connecting else ":material/link_off:"),
+            width="stretch",
+            disabled=blocked,
+            key=f"{key}_secondary_{'abort' if connecting else 'disconnect'}",
+        )
+    return primary_clicked, secondary_clicked
+
+
+def _cluster_key(cluster: connections.ClusterInfo) -> str:
+    return f"{cluster.name}|{cluster.location}"
 
 
 def render_connection_controls() -> None:
-    """Render project, cluster, connect, and disconnect controls on Setup."""
-    active_target = st.session_state.get("connected_target")
-    is_connected = active_target is not None
-    current_project = str(st.session_state.get("selected_project", "")).strip()
-
-    candidates = st.session_state.get("project_candidates", ())
-    candidate_sources = st.session_state.get("project_candidate_sources", {})
+    """Render project and cluster controls from the same state pages consume."""
+    controller = connection_controller()
+    candidates = controller.project_candidates
+    candidate_sources = {
+        candidate.project_id: candidate.source for candidate in candidates
+    }
     project_ids = [candidate.project_id for candidate in candidates]
     preferred_index = (
-        project_ids.index(current_project)
-        if current_project in project_ids
+        project_ids.index(controller.project_id)
+        if controller.project_id in project_ids
         else (0 if project_ids else None)
     )
-    pending_action = st.session_state.get(CONNECTION_ACTION_KEY)
-    action_kind = (
-        str(pending_action.get("kind", ""))
-        if isinstance(pending_action, dict)
-        else ""
-    )
-    if action_kind not in CONNECTION_ACTIONS:
-        action_kind = ""
-    is_working = bool(action_kind)
+    project_connecting = controller.action is ConnectionAction.PROJECT
+    project_connected = controller.project.phase is ConnectionPhase.CONNECTED
 
-    with st.container():
+    with st.container(border=True):
+        st.markdown("#### Step 1 · Project")
+        st.caption("Verify Google Cloud access and discover clusters.")
         selected_option = st.selectbox(
             "Project",
             project_ids,
@@ -319,177 +136,162 @@ def render_connection_controls() -> None:
             ),
             placeholder="Select or enter a Google Cloud project ID",
             accept_new_options=True,
-            disabled=is_connected or is_working,
+            disabled=project_connected or controller.working,
+            label_visibility="collapsed",
             key="connection_project_option",
         )
-        requested_project = str(selected_option or "").strip()
-        project_is_valid = is_valid_project_id(requested_project)
-        if requested_project and not project_is_valid:
+        project_id = str(selected_option or "").strip()
+        project_is_valid = is_valid_project_id(project_id)
+        if project_id and not project_is_valid:
             st.error("Enter a valid Google Cloud project ID.")
-
-        if (
-            not is_connected
-            and project_is_valid
-            and requested_project != current_project
-        ):
-            clear_connected_state()
-            _set_scope(requested_project)
+        if project_is_valid and project_id != controller.project_id:
+            controller.select_project(project_id)
+            st.query_params["project"] = project_id
+            st.query_params.pop("cluster", None)
+            st.query_params.pop("location", None)
             st.rerun()
 
-        project_id = requested_project
-        report = (
-            st.session_state.get(f"connection_report:{project_id}")
-            if project_is_valid
-            else None
-        )
-        host_count = len(report.kube_agents_hosts) if report else 0
-        manual_selection_required = bool(
-            report and report.clusters and host_count != 1 and not is_connected
-        )
-        if is_connected:
-            st.caption(
-                f"Cluster: {active_target.cluster_name} · {active_target.location}"
+        project_connect_clicked, project_secondary_clicked = (
+            _render_connection_actions(
+                "project_connection",
+                connected=project_connected,
+                connecting=project_connecting,
+                blocked=controller.working and not project_connecting,
+                connect_disabled=not project_is_valid,
+                can_disconnect=(
+                    project_connected
+                    and controller.connected_target is None
+                    and not controller.working
+                ),
             )
-        else:
-            st.caption("Cluster is selected automatically from kube-agents-host=true.")
-
-        connect, disconnect = st.columns(2)
-        connecting = action_kind in {"connect", "restore"}
-        if is_connected:
-            connect_label = "Connected"
-            connect_icon = ":material/check_circle:"
-        elif connecting:
-            connect_label = "Connecting…"
-            connect_icon = ":material/progress_activity:"
-        else:
-            connect_label = "Connect"
-            connect_icon = ":material/cable:"
-        connect_clicked = connect.button(
-            connect_label,
-            type="primary",
-            icon=connect_icon,
-            width="stretch",
-            disabled=(
-                is_connected
-                or manual_selection_required
-                or is_working
-                or not project_is_valid
-            ),
-            key=(
-                "connect_to_kube_agents_busy"
-                if connecting
-                else "connect_to_kube_agents"
-            ),
         )
-        disconnect_clicked = disconnect.button(
-            "Disconnect",
-            icon=":material/link_off:",
-            width="stretch",
-            disabled=not is_connected or is_working,
-            key="disconnect_project",
-        )
-
-        if disconnect_clicked:
-            clear_connected_state()
-            delete_connection()
-            st.session_state.persisted_connection = None
-            st.session_state.pop("connection_restore_attempted", None)
-            st.toast("Disconnected from kube-agents.")
+        if project_connect_clicked:
+            controller.connect_project(connection_executor())
             st.rerun()
-
-        if connect_clicked:
-            st.session_state[CONNECTION_ACTION_KEY] = {
-                "kind": "connect",
-                "project_id": project_id,
-            }
-            st.rerun()
-
-        cluster_by_key: dict[str, connections.ClusterInfo] = {}
-        if manual_selection_required:
-            if host_count == 0:
-                st.error(
-                    "Automatic cluster detection failed: no GKE cluster is labeled "
-                    "kube-agents-host=true. Select the cluster that hosts kube-agents."
-                )
+        if project_secondary_clicked:
+            if project_connecting:
+                controller.abort()
+                st.toast("Project connection aborted.")
             else:
-                st.error(
-                    "Automatic cluster detection failed: "
-                    f"{host_count} GKE clusters are labeled kube-agents-host=true. "
-                    "Select the intended host."
-                )
+                controller.disconnect_project()
+                st.query_params.pop("cluster", None)
+                st.query_params.pop("location", None)
+                st.toast("Disconnected from project.")
+            st.rerun()
+        if controller.project.error and not project_connecting:
+            st.error(controller.project.error)
 
-            ordered_clusters = sorted(
-                report.clusters,
-                key=lambda cluster: (
-                    not cluster.is_kube_agents_host,
-                    cluster.name,
-                    cluster.location,
-                ),
-            )
-            cluster_by_key = {
-                f"{cluster.name}|{cluster.location}": cluster
-                for cluster in ordered_clusters
-            }
+    if not project_connected:
+        with st.container(border=True):
+            st.markdown("#### Step 2 · Cluster")
+            st.caption("Connect the project to choose its kube-agents host.")
+        return
 
-            def cluster_label(key: str) -> str:
-                cluster = cluster_by_key[key]
-                suffix = " · kube-agents host" if cluster.is_kube_agents_host else ""
-                return f"{cluster.name} · {cluster.location}{suffix}"
+    report = controller.project.report
+    clusters = report.clusters if report else ()
+    verified_target = controller.connected_target
+    if verified_target and not any(
+        item.name == verified_target.cluster_name
+        and item.location == verified_target.location
+        for item in clusters
+    ):
+        clusters = (
+            *clusters,
+            connections.ClusterInfo(
+                verified_target.cluster_name,
+                verified_target.location,
+                "RUNNING",
+                verified_target.source == "kube-agents-host label",
+            ),
+        )
+    ordered_clusters = sorted(
+        clusters,
+        key=lambda cluster: (
+            not cluster.is_kube_agents_host,
+            cluster.name,
+            cluster.location,
+        ),
+    )
+    cluster_by_key = {_cluster_key(cluster): cluster for cluster in ordered_clusters}
+    selected_target = controller.selected_target
+    selected_key = (
+        f"{selected_target.cluster_name}|{selected_target.location}"
+        if selected_target
+        else ""
+    )
+    cluster_keys = list(cluster_by_key)
+    selected_index = cluster_keys.index(selected_key) if selected_key in cluster_keys else 0
+    cluster_connecting = controller.action in {
+        ConnectionAction.CLUSTER,
+        ConnectionAction.REFRESH,
+    }
+    cluster_connected = controller.cluster.phase is ConnectionPhase.CONNECTED
 
-            selected_key = st.selectbox(
-                "Cluster",
-                list(cluster_by_key),
-                format_func=cluster_label,
-                disabled=is_working,
-                key=f"manual_cluster:{project_id}",
-            )
-            selecting = action_kind == "select"
-            select_clicked = st.button(
-                "Selecting…" if selecting else "Select",
-                type="primary",
-                icon=(
-                    ":material/progress_activity:"
-                    if selecting
-                    else ":material/check:"
-                ),
-                width="stretch",
-                disabled=is_working,
-                key=(
-                    "select_kube_agents_cluster_busy"
-                    if selecting
-                    else "select_kube_agents_cluster"
-                ),
-            )
-            if select_clicked:
-                selected_cluster = cluster_by_key[selected_key]
-                st.session_state[CONNECTION_ACTION_KEY] = {
-                    "kind": "select",
-                    "project_id": project_id,
-                    "target": _target_for_cluster(project_id, selected_cluster),
-                }
-                st.rerun()
+    with st.container(border=True):
+        st.markdown("#### Step 2 · Cluster")
+        st.caption("Verify the selected kube-agents runtime.")
 
-        if is_connected:
-            st.caption(
-                f"Connected · {active_target.cluster_name} · {active_target.location}"
+        def cluster_label(cluster_key: str) -> str:
+            cluster = cluster_by_key[cluster_key]
+            suffix = " · kube-agents host" if cluster.is_kube_agents_host else ""
+            return f"{cluster.name} · {cluster.location}{suffix}"
+
+        selected_key = st.selectbox(
+            "Cluster",
+            cluster_keys,
+            index=selected_index if cluster_keys else None,
+            format_func=cluster_label,
+            placeholder="No GKE clusters found",
+            disabled=cluster_connected or controller.working,
+            label_visibility="collapsed",
+            key=f"cluster_connection_option:{controller.project_id}",
+        )
+        selected_cluster = cluster_by_key.get(str(selected_key)) if selected_key else None
+        if selected_cluster is not None:
+            target = controller.target_for_cluster(selected_cluster)
+            current = controller.selected_target
+            if current is None or (
+                current.project_id,
+                current.cluster_name,
+                current.location,
+            ) != (target.project_id, target.cluster_name, target.location):
+                controller.select_target(target)
+            st.query_params["cluster"] = target.cluster_name
+            st.query_params["location"] = target.location
+
+        cluster_connect_clicked, cluster_secondary_clicked = (
+            _render_connection_actions(
+                "cluster_connection",
+                connected=cluster_connected,
+                connecting=cluster_connecting,
+                blocked=controller.working and not cluster_connecting,
+                connect_disabled=selected_cluster is None,
+                can_disconnect=cluster_connected,
             )
-            st.caption("Revalidated every 10 minutes while this portal is open.")
-        else:
-            st.caption("Not connected")
-            if st.session_state.pop("connection_refresh_failed", False):
-                st.warning(
-                    "The saved connection failed revalidation. Reconnect to retry."
-                )
-            if report is not None:
-                runtime_check = next(
-                    (check for check in report.checks if check.key == "agent_runtime"),
-                    None,
-                )
-                if runtime_check and runtime_check.status != connections.CheckStatus.PASS:
-                    st.warning(runtime_check.summary)
-        persistence_error = st.session_state.get("connection_persistence_error")
-        if persistence_error:
-            st.warning(persistence_error)
-        action_error = st.session_state.pop("connection_action_error", None)
-        if action_error:
-            st.error(action_error)
+        )
+        if cluster_connect_clicked:
+            controller.connect_cluster(connection_executor())
+            st.rerun()
+        if cluster_secondary_clicked:
+            if cluster_connecting:
+                controller.abort()
+                st.toast("Cluster connection aborted.")
+            else:
+                controller.disconnect_cluster()
+                st.toast("Disconnected from cluster.")
+            st.rerun()
+        if not cluster_connected and not cluster_keys:
+            st.info("No GKE clusters were found in this project.")
+        elif not cluster_connected and not any(
+            cluster.is_kube_agents_host for cluster in clusters
+        ):
+            st.caption("No kube-agents host label was found; choose the host cluster.")
+        elif not cluster_connected and len(
+            tuple(c for c in clusters if c.is_kube_agents_host)
+        ) > 1:
+            st.caption("Multiple host labels were found; choose the intended cluster.")
+        if controller.cluster.error and not cluster_connecting:
+            st.error(controller.cluster.error)
+
+    if controller.persistence_error:
+        st.warning(controller.persistence_error)

--- a/admin_console/connection_sidebar.py
+++ b/admin_console/connection_sidebar.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import streamlit as st
 
@@ -13,6 +14,7 @@ from admin_console.connection_controller import (
     ConnectionController,
     ConnectionPhase,
 )
+from admin_console.connection_session import initialize_connection_controller
 from admin_console.project_config import is_valid_project_id
 
 
@@ -24,7 +26,11 @@ def connection_executor() -> ThreadPoolExecutor:
 def connection_controller() -> ConnectionController:
     controller = st.session_state.get(CONNECTION_CONTROLLER_KEY)
     if not isinstance(controller, ConnectionController):
-        raise RuntimeError("connection controller is not initialized")
+        package_parent = Path(__file__).resolve().parents[1]
+        controller = initialize_connection_controller(
+            package_parent,
+            connection_executor(),
+        )
     return controller
 
 
@@ -32,6 +38,9 @@ def connection_controller() -> ConnectionController:
 def maintain_connection() -> None:
     """Poll the one session controller and schedule bounded revalidation."""
     controller = connection_controller()
+    if controller.reconcile_persisted_lease():
+        st.rerun(scope="app")
+
     event = controller.poll()
     if event is not None:
         if event.outcome == "connected" and event.message:
@@ -59,6 +68,7 @@ def _render_connection_actions(
     *,
     connected: bool,
     connecting: bool,
+    revalidating: bool = False,
     blocked: bool = False,
     connect_disabled: bool = False,
     can_disconnect: bool = False,
@@ -74,6 +84,10 @@ def _render_connection_actions(
         primary_label = "Connecting…"
         primary_icon = ":material/progress_activity:"
         state = "connecting"
+    elif revalidating:
+        primary_label = "Revalidating…"
+        primary_icon = ":material/progress_activity:"
+        state = "revalidating"
     elif connected:
         primary_label = "Connected"
         primary_icon = ":material/check_circle:"
@@ -87,7 +101,9 @@ def _render_connection_actions(
         type="primary",
         icon=primary_icon,
         width="stretch",
-        disabled=(connected or connecting or blocked or connect_disabled),
+        disabled=(
+            connected or connecting or revalidating or blocked or connect_disabled
+        ),
         key=f"{key}_primary_{state}",
     )
     secondary_clicked = False
@@ -96,7 +112,7 @@ def _render_connection_actions(
             "Abort" if connecting else "Disconnect",
             icon=(":material/cancel:" if connecting else ":material/link_off:"),
             width="stretch",
-            disabled=blocked,
+            disabled=blocked and not (connected and can_disconnect),
             key=f"{key}_secondary_{'abort' if connecting else 'disconnect'}",
         )
     return primary_clicked, secondary_clicked
@@ -174,6 +190,7 @@ def render_connection_controls() -> None:
                 st.toast("Project connection aborted.")
             else:
                 controller.disconnect_project()
+                st.session_state.pop("connection_project_option", None)
                 st.query_params.pop("cluster", None)
                 st.query_params.pop("location", None)
                 st.toast("Disconnected from project.")
@@ -189,19 +206,19 @@ def render_connection_controls() -> None:
 
     report = controller.project.report
     clusters = report.clusters if report else ()
-    verified_target = controller.connected_target
-    if verified_target and not any(
-        item.name == verified_target.cluster_name
-        and item.location == verified_target.location
+    display_target = controller.connected_target or controller.selected_target
+    if display_target and not any(
+        item.name == display_target.cluster_name
+        and item.location == display_target.location
         for item in clusters
     ):
         clusters = (
             *clusters,
             connections.ClusterInfo(
-                verified_target.cluster_name,
-                verified_target.location,
+                display_target.cluster_name,
+                display_target.location,
                 "RUNNING",
-                verified_target.source == "kube-agents-host label",
+                display_target.source == "kube-agents-host label",
             ),
         )
     ordered_clusters = sorted(
@@ -221,10 +238,8 @@ def render_connection_controls() -> None:
     )
     cluster_keys = list(cluster_by_key)
     selected_index = cluster_keys.index(selected_key) if selected_key in cluster_keys else 0
-    cluster_connecting = controller.action in {
-        ConnectionAction.CLUSTER,
-        ConnectionAction.REFRESH,
-    }
+    cluster_connecting = controller.action is ConnectionAction.CLUSTER
+    cluster_refreshing = controller.action is ConnectionAction.REFRESH
     cluster_connected = controller.cluster.phase is ConnectionPhase.CONNECTED
 
     with st.container(border=True):
@@ -264,6 +279,7 @@ def render_connection_controls() -> None:
                 "cluster_connection",
                 connected=cluster_connected,
                 connecting=cluster_connecting,
+                revalidating=cluster_refreshing and not cluster_connected,
                 blocked=controller.working and not cluster_connecting,
                 connect_disabled=selected_cluster is None,
                 can_disconnect=cluster_connected,
@@ -280,6 +296,10 @@ def render_connection_controls() -> None:
                 controller.disconnect_cluster()
                 st.toast("Disconnected from cluster.")
             st.rerun()
+        if cluster_refreshing and cluster_connected:
+            st.caption("Revalidating in the background. Disconnect remains available.")
+        elif cluster_refreshing:
+            st.caption("Revalidating the saved connection before enabling runtime access.")
         if not cluster_connected and not cluster_keys:
             st.info("No GKE clusters were found in this project.")
         elif not cluster_connected and not any(

--- a/admin_console/connections.py
+++ b/admin_console/connections.py
@@ -11,6 +11,7 @@ import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
+from threading import Event
 from typing import Protocol
 
 from admin_console.project_config import DeploymentTarget, is_valid_project_id
@@ -39,6 +40,26 @@ class CommandResult:
 
 class CommandRunner(Protocol):
     def run(self, arguments: list[str], *, timeout: int = 15) -> CommandResult: ...
+
+
+class ConnectionChecksCancelled(RuntimeError):
+    """Stop a detached connection probe between bounded external calls."""
+
+
+class CancelAwareRunner:
+    """Stop submitting commands after the UI detaches a connection attempt."""
+
+    def __init__(self, runner: CommandRunner, cancelled: Event) -> None:
+        self.runner = runner
+        self.cancelled = cancelled
+
+    def run(self, arguments: list[str], *, timeout: int = 15) -> CommandResult:
+        if self.cancelled.is_set():
+            raise ConnectionChecksCancelled()
+        result = self.runner.run(arguments, timeout=timeout)
+        if self.cancelled.is_set():
+            raise ConnectionChecksCancelled()
+        return result
 
 
 class GcloudRunner:
@@ -283,12 +304,15 @@ def run_connection_checks(
     include_trace_probe: bool = True,
     include_agent_runtime_probe: bool = False,
     include_telemetry_probes: bool = True,
+    cancel_event: Event | None = None,
 ) -> ConnectionReport:
     """Run bounded, read-only diagnostics for one selected project."""
     if not is_valid_project_id(project_id):
         raise ValueError("invalid Google Cloud project ID")
     account = os.environ.get("KUBE_AGENTS_ADMIN_USER", "")
     runner = runner or GcloudRunner(account)
+    if cancel_event is not None:
+        runner = CancelAwareRunner(runner, cancel_event)
     checks: list[ConnectionCheck] = []
 
     cli_result = runner.run(["auth", "print-access-token"])
@@ -564,6 +588,8 @@ def run_connection_checks(
             )
 
             try:
+                if cancel_event is not None and cancel_event.is_set():
+                    raise ConnectionChecksCancelled()
                 runtime_provider = AgentRuntimeProvider(runtime_target)
                 agents = runtime_provider.list_agents()
                 if not agents:
@@ -589,6 +615,8 @@ def run_connection_checks(
                             f"session(s) from {agents[0]}.",
                         )
                     )
+                if cancel_event is not None and cancel_event.is_set():
+                    raise ConnectionChecksCancelled()
             except AgentRuntimeError as exc:
                 checks.append(
                     ConnectionCheck(

--- a/admin_console/connections.py
+++ b/admin_console/connections.py
@@ -118,12 +118,23 @@ class ConnectionReport:
 
 
 def connection_is_ready(report: ConnectionReport) -> bool:
-    """Return whether a report proves the portal's required read paths."""
+    """Return whether the selected cluster runtime is reachable.
+
+    Telemetry checks remain visible diagnostics, but a Logging or Trace outage
+    must not lock runtime-backed Chat, Kanban, or Cron pages.
+    """
     checks = {check.key: check.status for check in report.checks}
     required = {"cli_auth", "project", "gke", "agent_runtime"}
+    return all(checks.get(key) == CheckStatus.PASS for key in required)
+
+
+def project_connection_is_ready(report: ConnectionReport) -> bool:
+    """Return whether project access and GKE discovery are usable."""
+    checks = {check.key: check.status for check in report.checks}
     return (
-        all(checks.get(key) == CheckStatus.PASS for key in required)
-        and report.failed == 0
+        checks.get("cli_auth") == CheckStatus.PASS
+        and checks.get("project") == CheckStatus.PASS
+        and checks.get("gke") in {CheckStatus.PASS, CheckStatus.WARNING}
     )
 
 
@@ -271,6 +282,7 @@ def run_connection_checks(
     runner: CommandRunner | None = None,
     include_trace_probe: bool = True,
     include_agent_runtime_probe: bool = False,
+    include_telemetry_probes: bool = True,
 ) -> ConnectionReport:
     """Run bounded, read-only diagnostics for one selected project."""
     if not is_valid_project_id(project_id):
@@ -587,6 +599,14 @@ def run_connection_checks(
                         exc.guidance,
                     )
                 )
+
+    if not include_telemetry_probes:
+        return ConnectionReport(
+            project_id,
+            datetime.now(timezone.utc),
+            tuple(checks),
+            clusters,
+        )
 
     namespace = (
         expected_target.namespace

--- a/admin_console/cron_view.py
+++ b/admin_console/cron_view.py
@@ -66,13 +66,7 @@ def group_cron_executions(
 
     groups = []
     for title, items in grouped.items():
-        items.sort(
-            key=lambda execution: (
-                execution.status.lower() in ACTIVE_STATUSES,
-                execution_time(execution),
-            ),
-            reverse=True,
-        )
+        items.sort(key=execution_time, reverse=True)
         groups.append(CronExecutionGroup(title, tuple(items)))
     groups.sort(
         key=lambda group: (

--- a/admin_console/cron_view.py
+++ b/admin_console/cron_view.py
@@ -1,0 +1,85 @@
+"""Presentation model for concise scheduled-execution history."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from admin_console.agent_runtime import AgentCronExecution, AgentCronJob
+
+ACTIVE_STATUSES = {"claimed", "dispatching", "pending", "running", "started"}
+SUCCESS_STATUSES = {"completed", "ok", "success", "succeeded"}
+FAILED_STATUSES = {"error", "failed", "crashed"}
+
+
+def execution_time(execution: AgentCronExecution) -> datetime:
+    return execution.started_at or execution.claimed_at or datetime.fromtimestamp(0, UTC)
+
+
+@dataclass(frozen=True)
+class CronExecutionGroup:
+    """Executions sharing one user-facing job title."""
+
+    title: str
+    executions: tuple[AgentCronExecution, ...]
+
+    @property
+    def latest(self) -> AgentCronExecution:
+        return self.executions[0]
+
+    @property
+    def profiles(self) -> tuple[str, ...]:
+        return tuple(sorted({execution.profile for execution in self.executions}))
+
+    @property
+    def active(self) -> int:
+        return sum(
+            execution.status.lower() in ACTIVE_STATUSES
+            for execution in self.executions
+        )
+
+    @property
+    def succeeded(self) -> int:
+        return sum(
+            execution.status.lower() in SUCCESS_STATUSES
+            for execution in self.executions
+        )
+
+    @property
+    def failed(self) -> int:
+        return sum(
+            execution.status.lower() in FAILED_STATUSES
+            for execution in self.executions
+        )
+
+
+def group_cron_executions(
+    executions: tuple[AgentCronExecution, ...],
+    jobs_by_key: dict[tuple[str, str], AgentCronJob],
+) -> tuple[CronExecutionGroup, ...]:
+    """Aggregate executions by exact display title, newest first."""
+    grouped: dict[str, list[AgentCronExecution]] = {}
+    for execution in executions:
+        job = jobs_by_key.get((execution.profile, execution.job_id))
+        title = job.name if job else execution.job_id or "Unknown job"
+        grouped.setdefault(title, []).append(execution)
+
+    groups = []
+    for title, items in grouped.items():
+        items.sort(
+            key=lambda execution: (
+                execution.status.lower() in ACTIVE_STATUSES,
+                execution_time(execution),
+            ),
+            reverse=True,
+        )
+        groups.append(CronExecutionGroup(title, tuple(items)))
+    groups.sort(
+        key=lambda group: (
+            group.active > 0,
+            execution_time(group.latest),
+            group.title.lower(),
+        ),
+        reverse=True,
+    )
+    return tuple(groups)

--- a/admin_console/kube_access.py
+++ b/admin_console/kube_access.py
@@ -1,0 +1,355 @@
+"""Shared, process-private Kubernetes access for a selected GKE target."""
+
+from __future__ import annotations
+
+import atexit
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Callable
+
+from admin_console.project_config import (
+    DeploymentTarget,
+    is_valid_cluster_name,
+    is_valid_location,
+    is_valid_namespace,
+    is_valid_project_id,
+)
+
+
+class KubeFailure(StrEnum):
+    NONE = ""
+    KUBECTL_MISSING = "kubectl_missing"
+    GCLOUD_MISSING = "gcloud_missing"
+    AUTH_PLUGIN_MISSING = "auth_plugin_missing"
+    GKE_ACCESS_DENIED = "gke_access_denied"
+    CLUSTER_NOT_FOUND = "cluster_not_found"
+    AUTH_EXPIRED = "auth_expired"
+    CREDENTIAL_SETUP = "credential_setup"
+
+
+@dataclass(frozen=True)
+class KubeCommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    timed_out: bool = False
+    failure: KubeFailure = KubeFailure.NONE
+
+
+def kube_failure_guidance(result: KubeCommandResult) -> str:
+    """Map typed preparation failures to one safe, actionable sentence."""
+    return {
+        KubeFailure.KUBECTL_MISSING: "Install kubectl, then retry.",
+        KubeFailure.GCLOUD_MISSING: "Install the Google Cloud CLI, then retry.",
+        KubeFailure.AUTH_PLUGIN_MISSING: (
+            "Install gke-gcloud-auth-plugin, then retry."
+        ),
+        KubeFailure.GKE_ACCESS_DENIED: (
+            "Request permission to access the selected GKE cluster, then retry."
+        ),
+        KubeFailure.CLUSTER_NOT_FOUND: (
+            "Confirm the selected project, cluster, and location, then retry."
+        ),
+        KubeFailure.AUTH_EXPIRED: "Refresh gcloud authentication, then retry.",
+        KubeFailure.CREDENTIAL_SETUP: (
+            "Check GKE access and network connectivity, then retry."
+        ),
+    }.get(result.failure, "")
+
+
+class PrivateKubeconfigStore:
+    """Own one temporary kubeconfig for the lifetime of this portal process."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._temporary_directory: tempfile.TemporaryDirectory[str] | None = None
+        if path is None:
+            self._temporary_directory = tempfile.TemporaryDirectory(
+                prefix="kube-agents-admin-"
+            )
+            path = Path(self._temporary_directory.name) / "config"
+        self.path = path
+        self._lock = threading.Lock()
+
+    @property
+    def lock(self) -> threading.Lock:
+        return self._lock
+
+    def secure(self) -> None:
+        if self.path.is_file():
+            self.path.chmod(0o600)
+
+    def close(self) -> None:
+        """Remove a managed temporary kubeconfig; explicit paths are retained."""
+        if self._temporary_directory is not None:
+            self._temporary_directory.cleanup()
+            self._temporary_directory = None
+
+
+_SHARED_KUBECONFIG = PrivateKubeconfigStore()
+atexit.register(_SHARED_KUBECONFIG.close)
+
+
+class GKEKubeAccess:
+    """Prepare and run kubectl against one validated GKE target.
+
+    The selected target is always explicit, credentials are written only to a
+    process-private kubeconfig, and both buffered and streaming calls share the
+    same preparation and failure behavior.
+    """
+
+    def __init__(
+        self,
+        target: DeploymentTarget,
+        *,
+        account: str = "",
+        store: PrivateKubeconfigStore | None = None,
+    ) -> None:
+        if not (
+            is_valid_project_id(target.project_id)
+            and is_valid_cluster_name(target.cluster_name)
+            and is_valid_location(target.location)
+            and is_valid_namespace(target.namespace)
+        ):
+            raise ValueError("invalid GKE access target")
+        self.target = target
+        self.account = account or os.environ.get(
+            "KUBE_AGENTS_ADMIN_USER", ""
+        ).strip()
+        self.store = store or _SHARED_KUBECONFIG
+        self.context = (
+            f"gke_{target.project_id}_{target.location}_{target.cluster_name}"
+        )
+        self._prepared = False
+
+    def _environment(self) -> dict[str, str]:
+        environment = os.environ.copy()
+        environment["KUBECONFIG"] = str(self.store.path)
+        if self.account:
+            environment["CLOUDSDK_CORE_ACCOUNT"] = self.account
+        return environment
+
+    @staticmethod
+    def _missing_prerequisite() -> KubeCommandResult | None:
+        if shutil.which("kubectl") is None:
+            return KubeCommandResult(
+                127,
+                stderr="Kubernetes CLI is unavailable.",
+                failure=KubeFailure.KUBECTL_MISSING,
+            )
+        if shutil.which("gcloud") is None:
+            return KubeCommandResult(
+                127,
+                stderr="Google Cloud CLI is unavailable.",
+                failure=KubeFailure.GCLOUD_MISSING,
+            )
+        if shutil.which("gke-gcloud-auth-plugin") is None:
+            return KubeCommandResult(
+                127,
+                stderr="GKE authentication plugin is unavailable.",
+                failure=KubeFailure.AUTH_PLUGIN_MISSING,
+            )
+        return None
+
+    @staticmethod
+    def _completed(
+        completed: subprocess.CompletedProcess[str],
+    ) -> KubeCommandResult:
+        return KubeCommandResult(
+            completed.returncode,
+            completed.stdout,
+            completed.stderr,
+        )
+
+    def prepare(self, *, timeout: int = 30) -> KubeCommandResult | None:
+        """Ensure the private kubeconfig contains this target's context."""
+        if self._prepared:
+            return None
+        missing = self._missing_prerequisite()
+        if missing is not None:
+            return missing
+        environment = self._environment()
+        with self.store.lock:
+            try:
+                context_probe = subprocess.run(
+                    [
+                        "kubectl",
+                        "config",
+                        "get-contexts",
+                        self.context,
+                        "-o",
+                        "name",
+                    ],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                    env=environment,
+                )
+            except subprocess.TimeoutExpired:
+                return KubeCommandResult(
+                    124,
+                    timed_out=True,
+                    failure=KubeFailure.CREDENTIAL_SETUP,
+                )
+            except OSError:
+                return KubeCommandResult(
+                    127,
+                    stderr="Kubernetes CLI is unavailable.",
+                    failure=KubeFailure.KUBECTL_MISSING,
+                )
+            if context_probe.returncode != 0 or context_probe.stdout.strip() != self.context:
+                command = ["gcloud", "--quiet"]
+                if self.account:
+                    command.append(f"--account={self.account}")
+                command.extend(
+                    [
+                        "container",
+                        "clusters",
+                        "get-credentials",
+                        self.target.cluster_name,
+                        "--location",
+                        self.target.location,
+                        "--project",
+                        self.target.project_id,
+                    ]
+                )
+                try:
+                    credentials = subprocess.run(
+                        command,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                        timeout=timeout,
+                        env=environment,
+                    )
+                except subprocess.TimeoutExpired:
+                    return KubeCommandResult(
+                        124,
+                        timed_out=True,
+                        failure=KubeFailure.CREDENTIAL_SETUP,
+                    )
+                except OSError:
+                    return KubeCommandResult(
+                        127,
+                        stderr="Google Cloud CLI is unavailable.",
+                        failure=KubeFailure.GCLOUD_MISSING,
+                    )
+                if credentials.returncode != 0:
+                    error = credentials.stderr.lower()
+                    if "permission" in error or "forbidden" in error or "403" in error:
+                        detail = "GKE credential access was denied."
+                        failure = KubeFailure.GKE_ACCESS_DENIED
+                    elif "not found" in error or "does not exist" in error:
+                        detail = "The selected GKE cluster was not found."
+                        failure = KubeFailure.CLUSTER_NOT_FOUND
+                    elif "login" in error or "reauth" in error or "invalid_grant" in error:
+                        detail = "Google Cloud authentication expired."
+                        failure = KubeFailure.AUTH_EXPIRED
+                    else:
+                        detail = "GKE credentials could not be prepared."
+                        failure = KubeFailure.CREDENTIAL_SETUP
+                    return KubeCommandResult(
+                        credentials.returncode,
+                        stderr=detail,
+                        failure=failure,
+                    )
+                self.store.secure()
+            self._prepared = True
+        return None
+
+    def run(
+        self,
+        arguments: list[str],
+        *,
+        input_text: str | None = None,
+        timeout: int = 20,
+        line_callback: Callable[[str], None] | None = None,
+    ) -> KubeCommandResult:
+        preparation = self.prepare(timeout=min(timeout, 30))
+        if preparation is not None:
+            return preparation
+        command = ["kubectl", *arguments]
+        environment = self._environment()
+        if line_callback is None:
+            try:
+                completed = subprocess.run(
+                    command,
+                    input=input_text,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    env=environment,
+                )
+            except subprocess.TimeoutExpired:
+                return KubeCommandResult(124, timed_out=True)
+            except OSError:
+                return KubeCommandResult(
+                    127,
+                    stderr="Kubernetes CLI is unavailable.",
+                    failure=KubeFailure.KUBECTL_MISSING,
+                )
+            return self._completed(completed)
+
+        try:
+            process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=environment,
+            )
+        except OSError:
+            return KubeCommandResult(
+                127,
+                stderr="Kubernetes CLI is unavailable.",
+                failure=KubeFailure.KUBECTL_MISSING,
+            )
+
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+
+        def drain_stdout() -> None:
+            assert process.stdout is not None
+            for line in process.stdout:
+                stdout_lines.append(line)
+                line_callback(line.rstrip("\r\n"))
+
+        def drain_stderr() -> None:
+            assert process.stderr is not None
+            stderr_lines.extend(process.stderr)
+
+        stdout_thread = threading.Thread(target=drain_stdout, daemon=True)
+        stderr_thread = threading.Thread(target=drain_stderr, daemon=True)
+        stdout_thread.start()
+        stderr_thread.start()
+        assert process.stdin is not None
+        try:
+            process.stdin.write(input_text or "")
+            process.stdin.close()
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+            stdout_thread.join(timeout=1)
+            stderr_thread.join(timeout=1)
+            return KubeCommandResult(
+                124,
+                "".join(stdout_lines),
+                "".join(stderr_lines),
+                timed_out=True,
+            )
+        stdout_thread.join(timeout=1)
+        stderr_thread.join(timeout=1)
+        return KubeCommandResult(
+            process.returncode,
+            "".join(stdout_lines),
+            "".join(stderr_lines),
+        )

--- a/admin_console/pages/activity.py
+++ b/admin_console/pages/activity.py
@@ -11,18 +11,28 @@ if str(PACKAGE_PARENT) not in sys.path:
 
 import streamlit as st
 
-from admin_console.activity_scope import render_activity_scope
+from admin_console.activity_scope import (
+    load_activity_snapshot,
+    render_activity_load_more,
+    render_activity_scope,
+)
 from admin_console.connection_session import recover_app_shell
 from admin_console.charts import causality_sankey, interaction_timeline
 from admin_console.domain import AttributionLevel
-from admin_console.ui import render_telemetry_status, section_title
+from admin_console.ui import (
+    paginated_selectable_table,
+    render_telemetry_status,
+    section_title,
+)
 
 recover_app_shell()
 st.title("Activity Explorer")
 provider = render_activity_scope()
-all_events = provider.list_activity()
+snapshot = load_activity_snapshot(provider)
+all_events = list(snapshot.events)
 
-render_telemetry_status(provider)
+render_telemetry_status(snapshot)
+render_activity_load_more(provider)
 
 with st.container(border=True):
     filter_columns = st.columns([1.2, 1, 1, 1, 1.2])
@@ -37,6 +47,21 @@ with st.container(border=True):
     selected_triggers = filter_columns[2].multiselect("Trigger", triggers)
     selected_agents = filter_columns[3].multiselect("Agent", agents)
     selected_statuses = filter_columns[4].multiselect("Status", statuses)
+
+filter_token = repr(
+    (
+        query,
+        tuple(selected_users),
+        tuple(selected_triggers),
+        tuple(selected_agents),
+        tuple(selected_statuses),
+    )
+)
+previous_filter_token = st.session_state.get("activity_filter_token")
+if previous_filter_token is not None and previous_filter_token != filter_token:
+    st.query_params.pop("activity_page", None)
+    st.query_params.pop("activity_event", None)
+st.session_state.activity_filter_token = filter_token
 
 
 def matches(event) -> bool:
@@ -129,6 +154,9 @@ with timeline_tab:
             )
 
 with ledger_tab:
+    ordered_events = sorted(
+        events, key=lambda item: item.occurred_at, reverse=True
+    )
     rows = [
         {
             "Time": event.occurred_at.strftime("%Y-%m-%d %H:%M:%S"),
@@ -143,39 +171,52 @@ with ledger_tab:
             "Cluster": event.cluster or "—",
             "Event ID": event.event_id,
         }
-        for event in sorted(events, key=lambda item: item.occurred_at, reverse=True)
+        for event in ordered_events
     ]
-    selected = st.dataframe(
-        rows,
-        width="stretch",
-        hide_index=True,
-        on_select="rerun",
-        selection_mode="single-row",
+    event_ids = [event.event_id for event in ordered_events]
+    requested_event = str(st.query_params.get("activity_event", "")).strip()
+    selected_event = (
+        requested_event if requested_event in event_ids else event_ids[0]
     )
-    if selected.selection.rows:
-        event = sorted(events, key=lambda item: item.occurred_at, reverse=True)[
-            selected.selection.rows[0]
-        ]
-        with st.container(border=True):
-            st.subheader(event.action_name)
-            st.write(event.summary)
-            st.json(
-                {
-                    "event_id": event.event_id,
-                    "interaction_id": event.interaction_id,
-                    "session_id": event.session_id,
-                    "task_id": event.task_id,
-                    "parent_task_id": event.parent_task_id,
-                    "trace_id": event.trace_id,
-                    "resource": {
-                        "cluster": event.cluster,
-                        "namespace": event.namespace,
-                        "name": event.resource,
-                    },
-                    "attribution": event.attribution.value,
-                    "evidence": event.details,
-                }
-            )
-            evidence_url = event.details.get("evidence_url")
-            if evidence_url:
-                st.link_button("Open source evidence", evidence_url)
+    clicked_event, _ = paginated_selectable_table(
+        rows,
+        event_ids,
+        selected_event,
+        key_prefix="activity_ledger",
+        page_query="activity_page",
+        selection_query="activity_event",
+        state_token=filter_token,
+        page_size=50,
+        column_config={
+            "Action": st.column_config.TextColumn(width="large"),
+            "Event ID": st.column_config.TextColumn(width="large"),
+        },
+    )
+    if clicked_event != selected_event:
+        st.query_params["activity_event"] = clicked_event
+        st.rerun()
+    st.query_params["activity_event"] = selected_event
+    event = ordered_events[event_ids.index(selected_event)]
+    with st.container(border=True):
+        st.subheader(event.action_name)
+        st.write(event.summary)
+        st.json(
+            {
+                "event_id": event.event_id,
+                "interaction_id": event.interaction_id,
+                "session_id": event.session_id,
+                "task_id": event.task_id,
+                "parent_task_id": event.parent_task_id,
+                "trace_id": event.trace_id,
+                "resource": {
+                    "cluster": event.cluster,
+                    "namespace": event.namespace,
+                    "name": event.resource,
+                },
+                "attribution": event.attribution.value,
+                "evidence": event.details,
+            }
+        )
+        evidence_url = event.details.get("evidence_url")
+        if evidence_url:
+            st.link_button("Open source evidence", evidence_url)

--- a/admin_console/pages/activity.py
+++ b/admin_console/pages/activity.py
@@ -12,10 +12,12 @@ if str(PACKAGE_PARENT) not in sys.path:
 import streamlit as st
 
 from admin_console.activity_scope import render_activity_scope
+from admin_console.connection_session import recover_app_shell
 from admin_console.charts import causality_sankey, interaction_timeline
 from admin_console.domain import AttributionLevel
 from admin_console.ui import render_telemetry_status, section_title
 
+recover_app_shell()
 st.title("Activity Explorer")
 provider = render_activity_scope()
 all_events = provider.list_activity()

--- a/admin_console/pages/activity.py
+++ b/admin_console/pages/activity.py
@@ -16,9 +16,9 @@ from admin_console.activity_scope import (
     render_activity_load_more,
     render_activity_scope,
 )
+from admin_console.causal_flow import CausalFlowProjection
 from admin_console.connection_session import recover_app_shell
 from admin_console.charts import causality_sankey, interaction_timeline
-from admin_console.domain import AttributionLevel
 from admin_console.ui import (
     paginated_selectable_table,
     render_telemetry_status,
@@ -85,30 +85,21 @@ if not events:
 flow_tab, timeline_tab, ledger_tab = st.tabs(["Flow", "Timeline", "Forensic ledger"])
 
 with flow_tab:
-    proven_events = [
-        event
-        for event in events
-        if event.attribution
-        in {AttributionLevel.EXPLICIT, AttributionLevel.INHERITED}
-    ]
+    causal_flow = CausalFlowProjection.from_events(events)
     section_title(
         "Causal flow",
-        "Proven or inherited trigger/user → agent → tool/action → outcome. "
-        "Edge width is evidence-record count.",
+        "Trusted trigger/user → agent → LLM work → outcome. Edge width is "
+        "canonical action count, not raw telemetry volume.",
     )
-    if proven_events:
+    if causal_flow.events:
         st.plotly_chart(
-            causality_sankey(proven_events),
+            causality_sankey(list(causal_flow.events)),
             width="stretch",
             config={"displayModeBar": False},
         )
     else:
-        st.info("No explicit or inherited causal evidence exists in this scope.")
-    excluded = len(events) - len(proven_events)
-    st.caption(
-        f"{excluded} inferred or missing-attribution record(s) excluded from the flow. "
-        "No time-adjacent joins are created."
-    )
+        st.info("No trusted LLM or LLM-produced work exists in this scope.")
+    st.caption(causal_flow.summary)
 
 with timeline_tab:
     interaction_options = sorted(

--- a/admin_console/pages/activity.py
+++ b/admin_console/pages/activity.py
@@ -88,8 +88,8 @@ with flow_tab:
     causal_flow = CausalFlowProjection.from_events(events)
     section_title(
         "Causal flow",
-        "Trusted trigger/user → agent → LLM work → outcome. Edge width is "
-        "canonical action count, not raw telemetry volume.",
+        "Normalized OTel source → agent → LLM work → outcome. Edge width is "
+        "canonical action count; raw source fields remain in node evidence.",
     )
     if causal_flow.events:
         st.plotly_chart(
@@ -98,7 +98,7 @@ with flow_tab:
             config={"displayModeBar": False},
         )
     else:
-        st.info("No trusted LLM or LLM-produced work exists in this scope.")
+        st.info("No LLM or LLM-produced work exists in this scope.")
     st.caption(causal_flow.summary)
 
 with timeline_tab:

--- a/admin_console/pages/autonomous.py
+++ b/admin_console/pages/autonomous.py
@@ -16,6 +16,7 @@ if str(PACKAGE_PARENT) not in sys.path:
 
 import streamlit as st
 
+from admin_console.connection_session import recover_app_shell
 from admin_console.connection_gate import require_connection
 from admin_console.cron_view import (
     ACTIVE_STATUSES,
@@ -35,6 +36,8 @@ from admin_console.ui import AGENT_SELECTOR_HELP
 
 HISTORY_WINDOWS = {"24h": 1, "7d": 7, "30d": 30}
 INTERVAL_CADENCE = re.compile(r"^every\s+(\d+)m$", re.IGNORECASE)
+
+recover_app_shell()
 
 
 def query_value(name: str, default: str = "") -> str:
@@ -89,8 +92,12 @@ def execution_history_item(execution: AgentCronExecution) -> str:
             execution.profile,
         )
     )
+    escaped_error = html.escape(execution.error).replace("\r\n", "\n").replace(
+        "\r", "\n"
+    )
     error = (
-        f"<div class='ka-cron-error'>{html.escape(execution.error)}</div>"
+        "<div class='ka-cron-error'>"
+        f"{escaped_error.replace(chr(10), '<br>')}</div>"
         if execution.error
         else ""
     )
@@ -101,6 +108,8 @@ def render_execution_groups(groups: tuple[CronExecutionGroup, ...]) -> None:
     """Render one expandable HTML table with history nested in each job row."""
     rows = []
     for group in groups:
+        run_count = len(group.executions)
+        run_label = f"{run_count} {'run' if run_count == 1 else 'runs'}"
         history = "".join(
             execution_history_item(execution) for execution in group.executions
         )
@@ -111,7 +120,7 @@ def render_execution_groups(groups: tuple[CronExecutionGroup, ...]) -> None:
             "<tr>"
             f"<td><strong>{html.escape(group.title)}</strong></td>"
             "<td><details class='ka-cron-history'>"
-            f"<summary>{len(group.executions)} runs</summary>"
+            f"<summary>{run_label}</summary>"
             f"<ul>{history}</ul></details></td>"
             f"<td>{group.active}</td>"
             f"<td>{group.succeeded}</td>"
@@ -121,7 +130,7 @@ def render_execution_groups(groups: tuple[CronExecutionGroup, ...]) -> None:
             f"<td>{html.escape(', '.join(group.profiles))}</td>"
             "</tr>"
         )
-    st.markdown(
+    st.html(
         """
         <style>
         .ka-cron-table-wrap { overflow-x: auto; }
@@ -158,7 +167,6 @@ def render_execution_groups(groups: tuple[CronExecutionGroup, ...]) -> None:
         """
         + "".join(rows)
         + "</tbody></table></div>",
-        unsafe_allow_html=True,
     )
 
 

--- a/admin_console/pages/autonomous.py
+++ b/admin_console/pages/autonomous.py
@@ -17,6 +17,13 @@ if str(PACKAGE_PARENT) not in sys.path:
 import streamlit as st
 
 from admin_console.connection_gate import require_connection
+from admin_console.cron_view import (
+    ACTIVE_STATUSES,
+    CronExecutionGroup,
+    FAILED_STATUSES,
+    SUCCESS_STATUSES,
+    group_cron_executions,
+)
 from admin_console.agent_runtime import (
     CronSnapshot,
     AgentCronExecution,
@@ -26,8 +33,6 @@ from admin_console.agent_runtime import (
 )
 from admin_console.ui import AGENT_SELECTOR_HELP
 
-ACTIVE_STATUSES = {"claimed", "dispatching", "pending", "running", "started"}
-SUCCESS_STATUSES = {"completed", "ok", "success", "succeeded"}
 HISTORY_WINDOWS = {"24h": 1, "7d": 7, "30d": 30}
 INTERVAL_CADENCE = re.compile(r"^every\s+(\d+)m$", re.IGNORECASE)
 
@@ -69,6 +74,92 @@ def execution_state(status: str) -> str:
     if normalized in SUCCESS_STATUSES:
         return "Succeeded"
     return "Failed" if normalized in {"error", "failed", "crashed"} else status.title()
+
+
+def execution_history_item(execution: AgentCronExecution) -> str:
+    """Render one safe, compact execution entry inside its job row."""
+    started = timestamp(execution.started_at or execution.claimed_at)
+    trigger = "Manual" if execution.source == "direct" else execution.source
+    summary = " · ".join(
+        (
+            started,
+            execution_state(execution.status),
+            trigger,
+            duration(execution),
+            execution.profile,
+        )
+    )
+    error = (
+        f"<div class='ka-cron-error'>{html.escape(execution.error)}</div>"
+        if execution.error
+        else ""
+    )
+    return f"<li>{html.escape(summary)}{error}</li>"
+
+
+def render_execution_groups(groups: tuple[CronExecutionGroup, ...]) -> None:
+    """Render one expandable HTML table with history nested in each job row."""
+    rows = []
+    for group in groups:
+        history = "".join(
+            execution_history_item(execution) for execution in group.executions
+        )
+        latest_start = timestamp(
+            group.latest.started_at or group.latest.claimed_at
+        )
+        rows.append(
+            "<tr>"
+            f"<td><strong>{html.escape(group.title)}</strong></td>"
+            "<td><details class='ka-cron-history'>"
+            f"<summary>{len(group.executions)} runs</summary>"
+            f"<ul>{history}</ul></details></td>"
+            f"<td>{group.active}</td>"
+            f"<td>{group.succeeded}</td>"
+            f"<td>{group.failed}</td>"
+            f"<td>{html.escape(execution_state(group.latest.status))}</td>"
+            f"<td>{html.escape(latest_start)}</td>"
+            f"<td>{html.escape(', '.join(group.profiles))}</td>"
+            "</tr>"
+        )
+    st.markdown(
+        """
+        <style>
+        .ka-cron-table-wrap { overflow-x: auto; }
+        .ka-cron-table {
+          border-collapse: separate; border-spacing: 0; min-width: 900px;
+          width: 100%;
+        }
+        .ka-cron-table th, .ka-cron-table td {
+          border-bottom: 1px solid var(--ka-border); padding: 10px 12px;
+          text-align: left; vertical-align: top;
+        }
+        .ka-cron-table th {
+          color: var(--ka-muted); font-size: .75rem; font-weight: 650;
+        }
+        .ka-cron-history summary {
+          color: var(--ka-accent); cursor: pointer; font-weight: 650;
+          white-space: nowrap;
+        }
+        .ka-cron-history ul {
+          color: var(--ka-text); margin: 10px 0 2px; min-width: 410px;
+          padding-left: 18px;
+        }
+        .ka-cron-history li { margin: 7px 0; }
+        .ka-cron-error { color: #ff8b96; font-size: .78rem; margin-top: 2px; }
+        </style>
+        <div class="ka-cron-table-wrap">
+          <table class="ka-cron-table">
+            <thead><tr>
+              <th>Job</th><th>Executions</th><th>Active</th>
+              <th>Succeeded</th><th>Failed</th><th>Latest result</th>
+              <th>Latest start</th><th>Profiles</th>
+            </tr></thead>
+            <tbody>
+        """
+        + "".join(rows)
+        + "</tbody></table></div>",
+        unsafe_allow_html=True,
+    )
 
 
 def scheduler_label(job: AgentCronJob) -> str:
@@ -361,7 +452,7 @@ enabled = [job for job in snapshot.jobs if job.enabled]
 failed = [
     item
     for item in executions
-    if item.status.lower() in {"error", "failed", "crashed"}
+    if item.status.lower() in FAILED_STATUSES
 ]
 unscheduled = [job for job in enabled if job.scheduler != "active"]
 
@@ -381,22 +472,9 @@ if snapshot.jobs_truncated or snapshot.executions_truncated:
     st.warning("The bounded read limit was reached; this view is incomplete.")
 
 st.subheader("Active and recent executions")
-execution_rows = []
-for execution in executions:
-    job = jobs_by_key.get((execution.profile, execution.job_id))
-    execution_rows.append(
-        {
-            "State": execution_state(execution.status),
-            "Job": job.name if job else execution.job_id or "Unknown job",
-            "Profile": execution.profile,
-            "Trigger": "Manual" if execution.source == "direct" else execution.source,
-            "Started": timestamp(execution.started_at or execution.claimed_at),
-            "Duration": duration(execution),
-            "Error": execution.error,
-        }
-    )
-if execution_rows:
-    st.dataframe(execution_rows, hide_index=True, width="stretch")
+execution_groups = group_cron_executions(executions, jobs_by_key)
+if execution_groups:
+    render_execution_groups(execution_groups)
 else:
     st.info(f"No active or recent executions in the last {selected_window}.")
 

--- a/admin_console/pages/chat.py
+++ b/admin_console/pages/chat.py
@@ -14,6 +14,7 @@ if str(PACKAGE_PARENT) not in sys.path:
 
 import streamlit as st
 
+from admin_console.connection_session import recover_app_shell
 from admin_console.connection_gate import require_connection
 from admin_console.agent_runtime import (
     TaskUpdateResult,
@@ -37,6 +38,8 @@ HISTORY_WINDOWS = {
 TASK_POLL_INTERVAL = "5s"
 TASK_EMPTY_POLL_LIMIT = 3
 TASK_ERROR_POLL_LIMIT = 3
+
+recover_app_shell()
 
 
 def query_value(name: str) -> str:

--- a/admin_console/pages/connections.py
+++ b/admin_console/pages/connections.py
@@ -13,11 +13,13 @@ if str(PACKAGE_PARENT) not in sys.path:
 import streamlit as st
 
 from admin_console.connections import CheckStatus
+from admin_console.connection_session import recover_app_shell
 from admin_console.connection_sidebar import (
     connection_controller,
     render_connection_controls,
 )
 
+recover_app_shell()
 st.title("Connection")
 render_connection_controls()
 controller = connection_controller()

--- a/admin_console/pages/connections.py
+++ b/admin_console/pages/connections.py
@@ -13,45 +13,22 @@ if str(PACKAGE_PARENT) not in sys.path:
 import streamlit as st
 
 from admin_console.connections import CheckStatus
-from admin_console.connection_sidebar import render_connection_controls
+from admin_console.connection_sidebar import (
+    connection_controller,
+    render_connection_controls,
+)
 
 st.title("Connection")
 render_connection_controls()
+controller = connection_controller()
+if not controller.project_id:
+    st.stop()
+
+report = controller.cluster.report
+if report is None or controller.connected_target is None:
+    st.stop()
+
 st.divider()
-project_id = str(st.session_state.get("selected_project", "")).strip()
-connected_target = st.session_state.get("connected_target")
-
-if not project_id:
-    st.info("Choose a project above to connect.")
-    st.stop()
-
-report = st.session_state.get(f"connection_report:{project_id}")
-if report is None:
-    st.info("Connect above to run the verification checklist.")
-    st.stop()
-
-if connected_target and connected_target.project_id == project_id:
-    st.success(
-        f"Connected to {connected_target.cluster_name} · "
-        f"{connected_target.location}."
-    )
-elif report.clusters and len(report.kube_agents_hosts) != 1:
-    if report.kube_agents_hosts:
-        reason = (
-            f"{len(report.kube_agents_hosts)} clusters are labeled "
-            "kube-agents-host=true"
-        )
-    else:
-        reason = "no cluster is labeled kube-agents-host=true"
-    st.error(
-        f"Automatic cluster detection failed because {reason}. "
-        "Select the kube-agents host above."
-    )
-elif report.failed:
-    st.error("Connection was not established. Resolve the failed checks and retry.")
-else:
-    st.info("Not connected. Review the non-passing checks and retry above.")
-
 st.caption(f"Last checked {report.checked_at:%Y-%m-%d %H:%M:%S UTC}")
 metrics = st.columns(3)
 metrics[0].metric("Passed", report.passed)
@@ -74,7 +51,7 @@ for check in report.checks:
             st.markdown(check.guidance)
 
 st.subheader("Google Cloud")
-encoded_project = urllib.parse.quote(project_id, safe="")
+encoded_project = urllib.parse.quote(controller.project_id, safe="")
 link_columns = st.columns(3)
 link_columns[0].link_button(
     "Logs Explorer",

--- a/admin_console/pages/kanban.py
+++ b/admin_console/pages/kanban.py
@@ -13,12 +13,15 @@ if str(PACKAGE_PARENT) not in sys.path:
 
 import streamlit as st
 
+from admin_console.connection_session import recover_app_shell
 from admin_console.connection_gate import require_connection
 from admin_console.agent_runtime import AgentRuntimeError, AgentRuntimeProvider
 from admin_console.ui import AGENT_SELECTOR_HELP, paginated_selectable_table
 
 ACTIVE_STATUSES = {"todo", "ready", "running"}
 ATTENTION_STATUSES = {"blocked", "failed", "crashed", "cancelled"}
+
+recover_app_shell()
 
 
 def query_value(name: str) -> str:

--- a/admin_console/pages/overview.py
+++ b/admin_console/pages/overview.py
@@ -14,10 +14,12 @@ if str(PACKAGE_PARENT) not in sys.path:
 import streamlit as st
 
 from admin_console.charts import activity_over_time, attribution_donut
+from admin_console.connection_session import recover_app_shell
 from admin_console.activity_scope import render_activity_scope
 from admin_console.domain import AttributionLevel, TriggerKind
 from admin_console.ui import render_telemetry_status, section_title, status_label
 
+recover_app_shell()
 st.title("Overview")
 provider = render_activity_scope()
 events = provider.list_activity()

--- a/admin_console/pages/overview.py
+++ b/admin_console/pages/overview.py
@@ -15,14 +15,19 @@ import streamlit as st
 
 from admin_console.charts import activity_over_time, attribution_donut
 from admin_console.connection_session import recover_app_shell
-from admin_console.activity_scope import render_activity_scope
+from admin_console.activity_scope import (
+    load_activity_snapshot,
+    render_activity_load_more,
+    render_activity_scope,
+)
 from admin_console.domain import AttributionLevel, TriggerKind
 from admin_console.ui import render_telemetry_status, section_title, status_label
 
 recover_app_shell()
 st.title("Overview")
 provider = render_activity_scope()
-events = provider.list_activity()
+snapshot = load_activity_snapshot(provider)
+events = list(snapshot.events)
 interactions = {event.interaction_id for event in events}
 human_interactions = {
     event.interaction_id for event in events if event.trigger_kind == TriggerKind.HUMAN
@@ -45,7 +50,8 @@ linked = [
     if event.attribution in {AttributionLevel.EXPLICIT, AttributionLevel.INHERITED}
 ]
 
-snapshot = render_telemetry_status(provider)
+render_telemetry_status(snapshot)
+render_activity_load_more(provider)
 
 metric_columns = st.columns(5)
 metrics = (

--- a/admin_console/telemetry.py
+++ b/admin_console/telemetry.py
@@ -305,6 +305,12 @@ def normalize_logging_row(
         "audit_event": audit_event,
         "log_name": _first(row, "logName"),
     }
+    container_name = _first(labels, "container_name")
+    if container_name == "fluent-bit":
+        details["collector_container"] = container_name
+    pod_name = _first(labels, "pod_name")
+    if pod_name:
+        details["workload_pod"] = pod_name
     for source_key, detail_key in (
         ("args", "tool_arguments"),
         ("result", "tool_result"),
@@ -327,8 +333,8 @@ def normalize_logging_row(
         status=status,
         summary=summary,
         agent_name=_first(payload, "agent_profile", "agent_name")
-        or _first(labels, "container_name")
-        or "platform-agent",
+        or ("gateway-runtime" if container_name == "fluent-bit" else container_name)
+        or "agent-runtime",
         platform=_first(payload, "platform"),
         user_id=_first(payload, "user_id", "user.id"),
         session_id=session_id,
@@ -413,6 +419,11 @@ def normalize_trace(
         ),
         "",
     )
+    spans_by_id = {
+        _first(span, "spanId"): span
+        for span in spans
+        if isinstance(span, dict) and _first(span, "spanId")
+    }
     events: list[ActivityEvent] = []
     for span in spans:
         if not isinstance(span, dict):
@@ -462,13 +473,16 @@ def normalize_trace(
             f"?project={urllib.parse.quote(project_id, safe='')}"
             f"&tid={urllib.parse.quote(trace_id, safe='')}"
         )
+        parent_span_id = _first(span, "parentSpanId")
+        parent_span = spans_by_id.get(parent_span_id, {})
         details = {
             "source": "cloud_trace",
             "source_record_id": f"{trace_id}/{span_id}",
             "evidence_url": evidence_url,
             "span_name": name,
             "span_id": span_id,
-            "parent_span_id": _first(span, "parentSpanId"),
+            "parent_span_id": parent_span_id,
+            "parent_span_name": _first(parent_span, "name"),
             "correlation_id": _first(labels, "correlation.id"),
         }
         for keys, detail_key in (

--- a/admin_console/telemetry.py
+++ b/admin_console/telemetry.py
@@ -350,18 +350,16 @@ def normalize_logging_row(
     )
 
 
-def _trace_trigger(labels: dict[str, Any], session_id: str) -> TriggerKind:
-    kind = _first(labels, "trigger.kind", "hermes.session.kind")
-    if kind == "cron" or session_id.startswith("cron_"):
-        return TriggerKind.CRON
-    if kind == "event":
-        return TriggerKind.EVENT
-    if kind == "retry":
-        return TriggerKind.RETRY
-    if kind in {"agent_followup", "followup"}:
+def _trace_trigger(labels: dict[str, Any]) -> TriggerKind:
+    """Return only a trigger kind explicitly carried by OTel attributes."""
+    kind = _first(labels, "trigger.kind")
+    if kind in {item.value for item in TriggerKind}:
+        return TriggerKind(kind)
+    session_kind = _first(labels, "hermes.session.kind")
+    if session_kind in {item.value for item in TriggerKind}:
+        return TriggerKind(session_kind)
+    if session_kind == "followup":
         return TriggerKind.AGENT_FOLLOWUP
-    if _first(labels, "user.id", "hermes.sender.id", "chat.platform"):
-        return TriggerKind.HUMAN
     return TriggerKind.UNKNOWN
 
 
@@ -411,6 +409,25 @@ def normalize_trace(
         for span in spans
         if isinstance(span, dict)
     ]
+    origin_attributes = (
+        "session.id",
+        "user.id",
+        "hermes.sender.id",
+        "chat.platform",
+        "trigger.kind",
+        "hermes.session.kind",
+    )
+    trace_origin = {
+        attribute: next(
+            (
+                value
+                for labels in trace_labels
+                if (value := _first(labels, attribute))
+            ),
+            "",
+        )
+        for attribute in origin_attributes
+    }
     root_user = next(
         (
             _first(labels, "user.id", "hermes.sender.id")
@@ -442,12 +459,15 @@ def normalize_trace(
         action_type, action_name, status = _span_classification(name, labels)
         start = _parse_time(span.get("startTime"), datetime.now(UTC))
         end = _parse_time(span.get("endTime"), start)
-        trigger = _trace_trigger(labels, session_id)
+        trigger = _trace_trigger(
+            {
+                **trace_origin,
+                **{key: value for key, value in labels.items() if value},
+            }
+        )
         user_id = _first(labels, "user.id", "hermes.sender.id") or root_user
         if not user_id:
             user_id = session_users.get(session_id, "")
-            if user_id:
-                trigger = TriggerKind.HUMAN
         if _first(labels, "interaction.id"):
             attribution = AttributionLevel.EXPLICIT
         elif user_id or trigger != TriggerKind.UNKNOWN:
@@ -485,6 +505,12 @@ def normalize_trace(
             "parent_span_name": _first(parent_span, "name"),
             "correlation_id": _first(labels, "correlation.id"),
         }
+        for attribute in origin_attributes:
+            value = _first(labels, attribute)
+            if value:
+                details[f"otel.{attribute}"] = value
+            elif trace_origin[attribute]:
+                details[f"otel.trace.{attribute}"] = trace_origin[attribute]
         for keys, detail_key in (
             (("input.value", "gen_ai.input.messages"), "input"),
             (("output.value", "gen_ai.output.messages"), "output"),

--- a/admin_console/telemetry.py
+++ b/admin_console/telemetry.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import json
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -13,7 +15,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from admin_console.connections import CommandResult, CommandRunner, GcloudRunner
+from admin_console.connections import CommandRunner, GcloudRunner
 from admin_console.domain import (
     ActivityEvent,
     AttributionLevel,
@@ -40,7 +42,14 @@ _SECRET_PATTERNS = (
     ),
 )
 _DETAIL_LIMIT = 8_000
+DEFAULT_SOURCE_PAGES = 2
+SOURCE_PAGES_PER_LOAD = 2
+MAX_LOGGING_PAGES = 10
 MAX_TRACE_PAGES = 10
+LOGGING_PAGE_SIZE = 500
+LOGGING_TIMEOUT_SECONDS = 60
+TRACE_TIMEOUT_SECONDS = 30
+TELEMETRY_LOAD_DEADLINE_SECONDS = 90
 _SECRET_KEY = re.compile(rf"(?i){_SECRET_NAME}")
 
 
@@ -52,6 +61,7 @@ class TelemetrySourceState:
     truncated: bool
     detail: str
     pages_read: int = 0
+    can_load_more: bool = False
 
 
 @dataclass(frozen=True)
@@ -67,8 +77,19 @@ class TelemetrySnapshot:
     @property
     def incomplete(self) -> bool:
         return any(
-            source.status == "error" or source.truncated for source in self.sources
+            source.status in {"error", "partial"} or source.truncated
+            for source in self.sources
         )
+
+
+@dataclass
+class _PageCursor:
+    """Opaque source cursor retained only inside one portal UI session."""
+
+    next_token: str = ""
+    pages_read: int = 0
+    complete: bool = False
+    error: str = ""
 
 
 def _parse_time(value: object, fallback: datetime) -> datetime:
@@ -501,7 +522,7 @@ def normalize_trace(
 
 
 class CloudTelemetryProvider:
-    """Load a bounded snapshot from Cloud Logging and Cloud Trace."""
+    """Incrementally load a bounded snapshot from Logging and Trace."""
 
     def __init__(
         self,
@@ -511,9 +532,10 @@ class CloudTelemetryProvider:
         cluster: str = "",
         namespace: str = "kubeagents-system",
         hours: int = 24,
-        log_limit: int = 1_000,
+        log_limit: int = LOGGING_PAGE_SIZE,
+        log_pages: int = DEFAULT_SOURCE_PAGES,
         trace_limit: int = 100,
-        trace_pages: int = 1,
+        trace_pages: int = DEFAULT_SOURCE_PAGES,
         runner: CommandRunner | None = None,
     ) -> None:
         if not is_valid_project_id(project_id):
@@ -524,17 +546,44 @@ class CloudTelemetryProvider:
             raise ValueError("invalid Kubernetes namespace")
         if hours not in {1, 6, 24, 72, 168, 720}:
             raise ValueError("unsupported telemetry window")
+        if not 1 <= log_pages <= MAX_LOGGING_PAGES:
+            raise ValueError("logging pages must be between 1 and 10")
         if not 1 <= trace_pages <= MAX_TRACE_PAGES:
             raise ValueError("trace pages must be between 1 and 10")
+        if not 1 <= log_limit <= LOGGING_PAGE_SIZE:
+            raise ValueError("logging page size must be between 1 and 500")
+        if not 1 <= trace_limit <= 100:
+            raise ValueError("trace page size must be between 1 and 100")
         self.project_id = project_id
         self.cluster = cluster
         self.namespace = namespace
         self.hours = hours
         self.log_limit = log_limit
+        self.log_pages = log_pages
         self.trace_limit = trace_limit
         self.trace_pages = trace_pages
         self.runner = runner or GcloudRunner(account)
         self._snapshot: TelemetrySnapshot | None = None
+        self._start: datetime | None = None
+        self._end: datetime | None = None
+        self._logging_rows: dict[str, dict[str, Any]] = {}
+        self._logging_cursors = (_PageCursor(), _PageCursor())
+        self._trace_rows: dict[str, dict[str, Any]] = {}
+        self._trace_cursor = _PageCursor()
+
+    @property
+    def loaded(self) -> bool:
+        return self._snapshot is not None
+
+    @property
+    def can_load_more(self) -> bool:
+        return any(
+            not cursor.complete and cursor.pages_read < MAX_LOGGING_PAGES
+            for cursor in self._logging_cursors
+        ) or (
+            not self._trace_cursor.complete
+            and self._trace_cursor.pages_read < MAX_TRACE_PAGES
+        )
 
     def list_activity(self) -> list[ActivityEvent]:
         return list(self.get_snapshot().events)
@@ -544,124 +593,232 @@ class CloudTelemetryProvider:
             self._snapshot = self._load()
         return self._snapshot
 
-    def _load_logging(
-        self,
-    ) -> tuple[list[ActivityEvent], TelemetrySourceState, dict[str, str]]:
+    def load_more(
+        self, pages: int = SOURCE_PAGES_PER_LOAD
+    ) -> TelemetrySnapshot:
+        """Append the next bounded source pages without rereading prior pages."""
+        if pages < 1:
+            raise ValueError("pages must be positive")
+        if self._snapshot is None:
+            return self.get_snapshot()
+        deadline = time.monotonic() + TELEMETRY_LOAD_DEADLINE_SECONDS
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = []
+            if any(
+                not cursor.complete and cursor.pages_read < MAX_LOGGING_PAGES
+                for cursor in self._logging_cursors
+            ):
+                futures.append(
+                    executor.submit(self._advance_logging, pages, deadline)
+                )
+            if (
+                not self._trace_cursor.complete
+                and self._trace_cursor.pages_read < MAX_TRACE_PAGES
+            ):
+                futures.append(executor.submit(self._advance_trace, pages, deadline))
+            for future in futures:
+                future.result()
+        self._snapshot = self._build_snapshot()
+        return self._snapshot
+
+    def _logging_queries(self) -> tuple[str, str]:
         base = (
             'resource.type="k8s_container" '
             f'AND resource.labels.namespace_name="{self.namespace}"'
         )
         if self.cluster:
             base += f' AND resource.labels.cluster_name="{self.cluster}"'
-        # Separate indexed payload variants instead of one broad OR query. This
-        # is materially faster in Cloud Logging and keeps each read bounded.
-        queries = (
-            f'({base}) AND jsonPayload.log:"audit_event"',
-            f"({base}) AND jsonPayload.audit_event:*",
+        assert self._start is not None and self._end is not None
+        interval = (
+            f' timestamp>="{self._start:%Y-%m-%dT%H:%M:%SZ}"'
+            f' AND timestamp<="{self._end:%Y-%m-%dT%H:%M:%SZ}"'
+        )
+        return (
+            f'({base}) AND jsonPayload.log:"audit_event" AND{interval}',
+            f"({base}) AND jsonPayload.audit_event:* AND{interval}",
         )
 
-        def read(query: str) -> CommandResult:
-            return self.runner.run(
-                [
-                    "logging",
-                    "read",
-                    query,
-                    f"--project={self.project_id}",
-                    f"--freshness={self.hours}h",
-                    f"--limit={self.log_limit}",
-                    "--order=desc",
-                    "--format=json",
-                ],
-                timeout=20,
+    @staticmethod
+    def _remaining_timeout(deadline: float, maximum: int) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError
+        return max(1.0, min(float(maximum), remaining))
+
+    @staticmethod
+    def _http_error(source: str, exc: BaseException) -> str:
+        if isinstance(exc, urllib.error.HTTPError):
+            if exc.code in {401, 403}:
+                return f"{source} permission was denied."
+            return f"{source} returned HTTP {exc.code}."
+        if isinstance(exc, TimeoutError):
+            return f"{source} read timed out."
+        if isinstance(exc, urllib.error.URLError) and isinstance(
+            exc.reason, TimeoutError
+        ):
+            return f"{source} read timed out."
+        if isinstance(exc, json.JSONDecodeError):
+            return f"{source} returned invalid JSON."
+        return f"{source} could not be read."
+
+    def _logging_token(self) -> str:
+        result = self.runner.run(["auth", "print-access-token"], timeout=15)
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    def _advance_logging_query(
+        self,
+        query: str,
+        cursor: _PageCursor,
+        token: str,
+        pages: int,
+        deadline: float,
+    ) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        page_budget = min(pages, MAX_LOGGING_PAGES - cursor.pages_read)
+        for _ in range(page_budget):
+            if cursor.complete:
+                break
+            body: dict[str, Any] = {
+                "resourceNames": [f"projects/{self.project_id}"],
+                "filter": query,
+                "orderBy": "timestamp desc",
+                "pageSize": self.log_limit,
+            }
+            if cursor.next_token:
+                body["pageToken"] = cursor.next_token
+            request = urllib.request.Request(
+                "https://logging.googleapis.com/v2/entries:list",
+                data=json.dumps(body, separators=(",", ":")).encode("utf-8"),
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                method="POST",
             )
-
-        with ThreadPoolExecutor(max_workers=len(queries)) as executor:
-            results = list(executor.map(read, queries))
-        failures = [result for result in results if result.returncode != 0]
-        if failures:
-            detail = "Cloud Logging read failed."
-            if any(result.timed_out for result in failures):
-                detail = "Cloud Logging read timed out."
-            elif any(
-                "permission" in result.stderr.lower() or "403" in result.stderr
-                for result in failures
-            ):
-                detail = "Cloud Logging permission was denied."
-            return [], TelemetrySourceState(
-                "Cloud Logging", "error", 0, False, detail
-            ), {}
-        rows_by_id: dict[str, dict[str, Any]] = {}
-        for result in results:
             try:
-                result_rows = json.loads(result.stdout or "[]")
-            except json.JSONDecodeError:
-                return [], TelemetrySourceState(
-                    "Cloud Logging",
-                    "error",
-                    0,
-                    False,
-                    "Cloud Logging returned invalid JSON.",
-                ), {}
-            if not isinstance(result_rows, list):
-                continue
-            for row in result_rows:
-                if not isinstance(row, dict):
-                    continue
-                key = _first(row, "insertId") or _event_id("row", row)
-                rows_by_id[key] = row
-        rows = list(rows_by_id.values())
-        events = [
-            event
-            for row in rows
-            if isinstance(row, dict)
-            if (event := normalize_logging_row(row, self.project_id)) is not None
-        ]
-        session_users = {
-            event.session_id: event.user_id
-            for event in events
-            if event.session_id and event.user_id
-        }
-        truncated = any(
-            len(json.loads(result.stdout or "[]")) >= self.log_limit
-            for result in results
-        )
-        status = "ready" if events else "empty"
-        detail = (
-            f"Read {len(rows)} matching audit record(s)."
-            if rows
-            else "No matching audit records were found in this window."
-        )
-        return events, TelemetrySourceState(
-            "Cloud Logging", status, len(rows), truncated, detail
-        ), session_users
+                timeout = self._remaining_timeout(
+                    deadline, LOGGING_TIMEOUT_SECONDS
+                )
+                with urllib.request.urlopen(request, timeout=timeout) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except (
+                http.client.HTTPException,
+                urllib.error.HTTPError,
+                urllib.error.URLError,
+                TimeoutError,
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+            ) as exc:
+                cursor.error = self._http_error("Cloud Logging", exc)
+                break
+            page_rows = (
+                payload.get("entries", []) if isinstance(payload, dict) else []
+            )
+            if not isinstance(page_rows, list):
+                page_rows = []
+            rows.extend(row for row in page_rows if isinstance(row, dict))
+            cursor.pages_read += 1
+            cursor.next_token = (
+                str(payload.get("nextPageToken") or "")
+                if isinstance(payload, dict)
+                else ""
+            )
+            cursor.complete = not cursor.next_token
+            cursor.error = ""
+        return rows
 
-    def _load_trace(
+    def _advance_logging(self, pages: int, deadline: float) -> None:
+        token = self._logging_token()
+        if not token:
+            for cursor in self._logging_cursors:
+                cursor.error = "Cloud Logging authentication is unavailable."
+            return
+        try:
+            queries = self._logging_queries()
+            with ThreadPoolExecutor(max_workers=len(queries)) as executor:
+                futures = [
+                    executor.submit(
+                        self._advance_logging_query,
+                        query,
+                        cursor,
+                        token,
+                        pages,
+                        deadline,
+                    )
+                    for query, cursor in zip(
+                        queries, self._logging_cursors, strict=True
+                    )
+                ]
+                for future in futures:
+                    for row in future.result():
+                        key = _first(row, "insertId") or _event_id("row", row)
+                        self._logging_rows[key] = row
+        finally:
+            token = ""
+
+    def _logging_source_state(self) -> TelemetrySourceState:
+        rows = len(self._logging_rows)
+        pages = sum(cursor.pages_read for cursor in self._logging_cursors)
+        errors = tuple(
+            dict.fromkeys(
+                cursor.error
+                for cursor in self._logging_cursors
+                if cursor.error
+            )
+        )
+        truncated = any(not cursor.complete for cursor in self._logging_cursors)
+        can_load_more = any(
+            not cursor.complete and cursor.pages_read < MAX_LOGGING_PAGES
+            for cursor in self._logging_cursors
+        )
+        status = "partial" if errors and rows else "error" if errors else "ready"
+        if not rows and not errors:
+            status = "empty"
+        detail = f"Read {rows} matching audit record(s) across {pages} page(s)."
+        if not rows and not errors:
+            detail = "No matching audit records were found in this window."
+        if errors:
+            prefix = (
+                f"Retained {rows} audit record(s) from {pages} page(s). "
+                if rows
+                else ""
+            )
+            detail = prefix + " ".join(errors)
+        return TelemetrySourceState(
+            "Cloud Logging",
+            status,
+            rows,
+            truncated,
+            detail,
+            pages,
+            can_load_more,
+        )
+
+    def _read_trace_pages(
         self,
         start: datetime,
         end: datetime,
-        session_users: dict[str, str],
-    ) -> tuple[list[ActivityEvent], TelemetrySourceState]:
+        cursor: _PageCursor,
+        traces_by_id: dict[str, dict[str, Any]],
+        pages: int,
+        deadline: float,
+    ) -> None:
         token_result = self.runner.run(
             ["auth", "application-default", "print-access-token"], timeout=15
         )
         token = token_result.stdout.strip()
         if token_result.returncode != 0 or not token:
-            return [], TelemetrySourceState(
-                "Cloud Trace",
-                "error",
-                0,
-                False,
-                "Application Default Credentials are unavailable.",
-            )
+            cursor.error = "Application Default Credentials are unavailable."
+            return
         terms = ["label:session.id"]
         if self.cluster:
             terms.append(f"+k8s.cluster.name:{self.cluster}")
-        traces: list[dict[str, Any]] = []
-        next_page_token = ""
-        pages_read = 0
-        read_error = ""
+        page_budget = min(pages, MAX_TRACE_PAGES - cursor.pages_read)
         try:
-            for page_number in range(1, self.trace_pages + 1):
+            for _ in range(page_budget):
+                if cursor.complete:
+                    break
                 parameters = {
                     "startTime": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
                     "endTime": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -670,8 +827,8 @@ class CloudTelemetryProvider:
                     "orderBy": "start desc",
                     "filter": " ".join(terms),
                 }
-                if next_page_token:
-                    parameters["pageToken"] = next_page_token
+                if cursor.next_token:
+                    parameters["pageToken"] = cursor.next_token
                 query = urllib.parse.urlencode(parameters)
                 request = urllib.request.Request(
                     f"https://cloudtrace.googleapis.com/v1/projects/"
@@ -682,80 +839,151 @@ class CloudTelemetryProvider:
                     },
                 )
                 try:
-                    with urllib.request.urlopen(request, timeout=30) as response:
-                        payload = json.loads(response.read().decode("utf-8"))
-                except urllib.error.HTTPError as exc:
-                    read_error = (
-                        "Cloud Trace permission was denied."
-                        if exc.code in {401, 403}
-                        else f"Cloud Trace returned HTTP {exc.code}."
+                    timeout = self._remaining_timeout(
+                        deadline, TRACE_TIMEOUT_SECONDS
                     )
+                    with urllib.request.urlopen(request, timeout=timeout) as response:
+                        payload = json.loads(response.read().decode("utf-8"))
+                except (
+                    http.client.HTTPException,
+                    urllib.error.HTTPError,
+                    urllib.error.URLError,
+                    TimeoutError,
+                    UnicodeDecodeError,
+                    json.JSONDecodeError,
+                ) as exc:
+                    cursor.error = self._http_error("Cloud Trace", exc)
                     break
-                except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
-                    read_error = "Cloud Trace could not be read."
-                    break
-
                 page_traces = (
                     payload.get("traces", []) if isinstance(payload, dict) else []
                 )
                 if not isinstance(page_traces, list):
                     page_traces = []
-                traces.extend(
-                    trace for trace in page_traces if isinstance(trace, dict)
-                )
-                pages_read = page_number
-                next_page_token = (
+                for trace in page_traces:
+                    if not isinstance(trace, dict):
+                        continue
+                    key = _first(trace, "traceId") or _event_id("trace", trace)
+                    traces_by_id[key] = trace
+                cursor.pages_read += 1
+                cursor.next_token = (
                     str(payload.get("nextPageToken") or "")
                     if isinstance(payload, dict)
                     else ""
                 )
-                if not next_page_token:
-                    break
+                cursor.complete = not cursor.next_token
+                cursor.error = ""
         finally:
             token = ""
-            token_result = CommandResult(0)
 
-        events = [
-            event
-            for trace in traces
-            for event in normalize_trace(trace, self.project_id, session_users)
-        ]
-        if read_error:
-            detail = read_error
-            if traces:
-                detail = (
-                    f"Read {len(traces)} matching trace(s) across {pages_read} page(s) "
-                    f"before a later page failed. {read_error}"
-                )
-            return events, TelemetrySourceState(
-                "Cloud Trace",
-                "error",
-                len(traces),
-                bool(next_page_token),
-                detail,
-                pages_read,
-            )
-
-        truncated = bool(next_page_token)
-        status = "ready" if events else "empty"
+    def _trace_source_state(
+        self, events: list[ActivityEvent], cursor: _PageCursor
+    ) -> TelemetrySourceState:
+        traces = len(self._trace_rows)
+        truncated = not cursor.complete
+        if cursor.error:
+            status = "partial" if traces else "error"
+        else:
+            status = "ready" if traces else "empty"
         detail = (
-            f"Read {len(traces)} matching trace(s) and {len(events)} span(s) "
-            f"across {pages_read} page(s)."
+            f"Read {traces} matching trace(s) and {len(events)} span(s) "
+            f"across {cursor.pages_read} page(s)."
             if traces
             else "No session-attributed traces were found in this window."
         )
-        return events, TelemetrySourceState(
-            "Cloud Trace", status, len(traces), truncated, detail, pages_read
+        if cursor.error:
+            prefix = (
+                f"Retained {traces} trace(s) from {cursor.pages_read} page(s). "
+                if traces
+                else ""
+            )
+            detail = prefix + cursor.error
+        return TelemetrySourceState(
+            "Cloud Trace",
+            status,
+            traces,
+            truncated,
+            detail,
+            cursor.pages_read,
+            not cursor.complete and cursor.pages_read < MAX_TRACE_PAGES,
         )
 
-    def _load(self) -> TelemetrySnapshot:
-        end = datetime.now(UTC)
-        start = end - timedelta(hours=self.hours)
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            logging_future = executor.submit(self._load_logging)
-            trace_future = executor.submit(self._load_trace, start, end, {})
-            log_events, log_state, session_users = logging_future.result()
-            trace_events, trace_state = trace_future.result()
+    def _advance_trace(self, pages: int, deadline: float) -> None:
+        assert self._start is not None and self._end is not None
+        self._read_trace_pages(
+            self._start,
+            self._end,
+            self._trace_cursor,
+            self._trace_rows,
+            pages,
+            deadline,
+        )
+
+    def _load_trace(
+        self,
+        start: datetime,
+        end: datetime,
+        session_users: dict[str, str],
+    ) -> tuple[list[ActivityEvent], TelemetrySourceState]:
+        cursor = _PageCursor()
+        traces_by_id: dict[str, dict[str, Any]] = {}
+        self._read_trace_pages(
+            start,
+            end,
+            cursor,
+            traces_by_id,
+            self.trace_pages,
+            time.monotonic() + TELEMETRY_LOAD_DEADLINE_SECONDS,
+        )
+        events = [
+            event
+            for trace in traces_by_id.values()
+            for event in normalize_trace(trace, self.project_id, session_users)
+        ]
+        traces = len(traces_by_id)
+        if cursor.error:
+            status = "partial" if traces else "error"
+        else:
+            status = "ready" if traces else "empty"
+        detail = (
+            f"Read {traces} matching trace(s) and {len(events)} span(s) "
+            f"across {cursor.pages_read} page(s)."
+            if traces
+            else "No session-attributed traces were found in this window."
+        )
+        if cursor.error:
+            prefix = (
+                f"Retained {traces} trace(s) from {cursor.pages_read} page(s). "
+                if traces
+                else ""
+            )
+            detail = prefix + cursor.error
+        return events, TelemetrySourceState(
+            "Cloud Trace",
+            status,
+            traces,
+            not cursor.complete,
+            detail,
+            cursor.pages_read,
+            not cursor.complete and cursor.pages_read < MAX_TRACE_PAGES,
+        )
+
+    def _build_snapshot(self) -> TelemetrySnapshot:
+        assert self._start is not None and self._end is not None
+        log_events = [
+            event
+            for row in self._logging_rows.values()
+            if (event := normalize_logging_row(row, self.project_id)) is not None
+        ]
+        session_users = {
+            event.session_id: event.user_id
+            for event in log_events
+            if event.session_id and event.user_id
+        }
+        trace_events = [
+            event
+            for trace in self._trace_rows.values()
+            for event in normalize_trace(trace, self.project_id, session_users)
+        ]
         trace_events = [
             replace(
                 event,
@@ -779,9 +1007,27 @@ class CloudTelemetryProvider:
         return TelemetrySnapshot(
             self.project_id,
             self.cluster,
-            start,
-            end,
+            self._start,
+            self._end,
             datetime.now(UTC),
             tuple(events),
-            (log_state, trace_state),
+            (
+                self._logging_source_state(),
+                self._trace_source_state(trace_events, self._trace_cursor),
+            ),
         )
+
+    def _load(self) -> TelemetrySnapshot:
+        self._end = datetime.now(UTC)
+        self._start = self._end - timedelta(hours=self.hours)
+        deadline = time.monotonic() + TELEMETRY_LOAD_DEADLINE_SECONDS
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            logging_future = executor.submit(
+                self._advance_logging, self.log_pages, deadline
+            )
+            trace_future = executor.submit(
+                self._advance_trace, self.trace_pages, deadline
+            )
+            logging_future.result()
+            trace_future.result()
+        return self._build_snapshot()

--- a/admin_console/tests/test_admin_portal_ui.py
+++ b/admin_console/tests/test_admin_portal_ui.py
@@ -18,7 +18,10 @@ from admin_console.connections import (
     ConnectionReport,
 )
 from admin_console.connection_persistence import save_connection
-from admin_console.connection_sidebar import CONNECTION_JOB_KEY
+from admin_console.connection_controller import (
+    CONNECTION_CONTROLLER_KEY,
+    ConnectionController,
+)
 from admin_console.tests.activity_fixtures import FixtureTelemetryProvider
 from admin_console.agent_runtime import (
     CronSnapshot,
@@ -53,6 +56,9 @@ TARGET = DeploymentTarget(PROJECT, CLUSTER, LOCATION, NAMESPACE)
 def connection_report(
     *,
     runtime_status: CheckStatus = CheckStatus.PASS,
+    runtime_summary: str = "",
+    runtime_guidance: str = "",
+    audit_status: CheckStatus = CheckStatus.WARNING,
     clusters: tuple[ClusterInfo, ...] | None = None,
 ) -> ConnectionReport:
     checks = (
@@ -65,10 +71,12 @@ def connection_report(
             "agent_runtime",
             "Agent runtime read",
             runtime_status,
-            "Ready." if runtime_status == CheckStatus.PASS else "Unavailable.",
+            runtime_summary
+            or ("Ready." if runtime_status == CheckStatus.PASS else "Unavailable."),
+            runtime_guidance,
         ),
         ConnectionCheck("logging", "Cloud Logging", CheckStatus.PASS, "Ready."),
-        ConnectionCheck("audit", "Audit events", CheckStatus.WARNING, "No recent data."),
+        ConnectionCheck("audit", "Audit events", audit_status, "No recent data."),
         ConnectionCheck("trace", "Cloud Trace", CheckStatus.PASS, "Ready."),
     )
     return ConnectionReport(
@@ -261,6 +269,28 @@ class FakeHistoryProvider:
                 datetime(2026, 8, 5, 18, 30, tzinfo=UTC),
                 datetime(2026, 8, 5, 18, 30, 2, tzinfo=UTC),
                 "",
+            ),
+            AgentCronExecution(
+                "execution-2",
+                "cluster-test-01",
+                "job-visitors",
+                "cron",
+                "completed",
+                datetime(2026, 8, 5, 17, 29, tzinfo=UTC),
+                datetime(2026, 8, 5, 17, 30, tzinfo=UTC),
+                datetime(2026, 8, 5, 17, 30, 3, tzinfo=UTC),
+                "",
+            ),
+            AgentCronExecution(
+                "execution-3",
+                "cluster-test-01",
+                "job-visitors",
+                "cron",
+                "failed",
+                datetime(2026, 8, 5, 16, 29, tzinfo=UTC),
+                datetime(2026, 8, 5, 16, 30, tzinfo=UTC),
+                datetime(2026, 8, 5, 16, 30, 1, tzinfo=UTC),
+                "upstream <unavailable>",
             ),
         )
         return CronSnapshot(jobs, executions, False, False, read_at)
@@ -557,20 +587,40 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             {"project": PROJECT, "cluster": CLUSTER, "location": LOCATION}
         )
         if connected:
-            app.session_state.connected_target = TARGET
+            app.session_state[CONNECTION_CONTROLLER_KEY] = ConnectionController.verified(
+                "admin@example.com", TARGET, connection_report()
+            )
         return app
+
+    def controller(self, app: AppTest) -> ConnectionController:
+        return app.session_state[CONNECTION_CONTROLLER_KEY]
 
     def finish_connection_job(self, app: AppTest) -> AppTest:
         """Wait on the dependency itself, then let the UI consume its result."""
-        if "connected_target" in app.session_state:
-            return app
-        if CONNECTION_JOB_KEY not in app.session_state:
+        if CONNECTION_CONTROLLER_KEY not in app.session_state:
             app = app.run()
-        if "connected_target" in app.session_state:
+        controller = self.controller(app)
+        if controller.job is None:
             return app
-        job = app.session_state[CONNECTION_JOB_KEY]
+        job = controller.job
         job.future.result(timeout=20)
         return app.run()
+
+    def connect_project(self, app: AppTest) -> AppTest:
+        next(
+            button
+            for button in app.button
+            if button.key == "project_connection_primary_disconnected"
+        ).click().run()
+        return self.finish_connection_job(app)
+
+    def connect_cluster(self, app: AppTest) -> AppTest:
+        next(
+            button
+            for button in app.button
+            if button.key == "cluster_connection_primary_disconnected"
+        ).click().run()
+        return self.finish_connection_job(app)
 
     def test_provider_backed_pages_stay_visible_before_connection(self):
         for page, title in (
@@ -587,47 +637,94 @@ class AdminPortalFunctionalTest(unittest.TestCase):
                 self.assertEqual(app.title[0].value, title)
                 self.assertEqual(
                     app.info[0].value,
-                    "Connect to kube-agents on Connection.",
+                    "Connect a project and cluster on Connection.",
                 )
 
-    def test_successful_connection_establishes_verified_target(self):
+    def test_project_and_cluster_connect_independently(self):
         with patch(
             "admin_console.connections.run_connection_checks",
-            return_value=connection_report(),
+            return_value=connection_report(audit_status=CheckStatus.FAIL),
         ) as run_checks:
-            app = self.app().run()
-            next(
-                button
-                for button in app.button
-                if button.label == "Connect"
-            ).click().run()
-            app = self.finish_connection_job(app)
+            app = self.connect_project(self.app().run())
 
-        connected = app.session_state.connected_target
+            self.assertIsNone(self.controller(app).connected_target)
+            self.assertEqual(self.controller(app).connected_project, PROJECT)
+            self.assertTrue(
+                next(
+                    button
+                    for button in app.button
+                    if button.key == "project_connection_primary_connected"
+                ).disabled
+            )
+            self.assertFalse(
+                next(
+                    button
+                    for button in app.button
+                    if button.key == "cluster_connection_primary_disconnected"
+                ).disabled
+            )
+
+            app = self.connect_cluster(app)
+
+        connected = self.controller(app).connected_target
         self.assertEqual(
             (connected.project_id, connected.cluster_name, connected.location),
             (PROJECT, CLUSTER, LOCATION),
         )
-        self.assertTrue(any("Connected to" in item.value for item in app.success))
-        buttons = {button.label: button for button in app.button}
-        self.assertTrue(buttons["Connected"].disabled)
-        self.assertFalse(buttons["Disconnect"].disabled)
-        run_checks.assert_called_once_with(
-            PROJECT,
-            expected_target=None,
-            include_agent_runtime_probe=True,
-        )
-        self.assertEqual(app.title[0].value, "Connection")
+        self.assertEqual(run_checks.call_count, 2)
         self.assertFalse(
-            any(item.value == "### Connection" for item in app.markdown)
+            run_checks.call_args_list[0].kwargs["include_agent_runtime_probe"]
         )
-        self.assertEqual(len(app.sidebar.selectbox), 0)
-        self.assertEqual(len(app.sidebar.button), 0)
         self.assertFalse(
-            any("Cloud telemetry" in item.value for item in app.sidebar.caption)
+            run_checks.call_args_list[0].kwargs["include_telemetry_probes"]
+        )
+        self.assertIsNone(run_checks.call_args_list[0].kwargs["expected_target"])
+        self.assertTrue(
+            run_checks.call_args_list[1].kwargs["include_agent_runtime_probe"]
+        )
+        self.assertTrue(
+            run_checks.call_args_list[1].kwargs["include_telemetry_probes"]
+        )
+        expected_target = run_checks.call_args_list[1].kwargs["expected_target"]
+        self.assertEqual(
+            (
+                expected_target.project_id,
+                expected_target.cluster_name,
+                expected_target.location,
+                expected_target.namespace,
+            ),
+            (PROJECT, CLUSTER, LOCATION, NAMESPACE),
+        )
+        self.assertEqual(
+            sum(button.label == "Connected" for button in app.button),
+            2,
         )
 
-    def test_saved_connection_is_revalidated_and_restored_after_reopen(self):
+    def test_cluster_connection_is_shared_with_task_kanban(self):
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            return_value=connection_report(),
+        ), patch(
+            "admin_console.agent_runtime.AgentRuntimeProvider",
+            FakeHistoryProvider,
+        ):
+            app = self.connect_project(self.app().run())
+            app = self.connect_cluster(app)
+            app = app.switch_page("pages/kanban.py").run()
+
+        self.assertEqual(len(app.exception), 0)
+        self.assertEqual(len(app.info), 0)
+        self.assertEqual(app.title[0].value, "Task Kanban")
+        connected = self.controller(app).connected_target
+        self.assertEqual(
+            (connected.project_id, connected.cluster_name, connected.location),
+            (PROJECT, CLUSTER, LOCATION),
+        )
+        self.assertTrue(
+            any("Applications inspected" in item.value for item in app.success)
+        )
+
+    def test_saved_connection_resumes_with_live_revalidation(self):
         verified_at = datetime.now(UTC)
         save_connection("admin@example.com", TARGET, verified_at)
         with patch(
@@ -637,47 +734,34 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             app = AppTest.from_file(APP_PATH, default_timeout=20).run()
             app = self.finish_connection_job(app)
 
-        self.assertEqual(app.session_state.connected_target, TARGET)
+        self.assertEqual(self.controller(app).connected_target, TARGET)
         self.assertEqual(app.query_params["project"], [PROJECT])
         self.assertEqual(app.query_params["cluster"], [CLUSTER])
         self.assertEqual(app.query_params["location"], [LOCATION])
+        self.assertEqual([button.label for button in app.button].count("Connected"), 2)
+        self.assertEqual(len(app.selectbox), 2)
+        self.assertTrue(
+            any("Step 1 · Project" in item.value for item in app.markdown)
+        )
+        self.assertTrue(
+            any("Step 2 · Cluster" in item.value for item in app.markdown)
+        )
         run_checks.assert_called_once()
         self.assertEqual(run_checks.call_args.kwargs["expected_target"], TARGET)
+        self.assertTrue(run_checks.call_args.kwargs["include_agent_runtime_probe"])
 
-    def test_connection_restore_keeps_navigation_and_page_responsive(self):
-        save_connection("admin@example.com", TARGET, datetime.now(UTC))
-        release_check = Event()
-
-        def blocked_check(*args, **kwargs):
-            release_check.wait(timeout=20)
-            return connection_report()
-
+    def test_selected_target_without_saved_lease_does_not_auto_connect(self):
         with patch(
             "admin_console.connections.run_connection_checks",
-            side_effect=blocked_check,
-        ):
-            app = AppTest.from_file(APP_PATH, default_timeout=20).run()
-            self.assertEqual(app.title[0].value, "Connection")
-            project = next(item for item in app.selectbox if item.label == "Project")
-            self.assertEqual(project.value, PROJECT)
-            connecting = next(
-                item for item in app.button if item.label == "Connecting…"
-            )
-            self.assertTrue(connecting.disabled)
-            self.assertTrue(
-                any(
-                    "Restoring and verifying" in item.label
-                    for item in app.sidebar.status
-                )
-            )
-            release_check.set()
-            app = self.finish_connection_job(app)
+            return_value=connection_report(),
+        ) as run_checks:
+            app = self.app().run()
 
-        self.assertEqual(app.session_state.connected_target, TARGET)
-        connected = next(item for item in app.button if item.label == "Connected")
-        self.assertTrue(connected.disabled)
+        self.assertIsNone(self.controller(app).connected_project)
+        self.assertIsNone(self.controller(app).connected_target)
+        run_checks.assert_not_called()
 
-    def test_connect_button_reports_background_progress(self):
+    def test_project_connect_shows_matching_abort_pair(self):
         release_check = Event()
 
         def blocked_check(*args, **kwargs):
@@ -690,38 +774,122 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         ):
             app = self.app().run()
             next(
-                item for item in app.button if item.label == "Connect"
+                button
+                for button in app.button
+                if button.key == "project_connection_primary_disconnected"
             ).click().run()
 
             connecting = next(
-                item for item in app.button if item.label == "Connecting…"
+                button
+                for button in app.button
+                if button.key == "project_connection_primary_connecting"
             )
             self.assertTrue(connecting.disabled)
+            abort = next(
+                button
+                for button in app.button
+                if button.key == "project_connection_secondary_abort"
+            )
+            self.assertFalse(abort.disabled)
             self.assertTrue(
-                any("Connecting to kube-agents" in item.label for item in app.sidebar.status)
+                any(
+                    "Connecting to the selected project" in item.label
+                    for item in app.sidebar.status
+                )
             )
 
             release_check.set()
             app = self.finish_connection_job(app)
 
-        connected = next(item for item in app.button if item.label == "Connected")
-        self.assertTrue(connected.disabled)
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
+        self.assertIsNone(self.controller(app).connected_target)
 
-    def test_stale_connection_is_locked_when_periodic_revalidation_fails(self):
+    def test_project_abort_ignores_a_late_result(self):
+        release_check = Event()
+
+        def blocked_check(*args, **kwargs):
+            release_check.wait(timeout=20)
+            return connection_report()
+
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=blocked_check,
+        ):
+            app = self.app().run()
+            next(
+                button
+                for button in app.button
+                if button.key == "project_connection_primary_disconnected"
+            ).click().run()
+            next(
+                button
+                for button in app.button
+                if button.key == "project_connection_secondary_abort"
+            ).click().run()
+
+            self.assertIsNone(self.controller(app).connected_project)
+            self.assertIsNone(self.controller(app).connected_target)
+            self.assertIsNone(self.controller(app).job)
+            self.assertFalse(
+                next(
+                    button
+                    for button in app.button
+                    if button.key == "project_connection_primary_disconnected"
+                ).disabled
+            )
+
+            release_check.set()
+            app.run()
+
+        self.assertIsNone(self.controller(app).connected_project)
+
+    def test_cluster_abort_keeps_project_connected(self):
+        release_check = Event()
+
+        def connection_check(*args, expected_target=None, **kwargs):
+            if expected_target is None:
+                return connection_report()
+            release_check.wait(timeout=20)
+            return connection_report()
+
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=connection_check,
+        ):
+            app = self.connect_project(self.app().run())
+            next(
+                button
+                for button in app.button
+                if button.key == "cluster_connection_primary_disconnected"
+            ).click().run()
+            next(
+                button
+                for button in app.button
+                if button.key == "cluster_connection_secondary_abort"
+            ).click().run()
+            release_check.set()
+            app.run()
+
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
+        self.assertIsNone(self.controller(app).connected_target)
+
+    def test_failed_revalidation_disconnects_only_the_cluster(self):
         app = self.app(connected=True)
-        app.session_state.connection_last_verified_at = datetime(2020, 1, 1, tzinfo=UTC)
+        self.controller(app).verified_at = datetime(2020, 1, 1, tzinfo=UTC)
         with patch(
             "admin_console.connections.run_connection_checks",
             return_value=connection_report(runtime_status=CheckStatus.FAIL),
         ):
             app = app.run()
+            app = self.finish_connection_job(app)
 
-        self.assertNotIn("connected_target", app.session_state)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
         self.assertTrue(
-            any("failed revalidation" in item.value for item in app.warning)
+            any("Agent runtime read: Unavailable" in item.value for item in app.error)
         )
 
-    def test_connection_auto_selects_the_uniquely_labeled_host(self):
+    def test_unique_host_is_preselected_but_not_auto_connected(self):
         detected_cluster = "detected-host"
         report = connection_report(
             clusters=(ClusterInfo(detected_cluster, LOCATION, "RUNNING", True),)
@@ -730,14 +898,12 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             "admin_console.connections.run_connection_checks",
             return_value=report,
         ) as run_checks:
-            app = self.app().run()
-            next(
-                button for button in app.button if button.label == "Connect"
-            ).click().run()
+            app = self.connect_project(self.app().run())
 
-        connected = app.session_state.connected_target
-        self.assertEqual(connected.cluster_name, detected_cluster)
+        self.assertIsNone(self.controller(app).connected_target)
         self.assertEqual(app.query_params["cluster"], [detected_cluster])
+        cluster = next(item for item in app.selectbox if item.label == "Cluster")
+        self.assertEqual(cluster.value, f"{detected_cluster}|{LOCATION}")
         self.assertIsNone(run_checks.call_args.kwargs["expected_target"])
 
     def test_project_selector_accepts_custom_project_without_second_field(self):
@@ -748,7 +914,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             app = self.app().run()
 
         self.assertFalse(any(item.label == "Project ID" for item in app.text_input))
-        self.assertEqual(app.session_state.selected_project, "custom-project-01")
+        self.assertEqual(self.controller(app).project_id, "custom-project-01")
         self.assertEqual(app.query_params["project"], ["custom-project-01"])
 
     def test_invalid_custom_project_disables_connect(self):
@@ -761,48 +927,95 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertTrue(
             any("valid Google Cloud project ID" in item.value for item in app.error)
         )
-        connect = next(button for button in app.button if button.label == "Connect")
+        connect = next(
+            button
+            for button in app.button
+            if button.key == "project_connection_primary_disconnected"
+        )
         self.assertTrue(connect.disabled)
 
-    def test_missing_host_label_requires_manual_select(self):
+    def test_cluster_picker_handles_missing_host_label_without_an_error(self):
+        clusters = (
+            ClusterInfo("cluster-a", LOCATION, "RUNNING"),
+            ClusterInfo("cluster-b", LOCATION, "RUNNING"),
+        )
+        discovery = connection_report(clusters=clusters)
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            return_value=discovery,
+        ):
+            app = self.connect_project(self.app().run())
+
+            self.assertIsNone(self.controller(app).connected_target)
+            self.assertEqual(len(app.error), 0)
+            self.assertTrue(
+                any("No kube-agents host label" in item.value for item in app.caption)
+            )
+            cluster_select = next(
+                item for item in app.selectbox if item.label == "Cluster"
+            )
+            self.assertEqual(
+                cluster_select.options,
+                ["cluster-a · us-east4", "cluster-b · us-east4"],
+            )
+
+    def test_cluster_connect_shows_matching_abort_pair(self):
         clusters = (
             ClusterInfo("cluster-a", LOCATION, "RUNNING"),
             ClusterInfo("cluster-b", LOCATION, "RUNNING"),
         )
         discovery = connection_report(clusters=clusters)
         verified = connection_report(clusters=clusters)
+        release_check = Event()
+
+        def connection_check(*args, expected_target=None, **kwargs):
+            if expected_target is None:
+                return discovery
+            release_check.wait(timeout=20)
+            return verified
+
         with patch(
             "admin_console.connections.run_connection_checks",
-            side_effect=(discovery, verified),
+            side_effect=connection_check,
         ):
             app = self.app().run()
-            next(
-                button for button in app.button if button.label == "Connect"
-            ).click().run()
-
-            self.assertNotIn("connected_target", app.session_state)
-            self.assertNotIn("cluster", app.query_params)
-            self.assertNotIn("location", app.query_params)
-            self.assertTrue(
-                any("no GKE cluster is labeled" in item.value for item in app.error)
-            )
-            buttons = {button.label: button for button in app.button}
-            self.assertTrue(buttons["Connect"].disabled)
-            self.assertIn("Select", buttons)
-
+            app = self.connect_project(self.app().run())
             cluster_select = next(
                 item for item in app.selectbox if item.label == "Cluster"
             )
             cluster_select.select("cluster-b|us-east4").run()
             next(
-                button for button in app.button if button.label == "Select"
+                button
+                for button in app.button
+                if button.key == "cluster_connection_primary_disconnected"
             ).click().run()
 
-        connected = app.session_state.connected_target
-        self.assertEqual(connected.cluster_name, "cluster-b")
-        self.assertEqual(connected.source, "manual selection")
+            connecting = next(
+                button
+                for button in app.button
+                if button.key == "cluster_connection_primary_connecting"
+            )
+            self.assertTrue(connecting.disabled)
+            self.assertFalse(
+                next(
+                    button
+                    for button in app.button
+                    if button.key == "cluster_connection_secondary_abort"
+                ).disabled
+            )
+            self.assertEqual(len(app.error), 0)
+            self.assertTrue(
+                any(
+                    "Connecting to the selected cluster" in item.label
+                    for item in app.sidebar.status
+                )
+            )
+            release_check.set()
+            app = self.finish_connection_job(app)
 
-    def test_multiple_host_labels_show_red_manual_selection_notice(self):
+        self.assertEqual(self.controller(app).connected_target.cluster_name, "cluster-b")
+
+    def test_multiple_host_labels_use_the_same_cluster_picker(self):
         report = connection_report(
             clusters=(
                 ClusterInfo("host-a", LOCATION, "RUNNING", True),
@@ -813,64 +1026,92 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             "admin_console.connections.run_connection_checks",
             return_value=report,
         ):
-            app = self.app().run()
-            next(
-                button for button in app.button if button.label == "Connect"
-            ).click().run()
+            app = self.connect_project(self.app().run())
 
-        self.assertNotIn("connected_target", app.session_state)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertEqual(len(app.error), 0)
         self.assertTrue(
-            any("2 GKE clusters are labeled" in item.value for item in app.error)
-        )
-        self.assertTrue(
-            any(button.label == "Select" for button in app.button)
+            any("Multiple host labels" in item.value for item in app.caption)
         )
 
-    def test_connection_actions_are_mutually_exclusive(self):
-        disconnected = self.app().run()
-        buttons = {button.label: button for button in disconnected.button}
-        self.assertFalse(buttons["Connect"].disabled)
-        self.assertTrue(buttons["Disconnect"].disabled)
-
-        connected = self.app(connected=True).run()
-        buttons = {button.label: button for button in connected.button}
-        self.assertTrue(buttons["Connected"].disabled)
-        self.assertFalse(buttons["Disconnect"].disabled)
-
-    def test_failed_connection_does_not_unlock_observe(self):
+    def test_project_without_clusters_connects_but_disables_cluster_connect(self):
+        report = connection_report(clusters=())
         with patch(
             "admin_console.connections.run_connection_checks",
-            return_value=connection_report(runtime_status=CheckStatus.FAIL),
+            return_value=report,
         ):
-            app = self.app().run()
+            app = self.connect_project(self.app().run())
+
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertTrue(
             next(
                 button
                 for button in app.button
-                if button.label == "Connect"
-            ).click().run()
-
-        self.assertNotIn("connected_target", app.session_state)
-        self.assertTrue(
-            any("not established" in item.value for item in app.error)
+                if button.key == "cluster_connection_primary_disconnected"
+            ).disabled
         )
-        self.assertTrue(
-            any("Unavailable" in item.value for item in app.warning)
-        )
+        self.assertTrue(any("No GKE clusters" in item.value for item in app.info))
 
-    def test_disconnect_revokes_connected_state(self):
+    def test_failed_cluster_connection_keeps_project_connected(self):
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=(
+                connection_report(),
+                connection_report(
+                    runtime_status=CheckStatus.FAIL,
+                    runtime_summary="No running kube-agents gateway pods were found.",
+                    runtime_guidance="Confirm the selected cluster and namespace.",
+                ),
+            ),
+        ):
+            app = self.connect_project(self.app().run())
+            app = self.connect_cluster(app)
+
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertEqual(len(app.error), 1)
+        self.assertEqual(
+            app.error[0].value,
+            "Could not connect to cluster test-cluster-01. Agent runtime read: "
+            "No running kube-agents gateway pods were found. "
+            "Confirm the selected cluster and namespace.",
+        )
+        self.assertEqual(len(app.metric), 0)
+
+    def test_cluster_disconnect_keeps_project_connected(self):
+        app = self.app(connected=True).run()
+        self.assertEqual([button.label for button in app.button].count("Disconnect"), 1)
+        next(
+            button
+            for button in app.button
+            if button.key == "cluster_connection_secondary_disconnect"
+        ).click().run()
+
+        self.assertEqual(self.controller(app).connected_project, PROJECT)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertEqual(app.query_params["project"], [PROJECT])
+        self.assertEqual(app.query_params["cluster"], [CLUSTER])
+        self.assertEqual([button.label for button in app.button].count("Disconnect"), 1)
+
+    def test_nested_disconnects_expose_only_one_action_at_a_time(self):
         app = self.app(connected=True).run()
         next(
             button
             for button in app.button
-            if button.label == "Disconnect"
+            if button.key == "cluster_connection_secondary_disconnect"
+        ).click().run()
+        self.assertEqual([button.label for button in app.button].count("Disconnect"), 1)
+        next(
+            button
+            for button in app.button
+            if button.key == "project_connection_secondary_disconnect"
         ).click().run()
 
-        self.assertNotIn("connected_target", app.session_state)
+        self.assertIsNone(self.controller(app).connected_project)
+        self.assertIsNone(self.controller(app).connected_target)
         self.assertEqual(app.query_params["project"], [PROJECT])
-        self.assertEqual(app.query_params["cluster"], [CLUSTER])
-        buttons = {button.label: button for button in app.button}
-        self.assertFalse(buttons["Connect"].disabled)
-        self.assertTrue(buttons["Disconnect"].disabled)
+        self.assertNotIn("cluster", app.query_params)
 
     def test_chat_renders_real_projection_and_persists_safe_url_state(self):
         with patch(
@@ -1012,7 +1253,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             app = app.switch_page("pages/chat.py").run()
 
         self.assertEqual(len(app.exception), 0)
-        self.assertEqual(app.session_state.selected_cluster, CLUSTER)
+        self.assertEqual(self.controller(app).selected_target.cluster_name, CLUSTER)
         self.assertEqual(app.query_params["cluster"], [CLUSTER])
         self.assertEqual(len(app.chat_message), 2)
 
@@ -1135,9 +1376,21 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertEqual(app.title[0].value, "Scheduled Cron")
         self.assertEqual(app.query_params["cron_agent"], ["test-agent-01"])
         self.assertEqual(app.query_params["cron_window"], ["7d"])
-        self.assertEqual(len(app.dataframe), 2)
-        self.assertEqual(app.dataframe[0].value.iloc[0]["Trigger"], "Manual")
-        self.assertIn("Scheduler", app.dataframe[1].value.columns)
+        self.assertEqual(len(app.dataframe), 1)
+        self.assertIn("Scheduler", app.dataframe[0].value.columns)
+        execution_markup = next(
+            item.value
+            for item in app.markdown
+            if "ka-cron-table-wrap" in item.value
+        )
+        self.assertEqual(execution_markup.count("<tr>"), 2)
+        self.assertIn("Unique visitors", execution_markup)
+        self.assertIn("<summary>3 runs</summary>", execution_markup)
+        self.assertIn("2026-08-05 18:30 UTC", execution_markup)
+        self.assertIn("2026-08-05 17:30 UTC", execution_markup)
+        self.assertIn("2026-08-05 16:30 UTC", execution_markup)
+        self.assertIn("Manual", execution_markup)
+        self.assertIn("upstream &lt;unavailable&gt;", execution_markup)
         self.assertTrue(
             any("without a live scheduler" in item.value for item in app.warning)
         )

--- a/admin_console/tests/test_admin_portal_ui.py
+++ b/admin_console/tests/test_admin_portal_ui.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import unittest
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import Event
 from unittest.mock import patch
@@ -542,13 +542,24 @@ class FakeTelemetryProvider:
         self.trace_pages = trace_pages
         self.trace_limit = 100
         self.events = tuple(FixtureTelemetryProvider().list_activity())
+        self._snapshot = None
+
+    @property
+    def loaded(self):
+        return self._snapshot is not None
+
+    @property
+    def can_load_more(self):
+        return self.trace_pages < 2
 
     def list_activity(self):
         return list(self.events)
 
     def get_snapshot(self) -> TelemetrySnapshot:
+        if self._snapshot is not None:
+            return self._snapshot
         end = datetime.now(UTC)
-        return TelemetrySnapshot(
+        self._snapshot = TelemetrySnapshot(
             self.project_id,
             self.cluster,
             end,
@@ -562,9 +573,32 @@ class FakeTelemetryProvider:
                     len(self.events),
                     self.trace_pages < 2,
                     "Deterministic functional-test data.",
+                    can_load_more=self.trace_pages < 2,
                 ),
             ),
         )
+        return self._snapshot
+
+    def load_more(self):
+        self.trace_pages = 2
+        self._snapshot = None
+        return self.get_snapshot()
+
+
+class FakeLargeTelemetryProvider(FakeTelemetryProvider):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        source = self.events[0]
+        self.events = tuple(
+            replace(
+                source,
+                event_id=f"event-{index:03d}",
+                interaction_id=f"interaction-{index:03d}",
+                occurred_at=source.occurred_at - timedelta(seconds=index),
+            )
+            for index in range(105)
+        )
+        self.trace_pages = 2
 
 
 class AdminPortalFunctionalTest(unittest.TestCase):
@@ -1529,6 +1563,38 @@ class AdminPortalFunctionalTest(unittest.TestCase):
                 self.assertIn("Time window", labels)
                 self.assertIn("Cluster", labels)
                 self.assertEqual(len(app.sidebar.selectbox), 0)
+
+    def test_activity_ledger_paginates_fifty_events_at_a_time(self):
+        with patch(
+            "admin_console.activity_scope.CloudTelemetryProvider",
+            FakeLargeTelemetryProvider,
+        ):
+            app = self.app(connected=True).run().switch_page("pages/activity.py").run()
+            self.assertEqual(len(app.dataframe[0].value), 50)
+            next(button for button in app.button if button.label == "Next").click().run()
+
+        self.assertEqual(app.query_params["activity_page"], ["2"])
+        self.assertEqual(len(app.dataframe[0].value), 50)
+        self.assertTrue(
+            any("51–100 of 105" in item.value for item in app.caption)
+        )
+
+    def test_activity_load_more_appends_the_next_source_pages(self):
+        with patch(
+            "admin_console.activity_scope.CloudTelemetryProvider",
+            FakeTelemetryProvider,
+        ):
+            app = self.app(connected=True).run().switch_page("pages/activity.py").run()
+            next(
+                button
+                for button in app.button
+                if button.label == "Load more activity"
+            ).click().run()
+
+        self.assertEqual(len(app.exception), 0)
+        self.assertFalse(
+            any(button.label == "Load more activity" for button in app.button)
+        )
 
     def test_scheduled_cron_renders_live_jobs_runs_and_calendar(self):
         with patch(

--- a/admin_console/tests/test_admin_portal_ui.py
+++ b/admin_console/tests/test_admin_portal_ui.py
@@ -17,7 +17,11 @@ from admin_console.connections import (
     ConnectionCheck,
     ConnectionReport,
 )
-from admin_console.connection_persistence import save_connection
+from admin_console.connection_persistence import (
+    delete_connection,
+    load_connection,
+    save_connection,
+)
 from admin_console.connection_controller import (
     CONNECTION_CONTROLLER_KEY,
     ConnectionController,
@@ -46,6 +50,7 @@ from admin_console.telemetry import TelemetrySnapshot, TelemetrySourceState
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 APP_PATH = REPO_ROOT / "admin_console" / "app.py"
+CONNECTION_PAGE_PATH = REPO_ROOT / "admin_console" / "pages" / "connections.py"
 PROJECT = "test-project-01"
 CLUSTER = "test-cluster-01"
 LOCATION = "us-east4"
@@ -290,7 +295,7 @@ class FakeHistoryProvider:
                 datetime(2026, 8, 5, 16, 29, tzinfo=UTC),
                 datetime(2026, 8, 5, 16, 30, tzinfo=UTC),
                 datetime(2026, 8, 5, 16, 30, 1, tzinfo=UTC),
-                "upstream <unavailable>",
+                "upstream <unavailable>\nretry exhausted",
             ),
         )
         return CronSnapshot(jobs, executions, False, False, read_at)
@@ -640,6 +645,29 @@ class AdminPortalFunctionalTest(unittest.TestCase):
                     "Connect a project and cluster on Connection.",
                 )
 
+    def test_connection_page_bootstraps_when_streamlit_resumes_it_directly(self):
+        app = AppTest.from_file(CONNECTION_PAGE_PATH, default_timeout=20)
+        app.query_params.update(
+            {"project": PROJECT, "cluster": CLUSTER, "location": LOCATION}
+        )
+        app = app.run()
+
+        self.assertEqual(len(app.exception), 0)
+        self.assertEqual(app.title[0].value, "Connection")
+        self.assertIsInstance(self.controller(app), ConnectionController)
+        self.assertTrue(
+            any(
+                "Signed in as admin@example.com" in item.value
+                for item in app.sidebar.caption
+            )
+        )
+        self.assertTrue(
+            any(
+                button.key == "project_connection_primary_disconnected"
+                for button in app.button
+            )
+        )
+
     def test_project_and_cluster_connect_independently(self):
         with patch(
             "admin_console.connections.run_connection_checks",
@@ -749,6 +777,33 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         run_checks.assert_called_once()
         self.assertEqual(run_checks.call_args.kwargs["expected_target"], TARGET)
         self.assertTrue(run_checks.call_args.kwargs["include_agent_runtime_probe"])
+
+    def test_suspended_lease_stays_locked_until_revalidation_finishes(self):
+        release_check = Event()
+
+        def blocked_check(*args, **kwargs):
+            release_check.wait(timeout=20)
+            return connection_report()
+
+        save_connection(
+            "admin@example.com",
+            TARGET,
+            datetime.now(UTC),
+            usable=False,
+        )
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=blocked_check,
+        ):
+            app = AppTest.from_file(APP_PATH, default_timeout=20).run()
+            self.assertIsNone(self.controller(app).connected_target)
+            job = self.controller(app).job
+            self.assertIsNotNone(job)
+            release_check.set()
+            job.future.result(timeout=20)
+            app = app.run()
+
+        self.assertEqual(self.controller(app).connected_target, TARGET)
 
     def test_selected_target_without_saved_lease_does_not_auto_connect(self):
         with patch(
@@ -876,6 +931,11 @@ class AdminPortalFunctionalTest(unittest.TestCase):
     def test_failed_revalidation_disconnects_only_the_cluster(self):
         app = self.app(connected=True)
         self.controller(app).verified_at = datetime(2020, 1, 1, tzinfo=UTC)
+        save_connection(
+            "admin@example.com",
+            TARGET,
+            self.controller(app).verified_at,
+        )
         with patch(
             "admin_console.connections.run_connection_checks",
             return_value=connection_report(runtime_status=CheckStatus.FAIL),
@@ -885,9 +945,111 @@ class AdminPortalFunctionalTest(unittest.TestCase):
 
         self.assertIsNone(self.controller(app).connected_target)
         self.assertEqual(self.controller(app).connected_project, PROJECT)
+        saved = load_connection("admin@example.com")
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved.target, TARGET)
+        self.assertFalse(saved.usable)
         self.assertTrue(
             any("Agent runtime read: Unavailable" in item.value for item in app.error)
         )
+
+    def test_revalidation_exception_retains_suspended_target(self):
+        app = self.app(connected=True)
+        self.controller(app).verified_at = datetime(2020, 1, 1, tzinfo=UTC)
+        save_connection(
+            "admin@example.com",
+            TARGET,
+            self.controller(app).verified_at,
+        )
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=RuntimeError("probe crashed"),
+        ):
+            app = app.run()
+
+        self.assertIsNone(self.controller(app).connected_target)
+        saved = load_connection("admin@example.com")
+        self.assertIsNotNone(saved)
+        self.assertEqual(saved.target, TARGET)
+        self.assertFalse(saved.usable)
+        self.assertTrue(
+            any("stopped unexpectedly" in item.value for item in app.error)
+        )
+
+    def test_refresh_shows_disconnect_and_late_result_cannot_reconnect(self):
+        release_check = Event()
+
+        def blocked_check(*args, **kwargs):
+            release_check.wait(timeout=20)
+            return connection_report()
+
+        app = self.app(connected=True)
+        save_connection("admin@example.com", TARGET, datetime.now(UTC))
+        self.controller(app).verified_at = datetime(2020, 1, 1, tzinfo=UTC)
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=blocked_check,
+        ):
+            app = app.run()
+            self.assertEqual([button.label for button in app.button].count("Abort"), 0)
+            disconnect = next(
+                button
+                for button in app.button
+                if button.key == "cluster_connection_secondary_disconnect"
+            )
+            self.assertFalse(disconnect.disabled)
+            app = disconnect.click().run()
+            self.assertIsNone(self.controller(app).job)
+            self.assertIsNone(self.controller(app).connected_target)
+            self.assertIsNone(load_connection("admin@example.com"))
+            release_check.set()
+            app = app.run()
+
+        self.assertIsNone(self.controller(app).connected_target)
+
+    def test_other_tab_disconnect_detaches_persisted_session(self):
+        app = self.app(connected=True)
+        controller = self.controller(app)
+        save_connection("admin@example.com", TARGET, datetime.now(UTC))
+        controller.persisted_lease = True
+        app = app.run()
+        self.assertEqual(self.controller(app).connected_target, TARGET)
+
+        delete_connection()
+        app = app.run()
+
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertTrue(
+            any("changed in another portal tab" in item.value for item in app.error)
+        )
+
+    def test_other_tab_disconnect_cancels_suspended_lease_revalidation(self):
+        release_check = Event()
+
+        def blocked_check(*args, **kwargs):
+            release_check.wait(timeout=20)
+            return connection_report()
+
+        save_connection(
+            "admin@example.com",
+            TARGET,
+            datetime.now(UTC),
+            usable=False,
+        )
+        with patch(
+            "admin_console.connections.run_connection_checks",
+            side_effect=blocked_check,
+        ):
+            app = AppTest.from_file(APP_PATH, default_timeout=20).run()
+            self.assertIsNotNone(self.controller(app).job)
+            delete_connection()
+            app = app.run()
+            release_check.set()
+            app = app.run()
+
+        self.assertIsNone(self.controller(app).job)
+        self.assertIsNone(self.controller(app).connected_target)
+        self.assertIsNone(load_connection("admin@example.com"))
 
     def test_unique_host_is_preselected_but_not_auto_connected(self):
         detected_cluster = "detected-host"
@@ -1112,6 +1274,14 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertIsNone(self.controller(app).connected_target)
         self.assertEqual(app.query_params["project"], [PROJECT])
         self.assertNotIn("cluster", app.query_params)
+        self.assertEqual(len(app.error), 0)
+        self.assertFalse(
+            next(
+                button
+                for button in app.button
+                if button.key == "project_connection_primary_disconnected"
+            ).disabled
+        )
 
     def test_chat_renders_real_projection_and_persists_safe_url_state(self):
         with patch(
@@ -1379,9 +1549,9 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertEqual(len(app.dataframe), 1)
         self.assertIn("Scheduler", app.dataframe[0].value.columns)
         execution_markup = next(
-            item.value
-            for item in app.markdown
-            if "ka-cron-table-wrap" in item.value
+            item.proto.body
+            for item in app.get("html")
+            if "ka-cron-table-wrap" in item.proto.body
         )
         self.assertEqual(execution_markup.count("<tr>"), 2)
         self.assertIn("Unique visitors", execution_markup)
@@ -1391,6 +1561,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertIn("2026-08-05 16:30 UTC", execution_markup)
         self.assertIn("Manual", execution_markup)
         self.assertIn("upstream &lt;unavailable&gt;", execution_markup)
+        self.assertIn("&gt;<br>retry exhausted", execution_markup)
         self.assertTrue(
             any("without a live scheduler" in item.value for item in app.warning)
         )

--- a/admin_console/tests/test_agent_chat.py
+++ b/admin_console/tests/test_agent_chat.py
@@ -5,9 +5,9 @@ import unittest
 from collections.abc import Callable
 
 from admin_console.agent_chat import (
-    ChatCommandResult,
     AgentChatError,
     AgentChatProvider,
+    ChatCommandResult,
 )
 from admin_console.project_config import DeploymentTarget
 

--- a/admin_console/tests/test_causal_flow.py
+++ b/admin_console/tests/test_causal_flow.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime
+
+from admin_console.causal_flow import CausalFlowProjection
+from admin_console.charts import causality_sankey
+from admin_console.domain import ActivityEvent, AttributionLevel, TriggerKind
+
+
+def event(
+    event_id: str,
+    action_type: str,
+    *,
+    source: str = "cloud_trace",
+    span_name: str = "",
+    parent_span_name: str = "",
+    attribution: AttributionLevel = AttributionLevel.INHERITED,
+) -> ActivityEvent:
+    return ActivityEvent(
+        event_id=event_id,
+        occurred_at=datetime(2026, 8, 13, tzinfo=UTC),
+        interaction_id="interaction-one",
+        trigger_kind=TriggerKind.HUMAN,
+        action_type=action_type,
+        action_name=event_id,
+        status="completed",
+        summary="test event",
+        agent_name="platform-agent",
+        user_id="user-one",
+        session_id="session-one",
+        tool_name="terminal" if action_type == "tool" else "",
+        attribution=attribution,
+        trace_id="trace-one",
+        details={
+            "source": source,
+            "span_name": span_name,
+            "parent_span_name": parent_span_name,
+        },
+    )
+
+
+class CausalFlowProjectionTest(unittest.TestCase):
+    def test_keeps_only_trusted_llm_work_from_trace_lineage(self):
+        projection = CausalFlowProjection.from_events(
+            [
+                event("model-api", "model", span_name="api.model-default"),
+                event("model-wrapper", "model", span_name="llm.model-default"),
+                event("tool", "tool", parent_span_name="llm.model-default"),
+                event("orphan-tool", "tool", parent_span_name="agent"),
+                event(
+                    "approval", "approval", parent_span_name="llm.model-default"
+                ),
+                event("skill", "skill", parent_span_name="agent"),
+                event(
+                    "logging-copy",
+                    "tool",
+                    source="cloud_logging",
+                    parent_span_name="llm.model-default",
+                ),
+                event("lifecycle", "span", span_name="Gateway Dispatch"),
+                event(
+                    "unattributed-model",
+                    "model",
+                    span_name="api.model-default",
+                    attribution=AttributionLevel.MISSING,
+                ),
+            ]
+        )
+
+        self.assertEqual(
+            [item.event_id for item in projection.events],
+            ["model-api", "tool", "approval", "skill"],
+        )
+        self.assertEqual(projection.llm_calls, 1)
+        self.assertEqual(projection.tool_calls, 1)
+        self.assertEqual(projection.approvals, 1)
+        self.assertEqual(projection.skill_loads, 1)
+        self.assertEqual(projection.hidden_evidence, 5)
+        self.assertIn("5 transport, lifecycle", projection.summary)
+
+    def test_chart_labels_canonical_model_work_as_llm_call(self):
+        figure = causality_sankey(
+            [event("model-api", "model", span_name="api.model-default")]
+        )
+
+        self.assertIn("LLM call", tuple(figure.data[0].node.label))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin_console/tests/test_causal_flow.py
+++ b/admin_console/tests/test_causal_flow.py
@@ -16,6 +16,8 @@ def event(
     span_name: str = "",
     parent_span_name: str = "",
     attribution: AttributionLevel = AttributionLevel.INHERITED,
+    session_id: str = "session-one",
+    origin: dict[str, str] | None = None,
 ) -> ActivityEvent:
     return ActivityEvent(
         event_id=event_id,
@@ -28,7 +30,7 @@ def event(
         summary="test event",
         agent_name="platform-agent",
         user_id="user-one",
-        session_id="session-one",
+        session_id=session_id,
         tool_name="terminal" if action_type == "tool" else "",
         attribution=attribution,
         trace_id="trace-one",
@@ -36,12 +38,13 @@ def event(
             "source": source,
             "span_name": span_name,
             "parent_span_name": parent_span_name,
+            **(origin or {}),
         },
     )
 
 
 class CausalFlowProjectionTest(unittest.TestCase):
-    def test_keeps_only_trusted_llm_work_from_trace_lineage(self):
+    def test_keeps_canonical_llm_work_from_trace_lineage(self):
         projection = CausalFlowProjection.from_events(
             [
                 event("model-api", "model", span_name="api.model-default"),
@@ -70,14 +73,14 @@ class CausalFlowProjectionTest(unittest.TestCase):
 
         self.assertEqual(
             [item.event_id for item in projection.events],
-            ["model-api", "tool", "approval", "skill"],
+            ["model-api", "tool", "approval", "skill", "unattributed-model"],
         )
-        self.assertEqual(projection.llm_calls, 1)
+        self.assertEqual(projection.llm_calls, 2)
         self.assertEqual(projection.tool_calls, 1)
         self.assertEqual(projection.approvals, 1)
         self.assertEqual(projection.skill_loads, 1)
-        self.assertEqual(projection.hidden_evidence, 5)
-        self.assertIn("5 transport, lifecycle", projection.summary)
+        self.assertEqual(projection.hidden_evidence, 4)
+        self.assertIn("4 transport, lifecycle", projection.summary)
 
     def test_chart_labels_canonical_model_work_as_llm_call(self):
         figure = causality_sankey(
@@ -85,6 +88,118 @@ class CausalFlowProjectionTest(unittest.TestCase):
         )
 
         self.assertIn("LLM call", tuple(figure.data[0].node.label))
+
+    def test_chart_aggregates_raw_platform_origin_and_preserves_metadata(self):
+        watcher_origin = {
+            "otel.chat.platform": "k8s-watcher",
+            "otel.hermes.session.kind": "session",
+        }
+        figure = causality_sankey(
+            [
+                event(
+                    "watcher-one",
+                    "model",
+                    span_name="api.model-default",
+                    session_id="k8s-evt-one",
+                    origin={
+                        **watcher_origin,
+                        "otel.session.id": "k8s-evt-one",
+                    },
+                ),
+                event(
+                    "watcher-two",
+                    "model",
+                    span_name="api.model-default",
+                    session_id="k8s-evt-two",
+                    origin={
+                        **watcher_origin,
+                        "otel.session.id": "k8s-evt-two",
+                    },
+                ),
+            ]
+        )
+
+        labels = tuple(figure.data[0].node.label)
+        self.assertIn("k8s-watcher (chat.platform · 2 sessions)", labels)
+        self.assertFalse(any("Human" in label for label in labels))
+        watcher_index = labels.index("k8s-watcher (chat.platform · 2 sessions)")
+        self.assertIn(
+            "chat.platform=k8s-watcher",
+            figure.data[0].node.customdata[watcher_index],
+        )
+
+    def test_chart_prefers_raw_user_id_and_retains_its_platform(self):
+        figure = causality_sankey(
+            [
+                event(
+                    "chat-one",
+                    "model",
+                    span_name="api.model-default",
+                    origin={
+                        "otel.user.id": "google_chat:digest",
+                        "otel.chat.platform": "google_chat",
+                    },
+                )
+            ]
+        )
+
+        labels = tuple(figure.data[0].node.label)
+        label = "google_chat:digest (user.id · 1 session)"
+        self.assertIn(label, labels)
+        detail = figure.data[0].node.customdata[labels.index(label)]
+        self.assertIn("user.id=google_chat:digest", detail)
+        self.assertIn("chat.platform=google_chat", detail)
+
+    def test_chart_normalizes_cron_executions_by_job(self):
+        figure = causality_sankey(
+            [
+                event(
+                    "cron-one",
+                    "model",
+                    span_name="api.model-default",
+                    session_id="cron_compliance-audit_20260813_010203",
+                    origin={
+                        "otel.session.id": "cron_compliance-audit_20260813_010203"
+                    },
+                ),
+                event(
+                    "cron-two",
+                    "model",
+                    span_name="api.model-default",
+                    session_id="cron_compliance-audit_20260813_040506",
+                    origin={
+                        "otel.session.id": "cron_compliance-audit_20260813_040506"
+                    },
+                ),
+            ]
+        )
+
+        labels = tuple(figure.data[0].node.label)
+        label = "compliance-audit (cron · 2 sessions)"
+        self.assertIn(label, labels)
+        detail = figure.data[0].node.customdata[labels.index(label)]
+        self.assertIn("source.type=cron", detail)
+        self.assertIn("cron_compliance-audit_20260813_010203", detail)
+        self.assertIn("cron_compliance-audit_20260813_040506", detail)
+
+    def test_chart_uses_raw_session_id_when_no_richer_origin_exists(self):
+        figure = causality_sankey(
+            [
+                event(
+                    "session-only",
+                    "model",
+                    span_name="api.model-default",
+                    session_id="20260813_195953_7d1cac",
+                    origin={"otel.session.id": "20260813_195953_7d1cac"},
+                )
+            ]
+        )
+
+        labels = tuple(figure.data[0].node.label)
+        self.assertIn(
+            "20260813_195953_7d1cac (session.id · 1 session)", labels
+        )
+        self.assertFalse(any(label.startswith("unknown") for label in labels))
 
 
 if __name__ == "__main__":

--- a/admin_console/tests/test_connection_persistence.py
+++ b/admin_console/tests/test_connection_persistence.py
@@ -46,10 +46,52 @@ class ConnectionPersistenceTest(unittest.TestCase):
         self.assertIsNotNone(restored)
         self.assertEqual(restored.target, self.target)
         self.assertEqual(restored.verified_at, self.verified_at)
+        self.assertTrue(restored.usable)
         self.assertEqual(self.state_path.stat().st_mode & 0o777, 0o600)
         payload = self.state_path.read_text(encoding="utf-8")
         self.assertNotIn("token", payload.lower())
         self.assertNotIn("credential", payload.lower())
+
+    def test_revalidation_required_retains_target_but_is_not_usable(self):
+        save_connection(
+            "admin@example.com",
+            self.target,
+            self.verified_at,
+            usable=False,
+        )
+
+        restored = load_connection("admin@example.com")
+        self.assertIsNotNone(restored)
+        self.assertEqual(restored.target, self.target)
+        self.assertFalse(restored.usable)
+        self.assertEqual(
+            json.loads(self.state_path.read_text(encoding="utf-8"))["status"],
+            "revalidation_required",
+        )
+
+    def test_version_one_lease_remains_usable_during_schema_migration(self):
+        self.state_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "account": "admin@example.com",
+                    "project_id": self.target.project_id,
+                    "cluster_name": self.target.cluster_name,
+                    "location": self.target.location,
+                    "namespace": self.target.namespace,
+                    "source": self.target.source,
+                    "verified_at": self.verified_at.isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.state_path.chmod(0o600)
+
+        restored = load_connection("admin@example.com")
+
+        self.assertIsNotNone(restored)
+        self.assertEqual(restored.target, self.target)
+        self.assertTrue(restored.usable)
 
     def test_default_path_uses_kube_agent_state_directory(self):
         with patch.dict(
@@ -73,6 +115,12 @@ class ConnectionPersistenceTest(unittest.TestCase):
 
         self.state_path.chmod(0o600)
         self.state_path.write_text(json.dumps({"version": 1}), encoding="utf-8")
+        self.assertIsNone(load_connection("admin@example.com"))
+
+        save_connection("admin@example.com", self.target, self.verified_at)
+        payload = json.loads(self.state_path.read_text(encoding="utf-8"))
+        payload["status"] = "unknown"
+        self.state_path.write_text(json.dumps(payload), encoding="utf-8")
         self.assertIsNone(load_connection("admin@example.com"))
 
     def test_delete_forgets_the_target(self):

--- a/admin_console/tests/test_connection_persistence.py
+++ b/admin_console/tests/test_connection_persistence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from admin_console.connection_persistence import (
+    connection_state_path,
     delete_connection,
     load_connection,
     save_connection,
@@ -49,6 +50,17 @@ class ConnectionPersistenceTest(unittest.TestCase):
         payload = self.state_path.read_text(encoding="utf-8")
         self.assertNotIn("token", payload.lower())
         self.assertNotIn("credential", payload.lower())
+
+    def test_default_path_uses_kube_agent_state_directory(self):
+        with patch.dict(
+            os.environ,
+            {"KUBE_AGENTS_ADMIN_CONNECTION_STATE": ""},
+        ), patch("admin_console.connection_persistence.Path.home") as home:
+            home.return_value = Path("/home/admin")
+            self.assertEqual(
+                connection_state_path(),
+                Path("/home/admin/.kube-agent/state/admin-portal-connection.json"),
+            )
 
     def test_state_is_bound_to_the_launcher_identity(self):
         save_connection("admin@example.com", self.target, self.verified_at)

--- a/admin_console/tests/test_connections.py
+++ b/admin_console/tests/test_connections.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import json
 import os
 import unittest
+from threading import Event
 from unittest.mock import patch
 
 from admin_console.connections import (
     CheckStatus,
     CommandResult,
+    ConnectionChecksCancelled,
     connection_is_ready,
     project_connection_is_ready,
     run_connection_checks,
@@ -94,6 +96,27 @@ class AuditTimeoutRunner(SuccessfulRunner):
 
 
 class ConnectionDiagnosticsTest(unittest.TestCase):
+    def test_cancelled_probe_stops_after_current_bounded_command(self):
+        cancelled = Event()
+
+        class CancellingRunner:
+            calls = 0
+
+            def run(self, arguments, *, timeout=15):
+                self.calls += 1
+                cancelled.set()
+                return CommandResult(0, "ok")
+
+        runner = CancellingRunner()
+        with self.assertRaises(ConnectionChecksCancelled):
+            run_connection_checks(
+                "test-project-01",
+                runner=runner,
+                cancel_event=cancelled,
+            )
+
+        self.assertEqual(runner.calls, 1)
+
     @patch.dict(os.environ, {"KUBE_AGENTS_ADMIN_USER": "user@example.com"})
     def test_successful_read_checks_without_trace_network_probe(self):
         runner = SuccessfulRunner()

--- a/admin_console/tests/test_connections.py
+++ b/admin_console/tests/test_connections.py
@@ -9,6 +9,7 @@ from admin_console.connections import (
     CheckStatus,
     CommandResult,
     connection_is_ready,
+    project_connection_is_ready,
     run_connection_checks,
 )
 from admin_console.project_config import DeploymentTarget
@@ -76,6 +77,22 @@ class UnlabeledRunner(SuccessfulRunner):
         return super().run(arguments, timeout=timeout)
 
 
+class NoClustersRunner(SuccessfulRunner):
+    def run(self, arguments: list[str], *, timeout: int = 15) -> CommandResult:
+        if arguments[:3] == ["container", "clusters", "list"]:
+            self.calls.append(arguments)
+            return CommandResult(0, "[]")
+        return super().run(arguments, timeout=timeout)
+
+
+class AuditTimeoutRunner(SuccessfulRunner):
+    def run(self, arguments: list[str], *, timeout: int = 15) -> CommandResult:
+        if arguments[:2] == ["logging", "read"] and "audit_event" in arguments[2]:
+            self.calls.append(arguments)
+            return CommandResult(124, timed_out=True)
+        return super().run(arguments, timeout=timeout)
+
+
 class ConnectionDiagnosticsTest(unittest.TestCase):
     @patch.dict(os.environ, {"KUBE_AGENTS_ADMIN_USER": "user@example.com"})
     def test_successful_read_checks_without_trace_network_probe(self):
@@ -121,6 +138,32 @@ class ConnectionDiagnosticsTest(unittest.TestCase):
         self.assertIn("minimum read permissions", checks["project"].guidance)
         self.assertEqual(checks["logging"].status, CheckStatus.SKIPPED)
         self.assertEqual(checks["trace"].status, CheckStatus.SKIPPED)
+        self.assertFalse(project_connection_is_ready(report))
+
+    def test_project_connection_allows_readable_gke_without_clusters(self):
+        report = run_connection_checks(
+            "test-project-01",
+            runner=NoClustersRunner(),
+            include_trace_probe=False,
+        )
+
+        self.assertEqual(report.clusters, ())
+        self.assertTrue(project_connection_is_ready(report))
+
+    def test_project_connection_can_skip_slower_telemetry_probes(self):
+        runner = SuccessfulRunner()
+
+        report = run_connection_checks(
+            "test-project-01",
+            runner=runner,
+            include_telemetry_probes=False,
+        )
+
+        self.assertTrue(project_connection_is_ready(report))
+        self.assertFalse(
+            any(call[:2] == ["logging", "read"] for call in runner.calls)
+        )
+        self.assertFalse(any(check.key == "trace" for check in report.checks))
 
     @patch("admin_console.agent_runtime.AgentRuntimeProvider")
     def test_unlabeled_single_cluster_requires_manual_selection(self, provider_type):
@@ -159,6 +202,30 @@ class ConnectionDiagnosticsTest(unittest.TestCase):
         self.assertEqual(check.status, CheckStatus.PASS)
         self.assertIn("2 profile(s) and 11 session(s)", check.summary)
         provider.check_connection.assert_called_once_with("test-agent-01")
+        self.assertTrue(connection_is_ready(report))
+
+    @patch("admin_console.agent_runtime.AgentRuntimeProvider")
+    def test_telemetry_failure_does_not_lock_runtime_pages(self, provider_type):
+        provider = provider_type.return_value
+        provider.list_agents.return_value = ("test-agent-01",)
+        provider.check_connection.return_value = (2, 11)
+
+        report = run_connection_checks(
+            "test-project-01",
+            expected_target=DeploymentTarget(
+                "test-project-01",
+                "test-cluster-01",
+                "us-east4",
+            ),
+            runner=AuditTimeoutRunner(),
+            include_trace_probe=False,
+            include_agent_runtime_probe=True,
+        )
+
+        self.assertEqual(
+            next(check for check in report.checks if check.key == "audit").status,
+            CheckStatus.FAIL,
+        )
         self.assertTrue(connection_is_ready(report))
 
 

--- a/admin_console/tests/test_cron_view.py
+++ b/admin_console/tests/test_cron_view.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime
+
+from admin_console.agent_runtime import AgentCronExecution, AgentCronJob
+from admin_console.cron_view import group_cron_executions
+
+
+def job(profile: str, job_id: str) -> AgentCronJob:
+    return AgentCronJob(
+        profile,
+        job_id,
+        "Fleet inventory",
+        True,
+        "scheduled",
+        "every 5m",
+        "Inspect the fleet",
+        "",
+        "agent",
+        None,
+        None,
+        "ok",
+        "",
+        "active",
+        None,
+    )
+
+
+def execution(
+    execution_id: str,
+    profile: str,
+    job_id: str,
+    hour: int,
+    status: str,
+) -> AgentCronExecution:
+    started_at = datetime(2026, 8, 13, hour, tzinfo=UTC)
+    return AgentCronExecution(
+        execution_id,
+        profile,
+        job_id,
+        "cron",
+        status,
+        started_at,
+        started_at,
+        started_at,
+        "",
+    )
+
+
+class CronExecutionGroupTest(unittest.TestCase):
+    def test_same_title_across_profiles_and_job_ids_uses_one_group(self):
+        jobs = {
+            ("default", "job-a"): job("default", "job-a"),
+            ("cluster-a", "job-b"): job("cluster-a", "job-b"),
+        }
+        executions = (
+            execution("run-a", "default", "job-a", 10, "completed"),
+            execution("run-b", "cluster-a", "job-b", 11, "failed"),
+        )
+
+        groups = group_cron_executions(executions, jobs)
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].title, "Fleet inventory")
+        self.assertEqual(groups[0].profiles, ("cluster-a", "default"))
+        self.assertEqual(groups[0].latest.execution_id, "run-b")
+        self.assertEqual(groups[0].succeeded, 1)
+        self.assertEqual(groups[0].failed, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin_console/tests/test_cron_view.py
+++ b/admin_console/tests/test_cron_view.py
@@ -68,6 +68,22 @@ class CronExecutionGroupTest(unittest.TestCase):
         self.assertEqual(groups[0].succeeded, 1)
         self.assertEqual(groups[0].failed, 1)
 
+    def test_latest_is_chronological_even_when_an_older_run_is_active(self):
+        jobs = {("default", "job-a"): job("default", "job-a")}
+        executions = (
+            execution("older-active", "default", "job-a", 10, "running"),
+            execution("newer-complete", "default", "job-a", 11, "completed"),
+        )
+
+        group = group_cron_executions(executions, jobs)[0]
+
+        self.assertEqual(group.latest.execution_id, "newer-complete")
+        self.assertEqual(
+            [item.execution_id for item in group.executions],
+            ["newer-complete", "older-active"],
+        )
+        self.assertEqual(group.active, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/admin_console/tests/test_interaction_api.py
+++ b/admin_console/tests/test_interaction_api.py
@@ -639,6 +639,40 @@ class InteractionApiTest(unittest.TestCase):
         self.assertEqual(response.status_code, 409)
         self.assertEqual(response.json()["detail"]["error"]["code"], "stale_target_scope")
 
+    def test_api_rejects_target_pending_revalidation(self):
+        target = DeploymentTarget(
+            "test-project-01",
+            "test-cluster-01",
+            "us-central1",
+        )
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+            os.environ,
+            {
+                "KUBE_AGENTS_ADMIN_USER": "admin@example.com",
+                "KUBE_AGENTS_ADMIN_CONNECTION_STATE": str(
+                    Path(directory) / "connection.json"
+                ),
+            },
+        ):
+            save_connection(
+                "admin@example.com",
+                target,
+                datetime.now(UTC),
+                usable=False,
+            )
+            client, _ = client_for(ScriptedBackend())
+
+            response = client.get(
+                "/api/v1/agents",
+                headers=deployment_target_headers(target),
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.json()["detail"]["error"]["code"],
+            "connection_unavailable",
+        )
+
     def test_client_calls_the_cancel_endpoint(self):
         class CancelledResponse:
             status_code = 200

--- a/admin_console/tests/test_interaction_api.py
+++ b/admin_console/tests/test_interaction_api.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import json
 import os
+import sqlite3
 import time
 import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import closing
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import Event, Lock
@@ -16,7 +19,7 @@ from admin_console.agent_chat import ChatRunResult, MAX_HISTORY_MESSAGES
 from admin_console.agent_runtime import AgentTaskUpdate, TaskUpdateResult
 from admin_console.api.app import create_app
 from admin_console.chat.service import ChatService
-from admin_console.chat.models import Interaction, InteractionStatus
+from admin_console.chat.models import Interaction, InteractionStatus, TaskProjection
 from admin_console.chat.store import SQLiteInteractionStore
 from admin_console.clients.portal_api import PortalApiClient, PortalApiError
 from admin_console.connection_persistence import save_connection
@@ -688,6 +691,57 @@ class InteractionApiTest(unittest.TestCase):
             self.assertEqual(persisted.tool_calls[0].name, "kanban_create")
             self.assertEqual(events[-1].event, "interaction.completed")
             self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
+    def test_sqlite_store_ignores_additive_fields_from_another_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "interactions.db"
+            store = SQLiteInteractionStore(path)
+            now = datetime.now(UTC)
+            interaction = Interaction(
+                interaction_id="ix_additive_fields",
+                agent_id="platform-agent",
+                profile="default",
+                session_id="portal_additive_fields",
+                input_text="Inspect the cluster",
+                status=InteractionStatus.COMPLETED,
+                created_at=now,
+                updated_at=now,
+                tasks=(
+                    TaskProjection(
+                        task_id="task-1",
+                        title="Inspect",
+                        assignee="platform",
+                        status="done",
+                    ),
+                ),
+            )
+            store.create(interaction)
+            with closing(sqlite3.connect(path)) as connection, connection:
+                raw = connection.execute(
+                    "SELECT payload FROM interactions WHERE interaction_id = ?",
+                    (interaction.interaction_id,),
+                ).fetchone()[0]
+                payload = json.loads(raw)
+                payload["tasks"][0]["skills"] = ["runtime-debugging"]
+                payload["tool_calls"] = [
+                    {
+                        "name": "kanban_create",
+                        "status": "completed",
+                        "source": "root_run",
+                        "duration_ms": 42,
+                    }
+                ]
+                connection.execute(
+                    "UPDATE interactions SET payload = ? WHERE interaction_id = ?",
+                    (json.dumps(payload), interaction.interaction_id),
+                )
+
+            reopened = SQLiteInteractionStore(path)
+            persisted = reopened.get(interaction.interaction_id)
+
+            self.assertEqual(persisted.tasks[0].task_id, "task-1")
+            self.assertEqual(persisted.tool_calls[0].name, "kanban_create")
+            self.assertEqual(reopened.recover_incomplete(), 0)
 
     def test_sqlite_store_redacts_prompts_but_backend_receives_the_original(self):
         backend = ScriptedBackend()

--- a/admin_console/tests/test_kube_access.py
+++ b/admin_console/tests/test_kube_access.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from admin_console.kube_access import (
+    GKEKubeAccess,
+    KubeFailure,
+    PrivateKubeconfigStore,
+    kube_failure_guidance,
+)
+from admin_console.project_config import DeploymentTarget
+
+
+TARGET = DeploymentTarget(
+    "test-project-01",
+    "test-cluster-01",
+    "us-east4",
+    "kubeagents-system",
+)
+
+
+class GKEKubeAccessTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.kubeconfig = Path(self.temporary_directory.name) / "config"
+        self.store = PrivateKubeconfigStore(self.kubeconfig)
+
+    @staticmethod
+    def completed(
+        returncode: int = 0,
+        stdout: str = "",
+        stderr: str = "",
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+    @patch("admin_console.kube_access.shutil.which", return_value="/usr/bin/tool")
+    @patch("admin_console.kube_access.subprocess.run")
+    def test_missing_context_is_prepared_in_private_kubeconfig(
+        self,
+        run,
+        _which,
+    ) -> None:
+        def result(command, **_kwargs):
+            if command[:3] == ["kubectl", "config", "get-contexts"]:
+                return self.completed(1)
+            if command[0] == "gcloud":
+                self.kubeconfig.write_text("apiVersion: v1\n", encoding="utf-8")
+                return self.completed()
+            return self.completed(stdout='{"items": []}')
+
+        run.side_effect = result
+        access = GKEKubeAccess(
+            TARGET,
+            account="admin@example.com",
+            store=self.store,
+        )
+
+        command_result = access.run(["get", "pods"])
+
+        self.assertEqual(command_result.returncode, 0)
+        credential_command = run.call_args_list[1].args[0]
+        self.assertEqual(
+            credential_command,
+            [
+                "gcloud",
+                "--quiet",
+                "--account=admin@example.com",
+                "container",
+                "clusters",
+                "get-credentials",
+                TARGET.cluster_name,
+                "--location",
+                TARGET.location,
+                "--project",
+                TARGET.project_id,
+            ],
+        )
+        for call in run.call_args_list:
+            self.assertEqual(call.kwargs["env"]["KUBECONFIG"], str(self.kubeconfig))
+            self.assertEqual(
+                call.kwargs["env"]["CLOUDSDK_CORE_ACCOUNT"],
+                "admin@example.com",
+            )
+        self.assertEqual(self.kubeconfig.stat().st_mode & 0o777, 0o600)
+
+    @patch("admin_console.kube_access.shutil.which", return_value="/usr/bin/tool")
+    @patch("admin_console.kube_access.subprocess.run")
+    def test_existing_context_skips_credential_refresh(self, run, _which) -> None:
+        run.side_effect = (
+            self.completed(stdout="gke_test-project-01_us-east4_test-cluster-01\n"),
+            self.completed(stdout='{"items": []}'),
+        )
+        access = GKEKubeAccess(TARGET, store=self.store)
+
+        result = access.run(["get", "pods"])
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(run.call_count, 2)
+        self.assertEqual(run.call_args_list[-1].args[0], ["kubectl", "get", "pods"])
+
+    @patch("admin_console.kube_access.shutil.which", return_value="/usr/bin/tool")
+    @patch("admin_console.kube_access.subprocess.run")
+    def test_credential_failure_is_typed_and_sanitized(self, run, _which) -> None:
+        run.side_effect = (
+            self.completed(1),
+            self.completed(1, stderr="403 forbidden secret-token-value"),
+        )
+        access = GKEKubeAccess(TARGET, store=self.store)
+
+        result = access.run(["get", "pods"])
+
+        self.assertEqual(result.failure, KubeFailure.GKE_ACCESS_DENIED)
+        self.assertEqual(result.stderr, "GKE credential access was denied.")
+        self.assertNotIn("secret-token-value", result.stderr)
+        self.assertEqual(
+            kube_failure_guidance(result),
+            "Request permission to access the selected GKE cluster, then retry.",
+        )
+
+    @patch("admin_console.kube_access.shutil.which")
+    def test_missing_gcloud_has_an_actionable_failure(self, which) -> None:
+        which.side_effect = lambda command: (
+            "/usr/bin/kubectl" if command == "kubectl" else None
+        )
+        access = GKEKubeAccess(TARGET, store=self.store)
+
+        result = access.run(["get", "pods"])
+
+        self.assertEqual(result.failure, KubeFailure.GCLOUD_MISSING)
+        self.assertEqual(
+            kube_failure_guidance(result),
+            "Install the Google Cloud CLI, then retry.",
+        )
+
+    @patch("admin_console.kube_access.subprocess.Popen")
+    def test_streaming_output_uses_the_same_prepared_access(self, popen) -> None:
+        class Input:
+            def __init__(self) -> None:
+                self.value = ""
+
+            def write(self, value: str) -> None:
+                self.value += value
+
+            def close(self) -> None:
+                pass
+
+        class Process:
+            def __init__(self) -> None:
+                self.stdin = Input()
+                self.stdout = io.StringIO("first\nsecond\n")
+                self.stderr = io.StringIO("")
+                self.returncode = 0
+
+            def wait(self, timeout=None) -> None:
+                pass
+
+        process = Process()
+        popen.return_value = process
+        access = GKEKubeAccess(TARGET, store=self.store)
+        lines = []
+
+        with patch.object(access, "prepare", return_value=None):
+            result = access.run(
+                ["exec", "pod"],
+                input_text="payload",
+                line_callback=lines.append,
+            )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "first\nsecond\n")
+        self.assertEqual(lines, ["first", "second"])
+        self.assertEqual(process.stdin.value, "payload")
+        self.assertEqual(popen.call_args.args[0], ["kubectl", "exec", "pod"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin_console/tests/test_telemetry.py
+++ b/admin_console/tests/test_telemetry.py
@@ -328,6 +328,8 @@ class TelemetryNormalizationTest(unittest.TestCase):
         self.assertEqual(event.interaction_id, "task-1")
         self.assertEqual(event.status, "completed")
         self.assertEqual(event.details["source"], "cloud_logging")
+        self.assertEqual(event.agent_name, "gateway-runtime")
+        self.assertEqual(event.details["collector_container"], "fluent-bit")
 
     def test_normalizes_structured_user_audit_without_message_content(self):
         row = {
@@ -403,6 +405,7 @@ class TelemetryNormalizationTest(unittest.TestCase):
         )
         self.assertIn("[REDACTED]", events[1].details["tool_arguments"])
         self.assertNotIn("should-not-render", events[1].details["tool_arguments"])
+        self.assertEqual(events[1].details["parent_span_name"], "agent")
 
     def test_redaction_caps_and_masks_evidence(self):
         evidence = "Authorization: Bearer abc123 " + ("x" * 9_000)

--- a/admin_console/tests/test_telemetry.py
+++ b/admin_console/tests/test_telemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 import unittest
 from datetime import UTC, datetime
 from unittest.mock import patch
@@ -9,7 +10,9 @@ from urllib.parse import parse_qs, urlparse
 from admin_console.connections import CommandResult
 from admin_console.domain import AttributionLevel, TriggerKind
 from admin_console.telemetry import (
+    LOGGING_TIMEOUT_SECONDS,
     CloudTelemetryProvider,
+    _PageCursor,
     normalize_logging_row,
     normalize_trace,
     redact_evidence,
@@ -21,6 +24,13 @@ class TokenRunner:
         if arguments == ["auth", "application-default", "print-access-token"]:
             return CommandResult(0, "test-token\n")
         return CommandResult(1, stderr="unexpected command")
+
+
+class AllTokenRunner(TokenRunner):
+    def run(self, arguments: list[str], *, timeout: int = 15) -> CommandResult:
+        if arguments == ["auth", "print-access-token"]:
+            return CommandResult(0, "logging-token\n")
+        return super().run(arguments, timeout=timeout)
 
 
 class JsonResponse:
@@ -52,7 +62,143 @@ def trace_payload(trace_id: str) -> dict:
     }
 
 
+def logging_payload(insert_id: str) -> dict:
+    return {
+        "insertId": insert_id,
+        "timestamp": "2026-08-01T10:00:00Z",
+        "resource": {"labels": {}},
+        "jsonPayload": {
+            "audit_event": "tool_call_end",
+            "tool_name": "terminal",
+        },
+    }
+
+
 class TelemetryNormalizationTest(unittest.TestCase):
+    def test_logging_continues_from_server_cursors_without_rereading(self):
+        provider = CloudTelemetryProvider(
+            "demo-project",
+            log_limit=1,
+            log_pages=1,
+            runner=AllTokenRunner(),
+        )
+        provider._start = datetime(2026, 8, 1, tzinfo=UTC)
+        provider._end = datetime(2026, 8, 2, tzinfo=UTC)
+        requests = []
+
+        def read(request, *, timeout):
+            body = json.loads(request.data)
+            requests.append((request, body, timeout))
+            direct = "jsonPayload.audit_event" in body["filter"]
+            token = body.get("pageToken", "")
+            if not token:
+                return JsonResponse(
+                    {
+                        "entries": [logging_payload("shared")],
+                        "nextPageToken": "direct-next" if direct else "wrapped-next",
+                    }
+                )
+            return JsonResponse(
+                {
+                    "entries": [
+                        logging_payload("direct-two" if direct else "wrapped-two")
+                    ]
+                }
+            )
+
+        with patch(
+            "admin_console.telemetry.urllib.request.urlopen",
+            side_effect=read,
+        ):
+            provider._advance_logging(1, time.monotonic() + 90)
+            first_state = provider._logging_source_state()
+            provider._advance_logging(1, time.monotonic() + 90)
+
+        state = provider._logging_source_state()
+        self.assertEqual(first_state.records_read, 1)
+        self.assertTrue(first_state.truncated)
+        self.assertEqual(state.records_read, 3)
+        self.assertEqual(state.pages_read, 4)
+        self.assertFalse(state.truncated)
+        self.assertTrue(all(request.method == "POST" for request, _, _ in requests))
+        self.assertTrue(
+            all(request.full_url.endswith("/entries:list") for request, _, _ in requests)
+        )
+        self.assertTrue(
+            all(timeout <= LOGGING_TIMEOUT_SECONDS for _, _, timeout in requests)
+        )
+        self.assertTrue(all(timeout > 59 for _, _, timeout in requests))
+        continuation_bodies = [body for _, body, _ in requests if "pageToken" in body]
+        self.assertEqual(
+            {body["pageToken"] for body in continuation_bodies},
+            {"direct-next", "wrapped-next"},
+        )
+        self.assertTrue(
+            all("pageToken" not in request.full_url for request, _, _ in requests)
+        )
+
+    def test_logging_timeout_retains_successful_pages(self):
+        provider = CloudTelemetryProvider(
+            "demo-project",
+            log_limit=1,
+            runner=AllTokenRunner(),
+        )
+        cursor = _PageCursor()
+        responses = [
+            JsonResponse(
+                {
+                    "entries": [logging_payload("first")],
+                    "nextPageToken": "next",
+                }
+            ),
+            TimeoutError(),
+        ]
+
+        with patch(
+            "admin_console.telemetry.urllib.request.urlopen",
+            side_effect=responses,
+        ):
+            rows = provider._advance_logging_query(
+                "resource.type=\"k8s_container\"",
+                cursor,
+                "token",
+                2,
+                time.monotonic() + 90,
+            )
+
+        self.assertEqual([row["insertId"] for row in rows], ["first"])
+        self.assertEqual(cursor.pages_read, 1)
+        self.assertEqual(cursor.next_token, "next")
+        self.assertEqual(cursor.error, "Cloud Logging read timed out.")
+
+    def test_logging_keeps_one_query_when_the_other_times_out(self):
+        provider = CloudTelemetryProvider(
+            "demo-project",
+            log_limit=1,
+            log_pages=1,
+            runner=AllTokenRunner(),
+        )
+        provider._start = datetime(2026, 8, 1, tzinfo=UTC)
+        provider._end = datetime(2026, 8, 2, tzinfo=UTC)
+
+        def read(request, *, timeout):
+            body = json.loads(request.data)
+            if "jsonPayload.audit_event" in body["filter"]:
+                raise TimeoutError
+            return JsonResponse({"entries": [logging_payload("wrapped")]})
+
+        with patch(
+            "admin_console.telemetry.urllib.request.urlopen",
+            side_effect=read,
+        ):
+            provider._advance_logging(1, time.monotonic() + 90)
+
+        state = provider._logging_source_state()
+        self.assertEqual(state.status, "partial")
+        self.assertEqual(state.records_read, 1)
+        self.assertIn("Retained 1 audit record", state.detail)
+        self.assertIn("timed out", state.detail)
+
     def test_trace_progressively_reads_requested_pages(self):
         provider = CloudTelemetryProvider(
             "demo-project",
@@ -108,6 +254,43 @@ class TelemetryNormalizationTest(unittest.TestCase):
 
         self.assertTrue(state.truncated)
         self.assertEqual(state.records_read, 1)
+
+    def test_trace_continues_from_the_retained_cursor(self):
+        provider = CloudTelemetryProvider(
+            "demo-project",
+            trace_limit=1,
+            trace_pages=1,
+            runner=TokenRunner(),
+        )
+        cursor = _PageCursor()
+        traces = {}
+        responses = [
+            JsonResponse(
+                {"traces": [trace_payload("one")], "nextPageToken": "next"}
+            ),
+            JsonResponse({"traces": [trace_payload("two")]}),
+        ]
+        start = datetime(2026, 8, 1, tzinfo=UTC)
+        end = datetime(2026, 8, 2, tzinfo=UTC)
+
+        with patch(
+            "admin_console.telemetry.urllib.request.urlopen",
+            side_effect=responses,
+        ) as urlopen:
+            provider._read_trace_pages(
+                start, end, cursor, traces, 1, time.monotonic() + 90
+            )
+            provider._read_trace_pages(
+                start, end, cursor, traces, 1, time.monotonic() + 90
+            )
+
+        self.assertEqual(set(traces), {"one", "two"})
+        self.assertEqual(cursor.pages_read, 2)
+        self.assertTrue(cursor.complete)
+        second_query = parse_qs(
+            urlparse(urlopen.call_args_list[1].args[0].full_url).query
+        )
+        self.assertEqual(second_query["pageToken"], ["next"])
 
     def test_trace_page_budget_is_bounded(self):
         with self.assertRaisesRegex(ValueError, "trace pages"):

--- a/admin_console/tests/test_telemetry.py
+++ b/admin_console/tests/test_telemetry.py
@@ -399,13 +399,75 @@ class TelemetryNormalizationTest(unittest.TestCase):
 
         self.assertEqual(len(events), 2)
         self.assertTrue(all(event.interaction_id == "trace-123" for event in events))
-        self.assertTrue(all(event.trigger_kind == TriggerKind.HUMAN for event in events))
+        self.assertTrue(all(event.trigger_kind == TriggerKind.UNKNOWN for event in events))
         self.assertTrue(
             all(event.attribution == AttributionLevel.INHERITED for event in events)
         )
         self.assertIn("[REDACTED]", events[1].details["tool_arguments"])
         self.assertNotIn("should-not-render", events[1].details["tool_arguments"])
         self.assertEqual(events[1].details["parent_span_name"], "agent")
+        self.assertEqual(events[1].details["otel.session.id"], "web_abc")
+
+    def test_watcher_platform_remains_raw_and_is_not_classified_as_human(self):
+        trace = {
+            "traceId": "watcher-trace",
+            "spans": [
+                {
+                    "spanId": "model",
+                    "name": "api.model-default",
+                    "startTime": "2026-08-13T10:00:00Z",
+                    "endTime": "2026-08-13T10:00:01Z",
+                    "labels": {
+                        "session.id": "k8s-evt-abcd",
+                        "chat.platform": "k8s-watcher",
+                        "hermes.session.kind": "session",
+                    },
+                }
+            ],
+        }
+
+        event = normalize_trace(trace, "demo-project")[0]
+
+        self.assertEqual(event.trigger_kind, TriggerKind.UNKNOWN)
+        self.assertEqual(event.platform, "k8s-watcher")
+        self.assertEqual(event.details["otel.session.id"], "k8s-evt-abcd")
+        self.assertEqual(event.details["otel.chat.platform"], "k8s-watcher")
+        self.assertEqual(event.details["otel.hermes.session.kind"], "session")
+        self.assertNotIn("otel.user.id", event.details)
+
+    def test_trace_origin_is_preserved_on_child_spans(self):
+        trace = {
+            "traceId": "cron-trace",
+            "spans": [
+                {
+                    "spanId": "root",
+                    "name": "cron",
+                    "startTime": "2026-08-13T10:00:00Z",
+                    "endTime": "2026-08-13T10:00:02Z",
+                    "labels": {
+                        "session.id": "cron_compliance-audit_20260813_100000",
+                        "hermes.session.kind": "cron",
+                    },
+                },
+                {
+                    "spanId": "model",
+                    "parentSpanId": "root",
+                    "name": "api.model-default",
+                    "startTime": "2026-08-13T10:00:00Z",
+                    "endTime": "2026-08-13T10:00:01Z",
+                    "labels": {
+                        "session.id": "cron_compliance-audit_20260813_100000"
+                    },
+                },
+            ],
+        }
+
+        child = normalize_trace(trace, "demo-project")[1]
+
+        self.assertEqual(child.trigger_kind, TriggerKind.CRON)
+        self.assertEqual(
+            child.details["otel.trace.hermes.session.kind"], "cron"
+        )
 
     def test_redaction_caps_and_masks_evidence(self):
         evidence = "Authorization: Bearer abc123 " + ("x" * 9_000)

--- a/admin_console/ui.py
+++ b/admin_console/ui.py
@@ -268,9 +268,8 @@ def status_label(status: str) -> str:
     return f"{icons.get(status, '•')} {status.title()}"
 
 
-def render_telemetry_status(provider) -> object:
+def render_telemetry_status(snapshot) -> object:
     """Render the live snapshot scope and source completeness."""
-    snapshot = provider.get_snapshot()
     scope = snapshot.cluster or "all clusters"
     st.caption(
         f"LIVE READ · {snapshot.project_id} · {scope} · "
@@ -280,11 +279,13 @@ def render_telemetry_status(provider) -> object:
     for source in snapshot.sources:
         if source.status == "error":
             st.error(f"{source.name}: {source.detail}")
-        elif source.status == "empty":
+        elif source.status in {"empty", "partial"}:
             st.warning(f"{source.name}: {source.detail}")
         elif source.truncated:
-            st.warning(
-                f"{source.name}: {source.detail} Results reached the read limit; "
-                "this snapshot is incomplete."
+            suffix = (
+                "More results are available."
+                if source.can_load_more
+                else "The page limit was reached; narrow the time window for more detail."
             )
+            st.warning(f"{source.name}: {source.detail} {suffix}")
     return snapshot

--- a/admin_console/ui.py
+++ b/admin_console/ui.py
@@ -212,28 +212,26 @@ def apply_theme() -> None:
         .stButton button, .stLinkButton a {
           border-radius: 10px !important;
         }
-        .st-key-connect_to_kube_agents button:not(:disabled) {
-          background: #315efb !important;
-          border-color: #6f8cff !important;
-          color: #fff !important;
-        }
-        .st-key-connect_to_kube_agents button:not(:disabled):hover {
-          background: #2448cc !important;
-          border-color: #91a6ff !important;
-        }
-        .st-key-disconnect_project button:not(:disabled) {
+        .st-key-project_connection_secondary_disconnect button:not(:disabled),
+        .st-key-cluster_connection_secondary_disconnect button:not(:disabled) {
           background: #b4232f !important;
           border-color: #ef5b68 !important;
           color: #fff !important;
         }
-        .st-key-disconnect_project button:not(:disabled):hover {
+        .st-key-project_connection_secondary_disconnect button:not(:disabled):hover,
+        .st-key-cluster_connection_secondary_disconnect button:not(:disabled):hover {
           background: #8f1823 !important;
           border-color: #ff7a86 !important;
         }
-        .st-key-connect_to_kube_agents button:disabled,
-        .st-key-disconnect_project button:disabled,
-        .st-key-select_kube_agents_cluster_busy button:disabled,
-        .st-key-connect_to_kube_agents_busy button:disabled {
+        .st-key-project_connection_secondary_abort button:not(:disabled),
+        .st-key-cluster_connection_secondary_abort button:not(:disabled) {
+          border-color: #ef8f5b !important;
+          color: #ffc2a1 !important;
+        }
+        .st-key-project_connection_primary_connected button:disabled,
+        .st-key-cluster_connection_primary_connected button:disabled,
+        .st-key-project_connection_primary_connecting button:disabled,
+        .st-key-cluster_connection_primary_connecting button:disabled {
           background: #2a3343 !important;
           border-color: #46536a !important;
           color: #8fa1bd !important;
@@ -242,10 +240,10 @@ def apply_theme() -> None:
         @keyframes ka-connection-spin {
           to { transform: rotate(360deg); }
         }
-        .st-key-connect_to_kube_agents_busy [data-testid="stIconMaterial"],
-        .st-key-select_kube_agents_cluster_busy [data-testid="stIconMaterial"],
-        .st-key-connect_to_kube_agents_busy .material-symbols-rounded,
-        .st-key-select_kube_agents_cluster_busy .material-symbols-rounded {
+        .st-key-project_connection_primary_connecting [data-testid="stIconMaterial"],
+        .st-key-cluster_connection_primary_connecting [data-testid="stIconMaterial"],
+        .st-key-project_connection_primary_connecting .material-symbols-rounded,
+        .st-key-cluster_connection_primary_connecting .material-symbols-rounded {
           animation: ka-connection-spin .8s linear infinite;
         }
         </style>

--- a/docs/README.md
+++ b/docs/README.md
@@ -209,6 +209,7 @@ pull request:
 | `AGENTS.md` | Contributor rules | Workspace instructions: repo layout, skills guidelines, the canonical-home documentation rules, generated-regions rule, PR hygiene, the live-validation requirement, and the automated pull-request review contract. | Doc ownership table, `make docs-check`, Conventional Commits, fork PRs, bot review | AI coding agents and human contributors; owns the doc RULES |
 | `CLAUDE.md` | Contributor rules | Imports `AGENTS.md` and adds Claude-specific commit-authorship and PR-disclosure rules. | No co-author trailers; PRs mention Claude assistance | Claude Code sessions |
 | `admin_console/README.md` | Component README | Local setup and operating boundaries for the Kube Agents Console. | Connection, chat, observability, validation | Console users and contributors |
+| `admin_console/CONNECTION_SECURITY.md` | Security reference | Security contract for the local console's persisted connection lease. | Stored metadata, filesystem controls, identity binding, revalidation, trust boundary | Console users and security reviewers |
 
 ### `agents/` — agent blueprints (runtime documents)
 

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -645,12 +645,17 @@ override identity or correlation fields.
   attachments, and lifecycle events.
 - **Activity Explorer:** filters, aggregate Sankey, per-interaction timeline,
   a 50-row URL-paginated forensic ledger, and page-local activity scope.
-  The Sankey is a semantic projection over trusted Cloud Trace lineage: one
-  node contribution per individual `api.*` model request, LLM-child tool or
-  approval span, and agent skill load. It excludes aggregate `llm.*`/turn
-  wrappers, gateway/chat lifecycle spans, and parallel Logging evidence from
-  the flow only; Timeline and the forensic ledger retain the raw evidence.
-  Fluent Bit remains collector metadata and is never presented as an agent.
+  The Sankey is a semantic projection over Cloud Trace lineage: one node
+  contribution per individual `api.*` model request, LLM-child tool or approval
+  span, and agent skill load. Its typed source projection groups by raw OTel
+  user, platform, normalized cron job, explicit trigger, or session kind, with
+  raw `session.id` as the final fallback. It retains all available origin
+  evidence, its scope, distinct sessions, and bounded raw-value samples.
+  It does not map `k8s-watcher` to Human or Event. It excludes aggregate
+  `llm.*`/turn wrappers, gateway/chat lifecycle spans, and parallel Logging
+  evidence from the flow only; Timeline and the forensic ledger retain the raw
+  evidence. Fluent Bit remains collector metadata and is never presented as an
+  agent.
   Overview and Activity Explorer share the same visible loading component for
   initial reads, refreshes, and incremental source pages. Logging and Trace
   retain opaque continuation cursors only inside the Streamlit session, append
@@ -686,7 +691,7 @@ remain labeled as missing instead of being filled with demo data.
 | Attribution coverage                    | Computed from explicit, inherited, and missing live identifiers                                          | No     | Partial             | Yes                      | Propagate trusted interaction identity through every action                                             |
 | Recent work and active-agent summaries  | Aggregations over normalized live events                                                                 | No     | Yes                 | Yes                      | Join the Kanban task read model                                                                         |
 | Activity filters                        | URL-persisted project, cluster, and time; local event filters                                            | No     | Yes                 | Yes                      | Persist all investigation filters in the URL                                                            |
-| Causal-flow Sankey                      | Trusted Trace lineage for LLM requests, LLM-produced tools/approvals, and skill loads                    | No     | Partial             | Yes                      | Add first-class gaps and separately styled inferred joins                                               |
+| Causal-flow Sankey                      | Trace lineage plus typed source aggregation for LLM requests, tools/approvals, and skill loads           | No     | Partial             | Yes                      | Add first-class gaps and separately styled inferred joins                                               |
 | Interaction timeline                    | Uses trusted `interaction.id` when present, otherwise Trace ID                                           | No     | Partial             | Yes                      | Generate and propagate `interaction.id` at every trusted ingress                                        |
 | Forensic ledger and event details       | Live normalized evidence with source IDs and Console deep links                                          | No     | Yes                 | Yes                      | Add controlled evidence export                                                                          |
 | User prompts and agent responses        | Access-controlled Trace evidence, portal-redacted and size-bounded                                       | No     | Yes                 | Yes                      | Add policy-aware reveal auditing and upstream DLP scrubbing                                             |

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -645,6 +645,12 @@ override identity or correlation fields.
   attachments, and lifecycle events.
 - **Activity Explorer:** filters, aggregate Sankey, per-interaction timeline,
   a 50-row URL-paginated forensic ledger, and page-local activity scope.
+  The Sankey is a semantic projection over trusted Cloud Trace lineage: one
+  node contribution per individual `api.*` model request, LLM-child tool or
+  approval span, and agent skill load. It excludes aggregate `llm.*`/turn
+  wrappers, gateway/chat lifecycle spans, and parallel Logging evidence from
+  the flow only; Timeline and the forensic ledger retain the raw evidence.
+  Fluent Bit remains collector metadata and is never presented as an agent.
   Overview and Activity Explorer share the same visible loading component for
   initial reads, refreshes, and incremental source pages. Logging and Trace
   retain opaque continuation cursors only inside the Streamlit session, append
@@ -680,7 +686,7 @@ remain labeled as missing instead of being filled with demo data.
 | Attribution coverage                    | Computed from explicit, inherited, and missing live identifiers                                          | No     | Partial             | Yes                      | Propagate trusted interaction identity through every action                                             |
 | Recent work and active-agent summaries  | Aggregations over normalized live events                                                                 | No     | Yes                 | Yes                      | Join the Kanban task read model                                                                         |
 | Activity filters                        | URL-persisted project, cluster, and time; local event filters                                            | No     | Yes                 | Yes                      | Persist all investigation filters in the URL                                                            |
-| Causal-flow Sankey                      | Only explicit and inherited records; missing/inferred excluded                                           | No     | Partial             | Yes                      | Add first-class gaps and separately styled inferred joins                                               |
+| Causal-flow Sankey                      | Trusted Trace lineage for LLM requests, LLM-produced tools/approvals, and skill loads                    | No     | Partial             | Yes                      | Add first-class gaps and separately styled inferred joins                                               |
 | Interaction timeline                    | Uses trusted `interaction.id` when present, otherwise Trace ID                                           | No     | Partial             | Yes                      | Generate and propagate `interaction.id` at every trusted ingress                                        |
 | Forensic ledger and event details       | Live normalized evidence with source IDs and Console deep links                                          | No     | Yes                 | Yes                      | Add controlled evidence export                                                                          |
 | User prompts and agent responses        | Access-controlled Trace evidence, portal-redacted and size-bounded                                       | No     | Yes                 | Yes                      | Add policy-aware reveal auditing and upstream DLP scrubbing                                             |

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -644,7 +644,15 @@ override identity or correlation fields.
   dependencies, linked chat, delivery state, runs, results, comments,
   attachments, and lifecycle events.
 - **Activity Explorer:** filters, aggregate Sankey, per-interaction timeline,
-  forensic ledger, and page-local activity scope.
+  a 50-row URL-paginated forensic ledger, and page-local activity scope.
+  Overview and Activity Explorer share the same visible loading component for
+  initial reads, refreshes, and incremental source pages. Logging and Trace
+  retain opaque continuation cursors only inside the Streamlit session, append
+  two bounded pages per load, and preserve successful earlier pages when a
+  later page fails. Logging uses two non-overlapping queries with 500-record
+  pages and a 60-second request timeout; Trace and each Logging query stop
+  after ten pages, and both sources share a 90-second load deadline. Source
+  pagination and ledger pagination remain separate concerns.
 - **Scheduled Cron:** live Hermes job definitions, scheduler heartbeat state,
   and one execution table with a row per job title. Each row retains run and
   outcome counts, latest activity, and participating profiles, then expands in
@@ -685,7 +693,7 @@ remain labeled as missing instead of being filled with demo data.
 | Credential-proxy activity               | Not ingested; no proxy events are fabricated                                                             | N/A    | Yes                 | No                       | Normalize proxy request ID, policy decision, command digest, execution state, exit code, and duration   |
 | Approval activity                       | Live Trace spans and structured request/response audit records                                           | No     | Yes                 | Yes                      | Correlate requester, approver, policy, command digest, and interaction ID                               |
 | Scheduled Cron page                     | Bounded live Hermes job stores, execution databases, profile ticker health, and recent/upcoming calendar | No     | Yes                 | Yes                      | Add a dedicated policy-aware scheduler API and retained execution pagination                            |
-| Time window and retention state         | URL-persisted bounded windows and Trace page budget with source errors and truncation shown              | No     | Yes                 | Yes                      | Add retention and sampling metadata from source configuration                                           |
+| Time window and retention state         | URL window, session-local Logging/Trace cursors, and visible source errors/truncation                    | No     | Yes                 | Yes                      | Add retention and sampling metadata from source configuration                                           |
 | Refreshable and shareable investigation | Project, cluster, and window persist; local filters do not                                               | N/A    | N/A                 | Partial                  | Persist filters, interaction, and selected evidence in URL query parameters                             |
 | Saved case or evidence export           | Not implemented                                                                                          | N/A    | N/A                 | No                       | Export access-controlled evidence bundles with source IDs, query scope, redaction state, and timestamps |
 
@@ -746,8 +754,9 @@ present time-adjacent records as proven causality.
 ## Current boundaries
 
 - Activity is live and read-only; no demo events are used by application pages.
-- Logging and Trace reads are capped. Reaching a cap is shown as incomplete;
-  continuation-token pagination is not yet implemented.
+- Logging and Trace reads use session-local continuation cursors and are
+  capped. Reaching a cap is shown as incomplete and asks the user to narrow the
+  time window.
 - Common credential forms are redacted before evidence is rendered, but this
   is not a replacement for upstream secret and PII scrubbing.
 - Trusted interaction identity is not present on every source record. The UI

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -578,14 +578,18 @@ override identity or correlation fields.
 
 - **Connection:** two ordered cards—Step 1 Project, then Step 2 Cluster—use one
   shared action component and the same Connect, Connecting, and Connected state
-  machine. Only the deepest connected level exposes Disconnect, and only the
-  level currently connecting exposes Abort, so the page never presents two
-  competing teardown actions.
+  machine. Only the deepest connected level exposes Disconnect, and only an
+  explicit Connect attempt exposes Abort, so the page never presents two
+  competing teardown actions. Background revalidation keeps the cluster
+  Connected and leaves Disconnect available.
   A session-scoped connection controller is the single source for selection,
   both level phases, the pending verification, reports, failures, and the
   verified target. The Connection UI sends commands to that controller, and
   every provider-backed page reads its target through one shared gate; URL and
   persisted values are projections rather than parallel connection states.
+  Controller bootstrap is a shared idempotent operation because Streamlit may
+  resume the selected page directly after a development-server rebuild without
+  first executing the application entry point.
   Project Connect verifies identity, project access, and GKE discovery, then
   reveals the cluster picker; it never establishes the cluster connection.
   Exactly one GKE cluster labeled `kube-agents-host=true` is preselected, while
@@ -607,14 +611,16 @@ override identity or correlation fields.
   connections persist only validated target metadata in an owner-only
   server-side lease bound to the launcher-verified gcloud account; credentials
   and kubeconfig content are never stored. Reopen under the same account resumes
-  that exact lease and immediately revalidates it. A failed revalidation deletes
-  the lease and disconnects; URL, provisioning, and configured-project targets
-  without a verified lease cannot connect automatically. An open browser session
-  revalidates every ten minutes. Both connection levels and revalidation execute
-  outside Streamlit's render thread so navigation and page content remain
-  responsive. A sidebar status component observes the background future; only
-  its completed result changes verified state. Disconnect deletes the persisted
-  target.
+  that exact lease and immediately revalidates it. A failed revalidation locks
+  runtime access and marks the retained target as requiring revalidation; URL,
+  provisioning, and configured-project targets without a verified lease cannot
+  connect automatically. An open browser session revalidates every ten minutes.
+  Both connection levels and revalidation execute outside Streamlit's render
+  thread so navigation and page content remain responsive. A sidebar status
+  component observes the background future; only its completed result changes
+  verified state. Tabs reconcile the shared lease, so a disconnect, suspension,
+  or target change in one tab detaches stale tabs and late background results
+  cannot recreate an obsolete lease. Disconnect deletes the persisted target.
   The same page shows checklist results for CLI authentication, ADC, APIs, GKE,
   agent runtime state, Logging, structured audit events, and Trace.
 - **Agentic:** Chat is the interactive surface for working with the agent.

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -576,20 +576,45 @@ override identity or correlation fields.
 
 ## UI structure
 
-- **Connection:** one editable project selector with source-labeled suggestions,
-  project-ID validation, and mutually exclusive Connect and
-  Disconnect controls at the top of Setup. Connect auto-selects the one
-  GKE cluster labeled `kube-agents-host=true`. Zero or multiple labeled hosts
-  produce a red detection error and a separate manual cluster picker whose
-  action is Select. Selection is locked while connected. Observability remains
-  unavailable until required checks pass. Successful local connections persist
-  only validated target metadata in an owner-only server-side file bound to the
-  launcher-verified gcloud account. Reopen always revalidates before restoring
-  access; an open browser session revalidates every ten minutes. Connect, Select,
-  restore, and revalidation checks execute outside Streamlit's render thread so
-  navigation and page content remain responsive. A sidebar status component
-  observes the background future; only its completed result changes verified
-  state. Disconnect deletes the persisted target.
+- **Connection:** two ordered cards—Step 1 Project, then Step 2 Cluster—use one
+  shared action component and the same Connect, Connecting, and Connected state
+  machine. Only the deepest connected level exposes Disconnect, and only the
+  level currently connecting exposes Abort, so the page never presents two
+  competing teardown actions.
+  A session-scoped connection controller is the single source for selection,
+  both level phases, the pending verification, reports, failures, and the
+  verified target. The Connection UI sends commands to that controller, and
+  every provider-backed page reads its target through one shared gate; URL and
+  persisted values are projections rather than parallel connection states.
+  Project Connect verifies identity, project access, and GKE discovery, then
+  reveals the cluster picker; it never establishes the cluster connection.
+  Exactly one GKE cluster labeled `kube-agents-host=true` is preselected, while
+  zero or multiple labeled hosts produce one concise picker caption. Cluster
+  Connect verifies the selected kube-agents runtime. At either level, Abort
+  immediately detaches pending verification so its late result cannot change
+  state. A failed attempt shows one actionable error naming the failed check,
+  observed reason, and next action, with no partial checklist; the checklist
+  appears after both levels succeed. Disconnect unwinds the hierarchy: Cluster
+  Disconnect retains the project connection, then exposes Project Disconnect.
+  Selection is locked at its connected level. Cluster readiness requires
+  identity, project, GKE, and agent-runtime access. Logging or Trace failures
+  remain visible in the checklist and their own surfaces without locking
+  runtime-backed Chat, Task Kanban, or Scheduled Cron.
+  Observability remains unavailable until required checks pass. One shared GKE
+  access component obtains credentials in a process-private temporary
+  kubeconfig and serves connection verification, observability, cron, and Chat
+  without modifying the user's normal kubeconfig. Successful local
+  connections persist only validated target metadata in an owner-only
+  server-side lease bound to the launcher-verified gcloud account; credentials
+  and kubeconfig content are never stored. Reopen under the same account resumes
+  that exact lease and immediately revalidates it. A failed revalidation deletes
+  the lease and disconnects; URL, provisioning, and configured-project targets
+  without a verified lease cannot connect automatically. An open browser session
+  revalidates every ten minutes. Both connection levels and revalidation execute
+  outside Streamlit's render thread so navigation and page content remain
+  responsive. A sidebar status component observes the background future; only
+  its completed result changes verified state. Disconnect deletes the persisted
+  target.
   The same page shows checklist results for CLI authentication, ADC, APIs, GKE,
   agent runtime state, Logging, structured audit events, and Trace.
 - **Agentic:** Chat is the interactive surface for working with the agent.
@@ -615,11 +640,14 @@ override identity or correlation fields.
 - **Activity Explorer:** filters, aggregate Sankey, per-interaction timeline,
   forensic ledger, and page-local activity scope.
 - **Scheduled Cron:** live Hermes job definitions, scheduler heartbeat state,
-  active and recent executions, manual-versus-scheduled trigger evidence, and a
-  UTC calendar of recent runs and projected cron or interval occurrences for
-  the next 21 days. High-frequency schedules are summarized per job and day.
-  An enabled job without a live profile ticker is explicitly reported as
-  unable to run automatically.
+  and one execution table with a row per job title. Each row retains run and
+  outcome counts, latest activity, and participating profiles, then expands in
+  place to show every bounded execution's start, trigger, duration, status,
+  profile, and error without a second table. A UTC calendar shows recent runs
+  and projected cron or interval occurrences for the next 21 days.
+  High-frequency schedules are summarized per job and day. An enabled job
+  without a live profile ticker is explicitly reported as unable to run
+  automatically.
 
 ## Current data readiness
 


### PR DESCRIPTION
# Pull Request

## Why This Change

The admin console represented connection state through independent Streamlit keys and a persisted target. Connection could therefore report success while Task Kanban or Scheduled Cron rendered the connection gate. Revalidation and abort behavior also had races, and rebuilding Streamlit could resume a page without initializing the shared controller. In Scheduled Cron, high-frequency jobs produced one execution row per run and diluted the rest of the table.

## What Changed

**Files:**

- Connection lifecycle: `admin_console/connection_controller.py`, `connection_session.py`, `connection_sidebar.py`, `connection_gate.py`, and `connection_persistence.py`
- Shared consumers: `admin_console/app.py`, provider-backed pages, the FastAPI scope gate, and Chat backend
- Runtime diagnostics, activity projection/loading, and cron presentation: `admin_console/connections.py`, `telemetry.py`, `causal_flow.py`, `activity_scope.py`, `cron_view.py`, and the observability pages
- Tests and documentation under `admin_console/tests/`, `admin_console/README.md`, `admin_console/CONNECTION_SECURITY.md`, and `docs/designs/admin-console.md`

**Added/Changed/Fixed:**

- Added one session-scoped `ConnectionController` for project and cluster selection, phases, pending work, reports, failures, and the verified target.
- Made Connection and every provider-backed page consume the same controller-backed gate.
- Streamlined Connection into `Step 1 · Project` and `Step 2 · Cluster`, with one teardown action at a time. Explicit Project and Cluster connects show `Connecting…` plus `Abort`; background revalidation keeps `Connected` plus `Disconnect`.
- Added cooperative cancellation between bounded external calls. Detached or cross-tab-stale jobs cannot apply a late result.
- Persisted an explicit successful connection as a non-secret, owner-only, account-bound lease at `~/.kube-agent/state/admin-portal-connection.json`. Version 2 records `verified` or `revalidation_required`, while version-1 leases remain readable during migration.
- Kept a failed revalidation target on disk as unusable instead of deleting it. Streamlit pages, FastAPI, and Chat reject suspended leases until a later successful revalidation.
- Reconciled the shared lease across tabs, including a suspended lease with revalidation in progress, so another tab's disconnect or status change cannot be undone.
- Centralized idempotent session bootstrap. If Streamlit resumes a selected page directly after a server rebuild, the page reconstructs the normal navigation shell and shared controller instead of raising `connection controller is not initialized`.
- Defined runtime connectivity by identity, project, GKE, and agent-runtime access; Logging and Trace failures remain visible without locking Chat, Task Kanban, or Scheduled Cron.
- Added shared process-private GKE kubeconfig access without modifying the user's normal kubeconfig.
- Aggregated cron executions into one row per exact job title across profiles and job IDs. Each row's `N run(s)` disclosure expands in place to retain every bounded start time, trigger, duration, status, profile, and error.
- Rendered the cron table with `st.html`; multi-line errors are escaped and use explicit line breaks, so they cannot break the containing table. Latest execution is now chronological even when an older run remains active.
- Added one shared activity-loading component to Overview and Activity Explorer for initial reads, refreshes, and incremental page loads.
- Replaced fixed-limit Logging CLI reads with bounded `entries:list` cursor pagination: 500 records per page, two initial pages per query, a 60-second page timeout, a shared 90-second deadline, independent cursor recovery, deduplication, and partial-result retention. Trace uses the same incremental in-session model.
- Added `Load more activity` without rereading prior pages, plus independent 50-row URL pagination for the forensic ledger.
- Refactored Causal Flow into a lineage-aware Cloud Trace projection: individual `api.*` LLM requests, LLM-child tools/approvals, and agent skill loads. A typed source normalizer selects a stable raw OTel identity while retaining all available origin evidence; watcher sessions aggregate by `chat.platform=k8s-watcher` and are never relabeled Human or Event. Aggregate `llm.*`/turn wrappers, gateway/chat lifecycle spans, and parallel Logging evidence remain in Timeline/Ledger without inflating the Sankey.
- Corrected Fluent Bit presentation: it remains collector evidence and is no longer shown as an agent when the payload lacks profile identity.

## Why This Matters

- Connection state is coherent across Connection, Chat, Activity, Task Kanban, and Scheduled Cron.
- The flow has no competing Disconnect buttons, and Abort returns control immediately.
- Failed or stale leases fail closed without losing the user's selected target.
- Streamlit rebuilds recover through the normal app shell.
- High-frequency cron jobs occupy one summary row instead of drowning out lower-frequency jobs, while full execution evidence remains available in the same table row.
- Slow telemetry reads now provide immediate progress feedback, tolerate longer Logging responses, preserve successful pages after later failures, and let users request additional bounded history explicitly. Causal Flow now represents agent LLM work rather than log transport and framework bookkeeping, with low-friction aggregation that preserves raw source provenance.

## Context

This keeps the local, single-user portal boundary. The disk lease stores connection coordinates and verification status only—never tokens, credentials, or kubeconfig. Only a lease created by an explicit successful connection can resume; it is revalidated live immediately. Explicit Disconnect deletes it.

The required docs-drift review found no Blocking or Advisory findings. Changed documents remain in their canonical homes; no generated documentation source changed.

## Testing

- Full admin-console suite: 143 passed.
- `python -m compileall -q admin_console` — passed.
- `make docs-check` — passed across 241 Markdown files and all 214 mapped docs.
- Changed documentation passes the repository-pinned Prettier; `git diff --check` passes.
- Regression coverage includes explicit Abort and detached late results, non-abortable background refresh, failed/exception revalidation retention, API rejection of suspended leases, verified and suspended cross-tab races, version-1 lease migration, direct-page rebuild bootstrap, one hierarchical Disconnect, chronological cron latest status, one-row same-title aggregation, and escaped multi-line cron errors, retained Logging/Trace cursors, timeout partial results, load-more behavior, 50-row ledger pagination, Trace-lineage causal projection, typed source priority/fallback, watcher and cron aggregation, raw-origin propagation, and collector identity normalization.

### Live validation

- Install: project `kube-agents-autopush`, cluster `platform-agent-host`, location `us-east4`, namespace `kubeagents-system`.
- Images/operator version during validation: `k8s-operator`, `platform-agent`, and `credential-proxy` tag `32092a30f8515f6a8bd00a544d5d1fc2cb7a60a4`.
- The live connection passed 9 checks, warned only that the optional host label is absent, failed 0 checks, and read 7 profiles/8,331 sessions from `platform-agent`.
- Project Connect visibly changed to `Connecting…` plus `Abort`; Project completion exposed Cluster Connect. Cluster Connect also changed to `Connecting…` plus `Abort`. Both Abort actions returned immediately without a late result reconnecting the level.
- Hierarchical disconnect showed exactly one action: Cluster Disconnect retained the connected project, then exposed Project Disconnect.
- The live lease was version 2, status `verified`, mode `0600`, and contained only account, target coordinates, source, status, timestamp, and schema version.
- Scheduled Cron loaded from the connected runtime and rendered one HTML execution table with five grouped rows and five inline disclosures: two 66-run jobs, one 65-run job, one 2-run job, and one correctly singular `1 run` job.
- The portal process was restarted while the browser remained on `/scheduled-cron`; refreshing restored the full navigation shell and the same live cron table with no Streamlit exception while the saved lease revalidated in the background.
- The cluster is `RUNNING`; `PlatformAgent/platform-agent` reports `Ready`; and `Deployment/platform-agent-gateway` was 1/1 available during the validation. No cluster resources were mutated.
- In an isolated loopback portal session, Activity Explorer visibly showed `Loading activity from Cloud Logging and Cloud Trace…`, then loaded 1,752 normalized events. Logging read 403 audit records across four initial cursor pages without timing out. `Load more activity` showed its own spinner and advanced Logging to eight pages without rereading prior pages; the ledger rendered `1–50 of 1752 · Page 1 of 36`. Overview independently showed the same loading indicator and completed.
- A live 24-hour all-cluster read rendered 1,408 canonical actions (792 LLM calls, 526 LLM-produced tools, 76 approvals, 14 skill loads). Plotly contained exactly one `k8s-watcher (chat.platform · 10 sessions)` source node, whose raw evidence listed the contributing `k8s-evt-*` session IDs; it contained no synthetic Human node. Google Chat users remained grouped by their raw pseudonymous `user.id`, cron executions by normalized job name, and all 581 excluded transport/lifecycle/duplicate/non-work records remained available outside Flow.
- Both temporary portals, browser profiles, and copied non-secret leases were removed afterward; the existing portal and saved state were untouched.
- Not live-tested: a naturally occurring multi-line cron error was not present, so escaping/line-break behavior is covered by the Streamlit fixture test. Failed revalidation and simultaneous multi-tab disconnect races were not deliberately induced against the live cluster; deterministic controller/UI/API tests cover them.

---

Functional impact is limited to the local admin-console connection lifecycle, shared GKE read path, rebuild recovery, and read-only Cron presentation. The main risks are Streamlit rerun behavior and disk/UI concurrency; both now have direct regression coverage and live happy-path validation.