### PR TITLE
docs(agents): require agents to reply to and resolve review threads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   [Automated Review After Opening a Pull Request](#automated-review-after-opening-a-pull-request)
   for what it does and what you are expected to do with its findings.
 - **Leave no conversation unresolved.** `main` will not merge while a review thread is open, and
-  the open thread also keeps the pull request assigned to its author rather than its reviewers.
+  the open thread also keeps the pull request counted as its author's outstanding work.
   Reply, then resolve every thread you are confident is addressed — commands and the bar for
   "confident" are in
   [Automated Review After Opening a Pull Request](#automated-review-after-opening-a-pull-request).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,11 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   `kube-agents-bot`; see
   [Automated Review After Opening a Pull Request](#automated-review-after-opening-a-pull-request)
   for what it does and what you are expected to do with its findings.
+- **Leave no conversation unresolved.** `main` will not merge while a review thread is open, and
+  the open thread also keeps the pull request assigned to its author rather than its reviewers.
+  Reply, then resolve every thread you are confident is addressed — commands and the bar for
+  "confident" are in
+  [Automated Review After Opening a Pull Request](#automated-review-after-opening-a-pull-request).
 - **Local Validation Checks:** Before committing, try to run checks locally to avoid CI failures:
   - **Formatting:** Run `prettier --write <files>` on changed Markdown, JSON, or YAML files. You can check all files using `make prettier-check` (note: this checks files outside your PR scope; CI only checks the ones your branch changed). Install the version CI pins (see the Install Prettier step in `.github/workflows/prettier.yml`), e.g. `npm install -g prettier@<that version>` — the manifests gate in `k8s-operator-test.yml` asserts byte-equality against that version's output, so a skew fails CI on files you did not touch. Prefer the installed binary over `npx prettier`, which re-resolves the package against the npm registry on every run and fails outright behind an authenticated mirror — that failure is why this step has previously been skipped rather than run.
   - **Docker Build:** Validate the agent runner Dockerfile by building it locally (e.g., `docker build --platform linux/amd64 -f deploy/docker/Dockerfile --target platform .`). Keep `--platform linux/amd64`: the base images are multi-arch and deployment targets are amd64 GKE nodes, so a bare build on an arm64 machine produces an image that cannot run on the cluster (#560).
@@ -237,3 +242,63 @@ gh api repos/gke-labs/kube-agents/pulls/<number>/comments/<comment-id>/replies \
 
 After pushing fixes, remember that the push alone does not re-trigger anything: ask the user whether
 to comment `/review` for another pass.
+
+**Then resolve the conversations.** `main` requires every conversation on a pull request to be
+resolved before it can merge, and the triage sweep counts an open thread as work outstanding on the
+author — so a branch whose fixes have all landed still sits blocked, and still shows up as the
+author's problem rather than the reviewers'. Clearing the threads is part of finishing the change,
+not a courtesy someone else will get to. Do it once the fixes are pushed and the last `/review` pass
+has settled: a fresh review opens fresh threads, so resolving before it lands means doing it twice.
+
+Resolve a thread — the bot's or a human's — when you are **fully confident the issue is addressed**:
+the fix is on the pull request head and you can name the commit, or the finding is factually wrong
+and you have said why. Anything short of that stays open. A judgment call, a reviewer asking for
+something you chose not to do, a rebuttal nobody has answered yet — reply and leave it to them.
+Resolving says the conversation is finished; it is not a way to end a disagreement.
+
+Reply first, always. A resolved thread collapses, so the reviewer who opened it may never expand it
+again, and the reply is the only record of what happened. Name what changed and the commit that
+changed it. Then resolve:
+
+```bash
+# Every unresolved thread, with both ids you need: resolveReviewThread takes the
+# thread's node id, while the reply endpoint above takes the first comment's
+# databaseId. REST returns only the latter, which is why this one is GraphQL.
+gh api graphql -f query='
+query($pr: Int!) {
+  repository(owner: "gke-labs", name: "kube-agents") {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          id isResolved isOutdated viewerCanResolve path line
+          comments(first: 20) { nodes { databaseId author { login } body } }
+        }
+      }
+    }
+  }
+}' -F pr=<number> --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+  | select(.isResolved | not)
+  | "\(.path):\(.line // "outdated") thread \(.id) canResolve=\(.viewerCanResolve)
+  reply to \(.comments.nodes[0].databaseId) — \(.comments.nodes[0].author.login): \(.comments.nodes[0].body | split("\n")[0])
+  replies so far: \(.comments.nodes | length - 1)"'
+
+# Per thread, once the reply naming the fix is posted:
+gh api graphql -f query='
+mutation($thread: ID!) {
+  resolveReviewThread(input: {threadId: $thread}) { thread { isResolved } }
+}' -f thread='<PRRT_...>'
+```
+
+Four ways that goes wrong quietly:
+
+- `first: 100` is a cap, not a promise. A long-lived pull request can carry more threads than that;
+  page for the rest, or say you only looked at the first hundred rather than reporting the branch
+  clear.
+- `line` is `null` once a thread's line falls out of the diff. Outdated is not addressed — the code
+  moved, which says nothing about whether the finding still holds. Read the thread.
+- `viewerCanResolve` is the authoritative answer to whether your token can resolve at all; it
+  differs between a maintainer and a contributor pushing from a fork. Check it before you reply,
+  because a mutation that fails after the reply is posted leaves a half-answered thread that looks
+  handled.
+- `unresolveReviewThread`, same `threadId`, is the undo. Use it the moment the user disagrees with
+  something you resolved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,9 @@ has settled: a fresh review opens fresh threads, so resolving before it lands me
 
 Resolve a thread — the bot's or a human's — when you are **fully confident the issue is addressed**:
 the fix is on the pull request head and you can name the commit, or the finding is factually wrong
-and you have said why. Anything short of that stays open. A judgment call, a reviewer asking for
+and you have said why. Check that second one against the merge target as it stands now, not against
+your working copy — a finding that looks wrong because the file it cites does not say that is very
+often a stale checkout rather than a wrong finding. Anything short of that stays open. A judgment call, a reviewer asking for
 something you chose not to do, a rebuttal nobody has answered yet — reply and leave it to them.
 Resolving says the conversation is finished; it is not a way to end a disagreement.
 

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -99,8 +99,9 @@ Every pull request is also reviewed by `kube-agents-bot`, a GitHub App that runs
 - **Pushing more commits does not re-trigger it.** To ask for a fresh review of the current commit, comment `/review` on a line of its own. Owners, members, and collaborators can trigger it.
 - **Reading the result.** 👀 means the review started, a posted review means it finished. Findings are inline comments badged 🔴 High, 🟠 Medium, or 🟡 Low; findings about code outside the diff are listed in the summary body. "No findings" is the common outcome and is a real result — a 👀 with nothing following it is a bug in the bot.
 - **Opting out.** The `agent:ignore` label excludes a pull request from review and outranks `/review`.
+- **Resolving the threads is part of the work.** `main` will not merge while any conversation is open, whether the bot or a human started it, and an open thread keeps the pull request counted as its author's outstanding work. Whoever is confident a thread is addressed — author or reviewer — replies saying what changed, then resolves it. Threads that are still a judgment call stay open for the person who raised them.
 
-AI agents working in this repository have a further obligation: after opening a pull request they should offer to wait for this review and then walk its findings with you before changing any code. See [`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md).
+AI agents working in this repository have a further obligation: after opening a pull request they should offer to wait for this review and then walk its findings with you before changing any code, and they resolve the threads they have addressed. See [`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md).
 
 ## Where to file issues
 


### PR DESCRIPTION
## Summary

Agents in this repository read the bot's review, fix what it found, and then leave every
conversation open, because the docs never told them to close one and the mechanism is not reachable
from the commands the docs do give. `main` will not merge with an open thread, and the triage sweep
keeps such a pull request filed as its author's work rather than its reviewers', so the branch stops
there. This adds the missing step to `AGENTS.md` — the bar for resolving a thread you did not open,
the reply-that-must-come-first, the GraphQL query that yields the thread id, the mutation, and the
ways it fails quietly — plus a one-line mirror for humans on the contributing page.

## Why This Change

`main` is gated on `required_conversation_resolution` (branch protection, alongside the
`tide-only-merge` ruleset), so a single open review thread blocks the merge. The same signal decides
ownership: the triage sweep counts unresolved threads as a blocking reason and keeps the pull
request listed as its author's outstanding work, so open conversations are exactly what stops the
ball moving to reviewers.

The reason agents leave them open is in this repository's own docs. `AGENTS.md` documents how to
read the `kube-agents-bot` findings and how to reply to one, and stops there. There is no `gh`
subcommand for resolving — it takes the GraphQL `resolveReviewThread` mutation keyed by a thread
**node id**, and the REST comment listing the docs already recommend never returns that id. An agent
following the documented commands to the letter cannot resolve anything.

Without this, the backlog keeps growing: across the 40 most recently updated open pull requests,
#623 carries 40 unresolved threads (29 of them the bot's), #595 carries 37 (29), #548 carries 31
(19), #504 carries 15 (all bot). Every one is unmergeable and pinned to its author.

## What Changed

Documentation only — no code, no CI, no new script.

- `AGENTS.md`, "Automated Review After Opening a Pull Request": a new closing subsection covering
  why resolution is a merge gate rather than a courtesy, the bar for resolving a thread you did not
  open (fully confident it is addressed — the fix is on the head and you can name the commit, or the
  finding is factually wrong and you have said why), the reply-then-resolve rule, the GraphQL query
  that returns the thread node id and the reply comment id together, the `resolveReviewThread`
  mutation, and four quiet failure modes (`first: 100` is a cap, `line: null` means outdated not
  addressed, `viewerCanResolve` differs for a fork contributor, `unresolveReviewThread` is the undo).
- `AGENTS.md`, "Pull Request Hygiene": one bullet stating the merge gate where the other
  merge-blocking rules live, pointing at that subsection rather than restating it.
- `docs/site/src/content/docs/contributing.md`: one bullet in "Automated review" mirroring the rule
  for humans, deferring to `AGENTS.md` the way the rest of that section already does.

## Context

Generated with the help of Claude.

No open issue covers this. Seven open pull requests touch `AGENTS.md` or a `contributing.md` —
#688, #679, #659, #623, #615, #571, #548 — none for this reason; #623 and #548 are the likeliest
merge conflicts in the same files. Overlap here is a rebase warning, not duplicate work.

Deliberately out of scope: the existing backlog of unresolved threads (left to each author), a
helper script, and any CI auto-resolver. The bot's own code lives outside this repository, so
"resolve what I found fixed" on the bot side is not something this change can reach.

Merged `main` (through #685) into the branch, which is where the current template came from.

## Testing

- `make docs-check` — clean at the merged head (generated regions current, 241 files link-checked,
  terminology, map inventory).
- `prettier@3.9.6 --check AGENTS.md docs/site/src/content/docs/contributing.md` — clean. Version
  matches the one pinned in `.github/workflows/prettier.yml`.
- `docs/README.md` deliberately untouched: no document was added, moved, or deleted, and the map's
  rule is one line per new document with no re-alignment of existing rows.
- Both API names in the new recipe verified against the live GitHub GraphQL schema by introspection,
  not from memory: `resolveReviewThread` and `unresolveReviewThread` exist as mutations, and
  `ResolveReviewThreadInput` takes `threadId: ID!`.

### Live validation

The change is a procedure, so it was exercised as one against `gke-labs/kube-agents` itself. There
is no agent installation in the path of a documentation change, and the procedure's subject —
review threads on this repository's pull requests — is the real system it has to work against.

- The list query in the new recipe was run verbatim against real pull requests (#697, #571) before
  being written down. It returns what the recipe claims: the thread node id, the first comment's
  `databaseId` for the existing reply endpoint, `path:line`, and `viewerCanResolve`.
- The merge gate was read from the repository rather than assumed:
  `gh api repos/gke-labs/kube-agents/branches/main/protection` reports
  `required_conversation_resolution: {"enabled": true}`.
- **The full round trip ran on this pull request's own bot review, and caught me out.** The bot
  reported no code findings and one thread on the description (comment `3784333034`), saying the
  **Summary** and **Risk & Rollout** sections were unanswered. I checked the template in my
  checkout, found no such headings, replied that the finding was factually wrong, and resolved the
  thread with
  `resolveReviewThread(input: {threadId: "PRRT_kwDOSXCeHc6ZTIGx"})` → `{"thread":{"isResolved":true}}`.
  The bot was right and I was wrong: my checkout predated #685, which replaced the template with the
  one this description now fills. The reply chain on that thread records the correction, and the
  description was rewritten against the merged template. The commands work; the judgement they
  depend on is only as good as the tree you check against, which is why the new text makes
  "verified at the pull request's head" the bar for resolving rather than "sounds wrong to me".
- **The ownership half moved as claimed.** With the thread resolved, the triage sweep reports #698
  with `unresolved: 0` and `reasons: []` — no "open conversation(s)", so the pull request is no
  longer filed as its author's outstanding work and passes to its reviewers.
- **What this could not show:** `mergeStateStatus` stayed `BLOCKED` throughout, because CI is
  `PENDING` on a fresh pull request. The conversation gate itself is therefore evidenced by the
  branch-protection setting above and by the resolution round trip, not by watching the merge box
  turn green. No thread on anyone else's pull request was touched, and no test artifacts were left
  behind.

## Risk & Rollout

Low risk: documentation only, no runtime code path touched, nothing to roll out and nothing to
revert beyond the commit. The behavioural change is in what agents do after a review lands — they
now finish the conversation instead of leaving the branch blocked — and the guardrail against the
obvious failure mode (an agent closing a human's thread to clear the gate) is the stated bar plus
`unresolveReviewThread` as the documented undo.
