### PR TITLE
fix(platform): close the two follow-ups #780 deferred on the relay shims

### DIFF
--- a/agents/platform/scripts/google_chat_relay_patch.py
+++ b/agents/platform/scripts/google_chat_relay_patch.py
@@ -167,8 +167,12 @@ def install() -> None:
     original_registry_create = PlatformRegistry.create_adapter
     if not getattr(PlatformRegistry, "_credential_proxy_relay_patched", False):
 
-        def create_adapter(self: Any, name: str, config: Any) -> Any:
-            adapter = original_registry_create(self, name, config)
+        # Forwarded blind past ``name``: this wrapper adds a side effect and
+        # delegates, so upstream owns the signature. Restating one is how the
+        # Slack relay's registry shim took every platform down when the base
+        # image grew a new keyword-only argument (see slack_relay_patch).
+        def create_adapter(self: Any, name: str, *args: Any, **kwargs: Any) -> Any:
+            adapter = original_registry_create(self, name, *args, **kwargs)
             if name == "google_chat" and adapter is not None:
                 patch_adapter_class(type(adapter))
             return adapter

--- a/agents/platform/scripts/slack_relay_patch.py
+++ b/agents/platform/scripts/slack_relay_patch.py
@@ -691,8 +691,12 @@ def install() -> None:
     original_registry_create = PlatformRegistry.create_adapter
     if not getattr(PlatformRegistry, "_slack_credential_proxy_relay_patched", False):
 
-        def create_adapter(self: Any, name: str, config: Any) -> Any:
-            adapter = original_registry_create(self, name, config)
+        # ``*args``/``**kwargs`` rather than upstream's signature restated: this
+        # wrapper adds a side effect and delegates, so the signature is not its
+        # to own. Restating one is what took chat down when v2026.8.13 gave
+        # ``register`` a keyword-only ``scope`` -- see the note there.
+        def create_adapter(self: Any, name: str, *args: Any, **kwargs: Any) -> Any:
+            adapter = original_registry_create(self, name, *args, **kwargs)
             if name == "slack" and adapter is not None:
                 patch_adapter_class(type(adapter))
             return adapter
@@ -732,13 +736,19 @@ def install() -> None:
             # One residual difference from calling the original directly, and it
             # predates this wrapper's argument handling: when ``scope`` is
             # omitted the registry infers it from the caller's frame at a fixed
-            # depth, and this frame occupies the slot it reads. The inferred
-            # scope is lost rather than wrong -- register() falls back to the
-            # entry's adapter_factory and then its check_fn, both
-            # frame-independent -- so an entry can land in the global scope
-            # instead of a plugin one. Nothing in the runtime relies on that
-            # inference: the plugin loader passes ``scope`` explicitly, and the
-            # built-in relay path sets source="builtin", which skips it.
+            # depth (``_caller_plugin_scope`` reads ``sys._getframe(2)``), and
+            # this frame occupies the slot it reads. Three things keep that
+            # harmless. The inference is gated on ``entry.source == "plugin"``,
+            # so the built-in relay path never reaches it. ``register_platform``
+            # -- the path every bundled platform takes -- passes ``scope``
+            # explicitly. And where it does run, the shifted frame resolves to
+            # this module, which is not a plugin namespace, so upstream falls
+            # through to ``_plugin_scope_from_callable`` on the entry's own
+            # ``adapter_factory`` and then its ``check_fn``; both are
+            # frame-independent and recover the same scope
+            # (``platform_registry.py:515-520`` in v2026.8.13). Only an entry
+            # whose callables the tool registry cannot place lands in the global
+            # scope instead of a plugin one.
             return original_registry_register(self, entry, *args, **kwargs)
 
         PlatformRegistry.register = register
@@ -753,24 +763,53 @@ def install() -> None:
             registry_module = sys.modules.get("gateway.platform_registry")
             singleton = getattr(registry_module, "platform_registry", None)
             entries = getattr(singleton, "_entries", None)
-            if isinstance(entries, dict):
-                if "slack" in entries:
-                    patch_slack_entry(entries["slack"])
-            elif singleton is not None:
-                # The registry is up but its entries are not where this reads
-                # them. Normally that means nothing -- the register() wrapper
-                # above is the path that actually fires, and this fallback is
-                # for the ordering where the plugin got in first. But `_entries`
-                # is a private name: if upstream renames it, the two cases stop
-                # being distinguishable from here, and the one that matters
-                # fails by silently not relaying. Warn rather than debug, so a
-                # base-image bump that moves it leaves a trace.
+            # Both maps. Since v2026.8.13 a scoped registration lands in
+            # `_scoped_entries[scope]` rather than `_entries`, and
+            # `PluginContext.register_platform` always passes a scope (the
+            # profile's Hermes home), so the scoped map is where a plugin's
+            # Slack entry would be.
+            #
+            # Defensive, not a live fix: `sitecustomize`'s import hook calls
+            # install() the moment `gateway.platform_registry` finishes
+            # executing, so in the deployed process both maps are still empty
+            # here and the register() wrapper above is what does the work.
+            # Nothing else in the repo calls install(). This keeps the sweep
+            # honest for the ordering it claims to cover, so that it is not
+            # quietly wrong if install() ever acquires a second caller.
+            scoped = getattr(singleton, "_scoped_entries", None)
+            readable = [entries] if isinstance(entries, dict) else []
+            if isinstance(scoped, dict):
+                readable.extend(
+                    scope_entries
+                    for scope_entries in scoped.values()
+                    if isinstance(scope_entries, dict)
+                )
+            for scope_entries in readable:
+                slack_entry = scope_entries.get("slack")
+                if slack_entry is not None:
+                    # Idempotent, so an entry visible in both maps is safe.
+                    patch_slack_entry(slack_entry)
+            if singleton is not None and not (
+                isinstance(entries, dict) and isinstance(scoped, dict)
+            ):
+                # The registry is up but at least one of the two maps is not
+                # where this reads it. Both are private names, and a bump that
+                # renames either one leaves the sweep partially blind. Warn on
+                # *either* going missing rather than only on both: with
+                # `_scoped_entries` gone this still reads `_entries` and finds
+                # it empty, which is the quiet, wrong answer -- `_entries` is
+                # the map a scoped registration never lands in. Whatever is
+                # still readable is swept first, because half a sweep beats
+                # none. A base image that consolidates the two maps trips this
+                # too; that is the intended cost, since from here consolidation
+                # and a rename look the same and only one of them is safe.
                 LOGGER.warning(
                     "Slack relay: platform registry is loaded but its entries "
-                    "are not introspectable (_entries is %s); a Slack entry "
-                    "registered before this patch installed will not be "
-                    "patched",
+                    "are not introspectable (_entries is %s, _scoped_entries "
+                    "is %s); a Slack entry registered before this patch "
+                    "installed may not be patched",
                     type(entries).__name__,
+                    type(scoped).__name__,
                 )
         except Exception:
             LOGGER.debug("No pre-registered Slack entry to patch", exc_info=True)

--- a/agents/platform/scripts/test_slack_relay_patch.py
+++ b/agents/platform/scripts/test_slack_relay_patch.py
@@ -84,7 +84,11 @@ def _register_fake_modules() -> None:
         return f"cached_image.{ext}"
 
     class PlatformRegistry:
-        def create_adapter(self, name, config):
+        # Wide for the same reason ``register`` below is: the shim forwards
+        # everything past ``name`` blind, and a fake stuck on today's two-arg
+        # signature would agree with a wrapper stuck on it. The forwarding
+        # itself is exercised in SlackRelayPatchTest.
+        def create_adapter(self, name, *args, **kwargs):
             return None
 
         # Upstream made ``scope`` keyword-only in Hermes v2026.8.13. This
@@ -332,6 +336,45 @@ class SlackRelayPatchTest(unittest.TestCase):
     def _create_adapter(self, token=""):
         config = types.SimpleNamespace(token=token)
         return self.registry_class().create_adapter("slack", config)
+
+    def test_create_adapter_arguments_the_shim_knows_nothing_about_forward(self):
+        """``create_adapter`` is wrapped the same way, so it is pinned too.
+
+        Both wrappers on the registry class add a side effect and delegate.
+        The one that took chat down was ``register``, but nothing about that
+        was specific to it -- upstream is equally free to give
+        ``create_adapter`` an argument this shim has never heard of.
+        """
+        seen = []
+
+        def _create_adapter(_self, name, *args, **kwargs):
+            seen.append((name, args, kwargs))
+            if name != "slack":
+                return None
+            return self.adapter_module.FakeAdapter(args[0])
+
+        self.registry_class.create_adapter = _create_adapter
+        for sentinel in (
+            "_slack_credential_proxy_relay_patched",
+            "_slack_standalone_relay_patched",
+        ):
+            if hasattr(self.registry_class, sentinel):
+                delattr(self.registry_class, sentinel)
+        slack_relay_patch.install()
+
+        config = types.SimpleNamespace(token="xoxb-forwarded")
+        adapter = self.registry_class().create_adapter(
+            "slack", config, scope="/x", not_invented_yet=1
+        )
+
+        self.assertEqual(
+            [("slack", (config,), {"scope": "/x", "not_invented_yet": 1})], seen
+        )
+        # The side effect still happened: patching is keyed on the name, which
+        # is the only argument the shim reads.
+        self.assertTrue(
+            getattr(type(adapter), "_credential_proxy_relay_patched", False)
+        )
 
     def test_bolt_per_request_client_symbol_is_relay_backed(self):
         adapter = self._create_adapter()
@@ -604,11 +647,11 @@ class SlackStandaloneRelaySendTest(unittest.TestCase):
                 delattr(self.registry_class, sentinel)
 
         self.registered = []
-        self.register_scopes = []
 
+        # Upstream's signature, keyword-only ``scope`` included -- see the note
+        # on the module-level fake.
         def _register(_self, entry, *, scope=None):
-            self.registered.append(entry)
-            self.register_scopes.append(scope)
+            self.registered.append((entry, scope))
 
         self.registry_class.register = _register
 
@@ -662,7 +705,66 @@ class SlackStandaloneRelaySendTest(unittest.TestCase):
         # Tokenless, the probe has to say Slack is reachable — the relay is.
         self.assertTrue(entry.is_connected(types.SimpleNamespace(enabled=True)))
         # The entry still reaches the real registry, unswallowed.
-        self.assertEqual([entry], self.registered)
+        self.assertEqual([(entry, None)], self.registered)
+
+    def test_the_scope_upstream_passes_reaches_upstream(self):
+        """``register_platform`` scopes every registration; forward it verbatim.
+
+        Hermes v2026.8.13 made ``PlatformRegistry.register`` take a
+        keyword-only ``scope`` and had ``PluginContext.register_platform`` pass
+        the profile's Hermes home on every call. The shim is installed on the
+        class, so a signature narrower than upstream's does not fail Slack --
+        it fails Google Chat, Discord and every other platform with it, and the
+        gateway comes up with no chat adapters.
+        """
+        entry = self.entry_class(
+            name="slack", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry.register(entry, scope="/data/profiles/platform")
+
+        self.assertEqual([(entry, "/data/profiles/platform")], self.registered)
+        self.assertIsNot(entry.standalone_sender_fn, self.original_standalone_send)
+
+    def test_a_non_slack_entry_registers_with_a_scope_too(self):
+        """The wrapper is on the class: everyone's registration goes through it."""
+        entry = self.entry_class(
+            name="google_chat", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry.register(entry, scope="/data/profiles/platform")
+
+        self.assertEqual([(entry, "/data/profiles/platform")], self.registered)
+        self.assertIs(entry.standalone_sender_fn, self.original_standalone_send)
+
+    def test_arguments_the_shim_knows_nothing_about_are_forwarded(self):
+        """Whatever upstream adds next has to pass through untouched.
+
+        The wrapper contributes a side effect and delegates; the signature is
+        upstream's. Pinning ``scope`` by name would leave the shim broken by
+        the argument after it in exactly the same way.
+        """
+        seen = []
+
+        def _register(_self, entry, *args, **kwargs):
+            seen.append((entry, args, kwargs))
+
+        self.registry_class.register = _register
+        for sentinel in (
+            "_slack_credential_proxy_relay_patched",
+            "_slack_standalone_relay_patched",
+        ):
+            if hasattr(self.registry_class, sentinel):
+                delattr(self.registry_class, sentinel)
+        slack_relay_patch.install()
+
+        entry = self.entry_class(
+            name="slack", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry.register(entry, "positional", scope="/x", not_invented_yet=1)
+
+        self.assertEqual(
+            [(entry, ("positional",), {"scope": "/x", "not_invented_yet": 1})], seen
+        )
+        self.assertIsNot(entry.standalone_sender_fn, self.original_standalone_send)
 
     def test_a_non_slack_entry_is_left_alone(self):
         entry = self.entry_class(
@@ -671,29 +773,6 @@ class SlackStandaloneRelaySendTest(unittest.TestCase):
         self.registry.register(entry)
         self.assertIs(entry.standalone_sender_fn, self.original_standalone_send)
         self.assertIsNone(entry.is_connected)
-
-    def test_a_scoped_registration_is_forwarded_untouched(self):
-        entry = self.entry_class(
-            name="slack", standalone_sender_fn=self.original_standalone_send
-        )
-        self.registry.register(entry, scope="plugin:example")
-        self.assertEqual([entry], self.registered)
-        self.assertEqual(["plugin:example"], self.register_scopes)
-
-    def test_a_scoped_registration_of_another_platform_still_lands(self):
-        """The failure mode that takes the whole gateway down.
-
-        This wrapper is installed on the class, so a Slack patch that cannot
-        accept the registry's current keywords does not merely lose Slack --
-        every platform registers through it, and the gateway comes up with
-        Google Chat and A2A missing too.
-        """
-        entry = self.entry_class(
-            name="google_chat", standalone_sender_fn=self.original_standalone_send
-        )
-        self.registry.register(entry, scope="plugin:google_chat")
-        self.assertEqual([entry], self.registered)
-        self.assertEqual(["plugin:google_chat"], self.register_scopes)
 
     def test_an_existing_status_check_still_decides_when_a_token_exists(self):
         os.environ["SLACK_BOT_TOKEN"] = "xoxb-local"
@@ -844,12 +923,18 @@ class SlackRegisteredBeforeInstallTest(unittest.TestCase):
     """The ordering the register() wrapper cannot cover.
 
     Every other test here registers Slack *after* install(), so the wrapper
-    fires and the sweep of existing entries is dead code. If the plugin gets
+    fires and the sweep of existing entries is dead code. If the registry gets
     there first the wrapper never sees the entry, and the only thing that
-    patches it is the sweep over the registry's live entries. That sweep reads
-    a private ``_entries``, so it is exactly the part most likely to rot
-    against a base-image bump — and it rots silently, into "cron briefs stopped
-    arriving" with no error anywhere.
+    patches it is the sweep over the registry's live entries.
+
+    In the deployed process that ordering does not arise: ``sitecustomize``
+    hooks the import and calls install() the instant
+    ``gateway.platform_registry`` finishes executing, before anything can
+    register. The sweep is cover for install() ever gaining a caller that
+    runs later, and these tests are what keep it from being quietly wrong in
+    the meantime. It reads two private names, ``_entries`` and
+    ``_scoped_entries``, so it is also the part most likely to rot against a
+    base-image bump — hence the warning tests below.
     """
 
     def setUp(self):
@@ -919,6 +1004,43 @@ class SlackRegisteredBeforeInstallTest(unittest.TestCase):
         self.assertIsNot(entry.standalone_sender_fn, self.original_standalone_send)
         self.assertTrue(entry.is_connected(types.SimpleNamespace(enabled=True)))
 
+    def test_an_entry_pre_registered_into_a_scope_is_still_patched(self):
+        """Since v2026.8.13 the scoped map is where Slack would be.
+
+        ``register_platform`` always passes a scope -- the profile's Hermes
+        home -- and a scoped registration lands in ``_scoped_entries[scope]``,
+        leaving ``_entries`` empty. A sweep that reads only ``_entries`` finds
+        nothing, patches nothing and says nothing, which from here is
+        indistinguishable from a registry that has no Slack in it. Nothing
+        reaches the sweep in the deployed process (see the class docstring);
+        this pins the map it would have to read if anything did.
+        """
+        entry = self.entry_class(
+            name="slack", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry_module.platform_registry = types.SimpleNamespace(
+            _entries={},
+            _scoped_entries={"/data/profiles/platform": {"slack": entry}},
+        )
+
+        slack_relay_patch.install()
+
+        self.assertIsNot(entry.standalone_sender_fn, self.original_standalone_send)
+        self.assertTrue(entry.is_connected(types.SimpleNamespace(enabled=True)))
+
+    def test_a_scoped_non_slack_entry_is_left_alone(self):
+        entry = self.entry_class(
+            name="discord", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry_module.platform_registry = types.SimpleNamespace(
+            _entries={},
+            _scoped_entries={"/data/profiles/platform": {"discord": entry}},
+        )
+
+        slack_relay_patch.install()
+
+        self.assertIs(entry.standalone_sender_fn, self.original_standalone_send)
+
     def test_a_pre_registered_non_slack_entry_is_left_alone(self):
         entry = self.entry_class(
             name="discord", standalone_sender_fn=self.original_standalone_send
@@ -942,6 +1064,51 @@ class SlackRegisteredBeforeInstallTest(unittest.TestCase):
         self.assertTrue(
             any("not introspectable" in line for line in logs.output), logs.output
         )
+
+    def test_only_one_map_being_readable_still_warns(self):
+        # Half a rename is the case that fails quietly. With `_scoped_entries`
+        # gone the sweep still reads `_entries`, finds it empty and reports
+        # nothing -- and `_entries` is the map a scoped registration never
+        # lands in. Warning on either name going missing costs a line on a
+        # base image that consolidates the two; staying quiet costs Slack.
+        for label, singleton in (
+            ("scoped only", types.SimpleNamespace(_scoped_entries={})),
+            ("global only", types.SimpleNamespace(_entries={})),
+        ):
+            with self.subTest(label):
+                self.registry_module.platform_registry = singleton
+                for sentinel in (
+                    "_slack_credential_proxy_relay_patched",
+                    "_slack_standalone_relay_patched",
+                ):
+                    if hasattr(self.registry_class, sentinel):
+                        delattr(self.registry_class, sentinel)
+
+                with self.assertLogs(
+                    slack_relay_patch.LOGGER, level="WARNING"
+                ) as logs:
+                    slack_relay_patch.install()
+
+                self.assertTrue(
+                    any("not introspectable" in line for line in logs.output),
+                    logs.output,
+                )
+
+    def test_the_readable_map_is_still_swept_when_the_other_is_gone(self):
+        # Warning is not instead of working: whatever survived the rename is
+        # swept anyway, so a half-renamed registry loses the half it lost and
+        # not the half it kept.
+        entry = self.entry_class(
+            name="slack", standalone_sender_fn=self.original_standalone_send
+        )
+        self.registry_module.platform_registry = types.SimpleNamespace(
+            _scoped_entries={"/data/profiles/platform": {"slack": entry}}
+        )
+
+        with self.assertLogs(slack_relay_patch.LOGGER, level="WARNING"):
+            slack_relay_patch.install()
+
+        self.assertIsNot(entry.standalone_sender_fn, self.original_standalone_send)
 
     def test_no_registry_yet_is_not_worth_a_warning(self):
         # install() routinely runs before the registry module has a singleton;

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1135,9 +1135,19 @@ COPY --chown=hermes:hermes agents/platform/hindsight/ /opt/platform-template/hin
 # sources are called config.yaml), but the overlay and the merger can share one
 # COPY into the staging directory. Layers are budgeted here — see the note at
 # the top of the file.
+#
+# verify_slack_relay_registry_contract.py rides along in that second COPY, and
+# runs from the same RUN, for the layer budget alone — it has nothing to do
+# with the platform config. It checks the relay patches copied to
+# /opt/defaults/scripts above against the Hermes tree they monkeypatch, which
+# is why it cannot run in CI: `credential-proxy` builds FROM this stage and its
+# chain measured 119 of the 120 layers `scripts/check_image_layers.py` allows,
+# so a COPY/RUN pair of its own is a layer this file does not have. See the
+# module docstring for what a failure here means.
 COPY deploy/shared/defaults/config.yaml /tmp/platform-config/base.yaml
 COPY agents/platform/config.yaml \
      deploy/docker/merge_configs.py \
+     deploy/docker/patches/verify_slack_relay_registry_contract.py \
      /tmp/platform-config/
 RUN /opt/hermes/.venv/bin/python3 /tmp/platform-config/merge_configs.py /tmp/platform-config/base.yaml /tmp/platform-config/config.yaml && \
     cp /tmp/platform-config/base.yaml /opt/platform-template/config.yaml && \
@@ -1149,6 +1159,7 @@ caps = ToolCallGuardrailConfig.from_mapping(cfg.get('tool_loop_guardrails', {}))
 assert caps.max_web_searches == 200, 'per-card web_search budget lost: %r' % caps.max_web_searches; \
 assert caps.max_subagents == 50, 'overlay clobbered max_subagents: %r' % caps.max_subagents; \
 assert cfg.get('agent', {}).get('max_turns') == 250, 'iteration budget lost: %r' % cfg.get('agent', {}).get('max_turns')" && \
+    cd /opt/hermes && PYTHONPATH=/opt/defaults/scripts /opt/hermes/.venv/bin/python3 /tmp/platform-config/verify_slack_relay_registry_contract.py && \
     rm -rf /tmp/platform-config
 
 # Copy the Cluster Agent profile TEMPLATE (persona, config, skills), scaffolded

--- a/deploy/docker/patches/verify_slack_relay_registry_contract.py
+++ b/deploy/docker/patches/verify_slack_relay_registry_contract.py
@@ -1,0 +1,407 @@
+"""Build-time gate for the relay patches' grip on Hermes' platform registry.
+
+Run by ``deploy/docker/Dockerfile`` in the ``platform`` stage, against the real
+``/opt/hermes`` tree and the scripts that will be on the runtime PYTHONPATH.
+A failure here fails the image build.
+
+The unit suite in ``agents/platform/scripts/test_slack_relay_patch.py`` covers
+the shim against fakes, and fakes are written by the same hand as the shim.
+That is not a hypothetical weakness. ``slack_relay_patch.install()`` replaces
+``PlatformRegistry.register`` on the class, and until v2026.8.13 both the shim
+and both test fakes declared ``register(self, entry)``. The base-image bump in
+#718 gave upstream a keyword-only ``scope`` and had
+``PluginContext.register_platform`` pass it on every registration. The fakes
+agreed with the shim, CI was green, and the built image raised
+
+    TypeError: register() got an unexpected keyword argument 'scope'
+
+for *every* platform plugin -- Google Chat and Discord included, because the
+shim sits on the class the whole gateway registers through. The gateway came up
+with no chat adapters and nothing in the symptom pointed at a Slack file.
+
+So this checks the shim against the thing it actually wraps:
+
+1. the signatures of every upstream callable the two patches replace are still
+   the signatures they were written against;
+2. a plugin-sourced entry registers through the shim exactly as
+   ``hermes_cli/plugins.py`` registers one, scope and all, and comes back
+   relay-backed and findable;
+3. a non-Slack entry registers untouched -- the blast radius, not the symptom;
+4. the install-time sweep still finds an entry that was registered before the
+   patch loaded, which since v2026.8.13 means finding it in ``_scoped_entries``
+   rather than ``_entries``;
+5. all of that again in a child process wired the way the pod is -- relay URL
+   in the environment, scripts on ``PYTHONPATH`` -- so ``sitecustomize``'s
+   import hook is what installs the patch, not this file.
+
+Check 1 is a pin. When it fails, read the upstream method, decide whether the
+shim needs to change, and then update the expectation deliberately -- do not
+refresh it to whatever the new image says.
+
+Checks 1-4 run in a process where ``SLACK_RELAY_URL`` is *unset at startup*,
+because ``sitecustomize.install_hook()`` reads the environment as it is
+imported: with the variable set, the hook is armed before this file gets a
+word in and ``PlatformRegistry.register`` is already wrapped by the time the
+signatures are read, which would pin the shim against itself. The wired
+process is check 5's job, and it asserts the hook fired rather than installing
+anything by hand.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import subprocess
+import sys
+
+# Never dialled: every check here stops short of a request. It only has to look
+# like a configured relay to ``relay_without_token()``.
+RELAY_URL = "http://127.0.0.1:8765"
+
+# Set by the parent on the wired child, and the only thing that tells the two
+# runs apart.
+WIRED = "SLACK_RELAY_CONTRACT_WIRED"
+
+failures: list[str] = []
+
+
+def relay_patch_variables() -> tuple[tuple[str, str], ...]:
+    """``sitecustomize``'s own list of (env var, patch module) pairs.
+
+    Read from the module rather than restated, because the whole point of this
+    file is that a copy of upstream's shape drifts from it. An import error is
+    left to propagate: the scripts are on PYTHONPATH by the time this runs, so
+    a failure here means the build is wrong about that, and a fallback list
+    would hide it.
+    """
+    import sitecustomize
+
+    return tuple(sitecustomize.RELAY_PATCHES)
+
+
+def check(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        fail(label, f"expected {expected!r}, got {actual!r}")
+    else:
+        print(f"  ok    {label}")
+
+
+def fail(label: str, why: str) -> None:
+    failures.append(f"{label}: {why}")
+    print(f"  FAIL  {label}")
+
+
+def shape(func: object) -> str:
+    """Parameter names and kinds, without annotations or default values.
+
+    Annotations churn for cosmetic reasons (``Optional[str]`` becoming
+    ``str | None`` breaks nothing); an added, renamed or reordered parameter is
+    what breaks a shim.
+    """
+    rendered = []
+    for param in inspect.signature(func).parameters.values():
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            rendered.append(f"*{param.name}")
+        elif param.kind is inspect.Parameter.VAR_KEYWORD:
+            rendered.append(f"**{param.name}")
+        else:
+            if param.kind is inspect.Parameter.KEYWORD_ONLY and "*" not in "".join(
+                rendered
+            ):
+                rendered.append("*")
+            rendered.append(
+                param.name + ("=..." if param.default is not param.empty else "")
+            )
+    return ", ".join(rendered)
+
+
+# The signatures the two relay patches were written against. Keyed by a label
+# that names the shim that depends on each one.
+UPSTREAM_SIGNATURES = {
+    "PlatformRegistry.register": "self, entry, *, scope=...",
+    "PlatformRegistry.create_adapter": "self, name, config",
+    "SlackAdapter.connect": "self, *, is_reconnect=...",
+    "SlackAdapter.disconnect": "self",
+    "SlackAdapter._start_socket_mode_handler": "self",
+    "SlackAdapter._stop_socket_mode_handler": "self",
+    "SlackAdapter._ensure_socket_watchdog": "self",
+    "SlackAdapter._download_slack_file": "self, url, ext, audio=..., team_id=...",
+    "SlackAdapter._download_slack_file_bytes": "self, url, team_id=...",
+    "SlackAdapter.format_message": "self, content",
+    "slack._standalone_send": (
+        "pconfig, chat_id, message, *, thread_id=..., media_files=..., "
+        "force_document=..., caption=..."
+    ),
+    "GoogleChatAdapter.connect": "self, *, is_reconnect=...",
+    "GoogleChatAdapter.disconnect": "self",
+    "GoogleChatAdapter._new_authed_http": "self",
+    "GoogleChatAdapter._handle_setup_files_command": (
+        "self, chat_id, thread_id, raw_text, sender_email=..."
+    ),
+}
+
+
+def upstream_callables() -> dict[str, object]:
+    """Resolve every pinned callable out of the image's own Hermes tree."""
+    from gateway.platform_registry import PlatformRegistry
+    from plugins.platforms.google_chat import adapter as google_chat_adapter
+    from plugins.platforms.slack import adapter as slack_adapter
+
+    slack = slack_adapter.SlackAdapter
+    google_chat = google_chat_adapter.GoogleChatAdapter
+    return {
+        "PlatformRegistry.register": PlatformRegistry.register,
+        "PlatformRegistry.create_adapter": PlatformRegistry.create_adapter,
+        "SlackAdapter.connect": slack.connect,
+        "SlackAdapter.disconnect": slack.disconnect,
+        "SlackAdapter._start_socket_mode_handler": slack._start_socket_mode_handler,
+        "SlackAdapter._stop_socket_mode_handler": slack._stop_socket_mode_handler,
+        "SlackAdapter._ensure_socket_watchdog": slack._ensure_socket_watchdog,
+        "SlackAdapter._download_slack_file": slack._download_slack_file,
+        "SlackAdapter._download_slack_file_bytes": slack._download_slack_file_bytes,
+        "SlackAdapter.format_message": slack.format_message,
+        "slack._standalone_send": slack_adapter._standalone_send,
+        "GoogleChatAdapter.connect": google_chat.connect,
+        "GoogleChatAdapter.disconnect": google_chat.disconnect,
+        "GoogleChatAdapter._new_authed_http": google_chat._new_authed_http,
+        "GoogleChatAdapter._handle_setup_files_command": (
+            google_chat._handle_setup_files_command
+        ),
+    }
+
+
+async def upstream_sender(_pconfig, _chat_id, _message, **_kwargs):
+    """Stand-in for the plugin's own ``_standalone_send``."""
+    return {"success": True, "sender": "upstream"}
+
+
+def make_entry(name: str):
+    """A ``source="plugin"`` entry shaped the way ``register_platform`` builds one."""
+    from gateway.platform_registry import PlatformEntry
+
+    return PlatformEntry(
+        name=name,
+        label=name.title(),
+        adapter_factory=lambda config: None,
+        check_fn=lambda: True,
+        source="plugin",
+        standalone_sender_fn=upstream_sender,
+    )
+
+
+def register_scoped(label: str, entry, scope: str) -> bool:
+    """Register the way ``PluginContext.register_platform`` does, and say so.
+
+    ``hermes_cli/plugins.py`` builds a ``source="plugin"`` entry and calls
+    ``register(entry, scope=...)``. The scope is never ``None`` there --
+    ``PluginManager`` defaults it to ``hermes_home_key()`` -- so the keyword
+    the shim used to reject is on every real registration.
+
+    Returns whether it landed, because every check after it reads an entry
+    that a failed registration never touched: without this the regression
+    reports itself as a stack trace out of some later assertion instead of as
+    the one thing that went wrong.
+    """
+    from gateway.platform_registry import platform_registry
+
+    try:
+        platform_registry.register(entry, scope=scope)
+    except TypeError as exc:
+        fail(label, f"register(entry, scope=...) raised {exc}")
+        return False
+    print(f"  ok    {label}")
+    return True
+
+
+def relay_backed(entry) -> bool:
+    return getattr(
+        entry.standalone_sender_fn, "_credential_proxy_relay_patched", False
+    )
+
+
+def registry_checks(scope: str) -> None:
+    """The behaviour both the hand-installed and the wired process must show."""
+    from gateway.platform_registry import platform_registry
+
+    slack_entry = make_entry("slack")
+    slack_label = "a scoped Slack registration survives the shim"
+    if register_scoped(slack_label, slack_entry, scope):
+        check(
+            "the Slack entry relays its standalone sends",
+            relay_backed(slack_entry),
+            True,
+        )
+        check(
+            "the Slack entry reports itself reachable without a token",
+            # ``is_connected`` is an optional field, left None by the entry the
+            # plugin builds, so an unpatched entry has to read as a failed
+            # check rather than as a TypeError from calling None.
+            bool(slack_entry.is_connected and slack_entry.is_connected(None)),
+            True,
+        )
+        check(
+            "the Slack entry reached the registry",
+            platform_registry.get("slack"),
+            slack_entry,
+        )
+
+    # The blast radius, not the symptom: the shim sits on the class, so this is
+    # the registration the v2026.8.13 TypeError actually broke most of.
+    other = make_entry("google_chat")
+    if register_scoped("a non-Slack platform still registers", other, scope):
+        check(
+            "a non-Slack platform is left alone",
+            other.standalone_sender_fn,
+            upstream_sender,
+        )
+        check(
+            "the non-Slack entry reached the registry",
+            platform_registry.get("google_chat"),
+            other,
+        )
+
+
+def unwired() -> int:
+    """Pin the signatures, then drive the shim with an explicit ``install()``."""
+    from gateway.platform_registry import PlatformRegistry, platform_registry
+    from hermes_constants import hermes_home_key
+
+    # Read before anything installs, so a shim that replaced a method cannot be
+    # mistaken for upstream declaring it. The guard in main() strips the relay
+    # variables that would have armed one; this asserts the result rather than
+    # trusting it, because both patches leave the same marker and a pin read
+    # off a shim is a check that has quietly stopped checking anything.
+    for sentinel in (
+        "_slack_credential_proxy_relay_patched",
+        "_slack_standalone_relay_patched",
+        "_credential_proxy_relay_patched",
+    ):
+        check(
+            f"no relay patch installed before the pin is read ({sentinel})",
+            getattr(PlatformRegistry, sentinel, False),
+            False,
+        )
+
+    for label, func in upstream_callables().items():
+        check(f"upstream signature: {label}", shape(func), UPSTREAM_SIGNATURES[label])
+
+    os.environ["SLACK_RELAY_URL"] = RELAY_URL
+    # No token anywhere: the credential proxy holds the only one, and that is
+    # the deployment these patches exist for.
+    os.environ.pop("SLACK_BOT_TOKEN", None)
+
+    import slack_relay_patch
+
+    stock_register = PlatformRegistry.register
+    slack_relay_patch.install()
+    check(
+        "install() replaced PlatformRegistry.register",
+        PlatformRegistry.register is not stock_register,
+        True,
+    )
+
+    scope = hermes_home_key()
+    registry_checks(scope)
+
+    # --- the ordering the register() wrapper cannot cover -------------------
+    # An entry already in place when install() runs is reached only by the
+    # sweep over the registry's private entry maps. Since v2026.8.13 a scoped
+    # registration lands in _scoped_entries, so a sweep that reads only
+    # _entries finds nothing, patches nothing, and warns about nothing.
+    #
+    # This ordering does not occur in the pod: sitecustomize's hook calls
+    # install() as gateway.platform_registry finishes executing, before
+    # anything can register, and nothing else calls install(). The sweep is
+    # cover for install() gaining a later caller, and this check is what keeps
+    # it honest against a base image that moves the maps under it -- it has to
+    # be staged deliberately, as below, because nothing produces it on its own.
+    platform_registry.unregister("slack", scope=scope)
+    PlatformRegistry.register = stock_register
+    for sentinel in (
+        "_slack_credential_proxy_relay_patched",
+        "_slack_standalone_relay_patched",
+    ):
+        if hasattr(PlatformRegistry, sentinel):
+            delattr(PlatformRegistry, sentinel)
+    pre_registered = make_entry("slack")
+    platform_registry.register(pre_registered, scope=scope)
+    slack_relay_patch.install()
+    check(
+        "the sweep finds a Slack entry registered before the patch loaded",
+        relay_backed(pre_registered),
+        True,
+    )
+
+    return report("unwired")
+
+
+def wired() -> int:
+    """Assert the pod's own wiring installed the patch, and that it works.
+
+    Nothing here calls ``install()``. Importing the registry is what fires
+    ``sitecustomize``'s hook, exactly as the gateway process does it, so a
+    ``sitecustomize`` that stopped arming the hook fails this and passes
+    everything above.
+    """
+    from gateway.platform_registry import PlatformRegistry
+    from hermes_constants import hermes_home_key
+
+    if not getattr(PlatformRegistry, "_slack_standalone_relay_patched", False):
+        # Everything below asks what the patch did, so with no patch installed
+        # they answer a question nobody asked. Report the one real fault.
+        fail(
+            "importing the registry installed the Slack relay patch",
+            "PlatformRegistry._slack_standalone_relay_patched is unset -- "
+            "sitecustomize did not arm the hook for SLACK_RELAY_URL",
+        )
+        return report("wired")
+    print("  ok    importing the registry installed the Slack relay patch")
+
+    registry_checks(hermes_home_key())
+    return report("wired")
+
+
+def report(phase: str) -> int:
+    if failures:
+        print(f"\nverify_slack_relay_registry_contract [{phase}] FAILED:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"\nverify_slack_relay_registry_contract [{phase}]: all checks passed")
+    return 0
+
+
+def main() -> int:
+    if os.environ.get(WIRED):
+        return wired()
+
+    # Every variable ``sitecustomize`` arms a patch on, not just Slack's. The
+    # operator sets GOOGLE_CHAT_RELAY_URL on the agent container, and
+    # google_chat_relay_patch.install() replaces create_adapter too -- so
+    # running this inside a pod with only SLACK_RELAY_URL stripped reads the
+    # Google Chat shim and reports create_adapter as drifted when it has not.
+    # That misfire is worse than a missed check: the docstring above tells the
+    # reader to update the pin deliberately, and doing so here would pin the
+    # shim against itself and delete the only guard on that method.
+    inherited = [variable for variable, _ in relay_patch_variables() if os.environ.get(variable)]
+    if inherited:
+        clean_env = dict(os.environ)
+        for variable in inherited:
+            clean_env.pop(variable)
+        return subprocess.run(
+            [sys.executable, os.path.abspath(__file__)], env=clean_env, check=False
+        ).returncode
+
+    status = unwired()
+
+    print("\n-- again, wired the way the pod wires it --")
+    child_env = dict(os.environ, **{WIRED: "1", "SLACK_RELAY_URL": RELAY_URL})
+    child_env.pop("SLACK_BOT_TOKEN", None)
+    child = subprocess.run(
+        [sys.executable, os.path.abspath(__file__)], env=child_env, check=False
+    )
+    return status or child.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

#780 stopped the outage that Hermes v2026.8.13 caused — `slack_relay_patch`'s
`PlatformRegistry.register` wrapper had restated upstream's signature, upstream added a
keyword-only `scope`, and every platform plugin's registration raised `TypeError`. It named two
follow-ups and deliberately left them: `create_adapter` is wrapped the same way in both relay
patches and still restates a signature, and the install-time sweep over already-registered
entries still reads only `_entries` when a scoped registration lands in `_scoped_entries`. This
closes both, and adds a build-time check that runs the relay patches against the real
`/opt/hermes` tree so the next base-image bump fails the build rather than the gateway.

## Why This Change

The failure mode is worth naming precisely, because it is the reason for the third piece. Every
wrapper these patches install sits on a class the whole gateway registers through, so one
`TypeError` in one shim takes Slack, Google Chat and A2A down together. The tests could not catch
it: both registry fakes declared the same narrow signature the shim did, so the fake and the
wrapper agreed with each other and CI stayed green while the pod came up with no chat adapters.

`register` was fixed. `create_adapter` has the identical shape and the identical blind spot in the
fakes; nothing about the failure was specific to `register`, and upstream is as free to add an
argument to one as to the other. A fake can only ever agree with the shim, so the check that
matters has to run against the real tree.

## What Changed

- Both relay patches forward everything past `name` to `create_adapter` blind, the way `register`
  now does. No behaviour change against the pinned base image — the signature has not drifted.
- The install-time sweep reads `_scoped_entries` as well as `_entries`, and warns when *either*
  private name goes missing rather than only when both do. With `_scoped_entries` renamed away the
  old `or` kept reading the one map a scoped registration never lands in and reported success.
- The sweep's comments, its test docstrings and the build-time check now say it is defensive
  cover, not a live fix: `sitecustomize`'s import hook calls `install()` as
  `gateway.platform_registry` finishes executing, before anything can register, and nothing else
  calls `install()`. The previous wording implied a silent production failure this ordering cannot
  produce.
- The module-level test fakes declare wide signatures for both wrappers, and forwarding is
  asserted for each.
- `deploy/docker/patches/verify_slack_relay_registry_contract.py` runs at image build against the
  real Hermes tree: it pins the signature of every upstream callable the two relay patches
  replace, registers a plugin-sourced entry the way `plugins.py` does, and repeats the behavioural
  checks in a child process wired the way the pod is, where `sitecustomize`'s hook is what
  installs the patch. Before reading the pin it re-execs with every variable in
  `sitecustomize.RELAY_PATCHES` stripped and asserts no patch sentinel is set, so a run inside a
  pod cannot read a shim as upstream's own declaration.
- The check rides in an existing `COPY`/`RUN` pair rather than adding its own. `credential-proxy`
  builds `FROM` this stage and its chain measures 119 of the 120 layers
  `scripts/check_image_layers.py` allows.

## Context

No issue tracks this. #780 (merged) is the fix these two follow-ups were deferred from; its
description names both.

Overlap with open pull requests, none of it line-level:

- #720 touches `agents/platform/scripts/slack_relay_patch.py` and
  `agents/platform/scripts/google_chat_relay_patch.py`. Different regions of both files —
  a merge conflict warning, not a duplicate.
- #731, #728, #738 and #713 all touch `deploy/docker/Dockerfile`. This branch adds no layer, but
  the budget has one slot left, so whichever of those adds a `COPY` or `RUN` merges second will
  need to find it. Flagged rather than fixed: it is not this branch's layer to reclaim.

## Testing

- `python3 -m pytest agents/platform/scripts/test_slack_relay_patch.py` — 37 passed, 1 failed.
  The failure is `RelayedSlackErrorTest::test_an_unreadable_body_is_not_a_rejection`, pre-existing
  on `main` and local to Python 3.11: `HTTPError.read()` returns `str` rather than `bytes` when
  `fp` is `None` before 3.12. `main` fails the same test on the same interpreter (31 passed, 1
  failed); CI pins 3.12 and is green.
- `make docker-build-platform` — the build-time gate passes both phases, 27 checks unwired and 8
  wired.
- The gate fails in the direction it is meant to. Narrowing the `register` shim back to
  `(self, entry)` and simulating a future upstream signature change each exit 1 with the drifted
  callable named. The re-exec guard was verified both ways against the built image: the
  pre-fix script run with `GOOGLE_CHAT_RELAY_URL` inherited reports
  `PlatformRegistry.create_adapter: expected 'self, name, config', got 'self, name, *args, **kwargs'`
  — the false drift finding 1 describes — and the fixed script passes.
- `make docs-check` — clean.
- `make iac-parity-check` — clean, 16 checks.
- `python3 scripts/check_image_layers.py` against `credential-proxy:latest` — 119 layers, 1 under
  budget, unchanged by this branch.
- `prettier` — no Markdown, JSON or YAML files changed.

### Live validation

Install: `kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace
`kubeagents-system`, one `PlatformAgent` CR, model `claude-opus-5` via Vertex through LiteLLM.

Built and pushed `platform-agent:relayfix-fcd32d7` — the branch head, including the self-review
fixes below — and patched the CR's image tag from `dns-endpoint-7dac349`. The rollout was
confirmed at each layer: CR `.status.phase` `Ready` with "Agent sandbox and Envoy credential
sidecar are fully reconciled", the `platform-agent-gateway` Deployment's `platform-agent`
container on the new tag, and the pod `3/3 Running`.

Inside that pod, `PlatformRegistry.create_adapter`'s live signature reads
`(self, name, *args, **kwargs)` rather than the `(self, name, config)` it restated before — this
install has Slack disabled and Google Chat enabled, so it is `google_chat_relay_patch` that
installed it, which is the half of the change with no test that can distinguish a fake from the
real class.

The sweep was proved by A/B in that pod, not by reading the code. Slack being disabled means
`install()` early-returns on an unset `SLACK_RELAY_URL`, so the probe starts the interpreter with
it unset, registers a `source="plugin"` Slack entry into `_scoped_entries[scope]` the way
`register_platform` does — before `install()`, so the `register` wrapper cannot be what patches
it — then sets the variable and calls `install()`. Control was `main`'s `slack_relay_patch.py`
ahead of `/opt/defaults/scripts` on `sys.path`, with that directory left in place so
`sitecustomize` can still find `google_chat_relay_patch`. Each arm printed
`slack_relay_patch.__file__` and whether the loaded source mentions `_scoped_entries`, so the arms
are distinguishable in the output rather than by assumption:

```
[control] slack_relay_patch.__file__ = /tmp/probe/mainver/slack_relay_patch.py
[control] source mentions _scoped_entries = False
[control] entry landed in _scoped_entries = True, in _entries = False
[control] RESULT pre-registered scoped entry patched = False
[branch]  slack_relay_patch.__file__ = /opt/defaults/scripts/slack_relay_patch.py
[branch]  source mentions _scoped_entries = True
[branch]  entry landed in _scoped_entries = True, in _entries = False
[branch]  RESULT pre-registered scoped entry patched = True
```

Four earlier probe designs were wrong and are worth recording, because each looked like a result.
One returned a false negative from the `SLACK_RELAY_URL` early return. Two returned false
positives: the `register` shim `sitecustomize` had already installed patched the entry at
registration time, and a `sys.path.insert` made both arms load the branch's file. The fourth
dropped `/opt/defaults/scripts` from `sys.path` entirely and turned the control arm into an
unrelated `ModuleNotFoundError`.

Google Chat, the one live platform here, kept working on the new image: after two startup 503s
against the credential proxy at 20:28:59 — the relay loop polling before the sidecar was serving,
not a regression — the proxy logged a steady stream of `GET /v1/chat/events 200` and the agent
logged no further failures.

Not covered: no live Slack workspace is wired to this install, so an end-to-end relayed Slack
message was not sent. This branch does not change the patch's delivery behaviour.

Cleanup: the CR was reverted to `dns-endpoint-7dac349`, the pod confirmed `3/3 Running` and the CR
`Ready` on it; the probe directory was removed from the pod, the host temp files and the local
inspection image deleted, and the live-test lease released.
`platform-agent:relayfix-fcd32d7` was left in the gkedemos Artifact Registry.

## Self-Review

`review-adversarial` against the branch diff, run in a subagent handed the diff range and nothing
else. Angles that produced findings: contract drift between a check and what it actually checks,
comments and docstrings that outrun the code, the guard that fails in the quiet direction, and
test fakes that agree with the code under test. Seven findings, all confirmed; five fixed, two
reported.

1. **The build-time gate could report false drift, and invite the reader to make it permanent.**
   Fixed. The re-exec guard stripped only `SLACK_RELAY_URL`. The operator sets
   `GOOGLE_CHAT_RELAY_URL` on the agent container and `google_chat_relay_patch` replaces
   `create_adapter` too, so a run inside a pod read the Google Chat shim as upstream's declaration
   and reported drift that did not exist. Worse than a missed check: the module docstring tells
   the reader to update the pin deliberately, and doing so there would have pinned the shim
   against itself and deleted the only guard on that method. It now strips every variable in
   `sitecustomize.RELAY_PATCHES` — read from the module, not restated — and asserts no patch
   sentinel is set before reading the pin.
2. **The sweep's justification was not true.** Claims rewritten, code kept. The comment, a test
   docstring and the build check all described a silent production failure, but `sitecustomize`'s
   import hook makes that ordering unreachable: `install()` runs as the registry module finishes
   executing, before anything can register, and nothing else calls `install()`. Kept because the
   code is correct for the ordering it covers and cheap; the wording now says it is defensive
   cover, so a reader is not told the sweep is load-bearing when it is not. My first draft of the
   Live validation section above made the same overclaim, and this is what corrected it.
3. **The "not introspectable" guard failed quiet in the half that matters.** Fixed. The condition
   was `isinstance(entries, dict) or isinstance(scoped, dict)`, so a base image that renamed
   `_scoped_entries` alone left the sweep reading `_entries`, finding it empty, and saying
   nothing — and `_entries` is the map a scoped registration never lands in. It now warns when
   either name goes missing, and still sweeps whichever map is readable.
4. **A fake still had the exact blind spot this PR is about.** Fixed. The module-level
   `PlatformRegistry` fake's `create_adapter` was still `(self, name, config)` — the same
   fake-agrees-with-shim configuration that let #718 ship. Widened, with forwarding asserted the
   way `register`'s is.
5. **`shape()` erases default values, so a flipped upstream default passes the pin.** Reported,
   not fixed. Real, and narrower than it looks: for the two forwarding wrappers a changed default
   cannot break anything, since the wrapper passes through whatever the caller gave. It does
   matter for the adapter methods the patch reimplements rather than delegates to —
   `connect(self, *, is_reconnect=False)` is the example. Not fixed here because including
   defaults makes the pin churn on every upstream default tweak, most of them irrelevant, and
   deciding what the pin should tolerate is a change with its own argument to make. Filed as
   #794, which lays out the three options.
6. **A class docstring described a sweep that no longer exists.** Fixed. It still said the sweep
   reads a single private `_entries`.
7. **Layer-budget contention with open pull requests.** Reported, not fixed — see Context. This
   branch adds no layer; the last free slot goes to whoever takes it first.

## Risk & Rollout

The runtime change is confined to two monkeypatch modules that only load when the corresponding
relay URL is set. Against the pinned base image, widening `create_adapter` is a no-op: the
signature it forwards is the signature it used to restate. The sweep change alters a path
`sitecustomize` prevents from being reached, plus one new `LOGGER.warning` that can fire on a
future base image which consolidates the two entry maps — a log line, not a failure.

The new failure mode is a build one, and deliberate: a base-image bump that changes any pinned
signature now fails `make docker-build-platform` instead of producing an image that starts and
does not relay. Fixing it means reading the drift the check names and updating the shim, or the
pin, on purpose.

Revert is the single commit; nothing persists outside the image.

Nothing has to happen at merge time.

---

Generated with the help of Claude.

