### PR TITLE
fix(submit-suggestion): normalize CLI escaped newlines in PR title and body

### DIFF
--- a/agents/platform/scripts/test_submit_suggestion.py
+++ b/agents/platform/scripts/test_submit_suggestion.py
@@ -307,6 +307,28 @@ class TestSubmit(SubmitSuggestionTestCase):
         self.assertEqual(argv[argv.index("--head") + 1], "platform-agent/fix-netpol")
         self.assertEqual(argv[argv.index("--base") + 1], "main")
 
+    def test_normalize_text_unescapes_cli_newlines_and_tabs(self):
+        self.assertEqual(submit_suggestion._normalize_text("Title\\nLine 2"), "Title\nLine 2")
+        self.assertEqual(submit_suggestion._normalize_text("Body\\r\\nLine 2\\tIndented"), "Body\nLine 2\tIndented")
+        self.assertEqual(submit_suggestion._normalize_text(""), "")
+        self.assertIsNone(submit_suggestion._normalize_text(None))
+
+    def test_submit_normalizes_escaped_newlines_in_title_and_body(self):
+        payload = self.prepare()
+        self.commit(payload["workspace"])
+        self.submit(
+            payload["branch"],
+            payload["workspace"],
+            title="Fix: Update config\\nSub-title",
+            body="First paragraph\\n\\nSecond paragraph\\t- Item",
+        )
+        self.assertEqual(len(self.gh_calls), 1)
+        argv, _ = self.gh_calls[0]
+        title_val = argv[argv.index("--title") + 1]
+        body_val = argv[argv.index("--body") + 1]
+        self.assertEqual(title_val, "Fix: Update config\nSub-title")
+        self.assertEqual(body_val, "First paragraph\n\nSecond paragraph\t- Item")
+
     def test_another_agents_workspace_is_refused(self):
         # The check the credential proxy cannot make. The audit's tree holds a
         # perfectly valid `.lease` — just not ours.

--- a/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
+++ b/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
@@ -170,12 +170,21 @@ def handle_submit(args) -> int:
 
     push_branch(branch, workspace)
     base = gitops_workspace.resolve_base_branch(workspace, _runner)
-    pr_url = create_pull_request(branch, args.title, args.body, workspace, repo, base)
+    title = _normalize_text(args.title)
+    body = _normalize_text(args.body)
+    pr_url = create_pull_request(branch, title, body, workspace, repo, base)
     log(f"PR SUBMITTED SUCCESSFULLY! 🏆 URL: {pr_url}")
 
     # Print raw URL to stdout for the MCP tool to parse
     print(pr_url)
     return 0
+
+
+def _normalize_text(text: str) -> str:
+    """Unescape literal CLI escape sequences (like \\n or \\r\\n) into real whitespace."""
+    if not text:
+        return text
+    return text.replace("\\r\\n", "\n").replace("\\n", "\n").replace("\\t", "\t")
 
 
 def push_branch(branch_name: str, workspace: str) -> None:


### PR DESCRIPTION
## 🎯 Issue Description
When autonomous agent workers or LLMs invoke `submit_suggestion.py submit` via the shell, multi-line arguments passed to `--title` and `--body` often contain literal escape sequences (e.g., `\n`, `\r\n`, `\t`). Without normalization, GitHub renders these as raw text strings (e.g., literal `\n`) instead of actual line breaks and indentation, degrading PR readability and breaking markdown formatting.

## 🛠️ Changes Made
1. **Added `_normalize_text()` Helper**:
   - Unescapes literal CLI escape sequences (`\r\n`, `\n`, `\t`) into proper whitespace and newlines.
   - Handles edge cases such as empty strings, `None`, and standard text without modification.
2. **Applied Normalization in `handle_submit()`**:
   - Sanitizes both `args.title` and `args.body` before passing them to `create_pull_request()`.
3. **Added Comprehensive Unit Tests**:
   - Added `test_normalize_text_unescapes_cli_newlines_and_tabs` and `test_submit_normalizes_escaped_newlines_in_title_and_body` in `agents/platform/scripts/test_submit_suggestion.py`.

## 🧪 Verification
- Ran test suite: `python3 -m unittest discover -s agents/platform/scripts -p 'test_submit_suggestion.py' -v`
- **Result**: All 27 unit tests passed cleanly (including real bare repo git clone/branch/lease workflows and `gh` mock invocation checks).
- Verified that multiline PR descriptions containing `\n` render with proper paragraph breaks and markdown formatting.