### PR TITLE
fix(stockout): branch §3.11 remediation and refine §4 feasibility gate (#694)

### DIFF
--- a/agents/platform/cron/jobs.json
+++ b/agents/platform/cron/jobs.json
@@ -86,7 +86,7 @@
         "expr": "20 9 * * *",
         "display": "20 9 * * *"
       },
-      "prompt": "Run the daily fleet stockout prevention and capacity audit. Read the SOP at 'governance/stockout_prevention_sop.md' in your profile home — all 254 lines of it, before you run anything. Its twelve checks are section 3, lines 79-208, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily fleet stockout prevention and capacity audit. Read the SOP at 'governance/stockout_prevention_sop.md' in your profile home — all 262 lines of it, before you run anything. Its twelve checks are section 3, lines 79-211, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "all"

--- a/agents/platform/governance/stockout_prevention_sop.md
+++ b/agents/platform/governance/stockout_prevention_sop.md
@@ -219,7 +219,7 @@ gcloud logging read 'log_id("container.googleapis.com/cluster-autoscaler-visibil
 - **Remediation Feasibility Gate**: Before proposing a new machine family or Spot tier, verify that:
   1. The target GCP zone actually offers the machine type (`gcloud compute machine-types list --zones=<zone>`).
   2. For On-Demand proposals, the project quota for that family (`N4_CPUS`, `C4_CPUS`, GPU types) is greater than 0 (`gcloud compute regions describe <region> --project=<project>`).
-  3. For Spot proposals, the project's preemptible CPU quota (`PREEMPTIBLE_CPUS` or `PREEMPTIBLE_LOCAL_SSD_GB`) is greater than 0.
+  3. For Spot proposals, the project's preemptible CPU quota (`PREEMPTIBLE_CPUS`) is greater than 0 (and `PREEMPTIBLE_LOCAL_SSD_GB` is greater than 0 if requesting local SSDs).
 - Edit the manifest directly in `<workspace>`, adding the necessary fallback machine families, zones, or quota adjustments.
 - **Mandatory Remediation Comments**: For every modified line in YAML, append an inline `# Remediation: <reason>` comment.
 - Set `remediation.path` to the repo-relative file path, with `kind: manifest`.

--- a/agents/platform/governance/stockout_prevention_sop.md
+++ b/agents/platform/governance/stockout_prevention_sop.md
@@ -194,7 +194,10 @@ gcloud logging read 'log_id("container.googleapis.com/cluster-autoscaler-visibil
 - **Do NOT flag:** Clusters with clean autoscaler visibility logs over 24h.
 - **Severity:** `critical`.
 - **Impact:** "Autoscaler has actively failed scale-up attempts due to physical cloud stockouts, quota exhaustion, or pod subnet IP exhaustion."
-- **Remediation:** `kind: manifest`. Add secondary fallback families/zones to affected ComputeClasses, expand pod subnet CIDR if IP-exhausted, or request regional quota increase.
+- **Remediation:**
+  - `scale.up.error.out.of.resources`: If a `ComputeClass` manifest exists in the GitOps repo for the affected workload, `kind: manifest` (add secondary fallback machine families and multi-zone support). If no `ComputeClass` manifest exists in the GitOps clone (such as default Autopilot workloads), `kind: manual` (adopting a custom ComputeClass requires a workload-owner decision on which workloads adopt it and which families are acceptable; provide the recommended ComputeClass YAML definition with fallback priorities in `recommendation.action` verified against the §4 feasibility gate).
+  - `scale.up.error.quota.exceeded`: `kind: manual` (request a regional/family GCP compute quota increase via Google Cloud Console or `gcloud compute project-info describe`).
+  - `scale.up.error.ip.space.exhausted`: `kind: manual` (expand the VPC pod subnet secondary CIDR range).
 
 #### 3.12 Dangling, unlabelled, or invalid ComputeClass configurations (`dangling-compute-class`)
 
@@ -209,9 +212,14 @@ gcloud logging read 'log_id("container.googleapis.com/cluster-autoscaler-visibil
 ### 4. Generate remediation artifacts
 
 - Locate the existing declaration in the GitOps clone (`grep -rl "name: <object>" --include='*.yaml' <workspace>`).
+- **The Declaration Rule**:
+  - A remediation that changes an object that already exists must go to that object's **existing declaration in the GitOps repo**: locate it (`grep -rl "name: <object>" --include='*.yaml' .`), give that file's repo-relative path as `remediation.path`, and rewrite it as the object's complete desired manifest.
+  - If the workload or ComputeClass has no declaration in the clone, the finding is `kind: manual`. Put the manifest you would have written in `recommendation.action`.
+  - Never invent a new path for an object that is not declared in the repository.
 - **Remediation Feasibility Gate**: Before proposing a new machine family or Spot tier, verify that:
   1. The target GCP zone actually offers the machine type (`gcloud compute machine-types list --zones=<zone>`).
-  2. The project quota for that family (`N4_CPUS`, `C4_CPUS`, `PREEMPTIBLE_CPUS`, GPU types) is greater than 0.
+  2. For On-Demand proposals, the project quota for that family (`N4_CPUS`, `C4_CPUS`, GPU types) is greater than 0 (`gcloud compute regions describe <region> --project=<project>`).
+  3. For Spot proposals, the project's preemptible CPU quota (`PREEMPTIBLE_CPUS` or `PREEMPTIBLE_LOCAL_SSD_GB`) is greater than 0.
 - Edit the manifest directly in `<workspace>`, adding the necessary fallback machine families, zones, or quota adjustments.
 - **Mandatory Remediation Comments**: For every modified line in YAML, append an inline `# Remediation: <reason>` comment.
 - Set `remediation.path` to the repo-relative file path, with `kind: manifest`.


### PR DESCRIPTION
## Summary

Clarifies remediation instructions in `stockout_prevention_sop.md` check §3.11 (`autoscaler-out-of-resources`), unbundles three distinct error classes, and aligns Section 4 with the repository's canonical Declaration Rule and Spot quota feasibility checks. When autoscaler visibility logs report stockout or quota friction, the audit now explicitly emits `kind: manifest` (and opens an automated PR) if a declared `ComputeClass` manifest exists in the GitOps clone, and explicitly emits `kind: manual` with complete copy-pasteable YAML recommendations when workloads have no in-repo `ComputeClass` or when constrained by cloud-level quotas and IP subnets. Also updates `agents/platform/cron/jobs.json` prompt line citations to synchronize with the expanded SOP.

## Why This Change

Check §3.11 unconditionally prescribed `kind: manifest` for all three autoscaler failure types (`scale.up.error.out.of.resources`, `scale.up.error.quota.exceeded`, `scale.up.error.ip.space.exhausted`). On Autopilot clusters or fleets where workloads have no `ComputeClass` manifest in the GitOps clone, the audit lacked clear guidance, causing the agent to improvise and downgrade findings to `kind: manual`. Because `audit_report.py` only promotes `manifest` findings to PRs, critical autoscaler findings were stranded in the ledger without automated PRs or actionable recommendations. Furthermore, GCP quota and VPC subnet IP space exhaustion are cloud operations that cannot be remediated via in-repo Kubernetes manifests.

## What Changed

- **Check §3.11 Remediation Branching:**
  - `scale.up.error.out.of.resources`: Specifies `kind: manifest` when an existing `ComputeClass` manifest is found in the GitOps repository clone. Specifies `kind: manual` when no `ComputeClass` manifest exists in GitOps (noting that adopting custom ComputeClasses is a workload-owner policy decision and providing the recommended YAML snippet in `recommendation.action` verified against the §4 feasibility gate).
  - `scale.up.error.quota.exceeded`: Explicitly specifies `kind: manual` to request GCP compute quota increases via Google Cloud Console or `gcloud compute project-info describe`.
  - `scale.up.error.ip.space.exhausted`: Explicitly specifies `kind: manual` to expand the VPC pod subnet secondary CIDR range.
- **Section 4 Declaration Rule & Feasibility Gate:**
  - Added explicit Declaration Rule guidance instructing the agent how to discover and rewrite existing GitOps manifests for `kind: manifest` vs emitting `kind: manual` for undeclared resources.
  - Refined the feasibility gate to strictly verify `PREEMPTIBLE_CPUS > 0` for Spot proposals (with `PREEMPTIBLE_LOCAL_SSD_GB > 0` required only when local SSDs are attached) and regional family quotas (`N4_CPUS`, `C4_CPUS`) for On-Demand proposals before proposing fallback tiers.
- **Cron Job Configuration & Docs:**
  - Updated `agents/platform/cron/jobs.json` stockout-prevention prompt line count citations (`254` → `262` lines, section 3 span `79-208` → `79-211`) and regenerated reference documentation via `make docs-generate`.

## Context

Closes #694

## Self-Review

- [x] Unbundled all three failure classes in §3.11 with concrete remediation kinds and instructions.
- [x] Spot feasibility gate strictly requires `PREEMPTIBLE_CPUS > 0`.
- [x] Synchronized line numbers and section spans in `agents/platform/cron/jobs.json`.
- [x] All 507 `fleet-audit` tests passing (`make test-python`).
- [x] `make docs-check` and `prettier` checks pass cleanly.

## Testing

- `make docs-check`: Passed (verified links, terminology, family roster, and documentation map coverage).
- `prettier --check agents/platform/governance/stockout_prevention_sop.md agents/platform/cron/jobs.json`: Passed.
- `python3 -m unittest discover -s agents/platform/skills/fleet-audit/scripts -p "test_*.py"`: Passed (507 tests OK).

### Live validation

Validated against live GKE clusters (`platform-agent-host` in `us-east4`, `autopilot-cluster-1` in `us-central1`, and `c1` in `us-central1`) in GCP project `ss-stockout`:
1. **Declared in GitOps (`autopilot-cluster-1`):** `web-frontend.yaml` with a single Spot family was flagged by §3.11, §3.1, and §3.2. The agent located `clusters/autopilot-cluster-1/web-frontend.yaml`, emitted `kind: manifest`, and automatically opened a remediation Pull Request with fallback families (`N4`, `N2`) and an On-Demand floor.
2. **Undeclared in GitOps (`c1`):** A broken ComputeClass applied only to the cluster was flagged and cleanly degraded to `kind: manual`, logging actionable YAML recommendations in the ledger issue without attempting to invent unanchored GitOps paths.
3. **What was unexercised & why:** `scale.up.error.quota.exceeded` and `scale.up.error.ip.space.exhausted` were not induced on live GCP infrastructure because inducing genuine cloud project quota exhaustion or VPC subnet IP exhaustion would impact live shared infrastructure. Their manual remediation branches were verified by static analysis and unit test assertion. All temporary test deployments and test PRs were cleaned up following validation.

## Risk & Rollout

Low risk. Documentation and prompt line synchronization update only; no operator controller binary or cluster RBAC changes.
