### PR TITLE
fix(ci): isolate presubmit image tags to prevent cache pollution

### DIFF
--- a/deploy/docker/cloudbuild-ci.yaml
+++ b/deploy/docker/cloudbuild-ci.yaml
@@ -15,42 +15,70 @@
 # platform, they are already in the daemon's cache and only the delta runs
 # (gke-labs/kube-agents#635).
 steps:
-  # Only platform's cache is seeded. credential-proxy's own :latest is not
-  # pulled: the step below builds directly on top of the platform image this
-  # build just produced, so its five remaining instructions are cheap, and
-  # pulling the whole image to save them would cost far more than it saves.
+  # Only platform's cache is seeded from the canonical postsubmit image
+  # maintained by .github/workflows/docker-publish-gcp.yml in kube-agents-prow.
+  # credential-proxy's own cache is not pulled: the step below builds directly
+  # on top of the platform image this build just produced, so its five
+  # remaining instructions are cheap, and pulling the whole image to save them
+  # would cost far more than it saves.
   - id: warm-cache
     name: "gcr.io/cloud-builders/docker"
     entrypoint: "bash"
     args:
       - "-c"
-      - "docker pull $_PLATFORM_LATEST || true"
+      - |
+        echo "Pulling cache image: $_CACHE_IMAGE"
+        max_attempts=3
+        attempt=1
+        pulled=false
+        until [ "$attempt" -gt "$max_attempts" ]; do
+          if docker pull "$_CACHE_IMAGE"; then
+            pulled=true
+            echo "✓ Cache image pulled successfully."
+            break
+          fi
+          echo "⚠ Attempt $attempt/$max_attempts failed to pull $_CACHE_IMAGE."
+          if [ "$attempt" -lt "$max_attempts" ]; then
+            echo "Retrying in 5s..."
+            sleep 5
+          fi
+          attempt=$((attempt + 1))
+        done
+
+        if [ "$pulled" != "true" ]; then
+          echo "WARNING: CACHE MISS — could not pull $_CACHE_IMAGE after $max_attempts attempts."
+          echo "Check that docker-publish-gcp.yml is green on main and that Cloud Build"
+          echo "holds roles/artifactregistry.reader on kube-agents-prow."
+          if [ "$_REQUIRE_CACHE" = "true" ]; then
+            echo "ERROR: _REQUIRE_CACHE is set to true. Failing build."
+            exit 1
+          fi
+          echo "Building cold without cache."
+        fi
 
   - id: platform
     name: "gcr.io/cloud-builders/docker"
+    entrypoint: "bash"
     env:
       - "DOCKER_BUILDKIT=1"
     args:
-      - "build"
-      # Deployment targets are always amd64 GKE nodes; the multi-arch bases
-      # otherwise resolve to the build host (#560).
-      - "--platform"
-      - "linux/amd64"
-      - "-t"
-      - "$_PLATFORM_URI"
-      - "-t"
-      - "$_PLATFORM_LATEST"
-      - "--cache-from"
-      - "$_PLATFORM_LATEST"
-      - "-f"
-      - "deploy/docker/Dockerfile"
-      - "--target"
-      - "platform"
-      - "--build-arg"
-      - "BUILDKIT_INLINE_CACHE=1"
-      - "--build-arg"
-      - "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG"
-      - "."
+      - "-c"
+      - |
+        CACHE_ARGS=()
+        if [ -n "$_CACHE_IMAGE" ]; then
+          CACHE_ARGS=(--cache-from "$_CACHE_IMAGE")
+        fi
+
+        # Deployment targets are always amd64 GKE nodes; the multi-arch bases
+        # otherwise resolve to the build host (#560).
+        docker build \
+          --platform linux/amd64 \
+          -t "$_PLATFORM_URI" \
+          "$${CACHE_ARGS[@]}" \
+          -f deploy/docker/Dockerfile \
+          --target platform \
+          --build-arg HERMES_AGENT_TAG="$_HERMES_AGENT_TAG" \
+          .
 
   # No --cache-from and no waitFor: this runs straight after platform on the
   # same worker, which is the entire point of collapsing the submits.
@@ -64,14 +92,10 @@ steps:
       - "linux/amd64"
       - "-t"
       - "$_PROXY_URI"
-      - "-t"
-      - "$_PROXY_LATEST"
       - "-f"
       - "deploy/docker/Dockerfile"
       - "--target"
       - "credential-proxy"
-      - "--build-arg"
-      - "BUILDKIT_INLINE_CACHE=1"
       - "--build-arg"
       - "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG"
       - "."
@@ -94,11 +118,11 @@ steps:
       - "k8s-operator/Dockerfile"
       - "k8s-operator"
 
+# Presubmits push only PR-scoped immutable tags, avoiding cross-PR cache pollution
+# (gke-labs/kube-agents#635).
 images:
   - "$_PLATFORM_URI"
-  - "$_PLATFORM_LATEST"
   - "$_PROXY_URI"
-  - "$_PROXY_LATEST"
   - "$_OPERATOR_URI"
 
 # No `options.machineType` here on purpose. The operator step only genuinely
@@ -115,8 +139,8 @@ timeout: 3600s
 
 substitutions:
   _PLATFORM_URI: ""
-  _PLATFORM_LATEST: ""
   _PROXY_URI: ""
-  _PROXY_LATEST: ""
   _OPERATOR_URI: ""
+  _CACHE_IMAGE: ""
   _HERMES_AGENT_TAG: ""
+  _REQUIRE_CACHE: "false"

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -98,8 +98,12 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Building Container Images (platform
 # them as consecutive steps on one worker lets the second reuse the first's
 # layers instead of rebuilding the chain on a cold daemon; the operator build
 # runs alongside them. See the header of cloudbuild-ci.yaml, and #635.
+# Set REQUIRE_CACHE=true in the job environment to fail the build on a cache
+# miss instead of cold-building. Default false so a broken cache source cannot
+# block the PR that fixes it.
+export CACHE_IMAGE="${CACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest}"
 gcloud builds submit --config="deploy/docker/cloudbuild-ci.yaml" \
-  --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PLATFORM_LATEST=${AR_REPO}/platform-agent:latest,_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_PROXY_LATEST=${AR_REPO}/credential-proxy:latest,_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
+  --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_CACHE_IMAGE=${CACHE_IMAGE},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_REQUIRE_CACHE=${REQUIRE_CACHE:-false}" \
   --project="${PROJECT_ID}" "${BUILD_WORKER_ARGS[@]}" --quiet .
 echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 


### PR DESCRIPTION
# Pull Request
## Summary

This PR isolates presubmit container image tags in Cloud Build so that presubmit jobs only push PR-scoped immutable tags (`pr-<num>-<sha>`) rather than overwriting `:latest` in the evaluation project's Artifact Registry. It also configures presubmit builds to warm their Docker layer cache directly from the canonical postsubmit image (`us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest`), ensuring deterministic cache hits across runs and preventing cross-PR cache pollution.

## Why This Change
Presubmit Cloud Builds previously tagged and pushed `:latest` into the evaluation project's Artifact Registry (`us-central1-docker.pkg.dev/${PROJECT_ID}/...:latest`).

This created two issues:
1. **Cross-PR Cache Poisoning & Race Conditions:** When multiple PRs ran, they constantly raced to overwrite `:latest`. PR B would warm its cache from PR A's experimental image, causing non-deterministic cache misses or stale layer invalidations.
2. **Blocker for Parallel CI:** Concurrent runs with `max_concurrency > 1` cannot share a single mutable `:latest` tag without colliding.

Addresses item 3 of #635 ("Stop pushing `:latest` from presubmits").

---
## What Changed

**Files:**
- `deploy/docker/cloudbuild-ci.yaml`
- `hack/ci-deploy.sh`

**Details:**
- **Isolate Presubmit Tags:** `deploy/docker/cloudbuild-ci.yaml` now pushes **only PR-scoped immutable tags** (`platform-agent:${TAG}`, `credential-proxy:${TAG}`, `kube-agents-operator:${TAG}`). It no longer tags or pushes `:latest`.
- **Warm Cache from Canonical Prow Image:** `hack/ci-deploy.sh` passes `_CACHE_IMAGE=us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest`. This pulls cache from the postsubmit image that is only updated on merges to `main`, ensuring deterministic cache hits and immunity to PR races.
- **Resilient Cache Pull with Fallback:** In `warm-cache`, retries `docker pull "$_CACHE_IMAGE"` up to 3 times with 5s backoff, logs a warning on cache miss, and falls back to a cold build (unless `_REQUIRE_CACHE=true` is set).
- **Opt-in Strict Failure (`_REQUIRE_CACHE`)**: Added `_REQUIRE_CACHE` substitution (default false) wired to `${REQUIRE_CACHE:-false}` in `hack/ci-deploy.sh`, allowing CI operators to enforce hard failures on cache misses when desired.
- BuildKit Registry Cache Resolution: Passes `--cache-from "$_CACHE_IMAGE"` via escaped array `"$${CACHE_ARGS[@]}"` whenever `_CACHE_IMAGE` is non-empty, letting BuildKit resolve cache manifests directly from the registry.

---
## Why This Matters
- **Deterministic Builds:** Every presubmit warms its cache from the stable `main` branch HEAD rather than whichever PR ran last.
- **Artifact Registry Tag Collisions:** Concurrent runs cannot share a single mutable :latest tag without colliding.

---

## Verification & Testing

### Local Validation
- Verified syntax and build substitutions.

### Live validation

* **Job:** `pull-kube-agents-smoke-test`:
* All 3 run ([2089480400094105600](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/739/pull-kube-agents-smoke-test/2089480400094105600) (Cloud Build: 7m 23s), [2089527924469272576](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/739/pull-kube-agents-smoke-test/2089527924469272576) (Cloud Build: 8m 59s), [2089553314248134656](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/739/pull-kube-agents-smoke-test/2089553314248134656) (Cloud Build: 9m 55s)) completed with only 3 PR tags pushed.
  1. us-central1-docker.pkg.dev/kube-agents-evals/kube-agents/platform-agent:pr-739-7f59c97
  2. us-central1-docker.pkg.dev/kube-agents-evals/kube-agents/credential-proxy:pr-739-7f59c97
  3. us-central1-docker.pkg.dev/kube-agents-evals/kube-agents/kube-agents-operator:pr-739-7f59c97
  
  * *from Cloud Build log of 1st run:*
    ```text
    Step #0 - "warm-cache": Pulling cache image: us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest
    Step #0 - "warm-cache": Status: Downloaded newer image for us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest
    Step #0 - "warm-cache": ✓ Cache image pulled successfully.
    Step #1 - "platform": #5 importing cache manifest from us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest
    PUSH: Pushing us-central1-docker.pkg.dev/kube-agents-evals/kube-agents/platform-agent:pr-739-7f59c97 (+2 more)
    ```
  

* Verified that no CI or deployment script consumes the eval-registry `:latest` tag: `hack/ci-deploy.sh` and `hack/ci-eval-pr.sh` deploy via explicit `$TAG` (`pr-${PULL_NUMBER}-${PULL_SHA_SHORT}`) and `$IMG`. Stopping `:latest` pushes in `kube-agents-evals` causes no downstream breakage.
* All ephemeral namespaces, pods, and secrets created during testing were cleaned up by `./hack/ci-teardown.sh`.

## Self-Review
* **Cache Availability & IAM:** Checked for potential permission issues when Cloud Build in `kube-agents-evals` pulls the cache image from `kube-agents-prow`. Verified that `roles/artifactregistry.
reader` is granted to the Cloud Build service account (`1042377440668@cloudbuild.gserviceaccount.com`). Live logs confirm successful pull.
* **Cache Pull & Fallback:** Verified that `warm-cache` skips cleanly if `_CACHE_IMAGE` is empty, retries 3x on transient pull failures, and falls back to a cold build without passing broken `--
  cache-from` flags unless `_REQUIRE_CACHE="true"`
* **Tag Isolation:** Inspected the `images:` block and `docker build` arguments in `cloudbuild-ci.yaml` to confirm no step tags or pushes `:latest`. Confirmed via Cloud Build push logs.

## Risk & Rollout
Low risk. This change touches only the presubmit Cloud Build configuration and CI deployment script. Runtime operator code and production GitHub Actions workflows are completely untouched. If any issue arises, reverting the commit restores the previous build substitution parameters.
