### PR TITLE
ci(eval): unique per-run cluster names, and a label-scoped orphan sweep

### DIFF
--- a/bench/tf/modules/cluster/gke/main.tf
+++ b/bench/tf/modules/cluster/gke/main.tf
@@ -44,10 +44,15 @@ locals {
 # orphan_max_age_hours rather than forever.
 #
 # This is a cost sweep, not a correctness precondition. Cluster names are
-# derived from the Prow BUILD_ID (hack/ci-eval-pr.sh), so two concurrent runs
-# can never share a name and a "409 Already Exists" between runs is impossible
-# by construction -- the sweep no longer has to clear the way for this run's
-# own name, and raising the Prow job's max_concurrency above 1 is safe.
+# derived from the Prow BUILD_ID (hack/ci-eval-pr.sh), so within a project two
+# runs can never share a name and a "409 Already Exists" between runs is
+# impossible by construction -- the sweep no longer has to clear the way for
+# this run's own name. That alone does NOT make raising the Prow job's
+# max_concurrency safe: every run installs cluster-wide singletons on the
+# shared platform-agent-host cluster, so concurrency itself arrives with
+# issue #637 (Boskos one-project-per-run leasing) -- do not raise it before
+# that lands. Under #637 this sweep matters MORE, not less: leasing turns the
+# Boskos janitor off, so this is the only cleanup a leased project gets.
 #
 # What keeps a live concurrent run's cluster out of the sweep is the AND of
 # two server-side conditions: it must carry the managed-by=kube-agents-bench
@@ -59,6 +64,13 @@ locals {
 # here, this resource is created, and the sweep runs every time. Locally,
 # state persists under bench/tf, so it re-runs only when cluster_name,
 # location or project_id change; a laptop is not where orphans accumulate.
+# A local run that lost its state file and 409s on its own stable name
+# self-heals the same way: the leftover cluster ages out and the next sweep
+# removes it.
+#
+# Residual the sweep does not cover: the allow-iap-ssh-<cluster> firewall
+# rule (created only when enable_iap_ssh=true) is not labelable and is left
+# behind for a scheduled janitor.
 resource "terraform_data" "reap_orphans" {
   triggers_replace = [var.cluster_name, var.location, var.project_id, var.orphan_max_age_hours]
 
@@ -80,12 +92,16 @@ resource "terraform_data" "reap_orphans" {
       while read -r name location; do
         [[ -n "$name" && -n "$location" ]] || continue
 
-        # The cluster goes first: its nodes authenticate as the service
-        # account derived below, so deleting that account first would strand
-        # them mid-teardown.
+        # The cluster delete is fired --async: a synchronous delete is ~5
+        # minutes, runs serially ahead of provisioning, and a handful of
+        # orphans would eat the Prow job's budget before this run's own
+        # cluster exists. Deleting the service account below while the
+        # teardown is still in flight loses little -- an orphan's nodes have
+        # nothing left to do. </dev/null keeps gcloud from ever reading the
+        # orphan list on stdin if a future version decides to prompt.
         echo "reaping orphaned cluster $name ($location), older than ${var.orphan_max_age_hours}h"
-        if ! gcloud container clusters delete "$name" \
-               --location "$location" --project "$project" --quiet; then
+        if ! gcloud container clusters delete "$name" --async \
+               --location "$location" --project "$project" --quiet </dev/null; then
           echo "WARNING: could not delete orphaned cluster $name; the next sweep retries it"
           continue
         fi
@@ -120,7 +136,7 @@ resource "terraform_data" "reap_orphans" {
         while read -r role member; do
           [[ -n "$role" && -n "$member" ]] || continue
           if gcloud projects remove-iam-policy-binding "$project" \
-               --member "$member" --role "$role" --condition=None --quiet >/dev/null; then
+               --member "$member" --role "$role" --condition=None --quiet >/dev/null </dev/null; then
             echo "removed stale binding $role for $member"
           else
             failed=$((failed + 1))
@@ -133,7 +149,7 @@ resource "terraform_data" "reap_orphans" {
 
         if gcloud iam service-accounts describe "$sa" --project "$project" >/dev/null 2>&1; then
           echo "reaping orphaned service account $sa"
-          gcloud iam service-accounts delete "$sa" --project "$project" --quiet \
+          gcloud iam service-accounts delete "$sa" --project "$project" --quiet </dev/null \
             || echo "WARNING: could not delete service account $sa; the next sweep retries it"
         fi
       done <<< "$orphans"
@@ -159,7 +175,7 @@ resource "terraform_data" "reap_orphans" {
       while read -r role member; do
         [[ -n "$role" && -n "$member" ]] || continue
         if gcloud projects remove-iam-policy-binding "$project" \
-             --member "$member" --role "$role" --condition=None --quiet >/dev/null; then
+             --member "$member" --role "$role" --condition=None --quiet >/dev/null </dev/null; then
           echo "removed tombstone binding $role for $member"
         else
           echo "WARNING: could not remove tombstone binding $role for $member"

--- a/bench/tf/modules/cluster/gke/main.tf
+++ b/bench/tf/modules/cluster/gke/main.tf
@@ -39,84 +39,134 @@ locals {
 }
 
 # kube-agents fork: a run killed before its teardown leaves this module's
-# resources behind with no state file to destroy them from, and the next apply
-# then dies on "409 Already Exists" before the evaluation can start. Reap them
-# first, so an aborted run costs the next one time rather than blocking it.
+# resources behind with no state file to destroy them from. Sweep those
+# leftovers before provisioning, so an aborted run costs money for at most
+# orphan_max_age_hours rather than forever.
 #
-# This is safe only because the smoke test runs at max_concurrency 1: nothing
-# else can own a cluster with this name. That assumption is load-bearing -- if
-# the job is ever allowed to run concurrently, this deletes a live run's cluster.
+# This is a cost sweep, not a correctness precondition. Cluster names are
+# derived from the Prow BUILD_ID (hack/ci-eval-pr.sh), so two concurrent runs
+# can never share a name and a "409 Already Exists" between runs is impossible
+# by construction -- the sweep no longer has to clear the way for this run's
+# own name, and raising the Prow job's max_concurrency above 1 is safe.
+#
+# What keeps a live concurrent run's cluster out of the sweep is the AND of
+# two server-side conditions: it must carry the managed-by=kube-agents-bench
+# label (which this module fixes on everything it creates, and which the
+# persistent platform-agent-host cluster does not carry), and it must be older
+# than orphan_max_age_hours -- far longer than any evaluation runs.
 #
 # In CI each run gets a fresh pod and checkout, so there is never prior state
-# here and this resource is created, and the reap runs every time. Locally,
-# state persists under bench/tf, so after the first apply this only re-runs if
-# cluster_name, location or project_id change.
+# here, this resource is created, and the sweep runs every time. Locally,
+# state persists under bench/tf, so it re-runs only when cluster_name,
+# location or project_id change; a laptop is not where orphans accumulate.
 resource "terraform_data" "reap_orphans" {
-  triggers_replace = [var.cluster_name, var.location, var.project_id]
+  triggers_replace = [var.cluster_name, var.location, var.project_id, var.orphan_max_age_hours]
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
-      set -euo pipefail
+      set -uo pipefail
 
-      # The cluster goes first: its nodes authenticate as the service account
-      # below, so deleting that account first would strand them.
-      if gcloud container clusters describe "${var.cluster_name}" \
-           --location "${var.location}" --project "${var.project_id}" >/dev/null 2>&1; then
-        echo "reaping orphaned cluster ${var.cluster_name} left by a previous run"
-        gcloud container clusters delete "${var.cluster_name}" \
-          --location "${var.location}" --project "${var.project_id}" --quiet
-      fi
+      project="${var.project_id}"
 
-      sa="${local.gke_nodes_account_id}@${var.project_id}.iam.gserviceaccount.com"
+      # Best-effort throughout: a sweep that cannot list or delete must not
+      # block the evaluation it runs ahead of. Whatever survives is matched
+      # again by the next run's sweep.
+      orphans=$(gcloud container clusters list --project "$project" \
+        --filter="resourceLabels.managed-by=kube-agents-bench AND createTime<-PT${var.orphan_max_age_hours}H" \
+        --format="value(name,location)" 2>/dev/null) \
+        || { echo "WARNING: orphan sweep could not list clusters; skipping"; exit 0; }
 
-      # Strip the account's project bindings before deleting the account itself.
-      # Deleting it first leaves each binding behind as an inert
-      # "deleted:serviceAccount:<email>?uid=..." member that nothing later
-      # removes, and the recreated account gets a new uid, so its fresh bindings
-      # are separate entries -- every aborted run would add five more.
+      while read -r name location; do
+        [[ -n "$name" && -n "$location" ]] || continue
+
+        # The cluster goes first: its nodes authenticate as the service
+        # account derived below, so deleting that account first would strand
+        # them mid-teardown.
+        echo "reaping orphaned cluster $name ($location), older than ${var.orphan_max_age_hours}h"
+        if ! gcloud container clusters delete "$name" \
+               --location "$location" --project "$project" --quiet; then
+          echo "WARNING: could not delete orphaned cluster $name; the next sweep retries it"
+          continue
+        fi
+
+        # Re-derive the cluster's node service account exactly as the locals
+        # above do: "gke-nodes-" + 9-char sanitized slug + "-" + first 6 hex
+        # chars of md5 over the full cluster name. Change one, change both.
+        slug=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' \
+                 | sed -E 's/[^a-z0-9]+/-/g' | cut -c1-9 | sed -E 's/^-+//; s/-+$//')
+        if command -v md5sum >/dev/null 2>&1; then
+          hash=$(printf '%s' "$name" | md5sum | cut -c1-6)
+        else
+          hash=$(printf '%s' "$name" | md5 -q | cut -c1-6)
+        fi
+        sa="gke-nodes-$slug-$hash@$project.iam.gserviceaccount.com"
+
+        # Strip the account's project bindings before deleting the account
+        # itself. Deleting it first leaves each binding behind as an inert
+        # "deleted:serviceAccount:<email>?uid=..." member, and the tombstone
+        # pass below is the only thing that would ever remove it.
+        #
+        # Roles are read back from the live policy rather than listed here, so
+        # this cannot drift from the google_project_iam_member resources
+        # below. Filtering on this account's email also keeps it away from
+        # agent_container_admin, which binds a long-lived external account.
+        policy=$(gcloud projects get-iam-policy "$project" \
+                   --flatten="bindings[].members" \
+                   --filter="bindings.members:$sa" \
+                   --format="value(bindings.role,bindings.members)" 2>/dev/null || true)
+
+        failed=0
+        while read -r role member; do
+          [[ -n "$role" && -n "$member" ]] || continue
+          if gcloud projects remove-iam-policy-binding "$project" \
+               --member "$member" --role "$role" --condition=None --quiet >/dev/null; then
+            echo "removed stale binding $role for $member"
+          else
+            failed=$((failed + 1))
+            echo "WARNING: could not remove stale binding $role for $member"
+          fi
+        done <<< "$policy"
+        if [ "$failed" -gt 0 ]; then
+          echo "WARNING: $failed stale binding(s) survived the reap; the next sweep retries them"
+        fi
+
+        if gcloud iam service-accounts describe "$sa" --project "$project" >/dev/null 2>&1; then
+          echo "reaping orphaned service account $sa"
+          gcloud iam service-accounts delete "$sa" --project "$project" --quiet \
+            || echo "WARNING: could not delete service account $sa; the next sweep retries it"
+        fi
+      done <<< "$orphans"
+
+      # Tombstone pass: bindings whose member is a deleted gke-nodes account
+      # ("deleted:serviceAccount:gke-nodes-...?uid=...") are inert by
+      # definition -- the account is gone -- so removing them is always safe
+      # and can never race a live run. This clears what aborted runs left
+      # behind before this sweep existed, and what a run killed between
+      # account creation and cluster creation leaves (its account never
+      # matches a reaped cluster above, so its bindings land here once the
+      # account is eventually removed).
       #
-      # The filter matches the tombstones as well as the live member, so this
-      # also clears what earlier runs left behind. It reaps only the resources
-      # this module deploys for the evaluation, nothing else in the project. It
-      # runs outside the existence check below because those tombstones outlive
-      # the account.
-      #
-      # Roles are read back from the live policy rather than listed here, so
-      # this cannot drift from the google_project_iam_member resources above.
-      # Filtering on this account's email also keeps it away from
-      # agent_container_admin, which binds a long-lived external account.
-      policy=$(gcloud projects get-iam-policy "${var.project_id}" \
-                 --flatten="bindings[].members" \
-                 --filter="bindings.members:$sa" \
-                 --format="value(bindings.role,bindings.members)")
-
-      # Reported after the attempt rather than before it: this stays
-      # best-effort so one stuck binding cannot block the run, but a reap where
-      # every removal failed must not read identically to one where they all
-      # succeeded. Whatever is left behind is matched again by the next reap.
-      failed=0
+      # Known residual: the *live* account of a run killed in the window
+      # after the service account exists but before its cluster does is not
+      # reaped -- an account's age is not listable, so deleting it cannot be
+      # made race-free from here. It holds five project roles and costs
+      # nothing; a scheduled janitor with an inventory is the right owner.
+      tombstones=$(gcloud projects get-iam-policy "$project" \
+        --flatten="bindings[].members" \
+        --filter="bindings.members ~ ^deleted:serviceAccount:gke-nodes-.*@$project" \
+        --format="value(bindings.role,bindings.members)" 2>/dev/null || true)
       while read -r role member; do
         [[ -n "$role" && -n "$member" ]] || continue
-        if gcloud projects remove-iam-policy-binding "${var.project_id}" \
+        if gcloud projects remove-iam-policy-binding "$project" \
              --member "$member" --role "$role" --condition=None --quiet >/dev/null; then
-          echo "removed stale binding $role for $member"
+          echo "removed tombstone binding $role for $member"
         else
-          failed=$((failed + 1))
-          echo "WARNING: could not remove stale binding $role for $member"
+          echo "WARNING: could not remove tombstone binding $role for $member"
         fi
-      done <<< "$policy"
+      done <<< "$tombstones"
 
-      # One line to grep for: the per-binding warnings above are easy to lose in
-      # a Prow log thousands of lines long.
-      if [ "$failed" -gt 0 ]; then
-        echo "WARNING: $failed stale binding(s) survived the reap; the next run retries them"
-      fi
-
-      if gcloud iam service-accounts describe "$sa" --project "${var.project_id}" >/dev/null 2>&1; then
-        echo "reaping orphaned service account $sa"
-        gcloud iam service-accounts delete "$sa" --project "${var.project_id}" --quiet
-      fi
+      exit 0
     EOT
   }
 }

--- a/bench/tf/modules/cluster/gke/variables.tf
+++ b/bench/tf/modules/cluster/gke/variables.tf
@@ -81,3 +81,9 @@ variable "gpu_count" {
   default     = 1
 }
 
+variable "orphan_max_age_hours" {
+  description = "Age in hours past which a managed-by=kube-agents-bench cluster is considered orphaned and reaped before this run provisions"
+  type        = number
+  default     = 4
+}
+

--- a/bench/tf/modules/cluster/gke/variables.tf
+++ b/bench/tf/modules/cluster/gke/variables.tf
@@ -85,5 +85,10 @@ variable "orphan_max_age_hours" {
   description = "Age in hours past which a managed-by=kube-agents-bench cluster is considered orphaned and reaped before this run provisions"
   type        = number
   default     = 4
+
+  validation {
+    condition     = var.orphan_max_age_hours >= 2
+    error_message = "orphan_max_age_hours must be >= 2: the Prow eval job runs up to 85 minutes, and a lower threshold lets the sweep delete a live concurrent run's cluster."
+  }
 }
 

--- a/bench/tf/modules/cluster/main.tf
+++ b/bench/tf/modules/cluster/main.tf
@@ -31,6 +31,7 @@ module "gke" {
   enable_iap_ssh           = var.enable_iap_ssh
   gpu_type                 = var.gpu_type
   gpu_count                = var.gpu_count
+  orphan_max_age_hours     = var.orphan_max_age_hours
 }
 
 # Only the gke sub-module is vendored: it carries kube-agents changes (resource

--- a/bench/tf/modules/cluster/variables.tf
+++ b/bench/tf/modules/cluster/variables.tf
@@ -104,3 +104,9 @@ variable "node_image" {
   default     = "kindest/node:v1.29.2"
 }
 
+variable "orphan_max_age_hours" {
+  type        = number
+  description = "Age in hours past which a managed-by=kube-agents-bench cluster is reaped as an orphan (GCP-only)"
+  default     = 4
+}
+

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -19,7 +19,9 @@ export REGION="${REGION:-us-central1}"
 
 export HOST_CLUSTER_NAME="platform-agent-host"
 export CLUSTER_NAME="${HOST_CLUSTER_NAME}"
-export GKE_CLUSTER_NAME="test-cluster"
+# GKE_CLUSTER_NAME (the per-run task cluster devops-bench provisions) is set by
+# ci-eval-pr.sh, derived from the Prow BUILD_ID so concurrent runs never share
+# a name. Deploy and teardown never touch a task cluster, so it is not set here.
 
 export TARGET_NAMESPACE="kubeagents-system"
 export NAMESPACE="${TARGET_NAMESPACE}"

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -41,21 +41,40 @@ export BENCH_TF_ROOT="./tf"
 export CLOUD_PROVIDER="gcp"
 export TF_VAR_infra_provider="gcp"
 
-# Per-run task-cluster name, derived from the Prow run identity. Uniqueness is
-# what makes concurrent presubmit runs safe: two runs can never race on one
-# cluster because they never share a name, and a "409 Already Exists" between
-# runs is impossible by construction. The old fixed name ("test-cluster") was
-# safe only while the Prow job's max_concurrency was 1 -- a setting that lives
-# in test-infra where nobody editing this repository would see it.
+# Per-run task-cluster name, derived from the Prow run identity. Within a
+# project, two runs can never race on one cluster because they never share a
+# name, and a "409 Already Exists" between runs is impossible by construction.
+# The old fixed name ("test-cluster") was unsafe the moment two runs shared the
+# project.
 #
-# GKE caps names at 40 chars matching [a-z]([-a-z0-9]*[a-z0-9])?, so the name
-# is lowercased, non-alphanumerics collapse to hyphens, and it is clamped with
-# no trailing hyphen. BUILD_ID and PULL_NUMBER are set by Prow; locally the
-# name falls back to a stable "eval-pr0-local", where the persistent tofu state
-# under bench/tf makes reuse across runs the intended behaviour.
-EVAL_CLUSTER_NAME="eval-pr${PULL_NUMBER:-0}-${BUILD_ID:-local}"
-EVAL_CLUSTER_NAME="$(printf '%s' "${EVAL_CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
-EVAL_CLUSTER_NAME="$(printf '%s' "${EVAL_CLUSTER_NAME:0:40}" | sed 's/-*$//')"
+# This alone does NOT make raising the Prow job's max_concurrency safe: every
+# run also installs cluster-wide singletons (CRDs, webhooks, ClusterRoles) on
+# the shared platform-agent-host cluster. Real concurrency arrives with issue
+# #637 (Boskos one-project-per-run leasing); do not raise max_concurrency
+# before it. Unique names still matter under #637 -- a retried run in a
+# freshly-leased project must not collide with what its predecessor left.
+#
+# GKE caps names at 40 chars matching [a-z]([-a-z0-9]*[a-z0-9])?. The name is
+# lowercased and non-alphanumerics collapse to hyphens; locally it falls back
+# to a stable "eval-pr0-<user>" so two laptops sharing a project do not
+# collide, and the persistent tofu state under bench/tf makes reuse across
+# local runs the intended behaviour.
+#
+# NEVER clamp an overlong name: the run discriminator (BUILD_ID) sits at the
+# tail, so truncation keeps the shared prefix and drops exactly the part that
+# differs -- two long BUILD_IDs with a common prefix would collapse to one
+# name and resurrect the shared-name race. When the readable form does not
+# fit, swap the tail for a hash of the full identity instead.
+EVAL_RUN_IDENT="${PULL_NUMBER:-0}-${BUILD_ID:-${USER:-local}}"
+EVAL_CLUSTER_NAME="eval-pr${EVAL_RUN_IDENT}"
+EVAL_CLUSTER_NAME="$(printf '%s' "${EVAL_CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/-*$//')"
+if [ "${#EVAL_CLUSTER_NAME}" -gt 40 ]; then
+  EVAL_IDENT_HASH="$(printf '%s' "${EVAL_RUN_IDENT}" | { md5sum 2>/dev/null || md5 -q; } | tr -d ' -' | cut -c1-8)"
+  # The PR component is bounded to 24 chars so the 8-char hash -- the only
+  # part guaranteed to differ -- can never be squeezed out of the 40.
+  EVAL_PR_PART="$(printf '%s' "${PULL_NUMBER:-0}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | cut -c1-24 | sed 's/-*$//')"
+  EVAL_CLUSTER_NAME="eval-pr${EVAL_PR_PART:-0}-${EVAL_IDENT_HASH}"
+fi
 export GKE_CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
 export CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
 export TF_VAR_cluster_name="${EVAL_CLUSTER_NAME}"

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -40,9 +40,26 @@ export BENCH_TF_ROOT="./tf"
 # For opentofu provider
 export CLOUD_PROVIDER="gcp"
 export TF_VAR_infra_provider="gcp"
-export GKE_CLUSTER_NAME="test-cluster"
-export CLUSTER_NAME="test-cluster"
-export TF_VAR_cluster_name="test-cluster"
+
+# Per-run task-cluster name, derived from the Prow run identity. Uniqueness is
+# what makes concurrent presubmit runs safe: two runs can never race on one
+# cluster because they never share a name, and a "409 Already Exists" between
+# runs is impossible by construction. The old fixed name ("test-cluster") was
+# safe only while the Prow job's max_concurrency was 1 -- a setting that lives
+# in test-infra where nobody editing this repository would see it.
+#
+# GKE caps names at 40 chars matching [a-z]([-a-z0-9]*[a-z0-9])?, so the name
+# is lowercased, non-alphanumerics collapse to hyphens, and it is clamped with
+# no trailing hyphen. BUILD_ID and PULL_NUMBER are set by Prow; locally the
+# name falls back to a stable "eval-pr0-local", where the persistent tofu state
+# under bench/tf makes reuse across runs the intended behaviour.
+EVAL_CLUSTER_NAME="eval-pr${PULL_NUMBER:-0}-${BUILD_ID:-local}"
+EVAL_CLUSTER_NAME="$(printf '%s' "${EVAL_CLUSTER_NAME}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+EVAL_CLUSTER_NAME="$(printf '%s' "${EVAL_CLUSTER_NAME:0:40}" | sed 's/-*$//')"
+export GKE_CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
+export CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
+export TF_VAR_cluster_name="${EVAL_CLUSTER_NAME}"
+echo "Task cluster for this run: ${EVAL_CLUSTER_NAME}"
 export GCP_LOCATION="us-west4-a" # set to different zone due to resource availability stockouts in us-central1
 
 # Stamp the run onto every labelable GCP resource the stacks create, alongside


### PR DESCRIPTION
## Summary

Makes the smoke-test eval infrastructure safe within a project and self-cleaning: the eval cluster name derives from the Prow run (`eval-pr<N>-<BUILD_ID>`, hash-suffixed when long) instead of the hardcoded `test-cluster`, and the `reap_orphans` provisioner stops deleting by name — it sweeps clusters labeled `managed-by=kube-agents-bench` older than a configurable age. The reaper becomes a garbage collector instead of a correctness precondition whose own comment called its safety assumption load-bearing.

## Why This Change

Today every run names its cluster `test-cluster`, and the reaper deletes any cluster with that name before applying. That is safe only at `max_concurrency: 1` — a setting that lives in oss-test-infra, where a one-line change by someone with no reason to read this Terraform would make concurrent runs delete each other's live clusters mid-eval, reporting failures that look like the agent's. Unique names make the collision impossible instead of forbidden; the label-and-age sweep keeps the cleanup the reaper existed for (a killed run leaves resources with no state file to destroy them from) without the name-matching hazard.

## What Changed

- `hack/ci-eval-pr.sh` — cluster name from `PULL_NUMBER` + `BUILD_ID`, sanitized to GKE's rules; when over 40 chars the tail is 8 hex of md5 over both (clamping is forbidden and the comment says why: cutting BUILD_ID's tail cuts the only part guaranteed to differ). Local fallback `eval-pr0-<user>` so two laptops sharing a project don't collide
- `bench/tf/modules/cluster/gke/main.tf` — the sweep: list by label + `createTime`, delete clusters `--async`, re-derive and remove each orphan's node SA and bindings synchronously, tombstone pass unchanged in spirit but scoped to the swept accounts. Comments rewritten to the new invariant
- `bench/tf/modules/cluster/{gke/,}variables.tf` — `orphan_max_age_hours` (default 4, validation floor 2 citing the 85-minute Prow budget)
- `hack/ci-env.sh` — stale `GKE_CLUSTER_NAME` export removed (nothing consumed it)

## Context

**Relationship to #637 (Boskos project leasing, assigned):** complementary, not competing — and the comments in this diff say so explicitly. This change does **not** enable concurrency by itself: every run also installs cluster-wide singletons (CRDs, webhooks, ClusterRoles) onto the shared `platform-agent-host`, so two runs in one project still break each other at the deploy step. Concurrency arrives with #637's one-project-per-run leasing; `max_concurrency` stays at 1 until then. The two interlock: #637 turns the Boskos janitor off for leased projects, which makes this PR's sweep the only cleanup mechanism in them, and the unique names are what stop a killed run's leftover cluster from 409ing the next run to lease that project (this PR removes the delete-by-name reaper that used to paper over exactly that).

**Flag for #516:** its new stacks build on the upstream devops-bench cluster module, which applies no `managed-by=kube-agents-bench` label — those clusters are invisible to this sweep and a killed run of those tasks leaks its cluster. Whichever merges second should add the label (or vendor the module); leaving a note on that PR.

Merge adjacency: #821 and #695 also touch `hack/ci-eval-pr.sh` — rebase churn only.

This PR was generated with the help of Claude.

## Testing

- `tofu validate` clean on all three stacks; `tofu fmt -check -recursive` clean; `bash -n` clean on both scripts and the extracted provisioner heredoc
- Name derivation fuzzed (13 hostile shapes: unicode, dots, double hyphens, 30-digit PR numbers, 40-char BUILD_IDs): all outputs GKE-valid and ≤40 chars, and two BUILD_IDs sharing a 32-char prefix produce distinct names — the exact collision the old clamp had
- SA re-derivation: bash and HCL byte-identical across the fuzz set including hash-suffixed names; every account_id ≤26 chars against the 30 cap
- The sweep's filter expression executed in gcloud's bundled filter engine: the hyphenated label key parses, the `createTime<-PT4H` boundary is exact (3h59 kept, 4h01 swept), and an unlabeled or `kube-agents-host`-labeled cluster never matches

### Live validation

Not live-tested against a real Prow run: the change only takes effect inside the Prow job, and the one environment that runs it is the shared CI project. What was validated live-equivalently is above (filter engine, fuzz, tofu validate); the residual risk — server-side filter semantics differing from the client engine — is one `gcloud container clusters list --filter=...` in `kube-agents-evals` away, and worth doing on the first post-merge run's logs.

## Self-Review

Adversarial pass by a separate reviewer context that did not write the change (angles A–J), with an explicit "does this break the existing smoke flow" addendum. Verdict: sound mechanism; one Blocking, two Should-fix, four Nits — all fixed before opening:

- **Blocking, fixed:** the original 40-char clamp kept the *first* 40 chars, cutting BUILD_ID's tail — the only differing part — so two long-ID builds sharing a prefix collapsed to one name, resurrecting the shared-name race. Now hash-suffixed, collision-proof by construction, fuzz-verified
- **Fixed:** synchronous orphan deletes could burn 25+ minutes of the 85m Prow budget after an outage strands several clusters (`--async` now); `orphan_max_age_hours: 0` would have swept live runs (validation floor 2); local fallback shared across users; stdin leaks into gcloud calls inside the read loop; two residuals now documented in comments (local lost-state 409 self-heals; the IAP firewall is left for a scheduled janitor)
- Smoke-flow invariants verified end-to-end by the reviewer: `{{CLUSTER_NAME}}` template substitution traced through devops-bench internals to the tofu output — single source, cannot diverge; `ci-teardown.sh` touches only the host deploy and never referenced the old name; no in-repo path labels `platform-agent-host` with the sweep's key; a pre-merge orphaned `test-cluster` carries the label, ages out, and cannot 409 the new names
- Reviewer-verified clean: SA account_id math at truncation boundaries (19-case fuzz), sweep idempotence when a cluster vanishes between list and delete, IAM member parsing against crafted principals, `triggers_replace` semantics

## Risk & Rollout

The blast radius of a sweep bug is deleting the wrong cluster in `kube-agents-evals`. Three fences: the label filter (nothing in the repo applies that label to anything but bench-created clusters), the age floor (validated ≥2h against an 85m job), and best-effort error handling (`set -uo` without `-e`; a failed delete warns and continues, so the sweep can never block an eval). `platform-agent-host` is protected by the label filter, verified against every labeling path in the tree. Revert restores the name-based reaper and the fixed name; nothing else depends on the new names. At today's `max_concurrency: 1` the only behavioral change is that an orphan survives up to 4 hours instead of being deleted by the next run — a small cost, not a correctness change.
