### PR TITLE
chore(deps): upgrade the Go toolchain to 1.26.6

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -120,7 +120,7 @@ Before beginning installation, ensure your environment meets the following requi
 
 | CLI Tool / Utility              | Required Version                                | Verification Command       | Description                                                                                           |
 | :------------------------------ | :---------------------------------------------- | :------------------------- | :---------------------------------------------------------------------------------------------------- |
-| **Go**                          | `1.25+`                                         | `go version`               | Required for building operator binaries and running tests.                                            |
+| **Go**                          | `1.26+`                                         | `go version`               | Required for building operator binaries and running tests.                                            |
 | **Docker / Podman**             | `20.10+`                                        | `docker --version`         | Required to build container images for the operator.                                                  |
 | **kubectl**                     | `1.28+`                                         | `kubectl version --client` | Communicates with your target Kubernetes or GKE cluster.                                              |
 | **Kubernetes Cluster**          | `1.28+` (`1.35+` for `AgentPlugin` OCI volumes) | `kubectl version`          | Target Kubernetes or GKE cluster (`AgentPlugin` OCI volumes require K8s 1.35+ `ImageVolume` gate).    |

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -40,7 +40,7 @@ FROM envoyproxy/envoy:${ENVOY_VERSION} AS envoy-bin
 # $BUILDPLATFORM keeps the Go toolchain running natively on the build host; it
 # cross-compiles to TARGETARCH, the architecture of the image being produced.
 # The :-amd64 fallback only fires on builders that don't populate TARGETARCH.
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS watcher-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS watcher-builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace

--- a/docs/site/src/content/docs/operator/development.md
+++ b/docs/site/src/content/docs/operator/development.md
@@ -11,7 +11,7 @@ Everything below runs from `k8s-operator/`.
 
 ## Prerequisites
 
-- Go 1.25+.
+- Go 1.26+.
 - `docker` (or `podman`) for image builds.
 - `kubectl` pointed at a target cluster for `make install` / `make deploy`.
 - `make` — the entire workflow is Makefile-driven.

--- a/k8s-operator/Dockerfile
+++ b/k8s-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -12,7 +12,7 @@ The operator is built using the Kubebuilder framework and is written in Go.
 
 Before building or deploying the operator, ensure you have the following installed:
 
-- [Go](https://go.dev/doc/install) (version 1.25+)
+- [Go](https://go.dev/doc/install) (version 1.26+)
 - [Docker](https://docs.docker.com/get-docker/) or Podman (for building container images)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) (configured to access your Kubernetes/GKE cluster)
 - Access to a running Kubernetes/GKE cluster

--- a/k8s-operator/go.mod
+++ b/k8s-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/gke-labs/kube-agents/k8s-operator
 
-go 1.25.8
+go 1.26.6
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Summary

Moves the operator's Go toolchain from 1.25.8 to 1.26.6, and the two builder stages that compile against it from `golang:1.25-alpine` to `golang:1.26-alpine`.

## Why This Change

`k8s-operator/go.mod` is the single source of truth for the toolchain — every workflow resolves it with `go-version-file: k8s-operator/go.mod`, so CI needs no edit — but the two Dockerfiles that build the operator and the event watcher name their base image directly and have to be moved in step. Leaving them behind is how a builder image and the declared toolchain drift apart.

## What Changed

- `k8s-operator/go.mod` — `go 1.25.8` → `go 1.26.6`.
- `k8s-operator/Dockerfile` and the `watcher-builder` stage in `deploy/docker/Dockerfile` — `golang:1.25-alpine` → `golang:1.26-alpine`.
- `docs/site/src/content/docs/operator/development.md`, `INSTALL.md`, and `k8s-operator/README.md` — the stated minimum, `Go 1.25+` → `Go 1.26+`. `docs/README.md` §2 names `k8s-operator/go.mod` as the source for this identifier, so these go stale the moment `go.mod` moves; `make docs-check` does not catch it. The `k8s-operator/README.md` line was missed in the first push and added in a follow-up commit after the bot flagged it — `hack/check-docs-terminology.sh` greps `Go[^0-9]{0,20}1\.[0-9]+\+`, and that README writes the version behind a markdown link, which puts more than 20 characters between "Go" and the number.

## Context

This is one of six independent dependency bumps, each on its own branch off `main` and each revertable on its own. The live validation below comes from a single combined run, so here is the full set that was in the `bumps-20260814` build:

- #705 — LiteLLM v1.96.2
- #706 — Envoy v1.39.0
- #707 — fluent-bit 5.1.0
- #708 — cert-manager v1.21.1
- #709 — hindsight-api 0.9.1
- #710 — Go toolchain 1.26.6  ← this PR

A seventh bump — the Hermes base image to v2026.8.13 — is deliberately not in this set: it breaks eight of the build-time patch appliers under `deploy/docker/patches/`, which is a port rather than a bump.

Generated with the help of Claude.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` in `k8s-operator/` on 1.26.6 — clean.
- `make manifests generate` — reproduces the committed output byte for byte.
- Both builder stages build under `docker build --platform linux/amd64`.
- `make docs-check` and `prettier --check` with the pinned CI version (3.9.6) — clean.

### Live validation

The install: **`bhoekstra-gkedemos`** — GKE Standard cluster `kube-agents-cluster` (regional `us-central1`), namespace `kubeagents-system`, registry `us-central1-docker.pkg.dev/bhoekstra-gkedemos/kube-agents`. Baseline before the test: operator, platform-agent and credential-proxy all at tag `dns-endpoint-7dac349`; fluent-bit `5.0.7`; LiteLLM `v1.95.0`; cert-manager `v1.14.4`. All six bump branches were merged into a throwaway local branch (never pushed) and built and pushed under the distinct tag `bumps-20260814`, so this observation comes from one combined run. Commands used the scoped kubeconfig `~/.kube/kube-agents-gkedemos.config`; `~/.kube/config` is byte-identical before and after (md5 `4c0615cd…`). The `bumps-20260814` images have been deleted from Artifact Registry.

**The proof is that everything else in this batch was built by it.** The merged branch carries `go 1.26.6` in `go.mod` and `golang:1.26-alpine` in both builder stages, and every image used in this live test came out of it.

**What I observed.**

- The operator image built on `golang:1.26-alpine` from `k8s-operator/Dockerfile`, and the event-watcher binary built by the `watcher-builder` stage of `deploy/docker/Dockerfile`. Both pushed and pulled by the cluster.
- Running that operator, a `spec.deployment.tag` change on the PlatformAgent CR reconciled to `.status.phase: Ready` with `"Agent sandbox and Envoy credential sidecar are fully reconciled"`, and the sidecar defaults it computes were applied to the pod.
- Its admission webhook served correctly: a server-side dry-run adding a `hostPath` volume was rejected with `spec.deployment.extraVolumes[0].hostPath: Forbidden: hostPath volumes are forbidden for security reasons` — that string comes from the 1.26.6-built binary.
- The agent it manages answered a real chat turn end to end (`ACK-STACK` in `/opt/data/state.db`, from a synthetic event published to `platform-agent-chat-events`).

**Mechanism, not coincidence.** The previous operator on that cluster was built on 1.25; restoring it reconciled the pod back to the old defaults, so the two builds were both live and both observed doing work.

**Not covered.** No behaviour that is specific to the 1.26 runtime was targeted — a toolchain bump is exercised by everything compiling and running, which it did.

## Risk & Rollout

Low. A toolchain bump changes what compiles the binaries, not what they do; the golden manifests and the full operator test suite are unchanged and passing. The one thing to watch is that anyone building locally now needs Go 1.26 — hence the two doc edits. Rollback is reverting the commit.
