### PR TITLE
fix(scripts): require IMAGE_TAG only from the steps that deploy an image

### DIFF
--- a/k8s-operator/scripts/common.sh
+++ b/k8s-operator/scripts/common.sh
@@ -394,6 +394,11 @@ is_non_interactive() {
 # between deploys, so it is scoped to a single pipeline execution. provision.sh
 # prompts once up front and exports it; the per-step scripts inherit it from
 # the environment and only prompt when run standalone.
+#
+# Only the steps that deploy an image built from this repo need one, and they
+# say so by setting REQUIRES_IMAGE_TAG=1 before calling load_state. Demanding it
+# from every step made the secrets and integration steps — none of which mention
+# IMAGE_TAG — fail outright in non-interactive mode.
 init_var_image_tag() {
   if [ -z "${IMAGE_TAG:-}" ]; then
     if is_non_interactive; then
@@ -430,7 +435,9 @@ load_state() {
     && [ "$env_registry_prefix" != "$REGISTRY_PREFIX" ]; then
     print_warning "Ignoring exported REGISTRY_PREFIX='${env_registry_prefix}': the saved value '${REGISTRY_PREFIX}' from ${VARS_FILE} wins. Edit ${VARS_FILE} (REGISTRY_PREFIX and the saved *_IMAGE values) to change registries."
   fi
-  init_var_image_tag
+  if [ "${REQUIRES_IMAGE_TAG:-0}" -eq 1 ]; then
+    init_var_image_tag
+  fi
   init_var_registry_prefix
   export NAMESPACE="kubeagents-system"
   export PLATFORM_AGENT_KSA_NAME="kubeagents-platform-agent"

--- a/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
+++ b/k8s-operator/scripts/provision_03_gcp_gke_operator.sh
@@ -23,6 +23,8 @@ check_prereqs "gcloud" "kubectl" "make"
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
 print_step "Setting up Configuration State for Operator Deployment"
+# This step deploys the operator image from this repo, so it needs a tag.
+REQUIRES_IMAGE_TAG=1
 load_state
 
 ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"

--- a/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
+++ b/k8s-operator/scripts/provision_08_deploy_platform_agent.sh
@@ -28,6 +28,8 @@ check_prereqs "gcloud" "kubectl" "envsubst"
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
 print_step "Setting up Configuration State for Agent Deployment"
+# This step deploys the platform agent image from this repo, so it needs a tag.
+REQUIRES_IMAGE_TAG=1
 load_state
 
 ACTIVE_PROJECT="$(gcloud config get-value project 2>/dev/null || echo "")"

--- a/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
+++ b/k8s-operator/scripts/provision_11_deploy_inference_replay.sh
@@ -24,6 +24,8 @@ VARS_FILE="${SCRIPT_DIR}/vars.sh"
 source "${SCRIPT_DIR}/common.sh" "$@"
 
 # ─── Configuration & State Restoration ────────────────────────────────────────
+# This step deploys the replay proxy image from this repo, so it needs a tag.
+REQUIRES_IMAGE_TAG=1
 load_state
 
 # ─── Opt-In Gate ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Pull Request

## Why This Change

`Autopush Redeploy Integrations` has failed on **every run since 2026-08-10** — 12+ consecutive
failures on unrelated commits — at its very first step:

```
✗ IMAGE_TAG is required in non-interactive mode. Set it to an immutable release tag or validated commit SHA.
make: *** [Makefile:277: gcp-provision-07-secrets] Error 1
```

`provision-secrets` is a `needs:` dependency of both integration deploys, so `Redeploy LiteLLM
Gateway Integration` and `Redeploy GitHub Token Minter Integration` are **skipped, not run**. The
practical effect is that no change under `k8s-operator/config/integrations/` has reached a cluster
since that date. On autopush today, `github-token-minter` is in `CrashLoopBackOff` with 380+
restarts and the fix for it is sitting on `main`, undeployed.

The cause is in the shared provisioning code, not the workflow. `load_state` calls
`init_var_image_tag` unconditionally, so **every** step demands an `IMAGE_TAG` in non-interactive
mode — including the ones that have no image to tag. `grep -n IMAGE_TAG` finds no match in
`provision_07_gcp_k8s_secrets.sh`, `provision_09_deploy_litellm.sh`, or
`provision_10_deploy_github_minter.sh`; the latter two deploy pinned third-party images
(`ghcr.io/berriai/litellm`, `github-token-minter-server`). The integrations workflow sets no
`IMAGE_TAG` because it has none to set; `reusable-deploy-agent.yml` passes one only because
`provision_08` genuinely uses it.

The guard came in with #519. This does not remove it — it puts it where it applies.

## What Changed

**Files:**

- `k8s-operator/scripts/common.sh`
- `k8s-operator/scripts/provision_03_gcp_gke_operator.sh`
- `k8s-operator/scripts/provision_08_deploy_platform_agent.sh`
- `k8s-operator/scripts/provision_11_deploy_inference_replay.sh`

**Added/Changed/Fixed:**

- `load_state` now runs `init_var_image_tag` only when the caller sets `REQUIRES_IMAGE_TAG=1`.
- The three scripts that build image references from `IMAGE_TAG` — `provision_03` (operator),
  `provision_08` (platform agent), `provision_11` (replay proxy) — set it before calling
  `load_state`.
- `provision.sh` is untouched: it still calls `init_var_image_tag` directly, so a full interactive
  run prompts once up front exactly as before.

## Why This Matters

- Unblocks the integrations deploy path, which has been dead for days without anyone noticing —
  a redeploy workflow that only fires on a narrow `paths:` filter fails quietly.
- Fixes the same wall for a human running `make gcp-provision-07-secrets` non-interactively, not
  just for CI. Setting `IMAGE_TAG` in the workflow would have papered over that.
- Keeps #519's guard intact where it was aimed: the steps that deploy an image built from this repo
  still refuse to run untagged.

## Context

- Regression introduced by #519 (`282ef124`), which added the non-interactive `IMAGE_TAG` guard.
- Found while investigating why the `github-token-minter` fix from #676 never reached autopush.
- A **separate** bug is also keeping autopush unhealthy: `litellm-policy` permits DNS egress only to
  the kube-dns pod selectors and `169.254.20.10/32`, but the pods' `resolv.conf` points at the
  kube-dns ClusterIP `34.118.224.10`, so LiteLLM cannot resolve anything. That is a different fix
  and gets its own PR.
- This PR was generated with the help of Claude.

## Testing

- `bash -n` on `common.sh` and every `provision_*.sh` — clean.
- `make docs-check` — passes.

### Live validation

Not deployed to a cluster: this changes a provisioning-script precondition, and the path it unblocks
runs in CI against autopush. It was instead exercised directly against the scripts on a checkout of
this branch, reproducing the failure and its absence.

**Reproduced the reported failure first**, by stashing the fix and running the real script with the
variable unset, in the same non-interactive mode CI uses:

```
$ git stash
$ env -u IMAGE_TAG DRY_RUN=1 bash provision_07_gcp_k8s_secrets.sh --dry-run --no-confirm
>>>  Setting up Configuration State  <<<
  ✗ IMAGE_TAG is required in non-interactive mode. …
```

**With the fix applied**, the same command reaches configuration state and continues — no
`IMAGE_TAG` error.

**Proving the mechanism rather than a coincidence**, all six affected scripts were run the same way,
confirming the requirement moved rather than disappeared:

| Script | `IMAGE_TAG` unset, non-interactive |
| --- | --- |
| `provision_03_gcp_gke_operator.sh` | guard still fires ✅ |
| `provision_08_deploy_platform_agent.sh` | guard still fires ✅ |
| `provision_11_deploy_inference_replay.sh` | guard still fires ✅ |
| `provision_07_gcp_k8s_secrets.sh` | unblocked ✅ |
| `provision_09_deploy_litellm.sh` | unblocked ✅ |
| `provision_10_deploy_github_minter.sh` | unblocked ✅ |

**Not covered:** the workflow itself. Whether `Autopush Redeploy Integrations` goes green end to end
can only be observed after this merges to `main`, since it triggers on push. Everything before the
`IMAGE_TAG` gate is unchanged, and everything after it was already reachable whenever a tag happened
to be set. No cluster state was modified and no test artifacts were left behind — every run above
used `--dry-run`.

---

Low risk and reversible: three scripts opt in to a check they already satisfied, and one
`if` guards it for the rest. The blast radius if `REQUIRES_IMAGE_TAG` were wrong for some script is
that it prompts (interactive) or defaults (non-interactive) rather than erroring — and `grep` over
`k8s-operator/scripts/` confirms only those three reference the variable.
