### PR TITLE
test: cover the observability scripts and memory curator, fix a protected-branch bypass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,9 @@ prettier-write: ## Reformat all Markdown/YAML in place.
 # glob, so they had never once run in CI. defaults/hooks is here for the same
 # reason -- the plugins glob does not reach it, so the chat_message_audit hook
 # was untestable-by-CI however many tests it grew. Discovery is then run once
-# per directory rather than once over the tree, because none of them are
-# packages -- `unittest discover` pointed at agents/platform/skills finds
+# per directory rather than once over the tree, because most of them are not
+# packages (incident_context is the exception, and per-directory discovery
+# still collects it) -- `unittest discover` pointed at agents/platform/skills finds
 # nothing and still exits 0, which reads as a passing suite. That also keeps
 # deploy/docker, deploy/docker/patches and each deploy/docker/plugins/<name>
 # separate, which they must be: those tests import their subject by bare module

--- a/agents/chat/scripts/test_memory_ttl_curator.py
+++ b/agents/chat/scripts/test_memory_ttl_curator.py
@@ -1,0 +1,421 @@
+"""Unit tests for the memory TTL curator's selection and safety logic.
+
+Run: python3 -m unittest agents/chat/scripts/test_memory_ttl_curator.py
+
+This script deletes memory unattended, so the tests lean on the refusal paths:
+what survives matters more than what goes. Every guard that stops a run —
+too-small bank, missing retain strategy, no observations, unscopable
+observation, partial distil — is exercised, and the happy path asserts exactly
+which rows were retired and why. Hindsight is a fake; what is tested is the
+decision logic, not HTTP.
+"""
+
+import contextlib
+import io
+import json
+import sys
+import unittest
+import urllib.error
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.absolute()))
+
+import memory_ttl_curator as curator  # noqa: E402
+
+NOW = datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc)
+TTL_DAYS = 180
+BANK = "kube-agents-memory"
+
+
+def days_ago(days):
+    return (NOW - timedelta(days=days)).isoformat()
+
+
+def fact(uid, *, age_days, fact_type="world", context=None, tags=None):
+    unit = {
+        "id": uid,
+        "type": fact_type,
+        "state": "valid",
+        "mentioned_at": days_ago(age_days),
+        "tags": tags or ["user:alice"],
+    }
+    if context is not None:
+        unit["context"] = context
+    return unit
+
+
+def observation(uid, *, text="the fleet runs three clusters", tags=None):
+    return {
+        "id": uid,
+        "type": "observation",
+        "text": text,
+        "tags": ["user:alice"] if tags is None else tags,
+    }
+
+
+class FakeHindsight:
+    """Answers the five calls curate() makes, from an in-memory unit list.
+
+    `fail_retains` names 0-based retain-call indices that raise, which is how a
+    test stages a partial distil.
+    """
+
+    def __init__(self, units, strategies=(curator.CHECKPOINT_STRATEGY,),
+                 fail_retains=()):
+        self._units = list(units)
+        self._strategies = strategies
+        self._fail = set(fail_retains)
+        self.retain_calls = []
+        self.invalidated = []
+        self.consolidations = 0
+
+    def count(self, bank_id):
+        return len(self._units)
+
+    def bank_config(self, bank_id):
+        return {"retain_strategies": {s: {} for s in self._strategies}}
+
+    def units(self, bank_id, **filters):
+        found = []
+        for unit in self._units:
+            if "type" in filters and unit.get("type") != filters["type"]:
+                continue
+            if "state" in filters and unit.get("state", "valid") != filters["state"]:
+                continue
+            found.append(unit)
+        return found
+
+    def retain(self, bank_id, items):
+        index = len(self.retain_calls)
+        self.retain_calls.append(items)
+        if index in self._fail:
+            raise RuntimeError("HTTP 500 on POST /memories: extraction failed")
+        # `chunks` mode, one short item in -> one row out.
+        for i, item in enumerate(items):
+            self._units.append({
+                "id": f"cp-new-{index}-{i}",
+                "type": "world",
+                "state": "valid",
+                "context": item["context"],
+                "mentioned_at": NOW.isoformat(),
+                "tags": item["tags"],
+            })
+        return {}
+
+    def invalidate(self, bank_id, memory_id, reason):
+        self.invalidated.append((memory_id, reason))
+        return {}
+
+    def consolidate(self, bank_id):
+        self.consolidations += 1
+        return {}
+
+
+def run(api, *, commit=True, ttl_days=TTL_DAYS, min_units=1):
+    return curator.curate(api, BANK, ttl_days=ttl_days, min_units=min_units,
+                          commit=commit, now=NOW)
+
+
+# --------------------------------------------------------------------------- #
+# The guards that stop a run before it writes anything
+# --------------------------------------------------------------------------- #
+
+
+class TestGuards(unittest.TestCase):
+    def test_a_small_bank_is_left_alone(self):
+        api = FakeHindsight([fact("f1", age_days=400)])
+        summary = run(api, min_units=200)
+        self.assertIn("< min 200", summary["skipped"])
+        self.assertEqual(api.retain_calls, [])
+        self.assertEqual(api.invalidated, [])
+
+    def test_a_bank_without_the_checkpoint_strategy_is_refused(self):
+        # Without it Hindsight would paraphrase the checkpoints, and the retire
+        # pass would then trust the paraphrase.
+        api = FakeHindsight([fact("f1", age_days=400)], strategies=("concise",))
+        summary = run(api)
+        self.assertIn(repr(curator.CHECKPOINT_STRATEGY), summary["skipped"])
+        self.assertEqual(api.retain_calls, [])
+        self.assertEqual(api.invalidated, [])
+
+    def test_nothing_older_than_the_ttl_means_nothing_happens(self):
+        api = FakeHindsight([
+            fact("f1", age_days=10),
+            observation("o1"),
+        ])
+        summary = run(api)
+        self.assertEqual(summary["skipped"], f"nothing older than {TTL_DAYS}d")
+        self.assertEqual(api.invalidated, [])
+
+    def test_aged_facts_with_no_observations_are_kept_not_orphaned(self):
+        # Retiring here would delete the evidence with nothing distilled from
+        # it. Both consolidation-never-ran and consolidation-broken look like
+        # this, and both want a human.
+        api = FakeHindsight([fact("f1", age_days=400)])
+        summary = run(api)
+        self.assertIn("no observations to distil", summary["skipped"])
+        self.assertEqual(api.invalidated, [])
+
+    def test_an_unscopable_observation_aborts_the_whole_run(self):
+        # One observation with no scope tag is knowledge that would be retired
+        # without a home. The run stops before writing anything at all.
+        api = FakeHindsight([
+            fact("f1", age_days=400),
+            observation("o1"),
+            observation("o2", tags=["session:s1"]),  # no scope tag
+        ])
+        summary = run(api)
+        self.assertIn("cannot be scoped", summary["skipped"])
+        self.assertEqual(api.retain_calls, [])
+        self.assertEqual(api.invalidated, [])
+
+
+# --------------------------------------------------------------------------- #
+# Age selection — the boundary, and rows that cannot be dated
+# --------------------------------------------------------------------------- #
+
+
+class TestAgeSelection(unittest.TestCase):
+    def test_the_cutoff_is_exclusive_a_fact_exactly_at_ttl_survives(self):
+        api = FakeHindsight([
+            fact("boundary", age_days=TTL_DAYS),      # anchor == cutoff
+            fact("older", age_days=TTL_DAYS + 1),
+            observation("o1"),
+        ])
+        run(api)
+        retired = [uid for uid, _ in api.invalidated]
+        self.assertIn("older", retired)
+        self.assertNotIn("boundary", retired)
+
+    def test_a_row_with_an_unparseable_date_is_skipped_not_deleted(self):
+        # A malformed timestamp means the age is unknown, and unknown must not
+        # be treated as old.
+        mangled = fact("mangled", age_days=400)
+        mangled["mentioned_at"] = "not-a-date"
+        mangled.pop("date", None)
+        api = FakeHindsight([
+            mangled,
+            fact("older", age_days=400),
+            observation("o1"),
+        ])
+        run(api)
+        retired = [uid for uid, _ in api.invalidated]
+        self.assertIn("older", retired)
+        self.assertNotIn("mangled", retired)
+
+    def test_a_future_dated_row_is_not_swept(self):
+        # The `anchor < now` clause: a --ttl-days 0 run must not consume rows
+        # stamped after the run started.
+        future = fact("future", age_days=0)
+        future["mentioned_at"] = (NOW + timedelta(hours=1)).isoformat()
+        api = FakeHindsight([
+            future,
+            fact("older", age_days=1),
+            observation("o1"),
+        ])
+        run(api, ttl_days=0)
+        retired = [uid for uid, _ in api.invalidated]
+        self.assertIn("older", retired)
+        self.assertNotIn("future", retired)
+
+    def test_ingestion_date_wins_over_the_event_date(self):
+        # A fact about something years past, learned yesterday, is not stale.
+        recent_about_old = fact("recent", age_days=1)
+        recent_about_old["date"] = days_ago(1000)
+        api = FakeHindsight([
+            recent_about_old,
+            fact("older", age_days=400),
+            observation("o1"),
+        ])
+        run(api)
+        retired = [uid for uid, _ in api.invalidated]
+        self.assertNotIn("recent", retired)
+
+
+# --------------------------------------------------------------------------- #
+# The commit path — distil, verify, then retire
+# --------------------------------------------------------------------------- #
+
+
+class TestCommit(unittest.TestCase):
+    def make_api(self, **kwargs):
+        return FakeHindsight([
+            fact("aged", age_days=400),
+            fact("fresh", age_days=10),
+            fact("oldcp", age_days=7, context=curator.CHECKPOINT_CONTEXT),
+            observation("o1", tags=["user:alice", "session:s1"]),
+            observation("o2", tags=["scope:shared"]),
+        ], **kwargs)
+
+    def test_a_dry_run_reports_the_plan_and_writes_nothing(self):
+        api = self.make_api()
+        summary = run(api, commit=False)
+        self.assertEqual(summary["skipped"], "dry run")
+        self.assertEqual(summary["distilled"], 2)
+        self.assertEqual(summary["retired"], 2)  # aged + oldcp
+        self.assertEqual(api.retain_calls, [])
+        self.assertEqual(api.invalidated, [])
+        self.assertEqual(api.consolidations, 0)
+
+    def test_the_happy_path_retires_exactly_the_aged_and_the_superseded(self):
+        api = self.make_api()
+        summary = run(api)
+        self.assertIsNone(summary["skipped"])
+        self.assertEqual(summary["distilled"], 2)
+        self.assertEqual(summary["retired"], 2)
+
+        retired = dict(api.invalidated)
+        self.assertIn("aged", retired)
+        self.assertIn("oldcp", retired)
+        self.assertNotIn("fresh", retired)
+        # The reason distinguishes the TTL sweep from checkpoint supersession,
+        # because an operator un-retiring a row needs to know which it was.
+        self.assertIn("retained more than 180d ago", retired["aged"])
+        self.assertIn("superseded by a fresher checkpoint", retired["oldcp"])
+        self.assertEqual(api.consolidations, 1)
+
+    def test_checkpoints_are_written_one_per_call(self):
+        # Retain is neither atomic nor idempotent, so batching is how a single
+        # bad item once tripled a bank. One item per call is load-bearing.
+        api = self.make_api()
+        run(api)
+        self.assertEqual(len(api.retain_calls), 2)
+        for items in api.retain_calls:
+            self.assertEqual(len(items), 1)
+
+    def test_checkpoints_carry_the_scope_and_the_marker_context(self):
+        api = self.make_api()
+        run(api)
+        items = [items[0] for items in api.retain_calls]
+        by_scope = {item["observation_scopes"][0][0]: item for item in items}
+        self.assertEqual(set(by_scope), {"user:alice", "scope:shared"})
+        alice = by_scope["user:alice"]
+        # Every tag rides along so topical filters keep working; the scope is
+        # pinned separately so session tags cannot fragment consolidation.
+        self.assertEqual(alice["tags"], ["user:alice", "session:s1"])
+        self.assertEqual(alice["context"], curator.CHECKPOINT_CONTEXT)
+        self.assertEqual(alice["strategy"], curator.CHECKPOINT_STRATEGY)
+
+    def test_a_partial_distil_retires_nothing(self):
+        # The one way this script can lose knowledge is a full retire after a
+        # partial distil. A checkpoint that fails to land must stop the run.
+        api = self.make_api(fail_retains=(1,))
+        with contextlib.redirect_stderr(io.StringIO()):
+            summary = run(api)
+        self.assertIn("aborted before retiring", summary["skipped"])
+        self.assertIn("1/2 checkpoints landed", summary["skipped"])
+        self.assertEqual(api.invalidated, [])
+        self.assertEqual(api.consolidations, 0)
+
+    def test_an_observation_with_empty_text_is_dropped_without_aborting(self):
+        api = FakeHindsight([
+            fact("aged", age_days=400),
+            observation("blank", text="   "),
+            observation("o1"),
+        ])
+        summary = run(api)
+        self.assertIsNone(summary["skipped"])
+        self.assertEqual(len(api.retain_calls), 1)
+        self.assertEqual(summary["distilled"], 1)
+
+
+# --------------------------------------------------------------------------- #
+# The HTTP client's retry policy
+# --------------------------------------------------------------------------- #
+
+
+class _Http:
+    """A scripted urlopen: each entry is an int status to raise or a dict to return."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self.calls = 0
+
+    def __call__(self, request, timeout=None):
+        self.calls += 1
+        step = self._script.pop(0)
+        if isinstance(step, int):
+            raise urllib.error.HTTPError(
+                request.full_url, step, "boom", {}, io.BytesIO(b"detail"))
+        return io.BytesIO(json.dumps(step).encode())
+
+
+class TestHindsightClient(unittest.TestCase):
+    def api(self, script):
+        http = _Http(script)
+        patcher = patch("urllib.request.urlopen", http)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        # The backoff is real time.sleep; a test must not pay it.
+        sleeper = patch.object(curator.time, "sleep", lambda s: None)
+        sleeper.start()
+        self.addCleanup(sleeper.stop)
+        return curator.Hindsight("http://kv.example"), http
+
+    def test_a_rate_limit_is_retried_until_it_clears(self):
+        api, http = self.api([429, 429, {"ok": True}])
+        self.assertEqual(api.call("GET", "/x"), {"ok": True})
+        self.assertEqual(http.calls, 3)
+
+    def test_a_non_retryable_status_raises_immediately(self):
+        api, http = self.api([404])
+        with self.assertRaises(RuntimeError) as caught:
+            api.call("GET", "/x")
+        self.assertIn("HTTP 404", str(caught.exception))
+        self.assertEqual(http.calls, 1)
+
+    def test_retain_does_not_retry_a_500(self):
+        # Retain persists its successful prefix before failing, so a retried
+        # 500 duplicates rows — it once turned 646 units into 1,959. The 500
+        # must surface on the first attempt.
+        api, http = self.api([500])
+        with self.assertRaises(RuntimeError):
+            api.retain("bank", [{"content": "x"}])
+        self.assertEqual(http.calls, 1)
+
+    def test_everything_else_still_retries_a_500(self):
+        api, http = self.api([500, {"config": {}}])
+        self.assertEqual(api.bank_config("bank"), {})
+        self.assertEqual(http.calls, 2)
+
+
+# --------------------------------------------------------------------------- #
+# The helpers the selection rests on
+# --------------------------------------------------------------------------- #
+
+
+class TestHelpers(unittest.TestCase):
+    def test_parse_time_reads_zulu_and_naive_timestamps(self):
+        self.assertEqual(
+            curator.parse_time("2026-08-19T12:00:00Z"),
+            datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        naive = curator.parse_time("2026-08-19T12:00:00")
+        self.assertEqual(naive.tzinfo, timezone.utc)
+
+    def test_parse_time_returns_none_for_garbage_not_a_default(self):
+        for value in (None, "", "not-a-date", "2026-13-45T99:99:99Z"):
+            with self.subTest(value=value):
+                self.assertIsNone(curator.parse_time(value))
+
+    def test_scope_tags_keeps_scopes_and_drops_provenance(self):
+        unit = {"tags": ["user:alice", "session:s1", "scope:shared", "topic:gke"]}
+        self.assertEqual(curator.scope_tags(unit), ["user:alice", "scope:shared"])
+        self.assertEqual(curator.scope_tags({}), [])
+
+    def test_build_checkpoints_reports_every_unscopable_observation(self):
+        items, problems = curator.build_checkpoints([
+            observation("good"),
+            observation("untagged", tags=[]),
+            observation("torn", tags=["user:a", "user:b"]),
+        ])
+        self.assertEqual(len(items), 1)
+        self.assertEqual(len(problems), 2)
+        self.assertIn("no scope tag", problems[0])
+        self.assertIn("2 scope tags", problems[1])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/observability_script_harness.py
+++ b/agents/platform/scripts/observability_script_harness.py
@@ -7,9 +7,10 @@ of them defines a main() to import, so each test executes its subject with
 `gcloud` and `urllib.request.urlopen` stubbed. Nothing here ever touches the
 network.
 
-The tests live in this directory rather than beside the scripts for the same
-reason test_submit_suggestion.py does: CI discovers tests per directory in
-PYTHON_TEST_DIRS, and the skill's scripts/ directory is not one of them.
+The tests live in this directory to sit beside test_submit_suggestion.py and
+share this harness. PYTHON_TEST_DIRS would also discover them next to the
+scripts (the `agents/*/skills/*/scripts/test_*.py` glob is how the fleet-audit
+tests run), so this placement is a choice, not a constraint.
 """
 
 import io

--- a/agents/platform/scripts/observability_script_harness.py
+++ b/agents/platform/scripts/observability_script_harness.py
@@ -1,0 +1,82 @@
+"""Shared harness for the observability skill's script tests.
+
+The five scripts under `agents/platform/skills/kube-agents-observability/scripts/`
+are procedural: argparse, a gcloud token, one or more HTTPS calls, print. None
+of them defines a main() to import, so each test executes its subject with
+`runpy.run_path` — which keeps coverage attributed to the script file — with
+`gcloud` and `urllib.request.urlopen` stubbed. Nothing here ever touches the
+network.
+
+The tests live in this directory rather than beside the scripts for the same
+reason test_submit_suggestion.py does: CI discovers tests per directory in
+PYTHON_TEST_DIRS, and the skill's scripts/ directory is not one of them.
+"""
+
+import io
+import json
+import runpy
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS_DIR = HERE.parent / "skills" / "kube-agents-observability" / "scripts"
+
+
+class FakeResponse:
+    """The slice of an HTTPResponse the scripts use: a context manager with read()."""
+
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+        self.status = 200
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def run_script(name, argv, responses, token=b"fake-token\n"):
+    """Execute one observability script with its externals stubbed.
+
+    `responses` is a list of (url_fragment, payload) pairs. Each urlopen call is
+    answered by the first pair whose fragment appears in the requested URL; a
+    payload that is an Exception instance is raised instead, which is how a test
+    stages an HTTPError or URLError. A URL nothing matches is a test bug and
+    fails loudly.
+
+    Returns (exit_code, stdout). exit_code is 0 when the script ran to the end
+    without calling exit().
+    """
+    script = SCRIPTS_DIR / name
+
+    def fake_urlopen(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for fragment, payload in responses:
+            if fragment in url:
+                if isinstance(payload, Exception):
+                    raise payload
+                return FakeResponse(payload)
+        raise AssertionError(f"unexpected URL fetched: {url}")
+
+    out = io.StringIO()
+    code = 0
+    with patch.object(sys, "argv", [name, *argv]), \
+            patch("subprocess.check_output", return_value=token), \
+            patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+            redirect_stdout(out):
+        try:
+            runpy.run_path(str(script), run_name="observability_script")
+        except SystemExit as e:
+            if e.code is None:
+                code = 0
+            elif isinstance(e.code, int):
+                code = e.code
+            else:
+                code = 1
+    return code, out.getvalue()

--- a/agents/platform/scripts/test_analyze_trace_latency.py
+++ b/agents/platform/scripts/test_analyze_trace_latency.py
@@ -1,0 +1,103 @@
+"""Unit tests for the observability skill's trace-latency analysis.
+
+Run: python3 -m unittest agents/platform/scripts/test_analyze_trace_latency.py
+
+This script does duration arithmetic and states the result to an SRE as fact,
+so the tests pin the numbers: a recorded payload must come out as the exact
+seconds it encodes, and a seconds/milliseconds slip must be visible in the
+assertion, not hidden by a fuzzy match.
+"""
+
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from observability_script_harness import run_script  # noqa: E402
+
+SCRIPT = "analyze_trace_latency.py"
+ARGS = ["--project-id", "proj-1"]
+
+
+def trace_list(*trace_ids):
+    return {"traces": [{"traceId": t} for t in trace_ids]}
+
+
+def span(name, start, end):
+    return {"name": name, "startTime": start, "endTime": end}
+
+
+class TestAnalyzeTraceLatency(unittest.TestCase):
+    def test_a_recorded_trace_parses_to_the_expected_durations(self):
+        detail = {"spans": [
+            span("model-call", "2026-08-19T10:00:00Z", "2026-08-19T10:00:01.500000Z"),
+            span("tool-call", "2026-08-19T10:00:01.500000Z", "2026-08-19T10:00:02.500000Z"),
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [
+            ("traces?", trace_list("abc123")),
+            ("traces/abc123", detail),
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("Trace ID: abc123", out)
+        # 1.5s + 1s back to back: the trace spans exactly 2.5 seconds. A unit
+        # slip would print 2500.000 or 0.003 here.
+        self.assertIn("Total Duration: 2.500 seconds", out)
+        self.assertIn("Total Spans: 2", out)
+        # Sorted by duration descending, the slower span leads the breakdown.
+        self.assertLess(out.index("model-call"), out.index("tool-call"))
+        self.assertIn("1.500s", out)
+        self.assertIn("60.0%", out)
+
+    def test_nanosecond_timestamps_do_not_distort_the_arithmetic(self):
+        # Cloud Trace emits nanosecond precision; fromisoformat takes at most
+        # microseconds. The truncation must cost precision, not magnitude.
+        detail = {"spans": [
+            span("exact", "2026-08-19T10:00:00.123456789Z",
+                 "2026-08-19T10:00:02.123456789Z"),
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [
+            ("traces?", trace_list("t1")),
+            ("traces/t1", detail),
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("Total Duration: 2.000 seconds", out)
+        self.assertIn("2.000s", out)
+
+    def test_an_empty_window_says_no_traces_rather_than_reporting_zeroes(self):
+        code, out = run_script(SCRIPT, ARGS, [("traces?", {"traces": []})])
+        self.assertEqual(code, 0)
+        self.assertIn("No traces found in the specified window.", out)
+        self.assertNotIn("Total Duration", out)
+
+    def test_a_trace_whose_detail_fetch_fails_is_skipped_not_invented(self):
+        err = urllib.error.HTTPError("url", 500, "boom", {}, None)
+        err.read = lambda: b"backend error"
+        code, out = run_script(SCRIPT, ARGS, [
+            ("traces?", trace_list("gone")),
+            ("traces/gone", err),
+        ])
+        self.assertEqual(code, 0)
+        self.assertIn("HTTP Error 500", out)
+        self.assertNotIn("Trace ID: gone", out)
+
+    def test_spans_missing_timestamps_are_excluded_from_the_breakdown(self):
+        detail = {"spans": [
+            span("good", "2026-08-19T10:00:00Z", "2026-08-19T10:00:01Z"),
+            {"name": "no-times"},
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [
+            ("traces?", trace_list("t2")),
+            ("traces/t2", detail),
+        ])
+        self.assertEqual(code, 0)
+        # The span count is honest about what arrived; the duration math only
+        # uses what could be timed.
+        self.assertIn("Total Spans: 2", out)
+        self.assertIn("Total Duration: 1.000 seconds", out)
+        self.assertNotIn("no-times", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/test_check_token_usage.py
+++ b/agents/platform/scripts/test_check_token_usage.py
@@ -1,0 +1,119 @@
+"""Unit tests for the observability skill's token-usage delta.
+
+Run: python3 -m unittest agents/platform/scripts/test_check_token_usage.py
+
+The script sums counter deltas across time series and prints them as the day's
+token spend. The tests pin the integers exactly: point ordering, the int64
+string format the REST API uses, and counter resets all change the number, and
+a wrong number here is stated fluently to whoever asked.
+"""
+
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from observability_script_harness import run_script  # noqa: E402
+
+SCRIPT = "check_token_usage.py"
+ARGS = ["--project-id", "proj-1"]
+
+INPUT_METRIC = "litellm_input_tokens_metric_total"
+OUTPUT_METRIC = "litellm_output_tokens_metric_total"
+CACHED_METRIC = "litellm_input_cached_tokens_metric_total"
+
+
+def point(end_time, value):
+    return {"interval": {"endTime": end_time}, "value": value}
+
+
+def series(points):
+    return {"timeSeries": [{"points": points}]}
+
+
+EMPTY = {"timeSeries": []}
+
+
+def run(input_payload, output_payload=EMPTY, cached_payload=EMPTY):
+    return run_script(SCRIPT, ARGS, [
+        (INPUT_METRIC, input_payload),
+        (CACHED_METRIC, cached_payload),
+        (OUTPUT_METRIC, output_payload),
+    ])
+
+
+class TestCheckTokenUsage(unittest.TestCase):
+    def test_a_recorded_payload_parses_to_the_expected_delta(self):
+        # The API returns newest first; the script must sort before diffing,
+        # or 100 -> 350 reads as a reset and the delta comes out as 100.
+        payload = series([
+            point("2026-08-19T10:05:00Z", {"doubleValue": 350.0}),
+            point("2026-08-19T10:00:00Z", {"doubleValue": 100.0}),
+        ])
+        code, out = run(payload)
+        self.assertEqual(code, 0)
+        result = json.loads(out)
+        self.assertEqual(result["input_tokens"], 250)
+        self.assertEqual(result["output_tokens"], 0)
+        self.assertEqual(result["cached_input_tokens"], 0)
+
+    def test_int64_values_arrive_as_strings_and_still_count(self):
+        # REST returns int64Value as a string. Dropping it to the 0 fallback
+        # would report a silent zero for every counter metric.
+        payload = series([
+            point("2026-08-19T10:00:00Z", {"int64Value": "1000"}),
+            point("2026-08-19T10:05:00Z", {"int64Value": "4000"}),
+        ])
+        code, out = run(EMPTY, output_payload=payload)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["output_tokens"], 3000)
+
+    def test_a_counter_reset_adds_the_post_reset_value_not_a_negative(self):
+        # Pod restarts reset the counter: 500 -> 30 means 30 new tokens since
+        # the reset, not -470.
+        payload = series([
+            point("2026-08-19T10:00:00Z", {"doubleValue": 500.0}),
+            point("2026-08-19T10:05:00Z", {"doubleValue": 30.0}),
+        ])
+        code, out = run(payload)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["input_tokens"], 30)
+
+    def test_deltas_sum_across_pods(self):
+        payload = {"timeSeries": [
+            {"points": [point("2026-08-19T10:00:00Z", {"doubleValue": 0.0}),
+                        point("2026-08-19T10:05:00Z", {"doubleValue": 100.0})]},
+            {"points": [point("2026-08-19T10:00:00Z", {"doubleValue": 0.0}),
+                        point("2026-08-19T10:05:00Z", {"doubleValue": 42.0})]},
+        ]}
+        code, out = run(payload)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["input_tokens"], 142)
+
+    def test_no_data_reports_zeroes_in_the_documented_shape(self):
+        code, out = run(EMPTY)
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_input_tokens": 0,
+        })
+
+    def test_an_api_error_is_printed_beside_the_zero_it_causes(self):
+        # Current behaviour: a failed metric query contributes 0 but the error
+        # is printed first, so the zero is never silent. If this ever changes
+        # to a bare 0 with no message, that is a regression worth failing on.
+        err = urllib.error.HTTPError("url", 500, "boom", {}, None)
+        err.read = lambda: b"backend error"
+        code, out = run(err)
+        self.assertEqual(code, 0)
+        self.assertIn("HTTP Error 500", out)
+        self.assertIn(INPUT_METRIC, out)
+        self.assertIn('"input_tokens": 0', out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/test_fetch_traces.py
+++ b/agents/platform/scripts/test_fetch_traces.py
@@ -1,0 +1,58 @@
+"""Unit tests for the observability skill's raw trace fetch.
+
+Run: python3 -m unittest agents/platform/scripts/test_fetch_traces.py
+
+fetch_traces.py is a pass-through: whatever the Trace API returns is printed
+verbatim as JSON. The property worth pinning is exactly that — it neither
+invents nor drops anything — plus the failure paths exiting nonzero instead of
+printing something that could be mistaken for an empty result.
+"""
+
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from observability_script_harness import run_script  # noqa: E402
+
+SCRIPT = "fetch_traces.py"
+ARGS = ["--project-id", "proj-1"]
+TRACES_URL = "cloudtrace.googleapis.com"
+
+
+class TestFetchTraces(unittest.TestCase):
+    def test_a_recorded_payload_is_printed_verbatim(self):
+        payload = {"traces": [
+            {"traceId": "abc123", "projectId": "proj-1"},
+            {"traceId": "def456", "projectId": "proj-1"},
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(TRACES_URL, payload)])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), payload)
+
+    def test_an_empty_window_prints_the_empty_response_not_an_error(self):
+        code, out = run_script(SCRIPT, ARGS, [(TRACES_URL, {})])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), {})
+
+    def test_an_api_error_exits_nonzero_with_the_status_named(self):
+        err = urllib.error.HTTPError("url", 500, "boom", {}, None)
+        err.read = lambda: b"backend error"
+        code, out = run_script(SCRIPT, ARGS, [(TRACES_URL, err)])
+        self.assertEqual(code, 1)
+        self.assertIn("HTTP Error 500", out)
+
+    def test_a_connection_failure_exits_nonzero(self):
+        code, out = run_script(
+            SCRIPT, ARGS,
+            [(TRACES_URL, urllib.error.URLError("connection refused"))],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("Failed to connect", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/test_get_chat_users.py
+++ b/agents/platform/scripts/test_get_chat_users.py
@@ -1,0 +1,89 @@
+"""Unit tests for the observability skill's active-chat-users listing.
+
+Run: python3 -m unittest agents/platform/scripts/test_get_chat_users.py
+
+The script mines Cloud Logging entries for `User=<email>` markers and counts
+messages per user. The tests feed recorded entry shapes — textPayload, the
+jsonPayload fallback, and payloads with no marker — and pin the exact counts.
+"""
+
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from observability_script_harness import run_script  # noqa: E402
+
+SCRIPT = "get_chat_users.py"
+ARGS = ["--project-id", "proj-1"]
+ENTRIES_URL = "entries:list"
+
+
+def text_entry(email):
+    return {"textPayload": f"Logging incoming GChat event User={email} space=..."}
+
+
+class TestGetChatUsers(unittest.TestCase):
+    def test_a_recorded_payload_counts_messages_per_user(self):
+        payload = {"entries": [
+            text_entry("alice@example.com"),
+            text_entry("bob@example.com"),
+            text_entry("alice@example.com"),
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, payload)])
+        self.assertEqual(code, 0)
+        result = json.loads(out)
+        self.assertEqual(result["active_chat_users"], {
+            "alice@example.com": 2,
+            "bob@example.com": 1,
+        })
+        self.assertEqual(result["time_window_hours"], 24)
+
+    def test_users_are_sorted_by_email_for_a_stable_report(self):
+        payload = {"entries": [
+            text_entry("zoe@example.com"),
+            text_entry("ann@example.com"),
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, payload)])
+        self.assertEqual(code, 0)
+        emails = list(json.loads(out)["active_chat_users"].keys())
+        self.assertEqual(emails, ["ann@example.com", "zoe@example.com"])
+
+    def test_the_json_payload_fallback_still_finds_the_user(self):
+        payload = {"entries": [
+            {"jsonPayload": {"log": "Logging incoming GChat event User=carol@x.io"}},
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, payload)])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["active_chat_users"], {"carol@x.io": 1})
+
+    def test_entries_without_a_user_marker_are_not_counted(self):
+        payload = {"entries": [
+            {"textPayload": "Logging incoming GChat event with no user field"},
+            text_entry("dan@example.com"),
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, payload)])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["active_chat_users"], {"dan@example.com": 1})
+
+    def test_no_entries_reports_an_empty_mapping_not_a_fabricated_zero(self):
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, {})])
+        self.assertEqual(code, 0)
+        result = json.loads(out)
+        self.assertEqual(result["active_chat_users"], {})
+        self.assertEqual(result["time_window_hours"], 24)
+
+    def test_a_logging_api_error_exits_nonzero_rather_than_reporting_nobody(self):
+        err = urllib.error.HTTPError("url", 403, "denied", {}, None)
+        err.read = lambda: b"permission denied"
+        code, out = run_script(SCRIPT, ARGS, [(ENTRIES_URL, err)])
+        self.assertEqual(code, 1)
+        self.assertIn("HTTP Error 403", out)
+        self.assertNotIn("active_chat_users", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/test_get_metric_descriptors.py
+++ b/agents/platform/scripts/test_get_metric_descriptors.py
@@ -1,0 +1,66 @@
+"""Unit tests for the observability skill's metric-descriptor listing.
+
+Run: python3 -m unittest agents/platform/scripts/test_get_metric_descriptors.py
+"""
+
+import json
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from observability_script_harness import run_script  # noqa: E402
+
+SCRIPT = "get_metric_descriptors.py"
+ARGS = ["--project-id", "proj-1"]
+METRICS_URL = "metricDescriptors"
+
+
+class TestGetMetricDescriptors(unittest.TestCase):
+    def test_a_recorded_payload_keeps_only_the_litellm_metrics(self):
+        payload = {"metricDescriptors": [
+            {"type": "prometheus.googleapis.com/litellm_input_tokens_metric_total/counter"},
+            {"type": "kubernetes.io/container/cpu/core_usage_time"},
+            {"type": "prometheus.googleapis.com/litellm_output_tokens_metric_total/counter"},
+            {"description": "a descriptor with no type at all"},
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(METRICS_URL, payload)])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), [
+            "prometheus.googleapis.com/litellm_input_tokens_metric_total/counter",
+            "prometheus.googleapis.com/litellm_output_tokens_metric_total/counter",
+        ])
+
+    def test_no_matching_metrics_reports_an_empty_list(self):
+        payload = {"metricDescriptors": [
+            {"type": "kubernetes.io/container/memory/used_bytes"},
+        ]}
+        code, out = run_script(SCRIPT, ARGS, [(METRICS_URL, payload)])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), [])
+
+    def test_an_empty_response_reports_an_empty_list(self):
+        code, out = run_script(SCRIPT, ARGS, [(METRICS_URL, {})])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out), [])
+
+    def test_an_api_error_exits_nonzero_rather_than_reporting_no_metrics(self):
+        err = urllib.error.HTTPError("url", 500, "boom", {}, None)
+        err.read = lambda: b"backend error"
+        code, out = run_script(SCRIPT, ARGS, [(METRICS_URL, err)])
+        self.assertEqual(code, 1)
+        self.assertIn("HTTP Error 500", out)
+
+    def test_a_connection_failure_exits_nonzero(self):
+        code, out = run_script(
+            SCRIPT, ARGS,
+            [(METRICS_URL, urllib.error.URLError("no route to host"))],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("Failed to connect", out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/agents/platform/scripts/test_submit_suggestion.py
+++ b/agents/platform/scripts/test_submit_suggestion.py
@@ -195,6 +195,16 @@ class TestCheckBranch(unittest.TestCase):
                     submit_suggestion.check_branch(branch)
                 self.assertIn("CRITICAL SECURITY REFUSAL", str(caught.exception))
 
+    def test_a_protected_branch_is_refused_through_a_ref_prefix(self):
+        # "refs/heads/main".lower() is not in PROTECTED_BRANCHES, but pushing
+        # it moves main all the same. The check must compare the short name,
+        # whatever form the caller used.
+        for branch in ("refs/heads/main", "refs/heads/MASTER", "REFS/HEADS/production"):
+            with self.subTest(branch=branch):
+                with self.assertRaises(ValueError) as caught:
+                    submit_suggestion.check_branch(branch)
+                self.assertIn("CRITICAL SECURITY REFUSAL", str(caught.exception))
+
     def test_an_empty_branch_is_refused_before_the_protected_list(self):
         # `"".lower() in PROTECTED_BRANCHES` is False, so an empty name would
         # otherwise sail through and push whatever HEAD happens to be.

--- a/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
+++ b/agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py
@@ -45,7 +45,12 @@ def check_branch(branch_name: str) -> str:
     branch = (branch_name or "").strip()
     if not branch:
         raise ValueError("--branch is required and must not be empty")
-    if branch.lower() in PROTECTED_BRANCHES:
+    # Compare the short name: "refs/heads/main" is not in PROTECTED_BRANCHES,
+    # but pushing it moves main all the same.
+    short = branch.lower()
+    if short.startswith("refs/heads/"):
+        short = short[len("refs/heads/"):]
+    if short in PROTECTED_BRANCHES:
         raise ValueError(
             f"CRITICAL SECURITY REFUSAL: Force-pushing to protected branch "
             f"'{branch_name}' is strictly blocked by GKE SRE guardrails!"


### PR DESCRIPTION
## Summary

Closes the largest measured unit-test gaps outside the operator: the five observability skill scripts (317 statements, 0% covered) and the memory TTL curator (187 statements, 0%), and fixes a real authority bug the work uncovered — `submit_suggestion.py` refused pushes to `main` but not to `refs/heads/main`, so a fully-qualified ref walked through the protected-branch check. 105 tests on the branch, all green.

## Why This Change

The observability scripts produce the latency, token-usage, and user numbers the Platform Agent states to SREs as fact. A parsing or unit slip there is the wrong-but-fluent failure no LLM judge catches, because the prose reads fine; the only place to catch it is a unit test with a recorded payload and a pinned expectation. They had zero. The TTL curator deletes agent memory unattended on a schedule; its selection logic (what dies, what survives, what happens to a malformed row) also had zero tests. And the protected-branch bypass is exactly the class of bug the testing strategy exists for: the agent holds push credentials, and the guard checked the spelling rather than the destination.

## What Changed

- `agents/platform/scripts/` — `observability_script_harness.py` (runs each script via `runpy` with `gcloud` and `urlopen` stubbed; nothing touches the network) plus five test files, 26 tests: recorded payloads parse to the expected figures, empty responses say "no data" rather than 0, and the seconds/milliseconds arithmetic is pinned so a 1000x slip fails
- `agents/chat/scripts/test_memory_ttl_curator.py` — 23 tests: all five abort guards, the TTL boundary (a row at exactly the cutoff survives), an unparseable date is skipped rather than deleted, dry run writes nothing, and the retry policy (a retain must not retry a 500)
- `agents/platform/skills/submit-suggestion/scripts/submit_suggestion.py` — strips a `refs/heads/` prefix (case-insensitive) before the protected-branch comparison; the original comparison is untouched when the prefix is absent. The new test in `test_submit_suggestion.py` was written first and failed on the old code for `refs/heads/main`, `refs/heads/MASTER`, and `REFS/HEADS/production`

## Context

Part of the testing-strategy implementation work; companion to the coverage-measurement PR, which makes deltas like these visible on every PR. Merge adjacency: #813 and #565 touch `submit_suggestion.py` (different lines, different concerns — whoever merges second should re-run its tests), #504 carries a pre-fix copy of the file in its diff context but does not modify the guard.

An earlier draft of this branch also added tests and a Makefile glob for `agents/platform/plugins/incident_context/` — both arrived upstream independently while the branch was in review, so that commit was dropped in favour of upstream's. Two small angles upstream's tests do not cover (Authorization-header handling, enum-valued platforms) are noted for a follow-up.

This PR was generated with the help of Claude.

## Testing

- All 52 tests in the six touched `agents/platform/scripts/` modules pass in one process (which also demonstrates the runpy harness leaks no state between suites)
- 23 curator tests and upstream's 29 incident_context tests pass; full per-directory discovery re-run after rebasing onto current main
- Red/green on the fix verified by a reviewer who rebuilt the pre-fix layout: the new test fails on the old code, passes on the new
- `make docs-check` green

### Live validation

Not live-tested: the change is unit tests plus a three-line guard fix in a script whose protected-branch refusal path is exactly what the new test exercises. The guard cannot be safely demonstrated against a real installation without asking a live agent to push to a protected branch on a real repository, which is the event the guard exists to prevent; the red/green run against the pre-fix code is the evidence the mechanism works.

## Self-Review

Adversarial pass run by a separate reviewer context that did not write the change, following `.agents/skills/review-adversarial/SKILL.md` (angles A–J), plus a docs-drift pass. Findings and dispositions:

- **Should-fix, fixed:** the harness docstring claimed the tests could not live beside the scripts because the skill's `scripts/` directory is outside `PYTHON_TEST_DIRS` — false, the `agents/*/skills/*/scripts/test_*.py` glob has covered it all along. Rewritten to say the placement is a choice, not a constraint
- **Nit, fixed:** the Makefile comment "none of them are packages" went stale; corrected
- The fix was traced adversarially: `heads/main` and `refs/remotes/origin/main` as push destinations cannot move a protected branch (they land elsewhere in the ref namespace), while `refs/heads/main` can and is now refused; a branch literally named with slashes that resolves to `refs/heads/main` is refused correctly since pushing it does move `main`. Nothing is weakened — the pre-existing comparison is preserved verbatim when no prefix is present
- Verified not-mirrors: removing the trace-point sort, mishandling counter resets, or flipping the TTL boundary from `<` to `<=` each breaks the corresponding test
- Docs-drift: `declarative-workflow.md`'s protected-branch claim stays true (and becomes more true); no doc enumerates the glob list; no map entry owed (no doc files changed)

## Risk & Rollout

Low. The only behaviour change is `submit_suggestion.py` refusing strictly more inputs than before — inputs that were always meant to be refused. Everything else is additive test code. Revert is a clean revert of two commits. Whoever merges second between this and #813/#565 should re-run `test_submit_suggestion.py`.
