### PR TITLE
fix(install): let --gvisor sandbox the agent on Autopilot

### DIFF
--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -87,7 +87,7 @@ Changing your mind later is the same engine: `./install.sh --menu` opens a Day-2
 ## Common flags and toggles
 
 - `--dry-run` — always runs `terraform validate`, and adds a full `terraform plan` preview when Application Default Credentials exist; nothing is created, and state stays local. It still overwrites `vars.sh`.
-- `--gvisor=true` — provisions the gVisor sandbox node pool (the `gke-cluster` module's `enable_gvisor_node_pool`).
+- `--gvisor=true` — runs the agent under the `gvisor` RuntimeClass. On a Standard cluster that also provisions the sandbox node pool (the `gke-cluster` module's `enable_gvisor_node_pool`); Autopilot ships the RuntimeClass and needs no pool.
 - `--enable-google-chat` — provisions the Google Chat Pub/Sub backend and enables the CR's `googleChat` integration.
 - `--memory=file|hindsight|off` — the agent's long-term memory store; `hindsight` deploys the Hindsight API and Postgres into the cluster.
 

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -87,7 +87,7 @@ Changing your mind later is the same engine: `./install.sh --menu` opens a Day-2
 ## Common flags and toggles
 
 - `--dry-run` — always runs `terraform validate`, and adds a full `terraform plan` preview when Application Default Credentials exist; nothing is created, and state stays local. It still overwrites `vars.sh`.
-- `--gvisor=true` — runs the agent under the `gvisor` RuntimeClass. On a Standard cluster that also provisions the sandbox node pool (the `gke-cluster` module's `enable_gvisor_node_pool`); Autopilot ships the RuntimeClass and needs no pool.
+- `--gvisor=true` — runs the agent under the `gvisor` RuntimeClass. On a Standard cluster that also provisions the sandbox node pool (the `gke-cluster` module's `enable_gvisor_node_pool`); Autopilot ships the RuntimeClass and needs no pool, from GKE 1.27.4-gke.800 onwards. The installer stops before applying anything if an Autopilot cluster is older than that.
 - `--enable-google-chat` — provisions the Google Chat Pub/Sub backend and enables the CR's `googleChat` integration.
 - `--memory=file|hindsight|off` — the agent's long-term memory store; `hindsight` deploys the Hindsight API and Postgres into the cluster.
 

--- a/docs/site/src/content/docs/overview/architecture.mdx
+++ b/docs/site/src/content/docs/overview/architecture.mdx
@@ -106,7 +106,7 @@ Everything except the LLM (and, for hosted providers, the LLM API endpoint) runs
 
 - **Namespace**: `kubeagents-system`.
 - **Node pools**: default node pool is enough for the operator, Platform Agent, LiteLLM, and Minty. If you use vLLM, provision a GPU node pool separately.
-- **Optional gVisor node pool** for sandboxed skill execution (the `gke-cluster` module's `enable_gvisor_node_pool`, opt-in via the installer's `--gvisor=true`).
+- **Optional gVisor node pool** for sandboxed skill execution, opt-in via the installer's `--gvisor=true`. Standard only (the `gke-cluster` module's `enable_gvisor_node_pool`); Autopilot ships the `gvisor` RuntimeClass and needs no pool.
 - **Workload Identity** bindings are pre-provisioned by the [`kube-agents-iam` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/kube-agents-iam) — the Platform Agent gets a configurable permission set (`read-only`, `gke-admin`, or `custom`). See [Security & IAM](/kube-agents/reference/security-and-iam/).
 
 ### Capacity and isolation
@@ -114,7 +114,7 @@ Everything except the LLM (and, for hosted providers, the LLM API endpoint) runs
 The hub footprint (operator, Platform Agent, LiteLLM, Minty) is small and roughly fixed — it doesn't grow with the number of clusters the agent manages, since those are read remotely through the GKE MCP server. What actually drives node capacity:
 
 - **vLLM.** Local inference needs a GPU node pool; hosted LiteLLM does not.
-- **gVisor.** Sandboxed skill execution runs the agent pod on the optional `gvisor-pool` (the installer's `--gvisor=true`).
+- **gVisor.** Sandboxed skill execution puts the agent pod under the `gvisor` RuntimeClass (the installer's `--gvisor=true`). On Standard that means a `gvisor-pool` to run it on; on Autopilot it costs no extra capacity.
 
 For production, prefer a **dedicated cluster** for the harness. The agent GSA can hold broad GKE permissions in the `gke-admin` set, so a hard cluster boundary limits blast radius if the execution sandbox is ever compromised. A shared cluster (with the `kubeagents-system` namespace for logical isolation) is fine for development.
 

--- a/k8s-operator/scripts/installer_common.sh
+++ b/k8s-operator/scripts/installer_common.sh
@@ -490,6 +490,22 @@ write_tfvars_from_state() {
     fi
   fi
 
+  # ENABLE_GVISOR is one intent — run the agent sandboxed — and the two things
+  # that satisfy it differ by cluster shape. Standard needs the sandbox node
+  # pool AND the RuntimeClass on the pod; Autopilot ships the gvisor
+  # RuntimeClass natively and has no pool to manage, so asking the gke-cluster
+  # module for one there fails the plan. Deriving both from the probed
+  # cluster_mode keeps --gvisor=true meaning the same thing on either shape.
+  local gvisor_node_pool="false" agent_runtime_class=""
+  if is_truthy "${ENABLE_GVISOR:-false}"; then
+    agent_runtime_class="gvisor"
+    if [ "$cluster_mode" = "standard" ]; then
+      gvisor_node_pool="true"
+    else
+      print_info "Cluster '${CLUSTER_NAME}' is Autopilot: using its built-in gvisor RuntimeClass, with no sandbox node pool to provision."
+    fi
+  fi
+
   local old_umask
   old_umask="$(umask)"
   umask 077
@@ -507,8 +523,9 @@ write_tfvars_from_state() {
     echo "create_cluster             = ${create_cluster}"
     echo "allow_external_dns_traffic = true"
     echo "deletion_protection        = false"
-    echo "enable_gvisor_node_pool    = $(hcl_bool "${ENABLE_GVISOR:-false}")"
+    echo "enable_gvisor_node_pool    = ${gvisor_node_pool}"
     echo "gvisor_pool_name           = $(hcl_str "${GVISOR_POOL_NAME:-gvisor-pool}")"
+    echo "agent_runtime_class        = $(hcl_str "${agent_runtime_class}")"
     echo "enable_cert_manager        = ${enable_cert_manager}"
     echo ""
     echo "image_tag                  = $(hcl_str "${image_tag}")"

--- a/k8s-operator/scripts/installer_common.sh
+++ b/k8s-operator/scripts/installer_common.sh
@@ -75,6 +75,22 @@ is_valid_cmek_encryption_state() {
   return 1
 }
 
+# ─── GKE Version Comparison ───────────────────────────────────────────────────
+# The first GKE version whose Autopilot clusters ship the gvisor RuntimeClass:
+# https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods
+GVISOR_AUTOPILOT_MIN_VERSION="1.27.4-gke.800"
+
+# True when GKE version $1 is at or above $2. `sort -V` reads both the dotted
+# fields and the -gke.N suffix numerically, so it puts gke.800 below gke.1500
+# where a lexical compare does the opposite. Callers check the version's shape
+# themselves: an unparseable string here is "unknown", not "too old", and the
+# two deserve different answers.
+gke_version_at_least() {
+  local have="${1:-}" want="${2:-}"
+  [ "$have" = "$want" ] ||
+    [ "$(printf '%s\n%s\n' "$have" "$want" | sort -V | head -n1)" = "$want" ]
+}
+
 retry() {
   local max_retries=$1
   local delay=$2
@@ -502,6 +518,33 @@ write_tfvars_from_state() {
     if [ "$cluster_mode" = "standard" ]; then
       gvisor_node_pool="true"
     else
+      # Autopilot's gvisor RuntimeClass arrived in a specific GKE version, and
+      # asking an older cluster for it fails late and unrecognisably: the
+      # operator stops at its RuntimeClass check before writing the agent
+      # Deployment, the Helm release still reports success because that
+      # Deployment is operator-created rather than chart-rendered, and
+      # install.sh's post-apply gate exits 1 with "Expected deployment
+      # 'platform-agent-gateway' was not created" — after the cluster, IAM,
+      # KMS, cert-manager and the release have all been applied, naming
+      # nothing about a RuntimeClass. Refuse here instead, which is where the
+      # gke-cluster module's precondition refuses the equivalent Standard
+      # mistake. cluster_mode is only "autopilot" because the describe above
+      # succeeded, so there is always a live cluster to ask.
+      #
+      # `trap - ERR` as well as `|| true`, for the bash 3.2 reason the probe
+      # above gives: a gcloud failure here is a best-effort miss, not an abort.
+      local master_version
+      master_version="$(trap - ERR; gcloud container clusters describe "${CLUSTER_NAME}" \
+        --location "${REGION}" --project "${PROJECT_ID}" \
+        --format="value(currentMasterVersion)" 2>/dev/null || true)"
+      master_version="${master_version//[[:space:]]/}"
+      if [[ ! "$master_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-gke\.[0-9]+$ ]]; then
+        print_warning "Could not read the GKE version of Autopilot cluster '${CLUSTER_NAME}'; proceeding as though it supports GKE Sandbox. Below ${GVISOR_AUTOPILOT_MIN_VERSION} the agent Deployment is never created and this run fails at its final check."
+      elif ! gke_version_at_least "$master_version" "$GVISOR_AUTOPILOT_MIN_VERSION"; then
+        print_error "Autopilot cluster '${CLUSTER_NAME}' runs GKE ${master_version}, and its gvisor RuntimeClass needs ${GVISOR_AUTOPILOT_MIN_VERSION} or later."
+        print_info "Upgrade the cluster, or re-run with --gvisor=false. Continuing would apply every GCP and Helm resource and then fail on a missing agent Deployment."
+        return 1
+      fi
       print_info "Cluster '${CLUSTER_NAME}' is Autopilot: using its built-in gvisor RuntimeClass, with no sandbox node pool to provision."
     fi
   fi

--- a/terraform/examples/full-install/main.tf
+++ b/terraform/examples/full-install/main.tf
@@ -434,8 +434,11 @@ resource "helm_release" "kube_agents" {
         }
         availability = {
           # The gVisor pool only exists to run the agent sandboxed, so the
-          # pool and the runtimeClass move together.
-          runtimeClassName = var.enable_gvisor_node_pool ? "gvisor" : ""
+          # pool and the runtimeClass move together. That derivation covers
+          # Standard only: Autopilot has the gvisor RuntimeClass and no pool,
+          # so enable_gvisor_node_pool is false there by force and
+          # agent_runtime_class is what asks for the sandbox.
+          runtimeClassName = var.agent_runtime_class != "" ? var.agent_runtime_class : (var.enable_gvisor_node_pool ? "gvisor" : "")
         }
       }
       security = {

--- a/terraform/examples/full-install/terraform.tfvars.example
+++ b/terraform/examples/full-install/terraform.tfvars.example
@@ -43,6 +43,10 @@ api_server_key = "REPLACE_WITH_A_STRONG_RANDOM_KEY"
 # enable_gvisor_node_pool = true
 # gvisor_pool_name        = "gvisor-pool"
 
+# Sandboxing on Autopilot, which has the gvisor RuntimeClass built in and no
+# node pool to provision. enable_gvisor_node_pool must stay false there.
+# agent_runtime_class = "gvisor"
+
 # Cluster tuning
 # deletion_protection = true
 # release_channel     = "REGULAR"

--- a/terraform/examples/full-install/variables.tf
+++ b/terraform/examples/full-install/variables.tf
@@ -43,7 +43,7 @@ variable "gvisor_pool_name" {
 }
 
 variable "agent_runtime_class" {
-  description = "RuntimeClass for the agent pod, overriding what enable_gvisor_node_pool implies. Autopilot ships the gvisor RuntimeClass with no node pool to manage — and enable_gvisor_node_pool fails the plan there — so \"gvisor\" here is how an Autopilot install gets the sandbox. Empty derives the value from enable_gvisor_node_pool."
+  description = "RuntimeClass for the agent pod, overriding what enable_gvisor_node_pool implies. Autopilot ships the gvisor RuntimeClass with no node pool to manage — and enable_gvisor_node_pool fails the plan there — so \"gvisor\" here is how an Autopilot install asks for the sandbox without reaching for extra_helm_values. Empty derives the value from enable_gvisor_node_pool."
   type        = string
   default     = ""
 }

--- a/terraform/examples/full-install/variables.tf
+++ b/terraform/examples/full-install/variables.tf
@@ -42,6 +42,12 @@ variable "gvisor_pool_name" {
   default     = "gvisor-pool"
 }
 
+variable "agent_runtime_class" {
+  description = "RuntimeClass for the agent pod, overriding what enable_gvisor_node_pool implies. Autopilot ships the gvisor RuntimeClass with no node pool to manage — and enable_gvisor_node_pool fails the plan there — so \"gvisor\" here is how an Autopilot install gets the sandbox. Empty derives the value from enable_gvisor_node_pool."
+  type        = string
+  default     = ""
+}
+
 variable "deletion_protection" {
   description = "Whether deletion protection is enabled on the cluster. Passed through to the gke-cluster module; must be false before `terraform destroy` can remove the cluster."
   type        = bool

--- a/tests/test_installer_common.py
+++ b/tests/test_installer_common.py
@@ -208,6 +208,50 @@ class InstallerCommonTest(unittest.TestCase):
             self.assertIn('cluster_mode               = "standard"', content)
             self.assertIn("create_cluster             = true", content)
 
+    # ── ENABLE_GVISOR splits into a pool and a RuntimeClass by cluster shape ──
+
+    def test_tfvars_gvisor_on_standard_asks_for_pool_and_runtime_class(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            dest = pathlib.Path(out_dir) / "terraform.tfvars"
+            proc = self._run(
+                f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
+                env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
+                describe_stub="printf '\\n'; exit 0",
+            )
+            self.assertIn("rc=0", proc.stdout, proc.stderr)
+            content = dest.read_text()
+            self.assertIn("enable_gvisor_node_pool    = true", content)
+            self.assertIn('agent_runtime_class        = "gvisor"', content)
+
+    def test_tfvars_gvisor_on_autopilot_asks_for_runtime_class_only(self):
+        # enable_gvisor_node_pool fails the plan on Autopilot, which ships the
+        # gvisor RuntimeClass natively. Passing ENABLE_GVISOR straight through
+        # made --gvisor=true unusable there rather than sandboxing the agent.
+        with tempfile.TemporaryDirectory() as out_dir:
+            dest = pathlib.Path(out_dir) / "terraform.tfvars"
+            proc = self._run(
+                f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
+                env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
+                describe_stub="printf 'True\\n'; exit 0",
+            )
+            self.assertIn("rc=0", proc.stdout, proc.stderr)
+            content = dest.read_text()
+            self.assertIn("enable_gvisor_node_pool    = false", content)
+            self.assertIn('agent_runtime_class        = "gvisor"', content)
+
+    def test_tfvars_without_gvisor_sets_neither(self):
+        with tempfile.TemporaryDirectory() as out_dir:
+            dest = pathlib.Path(out_dir) / "terraform.tfvars"
+            proc = self._run(
+                f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
+                env={"API_SERVER_KEY": "k"},
+                describe_stub="printf '\\n'; exit 0",
+            )
+            self.assertIn("rc=0", proc.stdout, proc.stderr)
+            content = dest.read_text()
+            self.assertIn("enable_gvisor_node_pool    = false", content)
+            self.assertIn('agent_runtime_class        = ""', content)
+
     def test_tfvars_refuses_to_guess_on_a_transient_describe_failure(self):
         # Anything other than NOT_FOUND must abort: reading an auth expiry or
         # network blip as "cluster absent" regenerates standard/create=true

--- a/tests/test_installer_common.py
+++ b/tests/test_installer_common.py
@@ -39,6 +39,23 @@ DATA_MODE_STATE = _state_doc(
 )
 
 
+def _autopilot_describe_stub(version="1.31.5-gke.1023000"):
+    """A `clusters describe` stub for an Autopilot cluster.
+
+    The generator asks twice on this path — autopilot.enabled first, then
+    currentMasterVersion for the gVisor floor — so the stub answers on the
+    --format it is given. An empty `version` stands for a version that
+    could not be read.
+    """
+    return (
+        'case "$*" in\n'
+        f"  *currentMasterVersion*) printf '{version}\\n' ;;\n"
+        "  *) printf 'True\\n' ;;\n"
+        "esac\n"
+        "exit 0"
+    )
+
+
 class InstallerCommonTest(unittest.TestCase):
     def _run(
         self,
@@ -232,12 +249,59 @@ class InstallerCommonTest(unittest.TestCase):
             proc = self._run(
                 f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
                 env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
-                describe_stub="printf 'True\\n'; exit 0",
+                describe_stub=_autopilot_describe_stub(),
             )
             self.assertIn("rc=0", proc.stdout, proc.stderr)
             content = dest.read_text()
             self.assertIn("enable_gvisor_node_pool    = false", content)
             self.assertIn('agent_runtime_class        = "gvisor"', content)
+
+    def test_tfvars_gvisor_on_autopilot_below_the_version_floor_aborts(self):
+        # Autopilot's gvisor RuntimeClass has a version floor, and a cluster
+        # under it takes the whole apply before failing on a missing agent
+        # Deployment. Abort while nothing has been applied.
+        proc = self._run(
+            'rc=0; write_tfvars_from_state /dev/null || rc=$?; echo "rc=$rc"',
+            env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
+            describe_stub=_autopilot_describe_stub("1.26.9-gke.9999"),
+        )
+        self.assertIn("rc=1", proc.stdout, proc.stderr)
+        self.assertIn("1.26.9-gke.9999", proc.stderr)
+        self.assertIn("1.27.4-gke.800", proc.stderr)
+
+    def test_tfvars_gvisor_on_autopilot_warns_when_the_version_is_unreadable(self):
+        # An unparseable version is "unknown", not "too old": say so and carry
+        # on rather than blocking an install on a gcloud output change.
+        with tempfile.TemporaryDirectory() as out_dir:
+            dest = pathlib.Path(out_dir) / "terraform.tfvars"
+            proc = self._run(
+                'print_warning() { echo "WARN: $*" >&2; }; '
+                f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
+                env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
+                describe_stub=_autopilot_describe_stub(""),
+            )
+            self.assertIn("rc=0", proc.stdout, proc.stderr)
+            self.assertIn("Could not read the GKE version", proc.stderr)
+            self.assertIn('agent_runtime_class        = "gvisor"', dest.read_text())
+
+    def test_tfvars_gvisor_on_standard_does_not_check_the_autopilot_floor(self):
+        # The floor is Autopilot's. On Standard the node pool carries the
+        # RuntimeClass, so an old cluster there must not be rejected by it.
+        with tempfile.TemporaryDirectory() as out_dir:
+            dest = pathlib.Path(out_dir) / "terraform.tfvars"
+            proc = self._run(
+                f'write_tfvars_from_state "{dest}"; echo "rc=$?"',
+                env={"API_SERVER_KEY": "k", "ENABLE_GVISOR": "true"},
+                describe_stub=(
+                    'case "$*" in\n'
+                    "  *currentMasterVersion*) printf '1.24.0-gke.100\\n' ;;\n"
+                    "  *) printf '\\n' ;;\n"
+                    "esac\n"
+                    "exit 0"
+                ),
+            )
+            self.assertIn("rc=0", proc.stdout, proc.stderr)
+            self.assertIn("enable_gvisor_node_pool    = true", dest.read_text())
 
     def test_tfvars_without_gvisor_sets_neither(self):
         with tempfile.TemporaryDirectory() as out_dir:
@@ -251,6 +315,22 @@ class InstallerCommonTest(unittest.TestCase):
             content = dest.read_text()
             self.assertIn("enable_gvisor_node_pool    = false", content)
             self.assertIn('agent_runtime_class        = ""', content)
+
+    def test_gke_version_at_least_orders_the_gke_suffix_numerically(self):
+        # gke.800 is older than gke.1500, which a lexical compare gets backwards.
+        cases = {
+            "1.27.4-gke.800 1.27.4-gke.800": "0",
+            "1.27.4-gke.1500 1.27.4-gke.800": "0",
+            "1.30.11-gke.1131000 1.27.4-gke.800": "0",
+            "1.28.1-gke.100 1.27.4-gke.800": "0",
+            "1.27.4-gke.700 1.27.4-gke.800": "1",
+            "1.27.3-gke.1700 1.27.4-gke.800": "1",
+            "1.26.9-gke.9999 1.27.4-gke.800": "1",
+        }
+        for pair, want in cases.items():
+            with self.subTest(pair=pair):
+                proc = self._run(f"gke_version_at_least {pair}; echo \"rc=$?\"")
+                self.assertIn(f"rc={want}", proc.stdout, proc.stderr)
 
     def test_tfvars_refuses_to_guess_on_a_transient_describe_failure(self):
         # Anything other than NOT_FOUND must abort: reading an auth expiry or


### PR DESCRIPTION
## Summary

`install.sh --gvisor=true` cannot sandbox the agent on an Autopilot cluster, and on an adopted one it fails the install outright. `ENABLE_GVISOR` is written straight through to `enable_gvisor_node_pool`, and the composition derives the pod's `runtimeClassName` from that same variable — but a sandbox node pool is a Standard-only thing, and the `gke-cluster` module deliberately fails the plan when one is asked for on Autopilot. This splits the intent ("run the agent sandboxed") from the two different things that satisfy it on the two cluster shapes, and refuses up front on an Autopilot cluster too old to carry the RuntimeClass. The default does not change: no gVisor unless asked for.

## Why This Change

`install.sh --gvisor=true` against an adopted Autopilot cluster fails `terraform plan`, with no way for the user to work around it.

`write_tfvars_from_state` probes the live cluster and generates `cluster_mode = "autopilot"`, then emits `enable_gvisor_node_pool = true` from `ENABLE_GVISOR` regardless. That takes `google_container_node_pool.gvisor`'s count to 1, so its precondition evaluates and `gke-cluster/main.tf` rejects the plan — correctly, because a sandbox node pool is Standard-only and Autopilot ships the `gvisor` RuntimeClass natively. The generator rewrites `terraform.tfvars` on every run, so hand-editing it does not help. `install.sh` hardcodes `cluster_mode="standard"` for a fresh create, which is why this only bites on adoption.

Underneath it, `terraform/examples/full-install/main.tf:438` derives the pod's RuntimeClass from that same rejected variable — `runtimeClassName = var.enable_gvisor_node_pool ? "gvisor" : ""` — so the knob that decides sandboxing is forced false on the one cluster shape that sandboxes for free. Autopilot is the composition's default `cluster_mode`.

A direct Terraform user is underserved rather than blocked. `extra_helm_values` is deep-merged over the computed values document, so setting `platformAgent.deployment.availability.runtimeClassName` there already sandboxes the agent on Autopilot today — the composition's documented escape hatch for chart settings it does not expose as its own variable. `install.sh` cannot use it: the generator has no nested-object writer, and `extra_helm_values` belongs to the user, so writing into it would clobber whatever they set. Hence a named variable.

## What Changed

- `k8s-operator/scripts/installer_common.sh` — `write_tfvars_from_state` derives two values from `ENABLE_GVISOR` instead of one, using the `cluster_mode` it has already probed: `enable_gvisor_node_pool` (Standard only) and a new `agent_runtime_class`. On Autopilot with gVisor asked for it also reads `currentMasterVersion` and refuses below `GVISOR_AUTOPILOT_MIN_VERSION` (1.27.4-gke.800), where the RuntimeClass does not exist yet; `gke_version_at_least` compares with `sort -V`, so `gke.800` orders below `gke.1500`. A version string that does not parse warns and proceeds. Because `uninstall.sh` and `upgrade.sh` call the same generator, all three front doors stay consistent.
- `terraform/examples/full-install/variables.tf`, `main.tf`, `terraform.tfvars.example` — new `agent_runtime_class` (default `""`), and `runtimeClassName` prefers it, falling back to the existing `enable_gvisor_node_pool` derivation. An explicit conditional rather than `coalesce()`, which errors when every argument is empty.
- `tests/test_installer_common.py` — seven cases: Standard + gVisor asks for both, Autopilot + gVisor asks for the RuntimeClass only, neither without, the floor rejecting, an unreadable version warning, Standard not being subject to the Autopilot floor, and the `sort -V` ordering.
- `docs/site/src/content/docs/install/quickstart-gke.mdx`, `docs/site/src/content/docs/overview/architecture.mdx` — `--gvisor=true` no longer means "provisions the node pool" on both shapes.

`gke-cluster` is untouched: the precondition is right, and a direct Terraform user who sets `enable_gvisor_node_pool = true` on Autopilot should still get that error. `agent_runtime_class` is the answer it points them at, and its description says so.

## Context

This is against the install surface #797 (`1c06e1ab`). It was first opened against that branch as `gke-agentic/kube-agents#155` for discussion with @mplakhtiy; #797 merged before the patch was applied there, so this supersedes it and #155 is closed.

Four judgement calls worth pushing back on:

1. **A named variable rather than `extra_helm_values`.** **Why This Change** gives the reason. The narrower alternative is a boolean `enable_gvisor` at the composition level that derives both the pool and the class from `cluster_mode` internally, keeping `enable_gvisor_node_pool` an implementation detail. That is a bigger change to the variable surface, which is why I did not make it — but it puts the cluster-shape logic in Terraform rather than in bash.
2. **An unparseable GKE version warns and proceeds** rather than aborting: "unknown" is not "too old", and blocking an install on a change in `gcloud` output formatting is the worse failure. The cost is that a genuinely old cluster whose version cannot be read still reaches the late failure this check exists to prevent.
3. **The floor check lives in the shared generator, so `uninstall.sh` and `upgrade.sh` inherit the abort.** Neither has a `--gvisor` flag to turn it off, and both source `vars.sh` after the environment, so `ENABLE_GVISOR=false` in the environment does not override it. The reachable path is a Day-2 `install.sh --gvisor=true` against a sub-floor Autopilot cluster: `install.sh:1879` persists `ENABLE_GVISOR=true` to `vars.sh` before the generator refuses at `:1950`, and every later run of any front door then aborts until `vars.sh` is edited by hand. What keeps this off the table in practice is that 1.27.4-gke.800 is below every currently supported GKE release — a coupling rather than a guarantee. Gating on the calling front door would put install/uninstall knowledge into the shared generator, which seemed the worse trade.
4. **`agent_runtime_class` takes any string** and passes it to `runtimeClassName` unvalidated. Deliberate — a custom RuntimeClass is a legitimate thing to want — but it is a way to get a nonexistent RuntimeClass into the CR via tfvars. The operator catches it: `validateRuntimeClass` marks the CR `Degraded/RuntimeClassNotFound` rather than failing silently.

Open pull requests that touch the same files, neither solving this and neither a duplicate — flagging them as merge-conflict warnings:

- **#720** (@bnaylor, F10 slice 2b) — `full-install/main.tf`, `variables.tf`.
- **#504** (@kirill-kosov, multiple GitHub repos) — `full-install/main.tf`, `variables.tf`, `terraform.tfvars.example`.

**#496** (gVisor default-on) was closed on 2026-08-21: it modified `provision_02_gvisor_nodepool.sh` and `provision_08_deploy_platform_agent.sh`, which #797 deleted. This PR changes no default and does not depend on that decision.

## Testing

- `python3 -m unittest discover -s tests` — 206 tests, all pass.
- `python3 -m unittest tests.test_installer_common` — 23 pass, including the 7 added.
- `make docs-check` — passes (generated regions current, links resolve, terminology, map coverage).
- **Not run:** `terraform fmt -check` and `terraform validate`. No `terraform` binary in this environment; the HCL is hand-formatted to match the surrounding blocks.
- **Not run:** `prettier --check` on the changed `.mdx`. Not installed here. There is no `.prettierrc`, so `proseWrap` stays at the `preserve` default and the changed bullet lines do not reflow.
- **`pull-kube-agents-smoke-test`** failed on `79e93ce0` and is re-running on `de5f9b4e` against a newer base; not yet settled. It is not a required check, and the same job failed on #496 against an unrelated diff, but I could not read the build log to confirm either way.

### Live validation

Not live-tested. No kube-agents installation of either shape is reachable from where this was written, and no GCP project to create one in. No layer was observed live — not the generated tfvars against a real plan, not the CR, not the agent pod.

An earlier version of this section said the change is "only observable on an Autopilot cluster". That was wrong: the generator emits `agent_runtime_class` on every path and the `runtimeClassName` expression was rewritten for all cluster shapes, so the Standard half is testable on the shape `install.sh` creates by default.

Three runs a reviewer should ask for before merging, cheapest first:

1. **Standard, `--gvisor=true`** — the shape `install.sh` creates by default. Confirm `terraform.tfvars` carries `enable_gvisor_node_pool = true` and `agent_runtime_class = "gvisor"`, the plan is clean, and the agent pod comes up with `runtimeClassName: gvisor` on the `gvisor-pool`. This is the regression check: behaviour here must be identical to before.
2. **Autopilot at or above 1.27.4-gke.800, adopted, `--gvisor=true`** — the case this PR exists for. Confirm the plan no longer fails, no node pool is created, and the agent pod comes up with `runtimeClassName: gvisor`.
3. **Autopilot below the floor, `--gvisor=true`** — confirm the generator exits non-zero naming the version, with nothing applied. This needs a cluster below every currently supported GKE release, so it may only be reachable by stubbing `gcloud container clusters describe`, which is what the unit test does.

## Self-Review

Reviewed in a session that did not write the change, handed the branch and the pull request and nothing else. The first pass was run in the writing context, which AGENTS.md does not accept and whose cost the bot's first finding demonstrated; angles from that pass are folded in below where they still hold.

Angles, and what they found:

- **Does the problem still exist on `main`?** Re-checked 23 commits on. All four pieces unchanged: `full-install/main.tf:438`, the generator's straight-through `ENABLE_GVISOR`, the `gke-cluster` precondition, and no `agent_runtime_class`. None of those 23 commits touched a file this branch touches, so there is no rebase conflict either.
- **Is the stated problem the real one?** No, and this rewrote **Why This Change**. `extra_helm_values` is deep-merged over the computed values document, so a direct Terraform user could already reach `runtimeClassName` on Autopilot; "a new Autopilot install can never run the agent sandboxed" was false. The adoption breakage is the part with no workaround, and the section now leads with it.
- **Premises checked upstream, not against our own docs.** Google's GKE Sandbox page states "GKE Sandbox is ready to use in Autopilot clusters running GKE version 1.27.4-gke.800 and later" and confirms Autopilot provides the `gvisor` RuntimeClass with nothing to enable. Both load-bearing assumptions verified at the source rather than from `gke-cluster/main.tf` restating them.
- **Version comparator.** `gke_version_at_least` exercised over ten shapes beyond the seven in the test table, including `1.27.4` against `1.27.10` and six-digit `gke.` suffixes. Correct throughout. `sort -V` is an existing repo dependency (`min_versions.sh:30`), so it is not new portability risk.
- **The operator claim in the new comment.** Verified rather than taken on trust: `platformagent_controller.go:245-256` returns at step 10 before `reconcileWorkload`, so "no Deployment, therefore no pod" is accurate.
- **Blast radius on paths that already work.** Standard + gVisor still emits `enable_gvisor_node_pool = true` and resolves `runtimeClassName` to `gvisor`; unset still emits `false` and `""`. No previously-emitted tfvars value flips, so there is no regenerate-and-replace risk.
- **Where the refusal lands, across all three front doors.** Context item 3, and the one finding that changed the write-up rather than the code. The earlier reasoning for why the shared abort is safe — "an install below the floor cannot have been created" — was wrong, because adoption persists `ENABLE_GVISOR=true` to `vars.sh` before the generator refuses. What actually keeps it off the table is the floor sitting below every supported GKE release. Documented rather than moved, for the reason in that item.
- **`set -u`, ERR trap, redirect placement.** `${ENABLE_GVISOR:-false}` is guarded; `cluster_mode` is assigned before the new block; `trap - ERR` inside the substitution matches the probe above it; the `print_info` sits outside the `{ … } > "$dest"` block, which the tests confirm by reading the generated file back.
- **Comment accuracy against source.** `installer_common.sh`, `main.tf` and `terraform.tfvars.example` all check out. `variables.tf`'s description did not: it read as though `agent_runtime_class` were the only route on Autopilot, with `extra_helm_values` declared 350 lines below it in the same file. Fixed in `de5f9b4e`.

Deliberately not fixed: the `gke-cluster` module's precondition and error message. Pointing a reusable module at a variable belonging to one of its callers is the wrong coupling.

Not covered: `terraform validate` and `prettier`, for the reasons under **Testing**; no live run, see **Live validation**; and the failing smoke test, whose log I could not read.

## Risk & Rollout

The default is unchanged: with `ENABLE_GVISOR` unset the generator emits `enable_gvisor_node_pool = false` and `agent_runtime_class = ""`, identical in effect to today. Standard with `--gvisor=true` is unchanged too.

The new failure mode is Context item 3. On an Autopilot cluster below 1.27.4-gke.800, `--gvisor=true` now aborts the generator before anything is applied — an earlier and better-named failure than the `terraform plan` rejection it replaces, but reaching a wider set of commands, because `uninstall.sh` and `upgrade.sh` share the generator.

Reverting is a revert of three commits, or of the merge. The new tfvars key is additive: an older composition reading it warns about an undeclared variable rather than failing.

---

_This PR was prepared with the help of Claude._
