### PR TITLE
chore(deps): upgrade Envoy to v1.39.0

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -23,7 +23,7 @@
 #     python3 scripts/check_image_layers.py
 #
 ARG HERMES_AGENT_TAG
-ARG ENVOY_VERSION=v1.38.0
+ARG ENVOY_VERSION=v1.39.0
 FROM envoyproxy/envoy:${ENVOY_VERSION} AS envoy-bin
 
 # Every binary in the final image must match the architecture the image ships


### PR DESCRIPTION
## Summary

Bumps the Envoy binary that the credential-proxy sidecar is built from, from v1.38.0 to v1.39.0, by way of the `ENVOY_VERSION` build arg in `deploy/docker/Dockerfile`. That arg is the only reference to the version anywhere in the repository, so the diff is one line.

## Why This Change

v1.38.0 was released 2026-04-23 and is now a minor behind; v1.39.0 (2026-07-14) is the current stable. Envoy sits in the credential path for every outbound call the agent makes, so it is the component in this repository where staying on a supported upstream release matters most. Nothing is broken today — this is currency work.

## What Changed

- `deploy/docker/Dockerfile` — `ARG ENVOY_VERSION=v1.38.0` → `v1.39.0`.

`deploy/shared/envoy-credential-proxy.yaml` needs no change. It was checked against the new binary with `envoy --mode validate` before committing to a full image build, and the resulting image reports 1.39.0.

## Context

This is one of six independent dependency bumps, each on its own branch off `main` and each revertable on its own. The live validation below comes from a single combined run, so here is the full set that was in the `bumps-20260814` build:

- #705 — LiteLLM v1.96.2
- #706 — Envoy v1.39.0  ← this PR
- #707 — fluent-bit 5.1.0
- #708 — cert-manager v1.21.1
- #709 — hindsight-api 0.9.1
- #710 — Go toolchain 1.26.6

A seventh bump — the Hermes base image to v2026.8.13 — is deliberately not in this set: it breaks eight of the build-time patch appliers under `deploy/docker/patches/`, which is a port rather than a bump.

Generated with the help of Claude.

## Testing

- `envoy --mode validate` against `deploy/shared/envoy-credential-proxy.yaml` on the v1.39.0 binary — config accepted.
- `docker build --platform linux/amd64 -f deploy/docker/Dockerfile --target credential-proxy` — builds.
- `python3 scripts/check_image_layers.py` — 118 layers, 2 under the 120 budget. (The new binary adds no layers; this is the same count as before the bump.)
- `make docs-check` — clean.

### Live validation

The install: **`bhoekstra-gkedemos`** — GKE Standard cluster `kube-agents-cluster` (regional `us-central1`), namespace `kubeagents-system`, registry `us-central1-docker.pkg.dev/bhoekstra-gkedemos/kube-agents`. Baseline before the test: operator, platform-agent and credential-proxy all at tag `dns-endpoint-7dac349`; fluent-bit `5.0.7`; LiteLLM `v1.95.0`; cert-manager `v1.14.4`. All six bump branches were merged into a throwaway local branch (never pushed) and built and pushed under the distinct tag `bumps-20260814`, so this observation comes from one combined run. Commands used the scoped kubeconfig `~/.kube/kube-agents-gkedemos.config`; `~/.kube/config` is byte-identical before and after (md5 `4c0615cd…`). The `bumps-20260814` images have been deleted from Artifact Registry.

**What I did.** Built the credential-proxy image from the merged branch (`docker build --platform linux/amd64 --target credential-proxy`), pushed it as `bumps-20260814`, pointed the operator's `CREDENTIAL_PROXY_IMAGE` at it, and rolled the PlatformAgent CR onto the matching agent tag.

**What I observed.**

- In the built image: `envoy --version` → `9aed67d36497690a0d0dc65305ab823927441b77/1.39.0/Clean/RELEASE/BoringSSL`.
- `python3 scripts/check_image_layers.py` → `OK: credential-proxy:latest has 118 layers, 2 under the 120 budget`.
- In the running pod: `kubectl exec … -c envoy-credential-proxy -- /usr/local/bin/envoy --version` reports the same 1.39.0 build.
- The CR reconciled to `.status.phase: Ready` with `"Agent sandbox and Envoy credential sidecar are fully reconciled"`.
- Envoy carries every credentialed call the agent makes, so the real proof is a turn end to end: a synthetic Google Chat event published to `platform-agent-chat-events` produced `('assistant', 'ACK-STACK')` in `/opt/data/state.db` ~35 s later. The unix-socket cluster and the credential path work on 1.39.0.

**Mechanism, not coincidence.** 1.39.0 ≠ the 1.38.0 that was serving before, and the in-pod `--version` was read from the running container, not the build log. Reverting the sidecar to `dns-endpoint-7dac349` (Envoy 1.38.0) restored the previous version and the pod answered a further turn.

**Not covered.** No load or long-running soak — this was a functional check of the credential path, not a performance comparison.

## Risk & Rollout

Moderate for a one-line change, because Envoy terminates the credential proxy: if v1.39.0 rejected the config or changed unix-socket cluster behaviour, every credentialed call from the agent would fail. Both are covered above — the config validates and the built image serves. Rollback is reverting the ARG and rebuilding; running installs are unaffected until their credential-proxy image is repushed.
