### PR TITLE
test(fleet-audit): resolve every section a cron prompt cites, not just the checks span

### DIFF
--- a/agents/platform/cron/README.md
+++ b/agents/platform/cron/README.md
@@ -96,7 +96,11 @@ they rot the moment an SOP is edited.
 `test_cron_prompts_cite_the_real_sop_geography` in
 `../skills/fleet-audit/scripts/test_audit_report.py` re-derives both from the
 SOP itself, so an edit that skips re-measuring fails there rather than at 06:20
-in production. Run it after touching anything in `../governance/`.
+in production. It resolves every other section a prompt cites as well — the AI
+stream names the one that defines which workloads count as AI workloads, and
+cites it bare, with no line range to re-measure — so a section inserted ahead of
+that one renumbers it into a test failure rather than into a worker sent to the
+wrong section. Run it after touching anything in `../governance/`.
 
 No prompt is quoted here on purpose. A copy in prose is one more place for the
 same numbers to go stale, and the test above checks the roster against the SOPs

--- a/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
+++ b/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
@@ -2100,6 +2100,29 @@ class TestAuditCatalogue(unittest.TestCase):
                     f"has {len(spec.checks)} checks",
                 )
 
+                # Any other section the prompt cites has to resolve as well.
+                # The span check above covers the checks section only, and it
+                # is not the sole citation: the AI stream also points at the
+                # section defining which workloads count as AI workloads, so a
+                # section inserted ahead of that one renumbers it with nothing
+                # to notice. Sections are cited bare there, without a line
+                # range, which is why the `span` pattern does not reach it.
+                for cited in sorted(
+                    {int(n) for n in re.findall(r"[Ss]ection (\d+)\b", prompt)}
+                ):
+                    self.assertEqual(
+                        1,
+                        len(
+                            [
+                                n
+                                for n in starts
+                                if lines[n - 1].startswith(f"### {cited}. ")
+                            ]
+                        ),
+                        f"the {audit_id} prompt cites section {cited} of "
+                        f"{name}, which has no one heading numbered that",
+                    )
+
     def test_every_sop_states_the_rules_that_hold_on_every_stream(self):
         """A fix written into one SOP has to reach all the others.
 


### PR DESCRIPTION
## Summary

The Platform Agent's governance cron prompts cite their SOP by geography — how long the file is, and where in it the checks live — because a worker that stops reading early lands in the preamble and reports a clean fleet it never looked at. `test_cron_prompts_cite_the_real_sop_geography` already re-derives those numbers from the SOP on every run, which is why they are all correct today. It reaches them through a single pattern, `are section <n>, lines <a>-<b>`, so a citation written without a line range is invisible to it. There is one: the AI stream's prompt also says "Section 2 defines which workloads count as AI workloads." This makes the test resolve every section a prompt cites, not only the checks span.

## Why This Change

That citation is correct today and nothing holds it there. `ai_security_audit_sop.md` currently opens its AI-workload discriminator at `### 2. Collect workload state and identify the AI workloads`; insert a section ahead of it and the heading renumbers while the prompt does not. The existing guard passes, because the checks span it does police is re-measured independently and stays right.

The failure that leaks through is not cosmetic. That section is what decides which workloads the audit examines at all — a worker sent to the wrong one either audits the wrong set or finds no AI workloads and closes a clean ledger. This is the same class of silent-all-clear the line-number citations exist to prevent, arriving through the one door the test does not cover.

## What Changed

- `test_audit_report.py` — `test_cron_prompts_cite_the_real_sop_geography` now resolves every `Section <n>` a prompt cites against that SOP's real headings, reusing the fence-aware heading scan already in the test. Fenced-block headings stay excluded, so a `### ` inside a bash example is still not a section.
- `agents/platform/cron/README.md` — its "Hard-coded line numbers in prompts" section owns this contract and described the test as re-deriving the line numbers alone. Updated so the next person editing an SOP knows bare section references are checked too.

No prompt text and no SOP changed. `jobs.json` is untouched.

## Context

No related issue. No open PR is adding a section-citation guard; the seven open PRs touching these files (#504, #589, #591–595, #426) all conflict with `main` on their own already, except #426, which test-merges clean against this branch.

Worth recording for anyone who arrives here with the same idea I did: the obvious-looking change is to delete the line numbers from the prompts and point at heading names instead. That is wrong, and `agents/platform/cron/README.md` already says why — the numbers are load-bearing at runtime. I wrote that change first and it broke the existing test in all seven subtests. The gap was never the hardcoding; it was the one citation the guard could not see.

Generated with the help of Claude.

## Testing

- `python3 -m unittest discover -s agents/platform/skills/fleet-audit/scripts -p 'test_audit_report.py'` — 507 tests, OK.
- Negative test, prompt side: pointed the AI prompt at `Section 9`; fails with `the ai-security-audit prompt cites section 9 of ai_security_audit_sop.md, which has no one heading numbered that`. Reverted.
- Negative test, SOP side: inserted a section into `ai_security_audit_sop.md` ahead of the cited one so it renumbered; fails. Reverted. This is the case that motivated the change and the one the old guard passed.
- `make docs-check` — all four checks pass. `make docs-generate` leaves the tree clean.
- `prettier --check` with the CI-pinned 3.9.6 on the changed Markdown — clean.
- `review-docs-drift` run against the branch diff. It produced one finding, on this PR: the README section above under-described the test's scope. Fixed in this PR rather than reported and left.

### Live validation

Not live-tested. The change is a unit test plus the README paragraph documenting it; neither ships a runtime code path. `test_audit_report.py` sits in the skill directory that is staged into the image, but nothing in the pod executes it — the guard fires in CI, before a prompt can reach a worker. There is no layer on a running installation where this change would be observable, so exercising it against one would demonstrate nothing. No test artifacts were created; both negative tests were reverted immediately and the working tree is clean.

## Risk & Rollout

Low. No runtime code path, no prompt, and no SOP is touched — the only behavioural change is that CI now fails on a class of edit it previously accepted. The realistic failure mode is a false positive: a prompt that legitimately says "section" followed by a number meaning something other than an SOP heading. None exists today, and the assertion names the audit, the number and the file, so the diagnosis is in the failure message. Revert the commit to drop the check.
