### PR TITLE
docs(contributing): document make docs-check in local validation

### DIFF
--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -72,6 +72,16 @@ Before pushing, run the checks CI enforces:
   npm run build
   ```
 
+- **Docs checks** (if you touched any Markdown — the `Docs Check` CI job runs these on every PR, and a green docs build does not imply they pass):
+
+  ```bash
+  # from the repo root; runs the four checks the Docs Check job runs as separate steps:
+  # generated regions are up to date, cross-references resolve, terminology is consistent, and the docs map matches
+  make docs-check
+  ```
+
+  If the generated-regions step fails, `make docs-generate` rewrites them from their sources.
+
 ## Live validation
 
 The checks above tell you the code compiles, the docs resolve, and the unit tests agree with themselves. None of them tell you whether the operator reconciled your change or the agent pod picked it up — this project's failure mode is a green build that configures nothing. So every pull request fills in the template's **Testing → Live validation** section with how the change was exercised against a real, running kube-agents installation. If you don't have one, [INSTALL.md](https://github.com/gke-labs/kube-agents/blob/main/INSTALL.md) stands one up.


### PR DESCRIPTION
# Pull Request

## Why This Change

The **Local validation** section of the contributing guide lists the checks to run before pushing — Prettier, Validate Repo Structure, Docker Build, Operator Tests, and the `docs/site` build — but it never mentions the **Docs Check** CI job (`.github/workflows/docs-check.yml`).

That leaves a gap for the most common kind of contribution. Someone making a docs-only change follows the section, runs `npm run build`, sees it pass, pushes — and CI still fails on link resolution, terminology, the docs map, or stale generated regions. The docs build and the docs checks are unrelated gates, but the guide only names one of them.

## What Changed

**Files:**

- `docs/site/src/content/docs/contributing.md`

**Added/Changed/Fixed:**

- Added a **Docs checks** bullet to Local validation covering `make docs-check`, the root Makefile aggregate that runs the same four checks the Docs Check job runs as separate steps (`docs-check-generated`, `docs-check-links`, `docs-check-terminology`, `docs-check-map`).
- Noted that `make docs-generate` is the fix when the generated-regions step fails.

No content was moved or reworded; this is a single added bullet.

## Why This Matters

- Closes the one CI job that Local validation didn't represent, so the section is now complete rather than nearly complete.
- Catches docs-only failures locally in one command instead of on a CI round-trip.
- Points at the remedy for the generated-regions failure, which is the least self-evident of the four.

## Context

- The `Docs Check` workflow runs the four checks as separate steps; `make docs-check` (root `Makefile`) is the existing aggregate that already matched them. This PR only documents it — no Makefile or workflow changes.
- Sample PR opened to exercise the contribution flow. Happy to close it if it isn't wanted; the underlying gap is real either way.

## Testing

- `make docs-check` — passes (exit 0) with the change applied: 247 Markdown files link-checked, all relative links resolve, terminology check passed, docs map inventory covers all 218 tracked docs.
- Verified against the source of truth rather than the prose: confirmed `docs-check` and its four prerequisites exist in the root `Makefile`, and that `.github/workflows/docs-check.yml` runs those same four as separate steps.

**Live validation:** Not applicable — documentation-only change with no runtime, operator, or agent-configuration surface. Nothing is reconciled or deployed by this diff.

---

Zero functional impact: one added bullet in a contributing guide. Risk is limited to the docs site rebuild.
