### PR TITLE
ci: collapse superseded pull request runs with concurrency groups

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/agent-startup-test.yml
+++ b/.github/workflows/agent-startup-test.yml
@@ -17,6 +17,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/agentplugins-test.yml
+++ b/.github/workflows/agentplugins-test.yml
@@ -25,6 +25,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,6 +6,16 @@ on:
   push:
     branches: [main]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docs-freshness-check.yml
+++ b/.github/workflows/docs-freshness-check.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/installer-matrix-test.yml
+++ b/.github/workflows/installer-matrix-test.yml
@@ -14,9 +14,15 @@ on:
 permissions:
   contents: read
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
 concurrency:
-  group: installer-matrix-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate-installer:

--- a/.github/workflows/k8s-operator-test.yml
+++ b/.github/workflows/k8s-operator-test.yml
@@ -7,6 +7,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,6 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,16 @@ on:
   push:
     branches: [main]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,16 @@ on:
   schedule:
     - cron: "0 4 * * 1" # Weekly Monday scan
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,16 @@ on:
   push:
     branches: [main]
 
+# A re-push supersedes this pull request's earlier run instead of stacking a
+# second full set of checks behind it. Runs that are not from a pull request
+# fall back to github.run_id, which is unique, so each sits alone in its own
+# group and none is ever cancelled. A shared key would not be safe there:
+# GitHub holds only one run pending per group, so a burst of merges to main
+# would lose the runs in the middle before they started.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

The workflows that run on every pull request had no concurrency group, so pushing a new commit left the previous run executing and started a second full set of checks behind it. This adds a group to twelve of them, keyed on the pull request, so a re-push supersedes the earlier run rather than stacking on it. Runs from any other event — `push` to `main`, `schedule`, `workflow_dispatch` — fall back to `github.run_id` and so sit alone in their own group, which leaves their behaviour exactly as it is today.

## Why This Change

Measured over a two-hour window, 92 of 351 `pull_request` runs (26%) had a newer run of the same workflow and branch start before they finished. Every one of those was work whose result nobody would read, holding a runner slot while current work waited behind it.

That waste is invisible until the queue is contended, and then it dominates. At 20:50 UTC on 19 Aug, six pull requests were pushed inside fifteen minutes, each fanning out ~15 runs; the queue reached 100 runs against 2 executing, and the median run waited 13 minutes to start. The underlying demand is small — one pull request is 11.4 minutes of execution across 13 runner allocations, 11 of them under a minute — so the contention is burst shape rather than volume, and a quarter of the burst is superseded work.

## What Changed

- Twelve pull-request workflows gain a `concurrency` group keyed on `github.workflow` and the pull request number, with `cancel-in-progress` scoped to `pull_request` events.
- The fallback for non-pull-request runs is `github.run_id`, not `github.ref`. This is the part worth reading twice. GitHub holds only **one run pending per group**, and that cancellation happens regardless of `cancel-in-progress`, which protects only the run already executing. Keying `push` runs on the ref would therefore have cancelled the middle of every merge burst before it started — and 57% of consecutive commits on `main` land under 20 minutes apart, well inside a CI duration. Five of the six required contexts (`actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`) come from these workflows, so most of `main` would have merged with no post-merge validation, including the security scan. A unique `run_id` puts each such run alone in its group and removes the class.
- `.github/workflows/installer-matrix-test.yml` already had a group and the same defect — an unconditional `cancel-in-progress: true` that applied to its push-to-`main` runs too. It now follows the same convention.
- `.github/workflows/validate-pr-title.yml` is deliberately **not** included. It triggers on `edited`, which fires when a pull request *body* changes at an unchanged head SHA — the routine flow in this repository, where Self-Review is filled in after `gh pr create`. Two runs racing on one SHA can leave a `cancelled` status as the most recent for that context, and the job takes six seconds, so there is nothing to reclaim in exchange for the risk.

## Context

No issue tracks this, and no closed pull request has attempted it (`gh search prs --state closed` on `concurrency cancel-in-progress` and `workflow concurrency group` both returned nothing).

Six open pull requests touch files this one touches: #809 and #674 (`docker-build.yml`), #797 (`installer-matrix-test.yml`, `validate.yml`), #720 (`agent-startup-test.yml`, `k8s-operator-test.yml`, `validate.yml`), #806 (`validate.yml`), #496 (`agent-startup-test.yml`). None addresses CI queueing; all edit job bodies while this inserts a block between `on:` and `permissions:`. Merge-conflict warning rather than duplicate work, and mechanical to resolve either way.

Follow-up work this deliberately does not do, in leverage order: path-filter `Docker Build` (7.9 of the 11.4 minutes a pull request spends, and it runs on docs-only changes — `k8s-operator-test.yml` and `docs-build.yml` already use `dorny/paths-filter` for this), and reduce the number of runner allocations per pull request, which is the actually-scarce resource. The second trades against the deliberate job-splitting documented at `validate.yml:13-24` and should be discussed rather than assumed.

## Testing

- `actionlint` (v1.7.7) on the changed files and on all 35 workflows: clean.
- `prettier --check` (3.9.6, the version `prettier.yml` pins) on the changed files: clean.
- `make docs-check`: passes — generated regions current, 249 files' relative links resolve, terminology check passed, map inventory complete.
- Parsed every workflow with `yaml.safe_load` and printed the resolved `concurrency` block for all 25 that have one, to confirm the twelve are identical and the pre-existing groups elsewhere are untouched.
- Verified all 35 workflow `name:` values are unique, since `github.workflow` is the first segment of the group key.
- Enumerated the group key for every event each modified workflow can fire on; none evaluates empty and none collides across unrelated runs.

### Live validation

Not live-tested. This changes GitHub Actions scheduling only — no operator, agent, or cluster code path is touched, and there is nothing for a running kube-agents installation to reconcile or pick up.

The pull-request half is observable on this PR itself: pushing a second commit should show the first run's checks as `cancelled` rather than running to completion alongside the new set. The `push`-to-`main` half — the half that was wrong in the first draft — cannot be exercised from a fork branch before merge, which is exactly why the review finding below mattered. After merge it is confirmable by checking that a burst of consecutive commits on `main` each carry their own check runs.

## Self-Review

Ran `.agents/skills/review-adversarial/SKILL.md` in a subagent handed only the diff range and the repository, with none of the authoring context. Six findings.

- **HIGH, confirmed — `push` to `main` would drop CI on intermediate commits. Fixed.** The first draft used `github.ref` as the fallback with `cancel-in-progress: false`, on the belief that this left non-pull-request runs alone. It does not: `cancel-in-progress` governs only the executing run, and GitHub keeps one pending run per group, so runs 2..N-1 of any merge burst would have been cancelled before starting. The review corroborated this against the repository's own note in `auto_request_review.yml`, which was written to work around the same rule. Verified independently: required contexts on `main` are `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`, five of them from these workflows; and 57% of the last 79 consecutive commit pairs on `main` are under 20 minutes apart, the tightest 76–90 seconds. Fixed with the `github.run_id` fallback, which also made the `github.event_name` key segment unnecessary.
- **MEDIUM, confirmed — two `workflow_dispatch` runs on one ref would cancel the middle one. Fixed** by the same `run_id` change.
- **MEDIUM, confirmed — `installer-matrix-test.yml` contradicted the new convention. Fixed** by aligning it; it had the same push-to-`main` cancellation defect already.
- **MEDIUM, plausible — a superseded run on an unchanged head SHA can leave a required context `cancelled`. Partially fixed, residual accepted.** Two runs on one SHA both write check runs of the same name; if the cancelled one finishes winding down after the replacement completes, the current head carries a `cancelled` required context and nothing re-runs it. The review could not confirm GitHub's tie-break ordering, and neither could I. The routine trigger for this is `validate-pr-title.yml`'s `edited` event on body edits, so that file is dropped from the change entirely. The residual is `opened` → `reopened` on an unchanged SHA, which reaches the required contexts. Not fixed: the only fix is keying the group on the head SHA, which would stop a re-push superseding anything and defeat the change. Recovery is a push or a re-run, and the trigger is closing and reopening a pull request inside its own CI duration.
- **LOW, confirmed — the comment asserted things untrue of most files it sat in. Fixed** by rewriting it; it described a scheduled trigger that only `security-scan.yml` has, and push behaviour that four of the files cannot exhibit.
- **LOW, plausible — group uniqueness now depends on workflow `name:` uniqueness, which nothing enforces. Reported, not fixed.** All 35 names are currently distinct and none of the twelve is `workflow_call`-able, so there is no collision today; two files sharing a `name:` would silently cancel each other's runs. Adding a check to `validate.yml` is a reasonable follow-up but is a different change from this one.

Angles the pass checked and found clean: the scheduled security scan's key; `github.workflow` collision; per-event group-key enumeration across all reachable events including fork pull requests; `cancel-in-progress` as an expression; interaction with `auto_request_review.yml` and the `AI Review` check gating; whether cancellation could strand external state (none of these workflows authenticate to GCP or push images — `docker-build.yml` builds with `push: false`); action pinning, which this does not touch; and documentation staleness, where nothing in `docs/` or `AGENTS.md` describes CI concurrency.

One gap in the pass: it could not install `actionlint`, so it left the expression in `cancel-in-progress` unverified. I ran actionlint v1.7.7 separately, on the changed files and on all 35 workflows — clean.

## Risk & Rollout

Scheduling only; no runtime code path, no cluster-facing behaviour, nothing to migrate. Revert is `git revert` of the single commit, and the previous behaviour returns on the next event with no cleanup.

The new failure mode is a check reported `cancelled` instead of running to completion. On a pull request that is the intended outcome and applies to a superseded commit. Post-merge, the `run_id` fallback means a `main`, `schedule`, or `workflow_dispatch` run is never in a group with another run, so none can be cancelled — that property is what the HIGH finding above was about, and it is the thing to watch after merge: a burst of merges to `main` should leave every commit with its own check runs.

---

This pull request was generated with the help of Claude.
