### PR TITLE
fix(scripts): add storage.admin and compute.viewer roles to WIF setup

### DIFF
--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -12,7 +12,7 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 
 1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, `pubsub`, `gkebackup`) are enabled on your GCP project.
 2. **Creates a Service Account**: Provisions a dedicated GCP Service Account for GitHub Actions to impersonate.
-3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`).
+3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`).
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
 6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.
@@ -28,7 +28,7 @@ Before running the script, you must have the Google Cloud CLI (`gcloud`) install
 
 #### Options
 
-- `--admin`: Grants extended IAM roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`) for full autonomous install/uninstall lifecycle operations.
+- `--admin`: Grants extended IAM roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) for full autonomous install/uninstall lifecycle operations.
 - `ADMIN=true`: Environment variable alternative to `--admin`.
 
 > **Note:** IAM role grants made with `--admin` are additive and remain assigned to the service account in your GCP project until manually revoked.

--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -12,7 +12,7 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 
 1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, `pubsub`, `gkebackup`) are enabled on your GCP project.
 2. **Creates a Service Account**: Provisions a dedicated GCP Service Account for GitHub Actions to impersonate.
-3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`).
+3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, `roles/compute.viewer`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`).
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
 6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -110,6 +110,9 @@ if [ "$IS_ADMIN" = true ]; then
 
     # The gke-backup-plan module manages Backup for GKE plans
     "roles/gkebackup.admin"
+
+    # Terraform remote state management (creating and managing gs://<project>-kube-agents-tfstate)
+    "roles/storage.admin"
   )
 fi
 

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -91,6 +91,7 @@ echo "Granting necessary roles to the Service Account..."
 ROLES=(
   "roles/cloudkms.admin"
   "roles/container.admin"
+  "roles/compute.viewer"
   "roles/serviceusage.serviceUsageAdmin"
   "roles/serviceusage.serviceUsageConsumer"
 )


### PR DESCRIPTION
## Summary

Updates the GCP GitHub Actions Workload Identity Federation (WIF) setup script to include missing IAM roles required by the Terraform-based installation engine: `roles/storage.admin` for Terraform remote state bucket management and `roles/compute.viewer` for GKE Standard node pool Instance Group Managers inspection.

## Why This Change

Following the migration to Terraform + Helm in #797:
1. `lifecycle.sh` manages state in a versioned GCS bucket (`gs://<project>-kube-agents-tfstate`). Without `roles/storage.admin`, creating the bucket fails with HTTP 403 (`storage.buckets.create` denied).
2. The Terraform Google Provider inspects Compute Engine Instance Group Managers (`compute.instanceGroupManagers.list`) when provisioning GKE Standard clusters (`google_container_cluster.standard`). Without `roles/compute.viewer`, cluster provisioning fails with HTTP 403.

## What Changed

- `k8s-operator/scripts/dev/setup-gcp-github-wif.sh`:
  - Added `roles/compute.viewer` to base `ROLES` list.
  - Added `roles/storage.admin` to extended lifecycle administration roles in `--admin` mode.
- `k8s-operator/scripts/dev/README.md`:
  - Updated documentation to list `roles/compute.viewer` and `roles/storage.admin`.

## Context

Follow-up to #797 and #729.

## Testing

- Bash syntax validated with `bash -n`.
- Documentation formatting verified with `npx prettier --check` and `make docs-check`.

### Live validation

Validated against GCP project `kube-agents-rc` during RC Release E2E Pipeline run #32374178001:
- State bucket creation `gs://kube-agents-rc-kube-agents-tfstate` succeeded after granting `roles/storage.admin`.
- GKE Standard cluster provisioning succeeded after granting `roles/compute.viewer`.
- Full RC pipeline (deploy + E2E test suite + release tagging) passed cleanly.

## Self-Review

Reviewed diff for least privilege and consistency with existing role groups. `compute.viewer` is read-only and placed in base roles, while `storage.admin` is scoped to `--admin` full lifecycle mode.

## Risk & Rollout

Low risk. Does not affect runtime agent code or Kubernetes controller logic; strictly expands IAM setup for CI/CD WIF service accounts.