### PR TITLE
test: run the bench suite in CI, guard test discovery, lint domain coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,3 +43,28 @@ jobs:
       # never started a job at all.
       - name: Run Python unit tests
         run: make test-python
+
+  # Separate job because bench/tests is pytest-native and cannot run under the
+  # unittest discovery `make test-python` uses -- it sat outside every glob and
+  # had never once run in CI. Installing bench/ resolves devops-bench from the
+  # git SHA pinned in bench/pyproject.toml.
+  bench-tests:
+    name: Run Bench Harness Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install bench and its test runner
+        run: |
+          python3 -m pip install --upgrade pip
+          make test-bench-deps
+
+      - name: Run the bench harness tests
+        run: make test-bench

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BAD_SKILLS := $(wildcard agents/*/defaults/skills/*)
 BASE_IMAGE_VARS := HERMES_AGENT_IMAGE ENVOY_IMAGE GOLANG_IMAGE
 BASE_IMAGE_ARGS := $(foreach v,$(BASE_IMAGE_VARS),$(if $($(v)),--build-arg $(v)=$($(v))))
 
-.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map chart-sync chart-check tf-apply tf-destroy
+.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-push docker-push-agents docker-push-credential-proxy dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps test-bench test-bench-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map chart-sync chart-check tf-apply tf-destroy
 
 # The agent images this repository builds -- one per `--target` stage in
 # deploy/docker/Dockerfile, which is not the same thing as one per directory
@@ -197,6 +197,17 @@ test-python: ## Run the Python unit tests outside k8s-operator/.
 		fi; \
 		exit 1; \
 	fi
+
+# bench/tests is the one Python suite that cannot join PYTHON_TEST_DIRS: it is
+# pytest-native (fixtures, parametrize), and `unittest discover` collects two
+# of its tests and errors on both. So it runs under its own target, and
+# scripts/test_test_discovery.py keeps the exclusion explicit rather than an
+# accident of the globs above.
+test-bench-deps: ## Install what `make test-bench` needs: bench/ editable plus pytest. Resolves devops-bench from the git SHA pinned in bench/pyproject.toml, so the first run needs network.
+	@python3 -m pip install -e bench/ pytest
+
+test-bench: ## Run the bench harness tests under pytest.
+	@python3 -m pytest bench/tests/
 
 # The agent's own instructions are prose, and prose is not compiled: a persona
 # that cites a renamed skill or an SOP that names a moved script merges clean

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,11 @@ test-python-deps: ## Install the third-party imports `make test-python` needs.
 #
 # Added because the answer used to be three commands nobody could remember, and
 # a handoff doc had to carry the recipe. If you add a suite, add it here.
-verify: ## Run everything a PR must pass: go build, go vet, go test, python tests.
+# test-bench is deliberately not here: its deps target installs bench/
+# editable, which pulls devops-bench from a pinned git SHA over the network.
+# verify stays offline-runnable; the bench suite gates in CI (bench-tests job)
+# and runs locally with `make test-bench`.
+verify: ## Run everything a PR must pass offline: go build, go vet, go test, python tests. The bench suite needs network; run `make test-bench` separately.
 	@echo "==> go build"; cd k8s-operator && go build ./...
 	@echo "==> go vet";   cd k8s-operator && go vet ./...
 	@echo "==> go test";  cd k8s-operator && go test ./...

--- a/bench/CUSTOM-TASKS.md
+++ b/bench/CUSTOM-TASKS.md
@@ -193,10 +193,19 @@ A task gives the agent a prompt, describes the infrastructure to stand up, says 
 answer reads like, and — where the answer is objectively checkable — asserts it against the live
 cluster.
 
+A task that covers one of the ten testing domains also carries a top-level
+`domain: <slug>` field naming it. The slugs live in `docs/designs/domains.yaml`, and
+`scripts/test_domain_coverage.py` counts a domain as covered only when a task carries both
+its slug and a non-empty `verification_spec` — a spec without the field leaves the domain
+reported as uncovered, and the domain's allowlist entry in that file can then never be
+removed. devops-bench ignores the extra key (`extra: "ignore"` on its task model), so the
+field is free to carry.
+
 ```yaml
 # tasks/<task-name>/task.yaml
 id: my-provisioned-task
 name: Human-readable name
+domain: capacity # optional; required to count for domain coverage
 prompt: >-
   The evaluation cluster {{CLUSTER_NAME}} has just been provisioned.
   <what the agent should do>

--- a/docs/designs/domains.yaml
+++ b/docs/designs/domains.yaml
@@ -1,4 +1,7 @@
-# The ten domains of docs/designs/testing-strategy.md §4.2, as data.
+# The ten domains the Platform Agent operates in, as data. Each is a job area
+# with its own SOP, cron stream, and journeys (the testing-strategy design
+# document, in review, is the source of the list; until it lands this file is
+# self-contained).
 #
 # scripts/test_domain_coverage.py reads this file and fails when a domain has
 # no bench task carrying a deterministic verification_spec -- the rule "a

--- a/docs/designs/domains.yaml
+++ b/docs/designs/domains.yaml
@@ -1,0 +1,63 @@
+# The ten domains of docs/designs/testing-strategy.md §4.2, as data.
+#
+# scripts/test_domain_coverage.py reads this file and fails when a domain has
+# no bench task carrying a deterministic verification_spec -- the rule "a
+# domain with no blocking scenario is uncovered, not passing" as a build
+# failure rather than a sentence in a document.
+#
+# A task claims a domain with a top-level `domain: <slug>` field in its
+# task.yaml. It counts as covering the domain only when it also carries a
+# non-empty verification_spec.
+#
+# `allowlist` names the domains that are known-uncovered today. Delete entries
+# as Phase 2 lands scenarios; the lint refuses both an uncovered domain that
+# is not listed (a regression) and a listed domain that is covered (a stale
+# entry hiding progress). The shrinking allowlist is the tier-2 progress
+# metric of the testing implementation plan, as line coverage is the tier-1
+# one.
+
+domains:
+  - slug: chat-and-routing
+    name: Chat and routing
+    journey: Ask the fleet a question; routed to the right specialist, answered from observed evidence
+  - slug: reliability
+    name: Reliability (obtainability-audit)
+    journey: Daily reliability sweep names the workload that breaks on a drain or an upgrade
+  - slug: capacity
+    name: Capacity (stockout-prevention)
+    journey: Stockout audit names the pool at risk and the shortfall
+  - slug: cost
+    name: Cost (fleet-wide-cost-analysis)
+    journey: Weekly waste audit names the idle resource in resource units
+  - slug: security
+    name: Security (compliance-audit, ai-security-audit)
+    journey: RBAC and AI workload posture findings, each carrying a remediation
+  - slug: upgrades
+    name: Upgrades (security-patch-orchestrator)
+    journey: Upgrade readiness reports the versions and blockers it actually read
+  - slug: consistency
+    name: Consistency (fleet-consistency-drift)
+    journey: Drift sweep compares each cluster against the live-fleet majority
+  - slug: remediation
+    name: Remediation (github-issue-resolver)
+    journey: Triages a planted issue and files its report; nothing applied directly
+  - slug: cluster-debugging
+    name: Cluster debugging
+    journey: Debugs a workload; the Cluster Agent stays read-only and inside its own cluster
+  - slug: incident-triage
+    name: Incident triage (autoops)
+    journey: A warning event is triaged to a root cause and a pull request, never a cluster write
+
+# Known-uncovered. Today no bench task carries a verification_spec at all, so
+# every domain starts here. Phase 2's exit criterion is an empty list.
+allowlist:
+  - chat-and-routing
+  - reliability
+  - capacity
+  - cost
+  - security
+  - upgrades
+  - consistency
+  - remediation
+  - cluster-debugging
+  - incident-triage

--- a/scripts/test_domain_coverage.py
+++ b/scripts/test_domain_coverage.py
@@ -1,8 +1,8 @@
 """A domain with no blocking scenario is uncovered, not passing.
 
-docs/designs/testing-strategy.md §3 states the rule; docs/designs/domains.yaml
-holds the ten domains and the allowlist of known-uncovered ones. This test is
-what makes the rule a build failure:
+docs/designs/domains.yaml holds the ten domains and the allowlist of
+known-uncovered ones (its header states the rule and where it comes from).
+This test is what makes the rule a build failure:
 
 * a domain with no bench task carrying a non-empty ``verification_spec`` must
   be on the allowlist -- otherwise coverage regressed silently;

--- a/scripts/test_domain_coverage.py
+++ b/scripts/test_domain_coverage.py
@@ -1,0 +1,109 @@
+"""A domain with no blocking scenario is uncovered, not passing.
+
+docs/designs/testing-strategy.md §3 states the rule; docs/designs/domains.yaml
+holds the ten domains and the allowlist of known-uncovered ones. This test is
+what makes the rule a build failure:
+
+* a domain with no bench task carrying a non-empty ``verification_spec`` must
+  be on the allowlist -- otherwise coverage regressed silently;
+* a domain that IS covered must not stay on the allowlist -- otherwise the
+  list stops being the progress metric it exists to be;
+* a task claiming an unknown domain is a typo that would otherwise count as
+  coverage of nothing.
+
+Delete allowlist entries as Phase 2 lands scenarios. The shrinking allowlist
+is the tier-2 progress metric of the testing implementation plan.
+"""
+
+import pathlib
+import unittest
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOMAINS_FILE = REPO_ROOT / "docs" / "designs" / "domains.yaml"
+TASKS_GLOB = "bench/tasks/*/task.yaml"
+
+
+def load_domains():
+    data = yaml.safe_load(DOMAINS_FILE.read_text())
+    return data["domains"], set(data.get("allowlist") or [])
+
+
+def covered_domains():
+    """Domain slugs claimed by a task that carries a non-empty verification_spec."""
+    claimed = {}
+    for task_file in sorted(REPO_ROOT.glob(TASKS_GLOB)):
+        task = yaml.safe_load(task_file.read_text()) or {}
+        domain = task.get("domain")
+        if domain:
+            claimed.setdefault(domain, []).append(
+                (task_file.relative_to(REPO_ROOT).as_posix(), bool(task.get("verification_spec")))
+            )
+    return claimed
+
+
+class TestDomainCoverage(unittest.TestCase):
+    def test_every_domain_is_covered_or_allowlisted(self):
+        domains, allowlist = load_domains()
+        claimed = covered_domains()
+        uncovered = sorted(
+            d["slug"]
+            for d in domains
+            if d["slug"] not in allowlist
+            and not any(has_spec for _, has_spec in claimed.get(d["slug"], []))
+        )
+        self.assertEqual(
+            uncovered,
+            [],
+            "\n\nThese domains have no task with a verification_spec and are "
+            "not on the allowlist in docs/designs/domains.yaml:\n  "
+            + "\n  ".join(uncovered)
+            + "\n\nAdd a scenario, or add the domain back to the allowlist "
+            "with eyes open -- an uncovered domain never counts as passing.",
+        )
+
+    def test_a_covered_domain_leaves_the_allowlist(self):
+        domains, allowlist = load_domains()
+        claimed = covered_domains()
+        stale = sorted(
+            slug
+            for slug in allowlist
+            if any(has_spec for _, has_spec in claimed.get(slug, []))
+        )
+        self.assertEqual(
+            stale,
+            [],
+            "\n\nThese domains are covered but still allowlisted as uncovered; "
+            "delete them from docs/designs/domains.yaml so the allowlist stays "
+            "the progress metric:\n  " + "\n  ".join(stale),
+        )
+
+    def test_no_task_claims_an_unknown_domain(self):
+        domains, _ = load_domains()
+        known = {d["slug"] for d in domains}
+        claimed = covered_domains()
+        unknown = sorted(
+            f"{files[0][0]}: {slug}"
+            for slug, files in claimed.items()
+            if slug not in known
+        )
+        self.assertEqual(
+            unknown,
+            [],
+            "\n\nThese tasks claim a domain docs/designs/domains.yaml does not "
+            "define:\n  " + "\n  ".join(unknown),
+        )
+
+    def test_every_allowlist_entry_names_a_real_domain(self):
+        domains, allowlist = load_domains()
+        known = {d["slug"] for d in domains}
+        self.assertEqual(
+            sorted(allowlist - known),
+            [],
+            "Allowlist entries must name domains defined in the same file.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_test_discovery.py
+++ b/scripts/test_test_discovery.py
@@ -1,0 +1,130 @@
+"""Every test_*.py in the tree either runs in CI or is excluded here, by name.
+
+`make test-python` discovers tests from PYTHON_TEST_DIRS, a fixed list of
+wildcards. A test directory the wildcards miss does not fail anything -- it
+just never runs, and the suite reports green around it. That is how six test
+files (the memory provider's four and bench's two) sat unexecuted on every
+pull request for months: nothing owned the difference between "excluded on
+purpose" and "missed by a glob".
+
+This test owns that difference. It walks the tree for test_*.py files,
+subtracts EXCLUDED, and asserts every surviving directory is discovered. From
+here on, skipping a directory means adding a reviewed line to EXCLUDED with a
+reason -- it cannot happen by accident of a glob again.
+
+PYTHON_TEST_DIRS is read by invoking make itself on a wrapper makefile, not by
+parsing the Makefile's text: the value that matters is the one make expands,
+and a regex re-implementation would drift from it.
+"""
+
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Directory prefixes (repo-relative, POSIX) whose test files deliberately do
+# not run under `make test-python`. Every entry carries its reason; an entry
+# without one should not survive review.
+EXCLUDED = {
+    # Has its own Makefile target (`make -C k8s-operator test-python`) and its
+    # own CI workflow; the root suite does not reach into the operator.
+    "k8s-operator": "own suite, k8s-operator-test.yml",
+    # Has its own workflow (agentplugins-test.yml) and its own dependencies.
+    "agentplugins": "own suite, agentplugins-test.yml",
+    # pytest-native (fixtures, parametrize); unittest discovery collects two
+    # of its tests and errors on both. Runs under `make test-bench`.
+    "bench/tests": "pytest-native, runs under make test-bench",
+    # tests/e2e is deliberately NOT here: its file is gchat_agent_test.py,
+    # which the test_*.py pattern never matches. If a test_*.py ever lands
+    # there, the orphan check below fires and forces this list to say why the
+    # live-cluster suite must not join PYTHON_TEST_DIRS. That is the point.
+    #
+    # Imports kube_agents_memory, which imports hermes-agent's `agent` module
+    # at module scope -- a dependency requirements-test.txt deliberately does
+    # not install ("far too heavy to install for a unit-test run"). Whether to
+    # stub the provider or pay for the dependency is an open decision; until
+    # it is made, the suite cannot load, and this entry is the record that the
+    # omission is known rather than accidental.
+    "tests/memory": "hermes-agent dependency, decision pending",
+}
+
+# Directory names that are never test homes, at any depth.
+IGNORED_NAMES = {".venv", "node_modules", "__pycache__", ".git", ".coverage-data"}
+
+
+def discovered_dirs():
+    """The directories `make test-python` discovers, as make expands them."""
+    with tempfile.NamedTemporaryFile("w", suffix=".mk", delete=False) as wrapper:
+        wrapper.write("include Makefile\nprint-test-dirs:\n\t@echo $(PYTHON_TEST_DIRS)\n")
+        wrapper_path = wrapper.name
+    out = subprocess.run(
+        ["make", "-f", wrapper_path, "print-test-dirs"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return {d.rstrip("/") for d in out.split()}
+
+
+def test_file_dirs():
+    """Every directory holding a test_*.py, minus the ignored names."""
+    dirs = set()
+    for path in REPO_ROOT.rglob("test_*.py"):
+        rel = path.relative_to(REPO_ROOT)
+        if any(part in IGNORED_NAMES for part in rel.parts):
+            continue
+        dirs.add(rel.parent.as_posix())
+    return dirs
+
+
+def is_excluded(rel_dir):
+    return any(rel_dir == prefix or rel_dir.startswith(prefix + "/") for prefix in EXCLUDED)
+
+
+class TestEveryTestFileRuns(unittest.TestCase):
+    def test_every_test_directory_is_discovered_or_excluded_by_name(self):
+        discovered = discovered_dirs()
+        orphans = sorted(
+            d for d in test_file_dirs() if not is_excluded(d) and d not in discovered
+        )
+        self.assertEqual(
+            orphans,
+            [],
+            "\n\nThese directories hold test_*.py files that never run in CI:\n  "
+            + "\n  ".join(orphans)
+            + "\n\nEither add a matching wildcard to PYTHON_TEST_DIRS in the "
+            "Makefile, or add the directory to EXCLUDED in this file with the "
+            "reason it must not run there.",
+        )
+
+    def test_the_exclusion_list_does_not_rot(self):
+        # An exclusion whose directory no longer holds any test file is stale
+        # noise, and stale entries are how a list stops being trusted.
+        all_dirs = test_file_dirs()
+        stale = sorted(
+            prefix
+            for prefix in EXCLUDED
+            if not any(d == prefix or d.startswith(prefix + "/") for d in all_dirs)
+        )
+        self.assertEqual(
+            stale,
+            [],
+            "\n\nThese EXCLUDED entries match no test_*.py directory any more; "
+            "delete them:\n  " + "\n  ".join(stale),
+        )
+
+    def test_the_wrapper_reads_a_nonempty_list(self):
+        # If PYTHON_TEST_DIRS ever expands to nothing the first test would
+        # vacuously report every directory as an orphan; fail with the real
+        # story instead.
+        self.assertTrue(
+            discovered_dirs(),
+            "PYTHON_TEST_DIRS expanded to nothing -- the Makefile globs are stale.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_test_discovery.py
+++ b/scripts/test_test_discovery.py
@@ -2,8 +2,8 @@
 
 `make test-python` discovers tests from PYTHON_TEST_DIRS, a fixed list of
 wildcards. A test directory the wildcards miss does not fail anything -- it
-just never runs, and the suite reports green around it. That is how six test
-files (the memory provider's four and bench's two) sat unexecuted on every
+just never runs, and the suite reports green around it. That is how eight test
+files (the memory provider's six and bench's two) sat unexecuted on every
 pull request for months: nothing owned the difference between "excluded on
 purpose" and "missed by a glob".
 
@@ -17,6 +17,7 @@ parsing the Makefile's text: the value that matters is the one make expands,
 and a regex re-implementation would drift from it.
 """
 
+import os
 import pathlib
 import subprocess
 import tempfile
@@ -59,13 +60,16 @@ def discovered_dirs():
     with tempfile.NamedTemporaryFile("w", suffix=".mk", delete=False) as wrapper:
         wrapper.write("include Makefile\nprint-test-dirs:\n\t@echo $(PYTHON_TEST_DIRS)\n")
         wrapper_path = wrapper.name
-    out = subprocess.run(
-        ["make", "-f", wrapper_path, "print-test-dirs"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
+    try:
+        out = subprocess.run(
+            ["make", "-f", wrapper_path, "print-test-dirs"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    finally:
+        os.unlink(wrapper_path)
     return {d.rstrip("/") for d in out.split()}
 
 


### PR DESCRIPTION
## Summary

Closes out the unit tier's structural gaps: the bench harness suite (119 pytest tests that have never run in CI, covering 855 statements measured at 0%) gets a `make test-bench` target and a CI job; a new discovery guard makes it impossible for a test directory to silently fall outside `PYTHON_TEST_DIRS` again; and a new domain-coverage lint turns the rule "a domain with no blocking scenario is uncovered, not passing" into a build failure with an explicit, shrinkable allowlist.

## Why This Change

Eight test files (the memory provider's six, bench's two) sat unexecuted on every PR for months because nothing owned the difference between "excluded on purpose" and "missed by a glob". The bench half is fixed here directly — it needs pytest, which `unittest discover` cannot provide (reproduced: 2 collected, both error). The guard makes the class of bug impossible: from now on, skipping a directory means adding a reviewed line to an exclusion list with a reason, and a stale exclusion fails too. The domain lint is the same idea one level up, for behavioural scenarios instead of test files: ten domains, an allowlist of the known-uncovered ones, and a red build for anyone who deletes an entry without landing the scenario — or lands the scenario without deleting the entry.

## What Changed

- `Makefile` — `test-bench` / `test-bench-deps` (pytest, `bench/` installed editable; the deps target needs network for the pinned devops-bench git SHA, which is why `verify` deliberately does not include it — its comment and help text say so)
- `.github/workflows/python-tests.yml` — `bench-tests` job, appended at the end of the file to avoid conflict with #819's coverage job; no new action pins
- `scripts/test_test_discovery.py` — the guard; reads `PYTHON_TEST_DIRS` by running `make` on a wrapper makefile, never by re-parsing. Exclusions with reasons: `k8s-operator` (own suite), `agentplugins` (own workflow), `bench/tests` (runs under test-bench), `tests/memory` (blocked on the hermes-agent dependency question — see Context)
- `docs/designs/domains.yaml` + `scripts/test_domain_coverage.py` — the ten domains as data, the allowlist, and four tests including the honest-shrinkage rule (a covered domain must leave the allowlist). Tasks claim a domain via a top-level `domain:` field, now documented in `bench/CUSTOM-TASKS.md`; devops-bench ignores the extra key (verified against the pinned SHA's task model)

## Context

Part of the testing-strategy implementation work; sibling to #819/#820/#827. Deliberately left out:

- `tests/memory/` stays dark: three of its four files fail at import on a hermes-agent module that `requirements-test.txt` deliberately refuses to install ("far too heavy for a unit-test run"). That is a dependency decision, not a Makefile line — tracked as a follow-up issue, and the exclusion line in the guard cites it
- A `verify_mcp_remote_forward_errors.py` counterpart to its sixteen siblings: that patch edits TypeScript in the mcp-remote clone, so a faithful verify is a Node harness inside the image build — needs a machine that can run the docker build; not writable safely from here
- Heads-up for two open PRs, by design: #821 (adds `tests/e2e/test_*.py`) and #720 (adds `tests/conformance/`) will trip the discovery guard when they merge after this — that is the guard working; each needs one glob or one exclusion line

This PR was generated with the help of Claude.

## Testing

- `pytest bench/tests/`: 119 passed in 31s from a cold editable install (~1 min resolve of the git pin)
- Full `scripts/` discovery: 128 tests green including the 7 new ones; the guard runs under the same glob it polices
- Negative checks reproduced red in a throwaway copy, both by the author and independently by the reviewer: deleting a discovery exclusion fails naming the directory; deleting a domain allowlist entry fails; a covered-but-still-allowlisted domain fails; a malformed task.yaml raises rather than skipping
- `make docs-check` green (221 tracked docs); `make -n test-bench` expands as documented; both new targets in `.PHONY` and `make help`
- `prettier --check` not run locally (no node on this machine); CI is the arbiter

### Live validation

Not live-tested: build targets, CI wiring, and lints only — no runtime code path, nothing for an installation to pick up. The `bench-tests` job going green on this PR is the live test of the one piece that runs anywhere.

## Self-Review

Adversarial pass by a separate reviewer context that did not write the change (angles A–J per `.agents/skills/review-adversarial/SKILL.md`), plus a docs-drift pass. Verdict: no blockers; three should-fixes and three nits, all but one fixed:

- **Fixed:** two files cited a design document not yet in the tree — both now state their rule self-contained; the `domain:` field contract was undocumented in `bench/CUSTOM-TASKS.md` (an author following the canonical how-to would strand an allowlist entry) — now documented with the failure mode spelled out; `verify` violated its own "if you add a suite, add it here" comment — the deliberate omission and its reason are now in the comment and help text; the orphaned-file count said six where the tree says eight; the wrapper makefile leaked per run — now unlinked in a finally
- **Not fixed, deliberately:** the guard walks the working tree rather than `git ls-files`, so an oddly-named local venv can red it locally (never in CI, whose checkouts are clean). Kept: the walk is what catches a freshly written, not-yet-tracked test file before it becomes exactly the orphan this guard exists to prevent
- Reviewer-verified clean: the make wrapper fails closed (raises on make failure, on missing make, and on empty expansion); the domain lint fails closed on malformed YAML and refuses `domain:` without a spec; `MAKEFLAGS` inheritance can add garbage tokens but never remove real directories; the bench job works from a cold runner; no trailer violations

## Risk & Rollout

Low. No runtime code; the new CI job's failure mode is a plain pip/pytest error. Two coordination notes rather than risks: whoever merges second between this and #819 re-resolves one `.PHONY` line, and #821/#720 will each owe the guard one line when they land after this. Revert is a clean revert of four commits.
