### PR TITLE
fix(cron): restore the Google Chat home channel for named-profile ticks

### DIFF
--- a/agents/chat/scripts/profile_cron_tick.py
+++ b/agents/chat/scripts/profile_cron_tick.py
@@ -278,26 +278,28 @@ def home_target_env(root_home: Path) -> dict[str, str]:
     Read it back from ``config.yaml`` instead — a file on disk survives the
     boundary the environment does not.
 
-    That file is writable and ``/sethome`` is what normally fills it in. The
-    operator deliberately does *not* subPath-mount its rendering over
-    ``$HERMES_HOME/config.yaml`` — a subPath mount is a read-only mount point,
-    which broke every runtime write this file takes, ``/sethome`` included
-    (``buildDefaultVolumeMounts`` in ``platformagent_manifests.go``). The
-    rendering arrives as ``profile-default.overlay.yaml`` in a read-only
-    directory instead, and ``docker-entrypoint.sh`` step 2d merges image,
-    overlay and the runtime's own edits into a real file on the PVC.
-    ``deploy/shared/default_profile_config.py`` is what carries a
-    ``/sethome`` channel across a roll: ``platforms.<adapter>.home_channel`` is
-    undeclared by both baselines, so ``adopt``/``_reconcile_dict`` treat it as
-    runtime state and keep it. So on an install where somebody has run
-    ``/sethome``, the lookup below resolves and this change alone restores
-    delivery.
+    Deliberately says nothing about *who* writes that file. Whether the runtime
+    can write it has already flipped twice — mounted read-only over
+    ``$HERMES_HOME/config.yaml``, then merged into a writable PVC file by
+    ``docker-entrypoint.sh`` step 2d and ``default_profile_config.py``, with
+    issue #658 open against the arrangement — so a docstring that names either
+    one as the way things are will be wrong again on a date nobody can predict.
+    This function only requires that ``platforms.<platform>.home_channel`` be
+    on disk by the time it reads. It does not care which side put it there, and
+    should not be edited to.
 
-    Where it still finds nothing is an install that has never run ``/sethome``
-    — the channel only reaches the pod as ``GOOGLE_CHAT_HOME_CHANNEL``, which
-    is the environment variable this function exists to work around. Closing
-    that needs the operator to render a ``home_channel`` beside the ``enabled``
-    and ``typing_status_text`` it already writes for the platform.
+    That distinction matters because it decides who fills the key in:
+
+    * Writable: ``/sethome`` (``persist_home_channel``) does, and
+      ``adopt``/``_reconcile_dict`` keep it across a roll as undeclared runtime
+      state — so on an install where somebody has run it, this function alone
+      restores delivery.
+    * Read-only: ``/sethome`` cannot, and per #658 has never once succeeded on
+      an affected install, so nothing lands and the lookup below finds nothing.
+
+    Only the operator rendering a ``home_channel`` beside the ``enabled`` and
+    ``typing_status_text`` it already writes covers both, and covers the install
+    where nobody has typed ``/sethome`` at all. That is still missing.
 
     Two things to get right if you write that, both worse than the bug this
     function fixes. **The shape:** only ``chat_id`` is read here, but the whole
@@ -307,9 +309,10 @@ def home_target_env(root_home: Path) -> dict[str, str]:
     ``KeyError`` out of ``load_gateway_config`` and the scheduler gives up with
     "failed to load gateway config" for *every* platform, not just the
     malformed one. ``persist_home_channel`` writes
-    ``{platform: <name>, chat_id: <id>, name: "Home"}``. **The precedence:**
-    rendering the key at all moves it from undeclared to declared, and
-    ``_reconcile_dict``'s scalar rule then hands the baseline the win
+    ``{platform: <name>, chat_id: <id>, name: "Home"}``. **The precedence**,
+    while the merged-writable arrangement is the one in force: rendering the
+    key at all moves it from undeclared to declared, and ``_reconcile_dict``'s
+    scalar rule then hands the baseline the win
     (``if base_v is _ABSENT or theirs_v != base_v: continue``), so the first
     roll after that silently discards whatever ``/sethome`` had set. Emit no
     ``home_channel`` key when the CR field is empty — a pointer with

--- a/agents/chat/scripts/profile_cron_tick.py
+++ b/agents/chat/scripts/profile_cron_tick.py
@@ -221,15 +221,32 @@ def _rotate(log_path: Path) -> None:
 # never consults ``config.yaml``. So the child needs these in its environment
 # or it has nowhere to post.
 #
-# Slack-only because the entry criterion is "the platform's home-channel var is
-# on the provider-env blocklist", not "the harness supports the platform". Of
-# the platforms shipped here, ``tools/environments/local.py`` blocks Slack's
-# (and Telegram's, Discord's and Signal's); ``GOOGLE_CHAT_HOME_CHANNEL`` is
-# absent from that list, so it survives ``build_subprocess_env`` and the child
-# inherits it with nothing to restore. Add a platform here when its var joins
-# the blocklist, not when the platform is enabled.
+# One entry per platform this image ships — ``hermes-agent[slack]`` and
+# ``hermes-agent[google_chat]`` in deploy/docker/Dockerfile.
+#
+# The criterion used to be "the platform's home-channel var is on Hermes'
+# provider-env blocklist", and it was both wrong about Google Chat and
+# unmaintainable. Wrong because that list is not the literal set in
+# ``tools/environments/local.py``: ``_build_provider_env_blocklist`` derives it
+# at import, and ``_inject_platform_plugin_env_vars`` files every variable a
+# bundled ``plugin.yaml`` declares under ``category: "messaging"`` by default,
+# which the blocklist then blocks wholesale — ignoring the ``password: false``
+# that ``plugins/platforms/google_chat/plugin.yaml`` sets on this very key. So
+# ``GOOGLE_CHAT_HOME_CHANNEL`` *is* stripped, grepping upstream for it finds
+# nothing, and named-profile cron delivered nowhere on a Google-Chat install.
+#
+# Unmaintainable because that set is computed inside a pinned base image
+# (``HERMES_AGENT_TAG``) from manifests this repository does not own: it can
+# change under a copy kept here with nothing on this side moving. Ship-list is
+# a criterion we control. Restoring a variable that was never stripped is a
+# no-op — it rewrites the same value — so an entry costs nothing if upstream
+# ever stops blocking it.
 HOME_TARGET_ENV_KEYS = {
     "slack": ("SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_THREAD_ID"),
+    "google_chat": (
+        "GOOGLE_CHAT_HOME_CHANNEL",
+        "GOOGLE_CHAT_HOME_CHANNEL_THREAD_ID",
+    ),
 }
 
 
@@ -249,24 +266,47 @@ def _mapping(value: object) -> dict:
 def home_target_env(root_home: Path) -> dict[str, str]:
     """The home-target variables a cron child cannot inherit, re-read from disk.
 
-    ``SLACK_HOME_CHANNEL`` sits on Hermes' provider-env blocklist
-    (``tools/environments/local.py``), so ``build_subprocess_env`` strips it
-    from every ``no_agent`` script's environment — including this ticker's.
-    The value is therefore already gone by the time we spawn, and passing
-    ``os.environ`` through re-exports the hole: the child resolves
-    ``deliver=all`` to nothing and every job on a named profile records "no
-    delivery target resolved for deliver=all" while posting nowhere.
-    ``/sethome`` is not at fault; its value simply cannot cross the boundary.
+    Every ``*_HOME_CHANNEL`` sits on Hermes' provider-env blocklist, so
+    ``build_subprocess_env`` strips it from every ``no_agent`` script's
+    environment — including this ticker's. The value is therefore already gone
+    by the time we spawn, and passing ``os.environ`` through re-exports the
+    hole: the child resolves ``deliver=all`` to nothing and every job on a
+    named profile records "no delivery target resolved for deliver=all" while
+    posting nowhere. ``/sethome`` is not at fault; its value simply cannot
+    cross the boundary.
 
-    Read it back from the root profile's ``config.yaml`` — the file
-    ``/sethome`` writes — rather than from the environment it was scrubbed
-    from. A channel id is routing metadata, not a credential: it is on that
-    blocklist because Hermes manages it as config, alongside
-    ``SLACK_ALLOWED_USERS``. Restoring these two keys here leaves the blocklist
-    intact for everything it exists to protect — the tokens, the relay secret,
-    the provider API keys.
+    Read it back from ``config.yaml`` instead — a file on disk survives the
+    boundary the environment does not.
 
-    Both keys move together on purpose. ``SLACK_HOME_CHANNEL_THREAD_ID`` is
+    Under the operator that file is the *operator's* to write, not the
+    agent's: it is mounted from a ConfigMap with a ``subPath``, which the
+    kernel makes read-only, so ``/sethome``'s ``save_config`` dies with
+    ``EROFS`` and cannot put a channel there. Restoring a platform therefore
+    takes two things, and this function is only one of them — the other is the
+    operator rendering a ``home_channel`` beside the ``enabled`` and
+    ``typing_status_text`` it already writes. Until it does, the lookup below
+    finds nothing for that platform and delivery stays where it is. That is a
+    missing source, not a failure here.
+
+    Only ``chat_id`` is read here, but the whole ``HomeChannel`` has to be
+    written. ``gateway/config.py``'s ``HomeChannel.from_dict`` indexes
+    ``data["platform"]`` and ``data["chat_id"]`` directly, so a block carrying
+    the id alone raises ``KeyError`` out of ``load_gateway_config`` and the
+    scheduler gives up with "failed to load gateway config" — for *every*
+    platform, not just the malformed one, which is a worse failure than the
+    silent one this fix addresses. The shape ``persist_home_channel`` writes is
+    ``{platform: <name>, chat_id: <id>, name: "Home"}``.
+
+    A channel id is routing metadata, not a credential. It is on that
+    blocklist because ``category: "messaging"`` is the default bucket for
+    plugin-declared variables and the blocklist blocks that bucket whole,
+    without consulting the ``password: false`` the manifest itself sets.
+    Restoring these keys leaves the blocklist intact for everything it exists
+    to protect — the tokens, the relay secret, the provider API keys — and for
+    ``*_ALLOWED_USERS``, which is an authorization list rather than a
+    destination and is deliberately not restored here.
+
+    Both keys of a pair move together on purpose. The ``*_THREAD_ID`` half is
     *not* on the blocklist and does survive the spawn, so restoring only the
     channel id would leave a stale inherited thread id pointing into a thread
     the new home knows nothing about.

--- a/agents/chat/scripts/profile_cron_tick.py
+++ b/agents/chat/scripts/profile_cron_tick.py
@@ -278,24 +278,43 @@ def home_target_env(root_home: Path) -> dict[str, str]:
     Read it back from ``config.yaml`` instead — a file on disk survives the
     boundary the environment does not.
 
-    Under the operator that file is the *operator's* to write, not the
-    agent's: it is mounted from a ConfigMap with a ``subPath``, which the
-    kernel makes read-only, so ``/sethome``'s ``save_config`` dies with
-    ``EROFS`` and cannot put a channel there. Restoring a platform therefore
-    takes two things, and this function is only one of them — the other is the
-    operator rendering a ``home_channel`` beside the ``enabled`` and
-    ``typing_status_text`` it already writes. Until it does, the lookup below
-    finds nothing for that platform and delivery stays where it is. That is a
-    missing source, not a failure here.
+    That file is writable and ``/sethome`` is what normally fills it in. The
+    operator deliberately does *not* subPath-mount its rendering over
+    ``$HERMES_HOME/config.yaml`` — a subPath mount is a read-only mount point,
+    which broke every runtime write this file takes, ``/sethome`` included
+    (``buildDefaultVolumeMounts`` in ``platformagent_manifests.go``). The
+    rendering arrives as ``profile-default.overlay.yaml`` in a read-only
+    directory instead, and ``docker-entrypoint.sh`` step 2d merges image,
+    overlay and the runtime's own edits into a real file on the PVC.
+    ``deploy/shared/default_profile_config.py`` is what carries a
+    ``/sethome`` channel across a roll: ``platforms.<adapter>.home_channel`` is
+    undeclared by both baselines, so ``adopt``/``_reconcile_dict`` treat it as
+    runtime state and keep it. So on an install where somebody has run
+    ``/sethome``, the lookup below resolves and this change alone restores
+    delivery.
 
-    Only ``chat_id`` is read here, but the whole ``HomeChannel`` has to be
-    written. ``gateway/config.py``'s ``HomeChannel.from_dict`` indexes
-    ``data["platform"]`` and ``data["chat_id"]`` directly, so a block carrying
-    the id alone raises ``KeyError`` out of ``load_gateway_config`` and the
-    scheduler gives up with "failed to load gateway config" — for *every*
-    platform, not just the malformed one, which is a worse failure than the
-    silent one this fix addresses. The shape ``persist_home_channel`` writes is
-    ``{platform: <name>, chat_id: <id>, name: "Home"}``.
+    Where it still finds nothing is an install that has never run ``/sethome``
+    — the channel only reaches the pod as ``GOOGLE_CHAT_HOME_CHANNEL``, which
+    is the environment variable this function exists to work around. Closing
+    that needs the operator to render a ``home_channel`` beside the ``enabled``
+    and ``typing_status_text`` it already writes for the platform.
+
+    Two things to get right if you write that, both worse than the bug this
+    function fixes. **The shape:** only ``chat_id`` is read here, but the whole
+    ``HomeChannel`` has to be written, because ``gateway/config.py``'s
+    ``HomeChannel.from_dict`` indexes ``data["platform"]`` and
+    ``data["chat_id"]`` directly — a block carrying the id alone raises
+    ``KeyError`` out of ``load_gateway_config`` and the scheduler gives up with
+    "failed to load gateway config" for *every* platform, not just the
+    malformed one. ``persist_home_channel`` writes
+    ``{platform: <name>, chat_id: <id>, name: "Home"}``. **The precedence:**
+    rendering the key at all moves it from undeclared to declared, and
+    ``_reconcile_dict``'s scalar rule then hands the baseline the win
+    (``if base_v is _ABSENT or theirs_v != base_v: continue``), so the first
+    roll after that silently discards whatever ``/sethome`` had set. Emit no
+    ``home_channel`` key when the CR field is empty — a pointer with
+    ``omitempty``, not a value type — or an unset field will clobber a working
+    channel with a blank one.
 
     A channel id is routing metadata, not a credential. It is on that
     blocklist because ``category: "messaging"`` is the default bucket for

--- a/agents/chat/scripts/test_profile_cron_tick.py
+++ b/agents/chat/scripts/test_profile_cron_tick.py
@@ -717,6 +717,51 @@ class HomeTargetEnvTest(unittest.TestCase):
         restored = pct.home_target_env(self.home)
         self.assertEqual("C123", restored.get("SLACK_HOME_CHANNEL"))
 
+    def test_google_chat_is_restored_the_same_way_slack_is(self):
+        # It was missing on the claim that `GOOGLE_CHAT_HOME_CHANNEL` escapes
+        # the provider-env blocklist. It does not: the blocklist is derived at
+        # import and blocks the whole `messaging` category, which is the
+        # default bucket for every plugin-declared variable.
+        self.write_config(
+            {
+                "platforms": {
+                    "google_chat": {"home_channel": {"chat_id": "spaces/20MORyAAAAE"}}
+                }
+            }
+        )
+        self.assertEqual(
+            pct.home_target_env(self.home),
+            {
+                "GOOGLE_CHAT_HOME_CHANNEL": "spaces/20MORyAAAAE",
+                "GOOGLE_CHAT_HOME_CHANNEL_THREAD_ID": "",
+            },
+        )
+
+    def test_the_authorization_list_is_never_restored(self):
+        """`*_ALLOWED_USERS` is blocklisted too, and stays that way.
+
+        It sits beside the home channel in the same `messaging` category, but
+        it is an authorization list rather than a destination — a different
+        risk class, and nothing in cron delivery needs it. Restoring it would
+        be scope creep past what this function argues is safe.
+        """
+        self.write_config(
+            {
+                "platforms": {
+                    "google_chat": {
+                        "home_channel": {"chat_id": "spaces/AAA"},
+                        "allowed_users": ["someone@example.com"],
+                    },
+                }
+            }
+        )
+        restored = pct.home_target_env(self.home)
+        self.assertEqual(
+            {"GOOGLE_CHAT_HOME_CHANNEL", "GOOGLE_CHAT_HOME_CHANNEL_THREAD_ID"},
+            set(restored),
+        )
+        self.assertNotIn("GOOGLE_CHAT_ALLOWED_USERS", restored)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request

## Why This Change

`home_target_env` in `agents/chat/scripts/profile_cron_tick.py` exists to put back the
home-channel variables that Hermes' `build_subprocess_env` strips from a `no_agent` script's
environment. It listed Slack only, on the strength of a comment claiming that
`GOOGLE_CHAT_HOME_CHANNEL` is absent from the provider-env blocklist and therefore survives
the spawn.

It does not survive. The blocklist is not the literal set in `tools/environments/local.py`:
`_build_provider_env_blocklist` derives it at import, and `_inject_platform_plugin_env_vars`
files every variable a bundled `plugin.yaml` declares under the fallback
`category: "messaging"` — a bucket the blocklist blocks wholesale, without consulting the
`password: false` that `plugins/platforms/google_chat/plugin.yaml` sets on this very key.
Grepping upstream for the name finds nothing because it is manufactured at runtime, which is
why the claim looked true. Measured on a live pod:
`in_parent=True, survives_build_subprocess_env=False`.

`HOME_TARGET_ENV_KEYS` is the loop's **iteration domain**, not a hint — with no `google_chat`
key, `platforms.google_chat` is never read however well populated it is, and nothing else in
the file knows the variable's name. So every scheduled Platform Agent watchdog with
`deliver: "all"` resolved zero targets for Google Chat and logged
`no delivery target resolved` instead of reporting to chat.

## What Changed

**Files:**

- `agents/chat/scripts/profile_cron_tick.py`
- `agents/chat/scripts/test_profile_cron_tick.py`

**Added/Changed/Fixed:**

- Added the `google_chat` entry to `HOME_TARGET_ENV_KEYS`
  (`GOOGLE_CHAT_HOME_CHANNEL` / `GOOGLE_CHAT_HOME_CHANNEL_THREAD_ID`). Six executable lines;
  the body of `home_target_env` below its docstring is byte-identical to `main`.
- Replaced the comment that asserted the opposite, and restated the map's criterion as **one
  entry per platform this image ships**, not "one per blocklisted variable". The blocklist is
  computed inside a pinned base image from manifests this repository does not own, so a copy
  of it kept here cannot stay correct; the ship-list is a criterion we control. Restoring a
  variable that was never stripped just rewrites the same value, so an entry costs nothing if
  upstream stops blocking it.
- Extended the docstring with the `home_channel` **shape** the operator half has to write
  (see Context) — the one detail that turns this fix into a worse outage if got wrong.
- Two tests: `test_google_chat_is_restored_the_same_way_slack_is`, and
  `test_the_authorization_list_is_never_restored` rewritten to assert the restored key set is
  exactly the two channel keys.

`*_ALLOWED_USERS` stays blocklisted and unrestored — same category, but an authorization list
rather than a destination, and cron delivery has no use for it. The `*_THREAD_ID` half of each
pair is still cleared rather than forwarded.

## Why This Matters

- Every governance watchdog on the Platform Agent's roster sets `deliver: "all"` precisely so
  that a failure is audible (`agents/platform/cron/README.md`). On a Google-Chat-only install
  — the shipping default — `"all"` was resolving to nothing, so a failed audit was
  indistinguishable from a quiet fleet. That is the exact failure mode the `deliver` choice
  exists to prevent.
- The bug was invisible to code reading: the file carried a confident, wrong explanation of
  why it was safe, and the variable that disproves it does not exist in any upstream source
  file. It only shows up by measuring the blocklist on a running pod.
- Safe by construction: a re-injected value is re-stripped at the next `build_subprocess_env`
  boundary, so it does not leak into an `execute_code` child (verified, below).

## Context

- **This PR takes no position on whether `config.yaml` is writable, and does not need to.**
  `home_target_env` reads `platforms.<platform>.home_channel.chat_id` and requires only that
  the key be on disk when it reads. That matters because the answer has flipped twice —
  `2651658` reverted the writable work, #602 re-landed it, and **#658 is open and assigned**
  against the current arrangement. An earlier draft of this section asserted the read-only
  side as settled fact; `kube-agents-bot` correctly pointed out that `main` says the opposite
  today. Both framings are the same defect, so `1a5cbcf` removed the premise instead of
  inverting it.
- **Where the key comes from under each arrangement.** Writable: `/sethome` writes it and
  `adopt`/`_reconcile_dict` keep it across a roll, so this change alone restores delivery on
  an install where somebody has run it. Read-only: `/sethome` cannot, and per #658 never once
  has — three dispatches in that install's entire log history, all three failing, nothing
  persisted anywhere. Only the operator rendering `home_channel` covers both, plus the install
  where nobody has typed `/sethome` at all. That is still missing.
- **My live install measured `{}` for a reason that was not `main`'s.** `/proc/mounts` showed
  the file read-only and an append returned `Permission denied` — but that operator pod started
  2026-08-10 23:40 EDT, before #602 landed on 2026-08-12, so it still rendered a mount the
  merged tree had already dropped. Accurate measurement of a stale operator, generalised to
  `main`. What it does not undermine is the restore logic itself, which was tested against
  supplied input and is unaffected.
- **Follow-up (separate PR, deliberately not bundled):** ~13 lines in
  `k8s-operator/internal/controller/platformagent_manifests.go` to render `home_channel` into
  the `platforms.google_chat` block beside the `enabled` / `typing_status_text` already
  written there. The CRD field already exists (`platformagent_types.go`, `HomeChannel string`),
  so no API change and no `make manifests`. `slack.HomeChannel` has the identical gap, latent
  only because Slack is disabled here; whether it gets the same treatment is open.
- **Two traps that follow-up must avoid**, both recorded in the docstring. **(a) Precedence**
  (found by `kube-agents-bot`, and only while the merged-writable arrangement is in force):
  rendering `home_channel` moves it from undeclared to declared, and `_reconcile_dict`'s scalar
  rule then hands the baseline the win, so the first roll after it silently discards the user's
  `/sethome` choice — Slack included. Emit no key at all when the CR field is empty: a pointer
  with `omitempty`, not a value type. **(b) Shape**, hit while live-testing this:
  only `chat_id` is read here, but the whole `HomeChannel` has to be written.
  `gateway/config.py`'s `HomeChannel.from_dict` indexes `data["platform"]` and
  `data["chat_id"]` directly, so a block carrying the id alone raises `KeyError` out of
  `load_gateway_config` and the scheduler gives up with `failed to load gateway config` — for
  _every_ platform, not just the malformed one. Required shape:
  `{platform: <name>, chat_id: <id>, name: "Home"}`.

## Testing

- `test_profile_cron_tick.py` — 51 tests pass, run against the real interpreter and
  dependencies inside the agent pod (`/opt/hermes/.venv/bin/python3`); no pyyaml locally.
- `make docs-check` — clean (generated regions current, 239 files link-checked, terminology
  clean, map inventory covers all 212 tracked docs).
- `review-docs-drift` skill against the branch diff — **no findings**. No doc changed; neither
  file feeds a generated region or an identifier-sources row; no page states a fact this
  change falsifies. `agents/platform/cron/README.md`'s "`all` expands at fire time to every
  platform with a configured home channel" is what this fix moves _toward_, not away from.
- `prettier --check` — not applicable, no Markdown/JSON/YAML in the diff.

### Live validation

Install: GKE `platform-agent-host` (us-central1, project `toshiowang-gkedemos`), namespace
`kubeagents-system`, pod `platform-agent-gateway-745655cd4c-jjd5l`, agent image
`platform-agent:dev-20260812-143522`, operator `k8s-operator:latest`. Exercised 2026-08-13
~10:46 EDT.

**1. The premise, measured in the pod.** Imported Hermes' real `build_subprocess_env` and
asked it directly: `GOOGLE_CHAT_HOME_CHANNEL` → `in_parent=True`,
`survives_build_subprocess_env=False`. The comment this PR deletes was wrong.

**2. Restore logic, 2×2 with both negative controls** — stock vs. patched script, real pod
`config.yaml` vs. an operator-shaped scratch copy carrying `home_channel`:

|                    | real `config.yaml`             | scratch config with `home_channel`                                    |
| ------------------ | ------------------------------ | --------------------------------------------------------------------- |
| **stock script**   | `{}`                           | `{}` — the entry is required                                            |
| **patched script** | `{}` — the source is required  | `{GOOGLE_CHAT_HOME_CHANNEL: spaces/LIVETEST123, ..._THREAD_ID: ""}`     |

Distinctly different value, not a default: `spaces/LIVETEST123` appears nowhere on the
install. Both off-diagonal cells are the mechanism proof — neither half works alone.

**3. Real delivery, matched pair.** A scratch profile with one `deliver: "all"` `no_agent`
job, fired through this file's own `spawn_tick`, with the parent environment first put through
the real `build_subprocess_env` so the channel was genuinely absent. Same config, same job,
only the script differing:

```
STOCK    WARNING  cron.scheduler: no delivery target resolved for deliver=all
PATCHED  INFO     cron.scheduler: Job 'gchat-livetest': delivered to google_chat:spaces/20MORyAAAAE
```

The message arrived in the space. Delivery authenticates through `GOOGLE_CHAT_RELAY_URL`,
which survives the scrub, so the home channel was the only missing piece — there is no
service-account JSON in the pod at all.

**4. Safety.** Re-ran `build_subprocess_env` over the restored environment: the variable is
stripped again, so it does not reach an `execute_code` child.

**What this could not cover.** End-to-end delivery from a _real_ watchdog on the real Platform
Agent roster — impossible until the operator writes `home_channel`, as above. Step 3 had to
supply that key from a scratch config. The Slack path was not exercised (Slack is disabled on
this install); its code path is unchanged by this PR.

**Cleanup.** Scratch profile, scratch config and the test job were removed; the patched script
was reverted in the pod. The Platform Agent's roster is back to its 9 jobs, and no scratch job
leaked onto a real profile (verified after).

---

Six executable lines, no behaviour change on any platform other than Google Chat. Rollout is
the next pod roll, which syncs the script into `$HERMES_HOME/scripts`. On an install that has
a `home_channel` on disk, Google Chat watchdogs stop silently resolving no target and start
posting there — the intended fix, and a visible change rather than the no-op an earlier draft
of this line claimed. #658's own Blast radius section names this PR's gap independently
(*"`HOME_TARGET_ENV_KEYS` maps only `slack` … would not reach cron children even once
`config.yaml` is writable"*), which is the case for landing it whichever way that issue
resolves.

_This pull request was generated with the help of Claude._
