### PR TITLE
docs(install): record the recovery steps a from-scratch install needed

### DIFF
--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -74,6 +74,8 @@ curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash -s -- \
 
    You should see one `PlatformAgent` resource plus pods for the operator (`kubeagents-controller-manager`), the Platform Agent gateway (`platform-agent-gateway`), and LiteLLM (`litellm`). The GitHub token minter (`github-token-minter`) also appears if you enabled the GitHub integration. When the Platform Agent gateway pod is `Running` and Google Chat is configured, DM your Chat app and it should reply.
 
+   Read the gateway's log in the first few minutes and it looks worse than it is. Repeated `Connection refused` from the Google Chat relay, and a one-off `slack connect timed out after 30s`, are startup ordering: both relays dial the credential-proxy sidecar on loopback, and it is not listening yet. They retry, and on a fresh install these cleared themselves within about seven minutes. Treat them as a fault only if they are still arriving well after that — at which point the thing to inspect is the `envoy-credential-proxy` container, not the relay reporting the error.
+
 </Steps>
 
 ## What just happened

--- a/docs/site/src/content/docs/install/quickstart-gke.mdx
+++ b/docs/site/src/content/docs/install/quickstart-gke.mdx
@@ -74,7 +74,7 @@ curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash -s -- \
 
    You should see one `PlatformAgent` resource plus pods for the operator (`kubeagents-controller-manager`), the Platform Agent gateway (`platform-agent-gateway`), and LiteLLM (`litellm`). The GitHub token minter (`github-token-minter`) also appears if you enabled the GitHub integration. When the Platform Agent gateway pod is `Running` and Google Chat is configured, DM your Chat app and it should reply.
 
-   Read the gateway's log in the first few minutes and it looks worse than it is. Repeated `Connection refused` from the Google Chat relay, and a one-off `slack connect timed out after 30s`, are startup ordering: both relays dial the credential-proxy sidecar on loopback, and it is not listening yet. They retry, and on a fresh install these cleared themselves within about seven minutes. Treat them as a fault only if they are still arriving well after that — at which point the thing to inspect is the `envoy-credential-proxy` container, not the relay reporting the error.
+   The gateway logs errors while it starts up, and they do not mean the install failed. Repeated `Connection refused` from the Google Chat relay, and a one-off `slack connect timed out after 30s`, are ordering: both relays dial the credential-proxy sidecar on loopback before it is listening. They retry until it is, and on a fresh install the messages stopped on their own within about seven minutes. Treat them as a fault only if they are still arriving well after that, and inspect the `envoy-credential-proxy` container rather than the relay reporting the error.
 
 </Steps>
 

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -108,10 +108,99 @@ uniform bucket-level access, in the cluster's region — and a gitignored
 `gs://<bucket>/<prefix>`, where the prefix defaults to
 `kube-agents/<cluster_name>` (override with `KUBE_AGENTS_STATE_PREFIX`) so two
 installs in one project keep separate state. Versioning is the recovery story:
-a corrupted or mistakenly-overwritten state file can be restored from a prior
-generation with `gcloud storage restore`. If the state is gone entirely,
+a corrupted or mistakenly-overwritten state file can be rolled back to a prior
+generation by copying it over the live object (`gcloud storage ls -a` lists the
+generations; `gcloud storage restore` is for soft-deleted objects, which is a
+different feature and not one this bucket has on):
+
+```bash
+gcloud storage ls -a gs://<bucket>/<prefix>/default.tfstate
+gcloud storage cp gs://<bucket>/<prefix>/default.tfstate#<generation> \
+  gs://<bucket>/<prefix>/default.tfstate
+```
+
+If the state is gone entirely,
 re-run `lifecycle.sh apply` against the same tfvars — KMS adoption is
 automatic, and `terraform import` covers the rest.
+
+### Recovering from an interrupted apply
+
+An apply killed part-way — Ctrl-C, a dropped connection, a laptop lid — leaves
+state locked, and the next command fails with `Error acquiring the state lock`.
+`terraform force-unlock` is the release, and it works here; what trips people up
+is which identifier it wants. On the `gcs` backend the lock ID is the **GCS
+generation number** of the lock object, not a UUID, and it is the `ID:` in the
+error Terraform just printed:
+
+```text
+Lock Info:
+  ID:        1787242876096737
+  Path:      gs://<bucket>/<prefix>/default.tflock
+```
+
+```bash
+terraform force-unlock 1787242876096737
+```
+
+Pass a UUID from anywhere else — the `"ID"` field inside the lock object's own
+JSON, for instance — and it refuses with `Lock ID should be numerical value`,
+which reads like the backend not supporting `force-unlock` at all. It does.
+
+Prefer it to deleting the object, because it fails if the generation has moved,
+which is exactly the case where something else has taken the lock and you should
+not be breaking it. `gcloud storage rm gs://<bucket>/<prefix>/default.tflock` is
+the fallback for a lock whose ID you no longer have; it removes the lock
+unconditionally, so only do it once nothing is still applying. `<bucket>` and
+`<prefix>` are the ones from [Remote state](#remote-state) —
+`<project_id>-kube-agents-tfstate` and `kube-agents/<cluster_name>` by default.
+
+A connectivity drop mid-apply produces two failures worth recognising, because
+neither means what it looks like:
+
+- **`http2: client connection lost` on the state upload.** Terraform retries this
+  itself and the retry usually succeeds, so the run can report a state-write
+  failure it then recovered from. Check the bucket before concluding state was
+  lost — and remember versioning is on, so a bad write can be rolled back to the
+  previous generation as above.
+- **A `BackupPlan` create that fails while polling its operation.** The
+  long-running operation keeps going server-side, so the plan is often `READY`
+  even though Terraform recorded a failure and holds nothing in state. Check with
+  `gcloud beta container backup-restore backup-plans describe`, then import it and
+  re-apply rather than deleting the plan to let Terraform recreate it.
+
+  Import into the same state the apply used, which on a remote-state install
+  means the backend has to be configured first. `backend_override.tf` is
+  gitignored and written only by `lifecycle.sh`, so in a fresh clone a bare
+  `terraform import` silently writes a **local** `terraform.tfstate`, reports
+  success, and leaves the next apply still trying to create the plan. Run
+  `KUBE_AGENTS_STATE_BUCKET=<same value> ./lifecycle.sh adopt-kms` first — it is
+  the cheapest subcommand that initialises the backend — or work in a directory
+  `lifecycle.sh` has already initialised.
+
+  The import itself needs the placeholder Helm provider `adopt-kms` writes for
+  its own imports, and `lifecycle.sh` exposes no generic import subcommand to
+  borrow — so write it yourself. `terraform import` configures every provider
+  before it does anything, and the `helm` provider here is built from
+  `module.gke_cluster.cluster_endpoint`; the override was needed in practice even
+  with the cluster already in state. The filename suffix is what makes Terraform
+  treat it as an override, so keep it:
+
+  ```bash
+  cat > providers_lifecycle_override.tf <<'EOF'
+  provider "helm" {
+    kubernetes = {
+      host  = "https://127.0.0.1"
+      token = "placeholder"
+    }
+  }
+  EOF
+  terraform import 'module.gke_backup_plan[0].google_gke_backup_backup_plan.this' \
+    "projects/<project>/locations/<region>/backupPlans/<cluster_name>-backup-plan"
+  rm -f providers_lifecycle_override.tf
+  ```
+
+  Remove the override before the next apply — it is never meant to survive an
+  import, which is why `lifecycle.sh` deletes it on an `EXIT` trap.
 
 ### The `image_tag` rule
 

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -111,7 +111,8 @@ installs in one project keep separate state. Versioning is the recovery story:
 a corrupted or mistakenly-overwritten state file can be rolled back to a prior
 generation by copying it over the live object (`gcloud storage ls -a` lists the
 generations; `gcloud storage restore` is for soft-deleted objects, which is a
-different feature and not one this bucket has on):
+different feature — with versioning on, a previous generation is a noncurrent
+version rather than a soft-deleted object):
 
 ```bash
 gcloud storage ls -a gs://<bucket>/<prefix>/default.tfstate
@@ -141,6 +142,18 @@ Lock Info:
 ```bash
 terraform force-unlock 1787242876096737
 ```
+
+Run it from a directory whose backend is already configured, or it will not
+reach the lock at all. `force-unlock` acts on whatever backend the working
+directory has, this composition ships no backend block, and `backend_override.tf`
+is gitignored and written only by `lifecycle.sh` — so in a checkout that has
+never been through `lifecycle.sh`, Terraform is on local state and refuses with a
+local-state error that never mentions GCS. That matters here more than it looks:
+`install.sh`, `uninstall.sh` and `upgrade.sh` all drive the apply from a
+disposable clone, so the directory that took the lock is routinely gone by the
+time anyone goes looking for it. The fix is the same one the `BackupPlan` import
+below needs — `KUBE_AGENTS_STATE_BUCKET=<same value> KUBE_AGENTS_STATE_PREFIX=<same value> ./lifecycle.sh adopt-kms`
+first, or work in a directory `lifecycle.sh` has already initialised.
 
 Pass a UUID from anywhere else — the `"ID"` field inside the lock object's own
 JSON, for instance — and it refuses with `Lock ID should be numerical value`,
@@ -176,9 +189,11 @@ neither means what it looks like:
 
   Import into the same state the apply used, which on a remote-state install
   means the backend has to be configured first. `backend_override.tf` is
-  gitignored and written only by `lifecycle.sh`, so in a fresh clone a bare
-  `terraform import` silently writes a **local** `terraform.tfstate`, reports
-  success, and leaves the next apply still trying to create the plan. Run
+  gitignored and written only by `lifecycle.sh`, so in a checkout that has
+  `terraform.tfvars` but no override — one `install.sh` wrote into and something
+  later cleaned, say — a bare `terraform import` silently writes a **local**
+  `terraform.tfstate`, reports success, and leaves the next apply still trying to
+  create the plan. Run
   `KUBE_AGENTS_STATE_BUCKET=<same value> ./lifecycle.sh adopt-kms` first — it is
   the cheapest subcommand that initialises the backend — or work in a directory
   `lifecycle.sh` has already initialised. Carry `KUBE_AGENTS_STATE_PREFIX` across
@@ -187,6 +202,12 @@ neither means what it looks like:
   override points the backend at the default `kube-agents/<cluster_name>` object,
   and the import lands in an empty state that reports success while the real one
   still has no plan.
+
+  `terraform.tfvars` is gitignored too, so a literally fresh clone has neither
+  file and fails earlier and more loudly: `ensure_backend` evaluates
+  `var.project_id` before it can write the override, and `lifecycle.sh` exits
+  with "could not evaluate var.project_id". Restore the tfvars the install used
+  before either recipe.
 
   The import itself needs the placeholder Helm provider `adopt-kms` writes for
   its own imports, and `lifecycle.sh` exposes no generic import subcommand to

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -146,13 +146,19 @@ Pass a UUID from anywhere else — the `"ID"` field inside the lock object's own
 JSON, for instance — and it refuses with `Lock ID should be numerical value`,
 which reads like the backend not supporting `force-unlock` at all. It does.
 
-Prefer it to deleting the object, because it fails if the generation has moved,
-which is exactly the case where something else has taken the lock and you should
-not be breaking it. `gcloud storage rm gs://<bucket>/<prefix>/default.tflock` is
-the fallback for a lock whose ID you no longer have; it removes the lock
-unconditionally, so only do it once nothing is still applying. `<bucket>` and
-`<prefix>` are the ones from [Remote state](#remote-state) —
-`<project_id>-kube-agents-tfstate` and `kube-agents/<cluster_name>` by default.
+Establish that nothing is still applying before you run it. The ID in the error
+is the generation of the lock as it exists at that moment, so `force-unlock`
+matches it and releases it whether the holder is a dead process or a colleague's
+apply still running — the interactive confirmation is the only thing in the way,
+and `-force` removes that too. What the generation check does catch is a
+**stale** ID: one carried over from an earlier error, after which the lock was
+released and re-taken. Pass that and the command refuses rather than breaking a
+lock you were not looking at. That is the reason to prefer it to
+`gcloud storage rm gs://<bucket>/<prefix>/default.tflock`, which deletes the
+object whatever its generation and is the fallback for a lock whose ID you no
+longer have. `<bucket>` and `<prefix>` are the ones from
+[Remote state](#remote-state) — `<project_id>-kube-agents-tfstate` and
+`kube-agents/<cluster_name>` unless `KUBE_AGENTS_STATE_PREFIX` overrode it.
 
 A connectivity drop mid-apply produces two failures worth recognising, because
 neither means what it looks like:
@@ -175,7 +181,12 @@ neither means what it looks like:
   success, and leaves the next apply still trying to create the plan. Run
   `KUBE_AGENTS_STATE_BUCKET=<same value> ./lifecycle.sh adopt-kms` first — it is
   the cheapest subcommand that initialises the backend — or work in a directory
-  `lifecycle.sh` has already initialised.
+  `lifecycle.sh` has already initialised. Carry `KUBE_AGENTS_STATE_PREFIX` across
+  as well if the install set one. `ensure_backend` derives the prefix
+  independently of the bucket and inits with `-reconfigure`, so an omitted
+  override points the backend at the default `kube-agents/<cluster_name>` object,
+  and the import lands in an empty state that reports success while the real one
+  still has no plan.
 
   The import itself needs the placeholder Helm provider `adopt-kms` writes for
   its own imports, and `lifecycle.sh` exposes no generic import subcommand to

--- a/terraform/modules/github-minter/README.md
+++ b/terraform/modules/github-minter/README.md
@@ -16,6 +16,12 @@ cd /tmp/minty && go run ./cmd/minty tools import-pk \
 
 `install.sh` runs this import for you when it collects a PEM path. The minter's Kubernetes half (Deployment, Service, NetworkPolicy, KSA, minty rule ConfigMap) is the chart's `githubMinter.*` values; the minter pod fails its readiness probe until the key version imported here is ENABLED.
 
+The clone-and-run needs a Go toolchain that can build and execute a binary, which is not a given on a locked-down workstation. `gcloud` and `openssl` do the same wrapping in four commands — [Importing Without the Minty CLI](../../../k8s-operator/config/integrations/github/README.md#importing-without-the-minty-cli) is canonical for that path, including the wait for the import job to reach `ACTIVE` and the `CLOUDSDK_PYTHON_SITEPACKAGES=1` that the wrapping step needs. `<region>` there is the KMS location, which is this module's `location` with any zone suffix stripped: `us-central1-a` becomes `us-central1`.
+
+### Moving the install to another region means a new App key
+
+The keyring follows `var.location`, which the full-install composition passes straight from the cluster's location — so changing `location` on an install that has the minter enabled creates a **new, empty** keyring in the new region. The key is `import_only` and KMS never releases private key material, so the existing App key cannot be exported or copied across; generate a fresh private key for the GitHub App and import that one. The old keyring and key stay in the project forever, per the warning below.
+
 > **KMS resources cannot be deleted.** Cloud KMS key rings and keys are never actually
 > destroyed — `terraform destroy` only removes them from state, and a subsequent apply
 > with the same names fails with a 409. Recover by importing the existing resources

--- a/terraform/modules/github-minter/README.md
+++ b/terraform/modules/github-minter/README.md
@@ -16,9 +16,9 @@ cd /tmp/minty && go run ./cmd/minty tools import-pk \
 
 `install.sh` runs this import for you when it collects a PEM path. The minter's Kubernetes half (Deployment, Service, NetworkPolicy, KSA, minty rule ConfigMap) is the chart's `githubMinter.*` values; the minter pod fails its readiness probe until the key version imported here is ENABLED.
 
-The clone-and-run needs a Go toolchain that can build and execute a binary, which is not a given on a locked-down workstation. `gcloud` and `openssl` do the same wrapping in four commands — [Importing Without the Minty CLI](../../../k8s-operator/config/integrations/github/README.md#importing-without-the-minty-cli) is canonical for that path, including the wait for the import job to reach `ACTIVE` and the `CLOUDSDK_PYTHON_SITEPACKAGES=1` that the wrapping step needs. `<region>` there is the KMS location, which is this module's `location` with any zone suffix stripped: `us-central1-a` becomes `us-central1`.
+The clone-and-run needs a Go toolchain that can build and execute a binary, which is not a given on a locked-down workstation. `gcloud` and `openssl` do the same wrapping in four commands — [Importing Without the Minty CLI](../../../k8s-operator/config/integrations/github/README.md#importing-without-the-minty-cli) is canonical for that path, including the wait for the import job to reach `ACTIVE` and the `CLOUDSDK_PYTHON_SITEPACKAGES=1` that the wrapping step needs. It is parameterised on `${KMS_LOCATION}`, which is the same value as `<region>` in the clone-and-run above: this module's `location` with any zone suffix stripped, so `us-central1-a` becomes `us-central1`.
 
-### Moving the install to another region re-imports the App key
+## Moving the install to another region re-imports the App key
 
 The keyring follows `var.location`, which the full-install composition passes straight from the cluster's location — so changing `location` on an install that has the minter enabled creates a **new, empty** keyring in the new region. Nothing is copied across: the key is `import_only` and KMS never releases private key material, so the version in the old keyring stays where it is.
 

--- a/terraform/modules/github-minter/README.md
+++ b/terraform/modules/github-minter/README.md
@@ -18,9 +18,13 @@ cd /tmp/minty && go run ./cmd/minty tools import-pk \
 
 The clone-and-run needs a Go toolchain that can build and execute a binary, which is not a given on a locked-down workstation. `gcloud` and `openssl` do the same wrapping in four commands — [Importing Without the Minty CLI](../../../k8s-operator/config/integrations/github/README.md#importing-without-the-minty-cli) is canonical for that path, including the wait for the import job to reach `ACTIVE` and the `CLOUDSDK_PYTHON_SITEPACKAGES=1` that the wrapping step needs. `<region>` there is the KMS location, which is this module's `location` with any zone suffix stripped: `us-central1-a` becomes `us-central1`.
 
-### Moving the install to another region means a new App key
+### Moving the install to another region re-imports the App key
 
-The keyring follows `var.location`, which the full-install composition passes straight from the cluster's location — so changing `location` on an install that has the minter enabled creates a **new, empty** keyring in the new region. The key is `import_only` and KMS never releases private key material, so the existing App key cannot be exported or copied across; generate a fresh private key for the GitHub App and import that one. The old keyring and key stay in the project forever, per the warning below.
+The keyring follows `var.location`, which the full-install composition passes straight from the cluster's location — so changing `location` on an install that has the minter enabled creates a **new, empty** keyring in the new region. Nothing is copied across: the key is `import_only` and KMS never releases private key material, so the version in the old keyring stays where it is.
+
+What that costs depends on whether you still have the PEM GitHub issued. KMS is not the source of truth for the App key; that file is. `import_github_pem` derives the KMS location from the region, and imports `GITHUB_PEM_PATH` whenever the key in that location has no ENABLED version — which is exactly the state a region move produces — so re-running `install.sh` against the new region with the same PEM completes the move. `install.sh` persists `GITHUB_PEM_PATH` into `vars.sh`, and the gcloud path above takes the location as an input, so either route works.
+
+Only if the PEM is gone does the move cost a credential: GitHub does not re-issue a private key it has already handed out, and the KMS copy cannot be exported, so there is nothing left to import and you have to generate a fresh one on the App and import that. Either way the old keyring and key stay in the project forever, per the warning below.
 
 > **KMS resources cannot be deleted.** Cloud KMS key rings and keys are never actually
 > destroyed — `terraform destroy` only removes them from state, and a subsequent apply


### PR DESCRIPTION
## Summary

Five findings from #831 — the first from-scratch Terraform + Helm install after #797 — written up where the thing each describes already lives. Docs only; no behaviour changes. One of the five turned out to be wrong as reported, and testing it against a real GCS-backed state produced better advice than the issue asked for. Generated with the help of Claude.

## Why This Change

Each of these cost the installer real time and none of them was written down anywhere. The state-lock one is the worst of them: the recovery the issue landed on (delete the lock object) is the unsafe one, and the safe path was assumed not to work.

## What Changed

**`terraform/examples/full-install/README.md`** — a new "Recovering from an interrupted apply" section, plus a correction to "Remote state" while adjacent.

- **State lock.** #831 reported that `terraform force-unlock` does not work against the `gcs` backend. **It does.** Tested against a real GCS-backed state: the lock ID there is the lock object's **GCS generation number**, which is the `ID:` Terraform prints in its own error — `terraform force-unlock 1787242876096737` returned "successfully unlocked" and the next plan acquired the lock cleanly. Pass a UUID instead (the `"ID"` inside the lock object's JSON, say) and it refuses with `Lock ID should be numerical value`, which reads like the backend not supporting the command at all. `force-unlock` is now the documented recovery, with `gcloud storage rm` as the fallback for a lock whose ID you no longer have. The section says plainly that neither command protects a lock a concurrent apply is holding — the generation precondition rejects a *stale* ID, not a live one — so the "check nothing is still applying" caution applies to both.
- **Mid-apply network drop.** Two failures that do not mean what they look like: a state upload reporting `http2: client connection lost` that then succeeds on Terraform's own retry, and a `BackupPlan` create that fails while polling an operation the server completed anyway.
- **The BackupPlan import** needs the backend initialised first — `backend_override.tf` is gitignored and written only by `lifecycle.sh`, so in a fresh clone a bare `terraform import` writes a *local* state, reports success, and leaves the next apply still trying to create the plan. The recipe carries both `KUBE_AGENTS_STATE_BUCKET` and `KUBE_AGENTS_STATE_PREFIX`, because `ensure_backend` derives the prefix independently and inits with `-reconfigure`. It also needs the placeholder Helm provider `adopt-kms` writes for itself, which no generic `lifecycle.sh` subcommand exposes.
- **Rollback correction (pre-existing line).** `gcloud storage restore` is for soft-deleted objects; this bucket has versioning and no soft delete, so that command would not have recovered anything. Rolling back is a `gcloud storage cp` of the previous generation.

**`terraform/modules/github-minter/README.md`** — points at the gcloud + openssl import rather than repeating it. `k8s-operator/config/integrations/github/README.md` already owns that procedure per `docs/README.md`, and its copy carries two things a fresh transcription drops: the wait for the import job to reach `ACTIVE`, and `CLOUDSDK_PYTHON_SITEPACKAGES=1`. The module README's own new content is the region-move consequence: the keyring follows the cluster location, so changing `location` on a minter-enabled install creates a new, empty keyring and nothing is copied across. With the original PEM that is a re-import and costs nothing — `import_github_pem` imports `GITHUB_PEM_PATH` whenever the key in the derived location has no `ENABLED` version, which is exactly what a region move produces. Only a lost PEM costs a new GitHub App private key.

**`docs/site/src/content/docs/install/quickstart-gke.mdx`** — the Verify step now says the first-minutes `Connection refused` from the Google Chat relay and the one-off Slack connect timeout are startup ordering (both relays dial the credential-proxy sidecar on loopback before it listens), and names `envoy-credential-proxy` as the thing to inspect if they persist.

## Context

Refs #831. Covers items 2, 3, 4, 6 and 7. Item 8 was ops notes needing no change.

The two remaining items are **no longer out of scope** — they are now in flight as their own PRs, because they share nothing with this diff (Go operator and bash/Terraform respectively):

- **Item 1** — a pre-existing Pub/Sub topic/subscription 409s a fresh apply; `lifecycle.sh` adopts undeletable KMS resources but has no equivalent. Related to #344.
- **Item 5** — the operator wires the GKE managed OTLP endpoint when discovery authoritatively finds no collector, so the exporter retries a name that never resolves.

Merge-conflict warnings, none a duplicate: **#504** and **#720** touch `full-install/README.md`; **#496** touches `quickstart-gke.mdx`; **#504** also touches `k8s-operator/config/integrations/github/README.md`. Rebased onto `main` at `d3be984d`; the one file `main` had also moved (`quickstart-gke.mdx`, via #823) merged cleanly and was re-read afterwards.

## Testing

- `make docs-check` — passes (generated regions current, links resolve, terminology, map coverage) on the rebased head.
- `prettier@3.9.6 --check` on all three changed files — clean.
- No map edit owed: three existing tracked docs, no adds, renames or deletes.

### Live validation

The state-lock claim is the one thing here that is a testable assertion rather than a write-up, and it was tested against the real GCS backend of a live install in `mplakhtiy-gke-dev` (bucket `mplakhtiy-gke-dev-kube-agents-tfstate`, prefix `kube-agents/kube-agents`, Terraform 1.15.8):

1. Placed a lock object at `<prefix>/default.tflock`. `terraform plan` then failed with `Error acquiring the state lock` and reported `ID: 1787242876096737` — the object's GCS generation, not the UUID in the lock body.
2. `terraform force-unlock -force 11111111-…` → `Failed to unlock state: Lock ID should be numerical value` — the symptom #831 reported.
3. `terraform force-unlock -force 1787242876096737` → **"Terraform state has been successfully unlocked!"**
4. `terraform plan` afterwards acquired the lock and ran to completion.

That is what changed the recommendation from the issue's `gcloud storage rm` to `force-unlock`, with `rm` demoted to a fallback. Step 3 is also the observation behind the corrected safety framing: the ID that succeeded was the one Terraform printed for the lock that existed at that moment, which is why the section no longer claims the precondition protects a live lock.

Also verified against source rather than prose, since these are the load-bearing claims: the KMS algorithm and protection level in the linked procedure match `github-minter/main.tf` (`RSA_SIGN_PKCS1_2048_SHA256` / `SOFTWARE`); `location` does flow from the composition's `var.location` into the keyring, and the key is `import_only` with `skip_initial_version_creation`; the BackupPlan import address needs `[0]` because the module carries `count`; and `ensure_backend` derives the state prefix at `lifecycle.sh:72` with `-reconfigure` at `:91-95`.

**Not covered:** the mid-apply network-drop bullets (item 6) are a write-up of a one-off failure I cannot reproduce on demand — they describe what was observed, and the import recipe around them is the part that was checked. The gcloud KMS import sequence itself was not re-run; it is now a link to the copy that already existed rather than a new transcription. **Artifacts:** the test lock was released via `force-unlock`, not left behind, and the install it ran against has since been destroyed.

## Self-Review

Ran `.agents/skills/review-adversarial` and `.agents/skills/review-docs-drift` in a **subagent given only the diff range**, in a worktree, with no access to my reasoning. `kube-agents-bot` then reviewed the result and found two more; both are fixed.

Angles: every technical claim traced to source, canonical-home placement against AGENTS.md, anchor and link resolution, contradiction with existing docs, unchanged-but-re-exposed lines, sibling-PR overlap, and — after the bot round — whether each stated *reason* for a recommendation is the reason that actually holds.

Findings and disposition:

- **Blocking — duplicated procedure.** My gcloud import block was a second copy of one that already exists at the home `docs/README.md` assigns it, and the two already disagreed on three points at the moment of landing. **Replaced with a link.**
- **Blocking — `gcloud storage restore` is the wrong command** for a versioned rollback. **Fixed, including the pre-existing line my bullet was restating.**
- The transcription dropped the **import-job `ACTIVE` wait** and **`CLOUDSDK_PYTHON_SITEPACKAGES=1`**; pasting it would fail on the third command. **Dissolved by linking to the copy that has both.**
- **`terraform import` could write to a local state** in a fresh clone and silently look successful. **Added the backend step.**
- **The `force-unlock` claim was broader than the evidence** — marked PLAUSIBLE, not confirmed. Rather than leave it as an open question I **tested it on a live backend**, found the issue's conclusion was wrong, and rewrote the section around the result.
- 🟠 **The `force-unlock` safety property was inverted** (bot). The text justified preferring it over deleting the object "because it fails if the generation has moved, which is exactly the case where something else has taken the lock". It is not: the printed ID *is* the live lock's generation, so the precondition passes and the running apply's lock is released. The check catches a stale ID, which is a narrower and different guarantee. **Fixed in `7ebd4e8a`** — the paragraph now states what the precondition actually rejects, and the "nothing is still applying" caution now governs both commands rather than the `gcloud` fallback alone.
- 🟠 **The backend-init step named only the bucket** (bot). `ensure_backend` derives the prefix independently (`lifecycle.sh:72`) and inits with `-reconfigure`, so on a `KUBE_AGENTS_STATE_PREFIX`-overridden install the recipe would have imported into an empty state at the default prefix — relocating the failure it exists to prevent. **Fixed in `7ebd4e8a`**; verified against the source rather than the bot's description.
- 🟠 **The region-move section prescribed rotating the GitHub App key** (bot, second pass). The premise was right — the key is `import_only` and KMS never releases private key material — but the conclusion did not follow: KMS is not the source of truth for that key, the PEM is, and `import_github_pem` re-imports `GITHUB_PEM_PATH` whenever the key in the region-derived location has no `ENABLED` version (`install.sh:983-1029`), with the path persisted to `vars.sh` at `:1909`. A region move produces exactly that state, so the same PEM completes it. As written it told a reader to rotate a credential every consumer of the App shares, to solve something the installer already handles. **Fixed in `277543c1`**, including the heading, and split on the condition I had left unstated: only a lost PEM costs a new key. Verified against source, not the bot's description.
- 🟡 **Template section unanswered** (bot). **Risk & Rollout** was missing from this body. **Added.**

One advisory taken: the quickstart now names the credential-proxy sidecar, which the pass verified is what both relays actually dial.

Two bot passes have now run against this branch. The second found the region-move claim above and nothing else; the first found the two 🟠 items and the missing template section.

Verified clean by that pass and unchanged by the rebase: minter keyring/key names, algorithm, protection level and location derivation; the `get-public-key | diff` pipeline; `openssl pkcs8 -topk8` being the right conversion; the region-move reasoning; the BackupPlan import address and ID form; "no generic import subcommand" (true — `adopt-kms`, `apply`, `destroy`); `_override.tf` semantics and the `EXIT` trap; the `#remote-state` anchor.

## Risk & Rollout

Low risk: three Markdown files, no runtime code path, no chart, manifest or Terraform resource touched, so nothing to reconcile at merge time and no rollout ordering to observe. The blast radius is a reader following the wrong recovery procedure, which is what the change narrows — the pre-change text recommends `force-unlock` on a safety property it does not have, and the pre-change `gcloud storage restore` line names a command that would not have recovered anything. Revert is `git revert` of the two commits; it restores the previous prose and nothing else.
