### PR TITLE
perf(litellm): inject prompt-cache breakpoints at the gateway

### DIFF
--- a/charts/kube-agents/templates/_helpers.tpl
+++ b/charts/kube-agents/templates/_helpers.tpl
@@ -189,6 +189,23 @@ model_list:
       model: {{ printf "%s/%s" .provider .model }}
 litellm_settings:
   callbacks: {{ .callbacks }}
+{{- /*
+  Prompt caching. Kept identical to the kustomize base — scripts/check_iac_parity.py
+  compares the two — and see that file for why the breakpoints live here rather
+  than in the agent's own config, and why non-Anthropic backends are unaffected.
+*/}}
+router_settings:
+  default_litellm_params:
+    cache_control_injection_points:
+      - location: message
+        role: system
+        control:
+          type: ephemeral
+          ttl: 1h
+      - location: message
+        index: -3
+      - location: message
+        index: -1
 {{- end }}
 
 {{/*

--- a/docs/site/src/content/docs/concepts/inference-gateway.md
+++ b/docs/site/src/content/docs/concepts/inference-gateway.md
@@ -64,6 +64,31 @@ cd k8s-operator/scripts && ./provision_09_deploy_litellm.sh
 
 This rewrites the LiteLLM `ConfigMap` and rolls the gateway; the agent picks up the new model on its next request without any change to its own config.
 
+### Prompt caching
+
+Agent turns are mostly re-sent context: the same system prompt, skills, and conversation tail go up again on every tool call. Anthropic-family models bill that at full price unless the request marks where the reusable prefix ends, and the marks have to be in the request — so the gateway adds them, via [`cache_control_injection_points`](https://docs.litellm.ai/docs/tutorials/prompt_caching) in the shipped `config.yaml`:
+
+```yaml
+router_settings:
+  default_litellm_params:
+    cache_control_injection_points:
+      - location: message
+        role: system
+        control:
+          type: ephemeral
+          ttl: 1h
+      - location: message
+        index: -3
+      - location: message
+        index: -1
+```
+
+The agent cannot do this itself, and that is the point of putting it here. It asks for `model-default` over the Completions API and never learns what is behind the alias, while the harness only emits its own cache markers when it recognises a Claude-named model — so on an Anthropic backend it caches nothing. Teaching it otherwise would mean naming the model in the agent config, which is exactly the coupling the gateway exists to prevent. A 45-call agent session measured 3.5M input tokens and zero cache reads before this block; the first cron tick after it re-ran the same 83k-token prompt as a cache write, and subsequent ticks read it back.
+
+The system prompt takes the 1h tier because it is the largest static span, every profile and cron tick shares it, and a read refreshes the TTL — so a half-hourly cron schedule keeps it warm instead of missing a 5-minute window every time. The two rolling points ride the conversation tail on the default 5-minute tier. Anthropic allows four breakpoints per request; LiteLLM counts any the caller supplied and never overwrites them, so a client with its own layout still wins.
+
+Nothing here is provider-specific. Non-Anthropic backends drop the markers in their provider transforms — Gemini and Gemma routes answer normally with unchanged token counts — and Gemini's own implicit caching, which needs no markers at all, is unaffected. Leaving the block in place on a Gemini install costs nothing and means switching to `MODEL_PROVIDER=anthropic` doesn't quietly switch caching off.
+
 ### Vertex AI and Model Garden
 
 `MODEL_PROVIDER=vertex` routes `model-default` to Vertex AI in your own GCP project — the same first-party Gemini models, plus every Model Garden publisher model your project has access to (Anthropic Claude, Llama, Mistral, and the rest). Requests stay inside your project's billing and data boundary, and no model API key exists anywhere in the cluster.
@@ -123,6 +148,7 @@ Deploy it as part of the provisioner by setting `INFERENCE_REPLAY_ENABLED=true`.
 The Platform Agent's config (`agents/platform/config.yaml`) doesn't mention the LLM provider. Provider selection is entirely at the LiteLLM / vLLM layer — the agent always talks to the `litellm` Service, and provisioning decides what that Service resolves to. When the replay proxy is deployed, the `litellm` Service is repointed at the replay proxy and the original LiteLLM pods are re-exposed through a new `litellm-gateway` Service that the proxy forwards cache misses to. That means:
 
 - Swapping Gemini for Anthropic is a LiteLLM `ConfigMap` change.
+- So is [prompt caching](#prompt-caching) — the breakpoints are injected gateway-side, because only the gateway knows which model they are for.
 - Turning on replay is a `INFERENCE_REPLAY_ENABLED=true` reprovision.
 - Neither touches the agent's persona, skills, or governance layer.
 

--- a/k8s-operator/config/integrations/litellm/base/config.yaml
+++ b/k8s-operator/config/integrations/litellm/base/config.yaml
@@ -10,3 +10,32 @@ model_list:
       model: ${MODEL_PROVIDER}/${MODEL_DEFAULT_NAME}
 litellm_settings:
   callbacks: ["otel", "prometheus"]
+# Prompt caching, injected gateway-side so the agent config stays free of model
+# identity. Hermes reaches us as `provider: custom` on the OpenAI wire asking
+# for "model-default", and its own Anthropic cache_control layout only engages
+# for a Claude-named model on the Anthropic wire — so on an Anthropic-family
+# backend every turn re-prefilled the entire prompt. One 45-call agent session
+# measured 3.5M input tokens with zero cache reads before this block.
+#
+# The system prompt takes the 1h tier: it is the largest static span, every
+# profile and cron tick shares it, and a read refreshes the TTL, so half-hourly
+# cron traffic keeps it warm instead of missing a 5m window every time. The two
+# rolling points ride the conversation tail on the default 5m tier.
+#
+# Anthropic allows four breakpoints per request. LiteLLM counts client-supplied
+# ones and never overwrites them, so a caller that sends its own layout still
+# wins. Non-Anthropic backends drop the markers in their provider transforms —
+# gemini and gemma routes answer 200 with unchanged token counts, and their
+# implicit caching is untouched.
+router_settings:
+  default_litellm_params:
+    cache_control_injection_points:
+      - location: message
+        role: system
+        control:
+          type: ephemeral
+          ttl: 1h
+      - location: message
+        index: -3
+      - location: message
+        index: -1

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -269,6 +269,45 @@ def model_names(text: str, path: Path) -> list[str]:
     return names
 
 
+def cache_control_points(text: str, path: Path) -> list[str]:
+    """The prompt-cache breakpoints a LiteLLM config injects, in order.
+
+    Each point flattens to one ``key=value`` string, sorted within the point but
+    not across them: order is load-bearing, since the 1h system breakpoint has to
+    precede the rolling 5m ones. Nesting is discarded — ``control.ttl`` and a
+    hypothetical top-level ``ttl`` would compare equal — which is enough to catch
+    the drift this guards against without a YAML dependency.
+
+    Finding no block means caching moved elsewhere, not that the gateway injects
+    nothing, so it exits rather than returning [] for both surfaces and passing.
+    """
+    lines = text.splitlines()
+    for start, line in enumerate(lines):
+        if line.strip() == "cache_control_injection_points:":
+            outer = len(line) - len(line.lstrip())
+            break
+    else:
+        sys.exit(f"ERROR: no cache_control_injection_points in {path.relative_to(REPO)}")
+
+    points: list[dict[str, str]] = []
+    for line in lines[start + 1 :]:
+        body = line.strip()
+        if not body or body.startswith("#"):
+            continue
+        if len(line) - len(line.lstrip()) <= outer:
+            break
+        if body.startswith("- "):
+            points.append({})
+            body = body[2:].strip()
+        key, _, value = body.partition(":")
+        value = value.strip()
+        if value and points:
+            points[-1][key.strip()] = value.strip('"').strip("'")
+    if not points:
+        sys.exit(f"ERROR: cache_control_injection_points is empty in {path.relative_to(REPO)}")
+    return [" ".join(f"{k}={v}" for k, v in sorted(p.items())) for p in points]
+
+
 # ─── checks ───────────────────────────────────────────────────────────────────
 
 
@@ -340,6 +379,24 @@ def check_litellm_aliases(f: Failures) -> None:
         f.add(
             "litellm-model-aliases",
             f"chart serves {chart}, kustomize base serves {kustomize} "
+            f"({CHART_HELPERS.relative_to(REPO)} vs {LITELLM_CONFIG.relative_to(REPO)})",
+        )
+
+
+def check_litellm_cache_points(f: Failures) -> None:
+    """The prompt-cache breakpoints, which only the gateway config carries.
+
+    The agent asks for "model-default" over the OpenAI wire and never names a
+    model, so nothing on the agent side can place these — a chart install that
+    lost the block would run uncached against an Anthropic backend and show it
+    only as a bill.
+    """
+    kustomize = cache_control_points(read(LITELLM_CONFIG), LITELLM_CONFIG)
+    chart = cache_control_points(read(CHART_HELPERS), CHART_HELPERS)
+    if kustomize != chart:
+        f.add(
+            "litellm-cache-control",
+            f"chart injects {chart}, kustomize base injects {kustomize} "
             f"({CHART_HELPERS.relative_to(REPO)} vs {LITELLM_CONFIG.relative_to(REPO)})",
         )
 
@@ -737,6 +794,7 @@ def check_cert_manager_resources(f: Failures) -> None:
 CHECKS = (
     check_litellm_image,
     check_litellm_aliases,
+    check_litellm_cache_points,
     check_model_defaults,
     check_registry_prefix,
     check_iam_roles,

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -289,6 +289,86 @@ class ModelNamesTest(unittest.TestCase):
             parity.model_names("apiVersion: v1\nkind: ConfigMap\n", FAKE)
 
 
+class CacheControlPointsTest(unittest.TestCase):
+    """The prompt-cache breakpoints, which the chart repeats verbatim.
+
+    The chart's copy sits inside a `define`, so the extractor has to end the
+    block on the template's own `{{- end }}` as readily as on a sibling YAML key.
+    """
+
+    KUSTOMIZE = textwrap.dedent(
+        """\
+        router_settings:
+          default_litellm_params:
+            cache_control_injection_points:
+              - location: message
+                role: system
+                control:
+                  type: ephemeral
+                  ttl: 1h
+              - location: message
+                index: -1
+        general_settings:
+          master_key: sk-1234
+        """
+    )
+
+    CHART = textwrap.dedent(
+        """\
+        {{- define "kube-agents.litellmConfig" -}}
+        router_settings:
+          default_litellm_params:
+            cache_control_injection_points:
+              # Same points, one comment and a template terminator later.
+              - control:
+                  ttl: 1h
+                  type: ephemeral
+                role: system
+                location: message
+              - location: message
+                index: -1
+        {{- end }}
+        """
+    )
+
+    def test_flattens_each_point_and_stops_at_the_next_key(self):
+        self.assertEqual(
+            parity.cache_control_points(self.KUSTOMIZE, FAKE),
+            ["location=message role=system ttl=1h type=ephemeral", "index=-1 location=message"],
+        )
+
+    def test_chart_spelling_compares_equal(self):
+        """Key order within a point is not a difference; the two must match."""
+        self.assertEqual(
+            parity.cache_control_points(self.CHART, FAKE),
+            parity.cache_control_points(self.KUSTOMIZE, FAKE),
+        )
+
+    def test_point_order_is_a_difference(self):
+        """Breakpoints are positional: the same two in the other order differ."""
+        reordered = textwrap.dedent(
+            """\
+            cache_control_injection_points:
+              - location: message
+                index: -1
+              - location: message
+                role: system
+                control:
+                  type: ephemeral
+                  ttl: 1h
+            """
+        )
+        self.assertNotEqual(
+            parity.cache_control_points(reordered, FAKE),
+            parity.cache_control_points(self.KUSTOMIZE, FAKE),
+        )
+
+    def test_no_block_exits_rather_than_reporting_none(self):
+        """Caching dropped from both surfaces must fail, not compare equal."""
+        with self.assertRaises(SystemExit):
+            parity.cache_control_points("litellm_settings:\n  callbacks: []\n", FAKE)
+
+
 class DigTest(unittest.TestCase):
     def test_missing_key_exits(self):
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
## Summary

The Platform Agent gets no prompt caching, and the reason is structural rather than a missing flag: the operator pins the harness to `provider: custom` asking for the alias `model-default`, and the harness only emits Anthropic `cache_control` breakpoints when it recognises a Claude-named model — so against an Anthropic-family backend it sends none and every turn re-bills the entire prompt. Fixing that agent-side would mean naming the real model in the agent config, which is exactly the coupling the gateway exists to prevent. So this PR puts the breakpoints where the model identity already lives: `router_settings.default_litellm_params.cache_control_injection_points` in the LiteLLM config, on both install surfaces, with a parity check so the two cannot drift.

The layout is a 1h breakpoint on the system message plus two rolling 5m points on the conversation tail. The system prompt takes the long tier because it is the largest static span, every profile and cron tick shares it, and a read refreshes the TTL — so a half-hourly cron schedule keeps it warm instead of missing a 5-minute window every time. The setting is deliberately generic rather than per-provider: non-Anthropic backends drop the markers in their provider transforms, so leaving it on a Gemini install costs nothing and switching `MODEL_PROVIDER=anthropic` doesn't quietly turn caching off.

## Why This Change

Measured on a live install before the change: one 45-call agent session burned **3.5M input tokens with zero cache reads** — the same ~79k-token prefix re-sent 45 times — and spent 458s of its 598s wall clock inside the model, ~10.2s per round trip, most of it re-prefilling context the provider had just seen. A `github-issue-resolver` cron tick showed `in=83,196 read=0 write=0`, repeating every half hour.

Without this, every Anthropic-backed install pays full input price for context the provider would have served at a tenth of the cost, and each turn waits on a full prefill it did not need. Nothing in the agent config can reach it.

## What Changed

- `k8s-operator/config/integrations/litellm/base/config.yaml` — the injection points, with the reasoning inline. This is the source of truth; the chart mirrors it.
- `charts/kube-agents/templates/_helpers.tpl` — the same block in `kube-agents.litellmConfig`. `litellm.yaml` already hashes the rendered config into the Deployment's `checksum/config`, so chart users get the rollout without a further change.
- `scripts/check_iac_parity.py` — new `check_litellm_cache_points` (16 checks now, was 15) comparing the block across the two surfaces. Point order is significant and is compared in order; key order within a point is not. Finding no block on either surface exits rather than comparing two empty lists as equal.
- `scripts/test_check_iac_parity.py` — four tests for the extractor: flattening and block termination, the chart's spelling comparing equal to kustomize's, order being a difference, and a missing block exiting.
- `docs/site/src/content/docs/concepts/inference-gateway.md` — a "Prompt caching" section under the LiteLLM heading covering why the breakpoints cannot live agent-side and why the block is safe on non-Anthropic providers.

No Go, no operator, no agent config touched.

## Context

Fixes #776, which carries the measurements and the requirements this was built against.

Deliberately not in scope:

- **The intermittent misses.** With injection on, hit rates measured 47–49% rather than ~100%. The cause is upstream: LiteLLM's `AnthropicCacheControlHook._apply_message_injections` increments its `used_blocks` counter even when `_safe_insert_cache_control_in_message` cannot place a marker (a message with `content: None`), so it can exhaust its 4-block budget having placed fewer than four. Worth a `BerriAI/litellm` PR; not something to work around here.
- **The gateway's readiness gap.** Every `kubectl rollout restart deploy/litellm` produced ~20–30s of `Connection refused` with pods reporting 1/1 — `/health/readiness` passes before the proxy binds its port. Pre-existing, unrelated to this change, but it makes any LiteLLM config rollout a brief fleet outage and deserves its own issue.

## Testing

- `python3 scripts/check_iac_parity.py` — "IaC parity: 16 checks passed across scripts, Terraform, and the Helm chart."
- `python3 -m unittest scripts.test_check_iac_parity -v` — 40 tests, OK (36 before, 4 new).
- `helm template` with the chart's defaults — the rendered `litellm-config` ConfigMap carries the block, correctly indented, and the surrounding YAML is unchanged. Checked that the `{{- /* … */}}` comment chomps to exactly one newline rather than swallowing the `callbacks:` line.
- `make docs-check` — generated regions, 247 files' relative links, terminology, and the docs map all pass.
- `make prettier-check` — the 19 warnings it reports are pre-existing on a clean tree at the same base commit (all under `.agents/skills/`); none of the files in this PR are among them.
- `make test-python` fails locally on missing third-party imports (`fastapi`, `httpx`, `mcp`, …) in `admin_console/tests/` and `agents/platform/scripts/`, unrelated to this change; the `scripts/` suite this PR extends passes.

### Live validation

Applied to a running install (LiteLLM v1.96.2, `kubeagents-system`) by patching the live `litellm-config` ConfigMap and restarting the gateway, then verified at each layer:

- **Mechanism, not coincidence.** A/B against the live proxy with injection on and off. Injection **on**: the Claude-backed route returned `cache_creation_input_tokens` on the first call and `cache_read_input_tokens` on the repeat. Injection **off** (block removed, gateway restarted): the same requests returned zero for both. Reverted and the reads came back.
- **Wire independence.** Caching engages on the plain `/v1/chat/completions` path — no `api_mode: anthropic_messages` change is needed. I had initially assumed the Anthropic wire was required; testing disproved it, which is why no agent-side change appears in this diff.
- **Non-Anthropic providers.** `model-gemini35flash`, `model-gemini31`, and `model-gemma` routes were exercised with injection on and off. All returned 200 with token counts unchanged between the two runs — the markers are dropped in the provider transform and Gemini's implicit caching is unaffected. One `404 gemma-4-31b-it is not found` appeared once and reproduced with injection **off** as well, so it is a pre-existing intermittent on that route (one of the round-robin `GEMINI_API_KEY_N` entries), not caused by this change.
- **Real production traffic.** The `github-issue-resolver` cron tick at 14:31:01Z went from `in=83,196 read=0 write=0` before the change to `in=4 read=0 write=83,169` after — the whole prompt recorded as a cache write on the first tick, which is the expected first-tick shape.
- **TTL layouts compared.** Four were measured on live traffic before settling: all-1h 47%, all-5m 49%, 1h system + 5m tail 48%, 5m system + 5m tail 36%. Interactive performance is equivalent across the first three; the shipped layout is the one that also survives a 30-minute cron gap.

Not covered: a Vertex AI Model Garden Claude route (no such install available to me) and the ChatGPT-subscription overlay. Both take the same code path through the LiteLLM hook, and the non-Anthropic evidence above covers the "markers are harmlessly dropped" case.

Cleanup: the live ConfigMap was left carrying the same block this PR ships, with the pre-change ConfigMap saved off before the first patch. No other test artifacts were created in the cluster.

## Self-Review

Read the diff as a reviewer looking for the three ways a config-parity change goes wrong.

- **Does the parity check actually fail when it should?** Verified by hand-editing each surface's block in turn and re-running: a reordered point, a changed TTL, and a deleted block each produce a failure. The last one matters most — the naive extractor would return `[]` for both surfaces and pass, so it exits instead.
- **Does the chart render what the base file says?** Checked the rendered output rather than trusting the template, specifically the whitespace chomping around the new comment block. It matches the kustomize base line for line.
- **Is the block safe on a default (Gemini) install?** This is what most users get, and shipping something Anthropic-shaped to them by default needed evidence, not reasoning — hence the on/off A/B on all three Gemini-family routes.

Two findings I chose not to fix here. The 47–49% hit rate is an upstream LiteLLM accounting bug (detailed under Context); working around it in config would mean shipping a layout distorted to dodge someone else's off-by-one, and the partial caching is a strict improvement over none in the meantime. The rollout-time connection refusals are a pre-existing probe misconfiguration on a resource this PR only edits the config of; fixing probes in a caching PR would hide a fleet-wide behaviour change inside an unrelated diff.

One thing a reviewer should push on if they disagree: the 1h tier bills writes at 2× rather than 1.25×. On the measured traffic — a system prompt shared by every profile, tick, and session — it pays for itself many times over, but an install with genuinely low agent traffic and no cron schedule would do better on all-5m. That is a one-line change to the same block if anyone wants it configurable.

## Risk & Rollout

Small blast radius: one config block, no runtime code, no Go, no CRD or operator change. Providers that don't understand `cache_control` discard it in their transforms, which was verified rather than assumed, so the default Gemini install is unaffected.

Chart users get an automatic rollout — `litellm.yaml` hashes the rendered config into the Deployment's `checksum/config` annotation, and the config is mounted with `subPath`, which never updates in place. Kustomize users pick it up on their next `provision_09_deploy_litellm.sh`. Note that any LiteLLM rollout currently costs ~20–30s of refused connections because of the readiness gap described under Context, so it is worth timing away from a cron tick.

Reverting is deleting the `router_settings` block and rolling the gateway; behaviour returns to full-price prefills immediately, with no persisted state to unwind.

---

This PR was generated with the help of Claude.
