### PR TITLE
fix(ci): check out an immutable SHA and drop the module cache in the integrations deploy

### DIFF
--- a/.github/workflows/autopush-redeploy-integrations.yml
+++ b/.github/workflows/autopush-redeploy-integrations.yml
@@ -30,8 +30,12 @@ permissions:
 
 jobs:
   call-deploy:
+    # inherit, not an explicit mapping: the called workflow's jobs read
+    # GH_APP_ID, an environment secret. A `uses:` job cannot declare an
+    # environment, so mapping the secrets here would evaluate them in this job,
+    # pass GH_APP_ID through empty, and silently skip the minter deploy.
     secrets: inherit
-    uses: ./.github/workflows/reusable-deploy-integrations.yml
+    uses: ./.github/workflows/reusable-deploy-integrations.yml # zizmor: ignore[secrets-inherit]
     with:
       target_environment: "autopush"
       force_deploy: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/autopush-redeploy-integrations.yml
+++ b/.github/workflows/autopush-redeploy-integrations.yml
@@ -35,4 +35,4 @@ jobs:
     with:
       target_environment: "autopush"
       force_deploy: ${{ github.event_name == 'workflow_dispatch' }}
-      checkout_ref: ${{ github.ref }}
+      checkout_sha: ${{ github.sha }}

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -12,10 +12,10 @@ on:
         type: boolean
         default: false
         description: "If true, bypasses paths filter and forces deployment of all integrations"
-      checkout_ref:
+      checkout_sha:
         required: true
         type: string
-        description: "The git ref to pass to actions/checkout"
+        description: "Immutable commit SHA to check out. Must be a SHA, not a branch or tag ref: a mutable ref lets the deployed code differ from the code that passed validation."
 
 jobs:
   detect-changes:
@@ -28,7 +28,8 @@ jobs:
         if: ${{ inputs.force_deploy == false }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout_ref }}
+          ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
 
       - name: Detect changes
         if: ${{ inputs.force_deploy == false }}
@@ -75,13 +76,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout_ref }}
+          ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
-          cache-dependency-path: "k8s-operator/go.sum"
+          # No module cache: this job holds the target environment's deploy
+          # credentials, and a cache it writes on the default branch is
+          # restorable by every branch built off it.
+          cache: false
 
       - name: Authenticate to Google Cloud via WIF
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -134,13 +139,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout_ref }}
+          ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
-          cache-dependency-path: "k8s-operator/go.sum"
+          # No module cache: this job holds the target environment's deploy
+          # credentials, and a cache it writes on the default branch is
+          # restorable by every branch built off it.
+          cache: false
 
       - name: Authenticate to Google Cloud via WIF
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -235,13 +244,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout_ref }}
+          ref: ${{ inputs.checkout_sha }}
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: "k8s-operator/go.mod"
-          cache-dependency-path: "k8s-operator/go.sum"
+          # No module cache: this job holds the target environment's deploy
+          # credentials, and a cache it writes on the default branch is
+          # restorable by every branch built off it.
+          cache: false
 
       - name: Authenticate to Google Cloud via WIF
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -15,8 +15,12 @@ permissions:
 
 jobs:
   call-deploy:
+    # inherit, not an explicit mapping: the called workflow's jobs read
+    # GH_APP_ID, an environment secret. A `uses:` job cannot declare an
+    # environment, so mapping the secrets here would evaluate them in this job,
+    # pass GH_APP_ID through empty, and silently skip the minter deploy.
     secrets: inherit
-    uses: ./.github/workflows/reusable-deploy-integrations.yml
+    uses: ./.github/workflows/reusable-deploy-integrations.yml # zizmor: ignore[secrets-inherit]
     with:
       target_environment: "staging"
       force_deploy: true

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -20,4 +20,4 @@ jobs:
     with:
       target_environment: "staging"
       force_deploy: true
-      checkout_ref: ${{ github.ref }}
+      checkout_sha: ${{ github.sha }}


### PR DESCRIPTION
## Summary

`reusable-deploy-integrations.yml` is the one deploy workflow that PR #555 did not convert when it
hardened the agent and controller deploy pipelines: it still took a caller-supplied mutable git ref
and checked it out in four jobs, three of which hold the target environment's GKE and Workload
Identity credentials. Those same jobs warmed a Go module cache. This PR brings the integrations
pipeline in line with its two siblings — an immutable `checkout_sha`, `persist-credentials: false`,
and no module cache in a credentialed job.

## Why This Change

CodeQL alert [17](https://github.com/gke-labs/kube-agents/security/code-scanning/17)
(`actions/cache-poisoning/poisonable-step`, high) traces the `workflow_dispatch` trigger on
_Autopush Redeploy Integrations_ through `inputs.checkout_ref` into the credentialed redeploy steps.
A dispatch selects the branch, `github.ref` carried that branch straight into `actions/checkout`, and
the checked-out code then ran with deploy credentials and a warm cache. GitHub scopes caches by
branch and lets any branch read its parent's, so a cache written from a run on the default branch is
restorable by every branch built off it — the lateral-movement path the rule describes.

The mutable ref is a problem on its own, and it is the reason the alert exists on this file and not
on `reusable-deploy-agent.yml`: a ref resolved at checkout time can point at a different commit than
the one that triggered the run.

## What Changed

- `reusable-deploy-integrations.yml`: input `checkout_ref` → `checkout_sha`, with the same
  "must be a SHA, not a branch or tag ref" contract the agent and controller reusable workflows
  already state.
- Both callers pass `github.sha` instead of `github.ref`. Behaviour is unchanged for the two real
  triggers — on a push to `main` and on a `staging/**` tag, `github.sha` is the commit `github.ref`
  resolved to — but it is now fixed at dispatch time rather than at checkout time.
- `persist-credentials: false` on all four checkouts, matching the siblings.
- `cache: false` on the three `setup-go` steps. This is CodeQL's first recommendation ("avoid using
  caching in workflows that handle sensitive operations") and it is what actually removes the
  poisonable artifact: converting the ref alone does not, because a `workflow_dispatch` on a feature
  branch still runs that branch's unreviewed code by design. The cost is re-downloading the modules
  `go install` needs for kustomize on each deploy; `cache-dependency-path` pointed at
  `k8s-operator/go.sum`, which does not describe those modules anyway.

- `secrets: inherit` on both callers now carries a `zizmor: ignore[secrets-inherit]` and the reason
  for it. See Testing for why the finding appeared on this branch and why suppressing it is the
  honest answer rather than mapping the secrets explicitly.

## Context

Follow-up to #555, which fixed the same class of alert (13, 14) on `reusable-deploy-agent.yml` and
`reusable-deploy-controller.yml` and missed this file. No open PR or issue covers it. Generated with
the help of Claude.

`go` is genuinely required by two of the three jobs, so `setup-go` stays: `provision_09` runs
`make deploy-litellm`, which `go install`s kustomize, and `provision_10` runs `go run ./cmd/minty`
against a cloned third-party repo. Only `provision_07` needs no Go; I left its `setup-go` in place
rather than widen the diff.

## Testing

- `actionlint` 1.7.7 (the version `.github/workflows/actionlint.yml` pins): clean across all workflows.
- `prettier@3.9.6 --check` on the three changed files: clean.
- `zizmor` 1.25.2 with the config CI pulls from its bucket: the `zizmor-output` job failed on the
  first push with two medium `secrets-inherit` findings. Both are on `secrets: inherit` lines that
  exist on `main` unchanged — the gate scans only a branch's changed files, so touching these two
  callers is what pulled a pre-existing finding into scope. I reproduced the failure locally, then
  suppressed both with the reason in the file; `zizmor` now exits 0 on all three workflows.

  The finding is real but not safely fixable in this PR. An explicit `secrets:` mapping would have
  the caller evaluate `secrets.GH_APP_ID`, which is an *environment* secret on both `autopush` and
  `staging` (repo-level secrets are only `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, and unrelated ones).
  A job that calls a reusable workflow cannot declare an `environment:`, so the mapped value would
  arrive empty and `check-github-config` would skip the minter deploy with a notice rather than an
  error. Verifying the alternative needs a real deploy; worth a follow-up issue.
- `make docs-check`: clean. No document references these workflows or the renamed input, so there is
  no docs drift to fix; `grep` for `checkout_ref` across the tree returns nothing after the rename.

### Live validation

Not live-tested. The change is confined to GitHub Actions workflow definitions — nothing here reaches
a running kube-agents installation, and the code path only executes inside a GitHub-hosted runner.
Exercising it for real means dispatching _Autopush Redeploy Integrations_ and redeploying LiteLLM and
the GitHub Token Minter to the shared autopush cluster from branch code, which I did not want to do
unprompted on a shared environment.

Merging will not exercise it either: the autopush trigger filters on `k8s-operator/**` paths and this
branch touches only `.github/workflows/**`. So the plan is a manual `workflow_dispatch` of _Autopush
Redeploy Integrations_ on `main` immediately after merge, checking that `detect-changes` is skipped
(`force_deploy: true` on dispatch), that both deploy jobs check out the merge SHA, and that the two
rollouts verify. I will run that dispatch rather than leave it to the next integrations PR.

## Risk & Rollout

Low blast radius, but it is a deploy pipeline, so the failure mode is worth naming: if `cache: false`
turns out to interact badly with `setup-go`, the `Set up Go` step fails fast and no deployment
happens — the jobs fail closed, not half-applied. The other new failure mode is slower deploys
(one uncached module download per run, tens of seconds).

The merge to `main` matching `k8s-operator/**` paths will itself trigger _Autopush Redeploy
Integrations_ only if the merged commit touches the integration paths; this PR touches none of them,
so the first exercise will be the next integrations change or a manual dispatch. Worth a manual
dispatch on `main` after merge to confirm the pipeline is green rather than discovering it on someone
else's PR. Revert is a single revert commit; nothing outside `.github/workflows/` changes.
