### PR TITLE
docs: ask for each thing once in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,10 @@
-# Pull Request
+## Summary
+
+<!--
+One paragraph, in plain prose, explaining what this PR does — what a reviewer would
+want to know before reading the diff. Write it for a human, not as a bullet list or a
+restatement of the commit message.
+-->
 
 ## Why This Change
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,21 +8,19 @@ restatement of the commit message.
 
 ## Why This Change
 
-<!-- Explain the problem, motivation, or user need this PR addresses. -->
+<!--
+The problem, motivation, or user need this PR addresses, and what stays broken without
+it. Impact belongs here too — say it once, in the place that already explains why the
+problem is worth fixing.
+-->
 
 ## What Changed
 
-<!-- Summarize the important files, behavior, or workflow changes. -->
-
-**Files:**
-
-- `path/to/file`
-
-**Added/Changed/Fixed:**
-
--
-
-## Why This Matters
+<!--
+The important behaviour, interface, or workflow changes. GitHub's "Files changed" tab
+already lists every file, so name one only where the reviewer needs to know why that
+file matters.
+-->
 
 -
 
@@ -58,6 +56,10 @@ Full contract: AGENTS.md, "Pull Request Hygiene".
 
 -
 
----
+## Risk & Rollout
 
-<!-- Close with a short note on functional impact, risk, or rollout. -->
+<!--
+Blast radius, any new failure mode, how to revert, and anything that has to happen at
+merge time. A short paragraph. "Low risk, no runtime code paths touched" is a complete
+answer when it is true.
+-->


### PR DESCRIPTION
## Summary

This PR rewrites the top and bottom of the pull request template so it asks for each thing
once. It drops the `# Pull Request` heading, which restated the title GitHub already renders
above the body, and opens instead with a **Summary** section asking for one paragraph of
plain prose about what the change does. It then removes the duplication that heading was
hiding: **Why This Matters** folds into **Why This Change**, the hand-maintained `Files:`
list goes away in favour of GitHub's own Files-changed tab, and the unlabelled note after
the `---` becomes a real **Risk & Rollout** section scoped to blast radius and revert. Net
effect is one fewer section and four prose asks instead of seven, with the reviewer's first
paragraph telling them what they are about to read.

## Why This Change

The template opened with a redundant heading and then went straight into **Why This
Change**, so a reader met the motivation before they knew what the change was. Every other
section was a bullet list or narrow in scope, leaving nowhere for a human-readable overview
— reviewers reconstructed the shape of a PR from a file list.

Adding a Summary alone would have made a second problem worse. Four sections already
competed for the same narrative: **Why This Change**, **Why This Matters**, and the
unlabelled closer all wanted impact. Merged #670 shows the cost — its **Why This Change**
explains the consequences of the bug at length, and **Why This Matters** then restates those
same consequences as three bullets. A Summary on top would have been a fourth pass. Asking
four times is how you train authors to write filler for at least three of them, and it is
the reviewer who pays, reading the same point in four voices before reaching the diff.

The `Files:` list has the same defect the deleted heading had: it duplicates something
GitHub renders for free, and unlike the heading it also rots — it is written once and the
branch keeps moving. The template asked for the *important* files; in practice every sampled
PR listed all of them.

## What Changed

- Removed the `# Pull Request` H1 and added `## Summary` as the opening section, with
  guidance asking for one paragraph of prose written for a human — explicitly not a bullet
  list and not a restated commit message.
- Folded **Why This Matters** into **Why This Change**, whose comment now asks for impact
  in the place that already explains why the problem is worth fixing.
- Dropped the `**Files:**` block and the now-redundant `**Added/Changed/Fixed:**` sub-label
  from **What Changed**, which points at the Files-changed tab instead and asks authors to
  name a file only where the reviewer needs to know why it matters.
- Promoted the unlabelled note after the `---` to `## Risk & Rollout`, narrowed to blast
  radius, new failure modes, revert, and merge-time steps — the parts that were not
  duplicated elsewhere.
- Left **Context**, **Testing**, and **Live validation** untouched, including the full
  live-validation contract comment that AGENTS.md points at.

## Context

No open pull request touches `.github/PULL_REQUEST_TEMPLATE.md`. Nothing outside the
template references the removed section names — `AGENTS.md` and the site's contributing
guide link to the template rather than restating its structure, and no workflow, script, or
skill greps for `Why This Matters`, `**Files:**`, or `Added/Changed/Fixed`, so nothing needs
reconciling alongside this change.

Two decisions came from reading the last dozen merged PRs rather than from taste:

- **The closer was kept, not deleted.** Five of eight merged PRs that reach it write real
  risk and rollout content there — #651's "reverting is deleting five lines", #650's "the
  one new failure mode is the intentional hard exit". That is not a restatement of impact,
  so it earned a heading instead of the axe. Three of eight left it holding only the Claude
  attribution line, which is the fill-rate problem a heading is meant to fix.
- **The bare `-` placeholders stay.** They looked like a trap — an empty bullet under
  **Live validation** reads as answered — but zero of the eleven sampled merged PRs left one
  unfilled, so there is no problem here to solve.

This PR was generated with the help of Claude.

## Testing

- `prettier --check .github/PULL_REQUEST_TEMPLATE.md` — passes (prettier 3.9.6, the version
  CI pins).
- `make docs-check` — passes: generated regions current, 239 files' relative links resolve,
  terminology check clean, documentation map inventory complete.
- Sampled the last twelve merged PRs for section usage and unfilled placeholders; findings
  are in **Context** above.

### Live validation

Not live-tested. The change is a single Markdown file under `.github/` that GitHub renders
when a pull request is opened. It never reaches a running kube-agents installation — no
operator reconciliation, no Deployment env, no file or process inside the agent pod — so
there is no layer on a live install where its effect could be observed. The body of this
pull request is written with the new template, so it is the rendered result.

## Risk & Rollout

Documentation-only and scoped to the pull request body form; no runtime, chart, or operator
behaviour is affected. Nothing needs to roll out — the next pull request opened against the
repository picks up the new template, and open PRs written against the old one are
unaffected. Reverting is restoring one file. The one thing worth watching is that this
changes a form other contributors have internalised: an author working from muscle memory
may keep writing a `Files:` block, which is harmless, or may skip **Risk & Rollout** because
it used to be an unlabelled afterthought.
