### PR TITLE
docs(agents): harden adversarial review skill against lossy fallbacks and green-test bias

### DIFF
--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -76,12 +76,13 @@ makes this line wrong? Inverted or wrong conditions, off-by-one, nil/undefined d
 `await`, unchecked `err`, falsy-zero checks, wrong-variable copy-paste, an error swallowed in a
 catch, unescaped regex metacharacters.
 
-**Audit error handlers and fallback values**: for every `catch`, `except`, `if err != nil`, or
-fallback assignment on a failed resolution, trace the fallback value. Does it preserve the
-invariant downstream code assumes — a normalized 40-character SHA, a validated SemVer, an absolute
-path, a non-nil struct — or does it pass a raw, unvalidated input forward? Check if error
-suppression transforms a failed lookup on a malformed input into a benign empty result (`nil`,
-`""`, `[]`), silently disabling downstream collision, uniqueness, or security guards.
+**Audit error handlers and fallback values**: for every `catch`, `except`, `if err != nil`,
+`if ! cmd` (or `$? != 0`), or fallback assignment on a failed resolution, trace the fallback value.
+Does it preserve the invariant downstream code assumes — a normalized 40-character SHA, a validated
+SemVer, an absolute path, a non-nil struct — or does it pass a raw, unvalidated input forward? Check
+if error suppression (`|| true`, `_ = err`, `except: pass`) transforms a failed lookup on a
+malformed input into a benign empty result (`nil`, `""`, `[]`), silently disabling downstream
+collision, uniqueness, or security guards.
 
 **Angle B — removed-behavior auditor.** For every line the diff deletes or replaces, name the
 invariant it enforced, then find where the new code re-establishes it. If you cannot find it,

--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -76,6 +76,13 @@ makes this line wrong? Inverted or wrong conditions, off-by-one, nil/undefined d
 `await`, unchecked `err`, falsy-zero checks, wrong-variable copy-paste, an error swallowed in a
 catch, unescaped regex metacharacters.
 
+**Audit error handlers and fallback values**: for every `catch`, `except`, `if err != nil`, or
+fallback assignment on a failed resolution, trace the fallback value. Does it preserve the
+invariant downstream code assumes — a normalized 40-character SHA, a validated SemVer, an absolute
+path, a non-nil struct — or does it pass a raw, unvalidated input forward? Check if error
+suppression transforms a failed lookup on a malformed input into a benign empty result (`nil`,
+`""`, `[]`), silently disabling downstream collision, uniqueness, or security guards.
+
 **Angle B — removed-behavior auditor.** For every line the diff deletes or replaces, name the
 invariant it enforced, then find where the new code re-establishes it. If you cannot find it,
 that's a candidate: a removed guard, a dropped error path, a narrowed validation, a deleted test
@@ -97,6 +104,12 @@ precondition, a changed return shape, a renamed key a manifest still reads, a ti
 Trace runtime wiring through to the source — which container an env var lands in, which process
 reads a port, which service account a binding actually grants — rather than inferring it from
 names.
+
+**Audit sibling contract symmetry**: when reviewing code in a family of components (reconcilers,
+CLI tools, admission webhooks, API handlers), compare how identical domain inputs (a commit, a
+cluster name, a tag, credentials) are validated and handled across siblings. An unmotivated
+asymmetry — where one component hard-fails on an unresolvable entity while a sibling falls back
+silently — is an immediate candidate.
 
 Then trace the other direction, because a change written by an agent can call things that do not
 exist: for every symbol, method, flag, chart value, CRD field, environment variable, or file path
@@ -147,6 +160,13 @@ Then check that the intent is actually tested: for each behaviour the change cla
 that would fail if that behaviour regressed. Where there is none, the candidate is the untested
 behaviour, not the absent test — say which regression would ship silently. Bug fixes without a
 regression test, and new error paths nothing exercises, are the usual cases.
+
+**Do not treat green test suites as proof of correctness**: a passing suite proves only that the
+paths it exercises work on the fixtures it supplies. For every validation check, gate, and error
+path, check whether **negative inputs** (unresolvable identifiers, malformed strings, absent fields)
+are tested against the gate, or if the tests only pass valid fixtures through the happy path. Treat
+previously resolved findings in PR history as high-risk areas where adjacent defects and edge cases
+cluster.
 
 For a change that fixes something, naming the test is not enough — **run it against the pre-change
 behaviour and watch it fail.** A test that passes with the fix reverted is testing something else,

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -507,10 +507,7 @@ an ancestor of pr<N>`. Phase −1 is supposed to withhold the narrowed option in
   review comments on any sibling touching adjacent paths.
 
 - **No green-suite bypass.** Do not skip hunting candidates because CI or unit tests are passing.
-  Work every angle explicitly against the diff. Pay special attention to error fallbacks that pass
-  raw inputs forward, sibling contract symmetry across related components, and whether
-  negative/malformed inputs are tested against gates rather than assuming happy-path tests cover
-  all branches.
+  Work every angle explicitly against the diff as defined in `review-adversarial`.
 
 One thing the skill has no way to know about:
 

--- a/.claude/commands/pr-review-batch.md
+++ b/.claude/commands/pr-review-batch.md
@@ -506,6 +506,12 @@ an ancestor of pr<N>`. Phase −1 is supposed to withhold the narrowed option in
   `gh pr list --repo "$REPO" --author <login> --state open --json number,title,files`. Read the
   review comments on any sibling touching adjacent paths.
 
+- **No green-suite bypass.** Do not skip hunting candidates because CI or unit tests are passing.
+  Work every angle explicitly against the diff. Pay special attention to error fallbacks that pass
+  raw inputs forward, sibling contract symmetry across related components, and whether
+  negative/malformed inputs are tested against gates rather than assuming happy-path tests cover
+  all branches.
+
 One thing the skill has no way to know about:
 
 - **Merge mechanics are part of this review.** Run `gh pr checks <N> --repo "$REPO"`. If


### PR DESCRIPTION
# Pull Request

> This pull request was generated with the help of AI.

## Summary

Hardens the adversarial review skill (`review-adversarial`) and batch PR review runner (`pr-review-batch`) by introducing language-agnostic detection rules for lossy error fallbacks, sibling contract symmetry, and negative-space test auditing.

This initiative is the direct result of a post-mortem on a local adversarial review pass (on PR #732) that missed a critical High-severity defect — an unresolvable `TARGET_COMMIT` falling back to raw input and silently voiding collision/idempotency gates — which was subsequently surfaced by an additional `/review` pass by `kube-agents-bot`.

Local run: <img width="2356" height="1688" alt="image" src="https://github.com/user-attachments/assets/e9b44504-0360-452e-84dc-325dc44dc570" />

Bot result: 
<img width="1120" height="1068" alt="image" src="https://github.com/user-attachments/assets/5718e7cd-8e31-4a20-bdf1-12977d5d7da8" />


## Why This Change

Analyzing why the local review missed the defect revealed three systematic blind spots in the review methodology:
1. **Lossy Error Fallbacks**: When parsing or resolving an input fails, error handlers or fallback branches sometimes assign a raw, unvalidated input forward. When downstream checks swallow the error (e.g. via `|| true`, `except: pass`, or `_ = err`), malformed inputs look like empty results, silently bypassing uniqueness, collision, or security guards.
2. **Sibling Contract Asymmetry**: Sibling components in the same subsystem (controllers, CLI tools, scripts, API handlers) often handle identical domain inputs with unmotivated divergences in strictness (e.g., one script hard-failing with `exit 1` while a sibling falls back silently).
3. **Happy-Path / Green-Suite Complacency**: Reviewers often anchor on a passing test suite and fail to verify whether error paths, fallback branches, and malformed inputs are explicitly exercised in the test suite.

## What Changed

- **`.agents/skills/review-adversarial/SKILL.md`**:
  - **Angle A**: Added explicit audit for error handlers and fallback values (`catch`, `except`, `if err != nil`, `if ! cmd` / `$? != 0`) ensuring fallback values preserve type invariants rather than forwarding raw unvalidated inputs, and checking that error suppression (`|| true`, `_ = err`, `except: pass`) does not mask malformed inputs as empty results.
  - **Angle C**: Added **Sibling Contract Symmetry** rule comparing validation strictness and error semantics across related components handling identical domain entities.
  - **Angle I**: Added **Do not treat green test suites as proof of correctness** rule requiring verification of negative inputs against gates and error paths rather than relying solely on passing happy-path fixtures, and treating areas of previous PR fixes as high-risk clustering zones.
- **`.claude/commands/pr-review-batch.md`**:
  - In Phase 3 subagent instructions, added **No green-suite bypass** directive instructing subagents not to skip candidate hunting when CI is green and referencing the canonical `review-adversarial` skill.

## Context

- Post-mortem follow-up to PR #732 review calibration where an additional hostile `/review` pass caught a critical gate bypass missed during local self-review.

## Testing

- `make docs-check`: Passed (247 files checked, 0 errors).
- `make validate` & `make prompt-check`: Passed (97 instruction files, 42 skill bundles verified).
- `python3 -m unittest discover tests`: All 132 tests passing (`OK`).
- `(cd k8s-operator && go test ./...)`: All packages passing (`OK`).

### Live validation

- **Validated against PR #732 failure mode:** Verified that applying these updated rules against the PR #732 diff directly identifies the unhandled `TARGET_COMMIT` resolution failure and downstream collision gate bypass under Angle A (lossy fallback assignment) and Angle I (negative input test coverage).

## Self-Review

- **What was looked for:**
  - Adversarial review across the 10 quality angles (`review-adversarial`).
  - Generalized language-agnostic phrasing across Go, Python, TypeScript, and Shell (`catch`, `except`, `if err != nil`, `if ! cmd`, `|| true`).
  - One-home-per-fact documentation hygiene between `SKILL.md` (canonical) and `pr-review-batch.md` (runner wrapper).
  - Validation of doc links, terminology, and prompt reference resolution.
- **Findings and disposition:**
  - *Addressed reviewer feedback:* Removed duplicated angle rule text from `pr-review-batch.md`, added shell error forms to Angle A in `SKILL.md`, and synchronized rule titles and PR metadata.

## Risk & Rollout

- **Risk:** Low; documentation and agent review prompt enhancement only. Does not alter production runtime or deployment infrastructure.
