### PR TITLE
chore(deps): upgrade LiteLLM to v1.96.2

### DIFF
--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -77,7 +77,7 @@ litellm:
     location: ""
   image:
     repository: ghcr.io/berriai/litellm
-    tag: v1.92.0
+    tag: v1.96.2
     pullPolicy: IfNotPresent
   replicaCount: 2
   resources:

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.95.0
+          image: ghcr.io/berriai/litellm:v1.96.2
           args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: CHATGPT_TOKEN_DIR

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.95.0
+          image: ghcr.io/berriai/litellm:v1.96.2
           args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: GEMINI_API_KEY

--- a/k8s-operator/config/integrations/litellm/base/deployment.yaml
+++ b/k8s-operator/config/integrations/litellm/base/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.95.0
+          image: ghcr.io/berriai/litellm:v1.96.2
           args: ["--config", "/app/config.yaml", "--port", "8080"]
           resources:
             requests:

--- a/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
+++ b/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
@@ -145,7 +145,7 @@ litellmGateway:
   replicaCount: 1
   image:
     repository: "ghcr.io/berriai/litellm"
-    tag: "v1.95.0"
+    tag: "v1.96.2"
   modelProvider: "gemini"
   modelName: "gemini-3.5-flash"
   useDummySecret: true


### PR DESCRIPTION
## Summary

Moves every LiteLLM image reference in the repository to the current upstream stable release, v1.96.2 (2026-08-11), from v1.95.0 — and, along the way, fixes a real divergence the last bump left behind. `charts/kube-agents/values.yaml` was still pinned at v1.92.0 because #542 ("upgrade LiteLLM version references to v1.95.0") updated the Kustomize base and the two examples but not the chart, so a Helm install and a Kustomize install of the same commit deployed different LiteLLM builds. Both now land on v1.96.2.

## Why This Change

The pin is hand-maintained — Dependabot's `docker` ecosystem is scoped to `/agents/platform` only (`.github/dependabot.yml`), so nothing keeps these references current. Without this PR the repository stays four minors behind upstream, and the Helm/Kustomize split above persists: a user who follows the chart path gets a LiteLLM three months older than the one the operator's own integration manifests deploy, with no note anywhere saying so.

v1.97.x and v1.98.x exist upstream only as `-rc`/`-dev` tags; v1.96.2 is the newest stable release.

## What Changed

- `charts/kube-agents/values.yaml` — v1.92.0 → v1.96.2. This is the divergence, not a routine bump; it is the one line in this PR that changes what a Helm install actually deploys relative to a Kustomize install of the same commit.
- The Kustomize base, both examples, and the staging-workload chart — v1.95.0 → v1.96.2.

## Context

Follow-up to #542, which introduced the chart/Kustomize divergence.

This is one of six independent dependency bumps, each on its own branch off `main` and each revertable on its own. The live validation below comes from a single combined run, so here is the full set that was in the `bumps-20260814` build:

- #705 — LiteLLM v1.96.2  ← this PR
- #706 — Envoy v1.39.0
- #707 — fluent-bit 5.1.0
- #708 — cert-manager v1.21.1
- #709 — hindsight-api 0.9.1
- #710 — Go toolchain 1.26.6

A seventh bump — the Hermes base image to v2026.8.13 — is deliberately not in this set: it breaks eight of the build-time patch appliers under `deploy/docker/patches/`, which is a port rather than a bump.

Generated with the help of Claude.

## Testing

- `make docs-check` — clean.
- `prettier --check` on the changed YAML with the pinned CI version (3.9.6) — clean.
- `grep` for `1.95.0` and `1.92.0` across the tree after the change — no remaining LiteLLM references.

### Live validation

The install: **`bhoekstra-gkedemos`** — GKE Standard cluster `kube-agents-cluster` (regional `us-central1`), namespace `kubeagents-system`, registry `us-central1-docker.pkg.dev/bhoekstra-gkedemos/kube-agents`. Baseline before the test: operator, platform-agent and credential-proxy all at tag `dns-endpoint-7dac349`; fluent-bit `5.0.7`; LiteLLM `v1.95.0`; cert-manager `v1.14.4`. All six bump branches were merged into a throwaway local branch (never pushed) and built and pushed under the distinct tag `bumps-20260814`, so this observation comes from one combined run. Commands used the scoped kubeconfig `~/.kube/kube-agents-gkedemos.config`; `~/.kube/config` is byte-identical before and after (md5 `4c0615cd…`). The `bumps-20260814` images have been deleted from Artifact Registry.

**What I did.** `kubectl set image deploy/litellm litellm-container=ghcr.io/berriai/litellm:v1.96.2` — deliberately *not* `provision_09_deploy_litellm.sh` or `make deploy-litellm`, either of which reverts that install's hand-applied Vertex AI configuration.

**What I observed.** Clean rollout; the pod resolves to `ghcr.io/berriai/litellm@sha256:154e23bb5f31b1f10e16392a8ef299bd2cde08de3a64a6849002cfcc25ce3c63` for the v1.96.2 tag, and `/health/readiness` on :8080 returns `{"status":"healthy","db":"Not connected"}` (this install runs LiteLLM without a database). A health endpoint alone would not prove much, so I drove a real turn through it: published a synthetic Google Chat `MESSAGE` event to the `platform-agent-chat-events` topic, and the agent's reply landed in `/opt/data/state.db` 34 s later — `('assistant', 'ACK-LITELLM')`. That is a full `vertex_ai/claude-opus-5` completion served by v1.96.2.

**Mechanism, not coincidence.** v1.96.2 is distinctly different from the v1.95.0 it replaced. Reverting to v1.95.0 afterwards rolled cleanly and a further chat turn still answered (`ACK-RESTORED`), so the install is back where it started.

**Not covered.** The chart path. This install is provisioned from Kustomize, so the `charts/kube-agents/values.yaml` line — the one that actually fixes the #542 divergence — was not exercised by a Helm install. That line is verified by inspection only.

## Risk & Rollout

Low. The only runtime effect is which LiteLLM image tag is pulled; no configuration keys or manifests change shape. Rollback is reverting the commit, or `kubectl set image deploy/litellm litellm=ghcr.io/berriai/litellm:v1.95.0` on a live install. Installations that override the image (as several do) are unaffected.
