### PR TITLE
fix(scripts): remove exponential backtracking from the IaC parity case-arm regex

### DIFF
--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -352,7 +352,12 @@ def check_model_defaults(f: Failures) -> None:
         sys.exit(f"ERROR: no default_model_for_provider in {COMMON_SH.relative_to(REPO)}")
     script: dict[str, str] = {}
     fallback: str | None = None
-    for patterns, model in re.findall(r"^\s*([^\s)]+(?:\s*\|\s*[^\s)]+)*)\)\s*echo\s+\"([^\"]+)\"", body.group(1), re.M):
+    # The alternatives inside a case arm exclude "|" so each one has exactly one
+    # way to match. Letting [^\s)] swallow the separator too made "a|b|c" parse
+    # ambiguously and backtrack exponentially on a long unterminated arm (CodeQL
+    # py/redos). ArmScannerBacktrackingTest holds the line.
+    arm = re.compile(r"^\s*([^\s)|]+(?:\s*\|\s*[^\s)|]+)*)\)\s*echo\s+\"([^\"]+)\"", re.M)
+    for patterns, model in arm.findall(body.group(1)):
         for provider in (p.strip() for p in patterns.split("|")):
             if provider == "*":
                 # The catch-all arm, not a provider. Anything the case does not

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -19,10 +19,12 @@ directly::
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import re
 import tempfile
 import textwrap
+import time
 import unittest
 import unittest.mock
 from pathlib import Path
@@ -342,6 +344,14 @@ class ModelDefaultsTest(unittest.TestCase):
     def test_explicitly_cased_provider_still_compared(self):
         self.assertEqual(self._run('"anthropic" "claude-sonnet-4-5-20250929"'), [])
 
+    def test_both_alternatives_of_a_multi_pattern_arm_are_read(self):
+        """`chatgpt | openai)` names two providers, not one string with a pipe."""
+        self.assertEqual(self._run('"chatgpt" "gpt-5.4" "openai" "gpt-5.4"'), [])
+        self.assertEqual(
+            self._run('"openai" "gpt-4"'),
+            [("model-defaults", "openai: chart defaults to gpt-4, common.sh to gpt-5.4")],
+        )
+
     def test_drift_on_a_fall_through_provider_is_caught(self):
         """The regression the `*`-as-gemini reading would have hidden."""
         failures = self._run('"vertex_ai" "some-other-model"')
@@ -353,6 +363,55 @@ class ModelDefaultsTest(unittest.TestCase):
         failures = self._run('"nosuchprovider" "gemini-3.5-flash"')
         self.assertEqual(len(failures), 1, failures)
         self.assertIn("common.sh does not", failures[0][1])
+
+
+class ArmScannerBacktrackingTest(unittest.TestCase):
+    """The `case`-arm scanner must not backtrack exponentially (CodeQL py/redos).
+
+    While the alternative classes still admitted "|", they could match a
+    pipe-joined arm two ways — as one run of the first class, or as several
+    repetitions of the alternation — so an arm that never reached its
+    `) echo "..."` cost time exponential in the number of alternatives: 0.009 s
+    at 16, 0.15 s at 20, 2.7 s at 24, minutes not far above that.
+
+    The test drives the real ``check_model_defaults`` rather than a copy of the
+    pattern, because a copy would keep passing after the production regex
+    regressed. The budget sits five orders of magnitude above the fixed
+    scanner's ~5 us, so only a genuine return of the blowup trips it, not a
+    loaded CI runner. It is also why the count is 26 and not larger: it has to
+    stay cheap when the scanner is correct and be ruinous when it is not.
+    """
+
+    ALTERNATIVES = 26
+    BUDGET_SECONDS = 1.0
+
+    def test_pipe_joined_arm_with_no_body_is_rejected_promptly(self):
+        arm = "|".join("a" for _ in range(self.ALTERNATIVES))
+        common_sh = textwrap.dedent(
+            """\
+            default_model_for_provider() {
+              case "$1" in
+                %s X
+              esac
+            }
+            """
+        ) % arm
+
+        f = parity.Failures()
+        started = time.perf_counter()
+        with unittest.mock.patch.object(parity, "read", return_value=common_sh):
+            # The arm scan runs before anything reads the chart, so whatever the
+            # rest of the check makes of this fixture is beside the point.
+            with contextlib.suppress(SystemExit):
+                parity.check_model_defaults(f)
+        elapsed = time.perf_counter() - started
+
+        self.assertLess(
+            elapsed,
+            self.BUDGET_SECONDS,
+            f"scanning a {self.ALTERNATIVES}-alternative arm took {elapsed:.3f}s; "
+            f"the case-arm regex is backtracking exponentially again",
+        )
 
 
 class WebhookParityTest(unittest.TestCase):

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -345,7 +345,14 @@ class ModelDefaultsTest(unittest.TestCase):
         self.assertEqual(self._run('"anthropic" "claude-sonnet-4-5-20250929"'), [])
 
     def test_both_alternatives_of_a_multi_pattern_arm_are_read(self):
-        """`chatgpt | openai)` names two providers, not one string with a pipe."""
+        """`chatgpt | openai)` names two providers, not one string with a pipe.
+
+        This pins the alternation parse, not the backtracking fix — the
+        capture group wraps the whole alternation, so the pre-fix pattern
+        passes it too. ArmScannerBacktrackingTest is the guard for that. What
+        this one catches is a parser rewritten to stop splitting arms on "|"
+        at all, which would silently drop every provider after the first.
+        """
         self.assertEqual(self._run('"chatgpt" "gpt-5.4" "openai" "gpt-5.4"'), [])
         self.assertEqual(
             self._run('"openai" "gpt-4"'),


### PR DESCRIPTION
## Summary

`scripts/check_iac_parity.py` parsed `common.sh`'s `default_model_for_provider` case arms with a regex whose alternative class also matched the `|` separator, so a pipe-joined arm had more than one way to match and the scanner backtracked exponentially when an arm never reached its `) echo "..."`. Excluding `|` from both character classes leaves exactly one way to match each alternative and removes the blowup. Parsing behaviour is unchanged: old and new produce byte-identical output on the real `common.sh`.

## Why This Change

CodeQL `py/redos` on `main`, rated high severity. Without the fix the parity checker degrades exponentially on a malformed `common.sh` — 0.009 s at 16 alternatives, 0.15 s at 20, 2.7 s at 24, ~10 s at 26, minutes not far above that — so a bad edit to the shell function turns a fast lint into a hung CI job rather than a clean failure.

Worth stating plainly for the reviewer: the rating overstates the exposure here. The input is a repository-controlled file read by a CI-side lint, not anything attacker-supplied. The fix is still worth having; it is not an incident.

## What Changed

- `scripts/check_iac_parity.py` — `[^\s)]` → `[^\s)|]` in both alternative classes of the case-arm pattern, and the pattern hoisted to a named `re.compile` so the comment has something to attach to. This is the shape the file's neighbours already use: `check_prompt_assets.py:199` and `request_reviewers.py:135` both exclude their own separator, and CodeQL flags neither.
- `scripts/test_check_iac_parity.py` — two tests. `ArmScannerBacktrackingTest` is the guard for this change: a wall-clock bound on a 26-alternative unterminated arm, driving the real `check_model_defaults` because a copy of the pattern in the test would keep passing after the production regex regressed. `test_both_alternatives_of_a_multi_pattern_arm_are_read` pins the alternation parse and is explicitly *not* a guard for the backtracking fix — the pre-fix pattern passes it too. Its docstring says so. It stays because it catches a different regression: a parser that stops splitting arms on `|` and silently drops every provider after the first.

## Context

No open pull request touches `scripts/check_iac_parity.py`, and no open issue tracks this. `gh search prs` for `codeql`/`redos` returns nothing open or closed.

Fixes code scanning alert [18](https://github.com/gke-labs/kube-agents/security/code-scanning/18) — visible only to accounts with `security-events` access on the upstream repository, so the finding is restated in full above rather than left behind that link. It is the only open alert on the repository.

This PR was generated with the help of Claude.

## Testing

- `python3 -m pytest scripts/test_check_iac_parity.py` — 38 passed. The new test adds under 5 ms.
- `make iac-parity-check` — 15 checks passed across scripts, Terraform, and the Helm chart.
- `make docs-check` — clean.
- Equivalence: old and new patterns yield identical output on the real `common.sh` and on spaced (`x | y | z`), unspaced (`a|b`), and catch-all (`*`) arms.
- The regression test discriminates. Against the pre-fix regex it fails at 9.95 s versus the 1.0 s budget; against the fixed one it runs in ~5 µs. Five orders of magnitude of headroom, so a loaded runner will not trip it.

### Live validation

Not live-tested. The change is a CI-side Python lint with no path into a running kube-agents installation — it reads files out of the repository working tree and never touches the operator, the agent image, or any cluster object, so there is no CR `.status`, Deployment env, or in-pod file for an install to show. It was instead exercised directly against the real `k8s-operator/scripts/common.sh` it parses, as described under Testing. No test artifacts; the revert experiments ran on copies under `/tmp` and have been removed.

## Self-Review

Ran `.agents/skills/review-adversarial/SKILL.md` over the branch diff in a subagent that was handed the diff and nothing else — no rationale, no summary, no claim about what had been verified. Two findings, both confirmed, both fixed.

- **The first version of the test did not guard the change** (medium). It asserted that `chatgpt | openai)` registers two providers, and it passes identically against the pre-fix regex — the capture group wraps the whole alternation, so both patterns return the same string. I had checked it against a mutation that deleted the alternation group outright, which is not the change in this diff, and concluded too much from that. Fixed: added the timing bound described under Testing, and verified it fails at 9.95 s on the pre-fix regex. The original test stays, with its docstring narrowed to what it actually pins — it independently catches a parser that stops splitting arms on `|`, and is not a ReDoS guard.
- **The comment cited "alert 18"** (low), which no fork contributor can resolve — code scanning here is GitHub default setup with no checked-in workflow, and `security-events: read` is not available to them. Fixed: the comment now names the query and points at the test.

Two things the pass refuted that I would otherwise have carried into this description:

- The new pattern does reject some arms the old one accepted, but a fuzz over 400k random strings found that every divergence requires an empty alternative (`a|)`, `|a)`, `a||b)`). `bash -n` rejects all three, and `common.sh` is sourced by every provisioning script, so a file that triggers it is already broken. Not a behaviour change in practice.
- A separate quadratic remains in the same pattern: `^\s*` under `re.M` rescans whitespace from each line start, about 2.7 s on 16k blank lines. Measured byte-identical before and after (2.7044 s vs 2.7006 s). Pre-existing, untouched by this diff, and not something this PR claims to fix — recorded here so the next reader of that regex knows it is there.

Angles that turned up nothing: cross-file impact (the compiled pattern is function-local with one caller), altitude (of 30 regexes in the file, this was the only one with a quantified group over an overlapping class, so the fix is not one instance of a family), ops and security surface (no IAM, RBAC, NetworkPolicy, credential, or Actions change), reuse, simplification, conventions and generated docs, and sibling pull requests.

## Risk & Rollout

Low. No runtime code path, no cluster object, no chart or Terraform surface — the only consumer is `make iac-parity-check` in CI and locally. The parsing behaviour is unchanged on every arm bash will accept, so the checker's verdicts do not move. Revert is the single commit; the worst case on a bad revert is the lint getting slow again on a malformed `common.sh`, which the new test would catch first.



---

**Correction (ed52aaa).** The first version of this description said the non-guarding test had been *replaced*, and the **What Changed** bullet named only `ArmScannerBacktrackingTest`. Neither was true: the branch added both tests and removed nothing. `kube-agents-bot` caught it — the sections above are corrected, and `ed52aaa` narrows the kept test's docstring so it no longer reads as coverage of the backtracking fix.
