### PR TITLE
docs: keep Self-Review and Live validation current across re-runs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -74,8 +74,9 @@ not.
 
 Run the pass in a context that did not write the change — a subagent, or a fresh
 session, handed the diff range and nothing else. If your harness will not start
-one without a human's approval, ask for it; reviewing in the session that wrote
-the code is the one configuration that does not work.
+one without a human's approval, ask for it. A session that still holds the
+reasoning behind the diff re-derives that reasoning instead of testing it, so it
+clears the errors the reasoning caused.
 
 Fix what the pass confirms and report what it only suspects, and claim no more
 than you did: a Self-Review the diff contradicts is worse than none.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,6 +51,9 @@ cleaned up.
 If the change cannot reach a running installation — docs-only, a CI workflow, a path
 that needs infrastructure you do not have — write "Not live-tested" and say why.
 
+Re-testing after new commits folds into this section rather than stacking a round
+beneath it: keep what still holds, and re-run or flag what the new commits invalidated.
+
 Full contract: AGENTS.md, "Pull Request Hygiene".
 -->
 
@@ -68,6 +71,18 @@ with the reason.
 what you looked for. A reason for not fixing something is an answer when it is an
 argument about this change; "out of scope" and "will fix later" on their own are
 not.
+
+Run the pass in a context that did not write the change — a subagent, or a fresh
+session, handed the diff range and nothing else. If your harness will not start
+one without a human's approval, ask for it; reviewing in the session that wrote
+the code is the one configuration that does not work.
+
+Fix what the pass confirms and report what it only suspects, and claim no more
+than you did: a Self-Review the diff contradicts is worse than none.
+
+Re-running the pass folds into this section rather than stacking a round beneath
+it: keep what still holds, re-state what the new commits changed, and drop the
+superseded round rather than a finding's disposition.
 
 Full contract: AGENTS.md, "Pull Request Hygiene".
 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,9 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   - **If your harness will not spawn one without a human's approval, go and get the approval.** A
     setting that requires sign-off before starting a subagent blocks this step; it does not waive
     it. Ask when you hit it, not after the review, and say what you are blocked on. Quietly running
-    the pass in the session that wrote the code instead is the configuration the bullet above rules
-    out, and reporting it as a self-review without that caveat tells the reviewer something untrue.
+    the pass in the session that wrote the code instead buys a review from the context that already
+    believes the change is correct, and reporting that as a self-review without the caveat tells
+    the reviewer something untrue about how the change was checked.
   - **A finding you decide not to fix is an answer**, provided the reason is an argument about
     this change rather than a shrug. "Out of scope", "pre-existing", and "will fix later" are not
     reasons on their own; the separate issue you filed is.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,11 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
     talks you into approving it, and the blind spot sits exactly where you were already wrong. It
     is why `.claude/commands/pr-review-batch.md` gives every pull request its own subagent, and a
     self-review earns it for the same reason.
+  - **If your harness will not spawn one without a human's approval, go and get the approval.** A
+    setting that requires sign-off before starting a subagent blocks this step; it does not waive
+    it. Ask when you hit it, not after the review, and say what you are blocked on. Quietly running
+    the pass in the session that wrote the code instead is the configuration the bullet above rules
+    out, and reporting it as a self-review without that caveat tells the reviewer something untrue.
   - **A finding you decide not to fix is an answer**, provided the reason is an argument about
     this change rather than a shrug. "Out of scope", "pre-existing", and "will fix later" are not
     reasons on their own; the separate issue you filed is.
@@ -231,6 +236,16 @@ documentation map (`docs/README.md`) — the same four checks CI runs.
   - **If the change cannot reach a running installation** — docs-only, a CI workflow, a code path
     that needs infrastructure you do not have — write "Not live-tested" and say why. An empty
     section is not an answer.
+- **Keep these sections current, not chronological.** **Self-Review** and **Live validation** tell
+  a reviewer at a glance what has been reviewed and exercised against the branch as it stands. A
+  second pass — after review findings, after a rebase — folds into what is there rather than being
+  appended beneath it: work that still holds stays and is not re-run just to have been run against
+  the new head, a check the new commits invalidated is re-run or kept with a line saying it no
+  longer reaches the head, and new findings join the rest. What a re-run drops is the superseded
+  round, not the contents these sections owe a reviewer — the angles you ran, the layers you
+  observed, what you could not cover. Round-by-round history of a _reviewer's_ findings is the
+  exception: it belongs in the threads, where a reply naming the fix and its commit stays attached
+  to the finding it answers.
 - **IaC parity review when a PR touches more than one install surface's territory:**
   the provisioning scripts (`k8s-operator/scripts/`, `k8s-operator/config/`), the
   Terraform modules, and the Helm chart each express the same install, and nothing in
@@ -361,6 +376,14 @@ After pushing fixes, remember that the push alone does not re-trigger anything: 
 to comment `/review` for another pass — `/review` to confirm the fixes against a strict read,
 `/review all` when the branch changed enough that it deserves a first-review-width look again. Then
 wait for it the same way, counting reviews rather than watching for a second 👀.
+
+Pushing fixes is also what makes the pull request body stale. Fixes that answer a finding, and any
+live test you re-ran to confirm them, belong in **Self-Review** and **Live validation** — folded
+into what is already there, per "Keep these sections current, not chronological" above. Do it once
+the last `/review` pass has settled, for the reason the next paragraph gives about threads: a fresh
+review brings fresh findings, and folding them in twice is the same wasted round. Nothing else in
+this workflow reopens the body, so a branch whose sections still describe the commit it was opened
+at is the normal outcome of skipping it here.
 
 **Then resolve the conversations.** `main` requires every conversation on a pull request to be
 resolved before it can merge, and the triage sweep counts an open thread as work outstanding on the

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -96,13 +96,15 @@ Nobody reads a change as cheaply as the person who wrote it, and right now the f
 
 The method is the repository's own review skill, [`.agents/skills/review-adversarial/SKILL.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/skills/review-adversarial/SKILL.md) — run it against your branch diff with whatever agent you use. It works ten angles over the change, then re-derives each candidate from the source as a hostile second reader and throws out what it cannot defend.
 
-Give the pass a context that did not write the change — a subagent, or a fresh session, handed the diff range and nothing else. An agent asked to review a diff in the same conversation that produced it mostly restates why the code is right, because the reasoning that produced the code is still in front of it.
+Give the pass a context that did not write the change — a subagent, or a fresh session, handed the diff range and nothing else. An agent asked to review a diff in the same conversation that produced it mostly restates why the code is right, because the reasoning that produced the code is still in front of it. If your harness will not start a subagent without a human's approval, ask for the approval — that setting blocks this step rather than waiving it, and running the pass in the session that wrote the code instead is the one configuration that does not work.
 
 What the section should say:
 
 - **What you looked for**, in the skill's terms — which angles you ran, and which you could not.
 - **What it found, and where each finding ended up.** Fixed, naming the commit or hunk; or deliberately not fixed, with a reason. A reason is an argument about this change — the path is unreachable for a stated invariant, the fix belongs to the issue you just filed. "Out of scope" or "will fix later" alone is not.
-- **Nothing you cannot back.** A self-review the diff contradicts is worse than no self-review: it spends the reviewer's trust before they reach the code.
+- **Nothing you cannot back.** A self-review the diff contradicts is worse than no self-review: it spends the reviewer's trust before they reach the code. Fix what the pass confirms and report what it only suspects; a finding it could not pin down is an open question for the section, not a licence to rewrite working code.
+
+Re-running the pass folds into the section rather than stacking a round beneath it. Keep what still holds, re-state what the new commits changed, and drop the superseded round — not a finding's disposition. The same goes for **Live validation**: a reviewer should be able to see at a glance what has been reviewed and exercised against the branch as it stands.
 
 "No findings" is an ordinary outcome on a good change and costs you nothing — provided you also say what you looked for. A pass that names none of its angles is indistinguishable from no pass at all.
 

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -96,7 +96,7 @@ Nobody reads a change as cheaply as the person who wrote it, and right now the f
 
 The method is the repository's own review skill, [`.agents/skills/review-adversarial/SKILL.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/skills/review-adversarial/SKILL.md) — run it against your branch diff with whatever agent you use. It works ten angles over the change, then re-derives each candidate from the source as a hostile second reader and throws out what it cannot defend.
 
-Give the pass a context that did not write the change — a subagent, or a fresh session, handed the diff range and nothing else. An agent asked to review a diff in the same conversation that produced it mostly restates why the code is right, because the reasoning that produced the code is still in front of it. If your harness will not start a subagent without a human's approval, ask for the approval — that setting blocks this step rather than waiving it, and running the pass in the session that wrote the code instead is the one configuration that does not work.
+Give the pass a context that did not write the change — a subagent, or a fresh session, handed the diff range and nothing else. An agent asked to review a diff in the same conversation that produced it mostly restates why the code is right, because the reasoning that produced the code is still in front of it. If your harness will not start a subagent without a human's approval, ask for the approval — that setting blocks this step rather than waiving it.
 
 What the section should say:
 


### PR DESCRIPTION
## Summary

The Self-Review and Live validation rules in AGENTS.md are written in the singular — fill in the section, describe the pass — and never say what an author does on the second pass. This adds that rule: a re-run folds into what is already in the section rather than being appended as another round beneath it, so a reviewer can see at a glance what has been reviewed and exercised against the branch as it stands. It also closes two gaps the rule exposed — a harness that will not spawn a review subagent without human approval, and the absence of anything telling an author the PR body goes stale when fixes are pushed — and reconciles the two summaries AGENTS.md names by hand.

## Why This Change

An author who re-runs `review-adversarial` after review findings, or re-runs a live test after a rebase, has no rule to read. The two behaviours that follow are both bad: stack the new round beneath the old one, leaving the reviewer to work out which checks still apply to the current head, or replace the section wholesale and silently lose earlier verification that still holds. Without the rule, the second reader of a long-lived pull request cannot tell what has actually been verified against the code in front of them.

Two adjacent gaps surfaced while writing it:

- The requirement to run the pass in a context that did not write the change names a subagent as the way to get one, but says nothing about a harness that will not start one without a human's sign-off. The silent fallback is a pass in the session that wrote the code — the one configuration the rule rules out — reported afterwards as a self-review with no sign that it was.
- Nothing in the post-open workflow ever reopens the PR body. It goes findings → fixes → `/review` → resolve threads, so the new rule would have been inert in the case it names first.

## What Changed

- `AGENTS.md`, Pull Request Hygiene: a new top-level bullet after the Live-test bullet, covering both sections it names. Work that still holds stays; a check the new commits invalidated is re-run or kept with a line saying it no longer reaches the head; what a re-run drops is the superseded round, not the angles you ran or what you could not cover. Round-by-round history of a *reviewer's* findings stays in the threads.
- `AGENTS.md`: a sub-bullet under "Run the pass in a context that did not write the change" — a setting requiring approval blocks this step rather than waiving it, so ask when you hit it.
- `AGENTS.md`, Automated Review: the push-fixes paragraph now says the body goes stale there, and to fold the update in once the last `/review` pass has settled — same reasoning the next paragraph already gives for resolving threads.
- `.github/PULL_REQUEST_TEMPLATE.md` and `docs/site/src/content/docs/contributing.md`: reconciled to the canonical list, as those two bullets require. The template's Self-Review comment carried two of five sub-bullets; the three absent ones are backfilled, and both files gain the re-run rule.

## Context

No open issue. Of the open pull requests, only #807 (`docs(agents): branch from a freshly fetched main before starting work`) touches root `AGENTS.md` prose, at lines 39–121 in "Before Starting a Task" — no overlap with these hunks and no merge conflict expected. #792 touches `contributing.md`, in the local-validation section only.

## Testing

- `prettier --check` clean on all three changed files.
- `make docs-check` green: generated regions current, relative links resolve across 247 Markdown files, terminology check passed, map inventory covers all 218 tracked docs. No new files, so no `docs/README.md` row is owed.

### Live validation

Not live-tested. The change is documentation only — three Markdown files, none of which ships in an agent image or is read by the operator, the Helm chart, or any provisioning script. There is no layer of a running installation where its effect would be observable. The mechanical gates above are the whole of what can be exercised.

## Self-Review

Two `review-adversarial` passes, each in a subagent handed the diff range and nothing else. The second pass re-read the branch after the first round of fixes.

**Pass 1** (against the first draft of the AGENTS.md bullet) — seven findings, five fixed:

- The closing sentence sent round-by-round history to review threads. True for review findings, false for live validation: a live test re-run after a rebase has no thread to live in. Scoped the claim to a reviewer's findings.
- "a check the new commits invalidated is re-run or struck" — "struck" reads as both *deleted* and *marked struck-through*, and the deleting reading collides with the existing "say what you could not cover" rule. Replaced with "kept with a line saying it no longer reaches the head".
- A brevity instruction competed with the contents the two sections are separately required to carry, with the predictable failure being an author trimming the "could not cover" line. Rewritten to name the superseded round as the thing that gets dropped.
- Three synonymous formulations of one instruction, against the file's own rule-of-three-padding rule. Cut one.
- Nothing in the post-open workflow ever tells an author to reopen the PR body — it runs findings → fixes → `/review` → resolve threads — so the new rule would have been inert in the case it names first, "after review findings". Added the trigger to the push-fixes paragraph in `ec3863e3`.

The remaining two were declined as scope; both are named under **Declined** below.

**Pass 2** (against the two-commit diff, after those fixes) — five findings, all fixed:

- 🔴 The template's re-run line inverted the guard the AGENTS.md bullet exists to state: "drop only what the new commits superseded" makes the object of *drop* the content rather than the round, which reads as licence to delete a finding's disposition once its fix has landed. Mirrored to the AGENTS.md phrasing. This is the finding that justified the pass.
- The contributing guide, the other summary AGENTS.md names by hand, was not reconciled — so the diff widened the gap between the two summaries rather than closing it. Reconciled in `ae0ea8dd`.
- The new post-open paragraph timed the body update at the push, while the paragraph directly below it makes the opposite call for the structurally identical task ("once the fixes are pushed and the last `/review` pass has settled"). Two adjacent paragraphs, conflicting timing, no acknowledgement. Aligned to the later one.
- "Round-by-round history of the review findings themselves" still read as covering the author's own pass, which produces no threads and therefore contradicted the clause immediately before it. Narrowed to a *reviewer's* findings, marked as the exception.
- "not re-run for a fresh timestamp" cited a timestamp neither section records. Changed to the new head, which is the thing the rest of the sentence is about.

**Author read after pass 2** (`04e66804`) — two of the three new mentions of the fresh-context rule asserted that reviewing in the authoring session is "the one configuration that does not work" while dropping the mechanism the canonical bullet supplies right after the same phrase, leaving the claim bare. Stated the mechanism where it is claimed — a context holding the reasoning behind the diff re-derives it rather than testing it — and cut the clause entirely from the contributing guide, where the preceding sentence already says it.

**Declined, both raised in pass 1 and re-examined in pass 2:**

- *The sections are not required to name the commit or range a pass covered*, so a section folded forward on author judgement leaves no artifact, and a stale one is textually indistinguishable from a fresh one. Pass 2 re-rated this above "scope", on the grounds that the diff already solves it for the Live-validation half. It is a real gap and the fix is one clause, but it is a new requirement on every PR body rather than a defect in this change, so it belongs in its own change where it can be argued on its merits.
- *Neither "canonical statement" bullet cross-references the new top-level bullet*, so a future editor reconciling the template against the Self-Review sub-list could read the new template text as drift and delete it. Pass 2 agreed this is minor: both template comments close with "Full contract: AGENTS.md, 'Pull Request Hygiene'", which covers the whole section including the new bullet.

**Angles with no purchase here**, stated so the pass is legible: line-by-line correctness, removed behaviour, ops and security, reuse, efficiency, and altitude have nothing to work on in a prose diff that deletes nothing. The work was done by the internal-consistency and cross-file-consumer angles, which is where all twelve findings came from. Neither pass exercised anything at runtime; there is nothing to exercise.

## Risk & Rollout

Documentation only. Nothing here is read by the operator, the chart, the provisioning scripts, or any agent image — the three files are instructions for humans and agents working in this repository. No runtime code path, no migration, no rollout step. Revert is a plain revert of either commit; they are independent.
