### PR TITLE
ci: stop cancelling deploys mid-upgrade and wait out the helm release lock

### DIFF
--- a/.github/workflows/autopush-redeploy-agent.yml
+++ b/.github/workflows/autopush-redeploy-agent.yml
@@ -7,9 +7,19 @@ on:
     types:
       - completed
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: autopush-redeploy-agent
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/autopush-redeploy-controller.yml
+++ b/.github/workflows/autopush-redeploy-controller.yml
@@ -7,9 +7,19 @@ on:
     types:
       - completed
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: autopush-redeploy-controller
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/autopush-redeploy-integrations.yml
+++ b/.github/workflows/autopush-redeploy-integrations.yml
@@ -28,9 +28,19 @@ on:
         type: boolean
         default: true
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: autopush-redeploy-integrations
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-deploy-agent.yml
+++ b/.github/workflows/reusable-deploy-agent.yml
@@ -46,6 +46,7 @@ jobs:
   deploy:
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -125,7 +126,7 @@ jobs:
             exit 1
           fi
           echo "Redeploying platform-agent via helm upgrade with image: ${AGENT_IMAGE}:${IMAGE_TAG}"
-          helm upgrade kube-agents charts/kube-agents -n kubeagents-system \
+          ./scripts/helm_upgrade_retry.sh kube-agents charts/kube-agents -n kubeagents-system \
             --reset-then-reuse-values --set "platformAgent.deployment.image.tag=${IMAGE_TAG}" --wait --timeout 10m
 
       - name: Verify Agent Deployment Rollout

--- a/.github/workflows/reusable-deploy-controller.yml
+++ b/.github/workflows/reusable-deploy-controller.yml
@@ -42,6 +42,7 @@ jobs:
   deploy:
     needs: validate
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
@@ -110,5 +111,5 @@ jobs:
           # CRD schema changes never ride a helm upgrade (Helm's documented
           # behaviour for crds/), so apply them first.
           kubectl apply --server-side --force-conflicts -f charts/kube-agents/crds/
-          helm upgrade kube-agents charts/kube-agents -n kubeagents-system \
+          ./scripts/helm_upgrade_retry.sh kube-agents charts/kube-agents -n kubeagents-system \
             --reset-then-reuse-values --set "operator.image.tag=${IMAGE_TAG}" --wait --timeout 10m

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -79,13 +79,14 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.litellm == 'true' || needs.detect-changes.outputs.github == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
     environment: ${{ inputs.target_environment }}
     concurrency:
       group: ${{ inputs.target_environment }}-redeploy-secrets
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       NAMESPACE: "kubeagents-system"
     steps:
@@ -159,7 +160,7 @@ jobs:
           # bumped in the checkout's chart (the image pins this workflow
           # triggers on) would never reach the cluster again. Reset-then-reuse
           # keeps the release's own values and lets chart defaults refresh.
-          helm upgrade kube-agents charts/kube-agents -n kubeagents-system \
+          ./scripts/helm_upgrade_retry.sh kube-agents charts/kube-agents -n kubeagents-system \
             --reset-then-reuse-values --set "platformAgent.credentials.create=true" \
             "${args[@]}" --wait --timeout 10m
 
@@ -168,13 +169,14 @@ jobs:
     needs: [detect-changes, provision-secrets]
     if: ${{ needs.detect-changes.outputs.litellm == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
     environment: ${{ inputs.target_environment }}
     concurrency:
       group: ${{ inputs.target_environment }}-redeploy-litellm
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       NAMESPACE: "kubeagents-system"
     steps:
@@ -224,7 +226,7 @@ jobs:
           # this job's main trigger is a litellm.image.tag bump in values.yaml
           # / images.json, which --reuse-values would shadow forever behind
           # the previous release's snapshot of the old default.
-          helm upgrade kube-agents charts/kube-agents -n kubeagents-system \
+          ./scripts/helm_upgrade_retry.sh kube-agents charts/kube-agents -n kubeagents-system \
             --reset-then-reuse-values "${args[@]}" --wait --timeout 10m
 
       - name: Verify LiteLLM Deployment Rollout
@@ -292,13 +294,14 @@ jobs:
       [detect-changes, provision-secrets, check-github-config, deploy-litellm]
     if: ${{ !cancelled() && needs.provision-secrets.result == 'success' && needs.detect-changes.outputs.github == 'true' && needs.check-github-config.outputs.configured == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write
     environment: ${{ inputs.target_environment }}
     concurrency:
       group: ${{ inputs.target_environment }}-redeploy-github
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       GITHUB_PEM_PATH: "/tmp/github_app_pem_path"
       NAMESPACE: "kubeagents-system"
@@ -378,7 +381,7 @@ jobs:
           # --reset-then-reuse-values for the same reason as deploy-litellm:
           # a githubMinter.image.tag bump is this job's trigger, and only a
           # refreshed chart default can deliver it.
-          helm upgrade kube-agents charts/kube-agents -n kubeagents-system \
+          ./scripts/helm_upgrade_retry.sh kube-agents charts/kube-agents -n kubeagents-system \
             --reset-then-reuse-values --set "githubMinter.enabled=true" \
             --set-string "githubMinter.org=$GITHUB_ORG" \
             --set-string "githubMinter.repo=$GITHUB_REPO" \

--- a/.github/workflows/staging-redeploy-agent.yml
+++ b/.github/workflows/staging-redeploy-agent.yml
@@ -5,9 +5,19 @@ on:
     tags:
       - "staging/**"
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: staging-redeploy-agent
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/staging-redeploy-controller.yml
+++ b/.github/workflows/staging-redeploy-controller.yml
@@ -5,9 +5,19 @@ on:
     tags:
       - "staging/**"
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: staging-redeploy-controller
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/staging-redeploy-integrations.yml
+++ b/.github/workflows/staging-redeploy-integrations.yml
@@ -5,9 +5,19 @@ on:
     tags:
       - "staging/**"
 
+# The payload here is a `helm upgrade` on the shared `kube-agents` release.
+# Cancelling one mid-flight strands the release in pending-upgrade and every
+# later deploy fails until someone rolls it back by hand, so a running deploy
+# is never cancelled. A queued one has not reached the cluster and is safe to
+# supersede.
+#
+# Keep this group one component wide. GitHub holds only a single run pending
+# per group, so a group shared with the sibling redeploys would let them evict
+# each other and silently drop a deploy. They contend on the release lock
+# instead, which scripts/helm_upgrade_retry.sh waits out.
 concurrency:
   group: staging-redeploy-integrations
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/scripts/helm_upgrade_retry.sh
+++ b/scripts/helm_upgrade_retry.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Run `helm upgrade` with the arguments given, waiting out the release lock.
+#
+# The controller, agent, and integrations redeploys upgrade the same
+# `kube-agents` release from separate workflows, so two can reach helm at once
+# and the loser fails on the lock. Waiting costs a delay; the deploy it was
+# about to do is still valid.
+#
+# Only the lock error retries. Any other helm failure exits immediately with
+# helm's own status.
+#
+# The budget is wall-clock so it can be compared against the `--timeout 10m`
+# every call site gives its own upgrade, and it has to outlast the longest hold
+# a healthy deploy can take. That is an integrations run, which takes the lock
+# three times in sequence -- provision-secrets, deploy-litellm, deploy-github
+# -- for up to 30 minutes total.
+#
+# The default is sized against the callers' timeout-minutes: 60. Giving up
+# costs the budget itself, ~35 minutes. Winning the lock on the last attempt
+# costs more: that attempt starts at up to (budget - delay) and then runs its
+# own --timeout 10m, so ~44.5 minutes before the job's other steps.
+
+set -euo pipefail
+
+LOCK_ERROR="another operation (install/upgrade/rollback) is in progress"
+
+lock_timeout="${HELM_LOCK_TIMEOUT:-2100}"
+delay="${HELM_LOCK_RETRY_DELAY:-30}"
+
+deadline=$((SECONDS + lock_timeout))
+attempt=0
+
+while true; do
+  attempt=$((attempt + 1))
+
+  # The output is captured so the lock error can be matched, and echoed back on
+  # both paths so a failed deploy still shows why. helm writes that error to
+  # stderr, hence the 2>&1.
+  status=0
+  output="$(helm upgrade "$@" 2>&1)" || status=$?
+  printf '%s\n' "$output"
+
+  if [[ "$status" -eq 0 ]]; then
+    exit 0
+  fi
+
+  if [[ "$output" != *"$LOCK_ERROR"* ]]; then
+    exit "$status"
+  fi
+
+  # Stop before a sleep that would run past the deadline rather than after it,
+  # so the budget is a ceiling on the wait instead of a floor.
+  if ((SECONDS + delay >= deadline)); then
+    break
+  fi
+
+  echo "Release lock held by a concurrent deploy; retrying in ${delay}s (attempt ${attempt}, $((deadline - SECONDS))s of budget left)"
+  sleep "$delay"
+done
+
+# Deliberately not a bare "run helm rollback": from here a lock held by a live
+# deploy looks exactly like a wedged release, and rolling back the former kills
+# a deploy that was about to succeed.
+echo "::error::Timed out after ${lock_timeout}s waiting for the kube-agents release lock. Check whether another deploy is still running in this environment first -- if one is, let it finish and re-run this job. Only if nothing is running is the release wedged: 'helm history kube-agents -n kubeagents-system' shows the pending revision, and 'helm rollback kube-agents <last-deployed-revision> -n kubeagents-system' clears it."
+exit 1


### PR DESCRIPTION
## Summary

The six autopush and staging redeploy workflows ran with `cancel-in-progress: true`, and their payload is a `helm upgrade` against the shared `kube-agents` release — so cancelling a run that has already started strands the release in `pending-upgrade` and blocks every deploy after it. This turns cancellation off on all six (and on three jobs inside `reusable-deploy-integrations.yml` with the same defect), and adds `scripts/helm_upgrade_retry.sh` so the separate contention problem — three workflows upgrading one release — is handled by waiting for the lock rather than by a concurrency group.

## Why This Change

Autopush broke this way on 2026-08-20 and stayed broken for 50 minutes.

Two publishes for commit `95a7c04d` landed 43 seconds apart. Run [32379234435](https://github.com/gke-labs/kube-agents/actions/runs/32379234435) began its `helm upgrade` at 14:18:17; the superseding run cancelled it at 14:18:41 — after helm had written the `pending-upgrade` record for revision 22, before it applied anything. Every autopush deploy from then on failed with:

```
Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
```

Three Controller runs and three Agent runs failed that way. The cluster was healthy throughout — the pods were serving revision 21 — but the release metadata was locked, so autopush sat three commits behind `main` and could not move. Clearing it took a manual `helm rollback kube-agents 21 -n kubeagents-system`.

The guard each deploy step already runs does not catch this. `helm status kube-agents` exits 0 on a `pending-upgrade` release, so the step proceeds straight into the failing upgrade.

There is a second, independent problem in the same place: the controller, agent, and integrations redeploys all run `helm upgrade` against the same release from three separate workflows, so two can reach helm at once and the loser fails on the lock. That did not cause this outage, but it is reachable.

## What Changed

- `cancel-in-progress: false` on all six redeploy workflows, and on the `provision-secrets`, `deploy-litellm`, and `deploy-github` jobs in `reusable-deploy-integrations.yml`, which each run `helm upgrade` under their own job-level group and carried the identical defect.
- **New:** `scripts/helm_upgrade_retry.sh` retries `helm upgrade` while another deploy holds the release lock, and exits immediately with helm's own status on any other failure, so a chart that does not render still fails fast. The wait is bounded by wall clock (`HELM_LOCK_TIMEOUT`, default 2100s; `HELM_LOCK_RETRY_DELAY`, default 30s) so it can be compared against the `--timeout 10m` each call site gives its own upgrade; it has to outlast the longest healthy hold, which is the integrations run taking the lock three times in sequence for up to 30 minutes. Against the `timeout-minutes: 60` added here: giving up costs the budget itself, ~35 minutes, while winning the lock on the last attempt costs ~44.5 — that attempt can start at `budget - delay` and then run its own `--timeout 10m` — leaving ~15 minutes for the job's other steps. On expiry the job fails with a message that says to check for a running deploy *before* touching the release. All five `helm upgrade` call sites go through it.
- `timeout-minutes: 60` on the five lock-holding jobs, matching `rc-deploy-environment.yml`. Removing auto-cancel removes the escape hatch that used to clear a hung run, and GitHub's default is 360 minutes.

Concurrency **groups are deliberately left per-component.** Collapsing them to one group per environment is the obvious way to serialise three producers off one lock, and it is wrong: GitHub keeps only one run pending per group, so a third arrival evicts the queued one. The three staging workflows share a trigger (`push: tags: staging/**`) and start together, so that would silently drop one of the three on every staging tag. Each file's comment says this, to stop the next person reaching for it.

`rc-deploy-environment.yml` is untouched — separate `rc` environment, own provisioning script, already `cancel-in-progress: false`.

## Context

Both concurrency blocks date to #321. dabf9616 (#816) added concurrency groups to the PR-validation workflows around the same time and is easy to mistake for the cause; it touches no deploy workflow.

No open issue covers this. #504 is unrelated. **#821** (`sergiu1spiridon`) appends to `autopush-redeploy-agent.yml` at the end of the file — no textual conflict with the concurrency block, assessed from hunk position only, not by checking out the branch.

Incident remediation is already done and is not in this diff: the release was rolled back to revision 21 and the Controller and Agent redeploys re-run sequentially. autopush is on `4319f9a4` at revision 25, `deployed`.

## Testing

- `scripts/helm_upgrade_retry.sh` exercised against a stub `helm`: success first try (exit 0); a non-lock failure (exit 7 immediately, no retry, helm's status preserved); a lock that clears partway (exit 0, correct attempt count); and a lock that never clears (exit 1). The never-clearing case was driven against `HELM_LOCK_TIMEOUT`/`HELM_LOCK_RETRY_DELAY`, not an attempt count: at `HELM_LOCK_TIMEOUT=10 HELM_LOCK_RETRY_DELAY=4` it stopped at 8s, confirming the budget is a ceiling rather than a floor. Confirmed the `::error::` line lands on stdout, where the runner parses workflow commands.
- `shellcheck scripts/helm_upgrade_retry.sh` — clean.
- `make docs-check` — passes.
- `prettier@3.9.6 --check` on all nine changed workflows — clean.
- Asserted by parsing each file that every `concurrency` block is now `cancel-in-progress: false`, that group names are per-component, that the five lock-holding jobs carry `timeout-minutes: 60`, and that a checkout step precedes the script call in all five jobs that invoke it.
- `scripts/helm_upgrade_retry.sh` is committed mode `100755`.
- `actionlint` not run locally (not installed); CI's Actionlint job covers it.

### Live validation

Not live-tested, and it cannot be. GitHub Actions concurrency behaviour only exists once the workflow file is on the default branch, so no branch push can exercise it, and the retry script only runs from inside those workflows. The change touches no chart, manifest, image, or operator code path.

What *was* exercised live is the failure this prevents and the recovery from it, on `kube-agents-autopush` (`platform-agent-host`, `us-central1`):

- Confirmed the stuck state — `helm history` showed revision 22 `pending-upgrade` from 14:18:17, revision 21 `deployed`.
- Confirmed revision 22 never applied: the live controller was still on `5f9c0448` and the agent on `68e6735e`, the images revision 21 installed. That is what made the rollback safe.
- `helm rollback kube-agents 21` → revision 23 `deployed`, no workload churn beyond an Autopilot CPU-request adjustment on the controller.
- Re-ran the Controller then the Agent redeploy **sequentially** — deliberately not in parallel, since running them together would have exercised the very contention this PR fixes. Both green.
- Final state: revision 25 `deployed`; `kube-agents-controller-manager` and `platform-agent-gateway` both on `4319f9a4`; all five deployments ready.

Not covered: the retry script's lock branch has been proven against a stub helm, not against two real deploys racing. Nothing left behind — revisions 23–25 are ordinary release history.

## Self-Review

Ran `review-adversarial` over `upstream/main...HEAD` in a subagent handed the diff range and none of the reasoning behind it. It was pointed at the GitHub Actions semantics, starvation and deadlock, missed consumers of the release, caller/callee concurrency interaction, comment accuracy, doc drift, and whether the commit message overclaimed.

**It rejected the original design, and it was right.** The first version of this branch collapsed the three per-component groups into one per environment. Because GitHub queues only one run per group, and the three staging workflows share a trigger and start simultaneously, that would have cancelled one of three staging deploys on *every* staging tag — nondeterministically, reported as "cancelled" rather than failed. That is a worse regression than the bug being fixed. I verified the trigger blocks are byte-identical before accepting it. The collapse is gone; the retry script replaces it.

Findings and disposition:

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 1 | High | Shared group drops one of three staging deploys per tag | **Fixed** — reverted to per-component groups |
| 2 | High | Dropped autopush integrations deploy would not self-heal (its trigger is path-filtered) | **Fixed** by the same revert — no cross-component eviction remains |
| 3 | Med | Comment claimed eviction "stays free", then conceded it skips a deploy | **Fixed** — rewritten; now explains why *not* to collapse |
| 4 | Med | No `timeout-minutes`; without auto-cancel a hung run holds its group for 360m | **Fixed** — 60 on the five lock-holding jobs |
| 5 | Med | Commit message cited `reusable-deploy-integrations.yml` as prior art while that file still had three `cancel-in-progress: true` blocks on `helm upgrade` jobs; its serialisation is `needs:`, not concurrency | **Fixed** — claim dropped, and the three blocks fixed. Verified at `:86,175,299` |
| 6 | Med | Workflow concurrency structurally cannot express "serialise N producers" | **Addressed** — took one of its suggested directions, retry-on-lock-error |
| 7 | Low | The comment is duplicated across six files | **Not fixed.** Each workflow is read on its own and the reason not to collapse has to be where someone would try it. Now accurate for both environments — the incident reference is scoped to autopush |
| 8 | Low | #821 widens the eviction window | **No longer applicable** — no cross-component eviction. Noted under Context for merge order |

`kube-agents-bot` then reviewed the result and found one further defect, which is fixed:

| # | Sev | Finding | Disposition |
|---|-----|---------|-------------|
| 9 | Med | The retry budget was shorter than the lock hold it existed to absorb — 10 attempts × 30s is 9 sleeps, ~4.5 minutes, while every call site gives its own upgrade `--wait --timeout 10m` and the integrations chain takes the lock three times in sequence for up to 30. The give-up message also recommended `helm rollback`, which from the operator's side is indistinguishable from killing a live deploy | **Fixed** — budget is now wall-clock (`HELM_LOCK_TIMEOUT`, default 2100s), directly comparable to the callers' `--timeout 10m` and sized to outlast the 30-minute chain with room for the waiter's own upgrade inside `timeout-minutes: 60`. The message now says to check for a running deploy first |

| 10 | Med | The PR description still named `HELM_LOCK_RETRIES`, default 10 × 30s — a knob the script does not have — understating the ceiling by 7×; and it did not state that winning the lock on the final attempt costs ~44.5 minutes, not 35 | **Fixed** — description corrected, and the worst-case arithmetic is now in both the script header and **What Changed** |

I verified both premises before accepting it: all five call sites do pass `--wait --timeout 10m`, and `provision-secrets` → `deploy-litellm` → `deploy-github` is a strict `needs:` chain. The original budget provably could not cover the case the script was added for.

It also checked and found clean: caller/callee deadlock (no cycle exists), cross-environment interference (`grep -rl "helm upgrade" .github/workflows/` returns exactly this family of nine files, so no consumer of the release is missed), the `rc-deploy-environment.yml` comparison, docs drift (only `docs/designs/design_537148738.md` names any of these files, in a Zizmor-ignore list, saying nothing about concurrency), and action pins / permissions / fork guards, none of which this touches.

What the pass could not cover: GitHub's queue behaviour is only observable on live `gke-labs/kube-agents` infrastructure, so findings 1 and 2 were reasoned from documented semantics and the trigger definitions rather than observed. That is also why the fix avoids depending on those semantics at all.

## Risk & Rollout

Small blast radius. The concurrency and timeout changes affect only when GitHub starts and stops deploy jobs. The one new executable path is `scripts/helm_upgrade_retry.sh`, which is a pass-through to `helm upgrade` on every path except the lock error; a bad chart, a failed rollout, or an auth failure exits with helm's own status on the first attempt, as before.

Concurrency takes effect on merge to `main`, since it is read from the default branch. The retry script takes effect on the next deploy from any branch that has it. Reverting is a straight revert of the one commit.

Worth a reviewer's attention: staging is changed on the strength of having the identical shape to autopush, not because it was observed failing. And the retry's lock branch has been proven against a stub helm, not two real racing deploys — the first real exercise will be on autopush after merge.

---

This PR was generated with the help of Claude.
