### PR TITLE
fix(operator): probe the dashboard on loopback so it can pass readiness

### DIFF
--- a/docs/site/src/content/docs/deploy/kustomize.md
+++ b/docs/site/src/content/docs/deploy/kustomize.md
@@ -132,7 +132,7 @@ The `app.kubernetes.io/*` labels follow the project-wide contract that makes the
 The exposed ports:
 
 - `8642` — Hermes API server. Chat integrations and the operator health probes hit this.
-- `9119` — Hermes dashboard. Behind `harness.hermes.dashboardEnabled` in the CR.
+- `9119` — Hermes dashboard. Behind `harness.hermes.dashboardEnabled` in the CR. Nothing answers on the pod network; the listener is loopback-only — see [`PlatformAgent` CRD](/kube-agents/operator/platformagent-crd/#specharness) for how to reach it.
 
 ## Kustomize for operator integrations
 

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -58,6 +58,16 @@ the agent a usable kubectl context) when it has the complete triple; with one mi
 | `tuning.maxInProgress`                         | int    | Board-wide cap on concurrent kanban workers. Unset = operator default `2`.                                                                                   |
 | `experimental.platformFrontDoor`               | bool   | **Unsupported.** Run the gateway as the Platform Agent, so chat reaches it directly. Default `false`. See below.                                             |
 
+`dashboardEnabled` publishes port `9119` on the agent Service, but nothing answers there: `hermes
+dashboard` binds `127.0.0.1`, so a request arriving over the pod network gets connection refused.
+Reaching it means getting inside the pod's network namespace — `kubectl port-forward svc/<agent>
+9119:9119` on an ordinary node pool, and
+[`scripts/hermes-dashboard-tunnel.py`](https://github.com/gke-labs/kube-agents/blob/main/scripts/hermes-dashboard-tunnel.py)
+on a GKE Sandbox (gVisor) one, where port-forward is set up in the host-side netns and cannot see
+the sandbox's listener. That script is canonical on both the access path and why the loopback bind
+is deliberate. The container's readiness probe runs `curl` against loopback for the same reason a
+`tcpSocket` probe cannot work here: kubelet dials the pod IP, and nothing is listening on it.
+
 `sessionKVApiKeySecretRef` is optional in the API but not in practice, and the `503` above is the
 milder half of what its absence costs. The `k8s-event-watcher` in the credential sidecar
 authenticates to that same server, treats an empty `SESSION_KV_API_KEY` as fatal, and exits on every

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -56,6 +56,11 @@ const (
 	defaultAgentHome            = "/opt/data"
 	defaultStorageSize          = "5Gi"
 	credentialProxyPort         = 8765
+	// dashboardPort is the port `hermes dashboard` listens on. It is loopback-only
+	// (see the readiness probe in buildBaseContainers), so the container port, the
+	// Service port, and the NetworkPolicy rule below all describe a listener that
+	// only kubelet's port-forward can reach.
+	dashboardPort = 9119
 )
 
 // Shared-state ownership. Step 1.5 of deploy/shared/docker-entrypoint.sh reads this
@@ -2766,7 +2771,7 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 			Ports: []corev1.ContainerPort{
 				{
 					Name:          "dashboard",
-					ContainerPort: 9119,
+					ContainerPort: dashboardPort,
 				},
 			},
 			Env: dashboardEnvVars,
@@ -2781,17 +2786,51 @@ func buildBaseContainers(agent *agentv1alpha1.PlatformAgent, image string, envVa
 				},
 			},
 			VolumeMounts: append(dashboardVolumeMounts, extraVolumeMounts...),
-			// The Service publishes :9119 whenever the dashboard is enabled, so
-			// without this the UI port is advertised before anything listens on it.
+			// What this buys is not what a probe on a serving container buys. The
+			// Service's :9119 endpoint is unreachable over the pod network either
+			// way (see dashboardPort), so nothing is being kept out of rotation.
+			// Pod readiness is the AND of every container, so this reports a
+			// broken dashboard through the pod's own Ready condition — and, the
+			// other side of the same coin, a dashboard that hangs or OOM-loops
+			// now withdraws the agent API on :8642 with it. That coupling is the
+			// price of reporting it at all; the alternative is no probe here,
+			// which leaves a dead dashboard silent.
 			//
-			// tcpSocket rather than httpGet: this one binds all interfaces, so kubelet
-			// can reach it on the pod IP, but `hermes dashboard` exposes no health
-			// path we have verified — and a probe against a guessed path that 404s
-			// would hold the whole pod unready, taking the API down with it.
+			// exec on loopback, not tcpSocket. `hermes dashboard` takes no --host
+			// argument here and the CLI's default is 127.0.0.1, so a tcpSocket probe
+			// — which kubelet dials against the pod IP — was refused on every
+			// attempt and this container never went Ready. That held the whole pod
+			// NotReady, drove the CR to Ready=False, and failed the install's
+			// rollout gate on any install that did not pin dashboardEnabled=false
+			// (#822). The comment this replaces asserted the opposite binding.
+			// Same shape, and the same reason, as agentAPIProbe above.
+			//
+			// Binding all interfaces instead is not the smaller fix, and not just
+			// because no auth provider is configured: the dashboard's auth gate
+			// keys on the bind host, so 0.0.0.0 switches authentication on and the
+			// server then exits at startup rather than serve unauthenticated. The
+			// loopback bind is what keeps it usable. scripts/hermes-dashboard-
+			// tunnel.py is canonical on that and on how a human reaches it.
+			//
+			// No --fail and no health path: `hermes dashboard` exposes no health
+			// endpoint we have verified, and demanding a 2xx from a guessed one
+			// would 404 and hold the pod unready for the wrong reason. Without
+			// --fail curl exits 0 on any HTTP status, so serving the SPA at / is
+			// enough and so would be a 401. Plain http:// is right — that tunnel
+			// script relays cleartext HTTP off this port.
+			//
+			// So the exit code passes straight through: 0 means it answered, 7
+			// means connection refused — the exact state that made this container
+			// never go Ready — and 28 means it accepted and then hung. --max-time
+			// sits under TimeoutSeconds so 28 is curl's to report rather than
+			// kubelet's to kill.
 			ReadinessProbe: &corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
-					TCPSocket: &corev1.TCPSocketAction{
-						Port: intstr.FromString("dashboard"),
+					Exec: &corev1.ExecAction{
+						Command: []string{
+							"sh", "-c",
+							fmt.Sprintf("curl --silent --show-error --max-time 3 -o /dev/null http://127.0.0.1:%d/", dashboardPort),
+						},
 					},
 				},
 				InitialDelaySeconds: 5,
@@ -3188,9 +3227,14 @@ func buildPlatformService(agent *agentv1alpha1.PlatformAgent) *corev1.Service {
 	}
 
 	if dashboardEnabled {
+		// Connecting to this port from another pod gets connection refused: the
+		// dashboard listens on loopback only (see dashboardPort). It is published
+		// anyway because `kubectl port-forward svc/<agent> 9119:9119` needs the
+		// Service to name the port, and port-forward is how the dashboard is
+		// reached.
 		ports = append(ports, corev1.ServicePort{
 			Name:       "dashboard",
-			Port:       9119,
+			Port:       dashboardPort,
 			TargetPort: intstr.FromString("dashboard"),
 		})
 	}
@@ -3532,9 +3576,14 @@ func buildNetworkPolicy(agent *agentv1alpha1.PlatformAgent, apiCIDRs []string, d
 	}
 
 	if isDashboardEnabled(agent) {
+		// Kept in step with the Service port rather than because pod-network
+		// traffic reaches the dashboard — it does not, the listener is loopback
+		// (see dashboardPort). Removing the rule would make the policy the reason
+		// a future non-loopback bind fails, which is not the failure to leave
+		// behind.
 		ingressRules[0].Ports = append(ingressRules[0].Ports, networkingv1.NetworkPolicyPort{
 			Protocol: &tcp,
-			Port:     ptr.To(intstr.FromInt32(9119)),
+			Port:     ptr.To(intstr.FromInt32(dashboardPort)),
 		})
 	}
 

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -436,6 +436,30 @@ func TestBuildDeployment(t *testing.T) {
 		if dashboardC.Resources.Limits.Cpu().String() != "1" || dashboardC.Resources.Limits.Memory().String() != "2Gi" {
 			t.Errorf("expected CPU 1 and Mem 2Gi limits on dashboard container, got %v", dashboardC.Resources.Limits)
 		}
+		// The probe has to reach the listener over loopback. `hermes dashboard`
+		// binds 127.0.0.1, so the tcpSocket probe this replaces was dialled by
+		// kubelet against the pod IP, refused every time, and left the container
+		// — and therefore the whole pod — permanently NotReady (#822). Asserting
+		// the shape is the only guard available here: nothing in this suite can
+		// open a socket against the real CLI.
+		switch probe := dashboardC.ReadinessProbe; {
+		case probe == nil:
+			t.Errorf("expected a readiness probe on the dashboard container")
+		case probe.TCPSocket != nil:
+			t.Errorf("dashboard readiness probe must not be tcpSocket: kubelet dials the pod IP and the listener is loopback-only")
+		case probe.Exec == nil || len(probe.Exec.Command) == 0:
+			t.Errorf("expected an exec readiness probe on the dashboard container, got %+v", probe.ProbeHandler)
+		default:
+			cmd := strings.Join(probe.Exec.Command, " ")
+			if !strings.Contains(cmd, "http://127.0.0.1:9119/") {
+				t.Errorf("expected the dashboard readiness probe to target http://127.0.0.1:9119/, got %q", cmd)
+			}
+			// --fail would turn an auth-gated or non-2xx root path into an
+			// unready pod; the probe only asserts that something answers.
+			if strings.Contains(cmd, "--fail") {
+				t.Errorf("dashboard readiness probe must not use curl --fail: any HTTP response proves the listener is up, got %q", cmd)
+			}
+		}
 		if len(dashboardC.Env) != 6 {
 			t.Errorf("expected 6 env vars on dashboard container, got %d", len(dashboardC.Env))
 		} else {

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -677,11 +677,14 @@ spec:
             - containerPort: 9119
               name: dashboard
           readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl --silent --show-error --max-time 3 -o /dev/null http://127.0.0.1:9119/
             failureThreshold: 3
             initialDelaySeconds: 5
             periodSeconds: 15
-            tcpSocket:
-              port: dashboard
             timeoutSeconds: 5
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -632,11 +632,14 @@ spec:
             - containerPort: 9119
               name: dashboard
           readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl --silent --show-error --max-time 3 -o /dev/null http://127.0.0.1:9119/
             failureThreshold: 3
             initialDelaySeconds: 5
             periodSeconds: 15
-            tcpSocket:
-              port: dashboard
             timeoutSeconds: 5
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -677,11 +677,14 @@ spec:
             - containerPort: 9119
               name: dashboard
           readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl --silent --show-error --max-time 3 -o /dev/null http://127.0.0.1:9119/
             failureThreshold: 3
             initialDelaySeconds: 5
             periodSeconds: 15
-            tcpSocket:
-              port: dashboard
             timeoutSeconds: 5
           resources:
             limits:


### PR DESCRIPTION
## Summary

`hermes dashboard` listens on `127.0.0.1`, but the operator gave its container a `tcpSocket` readiness probe, which kubelet dials against the pod IP. The probe was refused on every attempt, so the container never became Ready — and because pod readiness is the AND of all containers, that held the whole agent pod `NotReady`, drove the `PlatformAgent` CR to `Ready=False`, and failed the install's rollout gate. This replaces the probe with an `exec` curl against loopback. Generated with the help of Claude.

## Why This Change

The comment above the old probe justified `tcpSocket` by asserting the dashboard "binds all interfaces, so kubelet can reach it on the pod IP". It does not, and `hermes dashboard --help` in the running container says so plainly: `--host` defaults to `127.0.0.1`.

The reach is wider than #822 reports. `isDashboardEnabled` defaults to **`true`** (`platformagent_manifests.go`), and `charts/kube-agents/values.yaml` leaves the field `null`, so the CRD default applies. Only `install.sh` escapes it, by pinning `HERMES_DASHBOARD_ENABLED=false` in `installer_common.sh`. A chart-only or plain-Terraform install gets an agent pod that can never go Ready.

Binding all interfaces is not the smaller fix, and the reason is stronger than "no auth provider is configured". `scripts/hermes-dashboard-tunnel.py` already records it, and the CLI's own help confirms it: the auth gate keys on the bind host, so a `0.0.0.0` bind turns authentication on and the server then exits at startup rather than serve unauthenticated. `--insecure` is `DEPRECATED / NO-OP`. The loopback bind is what keeps the dashboard usable.

## What Changed

- `platformagent_manifests.go` — the dashboard readiness probe becomes `exec` + `curl` against `127.0.0.1:9119`. No `--fail`, so any HTTP status counts as up; `7` (refused) and `28` (hung) still fail, and `--max-time 3` sits under `TimeoutSeconds: 5` so a hang is curl's to report rather than kubelet's to kill.
- A `dashboardPort` constant replaces the `9119` literal in the container port, the Service port, and the NetworkPolicy rule.
- The Service port and NetworkPolicy rule are **kept**. `kubectl port-forward svc/<agent> 9119:9119` needs the Service to name the port. The comments now say the endpoint is dead on the pod network instead of implying it is live.
- Docs: the CRD reference explains how the dashboard is actually reached, and points at `scripts/hermes-dashboard-tunnel.py` for GKE Sandbox, where port-forward cannot work.

## Context

Fixes #822.

Merge-order notes, neither a duplicate:

- **#674** (@AntonTyb, read-only root filesystem) touches the same three golden files and the adjacent lines of `platformagent_manifests.go` and its test. Textual conflict likely; functionally compatible — `readOnlyRootFilesystem` does not break `curl -o /dev/null`.
- **#824** (@shalinibhatiapl, netpol profile) moves the NetworkPolicy port literals this PR changed. Whoever merges second reconciles `dashboardPort` into the netpol profile.
- **#823** (@AntonTyb) widens the gVisor population to Autopilot. That makes the port-forward caveat documented here apply to more installs, not fewer.

## Testing

- `go build ./...`, `go vet ./internal/...` (type-checks tests), `gofmt -l` — all clean.
- `prettier@3.9.6 --check` on changed Markdown/YAML — clean. `make docs-check` — passes.
- `make -C k8s-operator manifests` — no diff under `config/`.
- New assertion in `TestBuildDeployment` pins the probe shape: not `tcpSocket`, targets loopback, no `--fail`. Red against the pre-change code.
- **Go tests were not executed.** Every `go test` binary is SIGKILLed at the OS level on this machine, including a trivial hello-world test in `/tmp`. The three golden files were therefore hand-edited rather than regenerated; I verified with an independent YAML parser that the `command` array in each matches the exact string `fmt.Sprintf` produces, and `CompareGolden` compares parsed trees rather than bytes. CI's Run Controller Tests is what settles this.

### Live validation

Install: `mplakhtiy-gke-dev` / cluster `kube-agents` / `us-central1`, GKE **Standard with a gVisor node pool** (pod `runtimeClassName: gvisor`), agent image `05a04fd8…`, created for this test and destroyed after. Terraform + Helm through `lifecycle.sh`, with `hermes_dashboard_enabled = true` — the profile normally pins it `false`, which is why this install had never hit the bug.

**Reproduced, with the stock operator `ghcr.io/gke-labs/kube-agents/k8s-operator:05a04fd8…`:**

- `platform-agent-gateway` at `3/4`; `platform-agent-dashboard` `ready=false`, 0 restarts.
- CR: `Ready=False reason=Provisioning msg=Waiting for deployment replicas to be ready`.
- **52** `Unhealthy` events, `15:35:12`→`15:45:19`, all `Readiness probe failed: dial tcp 10.120.3.5:9119: connect: connection refused` — kubelet on the pod IP.
- The container's own log at the same time: `HERMES_DASHBOARD_READY port=9119` / `Hermes Web UI → http://127.0.0.1:9119`. Up, on loopback.
- From inside that container: `http://10.120.3.5:9119/` → `rc=7`; `http://127.0.0.1:9119/` → `rc=0`.

**Fixed**, by rolling only the operator to a Cloud Build of this branch:

- Rendered probe is exactly this PR's command: `["sh","-c","curl --silent --show-error --max-time 3 -o /dev/null http://127.0.0.1:9119/"]`.
- Pod `4/4 Running`, all four containers `ready=true`; CR `Ready=True reason=Reconciled`, with `dashboardEnabled: true` still in the spec.
- Two probe misses during the dashboard's boot (`curl: (7) … 127.0.0.1 port 9119`), then nothing for the remaining 8+ minutes.

The mechanism, not a coincidence: the only thing that changed between `3/4` and `4/4` was the operator image, and the failure message changed from the pod IP to loopback-during-boot.

**Also confirmed against the running container**, since these were assumptions the issue made and the code now relies on:

- `hermes dashboard --help`: `--host HOST  Host (default 127.0.0.1)`; `--insecure  DEPRECATED / NO-OP … a public bind always requires an auth provider (password or OAuth). Bind 127.0.0.1 + tunnel`.
- `kubectl port-forward` to `9119` on this gVisor pod **fails**: `failed to connect to localhost:9119 inside namespace … connection refused`. This is why the docs change points at the tunnel script rather than calling port-forward the access path — an earlier draft of this PR got that wrong.

**Not covered:** the non-gVisor path (this install was sandboxed throughout), and any dashboard state beyond "serving on `/`". Teardown: `lifecycle.sh destroy`, 25 resources, cluster gone; only the KMS key rings remain, which GCP cannot delete.

## Self-Review

Ran `.agents/skills/review-adversarial` in a **subagent given only the diff range** — not this session, and not my reasoning for the change.

Angles it ran: intent-vs-diff, probe shell correctness, golden-file fidelity, repo-wide search for anything asserting the old probe or binding, constant-substitution typing, docs placement against AGENTS.md, and sibling-PR overlap.

What it found, and what I did:

- **Readiness now couples the agent API to a debug UI.** Pod readiness is the AND of all containers and nothing sets `publishNotReadyAddresses`, so a dashboard that OOM-loops or hangs now withdraws `:8642` after ~45s. Previously academic, because the pod was permanently NotReady whenever the dashboard was on. **Kept the probe, rewrote the justification** — the retained first line claimed the probe stops the Service advertising a port before anything listens, which is void when the endpoint is unreachable either way. The comment now states the real trade and names the alternative (no probe here at all). Flagging it as a live design question for the reviewer rather than deciding it unilaterally.
- **Docs said port-forward was *the* access path.** Wrong on GKE Sandbox, and it missed `scripts/hermes-dashboard-tunnel.py` entirely. **Fixed, then live-verified** the failure above.
- **Tolerated curl exit codes `35/52/56` were wrong.** `35` is unreachable over `http://` with no proxy, and the set was not the "connection accepted" equivalence the comment claimed. The tolerance existed only to hedge whether the dashboard spoke TLS; the tunnel script and the live run both show plain HTTP. **Removed it** — the exit code now passes straight through.
- **A history clause in the CRD reference** ("before that it could never pass…") — **removed**; docs describe current state.
- **The probe duplicates `agentAPIProbe`'s idiom.** Not extracted: two call sites, and the two probes tolerate deliberately different things. Flagging rather than refactoring.

Verified clean by that pass and re-checked by me: all three goldens semantically identical to what the Go renders; `curl` and `sh` present in the image; nothing else in the repo asserts the old probe; `dashboardPort` substituted without a type change; the `#specharness` anchor resolves.
