### PR TITLE
docs(agents): check for existing review coverage before reviewing a PR

### DIFF
--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -169,12 +169,24 @@ Then offer three choices: **skip it**, **review only what landed since `<sha>`**
 commit, the one the query prints as `lastbot … commit=` — or **a full pass anyway**. I decide —
 coverage is a suggestion, and "the bot found nothing" is not a review verdict of yours.
 
-One case is empty and you can say so from here: `since: nothing, the review is at the tip`. Offer
-two choices rather than three. Do **not** say it of the other way a review can be current, a tail of
-presumed base merges. That is the case where the option earns its keep — a conflicted merge's
-hand-written resolution is precisely the code no review has read, and from up here it looks exactly
-like a clean one. It may still turn out to hold nothing, but that is a result Phase 3 reports after
-running `git show --cc` in a worktree, not a promise you can make before spending it.
+Two of the filter's three `since:` outcomes take the narrowed option off the table, and for opposite
+reasons. Offer two choices, not three, when the line reads either of these:
+
+- **`since: nothing, the review is at the tip`** — there is nothing after the review to narrow to.
+- **`since: review commit is not among those N commits`** — there is no anchor at all. That commit
+  was force-pushed away, or the branch outran the `commits(last: 100)` window, and either way
+  "everything since `<sha>`" names a starting point that is not on the branch. Phase 1 fetches only
+  `refs/pull/<N>/head`, so the SHA would not even resolve in the worktree, and `git log
+"$SINCE_SHA"..pr<N>` fails with `fatal: bad revision` on empty stdout — indistinguishable, to a
+  subagent reading stdout, from a delta that is genuinely empty. This is the case a stale verdict
+  exists for: offer the full pass, and say the anchor is gone rather than that there is nothing to
+  see.
+
+Do **not** withhold it for the remaining case, a tail of presumed base merges. That is where the
+option earns its keep — a conflicted merge's hand-written resolution is precisely the code no review
+has read, and from up here it looks exactly like a clean one. It may still turn out to hold nothing,
+but that is a result Phase 3 reports after running `git show --cc` in a worktree, not a promise you
+can make before spending it.
 
 Fan out only for what I keep, and tell each subagent its verdict, its mode, and — for a narrowed
 pass — the SHA, which it has no way to recover from a decision I made in the main loop.
@@ -402,16 +414,29 @@ Two substitutions for this context:
   `git diff "$SINCE_SHA"..pr<N>`, is the wrong one: every base-branch commit an intervening merge
   pulled in lands inside it — on #675 that is 250 files and 25,323 insertions of already-reviewed
   work, more than the full pass I declined rather than less. The three-dot form is no escape, being
-  the identical diff whenever `$SINCE_SHA` is an ancestor of `pr<N>`, which here it always is. Read
-  the commits instead, and against `pr<N>` rather than `HEAD`, since `HEAD` after a clean merge
-  carries a merge commit Phase 1b created seconds ago that no author wrote:
+  the identical diff whenever `$SINCE_SHA` is an ancestor of `pr<N>` — which is a precondition to
+  check, not a property to assume. Read the commits instead, and against `pr<N>` rather than `HEAD`,
+  since `HEAD` after a clean merge carries a merge commit Phase 1b created seconds ago that no
+  author wrote:
 
   ```bash
+  # Precondition. Phase 1 fetched only refs/pull/<N>/head, so a rebased-away anchor is
+  # not in this worktree at all: every command below would then exit 128 on empty stdout.
+  git merge-base --is-ancestor "$SINCE_SHA" pr<N> || exit 1
+
   git log "$SINCE_SHA"..pr<N> --no-merges --not "$BASE_REF" --format=%H   # the author's own commits
   git show <sha>                                                          # one per commit above
   git log "$SINCE_SHA"..pr<N> --merges --format=%H                        # every merge in between
   git show --cc <merge-sha>                                               # one per merge above
   ```
+
+  **Stop if the precondition fails** and report `status: skipped`, reason `since-anchor <sha> is not
+an ancestor of pr<N>`. Phase −1 is supposed to withhold the narrowed option in exactly that case,
+  so reaching here means either it did not, or the branch was force-pushed between its query and
+  your fetch. Do not fall back to a full pass I did not ask for, and above all do not read the empty
+  stdout as an empty delta: `fatal: bad revision` and "nothing landed since" are the same two blank
+  lines, and Phase 2's skip conditions — which would otherwise have caught a stale anchor — are
+  disabled for this mode.
 
   `--not "$BASE_REF"` earns its place for the reason Phase 2 gives. `--cc` is what this mode exists
   for: it prints only the hunks a merge resolved by hand, so empty output is the clean base merge
@@ -419,9 +444,10 @@ Two substitutions for this context:
   pass. Those hunks together are what the skill's step 2 means by the range — its angles apply to
   them, read as always at their state in `pr<N>` rather than as isolated hunks.
 
-  **Both lists coming back empty is a real outcome**, and #675 is one — no author commits, and a
-  merge whose `--cc` is bare. Report the delta as empty and say what you ran; do not go looking for
-  something to say, and do not quietly widen to the full diff I did not ask for. A defect you happen
+  **Both lists coming back empty is a real outcome once the precondition has passed**, and #675 is
+  one — no author commits, and a merge whose `--cc` is bare. Report the delta as empty and say what
+  you ran; do not go looking for something to say, and do not quietly widen to the full diff I did
+  not ask for. A defect you happen
   to notice outside the delta is still worth reporting, but you have not read the rest of the diff,
   so do not imply you have — Phase 4 records the scope.
 

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -9,13 +9,165 @@ PRs always live in that repo. Everything else — remote names, the base branch,
 location — is discovered at runtime, so this command works for any teammate in any clone regardless
 of what they called their remotes or where they cloned to.
 
-Spawn **one subagent per PR number**, all in a single message so they run concurrently. Each
-subagent owns exactly one PR end to end and reports back a short structured result. Do not review
-any PR yourself in the main loop — your job is to fan out, then relay.
+Run **Phase −1 in the main loop first**, for every PR number, and wait for my answer. Then spawn
+**one subagent per PR number that survives it**, all in a single message so they run concurrently.
+Each subagent owns exactly one PR end to end and reports back a short structured result. Do not
+review any PR yourself in the main loop — your job is to pre-flight, fan out, then relay.
 
-Give each subagent the instructions below verbatim, with `<N>` replaced by its PR number.
+Give each subagent everything under **[Subagent instructions (per PR)](#subagent-instructions-per-pr)**
+verbatim, with `<N>` replaced by its PR number, plus the PR's pre-flight verdict and the review mode
+I chose for it. Phase −1 is yours and stops at that heading: it asks me a question, which a subagent
+cannot do, so handing it on would either hang the subagent or have it answer on my behalf.
 
 ---
+
+## Phase −1 — Pre-flight: is this review already covered? (main loop)
+
+Every PR here is read by `kube-agents-bot` on the way in, and the repo requires the author to have
+run `review-adversarial` over their own diff and written the disposition into the body before
+opening. When both of those happened and neither has gone stale, a third hostile read usually buys
+nothing — so find that out before spending it.
+
+This phase runs **in the main loop, before any subagent exists**, for two reasons. Its output is a
+question for me, and a subagent has no way to ask one. And it is pure GitHub API — no worktree, no
+fetch, no diff read — so it costs two calls per PR whatever the answer turns out to be.
+
+### The two queries
+
+The repo is named literally in both: Phase −1 runs before Phase 0 defines `$REPO`.
+
+```bash
+# Signal 1, in one call: the head SHA, the bot's reviews with the commit each one
+# actually read, the commit graph, and the open threads. The filter reports the
+# commits *after* the review's commit, which is what the currency test needs.
+gh api graphql -f query='
+query($pr:Int!){repository(owner:"gke-labs",name:"kube-agents"){pullRequest(number:$pr){
+  headRefOid isDraft state author{login}
+  reviews(last:20){nodes{author{login} state submittedAt body commit{oid}}}
+  commits(last:100){nodes{commit{oid messageHeadline parents{totalCount}}}}
+  reviewThreads(first:100){nodes{isResolved path}}
+}}}' -F pr=<N> --jq '.data.repository.pullRequest as $p
+| ([$p.reviews.nodes[] | select(.author.login == "kube-agents-bot")] | last) as $r
+| ($p.commits.nodes | map(.commit)) as $cs
+| ($cs | map(.oid) | index($r.commit.oid // "")) as $i
+| "head=\($p.headRefOid) state=\($p.state) draft=\($p.isDraft) commits=\($cs|length) unresolved=\([$p.reviewThreads.nodes[]|select(.isResolved|not)]|length)",
+  (if $r == null then "lastbot: NONE"
+   else "lastbot at=\($r.submittedAt) commit=\($r.commit.oid)",
+        ($r.body | split("\n") | [.[0], (.[] | select(startswith("_This was a")))] | join("\n")),
+        (if $i == null then "since: review commit is not among those \($cs|length) commits"
+         elif $i == ($cs|length) - 1 then "since: nothing, the review is at the tip"
+         else "since:\n  " + ($cs[$i+1:] | map("\(.oid[0:7]) parents=\(.parents.totalCount) \(.messageHeadline)") | join("\n  "))
+         end)
+   end)'
+
+# Signal 2: the PR description. Read it yourself — see below.
+gh pr view <N> --repo gke-labs/kube-agents --json body -q .body
+```
+
+Use GraphQL for the reviews rather than `gh api repos/$REPO/pulls/<N>/reviews`: the REST endpoint
+has been observed returning an empty body against this repo while `/pulls/<N>/comments` worked.
+(REST does carry the review's `commit_id`, so that is not the reason — availability is.)
+
+Keep the filter's `.[0]` / `startswith` shape if you edit it. `gh --jq` is gojq, but the same
+program gets piped through real `jq` often enough that it has to run in both, and jq rejects a field
+access applied straight to a function call — `capture("…").s` compiles under gojq and is a syntax
+error under jq 1.6.
+
+All three page sizes are caps rather than promises:
+
+- `reviews(last: 20)` and `reviewThreads(first: 100)` — on a long-lived PR, say you looked at the
+  last twenty reviews rather than reporting it clear off a truncated list.
+- `commits(last: 100)` — a branch can outrun that, and a review older than the window is then
+  indistinguishable from one whose commit was force-pushed away. Both print the same
+  `since: … not among those N commits`. That lands on stale either way, which is the safe direction,
+  but when `commits=100` say "could not confirm currency" rather than "force-pushed".
+
+### Signal 1 — a current, clean bot review
+
+Three things must hold.
+
+**Clean.** The **last** bot review's body opens with either of the two clean verdicts. GraphQL
+reports the login as `kube-agents-bot`, without the `[bot]` suffix the REST API adds. Take the last
+one: after a `/review` the earlier review is still sitting there, and reading it back looks exactly
+like the new one.
+
+- `**No findings.**` — nothing raised anywhere.
+- `**No findings in the code.**` — the bot cleared the diff and raised something outside it, a note
+  on the description usually. It counts, but quote the note in the evidence rather than letting the
+  word "clean" swallow it.
+
+Note the width too. The footer reads `_This was a strict pass: only what I am certain of…_` or
+`_This was a wider pass: as well as what I am certain of…_`. A strict-pass clean covers less ground
+than a wide-pass clean, and I may want the difference.
+
+**Current.** Either the review's commit is the head, or everything after it is a merge
+(`parents.totalCount > 1`). Merging the base branch in is not new work to review — this is the
+API-only twin of the `git log <sha>..HEAD --no-merges --not "$BASE_REF"` rule in Phase 2. Two ways
+it is softer than that rule, both worth saying out loud rather than papering over:
+
+- A conflicted merge carries hand-written resolution that no review has seen, and over the API it
+  looks exactly like a clean one. When the tail is merges, call them presumed base merges and offer
+  the delta pass; only a worktree (`git show --cc <sha>`) can tell the two apart, and Phase −1 has
+  no worktree by design.
+- A review commit missing from the list is stale, but see the `commits(last: 100)` caveat above for
+  which kind of stale.
+
+**Nothing left open.** No unresolved review thread. An open thread is outstanding work by the repo's
+own merge rules, however clean the latest review reads.
+
+### Signal 2 — the author reviewed and tested it themselves
+
+Read the body. Two of its sections are what AGENTS.md's "Pull Request Hygiene" requires before a
+pull request is opened at all:
+
+- **`## Self-Review`** — the disposition list from the author's own `review-adversarial` pass: what
+  they looked for, what it found, and for each finding whether they fixed it or decided not to and
+  why. This is the signal that matters most here, because it is the only one that says somebody
+  already read this diff hostilely.
+- **`### Live validation`** (and the `## Testing` section around it) — that the change was actually
+  exercised. `Not live-tested` with a stated reason is a filled section.
+
+Judge them by reading, not by measuring. A section holding only the template's HTML comment,
+whitespace, or a bare `-` is unfilled — but so is a paragraph that says "reviewed it, looks fine",
+because the bar AGENTS.md sets is that "no findings" counts **only alongside what was looked for**.
+Length settles neither question. Watch for the section heading appearing in prose elsewhere in the
+body, which is why this is a read rather than a regex: a PR that discusses the `## Self-Review`
+section is not a PR that filled one in.
+
+When the section is missing or unanswered, Signal 2 fails — say so plainly, since that is the first
+thing the review would report anyway.
+
+Do not reach for the author's inline comments as a substitute. Authors here do not leave top-level
+inline comments on their own diffs; what you see under an author's name are replies to bot threads,
+which is engagement with a review rather than one.
+
+### The verdicts
+
+| Verdict   | When                                                                    | What you do                                                                  |
+| --------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `skip`    | Draft, closed, or merged                                                | Report it and stop — no queries argued, no subagent                          |
+| `covered` | Signal 1 in full, plus Signal 2                                         | Report the evidence and **ask me** before reviewing                          |
+| `partial` | Clean bot review but stale, or Signal 2 missing, or a thread still open | Report it, name exactly what is missing, and offer a narrower or a full pass |
+| `review`  | No clean bot review — the bot found issues, or never ran                | Proceed to fan-out with no prompt                                            |
+
+`skip` is the same judgement Phase 2 makes and the same one it reports; making it here as well just
+saves spawning a subagent to reach it. A draft is the author saying they are not asking yet.
+
+### The ask
+
+If nothing is `covered` or `partial`, say so in one line and fan out. Otherwise, per such PR, put
+the evidence in front of me before you spend anything:
+
+- the bot review's first line, its width, and its date;
+- its commit versus the head, and what the commits in between are, if any;
+- what the Self-Review section says it looked for and found, in a line or two;
+- the Live-validation section in one line — what the author says they exercised;
+- for `partial`, the single thing that is missing.
+
+Then offer three choices: **skip it**, **review only what landed since `<sha>`** (the point of the
+`partial` case; empty by construction when the review is current), or **a full pass anyway**. I
+decide — coverage is a suggestion, and "the bot found nothing" is not a review verdict of yours.
+Fan out only for what I keep, and tell each subagent its verdict and mode.
 
 ## Subagent instructions (per PR)
 
@@ -165,6 +317,18 @@ matching this PR.
   wrong even when the author pushed nothing at all.
 
 A merge conflict is **not** a skip reason. Neither is an unmergeable `mergeStateStatus`.
+
+**Do not re-litigate coverage.** Phase −1 already weighed the bot's verdict and the author's
+evidence — either it found no coverage worth raising, or it raised it and was told to go ahead. You
+were spawned either way, so a clean bot review is not a skip reason at this point, and neither is a
+thorough Self-Review section. Review at the mode you were given.
+
+Both are still worth reading, for a different purpose. The Self-Review section is where AGENTS.md
+tells every reviewer to start — it says where the author's own pass stopped, so yours can start
+there — and the bot's review says what a second reader already cleared. Neither is a reason to drop
+a finding of your own; both are a reason to be able to say why they missed it. A finding on a line
+the bot passed, or one the author rejected with a reason, needs the skill's step 5 to answer them
+rather than talk past them.
 
 Otherwise proceed. If a prior review exists but new commits landed, review the current head in full
 and note in your report which findings from the prior review the new commits resolved. Read the

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -319,9 +319,9 @@ matching this PR.
   saying they are not asking for review yet, and review comments on unfinished work are noise at
   best. Wait for ready-for-review;
 - a saved review already exists for this PR **and** `headRefOid` matches the head SHA it recorded —
-  nothing has changed since;
+  nothing has changed since (`full` mode only, see below);
 - a saved review exists and the author has landed no work of their own since — merging the base
-  branch in is not new work to review:
+  branch in is not new work to review (`full` mode only, see below):
 
   ```bash
   git log <recorded-sha>..HEAD --no-merges --not "$BASE_REF"     # empty → skip
@@ -339,6 +339,16 @@ before them, so a matching head SHA there says that nothing new has landed, not 
 ever read whole — skipping on it would let one narrowed pass suppress the full one permanently.
 Proceed instead, and say in your report that the prior review was a narrowed one and what it
 covered. A saved review with no scope field predates the narrowed mode and was a full pass.
+
+**Neither condition applies at all when `$REVIEW_MODE` is `since`.** They read a saved review of
+ours; Phase −1 read the bot's and mine; and because the two never consult each other, the second
+condition silently cancels precisely the pass Phase −1 got authorisation for. It is empty _by
+construction_ on a merge tail — `--no-merges` drops the merge and `--not "$BASE_REF"` drops
+everything it pulled in — which is the same fact that made Phase −1 call the bot review current and
+offer the narrowed pass in the first place. Skipping there means the merge's `git show --cc` output
+is read by nobody, and that output is the whole reason I paid for the pass. So run it. If the delta
+turns out empty, Phase 3 says so and names what it ran, which is a report; `status: skipped` off a
+condition I was never asked about is not.
 
 A merge conflict is **not** a skip reason. Neither is an unmergeable `mergeStateStatus`.
 

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -15,9 +15,10 @@ Each subagent owns exactly one PR end to end and reports back a short structured
 review any PR yourself in the main loop — your job is to pre-flight, fan out, then relay.
 
 Give each subagent everything under **[Subagent instructions (per PR)](#subagent-instructions-per-pr)**
-verbatim, with `<N>` replaced by its PR number, plus the PR's pre-flight verdict and the review mode
-I chose for it. Phase −1 is yours and stops at that heading: it asks me a question, which a subagent
-cannot do, so handing it on would either hang the subagent or have it answer on my behalf.
+verbatim, with `<N>` replaced by its PR number, plus the PR's pre-flight verdict, the review mode I
+chose for it, and the SHA that mode starts from when it is a narrowed one. Phase −1 is yours and
+stops at that heading: it asks me a question, which a subagent cannot do, so handing it on would
+either hang the subagent or have it answer on my behalf.
 
 ---
 
@@ -164,10 +165,19 @@ the evidence in front of me before you spend anything:
 - the Live-validation section in one line — what the author says they exercised;
 - for `partial`, the single thing that is missing.
 
-Then offer three choices: **skip it**, **review only what landed since `<sha>`** (the point of the
-`partial` case; empty by construction when the review is current), or **a full pass anyway**. I
-decide — coverage is a suggestion, and "the bot found nothing" is not a review verdict of yours.
-Fan out only for what I keep, and tell each subagent its verdict and mode.
+Then offer three choices: **skip it**, **review only what landed since `<sha>`** — the bot review's
+commit, the one the query prints as `lastbot … commit=` — or **a full pass anyway**. I decide —
+coverage is a suggestion, and "the bot found nothing" is not a review verdict of yours.
+
+One case is empty and you can say so from here: `since: nothing, the review is at the tip`. Offer
+two choices rather than three. Do **not** say it of the other way a review can be current, a tail of
+presumed base merges. That is the case where the option earns its keep — a conflicted merge's
+hand-written resolution is precisely the code no review has read, and from up here it looks exactly
+like a clean one. It may still turn out to hold nothing, but that is a result Phase 3 reports after
+running `git show --cc` in a worktree, not a promise you can make before spending it.
+
+Fan out only for what I keep, and tell each subagent its verdict, its mode, and — for a narrowed
+pass — the SHA, which it has no way to recover from a decision I made in the main loop.
 
 ## Subagent instructions (per PR)
 
@@ -211,6 +221,13 @@ Set `BASE_REF` once to whichever applies and use `$BASE_REF` everywhere below.
 
 `$MAIN_ROOT` is the top of the primary checkout even when you are standing inside a worktree; it is
 where saved reviews live so that every run — and every teammate — sees the same history.
+
+Two more variables come from the main loop rather than from here, and carry the same way:
+`$REVIEW_MODE` is `full` or `since`, and in `since` mode `$SINCE_SHA` is the commit Phase −1 found
+already reviewed. Phase 3 picks what it reads off them and Phase 4 records them. **Spawned without
+a mode, you are `full`** — that is what the `review` verdict hands over, and it is the common case.
+Never infer a narrower one from the PR's history yourself: narrowing is mine to authorise, and a
+review that silently reads less than the whole diff still saves a file the next run trusts.
 
 ### Phase 1 — Worktree
 
@@ -316,6 +333,13 @@ matching this PR.
   skip. Phase 1b has already merged the base locally by this point, which makes the unfiltered range
   wrong even when the author pushed nothing at all.
 
+Both of those conditions read the saved review's **scope** as well as its SHA, and skip only on
+`scope: full`. A file recording `scope: since <sha>` covers the commits after that SHA and nothing
+before them, so a matching head SHA there says that nothing new has landed, not that the diff was
+ever read whole — skipping on it would let one narrowed pass suppress the full one permanently.
+Proceed instead, and say in your report that the prior review was a narrowed one and what it
+covered. A saved review with no scope field predates the narrowed mode and was a full pass.
+
 A merge conflict is **not** a skip reason. Neither is an unmergeable `mergeStateStatus`.
 
 **Do not re-litigate coverage.** Phase −1 already weighed the bot's verdict and the author's
@@ -360,8 +384,37 @@ Phase 4 already read the saved-review directory.
 
 Two substitutions for this context:
 
-- **The diff range is the one Phase 1b settled on** — `$BASE_REF...HEAD` after a clean merge, or
-  `$BASE_REF...pr<N>` when the merge conflicted and was aborted. Never `main` on its own.
+- **The diff range follows `$REVIEW_MODE`.** In `full` mode it is the one Phase 1b settled on —
+  `$BASE_REF...HEAD` after a clean merge, or `$BASE_REF...pr<N>` when the merge conflicted and was
+  aborted. Never `main` on its own.
+
+  `since` mode has **no such range, and you must not invent one.** The obvious answer,
+  `git diff "$SINCE_SHA"..pr<N>`, is the wrong one: every base-branch commit an intervening merge
+  pulled in lands inside it — on #675 that is 250 files and 25,323 insertions of already-reviewed
+  work, more than the full pass I declined rather than less. The three-dot form is no escape, being
+  the identical diff whenever `$SINCE_SHA` is an ancestor of `pr<N>`, which here it always is. Read
+  the commits instead, and against `pr<N>` rather than `HEAD`, since `HEAD` after a clean merge
+  carries a merge commit Phase 1b created seconds ago that no author wrote:
+
+  ```bash
+  git log "$SINCE_SHA"..pr<N> --no-merges --not "$BASE_REF" --format=%H   # the author's own commits
+  git show <sha>                                                          # one per commit above
+  git log "$SINCE_SHA"..pr<N> --merges --format=%H                        # every merge in between
+  git show --cc <merge-sha>                                               # one per merge above
+  ```
+
+  `--not "$BASE_REF"` earns its place for the reason Phase 2 gives. `--cc` is what this mode exists
+  for: it prints only the hunks a merge resolved by hand, so empty output is the clean base merge
+  Phase −1 could only presume it was, and non-empty output is the unreviewed code that justified the
+  pass. Those hunks together are what the skill's step 2 means by the range — its angles apply to
+  them, read as always at their state in `pr<N>` rather than as isolated hunks.
+
+  **Both lists coming back empty is a real outcome**, and #675 is one — no author commits, and a
+  merge whose `--cc` is bare. Report the delta as empty and say what you ran; do not go looking for
+  something to say, and do not quietly widen to the full diff I did not ask for. A defect you happen
+  to notice outside the delta is still worth reporting, but you have not read the rest of the diff,
+  so do not imply you have — Phase 4 records the scope.
+
 - **Angle J already has an author to filter by**, which the skill cannot assume:
   `gh pr list --repo "$REPO" --author <login> --state open --json number,title,files`. Read the
   review comments on any sibling touching adjacent paths.
@@ -382,13 +435,16 @@ your report back — everywhere.
 Save the review to `$MAIN_ROOT/.claude/pr-reviews/pr-<N>-<short-slug>.md`, matching the structure of
 the files already in that directory:
 
-- header block: title, author, review date, **head SHA reviewed** (needed for the skip check on the
-  next run), base branch and base SHA, diff stat, worktree path;
+- header block: title, author, review date, **head SHA reviewed**, **scope** — `full`, or
+  `since <sha>` — base branch and base SHA, diff stat, worktree path. The next run's skip check
+  needs both of the bold ones: it trusts a matching SHA only where the scope says the whole diff was
+  read, so a narrowed pass that records only the SHA reads exactly like a full one and cancels it;
 - **Intent** — the one-sentence claim from Phase 2b, so the next reader knows what the findings were
   measured against;
 - **Verdict** — can this merge as is, yes or no, with the blocking items named, and what the
   `mergeStateStatus` actually reflects. When the PR conflicts with its base, say so here and state
-  that the review covers the PR as authored, not as merged;
+  that the review covers the PR as authored, not as merged. In `since` mode say that too: the
+  verdict speaks for the commits you read, not for the pull request;
 - **Checks run** — commands executed and what they showed;
 - **Findings** — severity-ordered, each with anchor, description, failure scenario, and verdict;
 - **Not findings, for the record** — things that look wrong but are fine, so the next reader does
@@ -404,6 +460,7 @@ Report back to the main agent, and nothing more than this:
 pr: <N>
 status: reviewed | skipped
 reason: <one line, only when skipped>
+scope: full | since <sha>
 mergeable: yes | no
 block_reason: ci | review-required | labels | conflicts | none
 conflicts: none | <comma-separated paths>
@@ -420,8 +477,9 @@ blockers: <one line each, file:line — claim>
 
 Print one compact table across all PRs — number, title, verdict, block reason, blocker count,
 review file path — then the blocker one-liners grouped by PR. Call out explicitly any PR that was
-skipped and why, and any that was reviewed against a conflicting base (those reviews cover the PR
-as authored, not as merged).
+skipped and why, any that was reviewed against a conflicting base (those reviews cover the PR as
+authored, not as merged), and any reviewed at a narrowed scope, naming the SHA it started from —
+those cover the commits since that SHA and say nothing about the rest of the diff.
 
 Do not post to GitHub unless I ask. When I do, post findings only — no verdict, no CI summary, no
 closing section — and tell me whether you posted it as an issue comment or a formal review.

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -31,7 +31,8 @@ nothing — so find that out before spending it.
 
 This phase runs **in the main loop, before any subagent exists**, for two reasons. Its output is a
 question for me, and a subagent has no way to ask one. And it is pure GitHub API — no worktree, no
-fetch, no diff read — so it costs two calls per PR whatever the answer turns out to be.
+fetch, no diff read — so it costs two calls per PR, plus one per merge sitting after the bot's
+review, which is nearly always none or one.
 
 ### The two queries
 
@@ -45,7 +46,7 @@ gh api graphql -f query='
 query($pr:Int!){repository(owner:"gke-labs",name:"kube-agents"){pullRequest(number:$pr){
   headRefOid isDraft state author{login}
   reviews(last:20){nodes{author{login} state submittedAt body commit{oid}}}
-  commits(last:100){nodes{commit{oid messageHeadline parents{totalCount}}}}
+  commits(last:100){nodes{commit{oid messageHeadline parents(first:2){totalCount nodes{oid}}}}}
   reviewThreads(first:100){nodes{isResolved path}}
 }}}' -F pr=<N> --jq '.data.repository.pullRequest as $p
 | ([$p.reviews.nodes[] | select(.author.login == "kube-agents-bot")] | last) as $r
@@ -54,10 +55,10 @@ query($pr:Int!){repository(owner:"gke-labs",name:"kube-agents"){pullRequest(numb
 | "head=\($p.headRefOid) state=\($p.state) draft=\($p.isDraft) commits=\($cs|length) unresolved=\([$p.reviewThreads.nodes[]|select(.isResolved|not)]|length)",
   (if $r == null then "lastbot: NONE"
    else "lastbot at=\($r.submittedAt) commit=\($r.commit.oid)",
-        ($r.body | split("\n") | [.[0], (.[] | select(startswith("_This was a")))] | join("\n")),
+        ($r.body | split("\n") | [.[0], (.[] | select(startswith("### Findings outside") or startswith("#### ") or startswith("_This was a")))] | join("\n")),
         (if $i == null then "since: review commit is not among those \($cs|length) commits"
          elif $i == ($cs|length) - 1 then "since: nothing, the review is at the tip"
-         else "since:\n  " + ($cs[$i+1:] | map("\(.oid[0:7]) parents=\(.parents.totalCount) \(.messageHeadline)") | join("\n  "))
+         else "since:\n  " + ($cs[$i+1:] | map("\(.oid[0:7]) parents=\(.parents.totalCount)\(if .parents.totalCount > 1 then " p2=" + .parents.nodes[1].oid[0:7] else "" end) \(.messageHeadline)") | join("\n  "))
          end)
    end)'
 
@@ -97,19 +98,47 @@ like the new one.
   on the description usually. It counts, but quote the note in the evidence rather than letting the
   word "clean" swallow it.
 
+Where that note lives decides whether you have it. Sometimes it is in the first line, as on #684.
+Sometimes the body carries a whole `### Findings outside this diff` section — findings the bot could
+not anchor to a changed line — and on #709 that section ran to a 🔴 High and fifteen hundred words.
+The filter keeps the section heading and each finding's `####` title line, not the argument under
+them, which is enough to see that one exists and to quote it in a line. When the heading does
+appear, re-run the same query with `--jq '…| last | .body'` and read it before you put `covered` in
+front of me — one more call, on the rare PR that needs it. An unanchored High is a live finding on
+the pull request, and it must not vanish between the review and the evidence I am shown.
+
 Note the width too. The footer reads `_This was a strict pass: only what I am certain of…_` or
 `_This was a wider pass: as well as what I am certain of…_`. A strict-pass clean covers less ground
 than a wide-pass clean, and I may want the difference.
 
-**Current.** Either the review's commit is the head, or everything after it is a merge
-(`parents.totalCount > 1`). Merging the base branch in is not new work to review — this is the
-API-only twin of the `git log <sha>..HEAD --no-merges --not "$BASE_REF"` rule in Phase 2. Two ways
-it is softer than that rule, both worth saying out loud rather than papering over:
+**Current.** Either the review's commit is the head, or everything after it is a merge **from the
+base branch**. Merging the base branch in is not new work to review — this is the API-only twin of
+the `git log <sha>..HEAD --no-merges --not "$BASE_REF"` rule in Phase 2.
+
+`parents.totalCount > 1` is necessary and nowhere near sufficient. A sibling feature branch, or a
+colleague's fork branch, merges with two parents exactly like `main` does, and it brings an entire
+branch of code no review has read; `messageHeadline` is no backstop, since `Merge branch 'main'` is
+a string anyone can type. The git rule catches this and the parent count does not, which is why the
+filter prints the second parent as `p2=`. Confirm it is on the base branch before calling the review
+current:
+
+```bash
+# One call per merge in the tail. "identical" or "behind" means <p2> was already on
+# the base branch, so the merge brought in nothing unreviewed. "ahead" or "diverged"
+# means it brought in a branch of its own: the review is stale, not current.
+gh api repos/gke-labs/kube-agents/compare/<base-branch>...<p2> --jq .status
+```
+
+On #675 that is `behind` for `p2=5bc8165`, which is what makes its 8-commit tail a base merge. An
+octopus merge has parents past the second; check each of them the same way, or call the review stale
+and say why. Two ways this is still softer than the git rule, both worth saying out loud rather than
+papering over:
 
 - A conflicted merge carries hand-written resolution that no review has seen, and over the API it
-  looks exactly like a clean one. When the tail is merges, call them presumed base merges and offer
-  the delta pass; only a worktree (`git show --cc <sha>`) can tell the two apart, and Phase −1 has
-  no worktree by design.
+  looks exactly like a clean one — `compare` reports on the parent, not on what the author did with
+  it. When the tail is merges, call them presumed base merges and offer the delta pass; only a
+  worktree can tell the two apart, and Phase −1 has no worktree by design. Phase 3 does that check;
+  it does not use `git show --cc`, for a reason worth reading before you assume it would have.
 - A review commit missing from the list is stale, but see the `commits(last: 100)` caveat above for
   which kind of stale.
 
@@ -185,8 +214,8 @@ reasons. Offer two choices, not three, when the line reads either of these:
 Do **not** withhold it for the remaining case, a tail of presumed base merges. That is where the
 option earns its keep — a conflicted merge's hand-written resolution is precisely the code no review
 has read, and from up here it looks exactly like a clean one. It may still turn out to hold nothing,
-but that is a result Phase 3 reports after running `git show --cc` in a worktree, not a promise you
-can make before spending it.
+but that is a result Phase 3 reports after replaying the merge in a worktree, not a promise you can
+make before spending it.
 
 Fan out only for what I keep, and tell each subagent its verdict, its mode, and — for a narrowed
 pass — the SHA, which it has no way to recover from a decision I made in the main loop.
@@ -357,9 +386,9 @@ ours; Phase −1 read the bot's and mine; and because the two never consult each
 condition silently cancels precisely the pass Phase −1 got authorisation for. It is empty _by
 construction_ on a merge tail — `--no-merges` drops the merge and `--not "$BASE_REF"` drops
 everything it pulled in — which is the same fact that made Phase −1 call the bot review current and
-offer the narrowed pass in the first place. Skipping there means the merge's `git show --cc` output
-is read by nobody, and that output is the whole reason I paid for the pass. So run it. If the delta
-turns out empty, Phase 3 says so and names what it ran, which is a report; `status: skipped` off a
+offer the narrowed pass in the first place. Skipping there means the merge's hand-written
+resolution is read by nobody, and that resolution is the whole reason I paid for the pass. So run
+it. If the delta turns out empty, Phase 3 says so and names what it ran, which is a report; `status: skipped` off a
 condition I was never asked about is not.
 
 A merge conflict is **not** a skip reason. Neither is an unmergeable `mergeStateStatus`.
@@ -427,7 +456,11 @@ Two substitutions for this context:
   git log "$SINCE_SHA"..pr<N> --no-merges --not "$BASE_REF" --format=%H   # the author's own commits
   git show <sha>                                                          # one per commit above
   git log "$SINCE_SHA"..pr<N> --merges --format=%H                        # every merge in between
-  git show --cc <merge-sha>                                               # one per merge above
+
+  # Per merge: replay it, and diff the machine's result against the author's. What
+  # comes out is exactly what the human did that an automatic merge would not have.
+  AUTO=$(git merge-tree --write-tree <merge-sha>^1 <merge-sha>^2 | head -1)
+  git diff "$AUTO" <merge-sha>^{tree}
   ```
 
   **Stop if the precondition fails** and report `status: skipped`, reason `since-anchor <sha> is not
@@ -438,18 +471,36 @@ an ancestor of pr<N>`. Phase −1 is supposed to withhold the narrowed option in
   lines, and Phase 2's skip conditions — which would otherwise have caught a stale anchor — are
   disabled for this mode.
 
-  `--not "$BASE_REF"` earns its place for the reason Phase 2 gives. `--cc` is what this mode exists
-  for: it prints only the hunks a merge resolved by hand, so empty output is the clean base merge
-  Phase −1 could only presume it was, and non-empty output is the unreviewed code that justified the
-  pass. Those hunks together are what the skill's step 2 means by the range — its angles apply to
-  them, read as always at their state in `pr<N>` rather than as isolated hunks.
+  `--not "$BASE_REF"` earns its place for the reason Phase 2 gives, and it is doing more work than
+  it looks: a sibling branch merged into the PR contributes its own non-merge commits to that first
+  list, because they are reachable from `pr<N>` and not from the base. That is the git-side check
+  Phase −1 can only approximate with `compare`.
+
+  **Do not reach for `git show --cc` here**, however natural it looks. `--cc` prunes every hunk whose
+  merge result matches one of the parents, and taking one side wholesale — `git checkout --ours`,
+  `--theirs`, or picking a variant per hunk — is how most conflicts are actually resolved. A merge
+  that discarded the base branch's change to a file the PR also touched prints a bare 162-byte
+  header, byte-identical to a merge that had no conflict at all. Empty `--cc` means "nothing was
+  resolved into a form that differs from both parents", which is not the claim this mode needs.
+
+  `git merge-tree --write-tree` (git ≥ 2.38) makes the claim it needs. It replays the merge with no
+  worktree and prints the tree an automatic merge would have produced — conflict markers and all,
+  exiting 1 when it hit one — so diffing that tree against the merge's own tree yields precisely the
+  author's contribution: the resolution they wrote, or nothing at all when the merge really was
+  clean. Empty there **is** the clean base merge Phase −1 could only presume it was, and non-empty is
+  the unreviewed code that justified the pass. Two edges: on a merge with more than two parents
+  `merge-tree` takes only two, and on git below 2.38 the flag does not exist. In either case fall
+  back to `git show --cc`, and say in the review that the merge was checked with the weaker test.
+
+  The author's commits and whatever the replay turns up are together what the skill's step 2 means
+  by the range — its angles apply to them, read as always at their state in `pr<N>` rather than as
+  isolated hunks.
 
   **Both lists coming back empty is a real outcome once the precondition has passed**, and #675 is
-  one — no author commits, and a merge whose `--cc` is bare. Report the delta as empty and say what
-  you ran; do not go looking for something to say, and do not quietly widen to the full diff I did
-  not ask for. A defect you happen
-  to notice outside the delta is still worth reporting, but you have not read the rest of the diff,
-  so do not imply you have — Phase 4 records the scope.
+  one — no author commits, and a merge the replay reproduces exactly. Report the delta as empty and
+  say what you ran; do not go looking for something to say, and do not quietly widen to the full
+  diff I did not ask for. A defect you happen to notice outside the delta is still worth reporting,
+  but you have not read the rest of the diff, so do not imply you have — Phase 4 records the scope.
 
 - **Angle J already has an author to filter by**, which the skill cannot assume:
   `gh pr list --repo "$REPO" --author <login> --state open --json number,title,files`. Read the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,3 +367,36 @@ Four ways that goes wrong quietly:
   handled.
 - `unresolveReviewThread`, same `threadId`, is the undo. Use it the moment the user disagrees with
   something you resolved.
+
+## Before Reviewing Someone Else's Pull Request
+
+The section above is about your own pull request being reviewed, and it already says where a
+reviewer starts: the **Self-Review** section, before the diff. This one is the question that comes
+before even that — whether the review you have been asked for needs to happen at all.
+
+By the time anyone asks, a pull request here has usually been read twice already: `kube-agents-bot`
+reads every one, and "Pull Request Hygiene" separately required the author to run
+`review-adversarial` over their own diff, record the result in **Self-Review**, and exercise the
+change under **Live validation**. Where both of those hold and neither has gone stale, a third
+hostile read is usually redundant spend.
+
+So check for both first — and then **ask rather than decide**. Say what the evidence is and that
+the extra round may be unnecessary; let the person who asked choose whether to spend it. Skipping a
+review unilaterally is not yours to do, and neither is quietly running one you have reason to
+believe nobody needs.
+
+Two things make this go wrong quietly:
+
+- **Currency.** A clean review sitting at an older commit proves nothing about the current head —
+  unless the only commits since it are merges from the base branch, which are not new work to
+  review. Treat a review whose commit has vanished from the branch as stale, not clean. An
+  unresolved review thread says the same thing: work outstanding, however clean the latest review
+  reads.
+- **A Self-Review that is present but unanswered.** "No findings" counts only alongside what was
+  looked for, so a bare "reviewed it" is an absent section with characters in it — and, per the
+  section above, the first finding your review reports rather than a reason to skip it.
+
+[`.claude/commands/pr-review-batch.md`](.claude/commands/pr-review-batch.md) is the canonical home
+for the mechanics — the queries, what counts as a clean verdict, the verdicts they produce, and what
+to put in front of the user. Follow it whether or not the review was started through the slash
+command, and change it rather than this section when the mechanics move.


### PR DESCRIPTION
## Summary

A review request in this repository almost always lands on a pull request that two readers have already been through: `kube-agents-bot` reads every one on the way in, and "Pull Request Hygiene" requires the author to have run `review-adversarial` over their own diff and written the disposition into the body before opening it. This adds a pre-flight to `/pr-review-batch` that looks for that evidence before spending a review, and a rule in `AGENTS.md` so the same check fires when someone asks in prose rather than through the slash command. When the evidence is there, the agent reports it and asks whether the extra round is wanted — it never skips on its own.

## Why This Change

`/pr-review-batch` currently spends a full ten-angle pass unconditionally. Its Phase 2 gate catches only the obvious cases — closed, draft, already reviewed at this SHA — and cannot see the expensive one: a pull request that already carries a current clean bot review and a filled-in Self-Review. Without this, every "review PR #NNN" is a worktree, a fetch, a full diff read and a hostile pass over a change two readers have already cleared. The waste is invisible, because a third pass finding nothing looks exactly like a third pass that was worth running.

## What Changed

- **`.claude/commands/pr-review-batch.md`** — a new **Phase −1** between the intro and the subagent instructions. It runs in the main loop before any subagent exists, because its output is a question and a subagent cannot ask one, and because it is pure GitHub API: two calls per PR, no worktree, no fetch, no diff. It weighs a current clean bot review with no unresolved threads against the author's own Self-Review and Live-validation sections, and lands on one of four verdicts (`skip` / `covered` / `partial` / `review`). Phase 2 gains a paragraph telling the subagent not to re-litigate coverage that has already been settled above it.
- **`AGENTS.md`** — a new "Before Reviewing Someone Else's Pull Request" section after the automated-review one. It states the rule and the two traps (currency, a Self-Review that is present but unanswered) and defers to the command file for the mechanics, so the queries live in exactly one place.
- **`caec82f`, answering the bot's review of `49000a5`** — the narrowed pass Phase −1 offers is now implemented below it, where before it was offered and then silently ignored. `$REVIEW_MODE` and `$SINCE_SHA` carry from the main loop through Phase 0, Phase 3's diff-range substitution branches on the mode, Phase 4 records `scope: full | since <sha>` in the saved review and the report-back, and Phase 2's two SHA-based skip conditions skip only on `scope: full` — otherwise one narrowed pass would suppress the full one permanently. `since` mode reads a **commit list**, not a diff range; Live validation below is why.
- **`e02bd7e0` and `3131379`, answering the two strict re-reads that followed** — the narrowed mode is exempt from both of Phase 2's SHA-based skips (they are empty by construction on the merge tail the mode exists to read), and its anchor is now guarded at both ends: Phase −1 withholds the offer when the bot's commit is not on the branch, and Phase 3 asserts `git merge-base --is-ancestor` before it will treat an empty delta as an empty delta. Items 17 and 18 in the addendum.
- **`b4a91cf3`, answering the fourth strict pass** — Phase −1 keeps the bot's out-of-diff findings instead of filtering them away, its currency test checks that a tail merge's second parent is actually on the base branch, and Phase 3 replays merges with `git merge-tree --write-tree` rather than trusting an empty `git show --cc`. Items 19–21.

Two details in Phase −1 are load-bearing and easy to get wrong:

- **Currency.** A clean review at an older commit is still current if everything after it is a base merge — the API-only twin of Phase 2's `git log <sha>..HEAD --no-merges --not "$BASE_REF"`. The filter therefore prints the commits _after_ the review's commit with their parent counts, rather than making the reader guess. It is softer than the git rule in one way the section states plainly: a conflicted merge carries hand-written resolution no review has seen, and over the API it looks identical to a clean one.
- **Signal 2 is a read, not a regex.** Whether a Self-Review section actually answers is a judgement — "reviewed it, looks fine" has plenty of characters and says nothing — so the pre-flight fetches the body and reads it.

`.claude/` is exempt from the documentation map (`scripts/check_docs_map.py`), and `AGENTS.md` is already mapped, so no `docs/README.md` edit is needed.

## Context

Generated with the help of Claude.

Duplicate-work scan run before starting: no open pull request touches either file and no open issue describes this. It does build directly on #703, which merged mid-task and added the `## Self-Review` section this pre-flight reads — this branch is rebased onto it and Signal 2 targets that section by name.

## Testing

- `make docs-check` — clean (generated regions current, 243 files link-checked, terminology passed, map inventory covers all 215 tracked docs).
- `prettier@3.9.6 --check AGENTS.md .claude/commands/pr-review-batch.md` — clean.
- No Go, chart, or manifest surface is touched, so no build or unit-test target applies.

### Live validation

This change is agent instructions and repository rules. It reaches no cluster, no CR, no pod — there is nothing in a running kube-agents installation for it to affect, so the usual layers (`.status`, Deployment env, the file in the pod) have nothing to report. What it _does_ reach is the live GitHub API, and that is what was exercised: both Phase −1 queries were run by hand against real pull requests and each verdict checked against what the pull request actually is.

| PR       | What the query returned                                                                                   | Verdict it lands on                                                                  |
| -------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| **#675** | `commits=8 unresolved=0`, bot `**No findings.**` (strict pass) at `1a47277`, `since: 68e63b8 parents=2`   | current, **not** stale — the case a naive `commit.oid != headRefOid` test gets wrong |
| **#706** | `commits=1 unresolved=0`, bot `**No findings.**` (wider pass), `since: nothing, the review is at the tip` | currency trivially true; turns on Signal 2 alone                                     |
| **#684** | bot `**No findings in the code.**` at the tip, `unresolved=1`                                             | `partial` — the clean-on-code variant and the open-thread disqualifier, in one PR    |
| **#709** | bot `Found 2 issues.` at the tip                                                                          | `review`, no prompt                                                                  |
| **#720** | `state=OPEN commits=98 unresolved=0`, `lastbot: NONE`                                                     | `review` — the no-bot-review path                                                    |

Signal 2 was read on the same bodies: #703 carries a filled `## Self-Review`; #706 and #684 predate the template section and have none.

The filter was run under both engines with byte-identical output on #675 — `gh --jq` (gojq) and `jq -f` (jq 1.6) — because the documented program has to survive being pasted into either. That is not incidental: the first draft of the Signal 2 filter used `capture("…").s`, which compiles under gojq and is a hard syntax error under jq 1.6.

**Not covered:** the slash command was not driven end to end, so the fan-out plumbing — passing the verdict and chosen mode into each subagent prompt, and spawning nothing for a PR I choose to skip — is verified by reading, not by running. Nothing was posted to any pull request and no repository state was changed; every call above is a read.

#### `caec82f` — the narrowed mode's git side

Same treatment for the follow-up commit: every command it documents was run against #675, the merge-tail row above, with `SINCE=1a472772` (the commit the bot reviewed) and `BASE=5bc8165b` (the base tip at that moment).

| Command                                                     | What it returned                                                                  |
| ----------------------------------------------------------- | --------------------------------------------------------------------------------- |
| `git log $SINCE..pr675 --no-merges --not $BASE`             | empty — the author landed no work of their own after the review                   |
| `git log $SINCE..pr675 --merges --format=%H`                | `68e63b84`, the single presumed base merge                                        |
| `git show --cc 68e63b84`                                    | 244 bytes, header and no hunks — the merge really was clean                       |
| `git diff --stat $SINCE..pr675`                             | **250 files, 25,323 insertions, 4,439 deletions**                                 |
| `diff <(git diff $SINCE..pr675) <(git diff $SINCE...pr675)` | identical — two-dot and three-dot coincide, `$SINCE` being an ancestor of `pr675` |

The fourth row is a finding against my own first fix, which had `since` mode read `git diff "$SINCE_SHA"..pr<N>`: on a merge-tail PR that range is the entire base drift, so the "cheap" pass would have handed the subagent 250 files after the user declined a full one. The mode as committed reads the first three rows instead — the author's own commits, and `git show --cc` per merge — which on #675 is correctly empty. That empty result is itself the point of the third row: `--cc` is the only thing that can tell a clean base merge from a conflicted one, and Phase −1, having no worktree, can only presume.

**Not covered here either:** `since` mode was validated command by command, not by a subagent executing Phase 3 end to end, and no PR in flight currently has a merge carrying hand-written resolution — so the non-empty `--cc` case is verified by the command's documented behaviour rather than observed on a live PR.

#### `e02bd7e0` — the skip condition that cancelled the pass

The first row of the table above is also the reproduction for the bot's second-round finding. `git log 1a472772..pr675 --no-merges --not 5bc8165b` returning empty is exactly Phase 2's second skip condition firing: had a prior full review of ours been saved at `1a472772`, a subagent spawned in `since` mode would have reported `status: skipped` before Phase 3 ran `git show --cc 68e63b84` — the one command the pass existed for. Both SHA-based conditions now apply in `full` mode only.

#### `3131379` — the anchor precondition

The third-round finding turns on two commands being indistinguishable on stdout, so the exit codes are the evidence. Run in this checkout against `pr675`:

| Command                                                            | Exit | stdout  |
| ------------------------------------------------------------------ | ---- | ------- |
| `git merge-base --is-ancestor 1a472772 pr675` (real ancestor)      | 0    | —       |
| `git merge-base --is-ancestor 6fd4827c pr675` (valid non-ancestor) | 1    | —       |
| `git merge-base --is-ancestor deadbeef…deadbeef pr675` (no object) | 128  | —       |
| `git log deadbeef…deadbeef..pr675 --no-merges --format=%H`         | 128  | 0 bytes |

The last row is the whole finding: a rebased-away anchor produces byte-identical output to a delta that is genuinely empty, and the two preceding commits had removed every other guard — `since` mode is exempt from Phase 2's skip conditions, and Phase 3 tells the subagent an empty delta is a real outcome. `|| exit 1` catches both the 1 and the 128, so the precondition is a single line before anything reads stdout.

One test I got wrong on the way, since it changes what the second row proves: `git merge-base --is-ancestor upstream/main pr675` returns **0**, not 1 — `upstream/main` is a genuine ancestor here, because the author merged that tip into the branch. The non-ancestor row uses `6fd4827c`, the commit that landed #675 on `main` afterwards.

#### `b4a91cf3` — the three checks the fourth pass forced

Each fix replaces a claim with a command, so each was run rather than reasoned about.

**The filter.** The revised jq was run against #709 (`Found 2 issues` with an out-of-diff 🔴 High), #684 (`**No findings in the code.**`, note in the first line) and #675 (`**No findings.**`), under `gh --jq` (gojq) and under `jq 1.6` from a saved response. Byte-identical across engines, and #709 now prints its `### Findings outside this diff` heading and the High's title where before it printed neither. #675 gained `p2=5bc8165` on its merge row.

**The base-branch check.** `gh api repos/gke-labs/kube-agents/compare/main...5bc8165b --jq .status` → `behind`, which is what makes #675's tail a genuine base merge. `compare/main...68e63b84` (a commit on the PR branch, standing in for a sibling's tip) → `diverged`. The two statuses the rule turns on are the two it actually returns.

**The merge replay.** Built in a throwaway repo, because no PR in flight carries a hand-resolved merge: base tightens a line in a file the branch also changed, `git merge` conflicts, resolve with `git checkout --ours`, commit.

| Command                                            | Result                                                           |
| -------------------------------------------------- | ---------------------------------------------------------------- |
| `git show --cc <merge>` on the `--ours` resolution | **162 bytes, header only** — the base's change silently gone     |
| `git merge-tree --write-tree <m>^1 <m>^2`          | exit **1**, writes the auto-merge tree with conflict markers     |
| `git diff <auto-tree> <m>^{tree}`                  | **non-empty** — the resolution the author wrote                  |
| control: same three on a genuinely clean merge     | `--cc` bare header, merge-tree exit 0, tree diff **empty**       |
| #675's real base merge `68e63b84`                  | merge-tree exit 0, tree diff empty — agrees with its bare `--cc` |

The first and fourth rows are the finding: `--cc` cannot tell them apart and the replay can. Local git is 2.39.5, so the ≥ 2.38 requirement is met here; the fallback path for older git and for octopus merges is documented, not exercised.

## Self-Review

Ran `review-adversarial` over the branch diff in a separate context, all ten angles. It returned **14 findings, all CONFIRMED** — a high count for a two-file docs change, and fair: most of the diff is a procedure an agent will execute literally, so a wrong query or an unreachable verdict is a defect, not a wording nit. Two were HIGH. All 14 are fixed in `49000a5`; the two that a later fix mooted are noted as such rather than waved off.

Correctness of the queries:

1. **HIGH — the Signal 2 regex was unanchored,** so `## Self-Review` appearing in prose anywhere in the body matched. On #703 it "found" a 394-character section that was really a sentence in the Summary; the real section is 4,834 characters. Fixed by deleting the char-counter entirely and reading the body — which is also the right answer to "does this section actually answer", a question no regex can settle.
2. **HIGH — the GraphQL `--jq` discarded the commit graph it had just queried,** printing only head/draft/unresolved/last-bot-body. The currency rule was therefore unevaluable from the output the file told you to run. Fixed: the filter now indexes the review's commit into the commit list and prints everything after it with `parents=N`.
3. **A merge-only tail is not proof of currency** — a conflicted merge carries hand-written resolution no review has seen, and the API cannot distinguish it. Calling this test "the whole check, not a nicety" was an overclaim. Fixed: caveat stated, `git show --cc` named as the only discriminator, overclaim removed.
4. **`covered` was unreachable.** Signal 1 said "all four must hold" over a list whose first two bullets were mutually exclusive forms of the same verdict. Fixed: three conditions, with two accepted clean verdicts under the first.
5. **Phase −1 sat inside the hand-to-the-subagent-verbatim region.** The intro said "the instructions below", and Phase −1 is below it — so the phase whose entire point is asking the user would have been handed to an agent that cannot. Fixed: the intro names the `Subagent instructions (per PR)` section and says Phase −1 stops at that heading.
6. **A draft had no verdict row** and fell out of the table silently. Fixed: a `skip` row, consistent with Phase 2.
7. **CRLF bodies, and `capture("…").s` being a jq 1.6 syntax error** — two separate findings, both properties of the deleted regex. Mooted by finding 1's fix; the file now carries a note against reintroducing that shape, and the replacement was tested under both engines.

Claims that were not true:

8. **The `AGENTS.md` section restated the mechanics and had already drifted from them** — it said "three verdicts" and named `**No findings.**` as the only clean form. Fixed: it states the rule and defers, and says explicitly that the command file is what changes when the mechanics move.
9. **"a third run at the same ten angles"** attributed `review-adversarial`'s method to `kube-agents-bot`, which nothing establishes. Fixed: "a third hostile read".
10. **"GraphQL is the only source of the per-review `commit.oid`"** — false; REST reviews carry `commit_id`. Fixed: the reason for preferring GraphQL is narrowed to the empty REST response actually observed here.
11. **"#720 has more than a hundred [commits]"** — it has 98. Fixed: the claim is gone and the failure mode is stated without an example, which also removes a piece of pull-request-status prose that would have rotted.
12. **The bot's footers were misquoted** as `_This was a wider pass_` / `_This was a strict pass_`. The real strings run on past the word (`_This was a strict pass: only what I am certain of…_`), so anyone matching the documented string would match nothing. Fixed against the live bodies.
13. **A hard-coded "across the last twenty-three merged pull requests"** — not from the adversarial pass but from my own `review-docs-drift` read of the branch; a count with no source is exactly the drift magnet the docs rules call out. Fixed: the claim it supported is stated without the number.
14. **"the human already decided"** in Phase 2 is false on the `review` path, where Phase −1 asked nothing. Fixed to cover both ways a subagent gets spawned.

One thing the pass did not raise and I will name myself: Phase −1 adds two API calls per PR to every invocation, including the batch where nothing turns out to be covered. That is the price of the check, and it is obviously worth it against a worktree and a full diff read — but it is a real cost paid unconditionally.

### Addendum — the bot's review of `49000a5`

Two findings, both Medium, both real, both fixed in `caec82f`; each answered in its thread or in a comment.

15. **The delta pass was called "empty by construction when the review is current"** in exactly the case the currency rule singles out as hiding uninspected code — a tail of presumed base merges. My own text two paragraphs above said a conflicted merge's resolution is what no review has read, and then the ask told the user that option reviews nothing. Fixed: emptiness is claimed only for `since: nothing, the review is at the tip`, and explicitly not for a merge tail.
16. **The narrowed mode was offered and never implemented.** Phase 3 bound the range to the whole PR, Phase 4 recorded only the head SHA, and Phase 2's skip check keyed off that SHA — so either the subagent quietly ran the full pass the user declined, or it improvised a delta and saved it as if the whole diff had been read, permanently suppressing the full pass. Fixed as described under What Changed. The finding was narrower than the bug: implementing it turned up that the obvious delta range is 250 files on #675, so the mode reads commits instead.

Neither was raised by my own pass, and both are the same kind of miss: I reviewed the phase I had written as a unit and did not follow the thing it hands off downstream. Angle I (does the diff do what it claims) is where they should have surfaced — the claim "tell each subagent its mode" is not met by a document that never mentions the mode again.

A strict `/review` of `caec82f` found one more, fixed in `e02bd7e0`:

17. **Phase 2's saved-review skip cancelled the narrowed pass Phase −1 had just been authorised to run.** `git log <recorded-sha>..HEAD --no-merges --not "$BASE_REF"` is empty _by construction_ on a merge tail — the same fact that makes Phase −1 call a bot review current and offer the delta in the first place — so the subagent would report `status: skipped` before Phase 3 ever ran `git show --cc`, and the merge resolution the pass existed to read would be seen by nobody. Reproduced on #675 (see Live validation). Fixed by exempting `since` mode from both SHA-based conditions rather than patching the one that fires: the user named the SHA and paid for the pass, and an empty delta is better reported by Phase 3, which says what it ran, than by a skip the user was never asked about.

That one is my miss too, and a more interesting one than the first two: the finding is a collision between a mechanism I added and one that was already there, which is exactly what a self-review of a diff is worst at seeing — I read what I wrote, and the condition it breaks is an unchanged line eight paragraphs up. Its own blind spot is older than this branch and still open: condition 2 cannot tell a conflicted merge from a clean one in `full` mode either, which this change deliberately does not address.

A strict `/review` of `e02bd7e0` found one more, fixed in `3131379`:

18. **The narrowed pass could be offered anchored on a SHA that is not on the branch.** `since: review commit is not among those N commits` — a force-push, a rebase, or the `commits(last: 100)` window overflowing — still got all three choices, with `<sha>` taken unconditionally from `lastbot … commit=`. Phase 1 fetches only `refs/pull/<N>/head`, so that anchor does not resolve in the worktree and every Phase 3 command exits 128 on empty stdout. Fixed at both ends: Phase −1 withholds the option for that outcome, and Phase 3 asserts `git merge-base --is-ancestor "$SINCE_SHA" pr<N>` before trusting an empty result, stopping with a named reason if it fails. Exit codes in Live validation.

This one is the sharpest of the three, because it was **created by the two fixes above it**: fix 17 disabled Phase 2's skip conditions for `since` mode, and fix 16 told the subagent that an empty delta is a real outcome to report rather than a reason to stop. Individually right; together they turned `fatal: bad revision` into a clean review of a diff nobody read. I re-ran `review-adversarial` after each fix and it did not catch either interaction — the diff-scoped pass sees the hunk, not the two-commits-ago hunk it now combines with. Worth saying rather than burying: three consecutive strict passes found three real defects, all in code I had just written and reviewed.

A fourth strict pass, of `3131379`, found three more — all fixed in `b4a91cf3`:

19. **Signal 1's filter threw away the out-of-diff note the Clean rule tells the reader to quote.** It reduced the review body to `.[0]` and the `_This was a…_` footer, and everything between them is exactly where `### Findings outside this diff` lives. On #709 that section holds a 🔴 High and about fifteen hundred words, so a `**No findings in the code.**` verdict could be put to the user as an unqualified clean pass with its one live finding invisible. The filter now keeps the section heading and each finding's `#### …` title line, and the prose says to re-read the whole body when the heading appears.

20. **The currency test accepted any merge, not only merges from the base branch.** The rule was written as `parents.totalCount > 1`, and the query fetched nothing that could distinguish a `main` merge from a merged sibling or fork branch — which brings a whole branch of unreviewed code and satisfies the parent count identically. `AGENTS.md` in this same diff states the rule correctly and Phase 2's git twin enforces it, so the gap was between the two halves of one change. The query now returns the second parent, the filter prints it as `p2=`, and the rule checks `compare/<base>...<p2>`.

21. **An empty `git show --cc` was read as proof a merge was clean, which is the narrowed mode's load-bearing claim.** `--cc` prunes every hunk whose merge result matches a parent, so a conflict resolved by taking one side wholesale — `git checkout --ours`, the commonest resolution there is — prints a bare header indistinguishable from a merge that had no conflict at all. The base branch's discarded change is precisely the code the mode exists to catch. Phase 3 now replays each merge with `git merge-tree --write-tree` and diffs that tree against the author's, which is the resolution itself; `--cc` survives only as an explicitly-weaker fallback for octopus merges and git below 2.38.

My own live validation is what let 21 through, and in a way worth naming: it exercised a merge that really was trivial, so it was consistent with both the true and the false reading of `--cc` and could not have separated them. A test that passes under the hypothesis you are trying to check is not evidence for it. The reproduction is in Live validation now, built to fail the old reading.

## Risk & Rollout

No runtime code path, no chart, no manifest — this changes what an agent reads before reviewing. The worst realistic failure is a wrong `covered` verdict, and its blast radius is bounded by design: the agent must ask, and a human answers, so a bad verdict costs a question rather than a skipped review. Revert is the single commit.
