### PR TITLE
fix(platform): keep the Slack relay's register() shim signature-agnostic

### DIFF
--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -709,7 +709,7 @@ def install() -> None:
         PlatformRegistry, "_slack_standalone_relay_patched", False
     ):
 
-        def register(self: Any, entry: Any) -> Any:
+        def register(self: Any, entry: Any, *args: Any, **kwargs: Any) -> Any:
             if getattr(entry, "name", None) == "slack":
                 try:
                     patch_slack_entry(entry)
@@ -719,7 +719,23 @@ def install() -> None:
                     # import into a debug line. Raising here would disable the
                     # relay for the life of the process, and say nothing.
                     LOGGER.warning("Slack relay entry patch failed", exc_info=True)
-            return original_registry_register(self, entry)
+            # Forward the rest of the call blind instead of restating today's
+            # signature. This wrapper sits on the class, so every platform
+            # registers through it and one TypeError here takes Slack, Google
+            # Chat and A2A down together -- the gateway comes up with the
+            # built-in adapters missing and the pod answers no chat at all.
+            # v2026.8.13 added a keyword-only ``scope`` and did exactly that
+            # (#718 bumped the base image without touching this line); spelling
+            # the arguments out again would re-arm the same failure on the next
+            # bump.
+            #
+            # One residual difference from calling the original directly: when
+            # ``scope`` is omitted for a plugin-sourced entry the registry
+            # infers it from the call stack at a fixed depth, and this frame
+            # shifts that read. Nothing in the runtime hits it -- the gateway's
+            # plugin loader always passes ``scope`` explicitly -- but a caller
+            # that relies on inference would be attributed to this module.
+            return original_registry_register(self, entry, *args, **kwargs)
 
         PlatformRegistry.register = register
         PlatformRegistry._slack_standalone_relay_patched = True

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -719,22 +719,26 @@ def install() -> None:
                     # import into a debug line. Raising here would disable the
                     # relay for the life of the process, and say nothing.
                     LOGGER.warning("Slack relay entry patch failed", exc_info=True)
-            # Forward the rest of the call blind instead of restating today's
-            # signature. This wrapper sits on the class, so every platform
-            # registers through it and one TypeError here takes Slack, Google
-            # Chat and A2A down together -- the gateway comes up with the
+            # Forward everything after ``entry`` blind rather than restating
+            # today's signature. This wrapper sits on the class, so every
+            # platform registers through it and one TypeError here takes Slack,
+            # Google Chat and A2A down together -- the gateway comes up with the
             # built-in adapters missing and the pod answers no chat at all.
             # v2026.8.13 added a keyword-only ``scope`` and did exactly that
             # (#718 bumped the base image without touching this line); spelling
             # the arguments out again would re-arm the same failure on the next
             # bump.
             #
-            # One residual difference from calling the original directly: when
-            # ``scope`` is omitted for a plugin-sourced entry the registry
-            # infers it from the call stack at a fixed depth, and this frame
-            # shifts that read. Nothing in the runtime hits it -- the gateway's
-            # plugin loader always passes ``scope`` explicitly -- but a caller
-            # that relies on inference would be attributed to this module.
+            # One residual difference from calling the original directly, and it
+            # predates this wrapper's argument handling: when ``scope`` is
+            # omitted the registry infers it from the caller's frame at a fixed
+            # depth, and this frame occupies the slot it reads. The inferred
+            # scope is lost rather than wrong -- register() falls back to the
+            # entry's adapter_factory and then its check_fn, both
+            # frame-independent -- so an entry can land in the global scope
+            # instead of a plugin one. Nothing in the runtime relies on that
+            # inference: the plugin loader passes ``scope`` explicitly, and the
+            # built-in relay path sets source="builtin", which skips it.
             return original_registry_register(self, entry, *args, **kwargs)
 
         PlatformRegistry.register = register

--- a/agents/platform/scripts/test_slack_relay_patch.py
+++ b/agents/platform/scripts/test_slack_relay_patch.py
@@ -87,8 +87,13 @@ def _register_fake_modules() -> None:
         def create_adapter(self, name, config):
             return None
 
-        def register(self, entry):
+        # ``scope`` is keyword-only upstream as of Hermes v2026.8.13. A fake
+        # that omits it lets a wrapper which also omits it pass every test in
+        # this file and then fail on the first real registration, which is how
+        # #718 shipped a gateway with no chat adapters at all.
+        def register(self, entry, *, scope=None):
             self.registered = entry
+            self.registered_scope = scope
 
     @dataclasses.dataclass
     class PlatformEntry:
@@ -597,9 +602,11 @@ class SlackStandaloneRelaySendTest(unittest.TestCase):
                 delattr(self.registry_class, sentinel)
 
         self.registered = []
+        self.register_scopes = []
 
-        def _register(_self, entry):
+        def _register(_self, entry, *, scope=None):
             self.registered.append(entry)
+            self.register_scopes.append(scope)
 
         self.registry_class.register = _register
 
@@ -662,6 +669,29 @@ class SlackStandaloneRelaySendTest(unittest.TestCase):
         self.registry.register(entry)
         self.assertIs(entry.standalone_sender_fn, self.original_standalone_send)
         self.assertIsNone(entry.is_connected)
+
+    def test_a_scoped_registration_is_forwarded_untouched(self):
+        entry = self.entry_class(
+            name="slack", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry.register(entry, scope="plugin:example")
+        self.assertEqual([entry], self.registered)
+        self.assertEqual(["plugin:example"], self.register_scopes)
+
+    def test_a_scoped_registration_of_another_platform_still_lands(self):
+        """The failure mode that takes the whole gateway down.
+
+        This wrapper is installed on the class, so a Slack patch that cannot
+        accept the registry's current keywords does not merely lose Slack --
+        every platform registers through it, and the gateway comes up with
+        Google Chat and A2A missing too.
+        """
+        entry = self.entry_class(
+            name="google_chat", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry.register(entry, scope="plugin:google_chat")
+        self.assertEqual([entry], self.registered)
+        self.assertEqual(["plugin:google_chat"], self.register_scopes)
 
     def test_an_existing_status_check_still_decides_when_a_token_exists(self):
         os.environ["SLACK_BOT_TOKEN"] = "xoxb-local"

--- a/agents/platform/scripts/test_slack_relay_patch.py
+++ b/agents/platform/scripts/test_slack_relay_patch.py
@@ -87,13 +87,15 @@ def _register_fake_modules() -> None:
         def create_adapter(self, name, config):
             return None
 
-        # ``scope`` is keyword-only upstream as of Hermes v2026.8.13. A fake
-        # that omits it lets a wrapper which also omits it pass every test in
-        # this file and then fail on the first real registration, which is how
-        # #718 shipped a gateway with no chat adapters at all.
+        # Upstream made ``scope`` keyword-only in Hermes v2026.8.13. This
+        # stand-in is what install() captures as the original wherever a test
+        # does not install its own, so it has to accept what the real registry
+        # accepts -- a fake stuck on the old signature agrees with a wrapper
+        # stuck on the old signature, and #718 shipped a gateway with no chat
+        # adapters through exactly that blind spot. The forwarding itself is
+        # exercised through _register in SlackStandaloneRelaySendTest.setUp.
         def register(self, entry, *, scope=None):
             self.registered = entry
-            self.registered_scope = scope
 
     @dataclasses.dataclass
     class PlatformEntry:


### PR DESCRIPTION
## Summary

The Slack credential-proxy relay installs a wrapper over `PlatformRegistry.register`, and that wrapper hard-coded the two-parameter signature the method had before Hermes v2026.8.13. That release made `scope` keyword-only and the gateway's plugin loader passes it, so every registration raised `TypeError`. The wrapper sits on the class rather than on the Slack entry, so the failure was not confined to Slack — the gateway came up with no chat adapters at all. This forwards `*args`/`**kwargs` to the original instead of restating the signature, and gives the tests' registry fakes upstream's signature so the same mismatch cannot pass CI again.

## Why This Change

#718 bumped `HERMES_AGENT_TAG` from v2026.8.3 to v2026.8.13 and reworked around forty patch files, but not this one. Every agent pod built from `main` since then starts like this — taken from my own install's log at 14:05 today:

```
TypeError: install.<locals>.register() got an unexpected keyword argument 'scope'
WARNING gateway.run: No adapter available for google_chat
WARNING gateway.run: No adapter available for slack
INFO gateway.run: Gateway running with 1 platform(s)
```

The pod stays `4/4 Running` with no restarts and passes every probe. It just never answers a message, and because Slack and Google Chat both fail there is no channel left for it to report the fault on. `main` is in this state now.

## What Changed

- `slack_relay_patch.py` — the shim forwards positional and keyword arguments to the original `register` rather than naming them. The comment records why, so the next base-image bump does not tidy the signature back.
- `test_slack_relay_patch.py` — both registry fakes declared the old signature. A wrapper that omits `scope` and a fake that never passes one agree with each other, which is how #718 went green. The fakes now match upstream, and two tests cover the scoped path: one for Slack, one for a non-Slack platform — the blast radius that made this an outage rather than a Slack bug.

## Context

Caused by #718 (`1e2df49c`). No existing issue tracks it.

- #720 also touches `slack_relay_patch.py`, at the imports and the relay's `request()` headers, roughly 600 lines from this change. No textual conflict, and it does not address the signature.
- #741 is a separate defect in the sibling `google_chat_relay_patch.py`, unrelated to this one.
- Two follow-ups came out of the self-review below and are not fixed here. Both are written up and ready to file as issues; I held off because they were outside the change I was asked to put up. Say the word and I will file them, or fold the first into this PR if you would rather have it in one pass.

## Testing

`make verify` passes on the branch head: go build, go vet, go test, 8 operator Python tests, and 513 Python tests elsewhere, 32 of them in `test_slack_relay_patch.py`.

Mutation check, since a test that passes either way proves nothing: reverting the production change while keeping the new tests fails exactly those two tests, with the production error verbatim — `TypeError: install.<locals>.register() got an unexpected keyword argument 'scope'`. Restoring it turns them green. Run twice, once by me and once independently by the review pass.

`make docs-check` passes, and the `review-docs-drift` skill found no Blocking findings: nothing generates from `agents/platform/scripts/*.py`, no doc states the wrapper's contract, and the only doc naming the file (`overview/architecture.mdx:82`, "Slack uses `slack_relay_patch.py` in Socket Mode") is still accurate. `make iac-parity-check` not run — the diff touches no install surface, with `k8s-operator/scripts/`, `k8s-operator/config/`, `terraform/` and `charts/` all untouched. No Markdown, JSON or YAML changed, so prettier does not apply.

### Live validation

Install: `gke_adamparco-kage_us-east4_platform-agent-host`, namespace `kubeagents-system`, operator `k8s-operator:dev-92394c1-0817-155621`, agent image `platform-agent:dev-72b800e-0818-relayfix` on pod `platform-agent-gateway-d96ccddfc-jpz4q`. The agent runs Hermes **v0.20.1 (2026.8.13)** — the release that introduced the break — so this is exercised against the version that fails, not against the older base it was briefly rolled back to.

Both sides of the experiment are in one file, `/opt/data/logs/gateway.log` on the agent PVC:

- **Before** — 14:05:45, same base image without this change: the `TypeError` above, then `No adapter available for google_chat`, `No adapter available for slack`, `Gateway running with 1 platform(s)`.
- **After** — 15:27–15:28, this change applied: `✓ google_chat connected`, `✓ api_server connected`, `✓ slack reconnected successfully`, `3 platform(s)`. No `TypeError` and no `No adapter available` anywhere in the boot. Slack's first connect hits the usual 30s Socket Mode timeout and the reconnection watcher picks it up 30s later; that is pre-existing behaviour on this install, not something this change introduces.

I also confirmed the mechanism rather than just the symptom, reading from inside the running pod:

- Upstream is keyword-only in this release — `/opt/hermes/gateway/platform_registry.py:503` reads `def register(self, entry: PlatformEntry, *, scope: Optional[str] = None) -> None`.
- The caller does pass it — `hermes_cli/plugins.py` calls `platform_registry.register(entry, scope=scope)`.
- The shim is the installed `register` on the class in-process, and its signature is now `(self, entry, *args, **kwargs)`.

Before deploying, I ran a probe inside the same base image that drove the real `PlatformRegistry` through the patched shim: `slack`, `google_chat` and `a2a` each registered with `scope=`, plus a no-scope call, all passing.

What I did not cover: the deployed image also carries an unrelated local change of mine to the kanban report-format stanza, so the pod is not a pure build of this branch — that change lives in `kanban_tools.py` and touches no registration path. A2A registers, but I did not exercise an A2A message end to end. The two comment-only commits in `93cbcb6c` landed after the image was built and are not in the running pod; they change no behaviour. Artifacts: the probe script was deleted from the pod, nothing else was left behind.

## Self-Review

Ran the repo's `review-adversarial` skill against the branch diff in a fresh subagent handed the diff range and nothing else — not the plan, not the reasoning that produced the change. It verified its claims by reading `gateway/platform_registry.py` inside the pinned v2026.8.13 image rather than inferring them, and I re-checked each one against the running pod before acting on it.

Angles applied that found nothing: removed behaviour and weakened gates (nothing deleted but the narrow signature; no test removed, skipped or xfailed; no `continue-on-error` or CI trigger change; the diff is not test-only); cross-file tracer in both directions (this repo wraps `register` exactly once, so there is no divergent copy to drift); ops and security (no IAM, RBAC, NetworkPolicy, credential or redaction surface; `**kwargs` is forwarded, never logged); reuse and efficiency; altitude; conventions; scope creep; and sibling PRs.

Five findings — three fixed in `93cbcb6c`, two deferred.

**Fixed: the comment claimed "forward the rest of the call blind" while still naming `entry`.** Only what follows `entry` is forwarded. Reworded to say so.

**Fixed: the frame-shift note was wrong about its own consequence.** I had written that a caller relying on scope inference "would be attributed to this module". It would not. `_caller_plugin_scope()` resolves the shifted frame to `slack_relay_patch`, which is not a plugin namespace, so `register()` falls through to the entry's `adapter_factory` and then its `check_fn` (`platform_registry.py:514-520`). The scope is lost, not misattributed, and the entry can land in the global scope instead of a plugin one. Rewritten. I also dropped the "for a plugin-sourced entry" qualifier, since `PlatformEntry.source` defaults to `"plugin"` and the inference path is wider than that implied. The frame shift itself predates this PR — the wrapper was already in that stack — so it is a comment-accuracy fix, not a behaviour change.

**Fixed: a test comment claimed coverage it does not provide.** The module-level registry fake's comment said a fake with the old signature "lets a wrapper which also omits it pass every test in this file", but no test calls that fake's `register` — they all go through `_register` installed in `SlackStandaloneRelaySendTest.setUp`. Reworded to state what the fake is actually for, and dropped a dead `registered_scope` assignment nothing reads.

**Deferred: `create_adapter` has the identical exposure, here at `slack_relay_patch.py:694` and at `google_chat_relay_patch.py:170`.** This is the strongest of the five and I want to flag it rather than bury it: same class-level wrapper, same restated signature, one upstream parameter change away from repeating this outage for every platform at adapter-construction time. Latent rather than live — upstream is still `create_adapter(self, name: str, config: Any)` at `platform_registry.py:600` in the pinned image, which I checked. My reason for not folding it in is about this change specifically: the image I live-validated contains exactly this diff, and I would rather not ship untested edits alongside an outage fix that is currently proven running in a real install. Mechanical when someone does take it — neither wrapper body inspects `config`, it only forwards it — and the test fakes have to move with it or the blind spot that let #718 through is reproduced.

**Deferred: the pre-registration fallback sweep is inoperative, and says otherwise.** Pre-existing, in lines this PR does not touch. `install()` sweeps `singleton._entries` for a Slack entry registered before the patch loaded, but the same v2026.8.13 also made plugin registrations scoped, so they land in `_scoped_entries[scope]` and never in `_entries`. The sharp part is the guard: the `LOGGER.warning` for "entries are not introspectable" cannot fire, because `_entries` still exists and is still a `dict`, so the `isinstance` branch wins and the `elif` never runs. Its comment promises the warning will "leave a trace" on a base-image bump — the bump happened, and there is no trace. Not fixed here because it is a separate defect needing a real decision about scoped-entry semantics, and because the `register` wrapper is the path that actually fires in the deployed gateway, which handles scoped entries correctly once it accepts the keyword.

## Risk & Rollout

Blast radius is one function in one patch file. The change strictly widens what the wrapper accepts: calls that worked before still work, and calls that previously raised `TypeError` now reach the original. The wrapper does not interpret the extra arguments, it passes them through.

Reverting this commit restores the outage. Nothing has to happen at merge time — the fix is picked up on the next agent image build.

---

This PR was generated with the help of Claude.
