### PR TITLE
docs(agents): require direct, length-calibrated writing in docs and PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,17 @@ Rules:
   from several branches every week, and a re-aligned table rewrites rows your PR did not author.
   `docs/README.md` §5 owns the rest of that contract — including why a file inside an existing
   family needs no map edit at all.
+- **Write it straight.** Lead with the fact — no preamble, no restating the question, no "it's
+  worth noting". Cut hype and self-assessment (`comprehensive`, `robust`, `seamless`, `simply`,
+  `powerful`). Skip the "not X, but Y" antithesis and rule-of-three padding: one precise example
+  beats three synonyms. Prefer prose to a `**Bold term:** explanation` list. Claim first, caveat
+  after; a hedge in front of a fact hides it. `SKILL.md` files are the exception to the prose
+  preference — `.agents/skills/skill-review/SKILL.md` asks for terse imperative bullets there.
+- **Match a document's length to what the task needs.** Agent-written documents run long by
+  default, so cover the substance and stop: no filler sections, no summary that repeats the
+  section above it, no boilerplate scaffolding a reader will skip. Anthropic's
+  [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5)
+  is the upstream source for this and for the conciseness rule above.
 
 Run `make docs-check` before pushing. It verifies generated regions are current, relative links
 resolve, identifiers match their source, and every Markdown document has an entry in the
@@ -151,6 +162,12 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   SHA and the comment together.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
+- **Write PR titles, bodies, commit messages, and review replies the same way** the Documentation
+  Guidelines' "Write it straight" rule requires: what changed and why, in plain declaratives. Do
+  not grade your own work — "comprehensive", "significantly improves", and "production-ready" are
+  claims the diff either supports or does not, and the reviewer is the one who decides. Lead with
+  the outcome: the first sentence of a PR body, a review reply, or a report back to the user
+  answers "what happened", and the supporting detail follows it.
 - **Adversarial self-review before opening a PR, and record it in the PR body.** Run the
   `review-adversarial` skill (`.agents/skills/review-adversarial/SKILL.md`) against your branch
   diff, fix what it confirms, and fill in the template's **Self-Review** section with what you


### PR DESCRIPTION
## Summary

Two rules in `AGENTS.md` about how agents write here: "write it straight" and "match a document's length to the task", in Documentation Guidelines, plus a Pull Request Hygiene bullet applying both to PR titles, bodies, commit messages, and review replies. Three bullets appended to lists that already exist; nothing else changes.

## Why This Change

The house style here is already direct but undocumented, so every agent re-derives it and most land on the LLM defaults instead: preamble before the answer, "comprehensive" as a self-assessment, three synonyms where one example works. Anthropic's [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5) documents longer default responses and longer written files, and says the fix is to prompt for length explicitly. `AGENTS.md` is where this repository prompts.

## What Changed

- Documentation Guidelines — two rules, with `SKILL.md` carved out of the prose preference, since `.agents/skills/skill-review/SKILL.md` requires terse imperative bullets there.
- Pull Request Hygiene — one rule holding anything written into GitHub to the same standard, and asking it to lead with the outcome.

## Context

Generated with the help of Claude, from a [r/ClaudeAI thread](https://www.reddit.com/r/ClaudeAI/comments/1vr7bqj/anybody_have_a_good_method_to_tone_down_the/) and the Opus 5 guide. Reddit 403'd every fetch route, so the thread's contribution is second-hand; two rules it reportedly carries, a banned-word list and an em-dash ban, are deliberately absent — a word list needs enforcement to mean anything, and this file's own prose leans on em dashes.

No open issue covers this. #713 (draft) is the runtime equivalent — how the deployed agents write to end users — and shares no files; a cross-reference is worth adding if it lands first. #720 and #615 touch `AGENTS.md` only near line 14, so no conflict with lines 131 and 164.

## Testing

- `prettier --check AGENTS.md` (3.9.6) and `make docs-check` — both pass.

### Live validation

Not live-tested. `AGENTS.md` is contributor guidance read from this checkout: not baked into an image, mounted into a pod, or reconciled by the operator, so no layer of a running install can show it. The runtime equivalent is `agents/**`, untouched here.

## Self-Review

`review-adversarial`, ten angles, over both hunks. One deviation: the pass ran in the session that wrote the change, because this session is configured not to spawn subagents — the configuration the skill names as the one that reliably does not work. Weigh the findings accordingly.

Angles A–D and I found nothing: prose only, removes no rule, grants no permission, both hunks serve the intent. E–G have no purchase on a prose diff. J is the sibling scan under Context.

Two findings, both fixed before the commit:

1. **Conventions.** "Prefer prose to a `**Bold term:** explanation` list" contradicted `.agents/skills/skill-review/SKILL.md`, which requires that exact shape in `SKILL.md` files. Fixed by naming the exception in the rule.
2. **Staleness.** The length rule opened "Claude Opus 5 writes long files by default", dating guidance that outlives the model. Restated model-agnostically, attribution kept on the source link.

No test fails if this guidance is ignored; the reviewer is the enforcement, as with every other rule in these two sections.

## Risk & Rollout

Low. Prose only — no runtime paths, CI behaviour, or generated regions. Revert is a single commit.
