### PR TITLE
feat(admin): manage LiteLLM gateway and canonical agent identity

### DIFF
--- a/admin_console/CONNECTION_SECURITY.md
+++ b/admin_console/CONNECTION_SECURITY.md
@@ -23,6 +23,10 @@ deployment. The JSON document contains only:
 - the last successful verification time; and
 - whether runtime use is verified or requires revalidation.
 
+The file does not persist an agent ID. Runtime pages rediscover the canonical
+stock `PlatformAgent` from the connected Kubernetes target, so a stale cluster,
+Deployment, Service, or Hermes profile name cannot become installation identity.
+
 The account identifier and infrastructure names may be sensitive organizational
 metadata. Treat the file as private even though it is not a credential.
 
@@ -52,6 +56,27 @@ These controls protect against accidental disclosure and unsafe file
 substitution across local accounts. They do not defend against a process already
 running as the same Unix user; that process can also access the user's gcloud
 configuration and is outside the local portal's trust boundary.
+
+## Local API authorization
+
+The loopback listener is reachable by other local accounts, so binding to
+`127.0.0.1` is not the authorization boundary. At launch, the portal creates a
+random process-scoped bearer capability and passes it only to its private
+Streamlit child process. Every `/api/v1` request must present that capability,
+including requests that read the persisted connection lease or change LiteLLM
+configuration. Health probes and the browser-facing Streamlit proxy do not
+receive cluster access through this capability.
+
+The capability exists only in the portal processes' environment. It is not
+printed, placed in a URL, sent to the browser, or written to the persisted
+connection-state document. Restarting the portal replaces it. A same-user
+process remains outside this protection for the reason described above.
+
+An API-only client started separately can opt into the same launch by setting
+`KUBE_AGENTS_PORTAL_API_TOKEN` to the same independently generated value of at
+least 32 characters before starting both the portal and client. The client sends
+that value as `Authorization: Bearer ...`. Do not place it in a command-line
+argument or URL.
 
 ## Resume and revalidation
 

--- a/admin_console/README.md
+++ b/admin_console/README.md
@@ -132,8 +132,9 @@ no-recent-data outcomes. Cluster connectivity depends on the identity, project,
 GKE, and agent-runtime checks; an unavailable Logging or Trace source remains a
 visible checklist failure but does not lock runtime-backed Chat, Task Kanban, or
 Scheduled Cron. A failed cluster connection shows one actionable error by the
-controls. The portal never grants IAM, enables APIs, changes Kubernetes
-resources, or retains access tokens.
+controls. The Connection workflow never grants IAM, enables APIs, changes
+Kubernetes resources, or retains access tokens. The separate **LLM Gateway**
+page has explicit, narrowly scoped configuration actions described below.
 Observe and Chat pages are unavailable until the required checks pass for the
 selected project and cluster.
 
@@ -146,6 +147,24 @@ fails:
 gcloud auth application-default login
 ```
 
+## LLM Gateway
+
+Setup's **LLM Gateway** page reads the connected target's LiteLLM resources and
+runs one bounded request from the Platform Agent through `model-default`.
+**Refresh status** repeats that complete check. Kubernetes resources, recent
+container logs, and operation output stay collapsed under **Raw Logs**.
+
+The provider catalog defines Gemini, Anthropic, OpenAI, Vertex AI, and ChatGPT
+subscription configuration. API keys are write-only Secret patches; Vertex AI
+uses Workload Identity; ChatGPT tokens stay in a cluster PVC while the page
+shows LiteLLM's device-login output. A successful non-device change waits for
+one rollout and tests the updated connection. Device login is polled until the
+rollout completes, then tested. Helm-owned deployments show their live status
+but disable the configuration form; change those releases through Terraform or
+Helm. See the
+[inference gateway guide](../docs/site/src/content/docs/concepts/inference-gateway.md)
+for provider behavior.
+
 ## Chat
 
 Chat is always available in navigation. Without a verified target it provides a
@@ -156,10 +175,20 @@ Selecting a row updates the URL-selected session and renders its transcript and
 composer below the table.
 
 Portal-owned sessions use the connected deployment's default Hermes profile,
-the same front-door Planning Agent used by Google Chat and Slack. The Chat page uses
-the versioned `/api/v1` contract for agent discovery, session reads, messages,
+the same front-door Planning Agent used by Google Chat and Slack. The connected
+installation is the stock `PlatformAgent` named by the Helm default. The portal
+discovers that resource from the selected cluster and
+does not ask for an agent ID. If it is absent, the error lists every discovered
+`PlatformAgent` name. Cluster, Deployment, Service, and Hermes profile names are
+never substituted for the resource name. The Chat page uses the versioned
+`/api/v1` contract for discovery, session reads, messages,
 linked tasks, new interactions, and approvals; it does not call the Hermes
-adapter directly. The selected session is stored in the URL and its transcript
+adapter directly. The public API retains `agentId` in interaction records and
+URLs, but the portal populates it from the discovered canonical resource.
+Every local `/api/v1` request also carries a random launch-scoped bearer
+capability shared only with the private Streamlit child process. The capability
+is replaced on restart and is never stored with connection state.
+The selected session is stored in the URL and its transcript
 is reloaded from Hermes after a refresh. Google Chat and Slack sessions are
 visible but read-only; a portal follow-up creates a separate `portal_*` session
 so the console does not impersonate an external participant or unexpectedly
@@ -190,8 +219,9 @@ deployment boundary are owned by the
 [admin-console design](../docs/designs/admin-console.md#portal-api-and-shared-chat-abstraction).
 
 The portal does not retrieve the external Hermes API key. The transitional
-adapter runs a fixed, size-bounded client inside the selected `platform-agent`
-container. That in-container process reads `API_SERVER_KEY` from its own
+adapter runs a fixed, size-bounded client inside the live gateway container
+that exposes the operator-defined `api` port. That in-container process reads
+`API_SERVER_KEY` from its own
 environment and uses it only for the loopback request; the credential never
 enters the local portal process, stdout, or kubectl arguments. User prompts are
 sent over stdin rather than command arguments. If Hermes requests a tool
@@ -215,8 +245,7 @@ share one connection-gate component that directs the user to Connection;
 provider-backed content becomes available after connecting to a verified
 kube-agents host.
 
-Task Kanban reads the selected Agent's live shared board. Today each Agent entry is
-backed by a Kubernetes `PlatformAgent` custom resource. The page summarizes
+Task Kanban reads the canonical installation's live shared board. The page summarizes
 open, attention, and completed work, filters by status and assignee, and uses a
 25-row selectable table with URL-persisted pagination. Selecting a row keeps
 the task in the URL and renders its details below the table. Task inspection
@@ -230,8 +259,8 @@ values are redacted before rendering, raw delivery destinations and attachment
 storage paths are not returned, and the page never claims, retries, comments
 on, or otherwise changes a task.
 
-Scheduled Cron reads every bounded Hermes profile cron store in the selected
-Agent. Its execution table aggregates the selected history into one row per job
+Scheduled Cron reads every bounded Hermes profile cron store in the canonical
+installation. Its execution table aggregates the selected history into one row per job
 title with run and outcome counts, latest activity, and participating profiles.
 Each row expands in place to list every retained start time, trigger, duration,
 status, profile, and error—there is no separate detail table. The page also shows
@@ -254,10 +283,11 @@ read:
 - complete Hermes traces that contain the trusted `session.id` label.
 
 Chat History reads persisted user and assistant messages from every Hermes
-profile in the selected Agent runtime. Reads are bounded and credential-shaped
+profile in the canonical runtime. Reads are bounded and credential-shaped
 values are redacted. Sessions without trusted user metadata remain explicitly
 unattributed; tool output and model reasoning are not rendered. URL state keeps
-the selected agent, profile, platform, opaque user filter, and session.
+the profile, platform, opaque user filter, and session; it does not expose an
+agent selector.
 Free-text search stays out of the URL because it may contain sensitive data.
 
 The Activity Explorer retains each Logging insert ID or Trace/span ID, provides

--- a/admin_console/agent_chat.py
+++ b/admin_console/agent_chat.py
@@ -19,9 +19,14 @@ from admin_console.project_config import (
     is_valid_namespace,
     is_valid_project_id,
 )
+from admin_console.runtime_contract import (
+    CanonicalPlatformAgentMissing,
+    canonical_platform_agent_name,
+    gateway_endpoints,
+    select_canonical_platform_agent,
+)
 from admin_console.telemetry import redact_evidence
 
-_K8S_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$")
 _PROFILE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 _RUN_ID = re.compile(r"^run_[a-f0-9]{32}$")
 _SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}$")
@@ -261,9 +266,27 @@ class AgentChatProvider:
     def _base(self) -> list[str]:
         return ["--context", self.context, "-n", self.target.namespace]
 
-    def _gateway_pod(self, agent: str) -> str:
-        if not _K8S_NAME.fullmatch(agent):
-            raise ValueError("invalid PlatformAgent name")
+    def _gateway_endpoint(self, agent: str) -> tuple[str, str]:
+        expected = canonical_platform_agent_name()
+        if agent != expected:
+            raise ValueError(
+                f"agentId must be the canonical PlatformAgent "
+                f"{expected}"
+            )
+        resources = self.runner.run(
+            [*self._base(), "get", "platformagents", "-o", "json"],
+            input_text="",
+            timeout=20,
+        )
+        resource_payload = self._json(resources, "PlatformAgent discovery")
+        try:
+            select_canonical_platform_agent(resource_payload)
+        except CanonicalPlatformAgentMissing as exc:
+            raise AgentChatError(
+                str(exc),
+                f"Install the stock PlatformAgent/{expected} resource or select the "
+                "cluster containing it.",
+            ) from exc
         result = self.runner.run(
             [
                 *self._base(),
@@ -279,17 +302,14 @@ class AgentChatProvider:
             timeout=20,
         )
         payload = self._json(result, "Gateway discovery")
-        pods = sorted(
-            str((item.get("metadata") or {}).get("name") or "")
-            for item in payload.get("items", [])
-            if (item.get("metadata") or {}).get("name")
-        )
-        if not pods:
+        endpoints = gateway_endpoints(payload)
+        if not endpoints:
             raise AgentChatError(
-                "No running gateway pod was found.",
+                "No running gateway API container was found.",
                 f"Check PlatformAgent {agent} in namespace {self.target.namespace}.",
             )
-        return pods[0]
+        endpoint = endpoints[0]
+        return endpoint.pod, endpoint.container
 
     @staticmethod
     def _json(result: ChatCommandResult, component: str) -> dict:
@@ -332,7 +352,7 @@ class AgentChatProvider:
         timeout: int = 620,
         update_callback: Callable[[dict], None] | None = None,
     ) -> dict:
-        pod = self._gateway_pod(agent)
+        pod, container = self._gateway_endpoint(agent)
         parsed_lines: list[dict] = []
 
         def parse_line(line: str) -> None:
@@ -353,7 +373,7 @@ class AgentChatProvider:
                 "-i",
                 pod,
                 "-c",
-                "platform-agent",
+                container,
                 "--",
                 "/opt/hermes/.venv/bin/python3",
                 "-c",

--- a/admin_console/agent_runtime.py
+++ b/admin_console/agent_runtime.py
@@ -21,10 +21,17 @@ from admin_console.project_config import (
     is_valid_namespace,
     is_valid_project_id,
 )
+from admin_console.runtime_contract import (
+    CanonicalPlatformAgentMissing,
+    canonical_platform_agent_name,
+    gateway_endpoints,
+    select_canonical_platform_agent,
+)
 from admin_console.telemetry import redact_evidence
 
 _K8S_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$")
 _KANBAN_TASK = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+GATEWAY_PYTHON = "/opt/hermes/.venv/bin/python3"
 _READ_SCRIPT = r'''
 import json
 import sqlite3
@@ -797,6 +804,7 @@ class AgentRuntimeProvider:
             f"gke_{target.project_id}_{target.location}_{target.cluster_name}"
         )
         self.runner = runner or KubectlRunner(target)
+        self._canonical_agent: str | None = None
 
     def _base(self) -> list[str]:
         return ["--context", self.context, "-n", self.target.namespace]
@@ -835,76 +843,34 @@ class AgentRuntimeProvider:
         return payload
 
     def list_agents(self) -> tuple[str, ...]:
-        """Discover deployed agents from running gateway pods.
+        """Return the one stock PlatformAgent selected for this installation."""
+        return (self.canonical_agent(),)
 
-        History lives in the gateway PVC, so pod discovery is the narrowest
-        relevant source. Current deployments label credential-proxy pods; an
-        older deployment may lack that label, so a bounded PlatformAgent list
-        supplies validated app names for a second pod query.
-        """
-        result = self.runner.run(
-            [
-                *self._base(),
-                "get",
-                "pods",
-                "-l",
-                "kubeagents.x-k8s.io/has-credential-proxy=true",
-                "--field-selector=status.phase=Running",
-                "-o",
-                "json",
-            ],
-            timeout=15,
-        )
-        payload = self._json(result, "Gateway discovery")
-        agents = self._agent_names(payload)
-        if agents:
-            return agents
-
+    def canonical_agent(self) -> str:
+        """Discover and select the stock PlatformAgent, or fail closed."""
+        if self._canonical_agent is not None:
+            return self._canonical_agent
         resources = self.runner.run(
             [*self._base(), "get", "platformagents", "-o", "json"],
             timeout=15,
         )
         resource_payload = self._json(resources, "PlatformAgent discovery")
-        candidates = sorted(
-            {
-                str((item.get("metadata") or {}).get("name") or "")
-                for item in resource_payload.get("items", [])[:50]
-            }
-        )
-        candidates = [name for name in candidates if _K8S_NAME.fullmatch(name)]
-        if not candidates:
-            return ()
-        selector = "app in (" + ",".join(f"{name}-gateway" for name in candidates) + ")"
-        fallback = self.runner.run(
-            [
-                *self._base(),
-                "get",
-                "pods",
-                "-l",
-                selector,
-                "--field-selector=status.phase=Running",
-                "-o",
-                "json",
-            ],
-            timeout=15,
-        )
-        return self._agent_names(self._json(fallback, "Gateway discovery"))
+        try:
+            expected = select_canonical_platform_agent(resource_payload)
+        except CanonicalPlatformAgentMissing as exc:
+            raise AgentRuntimeError(
+                str(exc),
+                f"Install the stock PlatformAgent/{canonical_platform_agent_name()} "
+                "resource or select the cluster containing it.",
+            ) from exc
+        self._canonical_agent = expected
+        return self._canonical_agent
 
-    @staticmethod
-    def _agent_names(payload: dict) -> tuple[str, ...]:
-        agents = set()
-        for item in payload.get("items", []):
-            labels = (item.get("metadata") or {}).get("labels") or {}
-            app = str(labels.get("app") or "")
-            if app.endswith("-gateway"):
-                name = app.removesuffix("-gateway")
-                if _K8S_NAME.fullmatch(name):
-                    agents.add(name)
-        return tuple(sorted(agents))
-
-    def _gateway_pod(self, agent: str) -> str:
-        if not _K8S_NAME.fullmatch(agent):
-            raise ValueError("invalid PlatformAgent name")
+    def gateway_endpoint(self, agent: str) -> tuple[str, str]:
+        """Return one running gateway pod and its live API container name."""
+        canonical = self.canonical_agent()
+        if agent != canonical:
+            raise ValueError(f"agentId must be the canonical PlatformAgent {canonical}")
         result = self.runner.run(
             [
                 *self._base(),
@@ -918,30 +884,35 @@ class AgentRuntimeProvider:
             ],
             timeout=15,
         )
-        payload = self._json(result, "Gateway discovery")
-        pods = sorted(
-            str((item.get("metadata") or {}).get("name") or "")
-            for item in payload.get("items", [])
-            if (item.get("metadata") or {}).get("name")
-        )
-        if not pods:
+        endpoints = gateway_endpoints(self._json(result, "Gateway discovery"))
+        if not endpoints:
             raise AgentRuntimeError(
-                "No running gateway pod was found.",
+                "No running gateway API container was found.",
                 f"Check PlatformAgent {agent} in namespace {self.target.namespace}.",
             )
-        return pods[0]
+        endpoint = endpoints[0]
+        return endpoint.pod, endpoint.container
+
+    def gateway_pod(self, agent: str) -> str:
+        """Return one running gateway pod for a discovered PlatformAgent."""
+        pod, _container = self.gateway_endpoint(agent)
+        return pod
+
+    def _gateway_pod(self, agent: str) -> str:
+        """Compatibility wrapper for the runtime's internal read operations."""
+        return self.gateway_pod(agent)
 
     def _read(self, agent: str, arguments: list[str], *, timeout: int = 25) -> dict:
-        pod = self._gateway_pod(agent)
+        pod, container = self.gateway_endpoint(agent)
         result = self.runner.run(
             [
                 *self._base(),
                 "exec",
                 pod,
                 "-c",
-                "platform-agent",
+                container,
                 "--",
-                "/opt/hermes/.venv/bin/python3",
+                GATEWAY_PYTHON,
                 "-c",
                 _READ_SCRIPT,
                 *arguments,

--- a/admin_console/api/app.py
+++ b/admin_console/api/app.py
@@ -5,20 +5,28 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import secrets
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from typing import Callable
 
 from fastapi import FastAPI, HTTPException, Query, Request, status
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from admin_console import agent_runtime
-from admin_console.api.models import ApprovalRequest, StartInteractionRequest
+from admin_console.api.authorization import portal_api_token
+from admin_console.api.models import (
+    ApprovalRequest,
+    LlmConfigurationRequest,
+    StartInteractionRequest,
+)
 from admin_console.chat.backend import persisted_backend_factory
 from admin_console.chat.service import ChatService
 from admin_console.chat.store import SQLiteInteractionStore, interaction_state_path
 from admin_console.connection_persistence import load_connection
+from admin_console.llm_gateway import LlmGatewayService
 from admin_console.project_config import (
     TARGET_SCOPE_HEADERS,
     DeploymentTarget,
@@ -26,6 +34,7 @@ from admin_console.project_config import (
 )
 
 RuntimeProviderFactory = Callable[[], agent_runtime.AgentRuntimeProvider]
+LlmGatewayFactory = Callable[[DeploymentTarget], LlmGatewayService]
 
 
 def _error(code: str, message: str, *, retryable: bool = False) -> dict:
@@ -55,6 +64,8 @@ def create_app(
     service: ChatService | None = None,
     *,
     runtime_provider_factory: RuntimeProviderFactory | None = None,
+    llm_gateway_factory: LlmGatewayFactory | None = None,
+    bound_target: DeploymentTarget | None = None,
     lifespan: Callable[[FastAPI], AbstractAsyncContextManager] | None = None,
 ) -> FastAPI:
     account = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
@@ -65,16 +76,51 @@ def create_app(
     runtime_provider_factory = runtime_provider_factory or _persisted_runtime_factory(
         account
     )
+    llm_gateway_factory = llm_gateway_factory or LlmGatewayService
     app = FastAPI(
         title="kube-agents admin portal",
         version="1.0.0",
         lifespan=lifespan,
     )
     app.state.chat_service = service
+    expected_api_token = portal_api_token()
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error(_request: Request, exc: RequestValidationError):
+        # FastAPI's default 422 body repeats the rejected input. Commands can
+        # contain prompts or write-only provider credentials, so retain the
+        # field path and diagnostic while omitting caller-supplied values.
+        errors = [
+            {
+                key: value
+                for key, value in issue.items()
+                if key not in {"input", "ctx"}
+            }
+            for issue in exc.errors()
+        ]
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            content={"detail": errors},
+        )
 
     @app.middleware("http")
-    async def reject_stale_target(request: Request, call_next):
+    async def authorize_and_reject_stale_target(request: Request, call_next):
         if request.url.path.startswith("/api/v1/"):
+            scheme, _, supplied_token = request.headers.get(
+                "authorization", ""
+            ).partition(" ")
+            if scheme.lower() != "bearer" or not secrets.compare_digest(
+                supplied_token, expected_api_token
+            ):
+                return JSONResponse(
+                    status_code=401,
+                    content={
+                        "detail": _error(
+                            "portal_api_unauthorized",
+                            "This request is not authorized for the current portal launch.",
+                        )
+                    },
+                )
             supplied = {
                 header: request.headers.get(header, "")
                 for header, _ in TARGET_SCOPE_HEADERS
@@ -90,19 +136,22 @@ def create_app(
                             )
                         },
                     )
-                connection = load_connection(account)
-                if connection is None or not connection.usable:
-                    return JSONResponse(
-                        status_code=503,
-                        content={
-                            "detail": _error(
-                                "connection_unavailable",
-                                "No verified portal connection is available.",
-                                retryable=True,
-                            )
-                        },
-                    )
-                expected = deployment_target_headers(connection.target)
+                if bound_target is not None:
+                    expected = deployment_target_headers(bound_target)
+                else:
+                    connection = load_connection(account)
+                    if connection is None or not connection.usable:
+                        return JSONResponse(
+                            status_code=503,
+                            content={
+                                "detail": _error(
+                                    "connection_unavailable",
+                                    "No verified portal connection is available.",
+                                    retryable=True,
+                                )
+                            },
+                        )
+                    expected = deployment_target_headers(connection.target)
                 if supplied != expected:
                     return JSONResponse(
                         status_code=409,
@@ -123,6 +172,70 @@ def create_app(
     @app.get("/readyz")
     def ready() -> dict:
         return {"status": "ready"}
+
+    def request_target(request: Request) -> DeploymentTarget:
+        values = {
+            attribute: request.headers.get(header, "").strip()
+            for header, attribute in TARGET_SCOPE_HEADERS
+        }
+        if all(values.values()):
+            return DeploymentTarget(**values, source="portal request")
+        if bound_target is not None:
+            return bound_target
+        connection = load_connection(account)
+        if connection is None or not connection.usable:
+            raise HTTPException(
+                status_code=503,
+                detail=_error(
+                    "connection_unavailable",
+                    "No verified portal connection is available.",
+                    retryable=True,
+                ),
+            )
+        return connection.target
+
+    @app.get("/api/v1/llm-gateway")
+    def inspect_llm_gateway(request: Request) -> dict:
+        try:
+            return llm_gateway_factory(request_target(request)).status()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=_error("llm_gateway_unavailable", str(exc), retryable=True),
+            ) from exc
+
+    @app.get("/api/v1/llm-gateway/device-status")
+    def llm_gateway_device_status(request: Request) -> dict:
+        try:
+            return llm_gateway_factory(request_target(request)).device_status()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=_error("llm_device_status_failed", str(exc), retryable=True),
+            ) from exc
+
+    @app.post("/api/v1/llm-gateway/configuration")
+    def configure_llm_gateway(
+        request: Request,
+        payload: LlmConfigurationRequest,
+    ) -> dict:
+        try:
+            return llm_gateway_factory(request_target(request)).configure(
+                payload.provider_id,
+                payload.model,
+                credential=payload.credential,
+                settings=payload.settings,
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=_error("invalid_llm_configuration", str(exc)),
+            ) from exc
+        except Exception as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=_error("llm_configuration_failed", str(exc), retryable=True),
+            ) from exc
 
     @app.get("/api/v1/agents")
     def list_agents() -> dict:

--- a/admin_console/api/authorization.py
+++ b/admin_console/api/authorization.py
@@ -1,0 +1,32 @@
+"""Process-scoped authorization for the local admin portal API."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from functools import cache
+
+PORTAL_API_TOKEN_ENV = "KUBE_AGENTS_PORTAL_API_TOKEN"
+MINIMUM_TOKEN_LENGTH = 32
+
+
+@cache
+def portal_api_token() -> str:
+    """Return one token shared by the portal and its Streamlit child process."""
+
+    token = os.environ.get(PORTAL_API_TOKEN_ENV, "").strip()
+    if token and len(token) < MINIMUM_TOKEN_LENGTH:
+        raise RuntimeError(
+            f"{PORTAL_API_TOKEN_ENV} must contain at least "
+            f"{MINIMUM_TOKEN_LENGTH} characters"
+        )
+    if not token:
+        token = secrets.token_urlsafe(32)
+        os.environ[PORTAL_API_TOKEN_ENV] = token
+    return token
+
+
+def portal_api_headers() -> dict[str, str]:
+    """Build the authorization header for a portal-owned API client."""
+
+    return {"Authorization": f"Bearer {portal_api_token()}"}

--- a/admin_console/api/models.py
+++ b/admin_console/api/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from admin_console.agent_chat import MAX_HISTORY_MESSAGES
 from admin_console.chat.models import is_portal_session_id
+from admin_console.runtime_contract import canonical_platform_agent_name
 
 
 class InteractionInput(BaseModel):
@@ -24,7 +25,10 @@ class HistoryMessage(BaseModel):
 class StartInteractionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    agent_id: str = Field(alias="agentId", pattern=r"^[a-z0-9][a-z0-9.-]{0,62}$")
+    agent_id: str = Field(
+        default_factory=canonical_platform_agent_name,
+        alias="agentId",
+    )
     profile: str = Field(default="default", pattern=r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
     session_id: str = Field(default="", alias="sessionId", max_length=256)
     input: InteractionInput
@@ -40,8 +44,30 @@ class StartInteractionRequest(BaseModel):
             raise ValueError("sessionId must identify a portal-owned session")
         return value
 
+    @field_validator("agent_id")
+    @classmethod
+    def canonical_agent_only(cls, value: str) -> str:
+        expected = canonical_platform_agent_name()
+        if value != expected:
+            raise ValueError(
+                f"agentId must be the canonical PlatformAgent "
+                f"{expected}"
+            )
+        return value
+
 
 class ApprovalRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     choice: str = Field(pattern="^(once|deny)$")
+
+
+class LlmConfigurationRequest(BaseModel):
+    """Provider configuration; credential is write-only and never returned."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider_id: str = Field(alias="providerId", min_length=1, max_length=64)
+    model: str = Field(min_length=1, max_length=255)
+    credential: str = Field(default="", max_length=16_384)
+    settings: dict[str, str] = Field(default_factory=dict)

--- a/admin_console/app.py
+++ b/admin_console/app.py
@@ -47,6 +47,11 @@ pages = {
             icon=":material/cable:",
             default=True,
         ),
+        st.Page(
+            APP_DIRECTORY / "pages" / "llm_gateway.py",
+            title="LLM Gateway",
+            icon=":material/model_training:",
+        ),
     ],
     "Agentic": [
         st.Page(

--- a/admin_console/clients/portal_api.py
+++ b/admin_console/clients/portal_api.py
@@ -21,10 +21,12 @@ from admin_console.agent_runtime import (
     MessageResult,
     TaskUpdateResult,
 )
+from admin_console.api.authorization import portal_api_headers
 from admin_console.api.app import create_app, target_runtime_factory
 from admin_console.chat.backend import RuntimeChatBackend
 from admin_console.chat.service import ChatService
 from admin_console.project_config import DeploymentTarget, deployment_target_headers
+from admin_console.runtime_contract import canonical_platform_agent_name
 
 
 class Response(Protocol):
@@ -87,7 +89,10 @@ class PortalApiClient:
                 raise ValueError("target is required when using the portal API")
             self._transport = httpx.Client(
                 base_url=f"{base_url.rstrip('/')}/",
-                headers=deployment_target_headers(target),
+                headers={
+                    **deployment_target_headers(target),
+                    **portal_api_headers(),
+                },
                 timeout=httpx.Timeout(30, connect=5),
             )
             return
@@ -103,8 +108,10 @@ class PortalApiClient:
             create_app(
                 service,
                 runtime_provider_factory=target_runtime_factory(target),
+                bound_target=target,
             ),
             base_url="http://testserver/api/v1/",
+            headers=portal_api_headers(),
         )
         self._in_process = True
 
@@ -138,9 +145,74 @@ class PortalApiClient:
         )
         raise PortalApiError(message, guidance)
 
+    def _get(self, path: str, **kwargs) -> Response:
+        try:
+            return self._transport.get(path, **kwargs)
+        except httpx.TimeoutException as exc:
+            raise PortalApiError(
+                "Portal API request timed out.",
+                "The cluster may be slow or unreachable. Reconnect, then retry.",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise PortalApiError(
+                f"Portal API request failed: {exc}",
+                "Reconnect the portal or inspect the FastAPI service logs before retrying.",
+            ) from exc
+
+    def _post(self, path: str, **kwargs) -> Response:
+        try:
+            return self._transport.post(path, **kwargs)
+        except httpx.TimeoutException as exc:
+            raise PortalApiError(
+                "Portal API request timed out.",
+                "The cluster may be slow or unreachable. Reconnect, then retry.",
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise PortalApiError(
+                f"Portal API request failed: {exc}",
+                "Reconnect the portal or inspect the FastAPI service logs before retrying.",
+            ) from exc
+
     def list_agents(self) -> tuple[str, ...]:
-        payload = self._payload(self._transport.get("agents"))
+        payload = self._payload(self._get("agents"))
         return tuple(str(item) for item in payload.get("agents", []))
+
+    def canonical_agent(self) -> str:
+        agents = self.list_agents()
+        if len(agents) != 1:
+            expected = canonical_platform_agent_name()
+            raise PortalApiError(
+                "The portal API did not select one canonical PlatformAgent.",
+                f"Reconnect the target and confirm PlatformAgent/{expected} exists.",
+            )
+        return agents[0]
+
+    def inspect_llm_gateway(self) -> dict[str, Any]:
+        return self._payload(self._get("llm-gateway", timeout=120))
+
+    def llm_gateway_device_status(self) -> dict[str, Any]:
+        return self._payload(self._get("llm-gateway/device-status", timeout=30))
+
+    def configure_llm_gateway(
+        self,
+        *,
+        provider_id: str,
+        model: str,
+        credential: str = "",
+        settings: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return self._payload(
+            self._post(
+                "llm-gateway/configuration",
+                json={
+                    "providerId": provider_id,
+                    "model": model,
+                    "credential": credential,
+                    "settings": settings or {},
+                },
+                timeout=360,
+            )
+        )
 
     def list_conversations(
         self,
@@ -150,7 +222,7 @@ class PortalApiClient:
         limit: int = 200,
     ) -> HistoryResult:
         payload = self._payload(
-            self._transport.get(
+            self._get(
                 f"agents/{quote(agent, safe='')}/sessions",
                 params={"cutoff": cutoff.isoformat(), "limit": limit},
             )
@@ -188,7 +260,7 @@ class PortalApiClient:
             f"agents/{quote(agent, safe='')}/sessions/"
             f"{quote(profile, safe='')}/{quote(session_id, safe='')}/messages"
         )
-        payload = self._payload(self._transport.get(path, params={"limit": limit}))
+        payload = self._payload(self._get(path, params={"limit": limit}))
         messages = tuple(
             AgentMessage(
                 message_id=int(row["message_id"]),
@@ -211,7 +283,7 @@ class PortalApiClient:
             f"agents/{quote(agent, safe='')}/sessions/"
             f"{quote(session_id, safe='')}/tasks"
         )
-        payload = self._payload(self._transport.get(path, params={"limit": limit}))
+        payload = self._payload(self._get(path, params={"limit": limit}))
         tasks = tuple(
             AgentTaskUpdate(
                 task_id=str(row["task_id"]),
@@ -245,7 +317,7 @@ class PortalApiClient:
         profile: str = "default",
     ) -> InteractionView:
         payload = self._payload(
-            self._transport.post(
+            self._post(
                 "interactions",
                 json={
                     "agentId": agent,
@@ -268,7 +340,7 @@ class PortalApiClient:
 
     def get_interaction(self, interaction_id: str) -> InteractionView:
         payload = self._payload(
-            self._transport.get(f"interactions/{quote(interaction_id, safe='')}")
+            self._get(f"interactions/{quote(interaction_id, safe='')}")
         )
         return self._interaction(payload)
 
@@ -279,7 +351,7 @@ class PortalApiClient:
         choice: str,
     ) -> InteractionView:
         payload = self._payload(
-            self._transport.post(
+            self._post(
                 f"interactions/{quote(interaction_id, safe='')}/approval",
                 json={"choice": choice},
             )
@@ -288,7 +360,7 @@ class PortalApiClient:
 
     def cancel_interaction(self, interaction_id: str) -> InteractionView:
         payload = self._payload(
-            self._transport.post(
+            self._post(
                 f"interactions/{quote(interaction_id, safe='')}/cancel"
             )
         )

--- a/admin_console/connections.py
+++ b/admin_console/connections.py
@@ -591,30 +591,17 @@ def run_connection_checks(
                 if cancel_event is not None and cancel_event.is_set():
                     raise ConnectionChecksCancelled()
                 runtime_provider = AgentRuntimeProvider(runtime_target)
-                agents = runtime_provider.list_agents()
-                if not agents:
-                    checks.append(
-                        ConnectionCheck(
-                            "agent_runtime",
-                            "Agent runtime read",
-                            CheckStatus.WARNING,
-                            "No running kube-agents gateway pods were found.",
-                            "Confirm the selected cluster and namespace.",
-                        )
+                agent = runtime_provider.canonical_agent()
+                profile_count, session_count = runtime_provider.check_connection(agent)
+                checks.append(
+                    ConnectionCheck(
+                        "agent_runtime",
+                        "Agent runtime read",
+                        CheckStatus.PASS,
+                        f"Read {profile_count} profile(s) and {session_count} "
+                        f"session(s) from {agent}.",
                     )
-                else:
-                    profile_count, session_count = runtime_provider.check_connection(
-                        agents[0]
-                    )
-                    checks.append(
-                        ConnectionCheck(
-                            "agent_runtime",
-                            "Agent runtime read",
-                            CheckStatus.PASS,
-                            f"Read {profile_count} profile(s) and {session_count} "
-                            f"session(s) from {agents[0]}.",
-                        )
-                    )
+                )
                 if cancel_event is not None and cancel_event.is_set():
                     raise ConnectionChecksCancelled()
             except AgentRuntimeError as exc:

--- a/admin_console/llm_gateway.py
+++ b/admin_console/llm_gateway.py
@@ -165,6 +165,7 @@ class LlmGatewayService:
         timeout: int = 20,
         input_text: str | None = None,
     ) -> RawEvidence:
+        arguments = ["--context", self.kube.context, *arguments]
         result = self.kube.run(arguments, timeout=timeout, input_text=input_text)
         return RawEvidence.from_result(source, "kubectl " + " ".join(arguments), result)
 
@@ -378,6 +379,8 @@ except urllib.error.HTTPError as error:
 
     def _deployment(self, *, optional: bool = False) -> dict[str, Any] | None:
         arguments = [
+            "--context",
+            self.kube.context,
             "get",
             "deployment",
             str(self.catalog.gateway["deployment"]),

--- a/admin_console/llm_gateway.py
+++ b/admin_console/llm_gateway.py
@@ -1,0 +1,886 @@
+"""LiteLLM catalog, raw evidence collection, and configuration operations."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from admin_console.agent_runtime import (
+    GATEWAY_PYTHON,
+    AgentRuntimeProvider,
+    KubectlRunner,
+)
+from admin_console.kube_access import GKEKubeAccess, KubeCommandResult
+from admin_console.project_config import (
+    DeploymentTarget,
+    is_valid_project_id,
+    is_valid_region,
+    region_for_location,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CATALOG_PATH = (
+    REPO_ROOT
+    / "k8s-operator"
+    / "config"
+    / "integrations"
+    / "litellm"
+    / "providers.json"
+)
+LITELLM_ROOT = CATALOG_PATH.parent
+OPERATOR_ROOT = REPO_ROOT / "k8s-operator"
+MODEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,254}$")
+
+
+@dataclass(frozen=True)
+class Provider:
+    id: str
+    label: str
+    default_model: str
+    overlay: str
+    authentication: dict[str, Any]
+    settings: tuple[dict[str, str], ...] = ()
+    workload_identity: dict[str, str] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "defaultModel": self.default_model,
+            "overlay": self.overlay,
+            "authentication": self.authentication,
+            "settings": list(self.settings),
+            "workloadIdentity": self.workload_identity,
+        }
+
+
+class ProviderCatalog:
+    """Read the repository-owned provider contract without UI defaults."""
+
+    def __init__(self, path: Path = CATALOG_PATH) -> None:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if payload.get("schemaVersion") != 1:
+            raise ValueError("unsupported LiteLLM provider catalog schema")
+        self.default_provider = str(payload["defaultProvider"])
+        self.gateway = dict(payload["gateway"])
+        required_gateway_fields = {
+            "deployment",
+            "service",
+            "configMapBase",
+            "configVolume",
+            "container",
+            "servicePort",
+            "containerPort",
+            "readinessPath",
+            "inferencePath",
+            "modelAlias",
+            "rolloutTimeoutSeconds",
+        }
+        if required_gateway_fields - self.gateway.keys():
+            raise ValueError(
+                "LiteLLM provider catalog has an incomplete gateway contract"
+            )
+        self.providers = tuple(
+            Provider(
+                id=str(row["id"]),
+                label=str(row["label"]),
+                default_model=str(row["defaultModel"]),
+                overlay=str(row["overlay"]),
+                authentication=dict(row["authentication"]),
+                settings=tuple(row.get("settings", ())),
+                workload_identity=(
+                    dict(row["workloadIdentity"])
+                    if row.get("workloadIdentity")
+                    else None
+                ),
+            )
+            for row in payload["providers"]
+        )
+        if self.default_provider not in {item.id for item in self.providers}:
+            raise ValueError("default LiteLLM provider is not in the catalog")
+
+    def get(self, provider_id: str) -> Provider:
+        for provider in self.providers:
+            if provider.id == provider_id:
+                return provider
+        raise ValueError(f"unsupported LiteLLM provider: {provider_id}")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "defaultProvider": self.default_provider,
+            "gateway": self.gateway,
+            "providers": [provider.to_dict() for provider in self.providers],
+        }
+
+
+@dataclass(frozen=True)
+class RawEvidence:
+    source: str
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+
+    @classmethod
+    def from_result(
+        cls, source: str, command: str, result: KubeCommandResult
+    ) -> "RawEvidence":
+        return cls(
+            source,
+            command,
+            result.returncode,
+            result.stdout,
+            result.stderr,
+            result.timed_out,
+        )
+
+
+class LlmGatewayService:
+    """Operate only on the explicitly connected Kubernetes target."""
+
+    def __init__(
+        self,
+        target: DeploymentTarget,
+        *,
+        kube: GKEKubeAccess | None = None,
+        catalog: ProviderCatalog | None = None,
+    ) -> None:
+        self.target = target
+        self.kube = kube or GKEKubeAccess(target)
+        self.catalog = catalog or ProviderCatalog()
+
+    def _run(
+        self,
+        source: str,
+        arguments: list[str],
+        *,
+        timeout: int = 20,
+        input_text: str | None = None,
+    ) -> RawEvidence:
+        result = self.kube.run(arguments, timeout=timeout, input_text=input_text)
+        return RawEvidence.from_result(source, "kubectl " + " ".join(arguments), result)
+
+    def _current_configuration(
+        self,
+        deployment_evidence: RawEvidence,
+        config_map_evidence: RawEvidence,
+    ) -> dict[str, Any] | None:
+        """Read the resolved provider/model from live, non-secret resources."""
+        resolved = ""
+        if deployment_evidence.returncode == 0:
+            try:
+                resolved = str(
+                    json.loads(deployment_evidence.stdout)["spec"]["template"][
+                        "metadata"
+                    ]["annotations"]["kubeagents.x-k8s.io/model-config"]
+                )
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+        if not resolved and config_map_evidence.returncode == 0:
+            try:
+                config = str(
+                    json.loads(config_map_evidence.stdout)["data"]["config.yaml"]
+                )
+                match = re.search(
+                    r"(?ms)^\s*-\s+model_name:\s*['\"]?model-default['\"]?\s*$"
+                    r".*?^\s+model:\s*['\"]?([^'\"\s#]+)",
+                    config,
+                )
+                resolved = match.group(1) if match else ""
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+        if "/" not in resolved:
+            return None
+        provider_id, model = resolved.split("/", 1)
+        try:
+            provider = self.catalog.get(provider_id)
+        except ValueError:
+            return None
+        settings: dict[str, str] = {}
+        if deployment_evidence.returncode == 0:
+            try:
+                containers = json.loads(deployment_evidence.stdout)["spec"][
+                    "template"
+                ]["spec"]["containers"]
+                environment = {
+                    str(item.get("name")): str(item.get("value"))
+                    for container in containers
+                    if container.get("name") == self.catalog.gateway["container"]
+                    for item in container.get("env", [])
+                    if item.get("name") and "value" in item
+                }
+                settings = {
+                    str(item["id"]): environment[
+                        str(item["deploymentEnvironmentVariable"])
+                    ]
+                    for item in provider.settings
+                    if str(item["deploymentEnvironmentVariable"]) in environment
+                }
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+        return {
+            "providerId": provider.id,
+            "providerLabel": provider.label,
+            "model": model,
+            "settings": settings,
+        }
+
+    def inspect(self) -> dict[str, Any]:
+        """Return unclassified evidence from the live target as Kubernetes emits it."""
+        namespace = self.target.namespace
+        gateway = self.catalog.gateway
+        deployment = str(gateway["deployment"])
+        service = str(gateway["service"])
+        deployment_evidence = self._run(
+            f"deployment/{deployment}",
+            ["get", "deployment", deployment, "-n", namespace, "-o", "json"],
+        )
+        config_map = str(gateway["configMapBase"])
+        if deployment_evidence.returncode == 0:
+            try:
+                deployment_payload = json.loads(deployment_evidence.stdout)
+                volumes = deployment_payload["spec"]["template"]["spec"].get(
+                    "volumes", []
+                )
+                config_map = next(
+                    str(volume["configMap"]["name"])
+                    for volume in volumes
+                    if volume.get("name") == gateway["configVolume"]
+                    and volume.get("configMap", {}).get("name")
+                )
+            except (json.JSONDecodeError, KeyError, StopIteration, TypeError):
+                pass
+        container = str(gateway["container"])
+        config_map_evidence = self._run(
+            f"configmap/{config_map}",
+            ["get", "configmap", config_map, "-n", namespace, "-o", "json"],
+        )
+        evidence = (
+            deployment_evidence,
+            self._run(
+                f"service/{service}",
+                ["get", "service", service, "-n", namespace, "-o", "json"],
+            ),
+            self._run(
+                f"endpoints/{service}",
+                ["get", "endpoints", service, "-n", namespace, "-o", "json"],
+            ),
+            config_map_evidence,
+            self._run(
+                "LiteLLM container logs",
+                [
+                    "logs",
+                    f"deployment/{deployment}",
+                    "-n",
+                    namespace,
+                    "-c",
+                    container,
+                    "--all-pods=true",
+                    "--prefix=true",
+                    "--tail=100",
+                    "--limit-bytes=65536",
+                ],
+                timeout=30,
+            ),
+        )
+        helm_managed = False
+        if deployment_evidence.returncode == 0:
+            try:
+                helm_managed = self._is_helm_managed(
+                    json.loads(deployment_evidence.stdout)
+                )
+            except (json.JSONDecodeError, TypeError):
+                pass
+        return {
+            "target": asdict(self.target),
+            "checkedAt": datetime.now(UTC).isoformat(),
+            "catalog": self.catalog.to_dict(),
+            "configuration": self._current_configuration(
+                deployment_evidence, config_map_evidence
+            ),
+            "configurationWritable": not helm_managed,
+            "configurationGuidance": (
+                "This gateway is managed by Helm. Change its provider and model "
+                "through the Terraform/Helm installation so the setting persists."
+                if helm_managed
+                else ""
+            ),
+            "evidence": [asdict(item) for item in evidence],
+        }
+
+    def status(self) -> dict[str, Any]:
+        """Return resource evidence and the production-path request together."""
+        snapshot = self.inspect()
+        snapshot["verification"] = self.verify()["evidence"]
+        return snapshot
+
+    def verify(self) -> dict[str, Any]:
+        """Call LiteLLM from a real Platform Agent and return the response unchanged."""
+        gateway = self.catalog.gateway
+        runtime = AgentRuntimeProvider(
+            self.target,
+            runner=KubectlRunner(self.target, access=self.kube),
+        )
+        agent = runtime.canonical_agent()
+        pod, container = runtime.gateway_endpoint(agent)
+        script = """import json,urllib.request,urllib.error
+payload={'model':MODEL_ALIAS,'messages':[{'role':'user','content':'OK?'}],'max_tokens':8}
+body=json.dumps(payload).encode()
+request=urllib.request.Request(
+  URL,data=body,headers={'Content-Type':'application/json'})
+try:
+  response=urllib.request.urlopen(request,timeout=60)
+  print(response.status)
+  print(response.read().decode('utf-8','replace'))
+except urllib.error.HTTPError as error:
+  print(error.code)
+  print(error.read().decode('utf-8','replace'))
+  raise SystemExit(1)
+"""
+        script = script.replace(
+            "MODEL_ALIAS", repr(str(gateway["modelAlias"]))
+        ).replace(
+            "URL",
+            repr(
+                f"http://{gateway['service']}:{gateway['servicePort']}"
+                f"{gateway['inferencePath']}"
+            ),
+        )
+        evidence = self._run(
+            f"POST {gateway['inferencePath']} from Platform Agent {agent}",
+            [
+                "exec",
+                pod,
+                "-n",
+                self.target.namespace,
+                "-c",
+                container,
+                "--",
+                GATEWAY_PYTHON,
+                "-c",
+                script,
+            ],
+            timeout=75,
+        )
+        return {
+            "target": asdict(self.target),
+            "checkedAt": datetime.now(UTC).isoformat(),
+            "evidence": asdict(evidence),
+        }
+
+    def _deployment(self, *, optional: bool = False) -> dict[str, Any] | None:
+        arguments = [
+            "get",
+            "deployment",
+            str(self.catalog.gateway["deployment"]),
+            "-n",
+            self.target.namespace,
+            "-o",
+            "json",
+        ]
+        if optional:
+            arguments.append("--ignore-not-found")
+        result = self.kube.run(
+            arguments
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                result.stderr.strip() or "LiteLLM Deployment is unavailable."
+            )
+        if optional and not result.stdout.strip():
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("LiteLLM Deployment returned invalid JSON.") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("LiteLLM Deployment returned invalid JSON.")
+        return payload
+
+    def _secret_name(
+        self,
+        environment_variable: str,
+        deployment: dict[str, Any] | None = None,
+    ) -> str:
+        deployment = deployment or self._deployment()
+        if deployment is None:
+            raise RuntimeError("LiteLLM Deployment is unavailable.")
+        containers = deployment["spec"]["template"]["spec"].get("containers", [])
+        for container in containers:
+            for entry in container.get("env", []):
+                if entry.get("name") != environment_variable:
+                    continue
+                reference = entry.get("valueFrom", {}).get("secretKeyRef", {})
+                if reference.get("key") != environment_variable:
+                    raise RuntimeError(
+                        f"{environment_variable} uses an unexpected Secret key."
+                    )
+                if reference.get("name"):
+                    return str(reference["name"])
+        raise RuntimeError(
+            "The live LiteLLM Deployment has no "
+            f"{environment_variable} Secret reference."
+        )
+
+    def _restart(self) -> RawEvidence:
+        restart_patch = json.dumps(
+            {
+                "spec": {
+                    "template": {
+                        "metadata": {
+                            "annotations": {
+                                "kubeagents.x-k8s.io/config-restarted-at": datetime.now(
+                                    UTC
+                                ).isoformat()
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        return self._run(
+            f"deployment/{self.catalog.gateway['deployment']} restart",
+            [
+                "patch",
+                "deployment",
+                str(self.catalog.gateway["deployment"]),
+                "-n",
+                self.target.namespace,
+                "--type=merge",
+                "--patch-file=/dev/stdin",
+            ],
+            input_text=restart_patch,
+        )
+
+    def _write_credential(
+        self,
+        deployment: dict[str, Any],
+        environment_variable: str,
+        credential: str,
+    ) -> RawEvidence:
+        secret_name = self._secret_name(environment_variable, deployment)
+        patch = json.dumps({"stringData": {environment_variable: credential}})
+        return self._run(
+            f"secret/{secret_name}",
+            [
+                "patch",
+                "secret",
+                secret_name,
+                "-n",
+                self.target.namespace,
+                "--type=merge",
+                "--patch-file=/dev/stdin",
+            ],
+            input_text=patch,
+        )
+
+    def _write_catalog_credential(
+        self,
+        provider: Provider,
+        environment_variable: str,
+        credential: str,
+    ) -> RawEvidence:
+        secret_name = str(provider.authentication.get("secretName") or "")
+        if not secret_name:
+            raise RuntimeError(
+                f"{provider.label} has no credential Secret in the provider catalog."
+            )
+        patch = json.dumps({"stringData": {environment_variable: credential}})
+        return self._run(
+            f"secret/{secret_name}",
+            [
+                "patch",
+                "secret",
+                secret_name,
+                "-n",
+                self.target.namespace,
+                "--type=merge",
+                "--patch-file=/dev/stdin",
+            ],
+            input_text=patch,
+        )
+
+    @staticmethod
+    def _is_helm_managed(deployment: dict[str, Any]) -> bool:
+        metadata = deployment.get("metadata", {})
+        labels = metadata.get("labels", {})
+        annotations = metadata.get("annotations", {})
+        managed_by = str(labels.get("app.kubernetes.io/managed-by", "")).lower()
+        return managed_by == "helm" or bool(
+            annotations.get("meta.helm.sh/release-name")
+        )
+
+    @classmethod
+    def _assert_supported_install(cls, deployment: dict[str, Any] | None) -> None:
+        if deployment is not None and cls._is_helm_managed(deployment):
+            raise RuntimeError(
+                "This LiteLLM Deployment is managed by Helm. The portal will not "
+                "overwrite Helm-owned settings; update the Helm release instead."
+            )
+
+    @staticmethod
+    def _iam_bindings(payload: str) -> set[tuple[str, str]]:
+        try:
+            document = json.loads(payload)
+            return {
+                (str(binding.get("role", "")), str(member))
+                for binding in document.get("bindings", [])
+                for member in binding.get("members", [])
+            }
+        except (AttributeError, json.JSONDecodeError, TypeError) as exc:
+            raise RuntimeError("Google Cloud IAM returned invalid JSON.") from exc
+
+    @staticmethod
+    def _gcloud(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+        account = os.environ.get("KUBE_AGENTS_ADMIN_USER", "").strip()
+        scoped_arguments = [*arguments]
+        if account:
+            scoped_arguments.append(f"--account={account}")
+        try:
+            return subprocess.run(
+                ["gcloud", *scoped_arguments],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeError(f"Could not run gcloud: {exc}") from exc
+
+    def _assert_vertex_identity(
+        self, provider: Provider, settings: dict[str, str]
+    ) -> None:
+        contract = provider.workload_identity or {}
+        ksa = str(contract["kubernetesServiceAccount"])
+        gsa_name = str(contract["googleServiceAccount"])
+        gsa_email = f"{gsa_name}@{self.target.project_id}.iam.gserviceaccount.com"
+        vertex_project = settings.get("project_id", self.target.project_id)
+        required_api = str(contract["requiredApi"])
+        project_role = str(contract["requiredProjectRole"])
+        identity_role = str(contract["workloadIdentityRole"])
+        identity_member = (
+            f"serviceAccount:{self.target.project_id}.svc.id.goog"
+            f"[{self.target.namespace}/{ksa}]"
+        )
+
+        missing: list[str] = []
+        api = self._gcloud(
+            [
+                "services",
+                "list",
+                "--enabled",
+                f"--project={vertex_project}",
+                f"--filter=config.name={required_api}",
+                "--format=value(config.name)",
+            ]
+        )
+        if api.returncode != 0 or required_api not in api.stdout.splitlines():
+            missing.append(f"enabled API {required_api} on {vertex_project}")
+
+        service_account = self._gcloud(
+            [
+                "iam",
+                "service-accounts",
+                "describe",
+                gsa_email,
+                f"--project={self.target.project_id}",
+                "--format=value(email)",
+            ]
+        )
+        if service_account.returncode != 0 or gsa_email not in service_account.stdout:
+            missing.append(f"service account {gsa_email}")
+        else:
+            identity_policy = self._gcloud(
+                [
+                    "iam",
+                    "service-accounts",
+                    "get-iam-policy",
+                    gsa_email,
+                    f"--project={self.target.project_id}",
+                    "--format=json",
+                ]
+            )
+            if identity_policy.returncode != 0 or (
+                identity_role,
+                identity_member,
+            ) not in self._iam_bindings(identity_policy.stdout):
+                missing.append(
+                    f"{identity_role} binding for {self.target.namespace}/{ksa}"
+                )
+
+        project_policy = self._gcloud(
+            [
+                "projects",
+                "get-iam-policy",
+                vertex_project,
+                "--format=json",
+            ]
+        )
+        if project_policy.returncode != 0 or (
+            project_role,
+            f"serviceAccount:{gsa_email}",
+        ) not in self._iam_bindings(project_policy.stdout):
+            missing.append(f"{project_role} for {gsa_email} on {vertex_project}")
+
+        if missing:
+            raise RuntimeError(
+                "Vertex AI prerequisites are incomplete: "
+                + "; ".join(missing)
+                + ". Update the Terraform/Helm installation's Vertex AI identity, "
+                "then retry."
+            )
+
+    def device_status(self) -> dict[str, Any]:
+        """Return device-flow rollout state and the latest authorization log."""
+        deployment_evidence = self._run(
+            f"deployment/{self.catalog.gateway['deployment']}",
+            [
+                "get",
+                "deployment",
+                str(self.catalog.gateway["deployment"]),
+                "-n",
+                self.target.namespace,
+                "-o",
+                "json",
+            ],
+        )
+        log_evidence = self._run(
+            "ChatGPT device authorization log",
+            [
+                "logs",
+                f"deployment/{self.catalog.gateway['deployment']}",
+                "-n",
+                self.target.namespace,
+                "-c",
+                str(self.catalog.gateway["container"]),
+                "--pod-running-timeout=3s",
+                "--tail=100",
+                "--limit-bytes=65536",
+            ],
+            timeout=5,
+        )
+        ready = False
+        if deployment_evidence.returncode == 0:
+            try:
+                deployment = json.loads(deployment_evidence.stdout)
+                desired = int(deployment.get("spec", {}).get("replicas", 1))
+                status = deployment.get("status", {})
+                ready = (
+                    int(status.get("observedGeneration", 0))
+                    >= int(deployment.get("metadata", {}).get("generation", 1))
+                    and int(status.get("updatedReplicas", 0)) >= desired
+                    and int(status.get("readyReplicas", 0)) >= desired
+                    and int(status.get("availableReplicas", 0)) >= desired
+                    and int(status.get("unavailableReplicas", 0)) == 0
+                )
+            except (TypeError, ValueError, json.JSONDecodeError):
+                pass
+        return {
+            "target": asdict(self.target),
+            "checkedAt": datetime.now(UTC).isoformat(),
+            "ready": ready,
+            "evidence": [asdict(deployment_evidence), asdict(log_evidence)],
+        }
+
+    @staticmethod
+    def _substitute(manifest: str, values: dict[str, str]) -> str:
+        def replace(match: re.Match[str]) -> str:
+            name = match.group(1)
+            return values.get(name, match.group(0))
+
+        rendered = re.sub(r"\$\{([A-Z][A-Z0-9_]*)\}", replace, manifest)
+        unresolved = sorted(set(re.findall(r"\$\{([A-Z][A-Z0-9_]*)\}", rendered)))
+        if unresolved:
+            raise RuntimeError(
+                "Unresolved LiteLLM manifest values: " + ", ".join(unresolved)
+            )
+        return rendered
+
+    def _render(self, provider: Provider, model: str, settings: dict[str, str]) -> str:
+        renderer = OPERATOR_ROOT / "bin" / "kustomize"
+        if not renderer.is_file():
+            missing_tools = [
+                name for name in ("make", "go") if shutil.which(name) is None
+            ]
+            if missing_tools:
+                raise RuntimeError(
+                    "LiteLLM configuration requires the repository renderer. "
+                    "Install "
+                    + " and ".join(missing_tools)
+                    + ", or run `make -C k8s-operator kustomize` once."
+                )
+            ensure = subprocess.run(
+                ["make", "-C", str(OPERATOR_ROOT), "kustomize"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            if ensure.returncode != 0:
+                raise RuntimeError(
+                    ensure.stderr.strip() or "Kustomize is unavailable."
+                )
+        overlay = LITELLM_ROOT / (
+            "base" if provider.overlay == "base" else f"overlays/{provider.overlay}"
+        )
+        build = subprocess.run(
+            [str(OPERATOR_ROOT / "bin" / "kustomize"), "build", str(overlay)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if build.returncode != 0:
+            raise RuntimeError(
+                build.stderr.strip() or "LiteLLM manifests did not render."
+            )
+        inventory = json.loads((REPO_ROOT / "images.json").read_text(encoding="utf-8"))
+        image = next(row for row in inventory["images"] if row["name"] == "litellm")
+        values = {
+            "NAMESPACE": self.target.namespace,
+            "MODEL_PROVIDER": provider.id,
+            "MODEL_DEFAULT_NAME": model,
+            "LITELLM_IMAGE": f"{image['repository']}:{image['tag']}",
+            "PROJECT_ID": self.target.project_id,
+            "VERTEX_PROJECT_ID": settings.get("project_id", self.target.project_id),
+            "VERTEX_LOCATION": settings.get("location")
+            or region_for_location(self.target.location),
+        }
+        if provider.workload_identity:
+            values["LITELLM_KSA_NAME"] = provider.workload_identity[
+                "kubernetesServiceAccount"
+            ]
+            values["LITELLM_GSA_NAME"] = provider.workload_identity[
+                "googleServiceAccount"
+            ]
+        return self._substitute(build.stdout, values)
+
+    def configure(
+        self,
+        provider_id: str,
+        model: str,
+        *,
+        credential: str = "",
+        settings: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        provider = self.catalog.get(provider_id)
+        model = model.strip()
+        if not MODEL_PATTERN.fullmatch(model):
+            raise ValueError("Model name contains unsupported characters.")
+        settings = {key: value.strip() for key, value in (settings or {}).items()}
+        allowed_settings = {str(item["id"]) for item in provider.settings}
+        unknown_settings = sorted(set(settings) - allowed_settings)
+        if unknown_settings:
+            raise ValueError(
+                "Unsupported provider settings: " + ", ".join(unknown_settings)
+            )
+        if "project_id" in settings and not is_valid_project_id(settings["project_id"]):
+            raise ValueError("Vertex project is not a valid Google Cloud project ID.")
+        if (
+            "location" in settings
+            and settings["location"] != "global"
+            and not is_valid_region(settings["location"])
+        ):
+            raise ValueError("Vertex location must be a region or global.")
+        evidence: list[RawEvidence] = []
+        auth = provider.authentication
+        before = self._deployment(optional=True)
+        self._assert_supported_install(before)
+        if provider.authentication["type"] == "workload_identity":
+            self._assert_vertex_identity(provider, settings)
+        manifest = self._render(provider, model, settings)
+
+        variable = ""
+        if auth["type"] == "api_key" and credential:
+            variable = str(auth["environmentVariable"])
+            evidence.append(
+                self._write_credential(before, variable, credential)
+                if before is not None
+                else self._write_catalog_credential(provider, variable, credential)
+            )
+            if evidence[-1].returncode != 0:
+                return {
+                    "configurationApplied": False,
+                    "evidence": [asdict(item) for item in evidence],
+                }
+
+        evidence.append(
+            self._run(
+                "LiteLLM manifests",
+                ["apply", "-n", self.target.namespace, "-f", "-"],
+                input_text=manifest,
+                timeout=60,
+            )
+        )
+        if evidence[-1].returncode != 0:
+            return {
+                "configurationApplied": False,
+                "evidence": [asdict(item) for item in evidence],
+            }
+        after = self._deployment()
+        if after is None:
+            raise RuntimeError("LiteLLM Deployment is unavailable after apply.")
+        template_changed = before is None or (
+            before.get("spec", {}).get("template")
+            != after.get("spec", {}).get("template")
+        )
+        if not template_changed:
+            evidence.append(self._restart())
+            if evidence[-1].returncode != 0:
+                return {
+                    "configurationApplied": False,
+                    "evidence": [asdict(item) for item in evidence],
+                }
+        if provider.authentication["type"] == "device_oauth":
+            evidence.append(
+                self._run(
+                    "ChatGPT device authorization log",
+                    [
+                        "logs",
+                        f"deployment/{self.catalog.gateway['deployment']}",
+                        "-n",
+                        self.target.namespace,
+                        "-c",
+                        str(self.catalog.gateway["container"]),
+                        "--pod-running-timeout=45s",
+                        "--tail=100",
+                        "--limit-bytes=65536",
+                    ],
+                    timeout=50,
+                )
+            )
+        else:
+            rollout_timeout = int(self.catalog.gateway["rolloutTimeoutSeconds"])
+            evidence.append(
+                self._run(
+                    f"deployment/{self.catalog.gateway['deployment']} rollout",
+                    [
+                        "rollout",
+                        "status",
+                        f"deployment/{self.catalog.gateway['deployment']}",
+                        "-n",
+                        self.target.namespace,
+                        f"--timeout={rollout_timeout}s",
+                    ],
+                    timeout=rollout_timeout + 10,
+                )
+            )
+        return {
+            "target": asdict(self.target),
+            "provider": provider.to_dict(),
+            "model": model,
+            "configurationApplied": True,
+            "readyForTest": (
+                provider.authentication["type"] != "device_oauth"
+                and evidence[-1].returncode == 0
+            ),
+            "evidence": [asdict(item) for item in evidence],
+        }

--- a/admin_console/pages/autonomous.py
+++ b/admin_console/pages/autonomous.py
@@ -32,7 +32,6 @@ from admin_console.agent_runtime import (
     AgentRuntimeError,
     AgentRuntimeProvider,
 )
-from admin_console.ui import AGENT_SELECTOR_HELP
 
 HISTORY_WINDOWS = {"24h": 1, "7d": 7, "30d": 30}
 INTERVAL_CADENCE = re.compile(r"^every\s+(\d+)m$", re.IGNORECASE)
@@ -395,29 +394,18 @@ target = require_connection()
 provider = AgentRuntimeProvider(target)
 
 try:
-    agents = provider.list_agents()
+    selected_agent = provider.canonical_agent()
 except AgentRuntimeError as exc:
     st.error(str(exc))
     if exc.guidance:
         st.caption(exc.guidance)
     st.stop()
 
-if not agents:
-    st.warning("No running kube-agents gateway was found in this scope.")
-    st.stop()
-
-toolbar = st.columns([2, 1, 1])
-requested_agent = query_value("cron_agent")
-selected_agent = toolbar[0].selectbox(
-    "Agent",
-    agents,
-    index=agents.index(requested_agent) if requested_agent in agents else 0,
-    help=AGENT_SELECTOR_HELP,
-)
-set_query("cron_agent", selected_agent)
+st.query_params.pop("cron_agent", None)
+toolbar = st.columns([1, 1])
 requested_window = query_value("cron_window", "7d")
 window_options = list(HISTORY_WINDOWS)
-selected_window = toolbar[1].selectbox(
+selected_window = toolbar[0].selectbox(
     "History",
     window_options,
     index=(
@@ -427,7 +415,7 @@ selected_window = toolbar[1].selectbox(
     ),
 )
 set_query("cron_window", selected_window)
-if toolbar[2].button(
+if toolbar[1].button(
     "Refresh",
     icon=":material/refresh:",
     width="stretch",

--- a/admin_console/pages/chat.py
+++ b/admin_console/pages/chat.py
@@ -27,7 +27,7 @@ from admin_console.clients.portal_api import (
 from admin_console.chat.models import is_portal_session_id
 from admin_console.chat.service import ACTIVE_TASK_STATUSES
 from admin_console.project_config import DeploymentTarget
-from admin_console.ui import AGENT_SELECTOR_HELP, paginated_selectable_table
+from admin_console.ui import paginated_selectable_table
 
 HISTORY_WINDOWS = {
     "24h": ("24 hours", 24),
@@ -134,7 +134,6 @@ def render_task_cards(
     result: TaskUpdateResult,
     *,
     target: DeploymentTarget,
-    selected_agent: str,
 ) -> None:
     if not result.tasks:
         return
@@ -169,7 +168,6 @@ def render_task_cards(
                     "project": target.project_id,
                     "cluster": target.cluster_name,
                     "location": target.location,
-                    "kanban_agent": selected_agent,
                     "kanban_task": task.task_id,
                 },
             )
@@ -187,7 +185,7 @@ st.caption(f"{target.project_id} · {target.cluster_name} · {target.namespace}"
 runtime_provider = portal_api(target)
 
 try:
-    agents = runtime_provider.list_agents()
+    selected_agent = runtime_provider.canonical_agent()
 except PortalApiError as exc:
     st.error(str(exc))
     if exc.guidance:
@@ -195,19 +193,7 @@ except PortalApiError as exc:
     st.caption("Choose another project or cluster on Connection.")
     st.stop()
 
-if not agents:
-    st.warning("No running kube-agents gateway was found in this scope.")
-    st.caption("Choose another project or cluster on Connection.")
-    st.stop()
-
-requested_agent = query_value("chat_agent")
-selected_agent = st.selectbox(
-    "Agent",
-    agents,
-    index=agents.index(requested_agent) if requested_agent in agents else 0,
-    help=AGENT_SELECTOR_HELP,
-)
-set_query("chat_agent", selected_agent)
+st.query_params.pop("chat_agent", None)
 st.query_params.pop("chat_view", None)
 
 requested_window = query_value("chat_window") or "all"
@@ -470,7 +456,6 @@ with thread:
         render_task_cards(
             task_snapshot,
             target=target,
-            selected_agent=selected_agent,
         )
     elif state_key in task_read_errors:
         st.caption(f"Agent work unavailable: {task_read_errors[state_key]}")

--- a/admin_console/pages/kanban.py
+++ b/admin_console/pages/kanban.py
@@ -16,7 +16,7 @@ import streamlit as st
 from admin_console.connection_session import recover_app_shell
 from admin_console.connection_gate import require_connection
 from admin_console.agent_runtime import AgentRuntimeError, AgentRuntimeProvider
-from admin_console.ui import AGENT_SELECTOR_HELP, paginated_selectable_table
+from admin_console.ui import paginated_selectable_table
 
 ACTIVE_STATUSES = {"todo", "ready", "running"}
 ATTENTION_STATUSES = {"blocked", "failed", "crashed", "cancelled"}
@@ -57,27 +57,15 @@ target = require_connection()
 
 provider = AgentRuntimeProvider(target)
 try:
-    agents = provider.list_agents()
+    selected_agent = provider.canonical_agent()
 except AgentRuntimeError as exc:
     st.error(str(exc))
     if exc.guidance:
         st.caption(exc.guidance)
     st.stop()
 
-if not agents:
-    st.warning("No running kube-agents gateway was found in this scope.")
-    st.stop()
-
-toolbar = st.columns([3, 1])
-requested_agent = query_value("kanban_agent")
-selected_agent = toolbar[0].selectbox(
-    "Agent",
-    agents,
-    index=agents.index(requested_agent) if requested_agent in agents else 0,
-    help=AGENT_SELECTOR_HELP,
-)
-set_query("kanban_agent", selected_agent)
-if toolbar[1].button(
+st.query_params.pop("kanban_agent", None)
+if st.button(
     "Refresh",
     icon=":material/refresh:",
     width="stretch",
@@ -281,7 +269,6 @@ with overview:
                 "project": target.project_id,
                 "cluster": target.cluster_name,
                 "location": target.location,
-                "chat_agent": selected_agent,
                 "chat_window": "all",
                 "chat_session": f"default:{task.session_id}",
             }

--- a/admin_console/pages/llm_gateway.py
+++ b/admin_console/pages/llm_gateway.py
@@ -1,0 +1,386 @@
+"""Raw LiteLLM evidence and provider configuration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_PARENT = Path(__file__).resolve().parents[2]
+if str(PACKAGE_PARENT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_PARENT))
+
+import streamlit as st
+
+from admin_console.clients.portal_api import PortalApiClient, PortalApiError
+from admin_console.connection_gate import require_connection
+from admin_console.connection_session import recover_app_shell
+from admin_console.project_config import DeploymentTarget, region_for_location
+from admin_console.ui import render_command_evidence
+
+recover_app_shell()
+
+
+@st.cache_resource
+def portal_api(target: DeploymentTarget) -> PortalApiClient:
+    return PortalApiClient(target)
+
+
+st.title("LLM Gateway")
+target = require_connection()
+st.caption(
+    f"{target.project_id} · {target.cluster_name} · {target.location} · "
+    f"{target.namespace}"
+)
+client = portal_api(target)
+
+try:
+    with st.spinner("Checking LiteLLM resources and model connection…"):
+        snapshot = client.inspect_llm_gateway()
+except PortalApiError as exc:
+    st.error(str(exc))
+    if exc.guidance:
+        st.caption(exc.guidance)
+    st.stop()
+
+evidence = list(snapshot.get("evidence", []))
+scope_key = ":".join(
+    (target.project_id, target.cluster_name, target.location, target.namespace)
+)
+configurations = st.session_state.setdefault("llm_configurations", {})
+device_waits = st.session_state.setdefault("llm_device_waits", {})
+changes = st.session_state.setdefault("llm_configuration_changes", {})
+verification = snapshot.get("verification")
+configuration = configurations.get(scope_key)
+waiting_for_device = bool(device_waits.get(scope_key))
+latest_change = changes.get(scope_key)
+
+
+def connection_succeeded(item: object) -> bool:
+    return isinstance(item, dict) and int(item.get("returncode", 1)) == 0
+
+
+def concise_failure(item: object) -> str:
+    if not isinstance(item, dict):
+        return "The connection test returned no result."
+    output = str(item.get("stderr") or item.get("stdout") or "")
+    if output.strip():
+        compact = " ".join(output.split())
+        return compact if len(compact) <= 500 else compact[:497] + "…"
+    source = str(item.get("source") or "Connection test")
+    return f"{source} exited {int(item.get('returncode', 1))}."
+
+
+if waiting_for_device:
+    connection_status = "Waiting for sign-in"
+elif connection_succeeded(verification):
+    connection_status = "Connected"
+else:
+    connection_status = "Failed"
+
+current = snapshot.get("configuration") or {}
+configuration_writable = bool(snapshot.get("configurationWritable", True))
+status_columns = st.columns((1, 1, 2))
+status_columns[0].metric("Connection", connection_status)
+status_columns[1].metric("Provider", current.get("providerLabel") or "Unknown")
+status_columns[2].metric("Model", current.get("model") or "Unknown")
+if waiting_for_device:
+    st.info(
+        "Waiting for sign-in — complete authorization below; the connection "
+        "will then be tested automatically."
+    )
+elif connection_succeeded(verification):
+    st.success(
+        "Connected — the Platform Agent completed a model request through "
+        "LiteLLM."
+    )
+else:
+    st.error(f"Connection failed — {concise_failure(verification)}")
+
+st.button(
+    "Refresh status",
+    type="primary",
+    disabled=waiting_for_device,
+)
+
+@st.fragment(run_every="5s")
+def monitor_device_sign_in() -> None:
+    if not device_waits.get(scope_key):
+        return
+    st.subheader("Complete device sign-in")
+    try:
+        status = client.llm_gateway_device_status()
+    except PortalApiError as exc:
+        st.caption(f"Waiting for LiteLLM: {exc}")
+        return
+    status_evidence = list(status.get("evidence", []))
+    polled_log = next(
+        (
+            item
+            for item in status_evidence
+            if item.get("source") == "ChatGPT device authorization log"
+        ),
+        None,
+    )
+    stored_log = next(
+        (
+            item
+            for item in (
+                configuration.get("evidence", [])
+                if isinstance(configuration, dict)
+                else []
+            )
+            if item.get("source") == "ChatGPT device authorization log"
+        ),
+        None,
+    )
+    polled_output = (
+        str(polled_log.get("stdout") or polled_log.get("stderr") or "")
+        if isinstance(polled_log, dict)
+        else ""
+    )
+    device_log = (
+        polled_log
+        if polled_output and polled_log.get("returncode") == 0
+        else stored_log
+    )
+    if device_log:
+        output = str(device_log.get("stdout") or device_log.get("stderr") or "")
+        if output:
+            st.code(output, language="text", wrap_lines=True)
+        if isinstance(configuration, dict) and device_log is polled_log:
+            retained = [
+                item
+                for item in configuration.get("evidence", [])
+                if item.get("source") != "ChatGPT device authorization log"
+            ]
+            configuration["evidence"] = [*retained, device_log]
+    if not status.get("ready"):
+        st.caption("Waiting for device authorization…")
+        return
+    changes[scope_key]["state"] = "testing"
+    device_waits.pop(scope_key, None)
+    st.rerun(scope="app")
+
+
+st.divider()
+st.subheader("Configuration")
+if not configuration_writable:
+    st.info(
+        str(snapshot.get("configurationGuidance"))
+        or "This installation manages LiteLLM outside the portal."
+    )
+catalog = snapshot["catalog"]
+providers = list(catalog["providers"])
+provider_by_id = {item["id"]: item for item in providers}
+provider_ids = list(provider_by_id)
+current_provider = str(current.get("providerId") or catalog["defaultProvider"])
+if current_provider not in provider_by_id:
+    current_provider = str(catalog["defaultProvider"])
+
+selected_provider_id = st.selectbox(
+    "Provider",
+    provider_ids,
+    index=provider_ids.index(current_provider),
+    format_func=lambda item: provider_by_id[item]["label"],
+    key=f"llm_provider_{scope_key}",
+    disabled=not configuration_writable,
+)
+provider = provider_by_id[selected_provider_id]
+auth = provider["authentication"]
+credential = ""
+settings: dict[str, str] = {}
+with st.form(
+    f"llm_configuration_{selected_provider_id}",
+    clear_on_submit=True,
+):
+    model = st.text_input(
+        "Model",
+        value=(
+            str(current["model"])
+            if selected_provider_id == current.get("providerId")
+            and current.get("model")
+            else str(provider["defaultModel"])
+        ),
+        key=f"llm_model_{scope_key}_{selected_provider_id}",
+        help=(
+            "Any model identifier accepted by the selected LiteLLM provider "
+            "is supported."
+        ),
+        disabled=not configuration_writable,
+    )
+    if auth["type"] == "api_key":
+        credential = st.text_input(
+            "API key",
+            type="password",
+            placeholder="Leave blank to keep the existing key",
+            help=(
+                f"Stored as {auth['environmentVariable']}. Write-only: the portal "
+                "never reads the existing value or persists this input."
+            ),
+            disabled=not configuration_writable,
+        )
+    elif auth["type"] == "workload_identity":
+        current_settings = (
+            current.get("settings", {})
+            if selected_provider_id == current.get("providerId")
+            else {}
+        )
+        for setting in provider.get("settings", []):
+            default = (
+                current_settings.get(setting["id"])
+                or (
+                    target.project_id
+                    if setting["id"] == "project_id"
+                    else region_for_location(target.location)
+                )
+            )
+            settings[setting["id"]] = st.text_input(
+                setting["label"],
+                value=default,
+                disabled=not configuration_writable,
+            )
+        st.caption("Vertex AI uses Workload Identity; no API key is stored.")
+    elif auth["type"] == "device_oauth":
+        st.info(
+            "Applying this configuration starts ChatGPT device authorization. "
+            "The authorization URL and code will appear below exactly as "
+            "LiteLLM logs them."
+        )
+
+    button_label = (
+        "Start device sign-in"
+        if auth["type"] == "device_oauth"
+        else "Apply configuration"
+    )
+    configure = st.form_submit_button(
+        button_label,
+        width="stretch",
+        disabled=not configuration_writable,
+    )
+
+if configure:
+    device_waits.pop(scope_key, None)
+    provider_label = str(provider["label"])
+    try:
+        with st.spinner("Applying configuration…"):
+            result = client.configure_llm_gateway(
+                provider_id=selected_provider_id,
+                model=model,
+                credential=credential,
+                settings=settings,
+            )
+        configurations[scope_key] = result
+        result_evidence = list(result.get("evidence", []))
+        if not result.get("configurationApplied"):
+            failed_item = next(
+                (
+                    item
+                    for item in result_evidence
+                    if int(item.get("returncode", 1)) != 0
+                ),
+                None,
+            )
+            failure = concise_failure(failed_item)
+            changes[scope_key] = {
+                "state": "apply_failed",
+                "provider": provider_label,
+                "model": model,
+                "message": failure,
+            }
+            st.rerun()
+        if auth["type"] == "device_oauth":
+            device_waits[scope_key] = True
+            changes[scope_key] = {
+                "state": "waiting",
+                "provider": provider_label,
+                "model": model,
+                "message": "",
+            }
+        elif not result.get("readyForTest"):
+            failed_item = next(
+                (
+                    item
+                    for item in result_evidence
+                    if int(item.get("returncode", 1)) != 0
+                ),
+                None,
+            )
+            failure = concise_failure(failed_item)
+            changes[scope_key] = {
+                "state": "rollout_failed",
+                "provider": provider_label,
+                "model": model,
+                "message": failure,
+            }
+        else:
+            changes[scope_key] = {
+                "state": "testing",
+                "provider": provider_label,
+                "model": model,
+                "message": "",
+            }
+        st.rerun()
+    except PortalApiError as exc:
+        changes[scope_key] = {
+            "state": "apply_failed",
+            "provider": provider_label,
+            "model": model,
+            "message": str(exc),
+            "guidance": exc.guidance,
+        }
+        st.rerun()
+
+latest_change = changes.get(scope_key)
+if isinstance(latest_change, dict):
+    if latest_change.get("state") == "testing":
+        latest_change["state"] = (
+            "connected" if connection_succeeded(verification) else "connection_failed"
+        )
+        latest_change["message"] = concise_failure(verification)
+    change_target = " · ".join(
+        value
+        for value in (
+            str(latest_change.get("provider") or ""),
+            str(latest_change.get("model") or ""),
+        )
+        if value
+    )
+    state = latest_change.get("state")
+    if state == "connected":
+        st.success(f"Configuration applied · Connected · {change_target}")
+    elif state == "waiting":
+        st.info(f"Configuration applied · Waiting for device sign-in · {change_target}")
+    elif state == "connection_failed":
+        st.error(
+            f"Configuration applied · Connection failed · {change_target} — "
+            f"{latest_change.get('message') or 'No result was returned.'}"
+        )
+    elif state == "rollout_failed":
+        st.error(
+            f"Configuration applied · Rollout failed · {change_target} — "
+            f"{latest_change.get('message') or 'No result was returned.'}"
+        )
+    else:
+        st.error(
+            f"Configuration failed · {change_target} — "
+            f"{latest_change.get('message') or 'No result was returned.'}"
+        )
+        if latest_change.get("guidance"):
+            st.caption(str(latest_change["guidance"]))
+
+monitor_device_sign_in()
+
+st.divider()
+st.subheader("Raw Logs")
+st.caption(
+    "Exact Kubernetes command output, container logs, and connection responses. "
+    "The portal does not replace upstream messages."
+)
+if st.toggle("Show raw logs", value=False):
+    raw_items = list(evidence)
+    if isinstance(verification, dict):
+        raw_items.append(verification)
+    if isinstance(configuration, dict):
+        raw_items.extend(configuration.get("evidence", []))
+    for item in raw_items:
+        render_command_evidence(item, expanded=False)

--- a/admin_console/project_config.py
+++ b/admin_console/project_config.py
@@ -10,6 +10,7 @@ from pathlib import Path
 PROJECT_ID_PATTERN = re.compile(r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$")
 CLUSTER_NAME_PATTERN = re.compile(r"^[a-z](?:[a-z0-9-]{0,38}[a-z0-9])?$")
 LOCATION_PATTERN = re.compile(r"^[a-z]+-[a-z0-9]+[0-9](?:-[a-z])?$")
+REGION_PATTERN = re.compile(r"^[a-z]+-[a-z0-9]+[0-9]$")
 NAMESPACE_PATTERN = re.compile(
     r"^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$"
 )
@@ -57,6 +58,16 @@ def is_valid_cluster_name(value: str) -> bool:
 
 def is_valid_location(value: str) -> bool:
     return bool(LOCATION_PATTERN.fullmatch(value.strip()))
+
+
+def is_valid_region(value: str) -> bool:
+    return bool(REGION_PATTERN.fullmatch(value.strip()))
+
+
+def region_for_location(value: str) -> str:
+    """Return the enclosing region for a valid GCP region or zone."""
+    location = value.strip()
+    return re.sub(r"-[a-z]$", "", location)
 
 
 def is_valid_namespace(value: str) -> bool:

--- a/admin_console/runtime_contract.py
+++ b/admin_console/runtime_contract.py
@@ -1,0 +1,97 @@
+"""Repository-owned identity contract for the stock admin-portal target."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HELM_VALUES = REPO_ROOT / "charts" / "kube-agents" / "values.yaml"
+
+_K8S_NAME = re.compile(r"^[a-z0-9](?:[a-z0-9.-]{0,251}[a-z0-9])?$")
+
+
+def _mapping_value(path: Path, section: str, key: str) -> str:
+    """Read one scalar from a top-level YAML mapping without template expansion."""
+
+    active_section = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 0:
+            active_section = line.strip() == f"{section}:"
+            continue
+        if active_section and indent == 2:
+            name, separator, value = line.strip().partition(":")
+            if separator and name == key:
+                return value.strip().strip("'\"")
+    raise RuntimeError(f"{path} does not define {section}.{key}")
+
+
+@cache
+def canonical_platform_agent_name() -> str:
+    """Return the stock name from the canonical Helm install values."""
+
+    return helm_platform_agent_name()
+
+
+class CanonicalPlatformAgentMissing(RuntimeError):
+    """The connected target does not contain the stock installation resource."""
+
+
+def select_canonical_platform_agent(payload: dict) -> str:
+    """Select the stock resource from a live PlatformAgent list."""
+
+    expected = canonical_platform_agent_name()
+    discovered = sorted(
+        {
+            str((item.get("metadata") or {}).get("name") or "")
+            for item in payload.get("items", [])
+        }
+    )
+    discovered = [name for name in discovered if _K8S_NAME.fullmatch(name)]
+    if expected not in discovered:
+        names = ", ".join(discovered) if discovered else "none"
+        raise CanonicalPlatformAgentMissing(
+            f"Canonical PlatformAgent {expected} was not found; "
+            f"discovered PlatformAgent resources: {names}."
+        )
+    return expected
+
+
+def helm_platform_agent_name() -> str:
+    """Return the Helm installation default used by source-parity tests."""
+
+    name = _mapping_value(HELM_VALUES, "platformAgent", "name")
+    if not _K8S_NAME.fullmatch(name):
+        raise RuntimeError(f"{HELM_VALUES} has an invalid platformAgent.name")
+    return name
+
+
+@dataclass(frozen=True, order=True)
+class GatewayEndpoint:
+    """One live gateway pod and the container that owns its API port."""
+
+    pod: str
+    container: str
+
+
+def gateway_endpoints(payload: dict) -> tuple[GatewayEndpoint, ...]:
+    """Resolve gateway endpoints from operator-produced Kubernetes pod specs."""
+
+    endpoints: list[GatewayEndpoint] = []
+    for item in payload.get("items", []):
+        pod = str((item.get("metadata") or {}).get("name") or "")
+        candidates = []
+        for container in (item.get("spec") or {}).get("containers", []):
+            ports = container.get("ports") or []
+            if any(port.get("name") == "api" for port in ports):
+                name = str(container.get("name") or "")
+                if _K8S_NAME.fullmatch(name):
+                    candidates.append(name)
+        if pod and len(candidates) == 1:
+            endpoints.append(GatewayEndpoint(pod, candidates[0]))
+    return tuple(sorted(endpoints))

--- a/admin_console/tests/test_admin_portal_ui.py
+++ b/admin_console/tests/test_admin_portal_ui.py
@@ -99,7 +99,10 @@ class FakeHistoryProvider:
         self.target = target
 
     def list_agents(self) -> tuple[str, ...]:
-        return ("test-agent-01",)
+        return ("platform-agent",)
+
+    def canonical_agent(self) -> str:
+        return "platform-agent"
 
     def list_conversations(self, agent: str, *, cutoff, limit: int = 200) -> HistoryResult:
         conversation = AgentConversation(
@@ -1329,13 +1332,10 @@ class AdminPortalFunctionalTest(unittest.TestCase):
         self.assertEqual(
             [item.label for item in app.selectbox],
             [
-                "Agent",
                 "History",
                 "Source",
             ],
         )
-        agent_selector = next(item for item in app.selectbox if item.label == "Agent")
-        self.assertIn("PlatformAgent custom resource", agent_selector.help)
         self.assertEqual(len(app.dataframe), 1)
         self.assertEqual(
             list(app.dataframe[0].value.columns),
@@ -1352,7 +1352,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             app.dataframe[0].value.iloc[0]["Session"],
             "Cluster investigation",
         )
-        self.assertEqual(app.query_params["chat_agent"], ["test-agent-01"])
+        self.assertNotIn("chat_agent", app.query_params)
         self.assertEqual(app.query_params["chat_window"], ["all"])
         self.assertEqual(app.query_params["chat_session"], ["default:session-1"])
         self.assertNotIn("user@example.com", str(app.query_params))
@@ -1486,7 +1486,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
             if item.proto.label == "t_12345678"
         )
         self.assertEqual(task_link.proto.page, "kanban")
-        self.assertIn("kanban_agent=test-agent-01", task_link.proto.query_string)
+        self.assertNotIn("kanban_agent", task_link.proto.query_string)
         self.assertIn("kanban_task=t_12345678", task_link.proto.query_string)
 
     def test_chat_sends_a_real_run_and_renders_response(self):
@@ -1610,7 +1610,7 @@ class AdminPortalFunctionalTest(unittest.TestCase):
 
         self.assertEqual(len(app.exception), 0)
         self.assertEqual(app.title[0].value, "Scheduled Cron")
-        self.assertEqual(app.query_params["cron_agent"], ["test-agent-01"])
+        self.assertNotIn("cron_agent", app.query_params)
         self.assertEqual(app.query_params["cron_window"], ["7d"])
         self.assertEqual(len(app.dataframe), 1)
         self.assertIn("Scheduler", app.dataframe[0].value.columns)

--- a/admin_console/tests/test_agent_chat.py
+++ b/admin_console/tests/test_agent_chat.py
@@ -32,11 +32,35 @@ class ChatRunner:
         line_callback: Callable[[str], None] | None = None,
     ) -> ChatCommandResult:
         self.calls.append((arguments, input_text))
+        if "platformagents" in arguments:
+            return ChatCommandResult(
+                0,
+                json.dumps({"items": [{"metadata": {"name": "platform-agent"}}]}),
+            )
         if "get" in arguments and "pods" in arguments:
             return ChatCommandResult(
                 0,
                 json.dumps(
-                    {"items": [{"metadata": {"name": "test-agent-01-gateway-1"}}]}
+                    {
+                        "items": [
+                            {
+                                "metadata": {"name": "platform-agent-gateway-1"},
+                                "spec": {
+                                    "containers": [
+                                        {
+                                            "name": "runtime-from-pod",
+                                            "ports": [
+                                                {
+                                                    "name": "api",
+                                                    "containerPort": 8642,
+                                                }
+                                            ],
+                                        }
+                                    ]
+                                },
+                            }
+                        ]
+                    }
                 ),
             )
         output = json.dumps(self.response)
@@ -55,7 +79,7 @@ class AgentChatProviderTest(unittest.TestCase):
 
     def test_run_uses_fixed_in_pod_client_and_stdin_payload(self):
         result = self.provider.run(
-            "test-agent-01",
+            "platform-agent",
             prompt="Deploy the game",
             session_id="portal_0123456789abcdef0123456789abcdef",
             history=({"role": "assistant", "content": "Ready"},),
@@ -67,6 +91,7 @@ class AgentChatProviderTest(unittest.TestCase):
         arguments, input_text = self.runner.calls[-1]
         self.assertIn("exec", arguments)
         self.assertIn("-i", arguments)
+        self.assertEqual(arguments[arguments.index("-c") + 1], "runtime-from-pod")
         self.assertNotIn("sh", arguments)
         self.assertNotIn("Deploy the game", arguments)
         embedded_client = arguments[-1]
@@ -77,10 +102,42 @@ class AgentChatProviderTest(unittest.TestCase):
         self.assertEqual(payload["profile"], "default")
         self.assertEqual(payload["user_email"], "admin@example.com")
 
+    def test_direct_chat_fails_with_all_discovered_noncanonical_names(self):
+        class MissingCanonicalRunner(ChatRunner):
+            def run(self, arguments, **kwargs):
+                if "platformagents" in arguments:
+                    self.calls.append((arguments, kwargs.get("input_text", "")))
+                    return ChatCommandResult(
+                        0,
+                        json.dumps(
+                            {
+                                "items": [
+                                    {"metadata": {"name": "ux-e2e"}},
+                                    {"metadata": {"name": "custom-agent"}},
+                                ]
+                            }
+                        ),
+                    )
+                return super().run(arguments, **kwargs)
+
+        provider = AgentChatProvider(
+            self.provider.target,
+            runner=MissingCanonicalRunner(),
+        )
+
+        with self.assertRaises(AgentChatError) as caught:
+            provider.run(
+                "platform-agent",
+                prompt="hello",
+                session_id="portal_0123456789abcdef0123456789abcdef",
+            )
+
+        self.assertIn("custom-agent, ux-e2e", str(caught.exception))
+
     def test_rejects_invalid_portal_identity_before_kubectl(self):
         with self.assertRaises(ValueError):
             self.provider.run(
-                "test-agent-01",
+                "platform-agent",
                 prompt="hello",
                 session_id="portal_0123456789abcdef0123456789abcdef",
                 user_email="invalid identity",
@@ -90,13 +147,13 @@ class AgentChatProviderTest(unittest.TestCase):
     def test_approval_is_limited_to_once_or_deny(self):
         with self.assertRaises(ValueError):
             self.provider.resolve_approval(
-                "test-agent-01",
+                "platform-agent",
                 run_id="run_0123456789abcdef0123456789abcdef",
                 choice="always",
             )
 
         self.provider.resolve_approval(
-            "test-agent-01",
+            "platform-agent",
             run_id="run_0123456789abcdef0123456789abcdef",
             choice="once",
         )
@@ -113,7 +170,7 @@ class AgentChatProviderTest(unittest.TestCase):
         }
 
         result = self.provider.run(
-            "test-agent-01",
+            "platform-agent",
             prompt="Deploy the game",
             session_id="portal_0123456789abcdef0123456789abcdef",
             on_update=updates.append,
@@ -124,7 +181,7 @@ class AgentChatProviderTest(unittest.TestCase):
 
     def test_embedded_client_keeps_event_stream_open_across_approval(self):
         self.provider.run(
-            "test-agent-01",
+            "platform-agent",
             prompt="Deploy the game",
             session_id="portal_0123456789abcdef0123456789abcdef",
         )
@@ -154,7 +211,7 @@ class AgentChatProviderTest(unittest.TestCase):
 
         with self.assertRaises(AgentChatError) as caught:
             provider.run(
-                "test-agent-01",
+                "platform-agent",
                 prompt="hello",
                 session_id="portal_0123456789abcdef0123456789abcdef",
             )
@@ -165,7 +222,7 @@ class AgentChatProviderTest(unittest.TestCase):
     def test_rejects_oversized_prompt_before_kubectl(self):
         with self.assertRaises(ValueError):
             self.provider.run(
-                "test-agent-01",
+                "platform-agent",
                 prompt="x" * 32_001,
                 session_id="portal_0123456789abcdef0123456789abcdef",
             )

--- a/admin_console/tests/test_agent_runtime.py
+++ b/admin_console/tests/test_agent_runtime.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from admin_console.agent_runtime import (
     _READ_SCRIPT,
+    AgentRuntimeError,
     AgentRuntimeProvider,
     KubeCommandResult,
 )
@@ -24,30 +25,36 @@ class AgentRuntimeRunner:
 
     def run(self, arguments: list[str], *, timeout: int = 20) -> KubeCommandResult:
         self.calls.append(arguments)
-        if (
-            "pods" in arguments
-            and "kubeagents.x-k8s.io/has-credential-proxy=true" in arguments
-        ):
+        if "platformagents" in arguments:
+            return KubeCommandResult(
+                0,
+                json.dumps({"items": [{"metadata": {"name": "platform-agent"}}]}),
+            )
+        if "pods" in arguments:
             return KubeCommandResult(
                 0,
                 json.dumps(
                     {
                         "items": [
                             {
-                                "metadata": {
-                                    "name": "test-agent-01-gateway-1",
-                                    "labels": {"app": "test-agent-01-gateway"},
-                                }
+                                "metadata": {"name": "platform-agent-gateway-1"},
+                                "spec": {
+                                    "containers": [
+                                        {
+                                            "name": "runtime-from-pod",
+                                            "ports": [
+                                                {
+                                                    "name": "api",
+                                                    "containerPort": 8642,
+                                                }
+                                            ],
+                                        },
+                                        {"name": "credential-proxy"},
+                                    ]
+                                },
                             }
                         ]
                     }
-                ),
-            )
-        if "pods" in arguments:
-            return KubeCommandResult(
-                0,
-                json.dumps(
-                    {"items": [{"metadata": {"name": "test-agent-01-gateway-1"}}]}
                 ),
             )
         if "conversations" in arguments:
@@ -279,7 +286,7 @@ class AgentRuntimeRunner:
         return KubeCommandResult(1, stderr="unexpected command")
 
 
-class LegacyGatewayRunner:
+class NonCanonicalAgentRunner:
     def __init__(self) -> None:
         self.calls: list[list[str]] = []
 
@@ -289,26 +296,15 @@ class LegacyGatewayRunner:
             return KubeCommandResult(
                 0,
                 json.dumps(
-                    {"items": [{"metadata": {"name": "platform-agent"}}]}
+                    {
+                        "items": [
+                            {"metadata": {"name": "ux-e2e"}},
+                            {"metadata": {"name": "custom-agent"}},
+                        ]
+                    }
                 ),
             )
-        if "kubeagents.x-k8s.io/has-credential-proxy=true" in arguments:
-            return KubeCommandResult(0, json.dumps({"items": []}))
-        return KubeCommandResult(
-            0,
-            json.dumps(
-                {
-                    "items": [
-                        {
-                            "metadata": {
-                                "name": "platform-agent-gateway-1",
-                                "labels": {"app": "platform-agent-gateway"},
-                            }
-                        }
-                    ]
-                }
-            ),
-        )
+        return KubeCommandResult(1, stderr="unexpected command")
 
 
 class EmbeddedReadScriptTest(unittest.TestCase):
@@ -552,9 +548,9 @@ class AgentRuntimeProviderTest(unittest.TestCase):
         )
 
     def test_reads_real_conversation_metadata_and_redacts_preview(self):
-        self.assertEqual(self.provider.list_agents(), ("test-agent-01",))
+        self.assertEqual(self.provider.list_agents(), ("platform-agent",))
         result = self.provider.list_conversations(
-            "test-agent-01", cutoff=datetime(2023, 1, 1, tzinfo=UTC)
+            "platform-agent", cutoff=datetime(2023, 1, 1, tzinfo=UTC)
         )
 
         conversation = result.conversations[0]
@@ -563,17 +559,21 @@ class AgentRuntimeProviderTest(unittest.TestCase):
         self.assertIn("[REDACTED]", conversation.preview)
         self.assertNotIn("secret-value", conversation.preview)
 
-    def test_discovers_legacy_gateway_through_bounded_platformagent_fallback(self):
-        runner = LegacyGatewayRunner()
+    def test_missing_canonical_agent_lists_discovered_resources(self):
+        runner = NonCanonicalAgentRunner()
         provider = AgentRuntimeProvider(self.provider.target, runner=runner)
 
-        self.assertEqual(provider.list_agents(), ("platform-agent",))
-        fallback = runner.calls[-1]
-        self.assertIn("app in (platform-agent-gateway)", fallback)
+        with self.assertRaises(AgentRuntimeError) as caught:
+            provider.canonical_agent()
+
+        message = str(caught.exception)
+        self.assertIn("platform-agent", message)
+        self.assertIn("custom-agent, ux-e2e", message)
+        self.assertNotIn("test-cluster-01", message)
 
     def test_reads_only_user_and_assistant_projection(self):
         result = self.provider.get_messages(
-            "test-agent-01", profile="default", session_id="session-1"
+            "platform-agent", profile="default", session_id="session-1"
         )
 
         self.assertEqual(
@@ -589,13 +589,14 @@ class AgentRuntimeProviderTest(unittest.TestCase):
             ],
         )
         self.assertNotIn("sh", exec_call)
+        self.assertEqual(exec_call[exec_call.index("-c") + 1], "runtime-from-pod")
 
     def test_connection_probe_returns_only_counts(self):
-        self.assertEqual(self.provider.check_connection("test-agent-01"), (2, 5))
+        self.assertEqual(self.provider.check_connection("platform-agent"), (2, 5))
 
     def test_reads_linked_agent_work_and_redacts_summary(self):
         result = self.provider.get_task_updates(
-            "test-agent-01",
+            "platform-agent",
             session_id="portal_session_1",
         )
 
@@ -610,7 +611,7 @@ class AgentRuntimeProviderTest(unittest.TestCase):
         self.assertNotIn("hunter2", task.summary)
 
     def test_reads_bounded_kanban_board(self):
-        result = self.provider.list_kanban_tasks("test-agent-01")
+        result = self.provider.list_kanban_tasks("platform-agent")
 
         self.assertEqual(len(result.tasks), 1)
         task = result.tasks[0]
@@ -619,7 +620,7 @@ class AgentRuntimeProviderTest(unittest.TestCase):
         self.assertEqual(task.child_count, 1)
 
     def test_reads_kanban_task_detail_and_redacts_evidence(self):
-        detail = self.provider.get_kanban_task("test-agent-01", "t_12345678")
+        detail = self.provider.get_kanban_task("platform-agent", "t_12345678")
 
         self.assertEqual(detail.task.status, "done")
         self.assertEqual(detail.task.run_count, 101)
@@ -631,7 +632,7 @@ class AgentRuntimeProviderTest(unittest.TestCase):
         self.assertIn("[REDACTED]", detail.events[0].payload)
 
     def test_reads_cron_jobs_executions_and_scheduler_health(self):
-        snapshot = self.provider.get_cron_snapshot("test-agent-01")
+        snapshot = self.provider.get_cron_snapshot("platform-agent")
 
         self.assertEqual(snapshot.jobs[0].name, "unique-visitors")
         self.assertEqual(snapshot.jobs[0].scheduler, "missing")

--- a/admin_console/tests/test_connection_persistence.py
+++ b/admin_console/tests/test_connection_persistence.py
@@ -51,6 +51,8 @@ class ConnectionPersistenceTest(unittest.TestCase):
         payload = self.state_path.read_text(encoding="utf-8")
         self.assertNotIn("token", payload.lower())
         self.assertNotIn("credential", payload.lower())
+        self.assertNotIn("agent_id", payload.lower())
+        self.assertNotIn("agentid", payload.lower())
 
     def test_revalidation_required_retains_target_but_is_not_usable(self):
         save_connection(

--- a/admin_console/tests/test_connections.py
+++ b/admin_console/tests/test_connections.py
@@ -206,7 +206,7 @@ class ConnectionDiagnosticsTest(unittest.TestCase):
     @patch("admin_console.agent_runtime.AgentRuntimeProvider")
     def test_agent_runtime_probe_uses_the_selected_cluster(self, provider_type):
         provider = provider_type.return_value
-        provider.list_agents.return_value = ("test-agent-01",)
+        provider.canonical_agent.return_value = "platform-agent"
         provider.check_connection.return_value = (2, 11)
 
         report = run_connection_checks(
@@ -224,13 +224,13 @@ class ConnectionDiagnosticsTest(unittest.TestCase):
         check = next(item for item in report.checks if item.key == "agent_runtime")
         self.assertEqual(check.status, CheckStatus.PASS)
         self.assertIn("2 profile(s) and 11 session(s)", check.summary)
-        provider.check_connection.assert_called_once_with("test-agent-01")
+        provider.check_connection.assert_called_once_with("platform-agent")
         self.assertTrue(connection_is_ready(report))
 
     @patch("admin_console.agent_runtime.AgentRuntimeProvider")
     def test_telemetry_failure_does_not_lock_runtime_pages(self, provider_type):
         provider = provider_type.return_value
-        provider.list_agents.return_value = ("test-agent-01",)
+        provider.canonical_agent.return_value = "platform-agent"
         provider.check_connection.return_value = (2, 11)
 
         report = run_connection_checks(

--- a/admin_console/tests/test_interaction_api.py
+++ b/admin_console/tests/test_interaction_api.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 
 from admin_console.agent_chat import ChatRunResult, MAX_HISTORY_MESSAGES
 from admin_console.agent_runtime import AgentTaskUpdate, TaskUpdateResult
+from admin_console.api.authorization import portal_api_headers
 from admin_console.api.app import create_app
 from admin_console.chat.service import ChatService
 from admin_console.chat.models import Interaction, InteractionStatus, TaskProjection
@@ -68,10 +69,12 @@ class ScriptedBackend:
         self._lock = Lock()
         self.task_reads = 0
         self.prompts: list[str] = []
+        self.run_requests: list[tuple[tuple, dict]] = []
         self.approvals: list[str] = []
         self.approval_resolved = Event()
 
     def run(self, *args, **kwargs) -> ChatRunResult:
+        self.run_requests.append((args, kwargs))
         self.prompts.append(kwargs["prompt"])
         if self.root.status == "waiting_for_approval":
             kwargs["on_update"](self.root)
@@ -172,7 +175,7 @@ def client_for(
         task_timeout=1,
         max_workers=max_workers,
     )
-    return TestClient(create_app(service)), service
+    return TestClient(create_app(service), headers=portal_api_headers()), service
 
 
 class InteractionApiTest(unittest.TestCase):
@@ -228,6 +231,39 @@ class InteractionApiTest(unittest.TestCase):
             ],
         )
         self.assertGreaterEqual(backend.task_reads, 3)
+
+    def test_interaction_defaults_to_canonical_agent_and_chat_profile(self):
+        backend = ScriptedBackend()
+        client, _ = client_for(backend)
+
+        response = client.post(
+            "/api/v1/interactions",
+            json={"input": {"text": "Is the cluster healthy?"}},
+        )
+
+        self.assertEqual(response.status_code, 202)
+        result = self.wait_for_terminal(client, response.json()["interactionId"])
+        self.assertEqual(result["agentId"], "platform-agent")
+        self.assertEqual(result["profile"], "default")
+        arguments, keyword_arguments = backend.run_requests[0]
+        self.assertEqual(arguments[0], "platform-agent")
+        self.assertEqual(keyword_arguments["profile"], "default")
+
+    def test_interaction_rejects_noncanonical_agent_id(self):
+        backend = ScriptedBackend()
+        client, _ = client_for(backend)
+
+        response = client.post(
+            "/api/v1/interactions",
+            json={
+                "agentId": "platform-agent-host",
+                "input": {"text": "Is the cluster healthy?"},
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertNotIn("platform-agent-host", response.text)
+        self.assertEqual(backend.run_requests, [])
 
     def test_cancelled_queued_interaction_is_never_started(self):
         backend = BlockingBackend()
@@ -605,7 +641,22 @@ class InteractionApiTest(unittest.TestCase):
         self.assertEqual(client._target, target)
         self.assertEqual(
             constructor.call_args.kwargs["headers"],
-            deployment_target_headers(target),
+            {
+                **deployment_target_headers(target),
+                **portal_api_headers(),
+            },
+        )
+
+    def test_api_rejects_requests_without_the_launch_capability(self):
+        service = ChatService(lambda: ScriptedBackend())
+        client = TestClient(create_app(service))
+
+        response = client.get("/api/v1/agents")
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json()["detail"]["error"]["code"],
+            "portal_api_unauthorized",
         )
 
     def test_api_rejects_a_stale_tab_target(self):

--- a/admin_console/tests/test_llm_gateway.py
+++ b/admin_console/tests/test_llm_gateway.py
@@ -68,6 +68,9 @@ class FakeKube:
     def __init__(self, results: list[KubeCommandResult]) -> None:
         self.results = list(results)
         self.calls: list[tuple[list[str], str | None]] = []
+        self.context = (
+            f"gke_{TARGET.project_id}_{TARGET.location}_{TARGET.cluster_name}"
+        )
 
     def run(self, arguments, *, input_text=None, timeout=20, line_callback=None):
         self.calls.append((list(arguments), input_text))
@@ -229,11 +232,33 @@ class LlmGatewayServiceTest(unittest.TestCase):
             result = service.configure("chatgpt", "gpt-5.4")
 
         commands = [call[0] for call in kube.calls]
-        self.assertFalse(any(command[:2] == ["rollout", "status"] for command in commands))
-        self.assertFalse(any(command[:2] == ["patch", "deployment"] for command in commands))
-        self.assertEqual(commands[-1][0], "logs")
+        self.assertFalse(any(command[2:4] == ["rollout", "status"] for command in commands))
+        self.assertFalse(any(command[2:4] == ["patch", "deployment"] for command in commands))
+        self.assertEqual(commands[-1][2], "logs")
         self.assertIn("--pod-running-timeout=45s", commands[-1])
         self.assertIn("ABCD-EFGH", result["evidence"][-1]["stdout"])
+
+    def test_every_kubectl_command_pins_the_connected_context(self):
+        live_deployment = deployment()
+        kube = FakeKube(
+            [
+                KubeCommandResult(0, json.dumps(live_deployment)),
+                KubeCommandResult(0, "secret patched"),
+                KubeCommandResult(0, "resources applied"),
+                KubeCommandResult(0, json.dumps(live_deployment)),
+                KubeCommandResult(0, "deployment patched"),
+                KubeCommandResult(0, "rollout complete"),
+            ]
+        )
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        with patch.object(service, "_render", return_value="rendered manifest"):
+            service.configure(
+                "gemini", "gemini-3.5-flash", credential="super-secret"
+            )
+
+        for arguments, _ in kube.calls:
+            self.assertEqual(arguments[:2], ["--context", kube.context])
 
 
 class FakeGateway:

--- a/admin_console/tests/test_llm_gateway.py
+++ b/admin_console/tests/test_llm_gateway.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from admin_console.api.authorization import portal_api_headers
+from admin_console.api.app import create_app
+from admin_console.kube_access import KubeCommandResult
+from admin_console.llm_gateway import LlmGatewayService
+from admin_console.project_config import (
+    DeploymentTarget,
+    deployment_target_headers,
+)
+
+TARGET = DeploymentTarget(
+    "test-project-01",
+    "test-cluster-01",
+    "us-east4",
+    "kubeagents-system",
+)
+
+
+def deployment(provider: str = "gemini", model: str = "gemini-3.5-flash"):
+    return {
+        "metadata": {"generation": 2},
+        "spec": {
+            "replicas": 1,
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "kubeagents.x-k8s.io/model-config": f"{provider}/{model}"
+                    }
+                },
+                "spec": {
+                    "containers": [
+                        {
+                            "env": [
+                                {
+                                    "name": "GEMINI_API_KEY",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "name": "custom-credentials",
+                                            "key": "GEMINI_API_KEY",
+                                        }
+                                    },
+                                }
+                            ]
+                        }
+                    ]
+                },
+            },
+        },
+        "status": {
+            "observedGeneration": 2,
+            "updatedReplicas": 1,
+            "readyReplicas": 1,
+            "availableReplicas": 1,
+        },
+    }
+
+
+class FakeKube:
+    def __init__(self, results: list[KubeCommandResult]) -> None:
+        self.results = list(results)
+        self.calls: list[tuple[list[str], str | None]] = []
+
+    def run(self, arguments, *, input_text=None, timeout=20, line_callback=None):
+        self.calls.append((list(arguments), input_text))
+        return self.results.pop(0)
+
+
+class LlmGatewayServiceTest(unittest.TestCase):
+
+    def test_inspect_returns_raw_results_without_classification(self):
+        results = [
+            KubeCommandResult(0, stdout=f"raw-{index}", stderr=f"error-{index}")
+            for index in range(5)
+        ]
+        service = LlmGatewayService(TARGET, kube=FakeKube(results))
+
+        snapshot = service.inspect()
+
+        self.assertEqual(len(snapshot["evidence"]), 5)
+        self.assertEqual(snapshot["evidence"][0]["stdout"], "raw-0")
+        self.assertEqual(snapshot["evidence"][0]["stderr"], "error-0")
+        self.assertNotIn("status", snapshot["evidence"][0])
+        self.assertNotIn("message", snapshot["evidence"][0])
+
+
+
+    def test_api_key_is_sent_on_stdin_and_never_in_arguments_or_response(self):
+        live_deployment = deployment()
+        kube = FakeKube(
+            [
+                KubeCommandResult(0, json.dumps(live_deployment)),
+                KubeCommandResult(0, "secret patched"),
+                KubeCommandResult(0, "resources applied"),
+                KubeCommandResult(0, json.dumps(live_deployment)),
+                KubeCommandResult(0, "deployment patched"),
+                KubeCommandResult(0, "rollout complete"),
+            ]
+        )
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        with patch.object(service, "_render", return_value="rendered manifest"):
+            result = service.configure(
+                "gemini", "gemini-3.5-flash", credential="super-secret"
+            )
+
+        all_arguments = " ".join(" ".join(call[0]) for call in kube.calls)
+        self.assertNotIn("super-secret", all_arguments)
+        self.assertNotIn("super-secret", json.dumps(result))
+        patch_call = kube.calls[1]
+        self.assertIn("super-secret", patch_call[1])
+        self.assertIn("custom-credentials", patch_call[0])
+
+
+    def test_helm_owned_deployment_is_not_modified(self):
+        live_deployment = deployment()
+        live_deployment["metadata"]["labels"] = {
+            "app.kubernetes.io/managed-by": "Helm"
+        }
+        kube = FakeKube([KubeCommandResult(0, json.dumps(live_deployment))])
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        with self.assertRaisesRegex(RuntimeError, "managed by Helm"):
+            service.configure(
+                "gemini", "gemini-3.5-flash", credential="never-written"
+            )
+
+        self.assertEqual(len(kube.calls), 1)
+
+
+
+    def test_render_failure_does_not_change_credential(self):
+        kube = FakeKube([KubeCommandResult(0, json.dumps(deployment()))])
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        with (
+            patch.object(service, "_render", side_effect=RuntimeError("bad render")),
+            self.assertRaisesRegex(RuntimeError, "bad render"),
+        ):
+            service.configure(
+                "gemini", "gemini-3.5-flash", credential="never-written"
+            )
+
+        self.assertEqual(len(kube.calls), 1)
+
+    def test_vertex_switch_requires_complete_live_identity(self):
+        live_deployment = deployment()
+        kube = FakeKube([KubeCommandResult(0, json.dumps(live_deployment))])
+        service = LlmGatewayService(TARGET, kube=kube)
+        failed = subprocess.CompletedProcess(
+            ["gcloud"], 1, stdout="", stderr="permission denied"
+        )
+
+        with (
+            patch.object(service, "_gcloud", return_value=failed),
+            self.assertRaisesRegex(RuntimeError, "prerequisites are incomplete"),
+        ):
+            service.configure(
+                "vertex_ai",
+                "claude-sonnet-4-5@20250929",
+                settings={"project_id": TARGET.project_id, "location": "global"},
+            )
+
+        self.assertEqual(len(kube.calls), 1)
+
+
+    def test_verification_uses_production_service_path_and_returns_raw_error(self):
+        pods = {
+            "items": [
+                {
+                    "metadata": {
+                        "name": "platform-agent-pod",
+                        "labels": {"app": "platform-agent-gateway"},
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "runtime-from-pod",
+                                "ports": [{"name": "api", "containerPort": 8642}],
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        kube = FakeKube(
+            [
+                KubeCommandResult(
+                    0,
+                    json.dumps(
+                        {"items": [{"metadata": {"name": "platform-agent"}}]}
+                    ),
+                ),
+                KubeCommandResult(0, json.dumps(pods)),
+                KubeCommandResult(1, "401\nraw upstream response"),
+            ]
+        )
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        result = service.verify()
+
+        script = kube.calls[2][0][-1]
+        self.assertIn("http://litellm:80/v1/chat/completions", script)
+        self.assertIn("platform-agent-pod", kube.calls[2][0])
+        self.assertIn("runtime-from-pod", kube.calls[2][0])
+        self.assertEqual(result["evidence"]["returncode"], 1)
+        self.assertEqual(result["evidence"]["stdout"], "401\nraw upstream response")
+
+    def test_chatgpt_changed_configuration_uses_one_rollout_and_returns_device_log(self):
+        kube = FakeKube(
+            [
+                KubeCommandResult(0, json.dumps(deployment())),
+                KubeCommandResult(0, "resources applied"),
+                KubeCommandResult(0, json.dumps(deployment("chatgpt", "gpt-5.4"))),
+                KubeCommandResult(0, "Visit URL\nEnter code: ABCD-EFGH"),
+            ]
+        )
+        service = LlmGatewayService(TARGET, kube=kube)
+
+        with patch.object(service, "_render", return_value="rendered manifest"):
+            result = service.configure("chatgpt", "gpt-5.4")
+
+        commands = [call[0] for call in kube.calls]
+        self.assertFalse(any(command[:2] == ["rollout", "status"] for command in commands))
+        self.assertFalse(any(command[:2] == ["patch", "deployment"] for command in commands))
+        self.assertEqual(commands[-1][0], "logs")
+        self.assertIn("--pod-running-timeout=45s", commands[-1])
+        self.assertIn("ABCD-EFGH", result["evidence"][-1]["stdout"])
+
+
+class FakeGateway:
+    def status(self):
+        return {
+            "evidence": [{"stdout": "raw"}],
+            "verification": {"stdout": "401 upstream"},
+        }
+
+    def device_status(self):
+        return {"ready": False, "evidence": {"stdout": "pending"}}
+
+    def configure(self, provider_id, model, *, credential="", settings=None):
+        return {
+            "provider": provider_id,
+            "model": model,
+            "credentialReceived": bool(credential),
+            "settings": settings,
+        }
+
+
+class LlmGatewayApiTest(unittest.TestCase):
+    def setUp(self):
+        self.connection = SimpleNamespace(usable=True, target=TARGET)
+        loader = patch(
+            "admin_console.api.app.load_connection", return_value=self.connection
+        )
+        loader.start()
+        self.addCleanup(loader.stop)
+        self.client = TestClient(
+            create_app(llm_gateway_factory=lambda target: FakeGateway()),
+            headers=portal_api_headers(),
+        )
+        self.headers = deployment_target_headers(TARGET)
+
+    def test_status_includes_resources_and_verification(self):
+        status = self.client.get("/api/v1/llm-gateway", headers=self.headers)
+        device_status = self.client.get(
+            "/api/v1/llm-gateway/device-status", headers=self.headers
+        )
+
+        self.assertEqual(status.status_code, 200)
+        self.assertEqual(status.json()["evidence"][0]["stdout"], "raw")
+        self.assertEqual(
+            status.json()["verification"]["stdout"], "401 upstream"
+        )
+        self.assertFalse(device_status.json()["ready"])
+
+
+    def test_configuration_validation_never_echoes_rejected_credential(self):
+        marker = "SENSITIVE_MARKER_"
+        response = self.client.post(
+            "/api/v1/llm-gateway/configuration",
+            headers=self.headers,
+            json={
+                "providerId": "gemini",
+                "model": "gemini-3.5-flash",
+                "credential": marker + "x" * 16_384,
+                "settings": {},
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        self.assertNotIn(marker, response.text)
+        self.assertIn("credential", response.text)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/admin_console/ui.py
+++ b/admin_console/ui.py
@@ -32,10 +32,24 @@ ATTRIBUTION_COLORS = {
     AttributionLevel.MISSING: "#FF6B7A",
 }
 
-AGENT_SELECTOR_HELP = (
-    "Select the deployed agent runtime. Today each entry is backed by a "
-    "Kubernetes PlatformAgent custom resource."
-)
+def render_command_evidence(item: dict, *, expanded: bool = False) -> None:
+    """Render one raw external-command result consistently across pages."""
+    source = str(item.get("source") or "Evidence")
+    returncode = int(item.get("returncode", 0))
+    with st.expander(f"{source} · exit {returncode}", expanded=expanded):
+        command = str(item.get("command") or "")
+        if command:
+            st.caption(command)
+        stdout = str(item.get("stdout") or "")
+        stderr = str(item.get("stderr") or "")
+        if stdout:
+            st.code(stdout, language="text", wrap_lines=True)
+        if stderr:
+            st.code(stderr, language="text", wrap_lines=True)
+        if item.get("timed_out"):
+            st.caption("timed_out=true")
+        if not stdout and not stderr:
+            st.code("", language="text")
 
 
 def selectable_table(

--- a/bench/README.md
+++ b/bench/README.md
@@ -54,14 +54,21 @@ The matrix terms are:
   Goal, including repair diagnostics.
 
 When a Persona's credential reference resolves to a token, its Agent endpoint
-must use HTTPS. The evaluator rejects redirects instead of forwarding the
-credential; configure the Agent with the final canonical API URL.
+must use HTTPS, except on a loopback host (`127.0.0.1`, `::1`, `localhost`),
+where the token never leaves the machine. The evaluator rejects redirects
+instead of forwarding the credential; configure the Agent with the final
+canonical API URL.
 
-Run the checked-in read-only smoke matrix against a locally running portal:
+Run the checked-in read-only smoke matrix against a locally running portal.
+Every portal `/api/v1` request requires the portal's launch capability, so set
+`KUBE_AGENTS_PORTAL_API_TOKEN` (at least 32 characters) before starting
+`scripts/admin_portal.sh` — otherwise the portal generates a random token the
+evaluator cannot know — and run the matrix with the same value:
 
 ```bash
 cd bench
 KUBE_AGENTS_PORTAL_API_URL=http://127.0.0.1:8501/api/v1 \
+KUBE_AGENTS_PORTAL_API_TOKEN=<the portal's token> \
 EXPECTED_PROJECT=<project> \
 EXPECTED_CLUSTER=<cluster> \
 EXPECTED_LOCATION=<location> \

--- a/bench/kube_agents_bench/cuj.py
+++ b/bench/kube_agents_bench/cuj.py
@@ -173,7 +173,8 @@ class PortalTransport:
             raise ValueError("portal endpoint must be an absolute HTTP(S) URL")
         if parsed.username or parsed.password or parsed.query or parsed.fragment:
             raise ValueError("portal endpoint cannot contain credentials, query, or fragment")
-        if token and parsed.scheme != "https":
+        loopback = parsed.hostname in {"127.0.0.1", "::1", "localhost"}
+        if token and parsed.scheme != "https" and not loopback:
             raise ValueError("credentialed portal endpoints must use HTTPS")
         self.endpoint = endpoint
         self.timeout = timeout

--- a/bench/scenarios/portal-readonly-smoke.json
+++ b/bench/scenarios/portal-readonly-smoke.json
@@ -10,6 +10,7 @@
     "name": "Platform administrator",
     "userRole": "Platform Administrator",
     "description": "Designs and operates GKE infrastructure.",
+    "credentialEnv": "KUBE_AGENTS_PORTAL_API_TOKEN",
     "approvalPolicy": "deny"
   },
   "scenario": {

--- a/bench/tests/test_cuj.py
+++ b/bench/tests/test_cuj.py
@@ -142,6 +142,11 @@ class CUJEvaluatorTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must use HTTPS"):
             PortalTransport("http://portal.example.test/api/v1", token="secret")
 
+    def test_credentialed_transport_allows_loopback_http(self):
+        transport = PortalTransport("http://127.0.0.1:8501/api/v1", token="secret")
+
+        self.assertEqual(transport.headers["Authorization"], "Bearer secret")
+
     def test_transport_does_not_follow_redirects(self):
         PortalHandler.redirect_target_count = 0
         server = ThreadingHTTPServer(("127.0.0.1", 0), PortalHandler)

--- a/docs/README.md
+++ b/docs/README.md
@@ -150,6 +150,7 @@ identifier appears, add its source here.
 | GitOps clone layout (`/opt/data/gitops/...`) and leases | `agents/platform/scripts/gitops_workspace.py` |
 | fleet-audit finding-id pattern and rendering caps | `agents/platform/skills/fleet-audit/scripts/audit_report.py` |
 | Helm chart value defaults (KSA/secret names, image repos, tag rules) | `charts/kube-agents/values.yaml` |
+| Stock `PlatformAgent.metadata.name` used as the admin-console installation ID | `charts/kube-agents/values.yaml` (`platformAgent.name`) |
 | Terraform module defaults (GSA/KSA/namespace, role set, channel) | `terraform/modules/*/variables.tf` |
 | Memory bank name, scope-tag spelling, and provider name | `agents/chat/plugins/memory/kube_agents_memory/config_schema.py` |
 | Per-profile Hindsight recall settings the agent uses | `agents/chat/defaults/hindsight/config.json`, `agents/platform/hindsight/config.json` |
@@ -213,7 +214,7 @@ pull request:
 | `INSTALL.md` | Install guide | Self-contained, executable installation guide: automated GCP/GKE provisioning, manual Kubernetes deployment, local dev, declarative Terraform+Helm install (pointer to its canonical guide), teardown, troubleshooting. Commands only; explanation lives on the site. | Prerequisites, provisioning stages, integrations, teardown | Written to be runnable end-to-end by a human or an AI agent |
 | `AGENTS.md` | Contributor rules | Workspace instructions: repo layout, branching from a freshly fetched `main`, the pre-task scan of open pull requests and issues, skills guidelines, the canonical-home documentation rules, generated-regions rule, PR hygiene, the live-validation requirement, and the automated pull-request review contract. | Doc ownership table, `make docs-check`, fresh base, duplicate-work scan, Conventional Commits, fork PRs, bot review | AI coding agents and human contributors; owns the doc RULES |
 | `CLAUDE.md` | Contributor rules | Imports `AGENTS.md` and adds Claude-specific commit-authorship and PR-disclosure rules. | No co-author trailers; PRs mention Claude assistance | Claude Code sessions |
-| `admin_console/README.md` | Component README | Local setup and operating boundaries for the Kube Agents Console. | Connection, chat, observability, validation | Console users and contributors |
+| `admin_console/README.md` | Component README | Local setup and operating boundaries for the Kube Agents Console. | Connection, LLM gateway, chat, observability, validation | Console users and contributors |
 | `admin_console/CONNECTION_SECURITY.md` | Security reference | Security contract for the local console's persisted connection lease. | Stored metadata, filesystem controls, identity binding, revalidation, trust boundary | Console users and security reviewers |
 
 ### `agents/` — agent blueprints (runtime documents)

--- a/docs/designs/admin-console.md
+++ b/docs/designs/admin-console.md
@@ -8,11 +8,12 @@ Kube Agents Console is a first-party web interface for chatting with the
 kube-agents front door and explaining human-initiated and autonomous activity
 using normalized telemetry and explicit causality.
 
-The console is implemented in `admin_console/`. Setup's Connection page
-owns Google Cloud project selection, connection, disconnect, and the diagnostic
-checklist. The Observability pages read bounded live Cloud Logging and Cloud
-Trace data. Remote authentication and operator-managed deployment remain
-follow-up work.
+The console is implemented in `admin_console/`. Setup's Connection page owns
+Google Cloud project selection, connection, disconnect, and the diagnostic
+checklist. Setup's LLM Gateway page reads and updates the inference provider,
+then tests the same in-cluster path the agents use. The Observability pages read
+bounded live Cloud Logging and Cloud Trace data. Remote authentication and
+operator-managed deployment remain follow-up work.
 
 ## Product questions
 
@@ -43,14 +44,19 @@ Browser
             -> kanban read model
        -> Task Kanban inspector
             -> board, task, run, event, and delivery projections
+       -> LLM gateway service
+            -> Kubernetes Deployment, Service, ConfigMap, and Secret writes
+            -> production-path model request from a Platform Agent pod
 ```
 
 The production console should run in a separate Deployment with a dedicated
-read-only telemetry identity and a narrow, authenticated chat proxy. It must not
+read-only telemetry identity, a narrow authenticated chat proxy, and a distinct
+setup capability limited to the LiteLLM resources it manages. It must not
 receive the Platform Agent API key, operational credentials, or unrestricted
-access to the credential proxy. The current local prototype invokes a fixed
-client in the selected agent pod and uses only the operator-managed non-secret
-loopback trust sentinel.
+access to the credential proxy. The current loopback-only prototype uses the
+launcher-verified gcloud identity for its explicit setup mutations. Model API
+keys are write-only inputs patched into the Secret referenced by the live
+LiteLLM Deployment; they are never read back or retained in portal state.
 
 ## Portal API and shared chat abstraction
 
@@ -215,11 +221,46 @@ on commands and tolerated on reads to allow additive server evolution.
 GET  /healthz
 GET  /readyz
 GET  /api/v1/agents
-GET  /api/v1/agents/{agentId}
 ```
 
 Readiness checks the store and the configured upstream agent boundary without
 running a model turn. It never creates, repairs, or grants anything.
+
+The stock console has one installation identity: the Helm
+`platformAgent.name` default. `GET /api/v1/agents` discovers `PlatformAgent`
+resources from the connected target and returns only that canonical resource.
+If it is absent, discovery fails and lists the names it did find; it never uses
+the cluster, Deployment, Service, gateway container, or Hermes profile as an
+agent ID. The gateway container is separately discovered from the live pod
+spec as the container that owns the named `api` port.
+
+The public interaction and session resources retain `agentId` for stable stored
+records and URLs. Portal clients populate it from discovery rather than asking
+the user to enter or select it. Hermes routing is an independent `profile`
+field: portal chat defaults to `default`, while a direct Platform specialist
+request explicitly selects `platform`.
+
+#### LLM gateway setup
+
+```text
+GET  /api/v1/llm-gateway
+GET  /api/v1/llm-gateway/device-status
+POST /api/v1/llm-gateway/configuration
+```
+
+The status read returns live resource evidence, the provider catalog, and a
+bounded model request from a running Platform Agent
+through the in-cluster LiteLLM Service, so API-server Service proxy behavior
+cannot contradict the path agents actually use. Configuration accepts one
+catalog provider and model plus write-only credentials or provider settings.
+For repository-managed installs it applies the repository-owned Kustomize
+overlay and ensures one rollout. A Helm-owned deployment is status-only: the
+portal disables mutation and directs the operator back to Terraform or Helm.
+Vertex changes first verify the catalog-defined Google API and IAM contract.
+The API never serializes a submitted credential into command arguments,
+responses, validation errors, or portal state. Device OAuth returns the
+authorization log without waiting for readiness; a bounded status poll waits
+for the new rollout before verification.
 
 #### Start and observe an interaction
 
@@ -234,7 +275,6 @@ POST /api/v1/interactions/{interactionId}/cancel
 
 ```json
 {
-  "agentId": "platform-agent",
   "profile": "default",
   "sessionId": "portal_9c7c...",
   "input": { "text": "Design a stockout-resilient GKE cluster." },
@@ -242,9 +282,11 @@ POST /api/v1/interactions/{interactionId}/cancel
 }
 ```
 
-The caller may omit `sessionId` to create a session. The authenticated principal,
-not the body, determines user identity. The API rejects an idempotency key that
-is reused with a different body.
+The caller may omit `agentId` and `sessionId`; the service derives the canonical
+resource and creates a session. An explicitly supplied `agentId` must match the
+canonical resource. The authenticated principal, not the body, determines user
+identity. The API rejects an idempotency key that is reused with a different
+body.
 
 The response contains stable links rather than leaking the Hermes base URL:
 
@@ -419,7 +461,8 @@ and may consume the portal API only for observation and diagnostics.
 
 FastAPI owns authentication for both the UI and API:
 
-- local UI access continues to use the launcher-verified gcloud identity;
+- local UI access uses the launcher-verified gcloud identity and a random
+  launch-scoped bearer capability between the Streamlit server and FastAPI;
 - in-cluster human access uses the configured application or IAP identity;
 - automated evaluation uses a dedicated workload identity or short-lived OIDC
   token, never a shared browser cookie;
@@ -624,6 +667,13 @@ override identity or correlation fields.
   The same page shows checklist results for CLI authentication, ADC, APIs, GKE,
   agent runtime state, Logging, structured audit events, and Trace.
 - **Agentic:** Chat is the interactive surface for working with the agent.
+- **LLM Gateway:** a Setup page showing one result for the complete Platform
+  Agent → LiteLLM → provider path, the live provider and model, a catalog-driven
+  configuration form, device authorization, and default-collapsed raw command
+  evidence. Opening the page performs one bounded connection request. Refresh
+  rereads the evidence and repeats the same request as one action. After a
+  configuration change, the page waits for or monitors the rollout and replaces
+  the status with the updated connection result.
 - **Observability:** an always-visible navigation group containing Overview,
   Activity Explorer, Task Kanban, and Scheduled Cron. A shared connection gate
   replaces provider-backed content with concise connection guidance until the
@@ -685,6 +735,7 @@ remain labeled as missing instead of being filled with demo data.
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------ | ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
 | Signed-in identity                      | Active gcloud account passed by the local launcher                                                       | No     | Yes                 | Yes                      | Keep launcher verification for local use; use application-level authentication for remote deployment    |
 | Connection diagnostics                  | Bounded live checks for project, APIs, GKE, logs, audit, and Trace                                       | No     | Yes                 | Yes                      | Reuse the proven source adapters in the production telemetry provider                                   |
+| LLM gateway setup and verification      | Catalog-driven provider changes plus a bounded request through the live agent-to-gateway path            | No     | Yes                 | Yes                      | Split the production setup capability from the read-only telemetry identity                             |
 | Overview metrics                        | Aggregated from the selected live Logging and Trace snapshot                                             | No     | Yes                 | Yes                      | Add server-side aggregation for windows larger than the bounded snapshot                                |
 | Activity pulse                          | Live evidence records grouped into 15-minute buckets                                                     | No     | Yes                 | Yes                      | Add paginated historical aggregation                                                                    |
 | Human versus autonomous classification  | Trusted session and cron evidence; unsupported records remain unknown                                    | No     | Partial             | Yes                      | Create a trusted interaction and trigger record at chat, cron, event, retry, and follow-up ingress      |
@@ -774,6 +825,13 @@ present time-adjacent records as proven causality.
   does not create time-adjacent causal joins.
 - The Connection page performs bounded, read-only gcloud and Cloud Trace
   requests. It does not change APIs, IAM, or Kubernetes resources.
+- The LLM Gateway page is the explicit exception to the console's read-only
+  operational views. It may apply only repository-managed LiteLLM manifests,
+  patch the catalog or live Deployment's credential Secret, and restart that
+  Deployment. Helm ownership is a hard stop. Submitted keys travel in request
+  bodies and `kubectl` standard input, are cleared from the widget, and are not
+  persisted, echoed in validation errors, or returned. Each automatic
+  connection test may incur one provider request capped at eight output tokens.
 - The local persisted connection is not an authentication token. It contains
   account and deployment coordinates plus verification time, but no Google
   credential, chat content, or telemetry. Google Cloud CLI remains the

--- a/k8s-operator/config/integrations/litellm/overlays/chatgpt/deployment-patch.yaml
+++ b/k8s-operator/config/integrations/litellm/overlays/chatgpt/deployment-patch.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: litellm
 spec:
+  replicas: 1
   strategy:
     type: Recreate
     rollingUpdate: null

--- a/k8s-operator/config/integrations/litellm/overlays/chatgpt/deployment-patch.yaml
+++ b/k8s-operator/config/integrations/litellm/overlays/chatgpt/deployment-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+spec:
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    spec:
+      containers:
+        - name: litellm-container
+          env:
+            - name: CHATGPT_TOKEN_DIR
+              value: /data/litellm/chatgpt
+          volumeMounts:
+            - name: token-storage
+              mountPath: /data/litellm/chatgpt
+      volumes:
+        - name: token-storage
+          persistentVolumeClaim:
+            claimName: litellm-pvc

--- a/k8s-operator/config/integrations/litellm/overlays/chatgpt/kustomization.yaml
+++ b/k8s-operator/config/integrations/litellm/overlays/chatgpt/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The Helm chart intentionally rejects subscription OAuth because it does not
+# own a token PVC. This dev/admin overlay matches the hand-applied example.
+resources:
+  - ../../base
+  - pvc.yaml
+patches:
+  - path: deployment-patch.yaml

--- a/k8s-operator/config/integrations/litellm/overlays/chatgpt/pvc.yaml
+++ b/k8s-operator/config/integrations/litellm/overlays/chatgpt/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: litellm-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s-operator/config/integrations/litellm/providers.json
+++ b/k8s-operator/config/integrations/litellm/providers.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "defaultProvider": "gemini",
+  "gateway": {
+    "deployment": "litellm",
+    "service": "litellm",
+    "configMapBase": "litellm-config",
+    "configVolume": "config-volume",
+    "container": "litellm-container",
+    "servicePort": 80,
+    "containerPort": 8080,
+    "readinessPath": "/health/readiness",
+    "inferencePath": "/v1/chat/completions",
+    "modelAlias": "model-default",
+    "rolloutTimeoutSeconds": 300
+  },
+  "providers": [
+    {
+      "id": "gemini",
+      "label": "Gemini API",
+      "defaultModel": "gemini-3.5-flash",
+      "overlay": "base",
+      "authentication": {
+        "type": "api_key",
+        "environmentVariable": "GEMINI_API_KEY",
+        "secretName": "platform-agent-secrets"
+      }
+    },
+    {
+      "id": "vertex_ai",
+      "label": "Vertex AI",
+      "defaultModel": "gemini-3.5-flash",
+      "overlay": "vertex_ai",
+      "authentication": {
+        "type": "workload_identity"
+      },
+      "workloadIdentity": {
+        "kubernetesServiceAccount": "kubeagents-litellm",
+        "googleServiceAccount": "kubeagents-litellm-gsa",
+        "requiredApi": "aiplatform.googleapis.com",
+        "requiredProjectRole": "roles/aiplatform.user",
+        "workloadIdentityRole": "roles/iam.workloadIdentityUser"
+      },
+      "settings": [
+        {
+          "id": "project_id",
+          "label": "Vertex project",
+          "environmentVariable": "VERTEX_PROJECT_ID",
+          "deploymentEnvironmentVariable": "VERTEXAI_PROJECT"
+        },
+        {
+          "id": "location",
+          "label": "Vertex location",
+          "environmentVariable": "VERTEX_LOCATION",
+          "deploymentEnvironmentVariable": "VERTEXAI_LOCATION"
+        }
+      ]
+    },
+    {
+      "id": "anthropic",
+      "label": "Anthropic API",
+      "defaultModel": "claude-opus-5",
+      "overlay": "base",
+      "authentication": {
+        "type": "api_key",
+        "environmentVariable": "ANTHROPIC_API_KEY",
+        "secretName": "platform-agent-secrets"
+      }
+    },
+    {
+      "id": "chatgpt",
+      "label": "ChatGPT subscription",
+      "defaultModel": "gpt-5.4",
+      "overlay": "chatgpt",
+      "authentication": {
+        "type": "device_oauth",
+        "tokenDirectory": "/data/litellm/chatgpt"
+      }
+    },
+    {
+      "id": "openai",
+      "label": "OpenAI API",
+      "defaultModel": "gpt-5.4",
+      "overlay": "base",
+      "authentication": {
+        "type": "api_key",
+        "environmentVariable": "OPENAI_API_KEY",
+        "secretName": "platform-agent-secrets"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

This PR adds a local admin-portal workflow for inspecting and configuring LiteLLM, makes the stock `PlatformAgent/platform-agent` identity automatic throughout the portal, and protects the loopback API with a launch-scoped capability. Resource evidence and a production-path inference request now produce one connection result before and after a configuration change.

## Why This Change

The portal previously exposed conflicting readiness and inference results, required users to reason about an agent ID fixed by the stock installation, and offered no guided path to diagnose or repair developer LiteLLM credentials.

## What Changed

- Added a catalog-driven LLM Gateway page for live status, provider configuration, ChatGPT device authorization, rollout monitoring, and collapsed raw logs.
- Combined refresh and connection testing into one status request made through the live Platform Agent and LiteLLM Service.
- Kept Terraform/Helm ownership authoritative: Helm-managed gateways remain observable, but the portal disables mutation and directs changes back to Terraform or Helm. Repository Kustomize development installs remain configurable.
- Removed agent-ID controls. The portal reads the canonical resource name from the Helm default, requires that resource in the selected cluster, and keeps the `default` and `platform` Hermes profiles separate from installation identity.
- Discovered the gateway container from the live pod container that owns the named `api` port.
- Added a process-scoped bearer capability to local `/api/v1` requests.
- Removed the new UI simulation and duplicate contract tests while retaining service, API, canonical-discovery, chat, session, and task coverage.

## Context

PR #797 is merged; this branch is rebased on the current Terraform + Helm installer architecture. PR #815 is the separate Google Chat integration page stacked on this branch.

## Testing

- `.venv/bin/python -m unittest discover -s admin_console/tests -p 'test_*.py' -q` — 156 passed.
- `.venv/bin/python -m compileall -q admin_console` — passed.
- `make docs-check` — passed.
- Prettier 3.9.6 on changed Markdown and JSON — passed.
- `make -C k8s-operator` — controller generation, formatting, vet, and build passed.
- ChatGPT Kustomize overlay render — passed; the output contains one Deployment replica, the `ReadWriteOnce` token PVC, `Recreate` strategy, token environment, and volume mount.

### Live validation

- Project `haoxuw-gkedemos`, cluster `platform-agent-host`, location `us-east4`, namespace `kubeagents-system`. `PlatformAgent/platform-agent` reported `Ready=True`; `kubeagents-controller-manager` ran image `us-east4-docker.pkg.dev/haoxuw-gkedemos/kube-agents/k8s-operator:2e1bb0059e97ffd7b9f03f0fece9ae4eaedba7d3`; the agent gateway ran image `ghcr.io/gke-labs/kube-agents/platform-agent:a1456a4b0b5b60090b96bd70edb030a53873768d`.
- The squashed branch observed two ready LiteLLM replicas on `ghcr.io/berriai/litellm:v1.96.2`. It changed Gemini from `gemini-3.5-flash` to `gemini-3.1-flash-lite`; the rollout completed and the production-path request returned HTTP 200. It then restored `gemini-3.5-flash`, observed that model from the live Deployment/ConfigMap, and received HTTP 200 again. No test object or alternate model setting remains.
- A prior local launch on temporary loopback ports returned 401 for an uncredentialed API request; the launch capability passed authorization and reached the target-bound connection check. The temporary processes were stopped.

## Self-Review

- A fresh `review-adversarial` pass covered intent, removed behavior, cross-file consumers, security, reuse, conventions, scope, tests, and the stacked PR. It found three defects: Helm installs still displayed an unusable mutation form, versioned Vertex model IDs containing `@` were rejected, and a zonal cluster defaulted Vertex to a zone. The form is now disabled with Terraform/Helm guidance for Helm ownership, `@` is accepted, and zones map to their enclosing region while explicit zone input is rejected. A focused second pass found no surviving defect in those fixes.
- The `review-docs-drift` pass checked the admin README, design, security contract, current installer ownership, and canonical identifiers. It removed references to the deleted script manifest, made Helm the sole stock identity source, and documented the status-only Helm behavior. `make docs-check` found no remaining mechanical drift.

## Risk & Rollout

The portal can patch credentials and apply repository Kustomize manifests only to the explicitly connected non-Helm development target. It fails before mutation when catalog, render, identity, or ownership evidence is invalid. Helm-owned resources are read-only. Reverting the commit removes the page and API; provider credentials already written to a development cluster must be rotated or removed separately if rollback requires that cleanup.
