### PR TITLE
ci: notify on a broken main by tracking it as an issue

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,7 +1,20 @@
 name: Docker Build
 
+# `push: main` as well as the pull request, so that main itself is built.
+# `strict` is off in branch protection, so what a merge is allowed on is a green
+# check from a merge commit that may be hours stale -- if the base moved
+# underneath it, nothing re-runs, and without a push run nothing ever builds the
+# tree that actually landed. That is #812's shape, in Docker rather than Go.
+#
+# This overlaps docker-publish-ghcr.yml, which already builds the `platform` and
+# `credential-proxy` targets on every push here. It is not redundant: the layer
+# budget (#658) and the entrypoint shared-state gate are checked only in this
+# workflow, and those are exactly the two failures that otherwise surface in
+# Cloud Build, on main, after merge. It does add a second image build per merge.
 on:
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 # A re-push supersedes this pull request's earlier run instead of stacking a

--- a/.github/workflows/k8s-operator-test.yml
+++ b/.github/workflows/k8s-operator-test.yml
@@ -1,10 +1,35 @@
 name: Operator Tests
 
+# The two triggers filter in different places, and they have to.
+#
+# On a pull request the filtering is the `Detect changes` step below, because
+# `Run Controller Tests` is a required check: a workflow that `paths:` declines
+# to start posts no check at all, and branch protection waits for it forever.
+# The job therefore always runs and skips its own steps -- which means it
+# reports `success` on a pull request that ran no tests. That is fine there,
+# since the check only has to not block.
+#
+# On a push to main it is not fine. A run that tested nothing and reported
+# success is indistinguishable, in the run list and to anything reading the API,
+# from a run that tested everything and passed. That is how #812 hid: main was
+# red from 277de10, and the commits that followed which touched no Go each posted
+# a green `Operator Tests` without compiling a line of it, so the push history
+# reads red (2654), green (2655), red (2657), red (2658), then four greens before
+# the real fix at 2700. `main-broken-notify.yml` reads that history to decide
+# whether main has recovered, and would have believed every one of those greens.
+#
+# So the push trigger filters with `paths:` instead: a commit that touches
+# nothing here produces no run at all, and an absent run cannot lie. Keep this
+# list and the `operator:` filter below identical.
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
+    paths:
+      - "k8s-operator/**"
+      - "agents/platform/scripts/**"
+      - ".github/workflows/k8s-operator-test.yml"
   workflow_dispatch:
 
 # A re-push supersedes this pull request's earlier run instead of stacking a

--- a/.github/workflows/main-broken-notify.yml
+++ b/.github/workflows/main-broken-notify.yml
@@ -1,0 +1,106 @@
+name: Notify on Broken Main
+
+# Open a `ci:main-broken` issue when a required check fails on main, keep it
+# current while main stays broken, and close it when the check passes again.
+# `scripts/notify_broken_main.py` holds the reasoning and the issue format; this
+# file is the trigger and the guards.
+#
+# No setup: it writes with the workflow's own GITHUB_TOKEN and creates the label
+# the first time it needs one. Issues opened with GITHUB_TOKEN do not trigger
+# further workflows, so this cannot start a loop.
+#
+# `workflows:` matches on the workflow's `name:`, not its filename, and a rename
+# there silently stops this from firing.
+#
+# What may go on the list: a workflow whose green on a push to main is a
+# statement about the tree, not about the push. The script depends on that and
+# cannot check it -- see its docstring. All four below rebuild or re-check
+# everything they cover on every run they start, and `Operator Tests` only
+# starts on a push that touches an operator path.
+#
+# `Prettier Check` is required and deliberately absent. It scopes itself to the
+# files the push changed, so its green says those files are formatted and
+# nothing about the rest of the tree: a bad `docs/a.md` would go red, and the
+# next merge touching only Go would go green and close the issue with an
+# innocent commit named as the fix. Whole-tree prettier is not the fix either --
+# 19 files under `.agents/skills/` have never been formatted, so it would be red
+# from the first run. Prettier is also the check least exposed to the stale-base
+# merge this exists to catch: it reads file contents, which a stale merge base
+# does not change. `cla/google` is an external app with no run to watch.
+#
+# `Validate Repo Structure` runs a second, non-required job (`prompt-assets`)
+# alongside the required `validate`. Watching at run level means its failure
+# also files an issue, which is the more useful behaviour, not an oversight.
+
+on:
+  # zizmor: ignore[dangerous-triggers] - workflow_run is only dangerous when it checks
+  # out the triggering run's code; this checks out the default branch, runs only for
+  # push-to-main runs of this repository, and passes the event nothing but a run id.
+  workflow_run:
+    workflows:
+      - Actionlint
+      - Docker Build
+      - Operator Tests
+      - Validate Repo Structure
+    types: [completed]
+
+# Serialised per watched workflow. Two merges landing together would otherwise
+# both read "was the previous run failing?" against the same history, reach the
+# same answer, and race to open the same issue -- nothing in the API refuses the
+# second one.
+#
+# `cancel-in-progress: false` does not mean nothing is dropped: GitHub holds at
+# most one run pending per group, and a third arrival cancels the one waiting.
+# So a burst of merges loses the notify runs in the middle. That is survivable
+# only because the script reconciles state rather than reporting transitions --
+# it rebuilds the issue body from the run history, and closes an open issue on
+# any green run rather than only on the green that follows a red. A dropped run
+# therefore costs a "Still failing" comment, not a stuck issue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.workflow_id }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify on Broken Main
+    # The repository guard is required of any credentialed workflow that starts
+    # on its own (AGENTS.md, Pull Request Hygiene): a fork inherits the trigger
+    # and none of the secrets, so without it every fork sync mails its owner.
+    #
+    # `conclusion` is deliberately not narrowed to failure. A success can be the
+    # recovery that closes a breakage, and the script decides which; what is
+    # filtered here is only the two conclusions that say nothing either way.
+    if: >-
+      github.repository == 'gke-labs/kube-agents' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the script
+      actions: read # read the triggering run and the workflow's run history
+      issues: write # open, update and close the tracking issue, and its label
+    steps:
+      - name: Checkout the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      # The run id and nothing else. The script reads the conclusion, the
+      # commit and the history back from the API rather than trusting the
+      # event payload for them, so a stale or spoofed field cannot change what
+      # gets filed.
+      - name: Report on the run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: python3 scripts/notify_broken_main.py --run-id "$RUN_ID"

--- a/scripts/notify_broken_main.py
+++ b/scripts/notify_broken_main.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Track a required check failing on `main` as an automatically managed issue.
+
+`main` breaks without anyone being told. #812 is the worked example: #790 bumped
+`k8s.io/apimachinery`, #733 merged four hours later on a green check that had run
+eighteen hours before the bump, and the golden fixtures the two commits disagreed
+about took `Operator Tests` red. CI caught it immediately -- the push run on
+`277de10` failed, and so did the next two commits that touched an operator path --
+but nothing carried that anywhere a person would see it. The commits in between
+reported success without compiling a line of Go, because `k8s-operator-test.yml`
+skipped its own steps on a docs change: the push history on `main` reads red
+(2654), green (2655), red (2657), red (2658), then four greens before the real
+fix at 2700. It was three hours and forty-five minutes before anyone noticed.
+
+So this writes it down. `.github/workflows/main-broken-notify.yml` hands it the
+run id of a completed push run on `main` for one of the watched workflows, and
+it decides what that run says:
+
+    failing, previous run green     -> open an issue: "main is broken"
+    failing, previous run failing   -> add the commit to that issue, and comment
+    green                           -> close whatever issue is open, if any
+
+One issue per breakage, not per failing run. A breakage that spans several merges
+is one event, and keying the issue on the run that started the streak collapses
+it into a single thing that opens, accumulates the commits that landed on top of
+it, and closes itself when main recovers. The alternative -- an issue or a ping
+per red run -- tells a reader about the break and never tells them it was fixed.
+
+It reconciles state; it does not report transitions. That distinction is what
+makes it survive its own delivery being unreliable. A green run closes any open
+issue for its workflow whether or not the run before it was red, and the issue
+body is rebuilt from the run history rather than appended to. So a notify run
+that never happens -- GitHub keeps one run pending per concurrency group and
+cancels the rest of a burst -- costs a comment, not a stuck issue; a re-run of a
+red run that goes green closes the issue even though the history around it reads
+green-after-green; and handling the same run twice cannot double a row.
+
+A run whose news is already stale keeps quiet. If a later run of the same
+workflow has finished by the time this one is handled, that later run is the
+current state of main and this one would be announcing the past -- which, out of
+order, means opening a "main is broken" issue against a main that is green.
+
+What this trusts, and what has to hold for it to be right: a green run means the
+tree is green. A workflow that reports `success` while covering only part of what
+it is watched for breaks it -- that green closes the issue and names an innocent
+commit as the fix. `k8s-operator-test.yml` did exactly that by skipping its own
+steps on a docs change, and its push trigger now filters with `paths:` so a
+commit it has nothing to say about produces no run rather than a false one.
+`Prettier Check` cannot be fixed that way and is not watched; the watch list in
+`main-broken-notify.yml` says why. Anything added to that list has to be checked
+for the same shape, and this script cannot check it for you.
+
+Conclusions outside `REPORTING_CONCLUSIONS` are ignored: `cancelled`, `skipped`,
+`neutral`, `stale`, `action_required` are all a run declining to say anything,
+and treating any of them as green would close an issue on a broken main.
+
+Setup: none. It writes to this repository with the workflow's own `GITHUB_TOKEN`
+and creates the `ci:main-broken` label the first time it needs it.
+
+Run:  python3 scripts/notify_broken_main.py --run-id 123456789 --dry-run
+Test: cd scripts && python3 -m unittest test_notify_broken_main
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_ROOT = "https://api.github.com"
+
+# How a run says "main does not build". `cancelled` and `skipped` are not here:
+# the first is the concurrency group superseding a run, the second a path filter
+# deciding there was nothing to do, and neither is a statement about the tree.
+# `startup_failure` is -- it means the workflow file itself will not parse, which
+# is as broken as a failing test and reaches main the same way.
+FAILING_CONCLUSIONS = frozenset({"failure", "timed_out", "startup_failure"})
+
+# Conclusions that count as a run having reported on the tree at all. Anything
+# outside this set is ignored when looking back for the previous run, so a
+# cancelled run in the middle of a streak does not read as a recovery.
+REPORTING_CONCLUSIONS = FAILING_CONCLUSIONS | frozenset({"success"})
+
+# Runs of the triggering workflow to look back over. A streak longer than this
+# would have its episode key fall off the end of the history and open a second
+# issue -- an acceptable failure mode, given that fifty consecutive broken
+# merges is a problem this script is not the answer to.
+HISTORY_DEPTH = 50
+
+LABEL = "ci:main-broken"
+LABEL_COLOR = "d73a4a"
+LABEL_DESCRIPTION = "A required check is failing on main"
+
+REQUEST_ATTEMPTS = 3
+REQUEST_RETRY_SECONDS = 5
+# A `Retry-After` GitHub asks for is honoured up to this; beyond it the job would
+# sit burning runner minutes for news that the next run will carry anyway.
+REQUEST_RETRY_CEILING = 60
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def _rate_limited(error):
+    """Whether a 403 is GitHub throttling rather than refusing.
+
+    A secondary rate limit comes back as 403, not 429, and is the one 4xx worth
+    retrying on a write path. It carries `Retry-After`, or an exhausted primary
+    quota; a permissions 403 carries neither, so this does not turn a missing
+    `issues: write` into fifteen seconds of retries.
+    """
+    headers = error.headers or {}
+    return headers.get("Retry-After") is not None or headers.get("x-ratelimit-remaining") == "0"
+
+
+def _retry_delay(error):
+    """`Retry-After` when GitHub names one, capped, else the fixed backoff."""
+    requested = (error.headers or {}).get("Retry-After")
+    if requested and str(requested).strip().isdigit():
+        return min(int(str(requested).strip()), REQUEST_RETRY_CEILING)
+    return REQUEST_RETRY_SECONDS
+
+
+# --------------------------------------------------------------------------- #
+# Deciding whether there is anything to say
+# --------------------------------------------------------------------------- #
+
+
+def is_failing(run):
+    return run["conclusion"] in FAILING_CONCLUSIONS
+
+
+def reporting_history(runs, current):
+    """`runs` newest-first, minus the current run and anything that said nothing.
+
+    The API list includes the run that triggered this, and filtering it by id
+    rather than by position matters: two merges land close enough together that
+    the newest run is regularly not the one being handled.
+    """
+    return [
+        run
+        for run in runs
+        if run["id"] != current["id"]
+        and run["run_number"] < current["run_number"]
+        and run["conclusion"] in REPORTING_CONCLUSIONS
+    ]
+
+
+def failure_streak(current, history):
+    """The unbroken run of failures the current run sits at the end of.
+
+    Oldest last, so `[-1]` is the run that broke main. For a recovery the
+    current run is green and the streak is the one it just ended, so the current
+    run is not part of it.
+    """
+    streak = [current] if is_failing(current) else []
+    for run in history:
+        if not is_failing(run):
+            break
+        streak.append(run)
+    return streak
+
+
+def decide(current, history):
+    """What `current` says about main, or None if it says nothing.
+
+    Three kinds, not four: there is no separate "recovered". Whether a green run
+    is a recovery depends on whether an issue is open, which is a question for
+    `reconcile` and the API -- not for the run history, which cannot see a
+    notification that was dropped or a red run that was re-run into a green.
+
+    Returns a dict rather than a class: it is rendered straight into an issue
+    body and read straight out of the tests, and neither wants a constructor.
+    """
+    # A run that concluded `neutral`, `stale` or `action_required` reached here
+    # because the workflow's `if:` only filters `cancelled` and `skipped`. None
+    # of them is a statement about the tree, and anything not in
+    # FAILING_CONCLUSIONS would otherwise be read as green and close the issue.
+    if current["conclusion"] not in REPORTING_CONCLUSIONS:
+        return None
+
+    previous = history[0] if history else None
+    streak = failure_streak(current, history)
+
+    if is_failing(current):
+        kind = "still-broken" if previous is not None and is_failing(previous) else "broken"
+    else:
+        kind = "green"
+
+    return {
+        "kind": kind,
+        "run": current,
+        # Empty only for a "broken" with nothing before it in the history, which
+        # is the first run of a brand-new workflow. `broke_at` then falls back to
+        # the current run, which is correct: it is the run that broke main.
+        "broke_at": streak[-1] if streak else current,
+        # Oldest first, which is the order the issue's table reads in.
+        "streak": list(reversed(streak)),
+        "streak_length": len(streak),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def _commit_subject(run):
+    """The first line of the head commit's message, or the sha if there is none.
+
+    A squash merge puts the pull request title here, which is the single most
+    useful thing in the message -- it names the change that broke main.
+    """
+    message = ((run.get("head_commit") or {}).get("message") or "").strip()
+    return message.splitlines()[0] if message else run["head_sha"][:7]
+
+
+def _author(run):
+    """Who wrote the change, which is not who pushed it.
+
+    Nothing merges to main by hand here -- Prow's Tide does, so `actor` and
+    `triggering_actor` are both `google-oss-prow[bot]` on every push and naming
+    either tells a reader nothing. The squash commit keeps the pull request
+    author (`Brad Hoekstra` on 277de10, with GitHub itself as committer), so
+    that is the field to read. It is a display name and not a login, so it
+    renders as plain text; the pull request link beside it is the one worth
+    following.
+    """
+    name = ((run.get("head_commit") or {}).get("author") or {}).get("name")
+    if name:
+        return name
+    for key in ("triggering_actor", "actor"):
+        login = (run.get(key) or {}).get("login")
+        if login:
+            return login
+    return "unknown"
+
+
+# A squash merge ends its subject with the pull request number, which is the
+# one link a reader of a broken-main issue actually wants: the change, its
+# discussion, and its author are all one hop from there. Written bare (`#733`)
+# so GitHub autolinks it -- which also leaves a back-reference on the pull
+# request, pointing whoever broke main at the issue about it.
+_PR_SUFFIX = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def _pull_request(run):
+    match = _PR_SUFFIX.search(_commit_subject(run))
+    return f"#{match.group(1)}" if match else ""
+
+
+def _cell(text):
+    """A table cell. Only `|` needs escaping -- it is the column separator, and
+    a commit subject or an author's display name is free to contain one."""
+    return text.replace("|", "\\|")
+
+
+def _commit_link(run, repo):
+    return f"[`{run['head_sha'][:7]}`](https://github.com/{repo}/commit/{run['head_sha']})"
+
+
+def _provenance(run):
+    """Where a commit came from: its run, its author, and its pull request."""
+    where = f"[run {run['run_number']}]({run['html_url']}), by {_author(run)}"
+    number = _pull_request(run)
+    return f"{where} in {number}" if number else where
+
+
+def episode_marker(notification, workflow_id):
+    """The hidden line that ties an issue to one breakage of one workflow.
+
+    Keyed on the run that started the streak, so every update about one
+    breakage -- including the recovery that closes it -- finds the same issue,
+    and the next breakage of the same workflow opens a fresh one. Matching on
+    this rather than on the title means a renamed issue is still found.
+    """
+    return f"<!-- main-broken workflow={workflow_id} episode={notification['broke_at']['run_number']} -->"
+
+
+def workflow_marker(workflow_id):
+    """The prefix every episode marker for one workflow shares."""
+    return f"<!-- main-broken workflow={workflow_id} "
+
+
+def render_title(notification):
+    return f"🔴 main is broken: {notification['run']['name']}"
+
+
+def render_body(notification, repo, marker):
+    """The issue body, rebuilt from scratch on every update.
+
+    A table of the commits that have landed since main went red, oldest first.
+    It is derived entirely from the run history, so it is idempotent: handling
+    the same run twice produces the same body, and a hand-edited issue is
+    restored by the next failure.
+    """
+    run = notification["run"]
+    workflow = run["name"]
+    streak = notification["streak"]
+
+    lines = [f"🔴 **`{workflow}`** is failing on `main`.", ""]
+    if len(streak) > 1:
+        lines += [
+            f"Broken since {_commit_link(streak[0], repo)} — {len(streak)} consecutive failures.",
+            "",
+        ]
+    lines += ["| run | commit | author | PR |", "| --- | --- | --- | --- |"]
+    for failed in streak:
+        lines.append(
+            f"| [{failed['run_number']}]({failed['html_url']}) "
+            f"| {_commit_link(failed, repo)} "
+            f"| {_cell(_author(failed))} "
+            f"| {_pull_request(failed)} |"
+        )
+    lines += [
+        "",
+        f"Opened and closed automatically by "
+        f"[`main-broken-notify.yml`](https://github.com/{repo}/blob/main/.github/workflows/main-broken-notify.yml). "
+        f"It closes when `{workflow}` next passes on `main`; a failure after that opens a new issue.",
+        "",
+        marker,
+    ]
+    return "\n".join(lines)
+
+
+def render_comment(notification, repo):
+    """What to add to an existing issue, or None when the body says it all.
+
+    A new issue needs no comment -- opening it is the notification. The other
+    two kinds do: an issue body edit sends nobody anything, so without this a
+    reader subscribed to the issue would learn neither that another commit had
+    landed on a broken main nor that it had been fixed.
+
+    For a green run this is rendered unconditionally and used only if an issue
+    turns out to be open, which `reconcile` finds out and this cannot.
+    """
+    kind = notification["kind"]
+    run = notification["run"]
+
+    if kind == "green":
+        broken_for = notification["streak_length"]
+        if broken_for:
+            plural = "" if broken_for == 1 else "s"
+            ending = (
+                f"Fixed by {_commit_link(run, repo)} — {_provenance(run)}. "
+                f"{broken_for} consecutive failure{plural} before it."
+            )
+        else:
+            # Green, with an issue open, and no failure immediately before it.
+            # A dropped notify run, a red run re-run into a green, or two runs
+            # handled out of order -- this run is not the fix and must not claim
+            # to be, but main is green and the issue should not still be open.
+            ending = (
+                f"Green as of {_commit_link(run, repo)} — {_provenance(run)}. "
+                f"This issue was still open; the runs it lists are not the current state of `main`."
+            )
+        return f"✅ `{run['name']}` passes on `main` again.\n\n{ending}"
+    if kind == "still-broken":
+        return (
+            f"Still failing. {_commit_link(run, repo)} landed on a broken `main` — "
+            f"{_provenance(run)}.\n\n"
+            f"{notification['streak_length']} consecutive failures."
+        )
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# GitHub API
+# --------------------------------------------------------------------------- #
+
+
+class GitHubAPI:
+    def __init__(self, repo, token, root=API_ROOT, opener=urllib.request.urlopen, sleep=time.sleep):
+        self.repo = repo
+        self.token = token
+        self.root = root
+        self.opener = opener
+        self.sleep = sleep
+
+    def request(self, method, path, payload=None, tolerate=()):
+        """One API call, retried on the failures that are worth retrying.
+
+        A dropped write is the failure this whole script exists to prevent -- an
+        issue that never opened, or worse, one that never closed -- so a 5xx, a
+        429, and the 403 form of a secondary rate limit each get three attempts,
+        honouring `Retry-After` when GitHub sends one. A 403 that is really a
+        missing permission is not retried. `tolerate` names status codes the
+        caller has a meaning for; they come back as None instead of raising.
+        """
+        body = None if payload is None else json.dumps(payload).encode()
+        for attempt in range(1, REQUEST_ATTEMPTS + 1):
+            request = urllib.request.Request(
+                f"{self.root}{path}",
+                method=method,
+                data=body,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {self.token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "kube-agents-notify-broken-main",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            try:
+                with self.opener(request) as response:
+                    raw = response.read()
+                return json.loads(raw) if raw else None
+            except urllib.error.HTTPError as error:
+                if error.code in tolerate:
+                    return None
+                retryable = error.code == 429 or 500 <= error.code < 600 or (error.code == 403 and _rate_limited(error))
+                if not retryable or attempt == REQUEST_ATTEMPTS:
+                    raise
+                log(f"{method} {path} returned {error.code}; retrying ({attempt}/{REQUEST_ATTEMPTS})")
+                delay = _retry_delay(error)
+            except urllib.error.URLError as error:
+                if attempt == REQUEST_ATTEMPTS:
+                    raise
+                log(f"{method} {path} unreachable ({error.reason}); retrying ({attempt}/{REQUEST_ATTEMPTS})")
+                delay = REQUEST_RETRY_SECONDS
+            self.sleep(delay)
+
+    def get(self, path):
+        return self.request("GET", path)
+
+    def run(self, run_id):
+        return self.get(f"/repos/{self.repo}/actions/runs/{run_id}")
+
+    def history(self, workflow_id, branch="main", depth=HISTORY_DEPTH):
+        """Completed push runs of one workflow on `branch`, newest first.
+
+        `event=push` keeps pull-request runs of the same workflow out: they
+        vastly outnumber the push runs and say nothing about main.
+        """
+        query = urllib.parse.urlencode(
+            {
+                "branch": branch,
+                "event": "push",
+                "status": "completed",
+                "per_page": depth,
+            }
+        )
+        path = f"/repos/{self.repo}/actions/workflows/{workflow_id}/runs?{query}"
+        return self.get(path)["workflow_runs"]
+
+    def open_issues_for_workflow(self, workflow_id):
+        """Open `ci:main-broken` issues belonging to one workflow, newest first.
+
+        The list endpoint returns pull requests too -- they are issues as far as
+        this API is concerned -- so anything carrying a `pull_request` key is
+        dropped. Deliberately unpaginated: more than a hundred open issues on
+        this label is not a state worth writing code for.
+        """
+        query = urllib.parse.urlencode({"labels": LABEL, "state": "open", "per_page": 100})
+        issues = self.get(f"/repos/{self.repo}/issues?{query}") or []
+        prefix = workflow_marker(workflow_id)
+        return [
+            issue for issue in issues if "pull_request" not in issue and prefix in (issue.get("body") or "")
+        ]
+
+    def ensure_label(self):
+        """Create the label if this is the first breakage ever recorded.
+
+        422 is what GitHub returns for a label that already exists, which is the
+        overwhelmingly common case and not an error.
+        """
+        self.request(
+            "POST",
+            f"/repos/{self.repo}/labels",
+            {"name": LABEL, "color": LABEL_COLOR, "description": LABEL_DESCRIPTION},
+            tolerate=(422,),
+        )
+
+    def create_issue(self, title, body):
+        return self.request("POST", f"/repos/{self.repo}/issues", {"title": title, "body": body, "labels": [LABEL]})
+
+    def update_issue(self, number, **fields):
+        return self.request("PATCH", f"/repos/{self.repo}/issues/{number}", fields)
+
+    def comment(self, number, body):
+        return self.request("POST", f"/repos/{self.repo}/issues/{number}/comments", {"body": body})
+
+    def close_issue(self, number):
+        return self.update_issue(number, state="closed", state_reason="completed")
+
+
+# --------------------------------------------------------------------------- #
+# Reconciling the issue with what the run history says
+# --------------------------------------------------------------------------- #
+
+
+def reconcile(api, notification, repo, workflow_id):
+    """Bring the issues for this workflow into line with `notification`.
+
+    Returns a human-readable account of what it did, for the log.
+    """
+    open_issues = api.open_issues_for_workflow(workflow_id)
+    comment = render_comment(notification, repo)
+
+    if notification["kind"] == "green":
+        if not open_issues:
+            # The overwhelmingly common case: main is green and nothing claims
+            # otherwise. One list request per green run buys the guarantee that
+            # an issue is never left open on a green main.
+            return "green, and no issue is open for this workflow"
+        # Every open issue for this workflow, not just the episode this run's
+        # streak points at. Whatever the history says, main is green now, and an
+        # issue saying otherwise is wrong.
+        for issue in open_issues:
+            api.comment(issue["number"], comment)
+            api.close_issue(issue["number"])
+        return "closed " + ", ".join(f"#{issue['number']}" for issue in open_issues)
+
+    marker = episode_marker(notification, workflow_id)
+    title = render_title(notification)
+    body = render_body(notification, repo, marker)
+    current = next((issue for issue in open_issues if marker in (issue.get("body") or "")), None)
+    stale = [issue for issue in open_issues if issue is not current]
+
+    if current is None:
+        api.ensure_label()
+        current = api.create_issue(title, body)
+        done = f"opened #{current['number']}"
+    else:
+        api.update_issue(current["number"], title=title, body=body)
+        if comment:
+            api.comment(current["number"], comment)
+        done = f"updated #{current['number']}"
+
+    # An issue for an older breakage of this workflow is still open, which means
+    # its recovery never got recorded. Point it at the current one and close it
+    # rather than leaving two issues claiming main is broken.
+    for issue in stale:
+        api.comment(issue["number"], f"Superseded by #{current['number']}.")
+        api.close_issue(issue["number"])
+        done += f", superseded #{issue['number']}"
+    return done
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--run-id", type=int, required=True, help="the completed workflow run to report on")
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "gke-labs/kube-agents"),
+        help="owner/name (default: $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument("--branch", default="main", help="the branch whose health is being reported")
+    parser.add_argument("--dry-run", action="store_true", help="print the issue instead of writing it")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        log("GITHUB_TOKEN (or GH_TOKEN) is not set")
+        return 1
+
+    api = GitHubAPI(args.repo, token)
+    current = api.run(args.run_id)
+
+    # The workflow's `if:` has already checked these, against the event payload.
+    # Reading them back off the run is what makes a hand-run of this script on
+    # the wrong run id harmless rather than an issue about a pull request.
+    if current["head_branch"] != args.branch or current["event"] != "push":
+        log(f"Run {args.run_id} is {current['event']} on {current['head_branch']}, not push on {args.branch}")
+        return 0
+
+    workflow_id = current["workflow_id"]
+    runs = api.history(workflow_id, args.branch)
+
+    # Notify runs are queued in the order the runs they watch *finish*, which is
+    # not the order those runs started. Acting on a run that a later one has
+    # already superseded announces the past: out of order, a red run handled
+    # after the green that fixed it opens a "main is broken" issue against a
+    # green main. The later run's own notify carries the whole story -- the body
+    # is rebuilt from this same history -- so there is nothing lost by leaving
+    # it to that one. Only a later run that said something counts; one filtered
+    # out by the workflow's `if:` will never reconcile anything.
+    superseded = [
+        run
+        for run in runs
+        if run["run_number"] > current["run_number"] and run["conclusion"] in REPORTING_CONCLUSIONS
+    ]
+    if superseded:
+        newest = max(run["run_number"] for run in superseded)
+        log(f"Run {current['run_number']} is superseded by run {newest}; leaving it to that one")
+        return 0
+
+    notification = decide(current, reporting_history(runs, current))
+
+    if notification is None:
+        log(f"Run {current['run_number']} concluded {current['conclusion']}, which says nothing about main")
+        return 0
+
+    if args.dry_run:
+        log(f"--dry-run: {notification['kind']}")
+        if notification["kind"] != "green":
+            marker = episode_marker(notification, workflow_id)
+            log(f"\n# {render_title(notification)}\n\n{render_body(notification, args.repo, marker)}")
+        comment = render_comment(notification, args.repo)
+        if comment:
+            log(f"\n--- comment, if an issue is open ---\n{comment}")
+        return 0
+
+    log(reconcile(api, notification, args.repo, workflow_id))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_notify_broken_main.py
+++ b/scripts/test_notify_broken_main.py
@@ -1,0 +1,706 @@
+#!/usr/bin/env python3
+"""Unit tests for the broken-main issue notifier.
+
+Run: cd scripts && python3 -m unittest test_notify_broken_main
+
+The notifier cannot be exercised end to end before it is on main -- a
+`workflow_run` workflow only runs from the default branch's copy of itself -- so
+everything that can be decided without a runner is decided here. Three failure
+modes are worth more than the rest: staying quiet when main is broken, which
+reproduces the gap this exists to close; opening an issue on a green run, which
+trains everyone to ignore the label; and leaving an issue open after main
+recovers, which does the same thing more slowly.
+"""
+
+import json
+import re
+import unittest
+import urllib.error
+import urllib.parse
+from unittest import mock
+
+import notify_broken_main as notifier
+
+
+def run(number, conclusion, *, sha=None, subject="a commit", run_id=None, name="Operator Tests"):
+    """A workflow run, carrying only the fields the notifier reads."""
+    return {
+        "id": run_id if run_id is not None else 1000 + number,
+        "run_number": number,
+        "conclusion": conclusion,
+        "name": name,
+        "event": "push",
+        "head_branch": "main",
+        "head_sha": sha or f"{number:040x}",
+        "head_commit": {"message": f"{subject}\n\nbody", "author": {"name": "A Contributor"}},
+        # What Tide leaves behind on every merge here, and the reason the
+        # attribution is read off the commit rather than the run.
+        "actor": {"login": "google-oss-prow[bot]"},
+        "triggering_actor": {"login": "google-oss-prow[bot]"},
+        "html_url": f"https://github.com/gke-labs/kube-agents/actions/runs/{1000 + number}",
+        "workflow_id": 77,
+    }
+
+
+class DecideTest(unittest.TestCase):
+    """Which of the four cases a run falls into. This is the whole design."""
+
+    def test_first_failure_announces_a_break(self):
+        decision = notifier.decide(run(10, "failure"), [run(9, "success")])
+        self.assertEqual(decision["kind"], "broken")
+        self.assertEqual(decision["streak_length"], 1)
+        self.assertEqual(decision["broke_at"]["run_number"], 10)
+
+    def test_green_after_green_is_still_a_green_to_reconcile(self):
+        """Not None. Whether a green run has anything to do depends on whether
+        an issue is open, which the run history cannot see -- it cannot see a
+        notify run that was dropped, or a red run re-run into a green. `decide`
+        reports the state; `reconcile` decides whether it matters."""
+        decision = notifier.decide(run(10, "success"), [run(9, "success")])
+        self.assertEqual(decision["kind"], "green")
+        self.assertEqual(decision["streak_length"], 0)
+
+    def test_a_conclusion_that_says_nothing_says_nothing(self):
+        """`neutral`, `stale` and `action_required` all reach the script -- the
+        workflow's `if:` filters only `cancelled` and `skipped`. Read as green,
+        any of them closes the issue on a main that is still broken."""
+        for conclusion in ("neutral", "stale", "action_required", "cancelled", "skipped", None):
+            with self.subTest(conclusion=conclusion):
+                self.assertIsNone(notifier.decide(run(10, conclusion), [run(9, "failure")]))
+
+    def test_a_second_failure_is_a_follow_up_not_a_new_break(self):
+        decision = notifier.decide(run(11, "failure"), [run(10, "failure"), run(9, "success")])
+        self.assertEqual(decision["kind"], "still-broken")
+        self.assertEqual(decision["streak_length"], 2)
+        self.assertEqual(decision["broke_at"]["run_number"], 10)
+
+    def test_green_after_a_failure_carries_the_streak_it_ended(self):
+        decision = notifier.decide(run(12, "success"), [run(11, "failure"), run(10, "failure"), run(9, "success")])
+        self.assertEqual(decision["kind"], "green")
+        self.assertEqual(decision["streak_length"], 2)
+        self.assertEqual(decision["broke_at"]["run_number"], 10)
+
+    def test_the_recovery_is_not_counted_into_the_streak_it_ends(self):
+        """`broke_at` is the issue's identity, so a green run joining its own
+        streak would look for an issue that was never opened -- the reader would
+        see a break with no end and an end with no break."""
+        history = [run(11, "failure"), run(10, "failure"), run(9, "success")]
+        decision = notifier.decide(run(12, "success"), history)
+        self.assertEqual(decision["broke_at"]["run_number"], 10)
+        self.assertNotIn(12, [r["run_number"] for r in decision["streak"]])
+
+    def test_the_streak_reads_oldest_first(self):
+        """The order the issue's table is in: the commit that broke main at the
+        top, the ones that landed on top of it below."""
+        decision = notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure"), run(9, "success")])
+        self.assertEqual([r["run_number"] for r in decision["streak"]], [10, 11, 12])
+
+    def test_a_timeout_is_a_failure(self):
+        self.assertEqual(notifier.decide(run(10, "timed_out"), [run(9, "success")])["kind"], "broken")
+
+    def test_an_unparseable_workflow_is_a_failure(self):
+        """`startup_failure` reaches main exactly the way a failing test does,
+        and reads as 'nothing ran' if it is filtered out."""
+        self.assertEqual(notifier.decide(run(10, "startup_failure"), [run(9, "success")])["kind"], "broken")
+
+    def test_the_first_run_of_a_workflow_can_still_break_main(self):
+        """No history at all. `broke_at` has to fall back to the current run
+        rather than raising, or a newly added required check could never
+        report its first failure."""
+        decision = notifier.decide(run(1, "failure"), [])
+        self.assertEqual(decision["kind"], "broken")
+        self.assertEqual(decision["broke_at"]["run_number"], 1)
+
+
+class HistoryFilterTest(unittest.TestCase):
+    def test_the_triggering_run_is_removed_from_its_own_history(self):
+        """The API list includes it, and left in it would compare against
+        itself -- every failure would read as 'still broken'."""
+        current = run(10, "failure")
+        history = notifier.reporting_history([current, run(9, "success")], current)
+        self.assertEqual([r["run_number"] for r in history], [9])
+
+    def test_a_newer_run_is_not_treated_as_history(self):
+        """Merges land close enough together that the newest run in the list is
+        regularly not the one being handled."""
+        current = run(10, "failure")
+        history = notifier.reporting_history([run(11, "success"), current, run(9, "success")], current)
+        self.assertEqual([r["run_number"] for r in history], [9])
+
+    def test_a_cancelled_run_does_not_end_a_streak(self):
+        """A concurrency-superseded run says nothing about the tree. Counted as
+        a non-failure it would make the next failure look like a fresh break and
+        open a second issue."""
+        current = run(12, "failure")
+        history = notifier.reporting_history([run(11, "cancelled"), run(10, "failure")], current)
+        decision = notifier.decide(current, history)
+        self.assertEqual(decision["kind"], "still-broken")
+        self.assertEqual(decision["broke_at"]["run_number"], 10)
+
+    def test_a_skipped_run_does_not_end_a_streak_either(self):
+        current = run(12, "failure")
+        history = notifier.reporting_history([run(11, "skipped"), run(10, "failure")], current)
+        self.assertEqual(notifier.decide(current, history)["kind"], "still-broken")
+
+    def test_a_run_that_reports_success_without_testing_would_fool_this(self):
+        """The #812 shape, and the one thing this script cannot defend itself
+        against -- recorded as the contract it depends on rather than left for
+        someone to rediscover in production.
+
+        `k8s-operator-test.yml` used to skip its steps on a docs commit and
+        report `success` at run level anyway: run 2664 on main, `1d68f09`, every
+        real step `skipped` and the conclusion `success`. Replayed through
+        `decide` that green closes the issue -- and on the real history it does
+        so twice, at 2655 and again at 2664, naming a docs commit as the fix and
+        saying nothing when 2700 genuinely repaired main. The fix is in the
+        workflow: its push trigger filters with `paths:`, so no run is recorded
+        at all. This states why a watched workflow may not self-skip into a
+        green, and it is why `Prettier Check`, which scopes itself to the files
+        a push touched, is not on the watch list.
+        """
+        docs_commit_that_tested_nothing = run(11, "success")
+        decision = notifier.decide(docs_commit_that_tested_nothing, [run(10, "failure")])
+        self.assertEqual(
+            decision["kind"],
+            "green",
+            "if this stops reading as a green the guard has moved into the script, and "
+            "the paths: filter in k8s-operator-test.yml can be reconsidered",
+        )
+
+
+class EpisodeMarkerTest(unittest.TestCase):
+    """The hidden marker is how an update finds the issue it belongs to. Get it
+    wrong in either direction and the issue either duplicates or never closes."""
+
+    def test_one_breakage_is_one_issue(self):
+        break_decision = notifier.decide(run(10, "failure"), [run(9, "success")])
+        follow_up = notifier.decide(run(11, "failure"), [run(10, "failure"), run(9, "success")])
+        recovery = notifier.decide(run(12, "success"), [run(11, "failure"), run(10, "failure")])
+        markers = {notifier.episode_marker(d, 77) for d in (break_decision, follow_up, recovery)}
+        self.assertEqual(len(markers), 1, f"expected one issue, got {markers}")
+
+    def test_the_next_breakage_opens_a_new_issue(self):
+        first = notifier.decide(run(10, "failure"), [run(9, "success")])
+        second = notifier.decide(run(20, "failure"), [run(19, "success")])
+        self.assertNotEqual(notifier.episode_marker(first, 77), notifier.episode_marker(second, 77))
+
+    def test_two_workflows_breaking_at_once_do_not_share_an_issue(self):
+        """Run numbers are per workflow, so the workflow id has to be in the
+        marker or a coincidence of numbering merges two unrelated breakages."""
+        decision = notifier.decide(run(10, "failure"), [run(9, "success")])
+        self.assertNotEqual(notifier.episode_marker(decision, 77), notifier.episode_marker(decision, 88))
+
+    def test_the_workflow_prefix_matches_that_workflows_markers_only(self):
+        """`reconcile` uses the prefix to find stale issues to close. Matching
+        another workflow's issue would close a real breakage."""
+        decision = notifier.decide(run(10, "failure"), [run(9, "success")])
+        self.assertIn(notifier.workflow_marker(77), notifier.episode_marker(decision, 77))
+        self.assertNotIn(notifier.workflow_marker(88), notifier.episode_marker(decision, 77))
+
+    def test_the_prefix_does_not_match_a_workflow_whose_id_extends_it(self):
+        """Workflow 7 and workflow 77 are both plausible ids, and a prefix that
+        ended at the digits would confuse them."""
+        self.assertNotIn(notifier.workflow_marker(7), notifier.workflow_marker(77))
+
+
+class RenderTest(unittest.TestCase):
+    REPO = "gke-labs/kube-agents"
+
+    def _body(self, decision):
+        return notifier.render_body(decision, self.REPO, notifier.episode_marker(decision, 77))
+
+    def test_a_break_names_the_workflow_commit_and_run(self):
+        decision = notifier.decide(
+            run(10, "failure", sha="277de10c43e3b7311bfb159a4016eee2831ca6f7", subject="feat: add PDBs (#733)"),
+            [run(9, "success")],
+        )
+        body = self._body(decision)
+        self.assertIn("Operator Tests", body)
+        self.assertIn("277de10", body)
+        self.assertIn("actions/runs/1010", body)
+
+    def test_the_title_names_the_workflow_so_five_issues_are_distinguishable(self):
+        decision = notifier.decide(run(10, "failure", name="Prettier Check"), [run(9, "success")])
+        self.assertEqual(notifier.render_title(decision), "🔴 main is broken: Prettier Check")
+
+    def test_the_title_is_stable_across_an_episode(self):
+        """It is rewritten on every update, so a changing title would rename the
+        issue under anyone reading it."""
+        first = notifier.decide(run(10, "failure"), [run(9, "success")])
+        later = notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure")])
+        self.assertEqual(notifier.render_title(first), notifier.render_title(later))
+
+    def test_the_marker_is_in_the_body(self):
+        """Without it the next update cannot find this issue and opens another."""
+        decision = notifier.decide(run(10, "failure"), [run(9, "success")])
+        self.assertIn(notifier.episode_marker(decision, 77), self._body(decision))
+
+    def test_the_change_is_attributed_to_its_author_not_to_tide(self):
+        """`actor` is `google-oss-prow[bot]` on every merge here, so a body
+        built from it names the robot on every breakage and nobody else."""
+        body = self._body(notifier.decide(run(10, "failure"), [run(9, "success")]))
+        self.assertIn("A Contributor", body)
+        self.assertNotIn("prow", body)
+
+    def test_the_pull_request_is_named_so_github_autolinks_it(self):
+        """Bare `#733` rather than a URL: it renders as a link and leaves a
+        back-reference on the pull request that broke main."""
+        body = self._body(notifier.decide(run(10, "failure", subject="feat: add PDBs (#733)"), [run(9, "success")]))
+        self.assertIn("| #733 |", body)
+
+    def test_a_commit_with_no_pull_request_number_still_renders(self):
+        """A direct push, or a merge commit that does not carry the suffix. The
+        cell is empty rather than the row being dropped."""
+        body = self._body(notifier.decide(run(10, "failure", subject="hotfix, no PR"), [run(9, "success")]))
+        self.assertIn("A Contributor", body)
+        self.assertNotIn("#", body.split("| run |")[1].split("\n")[2])
+
+    def test_every_commit_in_the_streak_gets_a_row(self):
+        decision = notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure"), run(9, "success")])
+        body = self._body(decision)
+        rows = [line for line in body.splitlines() if line.startswith("| [")]
+        self.assertEqual(len(rows), 3)
+        self.assertIn("Broken since", body)
+        self.assertIn("3 consecutive failures", body)
+
+    def test_the_table_reads_oldest_first(self):
+        decision = notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure")])
+        rows = [line for line in self._body(decision).splitlines() if line.startswith("| [")]
+        self.assertEqual([row.split("]")[0] for row in rows], ["| [10", "| [11", "| [12"])
+
+    def test_a_first_failure_does_not_claim_a_streak(self):
+        """"Broken since X -- 1 consecutive failures" reads as a bug in the
+        counter. One row is its own explanation."""
+        body = self._body(notifier.decide(run(10, "failure"), [run(9, "success")]))
+        self.assertNotIn("Broken since", body)
+        self.assertNotIn("consecutive", body)
+
+    def test_rebuilding_the_body_for_the_same_run_is_idempotent(self):
+        """The body is rewritten, not appended to, so a redelivered event or a
+        re-run of the workflow cannot double a row."""
+        decision = notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure")])
+        self.assertEqual(self._body(decision), self._body(decision))
+
+    def test_a_pipe_in_an_author_name_does_not_break_the_table(self):
+        """An unescaped `|` in a cell silently splits the row into five columns,
+        and Markdown drops the overflow -- the PR link vanishes."""
+        odd = run(10, "failure")
+        odd["head_commit"]["author"]["name"] = "A | Contributor"
+        body = self._body(notifier.decide(odd, [run(9, "success")]))
+        row = [line for line in body.splitlines() if line.startswith("| [")][0]
+        self.assertIn(r"A \| Contributor", row)
+        separators = len(re.findall(r"(?<!\\)\|", row))
+        self.assertEqual(separators, 5, f"expected four cells, got {row}")
+
+    def test_a_commit_with_no_message_still_renders(self):
+        """`head_commit` is absent on some run payloads. A KeyError here would
+        take down the notification rather than degrade it."""
+        bare = run(10, "failure")
+        del bare["head_commit"]
+        body = self._body(notifier.decide(bare, [run(9, "success")]))
+        self.assertIn(bare["head_sha"][:7], body)
+
+    def test_a_new_issue_needs_no_comment(self):
+        """Opening the issue is the notification."""
+        self.assertIsNone(notifier.render_comment(notifier.decide(run(10, "failure"), [run(9, "success")]), self.REPO))
+
+    def test_a_follow_up_comments_because_a_body_edit_notifies_nobody(self):
+        comment = notifier.render_comment(
+            notifier.decide(run(12, "failure"), [run(11, "failure"), run(10, "failure")]), self.REPO
+        )
+        self.assertIn("Still failing", comment)
+        self.assertIn("3 consecutive failures", comment)
+
+    def test_the_recovery_comment_is_recognisably_not_another_break(self):
+        comment = notifier.render_comment(notifier.decide(run(12, "success"), [run(11, "failure")]), self.REPO)
+        self.assertIn("✅", comment)
+        self.assertNotIn("🔴", comment)
+        self.assertIn("Fixed by", comment)
+
+    def test_a_one_commit_breakage_is_not_pluralised(self):
+        comment = notifier.render_comment(notifier.decide(run(12, "success"), [run(11, "failure")]), self.REPO)
+        self.assertIn("1 consecutive failure before it.", comment)
+
+
+def _response(raw):
+    """What `urlopen` returns: a context manager yielding something with `read`.
+
+    `__exit__` returns False on purpose. A `MagicMock` there is truthy, which
+    swallows any exception raised inside the `with` -- including the ones these
+    tests exist to catch -- and surfaces it much later as an unrelated
+    `UnboundLocalError`.
+    """
+    return mock.MagicMock(
+        __enter__=mock.Mock(return_value=mock.Mock(read=lambda: raw)),
+        __exit__=mock.Mock(return_value=False),
+    )
+
+
+class RequestTest(unittest.TestCase):
+    def _api(self, responses):
+        """A `GitHubAPI` whose opener raises or returns per call."""
+        calls = []
+
+        def opener(request):
+            calls.append(request)
+            outcome = responses[len(calls) - 1]
+            if isinstance(outcome, Exception):
+                raise outcome
+            return _response(b"{}")
+
+        return notifier.GitHubAPI("o/r", "t", opener=opener, sleep=lambda _: None), calls
+
+    def test_a_5xx_is_retried(self):
+        """A dropped write is the exact failure this script exists to prevent --
+        an issue that never opened, or one that never closed."""
+        api, calls = self._api([urllib.error.HTTPError("u", 503, "busy", {}, None), None])
+        api.request("POST", "/x", {"a": 1})
+        self.assertEqual(len(calls), 2)
+
+    def test_a_4xx_is_not_retried(self):
+        """A permissions failure will not start working on the second attempt,
+        and the job should fail now rather than in fifteen seconds."""
+        api, calls = self._api([urllib.error.HTTPError("u", 403, "no", {}, None), None])
+        with self.assertRaises(urllib.error.HTTPError):
+            api.request("POST", "/x", {"a": 1})
+        self.assertEqual(len(calls), 1)
+
+    def test_giving_up_raises_rather_than_returning(self):
+        api, calls = self._api([urllib.error.HTTPError("u", 503, "busy", {}, None)] * notifier.REQUEST_ATTEMPTS)
+        with self.assertRaises(urllib.error.HTTPError):
+            api.request("POST", "/x", {"a": 1})
+        self.assertEqual(len(calls), notifier.REQUEST_ATTEMPTS)
+
+    def test_a_tolerated_status_is_not_an_error(self):
+        """`ensure_label` runs on every first failure and 422 means the label is
+        already there, which is the normal case."""
+        api, calls = self._api([urllib.error.HTTPError("u", 422, "exists", {}, None)])
+        self.assertIsNone(api.request("POST", "/labels", {"name": "x"}, tolerate=(422,)))
+        self.assertEqual(len(calls), 1)
+
+    def test_a_secondary_rate_limit_is_retried_even_though_it_is_a_403(self):
+        """GitHub throttles writes with 403, not 429. Treating every 403 as
+        fatal drops the write; treating every 403 as retryable turns a missing
+        `issues: write` into fifteen seconds of pointless retries."""
+        throttled = urllib.error.HTTPError("u", 403, "slow down", {"Retry-After": "1"}, None)
+        api, calls = self._api([throttled, None])
+        api.request("POST", "/x", {"a": 1})
+        self.assertEqual(len(calls), 2)
+
+    def test_an_exhausted_quota_is_retried_too(self):
+        exhausted = urllib.error.HTTPError("u", 403, "limit", {"x-ratelimit-remaining": "0"}, None)
+        api, calls = self._api([exhausted, None])
+        api.request("POST", "/x", {"a": 1})
+        self.assertEqual(len(calls), 2)
+
+    def test_retry_after_is_honoured_and_capped(self):
+        slept = []
+        api, _ = self._api([urllib.error.HTTPError("u", 429, "wait", {"Retry-After": "9"}, None), None])
+        api.sleep = slept.append
+        api.request("POST", "/x", {"a": 1})
+        self.assertEqual(slept, [9])
+        self.assertEqual(notifier._retry_delay(urllib.error.HTTPError("u", 429, "w", {"Retry-After": "9999"}, None)),
+                         notifier.REQUEST_RETRY_CEILING)
+
+
+class QueryTest(unittest.TestCase):
+    """The URLs the API layer builds. Nothing else covers them: `ReconcileTest`
+    fakes the API wholesale, so dropping `state=open` from the issue query or
+    `event=push` from the history query breaks the notifier while every other
+    test still passes."""
+
+    def _api(self, payload):
+        calls = []
+
+        def opener(request):
+            calls.append(request)
+            return _response(json.dumps(payload).encode())
+
+        return notifier.GitHubAPI("gke-labs/kube-agents", "t", opener=opener, sleep=lambda _: None), calls
+
+    def test_the_history_query_asks_only_for_completed_pushes_on_the_branch(self):
+        """A pull-request run of the same workflow says nothing about main, and
+        they outnumber the push runs by an order of magnitude."""
+        api, calls = self._api({"workflow_runs": []})
+        api.history(77, "main")
+        url = calls[0].full_url
+        self.assertIn("/actions/workflows/77/runs?", url)
+        for expected in ("branch=main", "event=push", "status=completed", f"per_page={notifier.HISTORY_DEPTH}"):
+            self.assertIn(expected, url)
+
+    def test_the_issue_query_is_scoped_to_the_open_labelled_issues(self):
+        api, calls = self._api([])
+        api.open_issues_for_workflow(77)
+        url = calls[0].full_url
+        self.assertIn("state=open", url)
+        self.assertIn(urllib.parse.quote(notifier.LABEL, safe=""), url)
+
+    def test_pull_requests_are_excluded_from_the_issue_list(self):
+        """`/issues` returns pull requests too. One carrying the marker -- this
+        change's own pull request quotes it -- would be commented on and closed
+        as though it were the tracking issue."""
+        marker = notifier.workflow_marker(77) + "episode=10 -->"
+        api, _ = self._api(
+            [
+                {"number": 1, "body": marker, "pull_request": {"url": "..."}},
+                {"number": 2, "body": marker},
+                {"number": 3, "body": "unrelated issue"},
+                {"number": 4, "body": None},
+            ]
+        )
+        self.assertEqual([i["number"] for i in api.open_issues_for_workflow(77)], [2])
+
+    def test_the_token_and_api_version_are_sent(self):
+        api, calls = self._api({"workflow_runs": []})
+        api.history(77)
+        self.assertEqual(calls[0].get_header("Authorization"), "Bearer t")
+        self.assertEqual(calls[0].get_header("X-github-api-version"), "2022-11-28")
+
+    def test_closing_an_issue_sends_a_patch_with_a_state_reason(self):
+        """`state_reason` is what makes the issue read as completed rather than
+        as abandoned in the issue list."""
+        api, calls = self._api({})
+        api.close_issue(901)
+        self.assertEqual(calls[0].method, "PATCH")
+        self.assertTrue(calls[0].full_url.endswith("/repos/gke-labs/kube-agents/issues/901"))
+        self.assertEqual(json.loads(calls[0].data), {"state": "closed", "state_reason": "completed"})
+
+    def test_creating_an_issue_carries_the_label(self):
+        """Without it `open_issues_for_workflow` never finds the issue again."""
+        api, calls = self._api({"number": 901})
+        api.create_issue("t", "b")
+        self.assertEqual(json.loads(calls[0].data)["labels"], [notifier.LABEL])
+
+
+class FakeAPI:
+    """Records what `reconcile` asks of the API and answers from a list of open
+    issues, which is the whole of the state it reads."""
+
+    def __init__(self, open_issues=()):
+        self.open_issues = list(open_issues)
+        self.actions = []
+        self.next_number = 900
+
+    def open_issues_for_workflow(self, workflow_id):
+        prefix = notifier.workflow_marker(workflow_id)
+        return [issue for issue in self.open_issues if prefix in (issue.get("body") or "")]
+
+    def ensure_label(self):
+        self.actions.append(("label",))
+
+    def create_issue(self, title, body):
+        self.next_number += 1
+        self.actions.append(("create", self.next_number, title, body))
+        return {"number": self.next_number}
+
+    def update_issue(self, number, **fields):
+        self.actions.append(("update", number, fields))
+
+    def comment(self, number, body):
+        self.actions.append(("comment", number, body))
+
+    def close_issue(self, number):
+        self.actions.append(("close", number))
+
+    def kinds(self):
+        return [action[0] for action in self.actions]
+
+
+def issue(number, workflow_id, episode, state="open"):
+    return {
+        "number": number,
+        "state": state,
+        "body": f"whatever\n\n<!-- main-broken workflow={workflow_id} episode={episode} -->",
+    }
+
+
+class ReconcileTest(unittest.TestCase):
+    REPO = "gke-labs/kube-agents"
+
+    def _reconcile(self, api, decision, workflow_id=77):
+        return notifier.reconcile(api, decision, self.REPO, workflow_id)
+
+    def test_a_first_failure_opens_an_issue(self):
+        api = FakeAPI()
+        self._reconcile(api, notifier.decide(run(10, "failure"), [run(9, "success")]))
+        self.assertEqual(api.kinds(), ["label", "create"])
+
+    def test_a_follow_up_updates_the_existing_issue_rather_than_opening_another(self):
+        """The failure that would flood the label with one issue per red run."""
+        api = FakeAPI([issue(901, 77, 10)])
+        self._reconcile(api, notifier.decide(run(11, "failure"), [run(10, "failure"), run(9, "success")]))
+        self.assertEqual(api.kinds(), ["update", "comment"])
+        self.assertEqual(api.actions[0][1], 901)
+
+    def test_a_recovery_closes_the_issue(self):
+        api = FakeAPI([issue(901, 77, 10)])
+        self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "failure"), run(10, "failure")]))
+        self.assertEqual(api.kinds(), ["comment", "close"])
+        self.assertIn("Fixed by", api.actions[0][2])
+
+    def test_a_recovery_with_nothing_open_is_quiet(self):
+        """Main was already red when this workflow was added, or someone closed
+        the issue by hand. Opening one just to close it would be noise."""
+        api = FakeAPI()
+        result = self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "failure")]))
+        self.assertEqual(api.actions, [])
+        self.assertIn("no issue is open", result)
+
+    def test_an_ordinary_green_run_writes_nothing(self):
+        """Nearly every run. It costs one list request to be sure, and that is
+        the price of never leaving an issue open on a green main."""
+        api = FakeAPI()
+        self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "success")]))
+        self.assertEqual(api.actions, [])
+
+    def test_a_green_run_closes_an_open_issue_even_with_no_failure_behind_it(self):
+        """The self-heal, and the reason `decide` no longer infers "recovered"
+        from the history. Three ways to get here, all real: the notify run that
+        would have closed the issue was cancelled out of its concurrency group;
+        a red run was re-run and passed, so its own history reads green after
+        green; or two runs were handled out of order."""
+        api = FakeAPI([issue(901, 77, 10)])
+        self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "success")]))
+        self.assertEqual(api.kinds(), ["comment", "close"])
+        self.assertIn("still open", api.actions[0][2])
+        self.assertNotIn("Fixed by", api.actions[0][2], "this run is not the fix and must not claim to be")
+
+    def test_another_workflows_issue_is_left_alone(self):
+        """Four workflows are watched and each breaks independently. Closing
+        another one's issue would hide a real breakage."""
+        api = FakeAPI([issue(901, 88, 10)])
+        self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "failure")]))
+        self.assertEqual(api.actions, [])
+
+    def test_redelivering_the_break_that_opened_the_issue_does_not_duplicate_it(self):
+        """GitHub redelivers `workflow_run` events, and a re-run of the notifier
+        replays one deliberately. For a `broken` this is free -- there is no
+        comment to repeat -- so the guarantee tested here is only that a second
+        issue is not opened."""
+        api = FakeAPI([issue(901, 77, 10)])
+        self._reconcile(api, notifier.decide(run(10, "failure"), [run(9, "success")]))
+        self.assertEqual(api.kinds(), ["update"], "a new break on an existing issue should not comment")
+
+    def test_redelivering_a_follow_up_repeats_its_comment(self):
+        """Known and accepted, recorded so it is a decision rather than a
+        surprise. The body is rebuilt so no row doubles; the "Still failing"
+        comment does. Deduplicating it means listing every comment on the issue
+        on every failure, which costs more than the duplicate does -- and a
+        redelivered `workflow_run` is rare, where a broken main is not."""
+        api = FakeAPI([issue(901, 77, 10)])
+        decision = notifier.decide(run(11, "failure"), [run(10, "failure"), run(9, "success")])
+        self._reconcile(api, decision)
+        self._reconcile(api, decision)
+        self.assertEqual(api.kinds(), ["update", "comment", "update", "comment"])
+
+    def test_a_stale_issue_from_an_earlier_breakage_is_closed(self):
+        """Only reachable if a close failed, but two open issues both claiming
+        main is broken is worse than the missed close that caused it."""
+        api = FakeAPI([issue(901, 77, 5)])
+        self._reconcile(api, notifier.decide(run(10, "failure"), [run(9, "success")]))
+        self.assertEqual(api.kinds(), ["label", "create", "comment", "close"])
+        self.assertIn("Superseded by #901", api.actions[2][2])
+        self.assertEqual(api.actions[3][1], 901)
+
+    def test_a_recovery_closes_every_open_issue_for_the_workflow(self):
+        """Same repair: main is green, so nothing about this workflow should
+        still be claiming otherwise."""
+        api = FakeAPI([issue(901, 77, 10), issue(902, 77, 5)])
+        self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "failure"), run(10, "failure")]))
+        self.assertEqual(api.kinds(), ["comment", "close", "comment", "close"])
+
+
+class MainTest(unittest.TestCase):
+    """The wiring, with the API and the reconciliation stubbed."""
+
+    def _main(self, current, history, argv, env):
+        api = mock.Mock()
+        api.run.return_value = current
+        api.history.return_value = history
+        with mock.patch.object(notifier, "GitHubAPI", return_value=api), mock.patch.dict(
+            "os.environ", env, clear=True
+        ), mock.patch.object(notifier, "reconcile", return_value="done") as reconcile:
+            return notifier.main(argv), reconcile
+
+    def test_a_break_is_reconciled(self):
+        status, reconcile = self._main(
+            run(10, "failure"), [run(9, "success")], ["--run-id", "1010"], {"GITHUB_TOKEN": "t"}
+        )
+        self.assertEqual(status, 0)
+        reconcile.assert_called_once()
+        self.assertEqual(reconcile.call_args[0][1]["kind"], "broken")
+
+    def test_a_green_run_still_reaches_reconcile(self):
+        """It has to: whether there is an issue to close is a question only the
+        API can answer. `reconcile` is what makes it cheap when there is not."""
+        status, reconcile = self._main(
+            run(10, "success"), [run(9, "success")], ["--run-id", "1010"], {"GITHUB_TOKEN": "t"}
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(reconcile.call_args[0][1]["kind"], "green")
+
+    def test_a_conclusion_that_says_nothing_reaches_nothing(self):
+        status, reconcile = self._main(
+            run(10, "neutral"), [run(9, "failure")], ["--run-id", "1010"], {"GITHUB_TOKEN": "t"}
+        )
+        self.assertEqual(status, 0)
+        reconcile.assert_not_called()
+
+    def test_a_run_a_later_one_has_overtaken_is_left_to_that_one(self):
+        """Out of order, a red run handled after the green that fixed it would
+        open a "main is broken" issue against a green main."""
+        status, reconcile = self._main(
+            run(11, "failure"),
+            [run(12, "success"), run(11, "failure"), run(10, "failure")],
+            ["--run-id", "1011"],
+            {"GITHUB_TOKEN": "t"},
+        )
+        self.assertEqual(status, 0)
+        reconcile.assert_not_called()
+
+    def test_a_later_run_that_said_nothing_does_not_silence_this_one(self):
+        """A `cancelled` run is filtered out by the workflow's `if:` and will
+        never reconcile anything, so deferring to it drops the notification
+        altogether -- the one outcome this script exists to prevent."""
+        status, reconcile = self._main(
+            run(11, "failure"),
+            [run(12, "cancelled"), run(11, "failure"), run(10, "success")],
+            ["--run-id", "1011"],
+            {"GITHUB_TOKEN": "t"},
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(reconcile.call_args[0][1]["kind"], "broken")
+
+    def test_a_pull_request_run_is_refused(self):
+        """Defence in depth behind the workflow's `if:`: a hand-run against the
+        wrong run id must not file a pull request as broken main."""
+        pr_run = run(10, "failure")
+        pr_run["event"] = "pull_request"
+        status, reconcile = self._main(pr_run, [], ["--run-id", "1010"], {"GITHUB_TOKEN": "t"})
+        self.assertEqual(status, 0)
+        reconcile.assert_not_called()
+
+    def test_a_run_on_another_branch_is_refused(self):
+        other = run(10, "failure")
+        other["head_branch"] = "release-1.2"
+        status, reconcile = self._main(other, [], ["--run-id", "1010"], {"GITHUB_TOKEN": "t"})
+        self.assertEqual(status, 0)
+        reconcile.assert_not_called()
+
+    def test_dry_run_never_writes(self):
+        status, reconcile = self._main(
+            run(10, "failure"),
+            [run(9, "success")],
+            ["--run-id", "1010", "--dry-run"],
+            {"GITHUB_TOKEN": "t"},
+        )
+        self.assertEqual(status, 0)
+        reconcile.assert_not_called()
+
+    def test_no_token_is_an_error(self):
+        with mock.patch.dict("os.environ", {}, clear=True):
+            self.assertEqual(notifier.main(["--run-id", "1"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

When a required check fails on a push to `main`, nothing tells anyone. This adds a workflow that watches the required checks' push runs and records a breakage as a single `ci:main-broken` issue — opened on the first failure, updated with each commit that lands on top of it, closed by the commit that fixes it.

## Why This Change

#812 is the worked example. #790 bumped `k8s.io/apimachinery`; #733 merged four hours later on a green check that had run eighteen hours before the bump, and the golden fixtures the two commits disagreed about took `Operator Tests` red. Branch protection has `strict` off, so a merge is allowed on a check from a merge commit that may be arbitrarily stale, and nothing re-runs when the base moves. CI did catch it on the push run — and then carried it nowhere a person would see. Three hours and forty-five minutes passed before anyone noticed, and four more commits landed on the broken tree in the meantime.

## What Changed

- `.github/workflows/main-broken-notify.yml` watches `Actionlint`, `Docker Build`, `Operator Tests` and `Validate Repo Structure` over `workflow_run` and hands each completed push run on `main` to the script. No setup: it writes with the workflow's own `GITHUB_TOKEN` and creates the label the first time it needs one.
- `scripts/notify_broken_main.py` decides what a run says and reconciles the issue to it. One issue per breakage, not per red run — a ping per failure tells a reader about the break and never tells them it was fixed.
- `.github/workflows/k8s-operator-test.yml` filters its push trigger with `paths:` rather than in-job. The `dorny/paths-filter` step is right on a pull request — `Run Controller Tests` is required, and a workflow `paths:` declines to start posts no check at all and blocks the merge forever — but on a push it produces a run reporting `success` without compiling a line of Go. That is how #812 hid: the push history reads red (2654), green (2655), red (2657), red (2658), then four greens before the real fix at 2700. An absent run cannot lie; a green one that tested nothing can.
- `.github/workflows/docker-build.yml` gains `push: main`, so the tree that actually landed gets built. It overlaps `docker-publish-ghcr.yml`, but the layer budget (#658) and the entrypoint shared-state gate run only here, and those are the two failures that otherwise surface in Cloud Build after merge.

The script reconciles state rather than reporting transitions, because its own delivery is not reliable: GitHub holds one run pending per concurrency group and cancels the rest of a burst, so the notify run for a merge in the middle of one never happens. A green run therefore closes any open issue for its workflow whether or not the run before it was red; the issue body is rebuilt from run history rather than appended to; and a run that a later run has already overtaken keeps quiet rather than announcing the past. A dropped run costs a "Still failing" comment, not a stuck issue.

`Prettier Check` is required and deliberately not watched. It scopes itself to the files the push changed, so a green says those files are formatted and nothing about the rest of the tree — a bad `docs/a.md` goes red, and the next Go-only merge goes green and closes the issue naming an innocent commit as the fix. Whole-tree prettier is not the remedy either: 19 files under `.agents/skills/` have never been formatted. Prettier is also the check least exposed to the stale-base merge this exists to catch, since it reads file contents, which a moving merge base does not change.

## Context

Follows from #812. Overlaps two open pull requests without conflicting: #720 touches `k8s-operator-test.yml` and #674 touches `docker-build.yml`, both in the job bodies rather than the `on:` blocks changed here — a rebase risk, not duplicate work. Follow-up filed as #838 (one shared GitHub API client for `scripts/`).

Generated with the help of Claude.

## Testing

- 70 unit tests in `scripts/test_notify_broken_main.py`, picked up by the existing `scripts/test_*.py` glob in `make test-python`, so `Python Unit Tests` runs them unfiltered on every PR and push. 191 tests pass across `scripts/`.
- `actionlint`, `prettier --check` (3.9.6, the pinned version), and `zizmor --persona=regular` on the three changed workflows. Zizmor reports two `artipacked` warnings, both pre-existing on checkout steps this branch does not touch.
- `make docs-check`.

### Live validation

Not live-tested against a kube-agents installation: nothing here reaches a cluster, an operator, or an agent pod — it is three GitHub Actions workflows and a script that talks only to the GitHub API.

What it was exercised against instead is the real data it exists to read. `Operator Tests` run history for `main` was pulled from the API for runs 2600–2700 — the #812 window — and replayed through `decide()`/`reconcile()` against a faked issues API, twice:

- **With this branch's `paths:` filter** (dropping the six runs that touch no operator path, which would no longer exist): one issue opens on run 2654 naming `277de10`, grows to three rows as `72c1813` and `731c813` land on the broken tree, each with a "Still failing" comment, and closes on run 2700 with "Fixed by `2b3f1e7` … 3 consecutive failures before it." That is #812, correctly reported end to end.
- **Against the history as it actually reads today**: the issue opens on 2654 and is closed one run later by `8d95429`, a docs commit, named as the fix. A second issue opens, is closed the same way, and the real fix is never mentioned. This is what the `paths:` change prevents, and the reason it is in this PR rather than a separate one.

Not covered: the `workflow_run` trigger itself. A `workflow_run` workflow only ever runs from the default branch's copy of itself, so it cannot fire until this merges. The first real breakage after merge is the first end-to-end exercise; if the trigger is wrong the failure mode is silence, which is the status quo. Nothing was left behind — the replay wrote to a fake API and touched no issue on the repository.

## Self-Review

Ran `review-adversarial` over `upstream/main..HEAD` in a subagent handed the diff range and nothing else. Angles: the trust assumption each watched workflow has to satisfy; failure modes of the state machine under duplicate, missing and out-of-order delivery; API error handling; whether the tests can distinguish a working notifier from a broken one; and whether the prose matches the code. Nine findings, all dispositioned:

**Fixed:**

1. 🔴 `Prettier Check` was on the watch list and gaining a `push: main` trigger. Its green covers only the files a push changed, so it would close the issue naming an innocent commit. Dropped from the list and the `prettier.yml` change reverted entirely; the reasoning is a comment in the watch list, because the next person to add a workflow needs it.
2. 🟠 `decide()` read any non-failure conclusion as green, so a `neutral` or `action_required` run would close an issue on a broken `main`. Added `REPORTING_CONCLUSIONS`: only `success` and the three real failures say anything.
3. 🟠 The concurrency comment claimed nothing is dropped. GitHub cancels the pending run when a third arrives in the group; the comment now says so.
4. 🟠 A red run re-run to green left the issue open, because the history around it reads green-after-green.
5. 🟠 Out-of-order delivery could open "main is broken" against a `main` that is already green.
6. 🟡 The #812 run sequence was wrong in three places' prose.
7. 🟡 GitHub signals a secondary rate limit with 403, not 429, so the retry never fired and the write was dropped. Now retried when `Retry-After` or `x-ratelimit-remaining: 0` is present, capped, and a 403 that is really a missing permission still fails on the first attempt.
8. 🟡 No test constructed a real `GitHubAPI`. Dropping `state=open` from the issue query or `event=push` from the history query broke the notifier while every test still passed. `QueryTest` now covers both queries, the pull-request exclusion, the headers, and the create/close payloads.

Findings 3, 4 and 5 shared one cause, and the fix was structural rather than three patches: the script reconciles state instead of reporting transitions, which is the paragraph in **What Changed** above. Fixing 1 also exposed a bug in the test fixture — `__exit__=mock.Mock()` is truthy, so it swallowed exceptions raised inside the `with` and resurfaced them as an unrelated `UnboundLocalError`; the shared `_response()` helper returns `False`.

**Not fixed:**

9. 🟡 `GitHubAPI` duplicates the one in `scripts/request_reviewers.py`, and the two have diverged — this one retries and does not paginate, that one paginates and does not retry. Real, and worth doing, but the fix edits a script this branch otherwise does not touch. Filed as #838 with both halves written down.

## Risk & Rollout

The notifier cannot break CI: it is a separate `workflow_run` job whose failure marks only itself red, and it holds `issues: write` plus two reads. Its worst realistic misbehaviour is a wrong or duplicate issue on one label, which is deletable. Revert is deleting the workflow file.

Two changes do affect existing checks. `docker-build.yml` adds roughly seven minutes of runner time per merge to `main`. `k8s-operator-test.yml`'s push trigger now skips commits touching no operator path — pull-request behaviour is unchanged, so the required check still posts on every PR and branch protection is unaffected.

The first breakage after merge is the first live exercise of the `workflow_run` trigger; if it is wrong, the failure mode is silence.
