### PR TITLE
fix(google-chat): say the failed-attachment notice in English

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -547,16 +547,58 @@ RUN cp /tmp/channel-directory/channel_directory_threads.py /opt/hermes/gateway/c
 # drives the real patched render_blocks over the reported line and asserts on
 # the elements it returns.
 # See the module docstring in deploy/docker/patches/apply_slack_code_emphasis.py.
+#
+# Google Chat: say the failed-attachment notice in English, and only offer
+# /setup-files where it works. Upstream writes the four user-facing lines of
+# `_post_attachment_fallback` in Spanish, inside an otherwise English adapter,
+# so a user who asked for a report in English gets a Spanish refusal and reads
+# it as the agent having switched language mid-thread. It is not a rare path:
+# native media.upload needs a *per-user* OAuth token, so until each user has run
+# /setup-files in their own DM every attachment lands here, and on the install
+# where this was reported no user had. The second half of the fix is the advice
+# itself: agents/platform/scripts/google_chat_relay_patch.py stubs /setup-files
+# out, and the operator sets GOOGLE_CHAT_RELAY_URL on every install with Google
+# Chat enabled, so on all of them that instruction is a dead end. The notice
+# branches on the _credential_proxy_relay_patched marker that patch leaves on
+# the class, and offers what does work there instead. The direct branch is for
+# an image run outside the operator; it is kept rather than folded away because
+# deleting it hard-codes the instruction off in the one place it works.
+#
+# A grep guard cannot catch this class of bug. The two branches differ only in
+# which strings are appended, so a patch that wired the condition backwards --
+# offering /setup-files precisely where it has been stubbed out -- greps
+# identically to a correct one, and the next reader of the difference is a user
+# following an instruction into a dead end.
+# verify_google_chat_attachment_notice.py therefore builds the real notice from
+# the patched adapter on both branches and asserts on the text.
+#
+# This rides the Slack block's COPY and RUN rather than buying two layers of its
+# own, and it is a different subsystem, which the channel-directory block above
+# treats as grounds for its own pair. The difference is the budget: this stage
+# is the base for `credential-proxy`, the longest chain in the file and the one
+# the layer note at the top of this file is about, so a pair of its own is two
+# layers out of what little that chain has left. Both patches here rewrite an
+# outbound message surface, which is as close to one subject as the grouping
+# gets.
+# See the module docstring in
+# deploy/docker/patches/apply_google_chat_attachment_notice.py.
 COPY deploy/docker/patches/apply_slack_code_emphasis.py \
      deploy/docker/patches/verify_slack_code_emphasis.py \
+     deploy/docker/patches/apply_google_chat_attachment_notice.py \
+     deploy/docker/patches/verify_google_chat_attachment_notice.py \
      deploy/docker/patches/patchlib.py \
-     /tmp/slack-code-emphasis/
-RUN /opt/hermes/.venv/bin/python3 /tmp/slack-code-emphasis/apply_slack_code_emphasis.py /opt/hermes && \
+     /tmp/message-surface/
+RUN /opt/hermes/.venv/bin/python3 /tmp/message-surface/apply_slack_code_emphasis.py /opt/hermes && \
     grep -q "_CODE_SENTINEL_RE" /opt/hermes/plugins/platforms/slack/block_kit.py && \
     ! grep -q "inline code is opaque" /opt/hermes/plugins/platforms/slack/block_kit.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/message-surface/apply_google_chat_attachment_notice.py /opt/hermes && \
+    grep -qF "kube-agents patch: attachment-fallback notice" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
+    grep -qF "_credential_proxy_relay_patched" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
+    ! grep -qF "No he podido adjuntar" /opt/hermes/plugins/platforms/google_chat/adapter.py && \
     cd /opt/hermes && \
-    /opt/hermes/.venv/bin/python3 /tmp/slack-code-emphasis/verify_slack_code_emphasis.py && \
-    rm -rf /tmp/slack-code-emphasis
+    /opt/hermes/.venv/bin/python3 /tmp/message-surface/verify_slack_code_emphasis.py && \
+    /opt/hermes/.venv/bin/python3 /tmp/message-surface/verify_google_chat_attachment_notice.py && \
+    rm -rf /tmp/message-surface
 
 # Perf: hide worker-only kanban tools from orchestrator profiles. Upstream gates
 # every lifecycle tool with _check_kanban_mode, which is true for any profile

--- a/deploy/docker/patches/apply_google_chat_attachment_notice.py
+++ b/deploy/docker/patches/apply_google_chat_attachment_notice.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Say the attachment failed in English, and say something that is true.
+
+Run by ``deploy/docker/Dockerfile`` against the Hermes tree at
+``plugins/platforms/google_chat/adapter.py``.
+
+The bug
+-------
+``_post_attachment_fallback`` is the notice a user gets when the bot produced a
+file and could not upload it. Upstream ships its four user-facing lines in
+Spanish, inside an otherwise English adapter with an English docstring above
+them::
+
+    f"⚠️ No he podido adjuntar **{filename}**.",
+    "Google Chat sólo permite adjuntar archivos cuando el bot tiene "
+    "permiso explícito tuyo (OAuth de usuario). Es un consentimiento "
+    "único que se hace desde este chat.",
+    "**Para activarlo:** envía `/setup-files` y sigue las instrucciones.",
+    f"Mientras tanto el archivo está en el host: `{path}`",
+
+Everything around it is English -- the adapter, its docstrings, the ``error=``
+string this same method returns -- so it reads to the person in the thread as
+the agent having switched language mid-conversation, which is how it was
+reported and what sent the first investigation after the model rather than
+after the adapter.
+
+Nothing about it is rare. Native ``media.upload`` needs a *per-user* OAuth
+token, so the notice fires on every attachment until each user has run
+``/setup-files`` in their own DM. On the staging install this was reported
+from, no user had: ``$HERMES_HOME/google_chat_user_tokens`` did not exist, so
+every card that attached a file took this path. Card ``t_e5e1ba5e`` delivered a
+9,867-byte report that way on 2026-08-18, and ``gateway.log`` carries the
+matching ``[Google_Chat] Failed to send media (.md)`` from 2026-08-11.
+
+The second defect
+-----------------
+The Spanish text tells the user to run ``/setup-files``. On an install that
+reaches Chat through the credential proxy, that command does nothing:
+``agents/platform/scripts/google_chat_relay_patch.py`` replaces
+``_handle_setup_files_command`` with a stub answering "File attachment setup is
+unavailable through the credential proxy", because the OAuth flow needs
+credentials the relay deliberately does not hold. Translating the line without
+touching it would ship an English dead end.
+
+Upstream's notice always ended with something the user could do, and dropping
+``/setup-files`` on the relay branch would end it with a host path they cannot
+reach. So that branch offers the one thing that does work there: asking the
+agent to paste the contents into the chat, which needs no credentials because
+the file is already on the agent's own disk.
+
+So the middle of the notice branches on whether the relay patch is installed,
+which it records as ``_credential_proxy_relay_patched`` (``RELAY_FLAG`` below)
+on the adapter class. The attribute is set in ``patch_adapter_class`` at adapter
+construction, well before any message is sent, and reading it through
+``type(self)`` means an install with no relay is unaffected: it keeps the
+``/setup-files`` instruction, because there the command works.
+
+Every install the operator deploys takes the relay branch --
+``k8s-operator/internal/controller/platformagent_manifests.go`` sets
+``GOOGLE_CHAT_RELAY_URL`` whenever ``integration.googleChat.enabled`` is true,
+and ``sitecustomize.py`` installs the patch on that variable alone. The other
+branch is for an image run outside the operator, and it is kept rather than
+folded away because deleting it would leave the instruction hard-coded off in
+the one configuration where it works.
+
+That the flag is private to the relay patch is the fragile part of this: a
+rename there silently restores the dead end and nothing in the adapter would
+notice. ``test_google_chat_attachment_notice.py`` reads the relay patch's own
+source and asserts the assignment, so the rename fails CI rather than shipping.
+
+What is deliberately not changed
+--------------------------------
+The ``error=`` string on the returned ``SendResult``. It is English already and
+it goes to ``gateway.log``, not to a user, so the one reader it has is someone
+grepping for why an upload failed — "run /setup-files in chat" is the right
+lead for them even on a relay install, where the next thing they find is the
+stub refusing.
+
+Neither does this make attachments work. The file still only exists on the
+agent host, and the notice still says so; the user-facing fix for that is
+either per-user OAuth or having the notifier inline a report rather than
+attach it, and both are larger than a string.
+
+Upstream: not reported. Worth doing — nobody running Hermes in an English
+deployment wants this — but the branch above is kube-agents-specific and would
+not survive the trip, so the two are separate pieces of work.
+
+Usage::
+
+    python3 apply_google_chat_attachment_notice.py [HERMES_ROOT]  # /opt/hermes
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import patchlib
+
+RELATIVE = "plugins/platforms/google_chat/adapter.py"
+
+# Asserted in the built bundle by the Dockerfile, so a patch that silently stops
+# applying fails the image build instead of shipping Spanish.
+BUILD_MARKER = "kube-agents patch: attachment-fallback notice"
+
+# The attribute agents/platform/scripts/google_chat_relay_patch.py leaves on the
+# adapter class it patched. Read by the notice below to decide whether
+# /setup-files is worth offering. It is that patch's private re-entrancy latch,
+# not an interface, so test_google_chat_attachment_notice.py pins the name
+# against the relay patch's source; see the module docstring.
+RELAY_FLAG = "_credential_proxy_relay_patched"
+
+# The docstring's second paragraph through the end of the message block. One
+# contiguous anchor rather than several, because the replacement rewrites the
+# whole of what it describes: the docstring promises a ``/setup-files`` flow
+# that the patched body only sometimes offers.
+ANCHOR = '''\
+        Tells the user that file delivery requires a one-time consent
+        flow (``/setup-files``) and reports the local-host path so the
+        file isn't lost. Returns ``success=False`` so callers know the
+        attachment did not land.
+        """
+        lines = []
+        if caption:
+            lines.append(caption)
+        lines.extend([
+            f"⚠️ No he podido adjuntar **{filename}**.",
+            "Google Chat sólo permite adjuntar archivos cuando el bot tiene "
+            "permiso explícito tuyo (OAuth de usuario). Es un consentimiento "
+            "único que se hace desde este chat.",
+            "**Para activarlo:** envía `/setup-files` y sigue las instrucciones.",
+            f"Mientras tanto el archivo está en el host: `{path}`",
+        ])
+'''
+
+PATCHED = '''\
+        Names the file, says why it could not be attached, and reports the
+        host path so the file is not lost. Returns ``success=False`` so
+        callers know the attachment did not land.
+
+        Whether the notice offers ``/setup-files`` depends on whether that
+        command can do anything here -- see the module docstring in
+        deploy/docker/patches/apply_google_chat_attachment_notice.py.
+        """
+        # kube-agents patch: attachment-fallback notice. Upstream wrote these
+        # lines in Spanish, which reads to the user as the agent changing
+        # language mid-thread, and pointed every install at /setup-files --
+        # including the ones whose relay patch has stubbed that command out.
+        relayed = getattr(type(self), "_credential_proxy_relay_patched", False)
+        lines = []
+        if caption:
+            lines.append(caption)
+        lines.append(f"⚠️ Couldn't attach **{filename}**.")
+        if relayed:
+            lines.append(
+                "File attachments are unavailable on this deployment: "
+                "uploading to Google Chat needs a per-user OAuth token, and "
+                "this install reaches Chat through the credential proxy, "
+                "which holds no user credentials."
+            )
+            lines.append(
+                "Ask me to paste the contents here if you need them in chat."
+            )
+        else:
+            lines.extend([
+                "Google Chat accepts an upload only once you have given the "
+                "bot explicit permission (user OAuth). It is a one-time "
+                "consent, done from this chat.",
+                "**To enable it:** send `/setup-files` and follow the steps.",
+            ])
+        lines.append(f"The file is on the agent host at: `{path}`")
+'''
+
+
+def apply(root: Path) -> None:
+    """Apply the patch under ``root``, or raise SystemExit with the reason."""
+    patch = patchlib.Patch(root, RELATIVE, prefix="google_chat_attachment_notice")
+    patch.refuse_if_patched(BUILD_MARKER)
+    patch.substitute(ANCHOR, PATCHED, label="attachment-fallback notice")
+    patch.commit("1 anchor")
+
+
+if __name__ == "__main__":
+    apply(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))

--- a/deploy/docker/patches/test_google_chat_attachment_notice.py
+++ b/deploy/docker/patches/test_google_chat_attachment_notice.py
@@ -1,0 +1,428 @@
+"""Unit tests for the Google Chat attachment-notice patch applied by the Dockerfile.
+
+Run: python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches
+
+``UPSTREAM`` below carries ``_post_attachment_fallback`` copied verbatim out of
+``plugins/platforms/google_chat/adapter.py`` in the pinned base image, wrapped in
+the smallest class and preamble that will run it. The anchor is exercised against
+the text it was derived from rather than against a paraphrase, and the patched
+result is then *run*, because the defect is in what the user reads: an applier
+whose anchor matched and which then emitted Spanish, or English pointing at a
+command that does nothing here, would be no use.
+
+The two branches are the substance. ``/setup-files`` is real guidance on an
+install that talks to Google Chat directly and a dead end on one that goes
+through the credential proxy, so which branch says it is the assertion that
+matters most, and it is the one a grep in the Dockerfile cannot make.
+"""
+
+import asyncio
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+from apply_google_chat_attachment_notice import (
+    BUILD_MARKER,
+    PATCHED,
+    RELAY_FLAG,
+    RELATIVE,
+    apply,
+)
+
+# deploy/docker/patches/ -> deploy/docker/ -> deploy/ -> repository root.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELAY_PATCH = REPO_ROOT / "agents/platform/scripts/google_chat_relay_patch.py"
+
+# Verbatim from plugins/platforms/google_chat/adapter.py in the pinned base
+# image, from ``async def`` to the closing paren of its ``return``. Everything
+# above the class is scaffolding: the real module reaches this method with
+# ``SendResult`` imported from gateway and a module logger already configured,
+# neither of which is worth dragging a Hermes tree in for.
+UPSTREAM = '''\
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class SendResult:
+    """Stand-in for gateway's dataclass of the same name.
+
+    Hand-rolled rather than ``@dataclass`` because the fixture is exec'd from a
+    spec that is never put in ``sys.modules``, and ``dataclass`` resolves
+    annotations through ``sys.modules[cls.__module__]``.
+    """
+
+    def __init__(self, success: bool, error: Optional[str] = None) -> None:
+        self.success = success
+        self.error = error
+
+
+class GoogleChatAdapter:
+    async def _post_attachment_fallback(
+        self,
+        chat_id: str,
+        path: str,
+        filename: str,
+        caption: Optional[str],
+        thread_id: Optional[str],
+    ) -> SendResult:
+        """Post a text notice when native attachment delivery is unavailable.
+
+        Tells the user that file delivery requires a one-time consent
+        flow (``/setup-files``) and reports the local-host path so the
+        file isn't lost. Returns ``success=False`` so callers know the
+        attachment did not land.
+        """
+        lines = []
+        if caption:
+            lines.append(caption)
+        lines.extend([
+            f"⚠️ No he podido adjuntar **{filename}**.",
+            "Google Chat s\xf3lo permite adjuntar archivos cuando el bot tiene "
+            "permiso expl\xedcito tuyo (OAuth de usuario). Es un consentimiento "
+            "\xfanico que se hace desde este chat.",
+            "**Para activarlo:** env\xeda `/setup-files` y sigue las instrucciones.",
+            f"Mientras tanto el archivo est\xe1 en el host: `{path}`",
+        ])
+        body: Dict[str, Any] = {"text": "\\n".join(lines)}
+        if thread_id:
+            body["thread"] = {"name": thread_id}
+        try:
+            await self._create_message(chat_id, body)
+        except Exception:
+            logger.debug(
+                "[GoogleChat] attachment fallback notice send failed",
+                exc_info=True,
+            )
+        return SendResult(
+            success=False,
+            error="google_chat: native attachment requires user OAuth — "
+            "run /setup-files in chat",
+        )
+'''
+
+# The report from card t_e5e1ba5e, whose notice was the reported message.
+FILENAME = "top-issue-deepdive.md"
+PATH = f"/opt/data/kanban/attachments/t_e5e1ba5e/{FILENAME}"
+
+# Every sentence upstream shipped. Asserted absent individually rather than as
+# one blob so a partial revert names which line came back.
+SPANISH = [
+    "No he podido adjuntar",
+    "Google Chat s\xf3lo permite adjuntar archivos",
+    "**Para activarlo:**",
+    "Mientras tanto el archivo",
+]
+
+# Log-facing, and deliberately untouched by the patch — see "What is
+# deliberately not changed" in the applier's module docstring.
+UPSTREAM_ERROR = (
+    "google_chat: native attachment requires user OAuth — "
+    "run /setup-files in chat"
+)
+
+
+def build(source=UPSTREAM):
+    """Materialise a fake Hermes tree containing ``source``."""
+    root = Path(tempfile.mkdtemp())
+    path = root / RELATIVE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    return root, path
+
+
+def load(path, name):
+    """Import the fixture so its behaviour can be asserted on."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def send(cls, *, caption=None, thread_id=None, filename=FILENAME, raises=False):
+    """Run the fallback on a bare instance; return ``(body_or_None, result)``.
+
+    ``object.__new__`` skips ``__init__``: the method touches nothing on the
+    instance but ``_create_message``, and a real adapter wants a config, a
+    Pub/Sub subscription and the Google SDK. ``raises`` makes the send fail, to
+    reach the swallow-and-still-return path.
+    """
+    adapter = object.__new__(cls)
+    sent = []
+
+    async def create_message(chat_id, body):
+        sent.append((chat_id, body))
+        if raises:
+            raise RuntimeError("Chat API said no")
+
+    adapter._create_message = create_message
+    result = asyncio.run(
+        cls._post_attachment_fallback(
+            adapter, "spaces/AAAA1234", PATH, filename, caption, thread_id
+        )
+    )
+    return (sent[0] if sent else None), result
+
+
+class UpstreamBugTest(unittest.TestCase):
+    """Pin the behaviour being fixed, so the patch is not asserted into a vacuum."""
+
+    def setUp(self):
+        _, path = build()
+        self.cls = load(path, "gc_adapter_upstream").GoogleChatAdapter
+
+    def test_upstream_answers_in_spanish(self):
+        """The message the user reported, reproduced from the shipped source."""
+        (_, body), _ = send(self.cls)
+        self.assertEqual(
+            body["text"],
+            f"⚠️ No he podido adjuntar **{FILENAME}**.\n"
+            "Google Chat s\xf3lo permite adjuntar archivos cuando el bot tiene "
+            "permiso expl\xedcito tuyo (OAuth de usuario). Es un consentimiento "
+            "\xfanico que se hace desde este chat.\n"
+            "**Para activarlo:** env\xeda `/setup-files` y sigue las instrucciones.\n"
+            f"Mientras tanto el archivo est\xe1 en el host: `{PATH}`",
+        )
+
+    def test_upstream_offers_setup_files_unconditionally(self):
+        """The second defect: no branch, so the relay install gets it too."""
+        relayed = type("Relayed", (self.cls,), {RELAY_FLAG: True})
+        (_, body), _ = send(relayed)
+        self.assertIn("/setup-files", body["text"])
+
+
+class PatchedFixture:
+    """Patch a fresh fixture per test and run real sends through the result."""
+
+    def setUp(self):
+        self.root, self.path = build()
+        apply(self.root)
+        self.mod = load(self.path, f"gc_adapter_{type(self).__name__}")
+        self.cls = self.mod.GoogleChatAdapter
+        # What the credential-proxy relay patch does to the class it installs
+        # into: agents/platform/scripts/google_chat_relay_patch.py sets this
+        # flag next to the /setup-files stub that makes the branch necessary.
+        self.relayed_cls = type(
+            "RelayedGoogleChatAdapter",
+            (self.cls,),
+            {RELAY_FLAG: True},
+        )
+
+    def text(self, cls=None, **kwargs):
+        (_, body), _ = send(cls or self.cls, **kwargs)
+        return body["text"]
+
+
+class LanguageTest(PatchedFixture, unittest.TestCase):
+    """The reported defect: the notice is English, in every branch."""
+
+    def test_no_spanish_survives_in_the_source(self):
+        source = self.path.read_text(encoding="utf-8")
+        for fragment in SPANISH:
+            with self.subTest(fragment=fragment):
+                self.assertNotIn(fragment, source)
+
+    def test_no_spanish_survives_in_either_rendered_notice(self):
+        for cls in (self.cls, self.relayed_cls):
+            for fragment in SPANISH:
+                with self.subTest(cls=cls.__name__, fragment=fragment):
+                    self.assertNotIn(fragment, self.text(cls))
+
+    def test_the_notice_is_ascii_apart_from_the_warning_sign(self):
+        """Catches a reintroduction in any language, not just the one seen.
+
+        Rendering with an ASCII filename and path is what makes this test the
+        whole notice rather than the caller's arguments — real ones can carry
+        anything.
+        """
+        for cls in (self.cls, self.relayed_cls):
+            with self.subTest(cls=cls.__name__):
+                rendered = self.text(cls, filename="report.md")
+                self.assertTrue(
+                    rendered.replace("⚠️", "").isascii(), rendered
+                )
+
+
+class BranchTest(PatchedFixture, unittest.TestCase):
+    """Which install is told to run ``/setup-files``, and which is told why not."""
+
+    def test_a_direct_install_keeps_the_setup_files_step(self):
+        """Asserted positively: fixing the language by deleting the guidance
+        would leave a user with a failed upload and nothing to do about it."""
+        rendered = self.text()
+        self.assertIn("/setup-files", rendered)
+        self.assertIn("OAuth", rendered)
+
+    def test_a_relay_install_does_not_offer_setup_files(self):
+        """The relay stubs the command out, so the instruction is a dead end."""
+        rendered = self.text(self.relayed_cls)
+        self.assertNotIn("/setup-files", rendered)
+        self.assertIn("credential proxy", rendered)
+
+    def test_a_relay_install_is_still_left_something_to_do(self):
+        """Upstream's notice always ended with an action, and this branch took
+        the only one it had away. What replaces it needs no credentials: the
+        file is already on the agent's disk, so it can be read out in chat."""
+        self.assertIn("paste", self.text(self.relayed_cls))
+
+    def test_the_flag_is_honoured_when_set_on_the_class_itself(self):
+        """How the relay patch actually sets it — on the class it patched.
+
+        The subclass used everywhere else in this suite would also pass under a
+        ``self.__dict__`` lookup, so without this the real call path is untested.
+        """
+        setattr(self.cls, RELAY_FLAG, True)
+        self.addCleanup(delattr, self.cls, RELAY_FLAG)
+        self.assertNotIn("/setup-files", self.text())
+
+    def test_an_absent_flag_reads_as_a_direct_install(self):
+        """The attribute does not exist upstream; a bare ``getattr`` would raise
+        and turn a cosmetic patch into a failed send."""
+        self.assertFalse(hasattr(self.cls, RELAY_FLAG))
+        self.assertIn("/setup-files", self.text())
+
+
+class NoticeContentTest(PatchedFixture, unittest.TestCase):
+    """What the notice has to carry however it is worded."""
+
+    def test_both_branches_name_the_file_and_where_it_ended_up(self):
+        """The host path is the only copy of the file that exists.
+
+        A notice that reports the failure without it loses a report the agent
+        spent a turn producing.
+        """
+        for cls in (self.cls, self.relayed_cls):
+            with self.subTest(cls=cls.__name__):
+                rendered = self.text(cls)
+                self.assertIn(FILENAME, rendered)
+                self.assertIn(PATH, rendered)
+
+    def test_the_caption_leads(self):
+        """``send_file`` passes the message the agent wrote alongside the file."""
+        rendered = self.text(caption="Here is the deep dive you asked for.")
+        self.assertTrue(
+            rendered.startswith("Here is the deep dive you asked for.\n"), rendered
+        )
+
+    def test_no_caption_means_no_leading_blank_line(self):
+        self.assertTrue(self.text().startswith("⚠️"))
+
+    def test_the_reply_stays_in_the_thread_it_was_asked_in(self):
+        (_, body), _ = send(self.cls, thread_id="spaces/AAAA1234/threads/xyz")
+        self.assertEqual(body["thread"], {"name": "spaces/AAAA1234/threads/xyz"})
+
+    def test_no_thread_id_sends_no_thread_key(self):
+        (_, body), _ = send(self.cls)
+        self.assertNotIn("thread", body)
+
+    def test_the_notice_goes_to_the_space_it_came_from(self):
+        (chat_id, _), _ = send(self.cls)
+        self.assertEqual(chat_id, "spaces/AAAA1234")
+
+
+class ContractTest(PatchedFixture, unittest.TestCase):
+    """What callers see. Unchanged by the patch, and worth proving unchanged."""
+
+    def test_the_result_still_reports_failure(self):
+        """``success=True`` here would tell the notifier the file was delivered."""
+        for cls in (self.cls, self.relayed_cls):
+            with self.subTest(cls=cls.__name__):
+                _, result = send(cls)
+                self.assertFalse(result.success)
+
+    def test_the_log_facing_error_string_is_untouched(self):
+        """It is English already and no user reads it; whoever greps gateway.log
+        for a failed upload wants the same lead they had before."""
+        _, result = send(self.cls)
+        self.assertEqual(result.error, UPSTREAM_ERROR)
+
+    def test_a_failed_send_is_still_swallowed(self):
+        """The notice is best-effort: if Chat rejects it too, the caller still
+        gets its SendResult rather than an exception out of an error path."""
+        _, result = send(self.cls, raises=True)
+        self.assertFalse(result.success)
+        self.assertEqual(result.error, UPSTREAM_ERROR)
+
+
+class ApplierTest(PatchedFixture, unittest.TestCase):
+    """The applier's own guarantees."""
+
+    def test_the_build_marker_is_present(self):
+        self.assertIn(BUILD_MARKER, self.path.read_text(encoding="utf-8"))
+
+    def test_a_second_run_is_refused(self):
+        with self.assertRaises(SystemExit) as caught:
+            apply(self.root)
+        self.assertIn("already patched", str(caught.exception))
+
+
+class RelayFlagContractTest(unittest.TestCase):
+    """Pin the branch to the attribute the relay patch actually sets.
+
+    ``_credential_proxy_relay_patched`` is private to
+    ``agents/platform/scripts/google_chat_relay_patch.py`` -- its re-entrancy
+    latch, not an interface it publishes. Renaming it there, to match
+    ``slack_relay_patch.py``'s ``_slack_credential_proxy_relay_patched`` say,
+    would leave every other test in this file green while the relay install
+    silently went back to being told to run a command that has been stubbed
+    out. So read the assignment out of that file rather than restating it.
+    ``verify_slack_relay_registry_contract.py`` pins its own sentinels the same
+    way.
+    """
+
+    def setUp(self):
+        if not RELAY_PATCH.is_file():
+            self.fail(f"{RELAY_PATCH} is gone; the notice's branch has no source")
+        self.source = RELAY_PATCH.read_text(encoding="utf-8")
+
+    def test_the_relay_patch_sets_the_flag_this_patch_reads(self):
+        self.assertIn(f"adapter_class.{RELAY_FLAG} = True", self.source)
+
+    def test_the_relay_patch_still_stubs_setup_files(self):
+        """Why the branch exists. If the stub goes, so should the branch."""
+        self.assertIn("adapter_class._handle_setup_files_command = ", self.source)
+
+    def test_the_patched_notice_reads_that_same_flag(self):
+        """``PATCHED`` is a source literal, so nothing else ties the two."""
+        self.assertIn(f'"{RELAY_FLAG}"', PATCHED)
+
+
+class DriftTest(unittest.TestCase):
+    def test_a_moved_anchor_fails_the_build(self):
+        """An anchor that stops matching must stop the image, not be skipped.
+
+        Rewording the docstring is the likeliest upstream drift, and the one
+        that would otherwise ship Spanish again with a green build.
+        """
+        moved = UPSTREAM.replace(
+            "        Tells the user that file delivery requires a one-time consent\n",
+            "        Tells the user that file delivery needs a one-time consent\n",
+        )
+        self.assertNotEqual(moved, UPSTREAM)
+        root, _ = build(moved)
+        with self.assertRaises(SystemExit) as caught:
+            apply(root)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_an_upstream_translation_fails_the_build(self):
+        """If upstream fixes this themselves the anchor stops matching, and the
+        build says so instead of the patch quietly re-Spanishing their English."""
+        translated = UPSTREAM.replace(
+            "No he podido adjuntar", "Could not attach"
+        )
+        root, _ = build(translated)
+        with self.assertRaises(SystemExit) as caught:
+            apply(root)
+        self.assertIn("found 0", str(caught.exception))
+
+    def test_a_missing_file_fails_the_build(self):
+        with self.assertRaises(SystemExit):
+            apply(Path(tempfile.mkdtemp()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/docker/patches/verify_google_chat_attachment_notice.py
+++ b/deploy/docker/patches/verify_google_chat_attachment_notice.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build-time behaviour gate for the Google Chat attachment-notice patch.
+
+Run by ``deploy/docker/Dockerfile`` against the patched ``/opt/hermes`` tree,
+immediately after ``apply_google_chat_attachment_notice.py``. The applier proves
+the anchor matched and that the file still parses; this proves the notice the
+adapter actually builds is English on both branches, and that the branch which
+offers ``/setup-files`` is the one where the command works.
+
+A grep cannot do that. The two branches differ only in which strings are
+appended, so a patch that wired the condition backwards -- offering
+``/setup-files`` precisely where the relay has stubbed it out -- greps
+identically to a correct one, and the next reader of the difference is a user
+following an instruction into a dead end.
+
+``test_google_chat_attachment_notice.py`` covers the applier against a fixture
+and cannot cover any of this: the edit lives inside Hermes' own module, and the
+unit suite never sees the file that ships.
+
+The module is loaded by path rather than imported as
+``plugins.platforms.google_chat.adapter`` so the gate does not depend on the
+package's ``__init__`` being importable at build time. ``adapter.py`` imports
+``gateway.*`` at module level, so ``_load`` puts the tree on ``sys.path`` first,
+the way verify_kanban_worker_tools.py and its siblings do. Running the script
+from ``/opt/hermes`` is not enough on its own: for ``python3 script.py``,
+``sys.path[0]`` is the script's directory, not the working directory.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+RELATIVE = "plugins/platforms/google_chat/adapter.py"
+
+# Verbatim fragments of what upstream shipped. Substrings rather than a language
+# heuristic: these four are the exact text that reached a user's thread, and
+# absence of them is the thing being asserted.
+SPANISH = (
+    "No he podido adjuntar",
+    "Google Chat sólo permite adjuntar archivos",
+    "Para activarlo",
+    "Mientras tanto el archivo",
+)
+
+# The one non-ASCII character the notice is allowed to carry. Anything else,
+# whether in a string constant inside the patched method (check 2) or in the
+# text it renders (``_notice``), is words in some language -- which is how this
+# regressed in the first place.
+WARNING_SIGN = "⚠️"
+
+PATH = "/opt/data/kanban/attachments/t_e5e1ba5e/report.md"
+FILENAME = "report.md"
+
+
+def _fail(detail: str) -> "SystemExit":
+    return SystemExit(f"google_chat_attachment_notice verify: {detail}")
+
+
+def _load(root: Path):
+    path = root / RELATIVE
+    if not path.is_file():
+        raise _fail(f"{path} does not exist")
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    spec = importlib.util.spec_from_file_location("gc_adapter_verify", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _notice(cls, *, caption=None) -> str:
+    """Drive the real method on a bare instance and return what it would send.
+
+    ``object.__new__`` skips ``__init__`` deliberately: the method reads nothing
+    off the instance but ``_create_message``, and constructing a real adapter
+    would want a config, a Pub/Sub subscription and the Google SDK.
+    """
+    adapter = object.__new__(cls)
+    sent: dict = {}
+
+    async def capture(chat_id, body):
+        sent["body"] = body
+
+    adapter._create_message = capture
+    result = asyncio.run(
+        cls._post_attachment_fallback(
+            adapter, "spaces/AAAA", PATH, FILENAME, caption, None
+        )
+    )
+    if result.success:
+        raise _fail("the fallback reported success; it delivered no attachment")
+    if "body" not in sent:
+        raise _fail("the fallback sent no message at all")
+    text = sent["body"]["text"]
+    # The rendered notice, not just the literals check 2 can see. That scan
+    # walks the method's own constants, so one level of indirection -- a
+    # module-level name holding the sentence, a .format() off a table -- passes
+    # it and ships text in any language. Both arguments this gate passes in
+    # (PATH, FILENAME) and every caption it uses are ASCII, so anything
+    # non-ASCII surviving here came from the notice.
+    if not text.replace(WARNING_SIGN, "").isascii():
+        raise _fail(f"non-ASCII text in the rendered notice: {text!r}")
+    return text
+
+
+def main(root: Path) -> None:
+    source = (root / RELATIVE).read_text(encoding="utf-8")
+    adapter_module = _load(root)
+    cls = adapter_module.GoogleChatAdapter
+
+    # 1) None of what upstream shipped may survive anywhere in the file.
+    for fragment in SPANISH:
+        if fragment in source:
+            raise _fail(f"upstream Spanish survives in the adapter: {fragment!r}")
+
+    # 2) Every string appended to ``lines`` is ASCII, bar the warning sign.
+    #    Catches a reintroduction this gate has no fragment for, in any
+    #    language, without guessing at which words are English. It reaches only
+    #    the literals written inside the method; ``_notice`` runs the same test
+    #    over the rendered result, which is what catches one held behind a name.
+    #
+    #    Scoped to the ``lines`` calls rather than the whole method because the
+    #    ``error=`` string on the returned SendResult is deliberately left as
+    #    upstream wrote it, em dash and all: it goes to gateway.log, not to a
+    #    user. Widening this to every constant in the method would fail on it.
+    method = next(
+        (
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "_post_attachment_fallback"
+        ),
+        None,
+    )
+    if method is None:
+        raise _fail("no _post_attachment_fallback in the patched adapter")
+    appends = [
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr in ("append", "extend")
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "lines"
+    ]
+    if not appends:
+        raise _fail("the notice is no longer built by appending to `lines`")
+    for call in appends:
+        for node in ast.walk(call):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if not node.value.replace(WARNING_SIGN, "").isascii():
+                raise _fail(
+                    f"non-ASCII text in the notice at line {node.lineno}: "
+                    f"{node.value[:60]!r}"
+                )
+
+    # 3) The default branch -- no relay -- keeps the /setup-files instruction,
+    #    because on that install the command works. Asserted positively so a
+    #    patch that fixed the language by deleting the guidance cannot pass.
+    plain = _notice(cls)
+    if "/setup-files" not in plain:
+        raise _fail(
+            f"an install without the relay lost its /setup-files step: {plain!r}"
+        )
+    if FILENAME not in plain or PATH not in plain:
+        raise _fail(f"the notice names neither the file nor its path: {plain!r}")
+
+    # 4) The relay branch drops it. The relay patch stubs
+    #    _handle_setup_files_command, so pointing a user at it is an
+    #    instruction that cannot be followed.
+    relayed_cls = type(
+        "RelayedGoogleChatAdapter", (cls,), {"_credential_proxy_relay_patched": True}
+    )
+    relayed = _notice(relayed_cls)
+    if "/setup-files" in relayed:
+        raise _fail(
+            "the credential-proxy branch still offers /setup-files, which the "
+            f"relay patch has stubbed out: {relayed!r}"
+        )
+    if "credential proxy" not in relayed:
+        raise _fail(f"the credential-proxy branch does not say why: {relayed!r}")
+    if PATH not in relayed:
+        raise _fail(f"the credential-proxy branch loses the host path: {relayed!r}")
+    # Having taken /setup-files away, this branch has to leave something in its
+    # place, or it ends on a host path the user cannot reach.
+    if "paste" not in relayed:
+        raise _fail(
+            f"the credential-proxy branch leaves the user nothing to do: {relayed!r}"
+        )
+
+    # 5) The caller's caption still leads. ``send_file`` passes the message the
+    #    agent wrote alongside the file, and a notice that buried or dropped it
+    #    would lose the only part a user asked for.
+    captioned = _notice(cls, caption="Here is the fleet report.")
+    if not captioned.startswith("Here is the fleet report.\n"):
+        raise _fail(f"the caption is no longer first: {captioned!r}")
+
+    print("google_chat_attachment_notice verify: ok")
+
+
+if __name__ == "__main__":
+    main(Path(sys.argv[1] if len(sys.argv) > 1 else "/opt/hermes"))


### PR DESCRIPTION
## Summary

Hermes' `_post_attachment_fallback` — the notice a Google Chat user gets when the agent produced a file it could not upload — writes its four user-facing lines in Spanish, inside an otherwise English adapter. This patches them to English and, at the same time, stops the notice telling every install to run `/setup-files`: on an install that reaches Chat through the credential proxy that command has been stubbed out, so the English translation on its own would have been a dead end. The middle of the notice now branches, and the relay branch offers the thing that does work there. Attachments still do not deliver; this is the string, not the mechanism.

## Why This Change

It was reported as "the agent responds in other languages sometimes". Everything around the four lines is English — the adapter, its docstrings, the `error=` string the same method returns — so a user who asked for a report in English gets a Spanish refusal and reads it as the model having switched language mid-thread. That is where the first investigation went, and none of it was the model.

The path is not rare. Native `media.upload` needs a *per-user* OAuth token, so until each user has run `/setup-files` in their own DM, every attachment lands here.

The second half is the advice itself. `agents/platform/scripts/google_chat_relay_patch.py` replaces `_handle_setup_files_command` with a stub, because the OAuth flow needs credentials the credential proxy deliberately does not hold — and `k8s-operator/internal/controller/platformagent_manifests.go` sets `GOOGLE_CHAT_RELAY_URL` on every install with `integration.googleChat.enabled`, which is what `sitecustomize.py` installs that patch on. So on every operator-deployed install, the instruction the user was given cannot be followed.

## What Changed

- `deploy/docker/patches/apply_google_chat_attachment_notice.py` — the anchored rewrite. The notice reads the `_credential_proxy_relay_patched` marker the relay patch leaves on the adapter class and takes one of two branches. The direct branch keeps `/setup-files`; the relay branch says why attachments are unavailable and asks the user to have the contents pasted into the chat instead, which needs no credentials because the file is already on the agent's own disk. Upstream's notice always ended with something the user could do, and dropping `/setup-files` without a replacement would have ended it on a host path they cannot reach.
- `deploy/docker/patches/verify_google_chat_attachment_notice.py` — build-time gate. Runs the real patched method on both branches and asserts on the text, because a patch that wired the condition backwards greps identically to a correct one. It also requires the rendered notice to be ASCII apart from `⚠️`, which is what catches a sentence in another language held behind a name rather than written inline.
- `deploy/docker/patches/test_google_chat_attachment_notice.py` — 27 tests against a verbatim copy of the upstream method. Includes a contract test that reads the relay patch's own source and asserts the marker assignment, so renaming that private latch fails CI instead of silently restoring the dead end.
- `deploy/docker/Dockerfile` — wiring. Rides the existing slack-code-emphasis `COPY`/`RUN` pair rather than adding one: zero new Docker instructions, and the `credential-proxy` chain measures 118 layers with this change, the same as without it.

The `error=` string on the returned `SendResult` is deliberately unchanged. It is English already and goes to `gateway.log`, not to a user; "run /setup-files in chat" is still the right lead for whoever greps for a failed upload.

## Context

Not tracked by an issue; reported directly by a user of a staging install.

- **#809** (`perf(docker): build credential-proxy from agent-base, not platform`) rebuilds the layer chain this change's layer argument rests on. It does not conflict — this adds no Docker instructions — but if #809 lands first the 118-layer measurement here is stale and worth re-taking.
- **#720** touches `agents/platform/scripts/google_chat_relay_patch.py`, the file the new contract test reads. It does not touch the marker or the `/setup-files` stub, so the two are an ordinary merge.
- **#713** (`docs(agents): give every user-facing message one output standard`) is adjacent — same subject, different surface — and does not overlap these files.

Not reported upstream. Worth doing for the language alone, but the relay branch is kube-agents-specific and would not survive the trip, so the two are separate pieces of work.

This PR was generated with the help of Claude.

## Testing

- `python3 -m unittest discover -s deploy/docker/patches -p 'test_*.py' -t deploy/docker/patches` — 867 tests, OK (1 skipped). 27 of them are this patch's.
- `docker build --platform linux/amd64 --target credential-proxy` from a clean checkout of this branch: both build-time gates print `ok` (`slack_code_emphasis verify: ok`, `google_chat_attachment_notice verify: ok`).
- `python3 scripts/check_image_layers.py` → `OK: credential-proxy:latest has 118 layers, 2 under the 120 budget`.
- `make docs-check` → exit 0. No document describes the attachment fallback, `/setup-files`, or the patch inventory, so there is no prose for this to drift from; I grepped for all three rather than assuming.
- The gates were checked by sabotage, not just by passing. Reverting the substitution turns 18 of the 27 tests red. Against the verifier: an unpatched tree, the two branches swapped, Spanish reintroduced, the caption dropped, the host path dropped, `/setup-files` removed from both branches, `success=True`, and no send at all are each rejected with a named failure. The two gates added in this round were sabotaged the same way — a French sentence behind a module-level name is caught by the rendered-text check, the relay branch stripped of its action by the "nothing to do" check, and renaming the marker in `google_chat_relay_patch.py` fails `RelayFlagContractTest`.

### Live validation

Exercised on a private GKE Autopilot staging install of this repository (`kubeagents-system`, europe-west1, operator `k8s-operator@sha256:b99789eb`). The project, cluster, and registry are a customer environment and are withheld from a public repository; everything below is what was observed there.

**Before.** Pod `platform-agent-gateway-84dd4b6ddc-h4g6s`, `platform-agent@sha256:69108a5d`. In the pod, `grep -cF "No he podido adjuntar" /opt/hermes/plugins/platforms/google_chat/adapter.py` → `1`, the patch marker → `0`. Driving the real method rendered the reported Spanish notice, `success=False`.

**Change.** Built the `platform` target from this branch's patch files, pushed it, confirmed the registry digest, and patched `PlatformAgent.spec.deployment.image` to it by digest. The operator reconciled: `.status.phase` went `Degraded(PodInitializing)` → `Ready`, `Ready=True(Reconciled)`; a new pod `platform-agent-gateway-6d56b8b7-ncws5` came up 4/4 Running with `imageID` matching the pushed digest.

**After.** In the pod: marker → `1`, Spanish → `0`, the new relay line → `1`. Rendering the real method on the real adapter class:

*Direct branch* — flag absent, which is how upstream ships:

```
Here is the deep dive you asked for.
⚠️ Couldn't attach **report.md**.
Google Chat accepts an upload only once you have given the bot explicit permission (user OAuth). It is a one-time consent, done from this chat.
**To enable it:** send `/setup-files` and follow the steps.
The file is on the agent host at: `/opt/data/kanban/attachments/t_e5e1ba5e/report.md`
```

*Relay branch* — reached by importing the install's own `/opt/defaults/scripts/google_chat_relay_patch.py` and running its `patch_adapter_class` over the adapter, rather than by setting the attribute by hand. That proves the two ends meet: the flag went `ABSENT` → `True`, and `_handle_setup_files_command.__qualname__` became `install.<locals>.patch_adapter_class.<locals>.setup_files` — the stub that makes the branch necessary.

```
Here is the deep dive you asked for.
⚠️ Couldn't attach **report.md**.
File attachments are unavailable on this deployment: uploading to Google Chat needs a per-user OAuth token, and this install reaches Chat through the credential proxy, which holds no user credentials.
Ask me to paste the contents here if you need them in chat.
The file is on the agent host at: `/opt/data/kanban/attachments/t_e5e1ba5e/report.md`
success= False
error  = google_chat: native attachment requires user OAuth — run /setup-files in chat
```

**Reverted.** CR patched back to `platform-agent@sha256:69108a5d`; `.status` settled to `Ready=True(Reconciled)` on pod `platform-agent-gateway-84dd4b6ddc-jcrjg`, 4/4 Running, and in that pod the marker is `0` and the Spanish literal is back at `1`. The old and new states are distinctly different in both directions, so this is the mechanism and not a coincidence.

**Not covered.** No message was posted into a real Google Chat space — that install's spaces are a customer's, and the notice would have landed in front of people who did not ask for a test. The notice was therefore rendered through the adapter's own send path with `_create_message` captured, one call short of the Chat API. The default `/setup-files` branch was exercised on a relay install with the flag not yet set, not on a genuinely relay-less deployment, since the operator does not produce one.

**Left behind.** Two throwaway `platform-agent` tags in that private registry, kept so the fix can be redeployed there before this merges. Nothing else; the cluster is back to its prior state.

## Self-Review

Ran the `review-adversarial` skill in a subagent given only the diff range and the repository — not this change's reasoning. It looked at the branch condition against what actually sets it, the gates' ability to fail, fixture fidelity, the layer-budget claim, scope creep, security and IaC surface, and overlap with open PRs. Seven findings, all now addressed:

1. **Nothing tied the runtime branch to the attribute the relay patch actually sets** (high, confirmed). `_credential_proxy_relay_patched` is that patch's private re-entrancy latch; both the test and the verifier synthesised it themselves, so renaming it there — to `_google_chat_credential_proxy_relay_patched`, matching `slack_relay_patch.py` — would pass everything and silently restore the dead end. **Fixed:** the name is a shared `RELAY_FLAG` constant, and `RelayFlagContractTest` reads `google_chat_relay_patch.py` and asserts both the assignment and the `/setup-files` stub, the way `verify_slack_relay_registry_contract.py` pins its own sentinels. Verified by renaming the flag in that file and watching the test fail.
2. **The "any language" gate was defeated by one level of indirection** (medium, confirmed — the reviewer executed it). A module-level name holding a French sentence passed all five checks. **Fixed:** the verifier now also requires the *rendered* notice to be ASCII apart from `⚠️`; the AST scan's comment says what it does and does not reach.
3. **The Dockerfile's "a command half of them cannot run" was wrong** (medium, confirmed). The operator sets `GOOGLE_CHAT_RELAY_URL` whenever Google Chat is enabled, so *every* operator-deployed install takes the relay branch; the direct branch is only reachable by an image run outside the operator. **Fixed:** reworded there and in the applier's docstring, and the branch is kept with the reason stated — deleting it hard-codes the instruction off in the one configuration where it works.
4. **The layer figure was stated twice and disagreed with itself** (medium, confirmed). The new comment said 118; the untouched `Dockerfile:1229` says 119. **Fixed** by not restating it: the comment now points at the layer note at the top of the file. On this branch the chain measures 118, so the pre-existing 119 at `:1229` is stale — **not fixed here**, because it is unrelated prose and #809 rebuilds that chain anyway, but it is worth someone's one-word commit.
5. **The verifier claimed the Dockerfile's `cd` puts `/opt/hermes` on `sys.path`** (low, confirmed). It does not; for `python3 script.py`, `sys.path[0]` is the script's directory. **Fixed:** `_load` inserts the tree explicitly, as four sibling verifiers do, and the docstring says why the `cd` is not enough.
6. **"The only non-English user-facing literal in the Hermes runtime" is unverifiable** (low, plausible) — a claim about a whole third-party tree. **Fixed** by dropping it for what is checkable: everything around these four lines is English.
7. **The relay branch left the user nothing to do** (low, confirmed behaviour change) — upstream's notice always ended with an action. **Fixed:** that branch now asks the user to have the contents pasted into the chat, and the verifier fails if the branch ends without an action.

Findings 1, 2 and 7 change what ships, so the live validation above was re-run in full against the amended patch rather than kept from the first round.

What the pass cleared: the anchor is properly guarded against double-apply and no-op; the verifier does catch an inverted condition; the fixture is byte-exact against the pinned base image; the tests assert behaviour rather than shape (reverting the substitution turns 18 of 27 red); no security, IAM, or IaC surface is touched; scope is clean. The subagent could not run a build or reach a cluster, so it could not check the layer count, the anchor against the real base image, or the relay branch end-to-end — all three are covered above.

## Risk & Rollout

One string in one error path, in a patch that fails the image build if its anchor stops matching. The blast radius is the text of a notice that already told the user the upload failed; nothing reads it programmatically, and the `SendResult` contract is unchanged and asserted unchanged. If upstream translates these lines themselves the anchor stops matching and the build fails loudly rather than re-Spanishing their English. Revert is the commit. Nothing to do at merge time.
