### PR TITLE
chore(deps): upgrade the fluent-bit logging sidecar to 5.1.0

### DIFF
--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -5,7 +5,7 @@ operator:
   # CREDENTIAL_PROXY_IMAGE / FLUENT_BIT_IMAGE:
   #   extraEnv:
   #     - name: FLUENT_BIT_IMAGE
-  #       value: registry.corp/mirror/fluent-bit:5.0.7
+  #       value: registry.corp/mirror/fluent-bit:5.1.0
   extraEnv: []
   image:
     repository: ghcr.io/gke-labs/kube-agents/k8s-operator

--- a/k8s-operator/config/manager/manager.yaml
+++ b/k8s-operator/config/manager/manager.yaml
@@ -57,7 +57,7 @@ spec:
             # - name: CREDENTIAL_PROXY_IMAGE
             #   value: "registry.example.com/kube-agents/credential-proxy:latest"
             # - name: FLUENT_BIT_IMAGE
-            #   value: "registry.example.com/mirror/fluent-bit:5.0.7"
+            #   value: "registry.example.com/mirror/fluent-bit:5.1.0"
           ports:
             - containerPort: 8081
               name: health

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -49,7 +49,7 @@ func fallbackPlatformAgentImage() string {
 }
 
 const (
-	fallbackFluentBitImage = "fluent/fluent-bit:5.0.7"
+	fallbackFluentBitImage = "fluent/fluent-bit:5.1.0"
 
 	// Operator-level image overrides for installs that mirror images into a
 	// private registry. Set on the controller-manager Deployment; a CR's

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -760,8 +760,8 @@ func TestBuildDeployment(t *testing.T) {
 	if fbContainer.Name != "fluent-bit" {
 		t.Errorf("expected container name fluent-bit, got %s", fbContainer.Name)
 	}
-	if fbContainer.Image != "fluent/fluent-bit:5.0.7" {
-		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.0.7, got %s", fbContainer.Image)
+	if fbContainer.Image != "fluent/fluent-bit:5.1.0" {
+		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.1.0, got %s", fbContainer.Image)
 	}
 
 	// Verify volumes
@@ -1123,10 +1123,10 @@ func TestImageEnvOverrides(t *testing.T) {
 }
 
 func TestFluentBitImageEnvOverride(t *testing.T) {
-	if got := fluentBitImage(); got != "fluent/fluent-bit:5.0.7" {
+	if got := fluentBitImage(); got != "fluent/fluent-bit:5.1.0" {
 		t.Fatalf("unexpected default fluent-bit image: %s", got)
 	}
-	t.Setenv("FLUENT_BIT_IMAGE", "registry.corp/mirror/fluent-bit:5.0.7")
+	t.Setenv("FLUENT_BIT_IMAGE", "registry.corp/mirror/fluent-bit:5.1.0")
 
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
@@ -1136,7 +1136,7 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 	for _, c := range dep.Spec.Template.Spec.Containers {
 		if c.Name == "fluent-bit" {
 			found = true
-			if c.Image != "registry.corp/mirror/fluent-bit:5.0.7" {
+			if c.Image != "registry.corp/mirror/fluent-bit:5.1.0" {
 				t.Fatalf("expected FLUENT_BIT_IMAGE override on sidecar, got %s", c.Image)
 			}
 		}
@@ -1155,7 +1155,7 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 func TestNoPublicRegistryWhenMirrored(t *testing.T) {
 	const mirror = "registry.corp/mirror"
 	t.Setenv("PLATFORM_AGENT_IMAGE", mirror+"/platform-agent:v1.2.3")
-	t.Setenv("FLUENT_BIT_IMAGE", mirror+"/fluent-bit:5.0.7")
+	t.Setenv("FLUENT_BIT_IMAGE", mirror+"/fluent-bit:5.1.0")
 	// CREDENTIAL_PROXY_IMAGE deliberately left unset: the sidecar must derive
 	// its registry from PLATFORM_AGENT_IMAGE, not fall back to ghcr.io.
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -688,7 +688,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
+          image: fluent/fluent-bit:5.1.0
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -642,7 +642,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
+          image: fluent/fluent-bit:5.1.0
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -688,7 +688,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.0.7
+          image: fluent/fluent-bit:5.1.0
           name: fluent-bit
           resources:
             limits:


### PR DESCRIPTION
## Summary

Moves the operator's default fluent-bit logging sidecar from 5.0.7 to the current upstream release, 5.1.0 (2026-08-06). The default itself is one constant — `fallbackFluentBitImage` in `k8s-operator/internal/controller/manifest_helpers.go` — and the rest of the diff is the places that assert or illustrate it.

## Why This Change

Every agent pod the operator reconciles gets this sidecar, and the pin is hand-maintained (Dependabot's `docker` ecosystem covers `/agents/platform` only). 5.0.7 is a minor behind. Nothing is broken; this keeps the shipped default on a current upstream release.

## What Changed

- `k8s-operator/internal/controller/manifest_helpers.go` — `fallbackFluentBitImage`, the value every reconcile uses when `FLUENT_BIT_IMAGE` is unset.
- The three expected manifests under `k8s-operator/internal/testing/testdata/platform/expected/` and the assertions in `platformagent_manifests_test.go`, which pin the string.
- The `FLUENT_BIT_IMAGE` override examples in `charts/kube-agents/values.yaml` and `k8s-operator/config/manager/manager.yaml` — comments, but they name a version, so they would go stale silently.

The override tests keep proving the mechanism rather than a coincidence: their expected value differs from the default by registry prefix, not just by tag, so an override that silently fell back to the default would still fail them.

## Context

This is one of six independent dependency bumps, each on its own branch off `main` and each revertable on its own. The live validation below comes from a single combined run, so here is the full set that was in the `bumps-20260814` build:

- #705 — LiteLLM v1.96.2
- #706 — Envoy v1.39.0
- #707 — fluent-bit 5.1.0  ← this PR
- #708 — cert-manager v1.21.1
- #709 — hindsight-api 0.9.1
- #710 — Go toolchain 1.26.6

A seventh bump — the Hermes base image to v2026.8.13 — is deliberately not in this set: it breaks eight of the build-time patch appliers under `deploy/docker/patches/`, which is a port rather than a bump.

Generated with the help of Claude.

## Testing

- `go build ./...` and `go test ./...` in `k8s-operator/` — all packages pass, including the golden-manifest comparisons.
- `make docs-check` — clean.
- `prettier --check` on the changed YAML with the pinned CI version (3.9.6) — clean.

### Live validation

The install: **`bhoekstra-gkedemos`** — GKE Standard cluster `kube-agents-cluster` (regional `us-central1`), namespace `kubeagents-system`, registry `us-central1-docker.pkg.dev/bhoekstra-gkedemos/kube-agents`. Baseline before the test: operator, platform-agent and credential-proxy all at tag `dns-endpoint-7dac349`; fluent-bit `5.0.7`; LiteLLM `v1.95.0`; cert-manager `v1.14.4`. All six bump branches were merged into a throwaway local branch (never pushed) and built and pushed under the distinct tag `bumps-20260814`, so this observation comes from one combined run. Commands used the scoped kubeconfig `~/.kube/kube-agents-gkedemos.config`; `~/.kube/config` is byte-identical before and after (md5 `4c0615cd…`). The `bumps-20260814` images have been deleted from Artifact Registry.

**What I did.** Built and pushed the operator from the merged branch, pointed the running operator Deployment at it, and let it reconcile the agent pod.

**What I observed.** The reconciled agent pod's sidecar is `fluent/fluent-bit:5.1.0`, and inside the container `fluent-bit --version` prints `Fluent Bit v5.1.0` / `Git commit: fe293d4270b27bc078e0bb82e7aa2afe08e723f8`. It is not just running — `kubectl logs … -c fluent-bit` shows live JSON records tailing the agent's files, e.g. `{"date":1786731849.65,"file_path":"/opt/data/logs/errors.log","log":"…","app":"agent","log_source":"agent-file"}`. No `FLUENT_BIT_IMAGE` override is set on this install, so this is the compiled-in default doing the work.

**Mechanism, not coincidence.** Proven in both directions and against distinctly different values: 5.0.7 before, 5.1.0 after the operator rolled forward, and back to 5.0.7 on the next reconcile once the previous operator image was restored. The sidecar image tracks the operator build's default, which is exactly the line this PR changes.

**Not covered.** Nothing material for this change. The `FLUENT_BIT_IMAGE` override path was not re-exercised live; it is covered by unit tests whose expected value differs from the default by registry prefix.

## Risk & Rollout

Low. A reconcile rolls the agent pod to pick up the new sidecar image; if 5.1.0 misbehaved, log shipping would degrade but the agent container is unaffected. Any install that sets `FLUENT_BIT_IMAGE` is untouched. Rollback is reverting the commit, or setting `FLUENT_BIT_IMAGE=fluent/fluent-bit:5.0.7` on the operator Deployment without a redeploy.
