### PR TITLE
docs(agents): require an adversarial self-review before opening a PR

### DIFF
--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -16,7 +16,23 @@ diff visibly breaks and leaves the rest of the documentation question to that sk
 
 # Procedure
 
-## 1. Fix the diff range
+## 1. Run this in a context that did not write the change
+
+If you are the agent that just produced the diff, **do not run the pass in the conversation that
+produced it**. Spawn a subagent, or start a new session, and hand it the diff range and the
+repository — not your reasoning, not your plan, not the summary you were about to write. A model
+reviewing work it has just justified is the weakest configuration there is: it is poorly calibrated
+about its own output, rates it higher than an outsider would, and the bias is worst on exactly the
+lines it got wrong. It is also more likely to "fix" something correct than to catch something
+broken, which is why step 5 exists and why step 6 will not let you edit on a hunch.
+
+That is why `.claude/commands/pr-review-batch.md` gives each pull request its own subagent. A
+self-review gets the same treatment for the same reason.
+
+You will be tempted to skip this on a small diff. The cost of a fresh context is one subagent; the
+cost of skipping it is that the pass reports what you already believed.
+
+## 2. Fix the diff range
 
 Everything below is measured against one range, so name it before you start:
 
@@ -30,7 +46,7 @@ The three-dot form keeps unrelated base-branch drift out of scope.
 Read the changed files at their **post-merge state**, not just the hunks. A hunk shows you what
 moved; the enclosing function tells you whether it still works.
 
-## 2. Establish intent
+## 3. Establish intent
 
 Write down, in one sentence, **what this change claims to do**. Take it from the issue it closes,
 the pull request body, or — for a branch with neither — the change itself. Keep that sentence: it
@@ -42,7 +58,7 @@ finding. And do not treat the stated intent as a description of the diff: where 
 the diff is what merges. A description promising a behaviour the diff does not implement, or
 silent about one it does, is itself a finding.
 
-## 3. Find candidates (ten angles)
+## 4. Find candidates (ten angles)
 
 Work all ten angles yourself, in sequence. Do not skip an angle because an earlier one found
 nothing there, and do not let one angle's conclusion suppress another's — if two angles flag the
@@ -50,7 +66,7 @@ same line for different reasons, record both.
 
 Each angle surfaces up to six candidates, each with a `file`, a `line`, a one-line `summary`, and a
 concrete `failure_scenario`. Pass every candidate with a nameable failure scenario through to step
-4 — silently dropping half-believed candidates is the dominant cause of misses. A candidate you
+5 — silently dropping half-believed candidates is the dominant cause of misses. A candidate you
 cannot express as a failure scenario is not yet a candidate.
 
 **Angle A — line-by-line diff scan.** Read every hunk, line by line. Then read the enclosing
@@ -65,12 +81,30 @@ invariant it enforced, then find where the new code re-establishes it. If you ca
 that's a candidate: a removed guard, a dropped error path, a narrowed validation, a deleted test
 that was covering a real case, a loosened RBAC or NetworkPolicy rule.
 
+**A weakened check is a removed invariant**, and it is the one an agent reaches for when a gate
+will not go green, so audit CI separately and by name: a test removed, renamed, or marked skip or
+xfail; a coverage threshold lowered; `|| true`, `continue-on-error`, or a silenced exit status
+appended to a step; a workflow that no longer triggers on pull requests or on forks; a step newly
+gated behind a condition it did not have. Any of these is a candidate on its own — the failure
+scenario is the class of defect that gate was catching, now shipping unobserved. **A diff whose
+only changes are to test files, on a branch whose CI was failing, is a candidate until you can
+show the test was wrong.** That is the shape of a change that makes the build green without making
+the code right.
+
 **Angle C — cross-file tracer.** For each function, template, chart value, or CRD field the diff
 changes, grep for its consumers and check whether the change breaks any of them: a new
 precondition, a changed return shape, a renamed key a manifest still reads, a timing dependency.
 Trace runtime wiring through to the source — which container an env var lands in, which process
 reads a port, which service account a binding actually grants — rather than inferring it from
 names.
+
+Then trace the other direction, because a change written by an agent can call things that do not
+exist: for every symbol, method, flag, chart value, CRD field, environment variable, or file path
+the diff **introduces a reference to**, open its definition. A plausible name is not evidence. The
+repo already applies this to prose — identifiers verified against source, not against other
+docs — and code gets it for the same reason. Watch for the neighbours: an import added for a symbol
+nothing uses, a dependency added without a pin or a provenance, a value hard-coded where the
+surrounding code reads configuration, and files changed that the stated intent never mentioned.
 
 **Angle D — operations and security.** This repo provisions clusters and holds credentials, so
 weigh blast radius: IAM and RBAC scope, credential handling and redaction, NetworkPolicy reach,
@@ -101,7 +135,7 @@ hand-edited, identifiers verified against source rather than against other docs.
 is the exhaustive form of that check and the author is required to have run it before opening —
 which is a reason to read what they reported, not a reason to skip this angle.
 
-**Angle I — scope and test coverage.** Hold the diff against the intent sentence from step 2. Flag
+**Angle I — scope and test coverage.** Hold the diff against the intent sentence from step 3. Flag
 changes that do not serve it: an unrelated refactor riding along, a dependency bump nobody asked
 for, a behaviour change buried in a change described as a rename, reformatting that inflates the
 diff and hides the real hunks. Repo convention is scoped changes and no unrelated formatting, so
@@ -113,6 +147,12 @@ Then check that the intent is actually tested: for each behaviour the change cla
 that would fail if that behaviour regressed. Where there is none, the candidate is the untested
 behaviour, not the absent test — say which regression would ship silently. Bug fixes without a
 regression test, and new error paths nothing exercises, are the usual cases.
+
+For a change that fixes something, naming the test is not enough — **run it against the pre-change
+behaviour and watch it fail.** A test that passes with the fix reverted is testing something else,
+and a fix with no test that can be made to fail usually means the defect was not understood. Say
+which it was. A red-then-green test is the one answer in this whole pass that does not come from
+your own reading, which is what makes it worth more than any amount of staring at the diff.
 
 **Angle J — sibling pull requests.** Every angle so far has looked only at this change. Widen
 once, to the open pull requests touching adjacent paths:
@@ -135,7 +175,7 @@ something has to be cut.
 Prefer running things over reasoning about them: execute the test suites the change touches and
 reproduce the failures you claim.
 
-## 4. Verify every claim (this step is not optional)
+## 5. Verify every claim (this step is not optional)
 
 Dedup first: candidates pointing at the same line and the same mechanism collapse into the one with
 the most concrete failure scenario.
@@ -179,9 +219,9 @@ Then clean up after the edit, because these are what give away a second pass:
 **The finished review must read as a single confident first pass.** No "Correction", no
 "Verification pass", no "on second look", no "an earlier draft said", no "downgraded from", no
 diff-of-claims, no changelog of your own reasoning. The reader should have no way to tell that step
-4 happened.
+5 happened.
 
-## 5. Act on what survived, and record the disposition
+## 6. Act on what survived, and record the disposition
 
 Every surviving finding gets a disposition, and there are only two:
 
@@ -190,6 +230,15 @@ Every surviving finding gets a disposition, and there are only two:
   path is unreachable for a stated invariant, the cost lands on a code path being deleted next
   week, the fix belongs to a separate issue that is now filed. "Out of scope", "pre-existing", and
   "will fix later" are not reasons on their own.
+
+**Edit on CONFIRMED, report on PLAUSIBLE.** A CONFIRMED finding on your own change is a defect you
+now know about, so fix it. A PLAUSIBLE one is a mechanism you could not pin down, and rewriting
+working code to chase it is how a self-review makes a change worse than it started: the temptation
+to "fix" something that was already right is the characteristic failure of reviewing your own work,
+and it is strongest on the lines you were least sure about. Write it into the section as an open
+question, say what would settle it, and leave the code alone unless the answer arrives. Recording a
+PLAUSIBLE finding you did not act on is a complete disposition — it hands the reviewer the doubt
+instead of a silent edit.
 
 When the review is your own, before opening a pull request, that disposition list **is** the PR
 body's **Self-Review** section. See `AGENTS.md`, "Pull Request Hygiene".
@@ -201,8 +250,8 @@ Severity-ordered findings, each with:
 - an anchor (`file:line`),
 - what is wrong, in one sentence,
 - the concrete failure scenario,
-- the verdict from step 4,
-- the disposition from step 5.
+- the verdict from step 5,
+- the disposition from step 6.
 
 Then two short sections:
 
@@ -212,4 +261,4 @@ Then two short sections:
   infrastructure you did not have. An honest gap is worth more than an implied one.
 
 "No findings" is an ordinary outcome on a good change. Report it as one, alongside what you looked
-for — never pad the list with something step 4 should have deleted.
+for — never pad the list with something step 5 should have deleted.

--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: review-adversarial
+description: Reviews a change adversarially — establishes what it claims to do, hunts candidates from ten angles, then re-derives every candidate from source as a hostile second reader and reports only what survives.
+---
+
+# Task
+
+Given a diff range, find the defects in it and report only the ones you can defend. This skill is
+the review method itself and holds no plumbing: it is run by an author against their own branch
+before opening a pull request (the `AGENTS.md` requirement), and by a reviewer against a pull
+request already open (`.claude/commands/pr-review-batch.md`, which wraps it in the GitHub-side
+work).
+
+`review-docs-drift` is the companion pass, not part of this one. Angle H stops at the rules the
+diff visibly breaks and leaves the rest of the documentation question to that skill.
+
+# Procedure
+
+## 1. Fix the diff range
+
+Everything below is measured against one range, so name it before you start:
+
+```bash
+git diff --stat "$BASE"...HEAD     # three-dot: against the merge base, not the base tip
+```
+
+`$BASE` is `main` for a branch you are about to propose, or the branch the pull request targets.
+The three-dot form keeps unrelated base-branch drift out of scope.
+
+Read the changed files at their **post-merge state**, not just the hunks. A hunk shows you what
+moved; the enclosing function tells you whether it still works.
+
+## 2. Establish intent
+
+Write down, in one sentence, **what this change claims to do**. Take it from the issue it closes,
+the pull request body, or — for a branch with neither — the change itself. Keep that sentence: it
+is the yardstick for Angle I, and it is what tells you whether a given hunk belongs here at all.
+
+Two failure modes. Do not let the stated intent talk you out of a defect — "known limitation,
+follow-up" does not make a dropped guard correct, though it does change how you phrase the
+finding. And do not treat the stated intent as a description of the diff: where the two disagree,
+the diff is what merges. A description promising a behaviour the diff does not implement, or
+silent about one it does, is itself a finding.
+
+## 3. Find candidates (ten angles)
+
+Work all ten angles yourself, in sequence. Do not skip an angle because an earlier one found
+nothing there, and do not let one angle's conclusion suppress another's — if two angles flag the
+same line for different reasons, record both.
+
+Each angle surfaces up to six candidates, each with a `file`, a `line`, a one-line `summary`, and a
+concrete `failure_scenario`. Pass every candidate with a nameable failure scenario through to step
+4 — silently dropping half-believed candidates is the dominant cause of misses. A candidate you
+cannot express as a failure scenario is not yet a candidate.
+
+**Angle A — line-by-line diff scan.** Read every hunk, line by line. Then read the enclosing
+function for each hunk — bugs in unchanged lines of a touched function are in scope, since the
+change re-exposes or fails to fix them. For every line ask: what input, state, timing, or platform
+makes this line wrong? Inverted or wrong conditions, off-by-one, nil/undefined deref, missing
+`await`, unchecked `err`, falsy-zero checks, wrong-variable copy-paste, an error swallowed in a
+catch, unescaped regex metacharacters.
+
+**Angle B — removed-behavior auditor.** For every line the diff deletes or replaces, name the
+invariant it enforced, then find where the new code re-establishes it. If you cannot find it,
+that's a candidate: a removed guard, a dropped error path, a narrowed validation, a deleted test
+that was covering a real case, a loosened RBAC or NetworkPolicy rule.
+
+**Angle C — cross-file tracer.** For each function, template, chart value, or CRD field the diff
+changes, grep for its consumers and check whether the change breaks any of them: a new
+precondition, a changed return shape, a renamed key a manifest still reads, a timing dependency.
+Trace runtime wiring through to the source — which container an env var lands in, which process
+reads a port, which service account a binding actually grants — rather than inferring it from
+names.
+
+**Angle D — operations and security.** This repo provisions clusters and holds credentials, so
+weigh blast radius: IAM and RBAC scope, credential handling and redaction, NetworkPolicy reach,
+what an agent is newly permitted to do, and whether a failure mode degrades or destroys. Check
+that third-party GitHub Actions are pinned to a full commit SHA with the version in a trailing
+comment.
+
+**Angle E — reuse.** The angles above hunt for bugs; this one and the next two hunt for cleanup in
+the changed code. Flag new code that re-implements something the codebase already has — grep
+shared and adjacent modules, and name the existing helper to call instead.
+
+**Angle F — simplification and efficiency.** Flag unnecessary complexity the diff adds: redundant
+or derivable state, copy-paste with slight variation, deep nesting, dead code left behind. And
+wasted work: repeated I/O, independent operations run sequentially, blocking work added to startup
+or a hot path. Name the simpler or cheaper form that does the same job.
+
+**Angle G — altitude.** Check that each change sits at the right depth rather than being a fragile
+bandaid. Special cases layered onto shared infrastructure are a sign the fix isn't deep enough —
+prefer generalizing the underlying mechanism.
+
+**Angle H — conventions and docs.** Read the `AGENTS.md` / `CLAUDE.md` files that govern the
+changed code: the repo root, plus any in a directory that is an ancestor of a changed file (a
+directory's file only applies at or below it). Flag a violation only when you can quote the exact
+rule and the exact line that breaks it — no style preferences, no "spirit of the doc" inferences.
+Name the file and quote the rule so the report can cite it. This is also where docs drift belongs:
+one canonical home per fact, generated `<!-- BEGIN GENERATED -->` regions regenerated rather than
+hand-edited, identifiers verified against source rather than against other docs. `review-docs-drift`
+is the exhaustive form of that check and the author is required to have run it before opening —
+which is a reason to read what they reported, not a reason to skip this angle.
+
+**Angle I — scope and test coverage.** Hold the diff against the intent sentence from step 2. Flag
+changes that do not serve it: an unrelated refactor riding along, a dependency bump nobody asked
+for, a behaviour change buried in a change described as a rename, reformatting that inflates the
+diff and hides the real hunks. Repo convention is scoped changes and no unrelated formatting, so
+cite the rule when it applies. Judge by whether a change serves the stated intent, not by how large
+it is — a big diff that does one thing is in scope, and a three-line change that does a second
+thing is not.
+
+Then check that the intent is actually tested: for each behaviour the change claims, name the test
+that would fail if that behaviour regressed. Where there is none, the candidate is the untested
+behaviour, not the absent test — say which regression would ship silently. Bug fixes without a
+regression test, and new error paths nothing exercises, are the usual cases.
+
+**Angle J — sibling pull requests.** Every angle so far has looked only at this change. Widen
+once, to the open pull requests touching adjacent paths:
+
+```bash
+gh pr list --repo gke-labs/kube-agents --state open --limit 100 --json number,title,author,files
+```
+
+Three things come out of this that nothing else can see. A finding already accepted on a sibling
+usually applies here unchanged — apply it rather than rediscovering it. A near-identical change
+that has diverged is itself a finding: name which copy carries the fix and which does not, because
+merge order then decides whether the fix survives. And where one change is a superset of another,
+say so — reviewing the subset in isolation spends effort on a diff that may never merge.
+
+For the cleanup, altitude, conventions, scope, and sibling candidates the `failure_scenario` states
+the concrete cost — what is duplicated, wasted, harder to maintain, out of scope, or which rule or
+untested behaviour is at risk — instead of a crash. Correctness bugs always outrank them when
+something has to be cut.
+
+Prefer running things over reasoning about them: execute the test suites the change touches and
+reproduce the failures you claim.
+
+## 4. Verify every claim (this step is not optional)
+
+Dedup first: candidates pointing at the same line and the same mechanism collapse into the one with
+the most concrete failure scenario.
+
+Then take each surviving candidate and re-derive it from the source as if you were a hostile second
+reviewer trying to get it thrown out. Open the actual file and read the actual code path — do not
+re-read your own notes, and do not accept a claim because it sounded right when you wrote it.
+Confirm the mechanism, not just the conclusion: a real defect reached by an imaginary code path is
+still a wrong finding. Assign each one a verdict:
+
+- **CONFIRMED** — you can name the inputs or state that trigger it and the resulting wrong output,
+  crash, or misconfiguration. Quote the line.
+- **PLAUSIBLE** — the mechanism is real but the trigger is uncertain (timing, environment, cluster
+  state). State what would confirm it. Realistic-but-unproven is PLAUSIBLE, not REFUTED:
+  concurrency races, nil on a rare-but-reachable path (error handler, cold cache, absent optional
+  field), falsy-zero treated as missing, off-by-one on a boundary the code does not exclude, a
+  regex or allowlist that lost an anchor.
+- **REFUTED** — factually wrong (the code doesn't say that), provably impossible (show the type,
+  constant, or invariant), already handled in this diff (cite the guard), or pure style with no
+  observable effect. Quote the line that proves it.
+
+Keep CONFIRMED and PLAUSIBLE. Then rewrite the finding list so it reflects only what survived:
+
+- **Claim holds** → keep it as written.
+- **Claim holds but the mechanism, severity, line number, or blast radius is wrong** → rewrite the
+  finding to the corrected version. The finding now reads as though the corrected version is what
+  you found in the first place.
+- **REFUTED, or you cannot verify it** → delete it entirely. Do not demote it to a footnote, a
+  "worth checking" aside, or a parenthetical. If the underlying uncertainty is genuinely worth
+  someone's time, restate it as an open question in its own right, with the uncertainty stated
+  plainly — never as a correction to something you previously asserted.
+
+Then clean up after the edit, because these are what give away a second pass:
+
+1. Re-sort findings by severity (`BLOCKER` / `HIGH` / `MEDIUM` / `LOW`) and **renumber from 1 with
+   no gaps**.
+2. Update every cross-reference between findings to the new numbers.
+3. Update any count in the prose ("three blockers") to match the surviving set.
+4. Re-read the whole document once for tense and voice consistency.
+
+**The finished review must read as a single confident first pass.** No "Correction", no
+"Verification pass", no "on second look", no "an earlier draft said", no "downgraded from", no
+diff-of-claims, no changelog of your own reasoning. The reader should have no way to tell that step
+4 happened.
+
+## 5. Act on what survived, and record the disposition
+
+Every surviving finding gets a disposition, and there are only two:
+
+- **Fixed** — name the commit or the hunk that fixes it.
+- **Deliberately not fixed** — give the reason. A reason is an argument about this change: the
+  path is unreachable for a stated invariant, the cost lands on a code path being deleted next
+  week, the fix belongs to a separate issue that is now filed. "Out of scope", "pre-existing", and
+  "will fix later" are not reasons on their own.
+
+When the review is your own, before opening a pull request, that disposition list **is** the PR
+body's **Self-Review** section. See `AGENTS.md`, "Pull Request Hygiene".
+
+# Output
+
+Severity-ordered findings, each with:
+
+- an anchor (`file:line`),
+- what is wrong, in one sentence,
+- the concrete failure scenario,
+- the verdict from step 4,
+- the disposition from step 5.
+
+Then two short sections:
+
+- **Not findings, for the record** — things that look wrong but are fine, so the next reader does
+  not re-litigate them.
+- **What this pass did not cover** — angles you could not run, suites you could not execute,
+  infrastructure you did not have. An honest gap is worth more than an implied one.
+
+"No findings" is an ordinary outcome on a good change. Report it as one, alongside what you looked
+for — never pad the list with something step 4 should have deleted.

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -175,15 +175,24 @@ restating the claim).
 ### Phase 2b — Establish intent
 
 Read the PR description (`body`) and any issue it links (`gh issue view <M> --repo "$REPO"`), and
-carry both into step 2 of the skill below. On a pull request the description is also a thing that
+carry both into step 3 of the skill below. On a pull request the description is also a thing that
 can be wrong: a body promising a behaviour the diff does not implement, or silent about one it
 does, is itself a finding.
 
 ### Phase 3 — Find the candidates and verify them
 
-Run `.agents/skills/review-adversarial/SKILL.md`. It is the repository's review method and the
-canonical home for the ten angles and the verification discipline; read it now and work it in
-order — intent, angles A–J, then the verification step, which is not optional.
+Run `$MAIN_ROOT/.agents/skills/review-adversarial/SKILL.md`. It is the repository's review method
+and the canonical home for the ten angles and the verification discipline; read it now and work it
+in order — intent, angles A–J, then the verification step, which is not optional.
+
+Its step 1 is already satisfied: you are a subagent that did not write this change, which is the
+separation it asks for. Do not spawn another one. Start at its step 2.
+
+`$MAIN_ROOT` is not decoration. You are standing in the worktree, which holds the pull request's
+own content: a bare path would load the review method **from the change under review**, so a fork
+branch could edit the angles that judge it, and a branch cut before the skill existed would find no
+file at all and silently review nothing. Read it from the primary checkout, the way Phase 2 and
+Phase 4 already read the saved-review directory.
 
 Two substitutions for this context:
 
@@ -200,7 +209,7 @@ One thing the skill has no way to know about:
   `REVIEW_REQUIRED`, missing labels, or the merge conflict you already found. The `tide` check
   usually states its reason outright. Report which it is; they mean very different things.
 
-The skill's step 5 does not apply: dispositions belong to the author, and you fix nothing here. Its
+The skill's step 6 does not apply: dispositions belong to the author, and you fix nothing here. Its
 "single confident first pass" constraint does, and it covers the saved file, the PR comment, and
 your report back — everywhere.
 

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -174,156 +174,37 @@ restating the claim).
 
 ### Phase 2b — Establish intent
 
-Read the PR description (`body`) and any issue it links (`gh issue view <M> --repo "$REPO"`), then
-write down, in one sentence, **what this PR claims to do**. Keep that sentence; it is the yardstick
-for Angle I and it is what tells you whether a given change belongs here at all.
+Read the PR description (`body`) and any issue it links (`gh issue view <M> --repo "$REPO"`), and
+carry both into step 2 of the skill below. On a pull request the description is also a thing that
+can be wrong: a body promising a behaviour the diff does not implement, or silent about one it
+does, is itself a finding.
 
-Two failure modes to avoid. Do not let the description talk you out of a defect — "known
-limitation, follow-up PR" in the body does not make a dropped guard correct, though it does change
-how you phrase the finding. And do not treat the description as a description of the diff: where
-the two disagree, the diff is what merges. A body that promises a behaviour the diff does not
-implement, or omits a behaviour the diff does, is itself a finding.
+### Phase 3 — Find the candidates and verify them
 
-### Phase 3 — Find candidates (ten angles)
+Run `.agents/skills/review-adversarial/SKILL.md`. It is the repository's review method and the
+canonical home for the ten angles and the verification discipline; read it now and work it in
+order — intent, angles A–J, then the verification step, which is not optional.
 
-Work through all ten angles below yourself, in sequence, in this context. Do not skip an angle
-because an earlier one found nothing there, and do not let one angle's conclusion suppress
-another's — if two angles flag the same line for different reasons, record both.
+Two substitutions for this context:
 
-Each angle surfaces up to six candidates, each with a `file`, a `line`, a one-line `summary`, and a
-concrete `failure_scenario`. Pass every candidate with a nameable failure scenario through to
-Phase 4 — finders that silently drop half-believed candidates are the dominant cause of misses.
-A candidate you cannot express as a failure scenario is not yet a candidate.
+- **The diff range is the one Phase 1b settled on** — `$BASE_REF...HEAD` after a clean merge, or
+  `$BASE_REF...pr<N>` when the merge conflicted and was aborted. Never `main` on its own.
+- **Angle J already has an author to filter by**, which the skill cannot assume:
+  `gh pr list --repo "$REPO" --author <login> --state open --json number,title,files`. Read the
+  review comments on any sibling touching adjacent paths.
 
-**Angle A — line-by-line diff scan.** Read every hunk, line by line. Then read the enclosing
-function for each hunk — bugs in unchanged lines of a touched function are in scope, since the PR
-re-exposes or fails to fix them. For every line ask: what input, state, timing, or platform makes
-this line wrong? Inverted or wrong conditions, off-by-one, nil/undefined deref, missing `await`,
-unchecked `err`, falsy-zero checks, wrong-variable copy-paste, an error swallowed in a catch,
-unescaped regex metacharacters.
+One thing the skill has no way to know about:
 
-**Angle B — removed-behavior auditor.** For every line the diff deletes or replaces, name the
-invariant it enforced, then find where the new code re-establishes it. If you cannot find it,
-that's a candidate: a removed guard, a dropped error path, a narrowed validation, a deleted test
-that was covering a real case, a loosened RBAC or NetworkPolicy rule.
+- **Merge mechanics are part of this review.** Run `gh pr checks <N> --repo "$REPO"`. If
+  `mergeStateStatus` is `BLOCKED` or `DIRTY`, determine _why_ — failing required checks, merely
+  `REVIEW_REQUIRED`, missing labels, or the merge conflict you already found. The `tide` check
+  usually states its reason outright. Report which it is; they mean very different things.
 
-**Angle C — cross-file tracer.** For each function, template, chart value, or CRD field the diff
-changes, grep for its consumers and check whether the change breaks any of them: a new
-precondition, a changed return shape, a renamed key a manifest still reads, a timing dependency.
-Trace runtime wiring through to the source — which container an env var lands in, which process
-reads a port, which service account a binding actually grants — rather than inferring it from names.
+The skill's step 5 does not apply: dispositions belong to the author, and you fix nothing here. Its
+"single confident first pass" constraint does, and it covers the saved file, the PR comment, and
+your report back — everywhere.
 
-**Angle D — operations and security.** This repo provisions clusters and holds credentials, so
-weigh blast radius: IAM and RBAC scope, credential handling and redaction, NetworkPolicy reach,
-what an agent is newly permitted to do, and whether a failure mode degrades or destroys. Check that
-third-party GitHub Actions are pinned to a full commit SHA with the version in a trailing comment.
-
-**Angle E — reuse.** The angles above hunt for bugs; this one and the next two hunt for cleanup in
-the changed code. Flag new code that re-implements something the codebase already has — grep shared
-and adjacent modules, and name the existing helper to call instead.
-
-**Angle F — simplification and efficiency.** Flag unnecessary complexity the diff adds: redundant
-or derivable state, copy-paste with slight variation, deep nesting, dead code left behind. And
-wasted work: repeated I/O, independent operations run sequentially, blocking work added to startup
-or a hot path. Name the simpler or cheaper form that does the same job.
-
-**Angle G — altitude.** Check that each change sits at the right depth rather than being a fragile
-bandaid. Special cases layered onto shared infrastructure are a sign the fix isn't deep enough —
-prefer generalizing the underlying mechanism.
-
-**Angle H — conventions and docs.** Read the `AGENTS.md` / `CLAUDE.md` files that govern the changed
-code: the repo root, plus any in a directory that is an ancestor of a changed file (a directory's
-file only applies at or below it). Flag a violation only when you can quote the exact rule and the
-exact line that breaks it — no style preferences, no "spirit of the doc" inferences. Name the file
-and quote the rule so the report can cite it. This is also where docs drift belongs: one canonical
-home per fact, generated `<!-- BEGIN GENERATED -->` regions regenerated rather than hand-edited,
-identifiers verified against source rather than against other docs.
-
-**Angle I — scope and test coverage.** Hold the diff against the intent sentence from Phase 2b.
-Flag changes that do not serve it: an unrelated refactor riding along, a dependency bump nobody
-asked for, a behaviour change buried in a PR described as a rename, reformatting that inflates the
-diff and hides the real hunks. Repo convention is scoped changes and no unrelated formatting, so
-cite the rule when it applies. Judge by whether a change serves the stated intent, not by how large
-it is — a big diff that does one thing is in scope, and a three-line change that does a second
-thing is not.
-
-Then check that the intent is actually tested: for each behaviour the PR claims, name the test that
-would fail if that behaviour regressed. Where there is none, the candidate is the untested
-behaviour, not the absent test — say which regression would ship silently. Bug fixes without a
-regression test, and new error paths nothing exercises, are the usual cases.
-
-**Angle J — sibling pull requests.** Every angle so far has looked only at this PR. Widen once:
-
-```bash
-gh pr list --repo "$REPO" --author <login> --state open --json number,title,files
-```
-
-Read the review comments on any sibling that touches adjacent paths. Three things come out of this
-that nothing else in the review can see. A finding already accepted on a sibling usually applies
-here unchanged — apply it rather than rediscovering it. A near-identical PR that has diverged is
-itself a finding: name which copy carries the fix and which does not, because merge order then
-decides whether the fix survives. And where one PR is a superset of others, say so — reviewing the
-subset in isolation spends effort on a diff that may never merge.
-
-For cleanup, altitude, conventions, scope, and sibling candidates the `failure_scenario` states the concrete
-cost — what is duplicated, wasted, harder to maintain, out of scope, or which rule or untested
-behaviour is at risk — instead of a crash. Correctness bugs always outrank them when the output cap
-forces a cut.
-
-Prefer running things over reasoning about them: execute the test suites the PR touches and
-reproduce the failures you claim. Also check merge mechanics: `gh pr checks <N> --repo "$REPO"`. If
-`mergeStateStatus` is `BLOCKED` or `DIRTY`, determine _why_ — failing required checks, merely
-`REVIEW_REQUIRED`, missing labels, or the merge conflict you already found. The `tide` check usually
-states its reason outright. Report which it is; they mean very different things.
-
-### Phase 4 — Verify every claim (this phase is not optional)
-
-Dedup first: candidates pointing at the same line and the same mechanism collapse into the one with
-the most concrete failure scenario.
-
-Then take each surviving candidate and re-derive it from the source as if you were a hostile second
-reviewer trying to get it thrown out. Open the actual file and read the actual code path — do not
-re-read your own notes, and do not accept a claim because it sounded right when you wrote it.
-Confirm the mechanism, not just the conclusion: a real defect reached by an imaginary code path is
-still a wrong finding. Assign each one a verdict:
-
-- **CONFIRMED** — you can name the inputs or state that trigger it and the resulting wrong output,
-  crash, or misconfiguration. Quote the line.
-- **PLAUSIBLE** — the mechanism is real but the trigger is uncertain (timing, environment, cluster
-  state). State what would confirm it. Realistic-but-unproven is PLAUSIBLE, not REFUTED:
-  concurrency races, nil on a rare-but-reachable path (error handler, cold cache, absent optional
-  field), falsy-zero treated as missing, off-by-one on a boundary the code does not exclude, a
-  regex or allowlist that lost an anchor.
-- **REFUTED** — factually wrong (the code doesn't say that), provably impossible (show the type,
-  constant, or invariant), already handled in this diff (cite the guard), or pure style with no
-  observable effect. Quote the line that proves it.
-
-Keep CONFIRMED and PLAUSIBLE. Then rewrite the finding list so it reflects only what survived:
-
-- **Claim holds** → keep it as written.
-- **Claim holds but the mechanism, severity, line number, or blast radius is wrong** → rewrite the
-  finding to the corrected version. The finding now reads as though the corrected version is what
-  you found in the first place.
-- **REFUTED, or you cannot verify it** → delete it entirely. Do not demote it to a footnote, a
-  "worth checking" aside, or a parenthetical. If the underlying uncertainty is genuinely worth the
-  author's time, restate it as an open question in its own right, with the uncertainty stated
-  plainly in the finding body — never as a correction to something you previously asserted.
-
-Then clean up after the edit, because these are what give away a second pass:
-
-1. Re-sort findings by severity (`BLOCKER` / `HIGH` / `MEDIUM` / `LOW`) and **renumber from 1 with
-   no gaps**.
-2. Update every cross-reference between findings to the new numbers.
-3. Update any count in the prose ("three blockers") to match the surviving set.
-4. Re-read the whole document once for tense and voice consistency.
-
-**The finished review must read as a single confident first pass.** It must contain no
-"Correction", "Verification pass", "on second look", "an earlier draft said", "downgraded from",
-"initially I thought", no diff-of-claims, and no changelog of your own reasoning. The reader should
-have no way to tell that Phase 4 happened. This constraint applies to the saved file, the PR
-comment, and your report back — everywhere.
-
-### Phase 5 — Output
+### Phase 4 — Output
 
 Save the review to `$MAIN_ROOT/.claude/pr-reviews/pr-<N>-<short-slug>.md`, matching the structure of
 the files already in that directory:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,24 @@ Full contract: AGENTS.md, "Pull Request Hygiene".
 
 -
 
+## Self-Review
+
+<!--
+Required: an empty section is not an answer. You are this change's first hostile
+reader, and this is where you say so. Which pass you ran, what you looked for,
+what it found, and what you did with each finding — fixed, or deliberately not,
+with the reason.
+
+"No findings" is a normal outcome and a complete answer only when you also say
+what you looked for. A reason for not fixing something is an answer when it is an
+argument about this change; "out of scope" and "will fix later" on their own are
+not.
+
+Full contract: AGENTS.md, "Pull Request Hygiene".
+-->
+
+-
+
 ## Risk & Rollout
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,9 +155,19 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   [contributing guide](docs/site/src/content/docs/contributing.md) and the comment in
   [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise it — change
   this list first, then reconcile them to it.
+  - **Run the pass in a context that did not write the change** — a subagent, or a new session,
+    handed the diff range and nothing else. Not your plan, not your reasoning, not the summary you
+    were about to write. Reviewing a diff in the conversation that produced it is the one
+    configuration that reliably does not work: the same context that talked you into the code
+    talks you into approving it, and the blind spot sits exactly where you were already wrong. It
+    is why `.claude/commands/pr-review-batch.md` gives every pull request its own subagent, and a
+    self-review earns it for the same reason.
   - **A finding you decide not to fix is an answer**, provided the reason is an argument about
     this change rather than a shrug. "Out of scope", "pre-existing", and "will fix later" are not
     reasons on their own; the separate issue you filed is.
+  - **Fix what the pass confirms; report what it only suspects.** A finding it could not pin down
+    is an open question for the section, not a licence to rewrite working code — chasing an
+    uncertain finding on your own change is how a self-review makes it worse than it started.
   - **"No findings" is an answer only alongside what you looked for.** The skill's angles are the
     vocabulary for that, and a pass that names none of them is indistinguishable from no pass.
   - **Do not claim more than you did.** A self-review the diff contradicts is worse than none: it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
   - `chat/`: The Chat Agent front door — the `default` Hermes profile that receives chat ingress and delegates to specialists.
   - `platform/`: Configuration for the Platform Agent, scaffolded at pod startup into the `platform` profile.
   - `cluster/`: The Cluster Agent profile _template_ (persona, scoped config, and runtime-debugging skills). The Platform Agent scaffolds this into per-cluster Hermes profiles at runtime; it is not deployed directly.
-- `.agents/skills/`: Repository-level skills, not shipped in the agent images — review skills (security audits, docs-drift, skill quality) run against pull requests and clusters, plus the `install-kube-agents`/`uninstall-kube-agents`/`upgrade-kube-agents` lifecycle skills that drive the repository's installer scripts.
+- `.agents/skills/`: Repository-level skills, not shipped in the agent images — review skills (adversarial change review, security audits, docs-drift, skill quality) run against pull requests and clusters, plus the `install-kube-agents`/`uninstall-kube-agents`/`upgrade-kube-agents` lifecycle skills that drive the repository's installer scripts.
 - `charts/`: Canonical Helm charts (`kube-agents`) for deploying the Kube-Agents operator and profiles.
 - `terraform/`: Companion reusable Terraform modules (`gke-cluster`, `kube-agents-iam`, `chat-pubsub`, `github-minter`) for infrastructure provisioning, plus `examples/full-install/`, the single-apply composition that installs the Helm chart on top.
 - `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
@@ -145,6 +145,23 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   SHA and the comment together.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
+- **Adversarial self-review before opening a PR, and record it in the PR body.** Run the
+  `review-adversarial` skill (`.agents/skills/review-adversarial/SKILL.md`) against your branch
+  diff, fix what it confirms, and fill in the template's **Self-Review** section with what you
+  looked for, what it found, and the disposition of each finding. This is a required pre-PR step
+  for AI agents working in this repository: you are the change's first hostile reader, and a
+  reviewer who has to find what you could have found spends their attention on the wrong things.
+  This bullet is the canonical statement of the requirement; the site's
+  [contributing guide](docs/site/src/content/docs/contributing.md) and the comment in
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise it — change
+  this list first, then reconcile them to it.
+  - **A finding you decide not to fix is an answer**, provided the reason is an argument about
+    this change rather than a shrug. "Out of scope", "pre-existing", and "will fix later" are not
+    reasons on their own; the separate issue you filed is.
+  - **"No findings" is an answer only alongside what you looked for.** The skill's angles are the
+    vocabulary for that, and a pass that names none of them is indistinguishable from no pass.
+  - **Do not claim more than you did.** A self-review the diff contradicts is worse than none: it
+    spends the reviewer's trust before they reach the code.
 - **Docs-drift review before opening a PR:** run the `review-docs-drift` skill
   (`.agents/skills/review-docs-drift/SKILL.md`) against your branch diff and address its
   Blocking findings. This is a required pre-PR step for AI agents working in this repository;
@@ -187,6 +204,18 @@ coding agent over the branch diff. It only comments — it never pushes commits 
 Opening a pull request is therefore not the end of the task. The bot introduces itself in a comment
 on every pull request it picks up, and that comment states its current contract; if it disagrees
 with what follows, believe the comment and fix this section.
+
+**What any reviewer reads first — human or agent, this bot included.** Read the pull request's
+**Self-Review** section before the diff. It tells you what the author already looked for, what they
+found, and what they consciously chose not to fix, so the review can start where theirs stopped.
+Three things to do with it:
+
+- **Absent, empty, or a bare "reviewed it"** → say so as the first thing you report. The section is
+  required (see Pull Request Hygiene) and an unanswered one is the finding.
+- **A claim it makes that the diff does not support** → that is a finding in its own right, and a
+  more serious one than most defects: it misdirects every reader after you.
+- **A finding the author rejected with a reason** → engage with the reason. Restating the finding
+  as though the reason were not there wastes both of you.
 
 **When it runs.** On `opened`, `reopened`, and draft-marked-ready. **Pushing more commits does not
 start another review** — an active branch would otherwise pay for a re-read on every push. To get a

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -24,6 +24,7 @@ This project follows [Google's Open Source Community Guidelines](https://opensou
 - **Branch location.** Push PR branches to your fork, not to the upstream repository.
 - **PR template.** Use [`.github/PULL_REQUEST_TEMPLATE.md`](https://github.com/gke-labs/kube-agents/blob/main/.github/PULL_REQUEST_TEMPLATE.md). Don't use `--fill` with `gh pr create` — it bypasses the template.
 - **Live validation.** Every PR describes how the change was exercised against a real, running installation. See [Live validation](#live-validation) below.
+- **Self-review.** Every PR arrives already reviewed by its author, and says what that review found. See [Self-review](#self-review) below.
 
 ## Local validation
 
@@ -86,6 +87,22 @@ What that section should say:
 - **Cleanup.** Remove test artifacts, restore prior state, and note anything left behind.
 
 Some changes can't reach a running installation — docs-only edits, CI workflow changes, code paths that need infrastructure you don't have. Write "Not live-tested" and say why. An empty section is not an answer.
+
+## Self-review
+
+Nobody reads a change as cheaply as the person who wrote it, and right now the first hostile reader of most pull requests here is a reviewer who has never seen the code. So every pull request is reviewed by its author first, and the template's **Self-Review** section says what that pass found.
+
+[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement in full and is canonical; what follows summarises it, so trust it over this page if the two ever differ.
+
+The method is the repository's own review skill, [`.agents/skills/review-adversarial/SKILL.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/skills/review-adversarial/SKILL.md) — run it against your branch diff with whatever agent you use. It works ten angles over the change, then re-derives each candidate from the source as a hostile second reader and throws out what it cannot defend.
+
+What the section should say:
+
+- **What you looked for**, in the skill's terms — which angles you ran, and which you could not.
+- **What it found, and where each finding ended up.** Fixed, naming the commit or hunk; or deliberately not fixed, with a reason. A reason is an argument about this change — the path is unreachable for a stated invariant, the fix belongs to the issue you just filed. "Out of scope" or "will fix later" alone is not.
+- **Nothing you cannot back.** A self-review the diff contradicts is worse than no self-review: it spends the reviewer's trust before they reach the code.
+
+"No findings" is an ordinary outcome on a good change and costs you nothing — provided you also say what you looked for. A pass that names none of its angles is indistinguishable from no pass at all.
 
 ## Code review
 

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -96,6 +96,8 @@ Nobody reads a change as cheaply as the person who wrote it, and right now the f
 
 The method is the repository's own review skill, [`.agents/skills/review-adversarial/SKILL.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/skills/review-adversarial/SKILL.md) — run it against your branch diff with whatever agent you use. It works ten angles over the change, then re-derives each candidate from the source as a hostile second reader and throws out what it cannot defend.
 
+Give the pass a context that did not write the change — a subagent, or a fresh session, handed the diff range and nothing else. An agent asked to review a diff in the same conversation that produced it mostly restates why the code is right, because the reasoning that produced the code is still in front of it.
+
 What the section should say:
 
 - **What you looked for**, in the skill's terms — which angles you ran, and which you could not.


### PR DESCRIPTION
## Summary

This repository already asks a lot of a pull-request author before they open — scoped changes, a
docs-drift pass, live validation, prettier, the image layer budget — but it never asks them to read
their own diff adversarially first. The consequence is that `kube-agents-bot` and the human reviewer
are the change's first hostile readers, and they spend their attention on defects the author could
have found in one pass. This PR closes that gap: it extracts the repository's adversarial review
procedure into a skill an author can run against their own branch, makes running it a required
pre-PR step, and adds a `## Self-Review` section to the template where the pass and the disposition
of each finding get recorded.

The procedure itself is not new. It has lived in `.claude/commands/pr-review-batch.md` since that
command was written, but it was written for a pull request that is already open and addressed to
someone reviewing *other people's* work — nothing pointed an author at it before they pushed. Moving
it into `.agents/skills/review-adversarial/SKILL.md`, written against a diff range rather than a PR
number, lets both callers share one copy.

## Why This Change

A reviewer who starts from a filled-in Self-Review section starts from what the author already
knows, and can spend the review on what the author missed rather than rediscovering what they
found. A self-review whose claims the diff does not support becomes a finding in its own right —
which is more useful than either party silently assuming the other looked.

Without it, the first adversarial read of every change happens after it is proposed, by someone
other than the person who wrote it.

## What Changed

- **`.agents/skills/review-adversarial/SKILL.md`** (new) — the canonical home of the review method:
  fix the diff range, establish intent, ten angles, verify every claim (CONFIRMED / PLAUSIBLE /
  REFUTED, re-derived from source), then a disposition per surviving finding. Harness-neutral and
  written against a diff range, so an author before pushing and a reviewer on an open PR run the
  same pass.
- **`.claude/commands/pr-review-batch.md`** — the largest diff and the only one that can regress
  existing behaviour. Phases 2b–4 now point at the skill instead of restating it, and keep in place
  only what the skill has no way to know: the PR-specific reading of intent, `gh pr list --author`
  for Angle J, and the merge-mechanics check. Everything outside those phases is untouched.
- **`AGENTS.md`** — a required pre-PR bullet in *Pull Request Hygiene*, sitting next to the
  docs-drift bullet so the two passes read as a pair, and a short block in *Automated Review* on
  what any reviewer reads first.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — the `## Self-Review` section.
- **`docs/site/src/content/docs/contributing.md`** — reconciled to `AGENTS.md`, which stays
  canonical.

A second commit (`15c4d37`) hardens the above against what is actually known about agents reviewing
their own work — see **Context → Grounding** and the last three Self-Review entries.

## Context

The enforcement is mostly already built, which is why this PR is as small as it is.
`kube-agents-bot` splits description checking in two. The mechanical half (`app/pr_body.py`) parses
the template's headings out of the **base** commit and reports every section the body leaves absent
or empty, as an inline thread — and this repository requires conversation resolution before merging.
So adding `## Self-Review` to the template buys a merge-holding thread for a skipped self-review
with **no bot change at all**. Only the judgement half — teaching the description pass that
"reviewed it, LGTM" is a non-answer — needs code, and that is the companion PR:
[bradhoekstra/kube-agents-bot#1](https://github.com/bradhoekstra/kube-agents-bot/pull/1). The two
are independent; this one is useful on its own.

### Grounding

The requirement is shaped by the research on self-correction rather than by taste, because the
obvious way to implement it is the way that does not work.

- **Intrinsic self-correction — a model critiquing its own output with no external signal — makes
  results worse as often as better.** Huang et al. ([ICLR 2024](https://arxiv.org/abs/2310.01798))
  measured GPT-4 dropping 95.5% → 91.5% on GSM8K after self-correction, because the model turned
  correct answers wrong more often than it repaired real errors. The
  [TACL 2024 survey](https://direct.mit.edu/tacl/article/doi/10.1162/tacl_a_00713/125177/When-Can-LLMs-Actually-Correct-Their-Own-Mistakes)
  finds self-correction works when — and largely only when — there is reliable external feedback,
  such as a test runner. Hence **step 1** (fresh context, so the pass is not intrinsic), **step 6**
  (fix CONFIRMED, only report PLAUSIBLE, so an uncertain finding never becomes an edit), and
  **Angle I**'s red-then-green requirement (the one external signal in the pass).
- **Self-preference bias tracks self-recognition, and is worst where the model erred.**
  [Panickssery et al., NeurIPS 2024](https://proceedings.neurips.cc/paper_files/paper/2024/file/7f1f0218e45f5414c79c0679633e47bc-Paper-Conference.pdf).
  A pass run in the context that wrote the code is the maximally self-recognising case.
- **CI gaming, reuse blindness, and hallucinated correctness are the named failure modes of
  agent-written code** —
  [GitHub, "Agent pull requests are everywhere"](https://github.blog/ai-and-ml/generative-ai/agent-pull-requests-are-everywhere-heres-how-to-review-them/).
  Angle E already covered duplication. Angles B and C now cover the other two.

One argument against, stated because a reviewer should not have to raise it: the practical
literature recommends *gating* self-review on a failed external check rather than running it
unconditionally, since reflection multiplies token cost with unreliable gains. This requires it on
every PR, including one-liners. I think it holds — the pass runs once rather than in a loop, CI and
live validation are the external check it is gated behind in practice, and "no findings" is
explicitly a complete answer — but it is the strongest case against, and if the ceremony proves not
to pay for itself on small diffs the honest fix is a size threshold, not a weaker pass.

We deliberately did **not** adopt GitHub's "split if the diff touches more than five unrelated
files". Angle I already judges scope by whether a change serves the stated intent, which is the
better test — a big diff that does one thing is fine, and a three-line diff that does two is not.

No `docs/README.md` row: `scripts/check_docs_map.py` exempts root-level dot-directories, and
`.agents/skills/` is not part of the generated skill catalogue.

Related open work, all merge-conflict risk rather than duplication — none of it is doing this:

- **#698** — `AGENTS.md` + `contributing.md`, requiring agents to reply to and resolve review
  threads. Adjacent subject, and it edits the same *Automated Review* section this PR inserts into.
  Highest conflict risk; whichever lands second rebases.
- **#701** — `AGENTS.md` + `contributing.md`, bot-review timing. Same two files.
- **#659** (draft) — adds `.agents/skills/review-iac-parity/SKILL.md` plus an `AGENTS.md` bullet.
  Not a conflict of intent; it is the precedent for the shape of the new skill here.
- **#571**, **#615**, **#688** also touch `AGENTS.md`.

Generated with the help of Claude.

## Testing

- `make docs-check` — clean.
- `make validate` — clean.
- `prettier@3.9.6` (the version `.github/workflows/prettier.yml` pins) `--check` on every changed
  Markdown file — clean.
- Ran the `review-docs-drift` skill against the branch, as `AGENTS.md` requires. Its one blocking
  finding is recorded under Self-Review below.

### Live validation

Live-tested against the deployed `kube-agents-bot` (Cloud Run `kube-agents-bot`, project
`bhoekstra-gkedemos`, current revision — unchanged by this PR), using the fork as the proving ground
the runbook designates for exactly this.

`app/pr_body.py` reads the template from the **base** commit, so an upstream PR opened today cannot
exercise the new section — its base does not have it yet. To reach the real mechanism I pushed this
branch to `bradhoekstra/kube-agents` as `proving/self-review-base` and opened
[bradhoekstra/kube-agents#8](https://github.com/bradhoekstra/kube-agents/pull/8) against it: a
one-word README diff whose body fills in every template section **except** Self-Review.

Observed, in order:

1. **PR opened, body filling every template section except Self-Review** → the bot posted its
   description thread: *"The description does not fill in the pull request template. Unanswered
   section: **Self-Review**. The template is `.github/PULL_REQUEST_TEMPLATE.md` as of
   `proving/self-review-base`."* It named the section, and it named the base commit it read the
   template from. On `gke-labs/kube-agents`, where conversation resolution is required, that thread
   is the merge blocker — the fork does not enforce resolution, so that last step is the one part of
   the chain the proving ground cannot show.
2. **Second `/review`, body still unchanged** → the code-review pass independently re-derived the
   same thing as a 🟠 Medium, quoting the new `AGENTS.md` bullet and the new template section by
   permalink. Unplanned, and the more interesting half: the rule as worded in this diff is
   enforceable by a reader who has only the diff.
3. **Body edited to carry a real Self-Review section, third `/review`** → **No findings.** The
   section stops being flagged once it is answered, which is the negative control — the first
   observation was the mechanism, not a coincidence.

One thing worth knowing before this merges, which the proving ground surfaced: the description
thread is posted at most once per pull request (`app/main.py:494` — where conversation resolution is
required, a duplicate thread is a duplicate merge blocker). A `/review` after you fill the section
does not withdraw the thread; you resolve it. That is the bot's existing contract for every template
section, not something this change introduces.

What this does **not** cover: the judgement half. Whether the description pass calls a filled-but-
empty self-review ("Self-review: done, no issues.") a non-answer depends on the prompt change in the
companion bot PR, which is not deployed. That observation belongs to that PR's live validation, not
this one. Nothing in this PR's diff is involved in it.

Cleanup: the probe pull request and both `proving/*` branches on the fork are deleted.

## Self-Review

Ran `review-adversarial` against `main...docs/require-self-review` — the requirement this PR
introduces, applied to itself. Intent sentence: *make an adversarial self-review a required,
recorded step before opening a pull request, without stating the method in more than one place.*

Findings and dispositions:

1. **`.claude/commands/pr-review-batch.md`, Angle H — guidance lost in the splice. CONFIRMED.
   Fixed.** Angle B, run over the ~148 removed lines, caught that the skill's Angle H had replaced
   the docs-drift *substance* (one canonical home per fact, generated regions regenerated rather
   than hand-edited, identifiers verified against source) with a bare deferral to
   `review-docs-drift`. That is a real behaviour regression: the batch-review command never runs
   that skill, so the deferral pointed at a pass that does not happen and the angle became a no-op.
   Restored the substance and reframed the pointer as "the exhaustive form of this check".
2. **`.claude/commands/pr-review-batch.md`, Angle J — rationale lost in the splice. CONFIRMED.
   Fixed.** The superset clause lost its reason ("reviewing the subset in isolation spends effort on
   a diff that may never merge"), leaving an instruction with nothing behind it. Restored.
3. **`AGENTS.md:13` — docs drift introduced by this PR. CONFIRMED. Fixed.** The repository-layout
   entry for `.agents/skills/` enumerates the review skills by name and did not list the new one.
   Found by the required `review-docs-drift` pass, which is the finding it exists to catch.
4. **`.claude/commands/pr-review-batch.md`, new Phase 3 — redundancy. CONFIRMED. Fixed.** The
   replacement text restated the "a finding already answered in a thread" rule that Phase 2 already
   owns. Removed the duplicate.
5. **`.claude/commands/pr-review-batch.md` — phase numbering gap. CONFIRMED. Fixed.** Removing
   Phase 4 left 3 → 5. Renamed Phase 5 to Phase 4 and grepped the file and the repository for
   cross-references to the old number; there were none.

6. **`.claude/commands/pr-review-batch.md:184` — the review method was loaded from the branch under
   review. CONFIRMED. Fixed in `15c4d37`.** *Found by `kube-agents-bot`, not by me — recorded here
   because a self-review that hides what it missed is worse than one that admits it.* Phase 1 does
   `cd "$WT"`, so my bare relative path to `SKILL.md` resolved inside the pull request's own
   worktree: a fork branch could edit the angles used to judge it, and a branch cut before the skill
   existed would find no file and silently review nothing while Phase 4 still wrote
   `status: reviewed`. Now `$MAIN_ROOT/`-prefixed, matching what Phase 2 and Phase 4 already do.
   My pass should have caught this — Angle C is aimed squarely at it ("trace runtime wiring through
   to the source rather than inferring it from names") and I ran Angle C over these shell snippets
   without following the path resolution through the `cd`.
7. **The requirement told an agent to self-review without saying in what context. CONFIRMED. Fixed
   in `15c4d37`.** The natural reading was "run it in the conversation that just wrote the change",
   which is the one configuration the evidence says fails (see **Context → Grounding**). Step 1 of
   the skill and a new `AGENTS.md` sub-bullet now require a subagent or a fresh session.
8. **`AGENTS.md` said "fix what it confirms", the skill said "every surviving finding". CONFIRMED.
   Fixed in `15c4d37`.** PLAUSIBLE findings survive step 5, so the two documents disagreed about
   whether to edit on one — and editing on an uncertain self-finding is the specific mechanism by
   which self-review degrades a change. Step 6 now says fix CONFIRMED, report PLAUSIBLE.
9. **`.claude/commands/pr-review-batch.md` Phase 3 — instruction that contradicts itself under the
   new step 1. CONFIRMED. Fixed in `15c4d37`.** Phase 3 says to work the skill "in order", and the
   new step 1 says to spawn a subagent — but the reader there already *is* the review subagent, so
   taken literally it would spawn a second one per PR. Phase 3 now says step 1 is already satisfied
   and to start at step 2. Found by re-running Angle C after the step-1 insertion.

Nothing was deliberately left unfixed.

**Not findings, for the record**, so the next reader does not re-litigate them:

- The new skill needs no `docs/README.md` row and no `make docs-generate` run —
  `scripts/check_docs_map.py` exempts root-level dot-directories, and `.agents/skills/` is not in
  the generated catalogue. Verified against the script, not against another doc.
- The new `## Self-Review` heading does not break `kube-agents-bot`'s `tests/test_pr_body.py`: that
  `TEMPLATE` fixture is a deliberately independent snapshot, and the parser is template-driven, so
  it needs no change to handle a seventh section.

**What this pass did not cover**, including the part that is awkward:

- **The pass on the second commit was not itself run in a fresh context** — the very thing that
  commit makes mandatory. This session is configured not to spawn subagents, so it ran inline, in
  the context that wrote the change. Finding 9 is the kind of thing that catches (a cross-file
  contradiction); finding 6 is the kind it misses (a trust boundary I had already convinced myself
  about), and a bot with no stake in my reasoning is what caught that one. Treat that as evidence
  for the rule rather than against it, but do not read the later entries as the product of the
  procedure they describe.
- There is no runtime code path in this diff, so Angles A and D had little to bite on beyond the
  command file's shell snippets. The behavioural risk is concentrated in the splice and in the path
  resolution, which is where Angles B and C were aimed.
- The new CI-integrity and existence-check angles are untested against a real change: nothing in
  this diff touches a workflow or introduces a code reference for them to catch.

## Risk & Rollout

Low blast radius and no runtime code paths. The one behavioural change is ceremony: from the merge
of this PR, a body that omits or leaves empty the Self-Review section gets a merge-holding thread
from the bot, including on one-line docs fixes. Both the template comment and `AGENTS.md` explicitly
accept a short honest answer — "no findings, here is what I looked for" — so that the section does
not become a box people paste "done" into.

Revert is a single revert commit; nothing persists outside the repository.

The `AGENTS.md` conflict with #698 and #701 is a merge-order question, not a correctness one.
