### PR TITLE
ci: guard the remaining deploy and release workflows against fork runs

### DIFF
--- a/.github/workflows/autopush-redeploy-integrations.yml
+++ b/.github/workflows/autopush-redeploy-integrations.yml
@@ -33,6 +33,9 @@ permissions:
 
 jobs:
   call-deploy:
+    # A fork inherits the push trigger but none of the deploy credentials, so
+    # the job would fail there and mail the fork owner on every sync of main.
+    if: github.repository == 'gke-labs/kube-agents'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/rc-release-pipeline.yml
+++ b/.github/workflows/rc-release-pipeline.yml
@@ -25,6 +25,11 @@ concurrency:
 jobs:
   step-1-create-tag:
     name: Step 1 - Create Release Candidate Tag
+    # A fork inherits the cron but none of the release credentials, so every
+    # scheduled run there fails and mails the fork owner. The guard repeats on
+    # each job rather than relying on the skip cascading through `needs`: an
+    # `always()` added to a later job would silently un-guard the pipeline.
+    if: github.repository == 'gke-labs/kube-agents'
     uses: ./.github/workflows/rc-create-tag.yml
     permissions:
       contents: write
@@ -38,7 +43,9 @@ jobs:
   step-2-deploy-env:
     name: Step 2 - Provision RC Environment
     needs: step-1-create-tag
-    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
+    if: |
+      github.repository == 'gke-labs/kube-agents' &&
+      needs.step-1-create-tag.outputs.skip_rc != 'true'
     uses: ./.github/workflows/rc-deploy-environment.yml
     permissions:
       contents: read
@@ -51,7 +58,9 @@ jobs:
   step-3-run-e2e-tests:
     name: Step 3 - Run E2E Tests
     needs: [step-1-create-tag, step-2-deploy-env]
-    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
+    if: |
+      github.repository == 'gke-labs/kube-agents' &&
+      needs.step-1-create-tag.outputs.skip_rc != 'true'
     runs-on: ubuntu-latest
     environment: rc
     concurrency:
@@ -110,7 +119,9 @@ jobs:
   step-4-tag-validated:
     name: Step 4 - Tag Validated Release
     needs: [step-1-create-tag, step-3-run-e2e-tests]
-    if: needs.step-1-create-tag.outputs.skip_rc != 'true'
+    if: |
+      github.repository == 'gke-labs/kube-agents' &&
+      needs.step-1-create-tag.outputs.skip_rc != 'true'
     uses: ./.github/workflows/rc-tag-validated.yml
     permissions:
       contents: write

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -14,6 +14,9 @@ permissions:
 
 jobs:
   call-deploy:
+    # A fork inherits the tag trigger but none of the deploy credentials, so a
+    # staging/** tag pushed there would fail and mail the fork owner.
+    if: github.repository == 'gke-labs/kube-agents'
     permissions:
       contents: read
       id-token: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,17 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   (`@v4`, `@main`) are not permitted — a retagged release would silently change what CI runs.
   Local reusable workflows (`uses: ./.github/workflows/…`) are exempt. Dependabot updates the
   SHA and the comment together.
+- **Guard automatically-triggered credentialed workflows against forks.** A workflow that needs
+  this repository's secrets and starts on its own — `push`, a tag, `schedule`, or `workflow_run`
+  — carries `if: github.repository == 'gke-labs/kube-agents'` on every job. A fork inherits those
+  triggers but none of the secrets, so an unguarded job fails there on every sync and mails the
+  fork owner. Put the guard on each job rather than trusting the skip to cascade through `needs`;
+  an `always()` added later removes the implicit `success()` and the job runs anyway. Two classes
+  need no guard: a workflow reachable only through `workflow_call` is gated by its caller
+  (`reusable-deploy-*.yml`), and a `workflow_dispatch`-only one runs only when someone deliberately
+  starts it (`rc-create-tag.yml`, `rc-deploy-environment.yml`, `rc-tag-validated.yml`,
+  `e2e-gchat-test.yml`). `docs-deploy.yml` is push-triggered and deliberately unguarded, so a fork
+  can publish its own Pages site.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
 - **Write PR titles, bodies, commit messages, and review replies the same way** the Documentation


### PR DESCRIPTION
## Summary

Three automatically-triggered workflows that need this repository's credentials had no fork guard, so they ran and failed on every fork with Actions enabled. This adds `if: github.repository == 'gke-labs/kube-agents'` to their jobs, matching the eight workflows that already carry it, and records the convention in `AGENTS.md` so the next credentialed workflow gets it.

## Why This Change

A fork inherits the triggers but none of the secrets. On `bradhoekstra/kube-agents` the RC pipeline's `17 */3 * * *` cron fired eight times a day, died at the Workload Identity Federation step, and mailed the fork owner `Run failed: RC Release E2E Pipeline` each time; `Autopush Redeploy Integrations` did the same on every sync of `main`, failing in `Provision Kubernetes Secrets`. Nothing about those runs is actionable — the credentials are upstream's by design — so the mail is pure noise, and the fix is to not run rather than to run and fail.

## What Changed

- `.github/workflows/rc-release-pipeline.yml` — the guard on all four jobs. Guarding `step-1-create-tag` alone would cascade today, since a dependent whose `if:` holds no status-check function keeps the implicit `success()`, but an `always()` added to a later job would silently un-guard the pipeline. Steps 2–4 fold the guard into their existing `skip_rc` condition.
- `.github/workflows/autopush-redeploy-integrations.yml`, `.github/workflows/staging-redeploy-integrations.yml` — the guard on `call-deploy`. The staging one is not failing today only because nobody has pushed a `staging/**` tag to a fork; its two siblings already carry the guard, so this is a parity fix.
- `AGENTS.md` — one bullet under Pull Request Hygiene, next to the action-pinning rule. It is scoped to workflows that start on their own (`push`, tag, `schedule`, `workflow_run`) and names the two classes that need no guard: `workflow_call`-only workflows, gated by their caller, and `workflow_dispatch`-only ones, which run only when someone deliberately starts them.

`docs-deploy.yml` stays unguarded. It is push-triggered and meant to publish a fork's own Pages site, and it succeeds on the fork above on every push.

## Context

No related issue. No open PR touches these files.

One forward-looking conflict: `.github/workflows/release-build-publish.yml`, proposed in #620 (and carried by #623 and #548), is tag-triggered, publishes charts and images, and has no guard. If it merges after this, it breaks the convention this PR documents on day one. Flagging rather than reaching into that branch.

## Testing

- `actionlint` 1.7.7 (the version `actionlint.yml` pins) — clean across all workflows.
- `prettier@3.9.6 --check` — clean on the four changed files.
- `make docs-check` — generated regions current, 246 files' links resolve, terminology clean, map inventory complete.
- Parsed each changed workflow with PyYAML and asserted every job carries the guard and kept the job-level `permissions` block that #492 introduced.

### Live validation

This is CI configuration and cannot reach a kube-agents installation, so it was exercised where it actually runs: GitHub Actions on a fork.

Install: `bradhoekstra/kube-agents`, a fork of `gke-labs/kube-agents` with Actions enabled — the fork that was generating the failure mail.

- **Before.** `gh run list --repo bradhoekstra/kube-agents --workflow rc-release-pipeline.yml` shows an unbroken run of `failure` conclusions from the schedule on `main`, the most recent [run 32140728714](https://github.com/bradhoekstra/kube-agents/actions/runs/32140728714).
- **After.** Pushed this branch to the fork and dispatched the pipeline against it: `gh workflow run "RC Release E2E Pipeline" --repo bradhoekstra/kube-agents --ref ci/guard-deploy-workflows-against-forks -f commit_sha=e41cd7a`. [Run 32142501341](https://github.com/bradhoekstra/kube-agents/actions/runs/32142501341) concluded `skipped`, with all four jobs individually `skipped` — Step 1 Create Release Candidate Tag, Step 2 Provision RC Environment, Step 3 Run E2E Tests, Step 4 Tag Validated Release. A `skipped` run sends no failure notification.
- **The mechanism, not a coincidence.** Both runs are the same workflow on the same fork with the same missing credentials. The only difference is the guard: unguarded `main` fails, guarded branch skips. The guard is an equality against `github.repository`, which is `gke-labs/kube-agents` upstream under `schedule`, `push`, and `workflow_dispatch` alike, so the upstream path is unchanged.

Not covered: the upstream side was not run. Dispatching the real RC pipeline on `gke-labs/kube-agents` would cut a release candidate tag and provision the RC environment, which is not a thing to do to prove a skip condition. The eight workflows already using this exact guard run normally upstream today, which is the evidence for that direction. `staging-redeploy-integrations.yml` was not exercised either — it needs a `staging/**` tag push, and creating one on a fork to watch a job skip is not worth the tag.

Cleanup: the fork's `RC Release E2E Pipeline` and `Autopush Redeploy Integrations` were disabled before this work and are disabled again after it (`gh workflow disable`), so the fork is in the state it started in. Nothing was created upstream. The dispatched run created no tag — Step 1 never executed.

## Self-Review

Ran `review-adversarial` and `review-docs-drift` against `main...HEAD` in two fresh subagent contexts that had the diff and nothing else — not the reasoning that produced it. Angles covered: expression semantics of the added conditions, whether skipped jobs cascade correctly through `needs`, whether any trigger path on the touched workflows is left unguarded, whether the guard could wrongly block a legitimate upstream run (including `workflow_dispatch` and `workflow_call` from another workflow), completeness of the enumeration across all workflows, and doc/source agreement.

Both passes confirmed the guards themselves are correct and found nothing wrong with the three workflow files. Four findings, all against the surrounding claims:

- **`AGENTS.md` asserted an invariant `main` does not satisfy** (Blocking / Medium, raised independently by both passes). The bullet originally read "Every job in a workflow that needs this repository's credentials carries the guard", with `docs-deploy.yml` as the sole exception. Seven credentialed workflows have no guard — `rc-create-tag`, `rc-deploy-environment`, `rc-tag-validated`, `e2e-gchat-test`, and the three `reusable-deploy-*` — and none of them is `docs-deploy`. **Fixed:** the bullet is now scoped to automatically-triggered workflows and names the `workflow_call`-only and `workflow_dispatch`-only classes as needing no guard, which is the distinction the code actually draws.
- **The recorded reason for the `docs-deploy.yml` exemption.** The adversarial pass argued the workflow's header claim that it is "inert on forks" is wrong — it is push-triggered with no job guard — and that `deploy` would fail on a fork without Pages configured. It marked that failure mode PLAUSIBLE, not confirmed, having no such fork to test. I checked: `docs-deploy` has succeeded on every push on `bradhoekstra/kube-agents`, so the scenario does not reproduce there, and it is not one of the workflows sending mail. **Partly fixed:** the bullet no longer repeats the "inert" claim, and says only that the workflow is deliberately unguarded so a fork can publish its own Pages site. Correcting the workflow's own header comment is a separate change to a file this PR does not otherwise touch.
- **Nothing mechanically enforces the new rule** (Low). True: `actionlint` does not inspect job conditions, and any of the guards can be deleted with CI staying green — which is how three workflows drifted in the first place. **Deliberately not fixed here.** A checker belongs with `check_iac_parity.py` and `check_image_layers.py` under `python-tests.yml`, and it needs the classification this PR only just established — which triggers are automatic, which entry points are manual — to avoid flagging the seven correctly-unguarded workflows. Writing that alongside the guards would mean shipping the rule and its enforcement in one PR with the rule untested. Happy to open the follow-up issue.
- **`release-build-publish.yml` in #620 will violate the rule on merge** (Low). Recorded under Context above; not actionable from this branch.

The branch was cut from a `main` four commits stale, which the adversarial pass caught — the enumeration had been made against a tree missing `security-scan.yml` (#492). Rebased onto `upstream/main` and re-ran it: `security-scan.yml` has a weekly cron but uses no secrets, no vars, and no environments, so it correctly needs no guard, and the conclusion is unchanged. The rebase also conflicted with #492's move of `permissions` to the job level in the two integrations workflows; both blocks are kept.

## Risk & Rollout

Low. No runtime code paths, no operator or chart changes. The blast radius is which jobs GitHub schedules, and only on the three touched workflows. The failure mode worth naming is the guard being wrong in the other direction — an upstream run skipping when it should have run — which would show up as the RC cron quietly concluding `skipped` on `gke-labs/kube-agents` instead of cutting a candidate; the string is an exact match on `github.repository`, and eight workflows already run upstream with the identical condition. Revert is a single-commit `git revert`, with no state to unwind. Nothing has to happen at merge time; fork owners get the fix when they sync `main`.

---

Generated with the help of Claude.
