### PR TITLE
fix(operator): drop the stale creationTimestamp from the PodDisruptionBudget goldens

### DIFF
--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -1008,7 +1008,6 @@ status:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubeagents-system-platformagent
     app.kubernetes.io/managed-by: platformagent-controller

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -960,7 +960,6 @@ status:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubeagents-system-platformagent
     app.kubernetes.io/managed-by: platformagent-controller

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -1008,7 +1008,6 @@ status:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubeagents-system-platformagent
     app.kubernetes.io/managed-by: platformagent-controller


### PR DESCRIPTION
## Summary

  `TestAgentsGolden` fails on `main`. Three golden manifests still expect a `creationTimestamp: null` line on their PodDisruptionBudget's `metadata`, and the pinned `k8s.io/apimachinery` no longer serialises that field. This deletes those three
  lines and nothing else.

  ## Why This Change
  
  Two commits that landed on 2026-08-19 interacted.

  [#790](https://github.com/gke-labs/kube-agents/pull/790) (`09686d3`) bumped `k8s.io/apimachinery` from v0.31.0 to v0.36.3. The tag on `ObjectMeta.CreationTimestamp` changed:

  ```go
  // v0.31.0  pkg/apis/meta/v1/types.go:188
  CreationTimestamp Time `json:"creationTimestamp,omitempty" ...`
  // v0.36.3  pkg/apis/meta/v1/types.go:208
  CreationTimestamp Time `json:"creationTimestamp,omitempty,omitzero" ...`
  ```

  `omitempty` is a no-op on a struct, so a zero `Time` used to marshal to `null`. `omitzero` (Go ≥ 1.24; the module declares `go 1.26.6`) consults `IsZero()`, which `metav1.Time` implements, so the field is dropped. #790 deleted every
  `creationTimestamp` line from the three goldens to match — 17, 17 and 16 lines, pure deletions with zero insertions.

  [#733](https://github.com/gke-labs/kube-agents/pull/733) (`277de10`) then added PodDisruptionBudgets and readiness probes. Its branch was cut before the bump, so its goldens were generated against the old library. Its hunks applied cleanly
  onto post-bump `main` and re-introduced exactly one `creationTimestamp: null` per golden — on the PDB, the one object in each file that the earlier regeneration could not have covered.

  The comparison in `CompareGolden` is semantic, but not presence-insensitive: `creationTimestamp: null` parses to a map key present with a nil value, omission produces no key, and `cmp.Diff` reports the differing key sets. So this is a red
  test, not a cosmetic mismatch.

  Every run of `Operator Tests` on `main` that has actually executed the suite since #733 has failed:

  | commit                          | touches the paths-filter | Operator Tests    |
  | ------------------------------- | ------------------------ | ----------------- |
  | `277de10` (#733)                | 20 files                 | failure           |
  | `8d95429`                       | 0                        | success (skipped) |
  | `72c1813` (#716)                | 6 files                  | failure           |
  | `731c813` (#731)                | 5 files                  | failure           |
  | `1d68f09`, `4a925ba`, `c714050` | 0                        | success (skipped) |

  Worth stating plainly, because it is easy to misread: `main`'s three most recent `Operator Tests` runs are green only because `k8s-operator-test.yml` gates every step behind a `dorny/paths-filter` on `k8s-operator/**`,
  `agents/platform/scripts/**`, and the workflow file. Those three commits are docs and CI changes, so the job ran nothing and reported success. Open PRs touching operator paths fail the same way.

  ## What Changed

  - One line deleted from each of `platformagent.yaml`, `platformagent-tagged.yaml`, and `platformagent-telemetry.yaml` under `k8s-operator/internal/testing/testdata/platform/expected/`. Three deletions, no insertions, no other file.

  Hand-edited rather than regenerated, and the result is what `-update` would produce in content but not in formatting. The goldens are prettier-formatted: `sigs.k8s.io/yaml` v1.6.0 marshals through `go.yaml.in/yaml/v2`, which does not indent
  block sequences, yet the committed files indent them (`  ownerReferences:` → `    - apiVersion:`). Nothing runs prettier over `internal/testing/testdata/` — the operator Makefile's `manifests` target does that only for `config/` — so a bare
  `go test ./internal/testing/ -update` would leave the files prettier-dirty and fail `Prettier Check` on a diff hundreds of lines wide. Deleting the three lines keeps the committed formatting, and since the comparison is semantic, formatting
  cannot change the test's verdict either way.

  ## Context
  
  `main` is broken by the interaction of #790 and #733; neither is wrong on its own. No open PR or issue covers this — I listed all 47 open PRs and searched issues and PRs for `TestAgentsGolden`, `golden`, and `creationTimestamp`, and found only
  closed matches.
  
  The general hazard is worth naming: **a PR that adds a new golden object needs its goldens regenerated against current `main`, not against the base it was cut from.** Text-level merge cannot catch it. One PR regenerates every fixture, another
  adds an object type, both merge cleanly, and `main` goes red on the next commit that touches an operator path.

  A CI guard would have caught it — requiring the branch to be up to date with the base before merge, so the operator tests run against the actual post-merge tree. I could not check whether that branch-protection setting is on, and I am not
  building it here as it is a repository-settings question rather than a fixture change. Flagging it as a suggestion.                                                                                                        

  Generated with the help of Claude.

  ## Testing

  - `go build ./...` and `go vet ./...` in `k8s-operator/`: clean.
  - `make docs-check`: passes.
  - `make docs-generate`: leaves the tree clean apart from this change, so no generated region depends on these fixtures.
  - `prettier@3.9.6 --check` on all three changed YAML files: passes. (`internal/testing/testdata/` is not in `.prettierignore`, and `prettier.yml` checks every changed `.yaml`, so this gate is live for this diff.)
  - Structural check that the edit equals a regeneration: both versions parsed through the same split-and-unmarshal that `parseMultiDocYAML` performs. 17/17/16 documents on each side, exactly one document differs per file (the
  `PodDisruptionBudget`), the only metadata key delta is `creationTimestamp`, and no non-metadata drift. `git diff --check` clean; LF-only, trailing newline intact.
  - **`go test` could not be run.** The machine this was prepared on SIGKILLs every locally built Go binary: `go test ./internal/testing/` dies with `signal: killed` at ~0.5s, and so does a trivial `main.go` built against the same module, with
  the sandbox disabled and after ad-hoc codesigning. So I cannot paste a red-before and green-after run, and I am not going to imply otherwise. The regression evidence is the CI table above plus the source-level mechanism; CI on this PR is the
  first place the test actually executes.

  ### Live validation

  Not live-tested. The change is a test fixture — it is read only by `TestAgentsGolden` and ships in no image, chart, or manifest, so there is no layer of a running installation it could reach. Nothing was deployed and no test artifacts exist to
  clean up.

  ## Self-Review

  Ran `review-adversarial` in a subagent handed the diff range, the repository, and nothing else — no plan, no reasoning, no draft of this description. It re-derived the mechanism from the module cache independently.

  What it was asked to attack, and what it found:

  - **Is the deletion correct?** Confirmed, through four links: the v0.31.0 → v0.36.3 tag change; `metav1.Time.IsZero` at `time.go:61` (pointer receiver, which `encoding/json` handles by boxing into an addressable temporary, so it does not
  defeat `omitzero`); the `go 1.26.6` directive; and `sigs.k8s.io/yaml.Marshal` delegating to stdlib `encoding/json`. `buildPlatformPDB` never sets the field, so it is zero at marshal time.
  - **Is the fix unnecessary — does the semantic comparison ignore a null key?** Confirmed it does not. Present-with-nil and absent are different key sets and `cmp.Diff` reports them.
  - **Is the change incomplete?** Confirmed complete. A repo-wide grep finds zero remaining `creationTimestamp` in any fixture; the surviving hits are CRD printcolumn jsonPaths, `kubectl --sort-by` strings, and a strip-list in
  `platform_mcp_server.py`. It also checked the other half of the collision: `277de10` did not regenerate CRDs, and `charts/kube-agents/crds/` is byte-identical to `k8s-operator/config/crd/bases/`, so the manifests gate has no second stale
  artifact waiting.
  - **Did #733 add other pre-bump content?** Confirmed no. `omitzero` appears exactly once in all of apimachinery v0.36.3 and not at all in `k8s.io/api` v0.36.3; `PodDisruptionBudgetSpec`/`Status` and the `Probe` tag sets are identical between
  v0.31.0 and v0.36.3. #790's golden diff having zero insertions is the empirical form of the same point.
  - **Does anything else assert on these files?** Confirmed no. `TestAgentsGolden` is the sole consumer; no Makefile target or workflow invokes `-update`.
  - **Is a hand-edit equivalent to `-update`?** Confirmed, and it surfaced the prettier point recorded under **What Changed** — the reason a bare `-update` would have been worse here.
  - **Removed-behaviour** got named rather than waved past, since this diff has the shape the skill flags: only test files change, on a branch whose CI was red. The invariant the deleted lines encoded is false at the pinned versions, and the
  remaining assertion still pins every other byte of the PDB document, so coverage does not narrow.
  - No findings on line-by-line, operations and security, reuse, simplification, conventions, or scope. The diff adds no code, touches no IAM, RBAC, NetworkPolicy, credential, or workflow surface, and contains no unrelated hunk.

  One observation it could not pin down, reported rather than acted on: nothing prevents this recurring on the next library bump, which is the CI-guard suggestion in **Context**. It could not read the branch-protection setting that would decide
  it.

  Two things the pass did not cover. It could not execute the test either, for the same reason given under **Testing** — its evidence is analytical, not observed. And it had no `gh`, so it could not run the sibling-PR angle; I ran that
  separately against the GitHub REST API and reported the result in **Context**.

  ## Risk & Rollout

  Low. No runtime code path, no image, no manifest — the only consumer is `TestAgentsGolden`. Nothing to do at merge time. Reverting restores the failing test.
