### PR TITLE
chore(deps): upgrade hindsight-api to 0.9.1

### DIFF
--- a/docs/designs/memory.md
+++ b/docs/designs/memory.md
@@ -449,7 +449,7 @@ It adds exactly two workloads to `kubeagents-system`.
 
 **1. `hindsight-api` — a `Deployment`, one replica** (`api.yaml`).
 
-- Image `ghcr.io/vectorize-io/hindsight-api:0.8.6`, pinned by digest.
+- Image `ghcr.io/vectorize-io/hindsight-api:0.9.1`, pinned by digest.
 - Serves HTTP on **8888** behind a ClusterIP `Service` of the same name;
   `/health` backs both probes. Liveness waits 30s because model loading dominates
   cold start.

--- a/k8s-operator/config/integrations/hindsight/api.yaml
+++ b/k8s-operator/config/integrations/hindsight/api.yaml
@@ -47,7 +47,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: api
-          image: ghcr.io/vectorize-io/hindsight-api:0.8.6@sha256:3db1536d84a14a10afbd08cc8f82bf4eec03c123d950705226c999bea14ca0f0
+          image: ghcr.io/vectorize-io/hindsight-api:0.9.1@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab
           ports:
             - name: http
               containerPort: 8888


### PR DESCRIPTION
## Summary

Moves the memory integration's hindsight-api image from 0.8.6 to 0.9.1 (2026-08-14), tag and digest together, and updates the one line in the design doc that names the version.

## Why This Change

The memory integration is optional and off by default, but the manifest it ships is what any install that turns it on will deploy. The pin is hand-maintained and had drifted a minor behind.

## What Changed

- `k8s-operator/config/integrations/hindsight/api.yaml` — tag and `@sha256:` digest updated together, so the pin stays immutable.
- `docs/designs/memory.md` — the version reference.

Nothing the manifest depends on moved between the two releases: the container still serves 8888, still answers `/health`, and still reads `HINDSIGHT_API_PORT`, `HF_HUB_OFFLINE` and `TRANSFORMERS_OFFLINE`. Neither the 0.9.0 nor the 0.9.1 release notes declare a breaking change. 0.9.0 deprecates the standalone `hindsight-hermes` plugin, which this repository does not install.

## Context

This is one of six independent dependency bumps, each on its own branch off `main` and each revertable on its own. The live validation below comes from a single combined run, so here is the full set that was in the `bumps-20260814` build:

- #705 — LiteLLM v1.96.2
- #706 — Envoy v1.39.0
- #707 — fluent-bit 5.1.0
- #708 — cert-manager v1.21.1
- #709 — hindsight-api 0.9.1  ← this PR
- #710 — Go toolchain 1.26.6

A seventh bump — the Hermes base image to v2026.8.13 — is deliberately not in this set: it breaks eight of the build-time patch appliers under `deploy/docker/patches/`, which is a port rather than a bump.

Generated with the help of Claude.

## Testing

- Checked the 0.9.0 and 0.9.1 release notes for breaking changes and for the env vars and port this manifest relies on.
- `make docs-check` — clean.
- `prettier --check` on the changed YAML and Markdown with the pinned CI version (3.9.6) — clean.

### Live validation

The install: **`bhoekstra-gkedemos`** — GKE Standard cluster `kube-agents-cluster` (regional `us-central1`), namespace `kubeagents-system`, registry `us-central1-docker.pkg.dev/bhoekstra-gkedemos/kube-agents`. Baseline before the test: operator, platform-agent and credential-proxy all at tag `dns-endpoint-7dac349`; fluent-bit `5.0.7`; LiteLLM `v1.95.0`; cert-manager `v1.14.4`. All six bump branches were merged into a throwaway local branch (never pushed) and built and pushed under the distinct tag `bumps-20260814`, so this observation comes from one combined run. Commands used the scoped kubeconfig `~/.kube/kube-agents-gkedemos.config`; `~/.kube/config` is byte-identical before and after (md5 `4c0615cd…`). The `bumps-20260814` images have been deleted from Artifact Registry.

**Partial, and here is why.** Memory is disabled on this install (`spec.harness.memory.memoryEnabled: false`), so hindsight is not wired into the agent there and no end-to-end memory path exists to exercise.

**What I did.** Applied `k8s-operator/config/integrations/hindsight/` into a scratch namespace, `hindsight-bumptest`, to prove the new digest pulls and the API comes up.

**What I observed.** The pinned digest resolves and pulls — `imageID ghcr.io/vectorize-io/hindsight-api@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab`, 1.4 GB, 2 m 30 s. The API reaches Ready and `/health` returns `{"status":"healthy","database":"connected","db_pool_max":100,…}`, so it also connects to the Postgres from the same kustomization.

**One thing worth knowing.** On the cold start — a fresh pull onto a node that had never seen the image — the container was killed twice by the liveness probe (`initialDelaySeconds: 30`, `failureThreshold: 3` at `periodSeconds: 10`, so t=50 s) before it finished binding :8888. It exits cleanly each time ("All services stopped cleanly") and converges on the third attempt.

_Correcting a measurement an earlier version of this section made._ It reported "~2 min warm for 0.9.1 against ~40 s for a 0.8.6 control, so 0.9.1 starts more slowly." That comparison does not hold: the ~2 min was mostly `ContainerCreating` — near-certainly a re-pull of the 1.4 GB image after the pod was rescheduled — not container init, and I did not control for node placement or image cache. The warm run also showed **zero** restarts, which a container exceeding the 50 s liveness budget could not have done. What is directly observed and stands: 0.9.1 was liveness-killed twice on a genuinely cold start, and the 0.8.6 control was not killed on its first start. I do not have a clean startup-time comparison between the two.

The probe block is untouched by this PR and is identical on 0.8.6, so this is a pre-existing weakness rather than a regression — but a real one, and the repo already solves the same shape with a `startupProbe` in `charts/kube-agents/templates/litellm.yaml`. Filed as #712 rather than fixed here, to keep a version bump a version bump.

**Not covered.** No memory read or write through an agent, and no in-place upgrade over existing 0.8.6 data — this install has neither. The scratch namespace has been deleted.

## Risk & Rollout

Low, and scoped to installs that enable the memory integration — which is off by default. Nothing else references the image. Rollback is reverting the commit.
