### PR TITLE
test: task-registration lint, and a queryable-fixture wait for the gpu task

### DIFF
--- a/bench/CUSTOM-TASKS.md
+++ b/bench/CUSTOM-TASKS.md
@@ -201,6 +201,13 @@ reported as uncovered, and the domain's allowlist entry in that file can then ne
 removed. devops-bench ignores the extra key (`extra: "ignore"` on its task model), so the
 field is free to carry.
 
+A new task must also be registered: the presubmit runs only what the `TASKS` array in
+`hack/ci-eval-pr.sh` names, and `scripts/test_task_registration.py` fails the build for a
+task that appears nowhere. A commented-out `TASKS` entry counts as registered, pending
+activation — that is how scenarios wait for infrastructure that does not exist yet — and a
+task that deliberately must not run needs a reviewed entry in that lint's
+`KNOWN_UNREGISTERED` with the reason.
+
 ```yaml
 # tasks/<task-name>/task.yaml
 id: my-provisioned-task

--- a/bench/tf/prebuilt/gpu-stress-test/main.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/main.tf
@@ -98,41 +98,41 @@ resource "null_resource" "write_synthetic_logs" {
       # would otherwise read as "not ingested yet" for the full 120s and
       # bury the real cause. Three consecutive command failures fail
       # fast with gcloud's own stderr; a timeout prints it too.
-      err_file="$${TMPDIR:-/tmp}/synthetic-log-poll-$$$$.err"
+      err_file="$(mktemp)"
       elapsed=0
       poll_errs=0
       while :; do
-        if found="$$(gcloud logging read "logName=\"projects/${var.project_id}/logs/container\" AND resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${module.cluster.cluster_name}\" AND (jsonPayload.message:\"GCS FUSE buffer exhaustion\" OR jsonPayload.message:\"HPA max-replica saturation\")" --project=${var.project_id} --freshness=10m --limit=10 --format='value(jsonPayload.message)' 2>"$$err_file")"; then
+        if found="$(gcloud logging read "logName=\"projects/${var.project_id}/logs/container\" AND resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${module.cluster.cluster_name}\" AND (jsonPayload.message:\"GCS FUSE buffer exhaustion\" OR jsonPayload.message:\"HPA max-replica saturation\")" --project=${var.project_id} --freshness=10m --limit=10 --format='value(jsonPayload.message)' 2>"$err_file")"; then
           poll_errs=0
         else
-          poll_errs=$$((poll_errs + 1))
+          poll_errs=$((poll_errs + 1))
           found=""
-          if [ "$$poll_errs" -ge 3 ]; then
-            echo "ERROR: the ingestion poll itself failed $$poll_errs times running -- this is not an ingestion delay. Check logging.logEntries.list on the calling service account. gcloud said:" >&2
-            cat "$$err_file" >&2
-            rm -f "$$err_file"
+          if [ "$poll_errs" -ge 3 ]; then
+            echo "ERROR: the ingestion poll itself failed $poll_errs times running -- this is not an ingestion delay. Check logging.logEntries.list on the calling service account. gcloud said:" >&2
+            cat "$err_file" >&2
+            rm -f "$err_file"
             exit 1
           fi
         fi
         ok=0
-        printf '%s' "$$found" | grep -q "GCS FUSE buffer exhaustion" && ok=$$((ok + 1))
-        printf '%s' "$$found" | grep -q "HPA max-replica saturation" && ok=$$((ok + 1))
-        if [ "$$ok" -eq 2 ]; then
+        printf '%s' "$found" | grep -q "GCS FUSE buffer exhaustion" && ok=$((ok + 1))
+        printf '%s' "$found" | grep -q "HPA max-replica saturation" && ok=$((ok + 1))
+        if [ "$ok" -eq 2 ]; then
           echo "Synthetic log entries queryable after $${elapsed}s."
-          rm -f "$$err_file"
+          rm -f "$err_file"
           break
         fi
-        if [ "$$elapsed" -ge 120 ]; then
-          echo "ERROR: synthetic log entries not queryable after $${elapsed}s (found $$ok of 2); the post-incident fixture does not exist and the evaluation must not start." >&2
-          if [ -s "$$err_file" ]; then
+        if [ "$elapsed" -ge 120 ]; then
+          echo "ERROR: synthetic log entries not queryable after $${elapsed}s (found $ok of 2); the post-incident fixture does not exist and the evaluation must not start." >&2
+          if [ -s "$err_file" ]; then
             echo "Last poll stderr:" >&2
-            cat "$$err_file" >&2
+            cat "$err_file" >&2
           fi
-          rm -f "$$err_file"
+          rm -f "$err_file"
           exit 1
         fi
         sleep 5
-        elapsed=$$((elapsed + 5))
+        elapsed=$((elapsed + 5))
       done
     EOT
   }

--- a/bench/tf/prebuilt/gpu-stress-test/main.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/main.tf
@@ -83,21 +83,52 @@ resource "null_resource" "write_synthetic_logs" {
       # bounded, and fail the apply if they never do: a fixture that is
       # not queryable is an infrastructure failure, and it should die
       # here, loudly, rather than surface as a judged zero that reads as
-      # the agent's mistake. The filter leans on the cluster name, which
-      # is unique per run, so a concurrent run's entries cannot satisfy
-      # this one's wait.
+      # the agent's mistake.
+      #
+      # The filter pins all three axes the writes control: the logName
+      # (the writes above use log id "container"; GKE's own agents log
+      # under different logNames, so without this a busy cluster's system
+      # entries flood the newest-first --limit window and starve the
+      # fixture pair out of it forever -- a healthy apply failing on a
+      # noisy neighbour), the cluster name (unique per run, so a
+      # concurrent run's entries cannot satisfy this one's wait), and the
+      # two seeded message strings themselves.
+      #
+      # A failing poll is not a slow poll: gcloud erroring (IAM, API)
+      # would otherwise read as "not ingested yet" for the full 120s and
+      # bury the real cause. Three consecutive command failures fail
+      # fast with gcloud's own stderr; a timeout prints it too.
+      err_file="$${TMPDIR:-/tmp}/synthetic-log-poll-$$$$.err"
       elapsed=0
+      poll_errs=0
       while :; do
-        found="$$(gcloud logging read "resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${module.cluster.cluster_name}\"" --project=${var.project_id} --freshness=10m --limit=10 --format='value(jsonPayload.message)' 2>/dev/null)" || found=""
+        if found="$$(gcloud logging read "logName=\"projects/${var.project_id}/logs/container\" AND resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${module.cluster.cluster_name}\" AND (jsonPayload.message:\"GCS FUSE buffer exhaustion\" OR jsonPayload.message:\"HPA max-replica saturation\")" --project=${var.project_id} --freshness=10m --limit=10 --format='value(jsonPayload.message)' 2>"$$err_file")"; then
+          poll_errs=0
+        else
+          poll_errs=$$((poll_errs + 1))
+          found=""
+          if [ "$$poll_errs" -ge 3 ]; then
+            echo "ERROR: the ingestion poll itself failed $$poll_errs times running -- this is not an ingestion delay. Check logging.logEntries.list on the calling service account. gcloud said:" >&2
+            cat "$$err_file" >&2
+            rm -f "$$err_file"
+            exit 1
+          fi
+        fi
         ok=0
         printf '%s' "$$found" | grep -q "GCS FUSE buffer exhaustion" && ok=$$((ok + 1))
         printf '%s' "$$found" | grep -q "HPA max-replica saturation" && ok=$$((ok + 1))
         if [ "$$ok" -eq 2 ]; then
           echo "Synthetic log entries queryable after $${elapsed}s."
+          rm -f "$$err_file"
           break
         fi
         if [ "$$elapsed" -ge 120 ]; then
           echo "ERROR: synthetic log entries not queryable after $${elapsed}s (found $$ok of 2); the post-incident fixture does not exist and the evaluation must not start." >&2
+          if [ -s "$$err_file" ]; then
+            echo "Last poll stderr:" >&2
+            cat "$$err_file" >&2
+          fi
+          rm -f "$$err_file"
           exit 1
         fi
         sleep 5

--- a/bench/tf/prebuilt/gpu-stress-test/main.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/main.tf
@@ -75,6 +75,34 @@ resource "null_resource" "write_synthetic_logs" {
     command = <<EOT
       gcloud logging write "container" "{\"message\": \"hypercomputer-agent: GCS FUSE buffer exhaustion during checkpoint load\", \"container_name\": \"hypercomputer-agent\"}" --severity=ERROR --project=${var.project_id} --payload-type=json --monitored-resource-type=k8s_container --monitored-resource-labels=project_id=${var.project_id},location=${module.cluster.location},cluster_name=${module.cluster.cluster_name},namespace_name=default,pod_name=hypercomputer-agent-deployment-xyz,container_name=hypercomputer-agent
       gcloud logging write "container" "{\"message\": \"HorizontalPodAutoscaler: HPA max-replica saturation for deployment/hypercomputer-agent (max: 10)\", \"container_name\": \"hpa-controller\"}" --severity=WARNING --project=${var.project_id} --payload-type=json --monitored-resource-type=k8s_container --monitored-resource-labels=project_id=${var.project_id},location=${module.cluster.location},cluster_name=${module.cluster.cluster_name},namespace_name=default,pod_name=hpa-controller-xyz,container_name=hpa-controller
+
+      # Cloud Logging ingestion is asynchronous: the writes above return
+      # before the entries are queryable, and the evaluation starts the
+      # moment this apply finishes -- so the agent could look for the
+      # incident before it exists. Poll until both entries read back,
+      # bounded, and fail the apply if they never do: a fixture that is
+      # not queryable is an infrastructure failure, and it should die
+      # here, loudly, rather than surface as a judged zero that reads as
+      # the agent's mistake. The filter leans on the cluster name, which
+      # is unique per run, so a concurrent run's entries cannot satisfy
+      # this one's wait.
+      elapsed=0
+      while :; do
+        found="$$(gcloud logging read "resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"${module.cluster.cluster_name}\"" --project=${var.project_id} --freshness=10m --limit=10 --format='value(jsonPayload.message)' 2>/dev/null)" || found=""
+        ok=0
+        printf '%s' "$$found" | grep -q "GCS FUSE buffer exhaustion" && ok=$$((ok + 1))
+        printf '%s' "$$found" | grep -q "HPA max-replica saturation" && ok=$$((ok + 1))
+        if [ "$$ok" -eq 2 ]; then
+          echo "Synthetic log entries queryable after $${elapsed}s."
+          break
+        fi
+        if [ "$$elapsed" -ge 120 ]; then
+          echo "ERROR: synthetic log entries not queryable after $${elapsed}s (found $$ok of 2); the post-incident fixture does not exist and the evaluation must not start." >&2
+          exit 1
+        fi
+        sleep 5
+        elapsed=$$((elapsed + 5))
+      done
     EOT
   }
 

--- a/scripts/test_task_registration.py
+++ b/scripts/test_task_registration.py
@@ -10,8 +10,18 @@ same failure as a domain nobody covered.
 
 This test owns that difference. A task passes by being named in TASKS (a
 commented-out entry counts: it is registered, pending activation, which is how
-scenarios wait for the seeded fleet), by declaring `tier: nightly` in its
-task.yaml, or by a reviewed entry in KNOWN_UNREGISTERED with the reason.
+scenarios wait for the seeded fleet) or by a reviewed entry in
+KNOWN_UNREGISTERED with the reason. There is deliberately no nightly
+exemption yet: no nightly runner exists anywhere in the tree, and an
+exemption into a runner that does not exist is an exemption into nothing.
+It returns with the nightly tier (testing implementation plan, Phase 4).
+
+Pending is not covered: scripts/test_domain_coverage.py counts a domain
+covered only when its task's path is an ACTIVE, uncommented TASKS entry, so
+a scenario parked here as commented-out keeps its domain on that lint's
+allowlist until someone activates it. The two lints ratchet together --
+this one guarantees every task is at least registered, that one guarantees
+a registered-but-dormant task never counts as coverage.
 
 TASKS is read from the script's text rather than by executing it: the script
 provisions clusters and reads secrets, so running it to ask a question is not
@@ -48,16 +58,15 @@ KNOWN_UNREGISTERED = {
 def registered_tasks():
     """Task names in the TASKS array, commented entries included."""
     text = EVAL_SCRIPT.read_text()
-    match = re.search(r"^TASKS=\((.*?)\)", text, re.M | re.S)
+    # Multi-line arrays end at a line holding only ")": stopping at the first
+    # bare ")" character instead would truncate the block at a parenthesis
+    # inside a comment and silently drop every entry below it.
+    match = re.search(r"^TASKS=\((.*?)^\)", text, re.M | re.S) or re.search(
+        r"^TASKS=\((.*)\)\s*$", text, re.M
+    )
     if match is None:
         return None
     return set(re.findall(r"tasks/([A-Za-z0-9_-]+)/task\.yaml", match.group(1)))
-
-
-def declared_tier(task_yaml):
-    """The task's top-level tier field, or None."""
-    match = re.search(r"^tier:\s*[\"']?([A-Za-z0-9_-]+)", task_yaml.read_text(), re.M)
-    return match.group(1) if match else None
 
 
 def bench_tasks():
@@ -74,10 +83,8 @@ class TestEveryTaskIsRegistered(unittest.TestCase):
         )
         orphans = sorted(
             name
-            for name, yaml_path in bench_tasks().items()
-            if name not in registered
-            and declared_tier(yaml_path) != "nightly"
-            and name not in KNOWN_UNREGISTERED
+            for name in bench_tasks()
+            if name not in registered and name not in KNOWN_UNREGISTERED
         )
         self.assertEqual(
             orphans,
@@ -85,9 +92,8 @@ class TestEveryTaskIsRegistered(unittest.TestCase):
             "\n\nThese bench tasks are registered nowhere and never run:\n  "
             + "\n  ".join(orphans)
             + "\n\nEither add each to TASKS in hack/ci-eval-pr.sh (a commented "
-            "entry counts as registered, pending activation), declare "
-            "`tier: nightly` in its task.yaml, or add it to KNOWN_UNREGISTERED "
-            "in this file with the reason it must not run.",
+            "entry counts as registered, pending activation), or add it to "
+            "KNOWN_UNREGISTERED in this file with the reason it must not run.",
         )
 
     def test_the_exclusion_list_does_not_rot(self):
@@ -111,6 +117,19 @@ class TestEveryTaskIsRegistered(unittest.TestCase):
             registered,
             "The TASKS array in hack/ci-eval-pr.sh parsed to no tasks -- "
             "either the array is empty or this test's parse has drifted.",
+        )
+
+    def test_the_array_is_declared_exactly_once(self):
+        # The parse reads the first TASKS=( ... ) block. A later reassignment
+        # would silently win in the shell while this test kept reading the
+        # first -- the one escape that would not fail loudly red.
+        # Anchored to line start: FAILED_TASKS=( contains the bare substring.
+        count = len(re.findall(r"^TASKS=\(", EVAL_SCRIPT.read_text(), re.M))
+        self.assertEqual(
+            count,
+            1,
+            f"hack/ci-eval-pr.sh declares TASKS=( {count} times; this test "
+            "reads the first, the shell obeys the last -- keep it to one.",
         )
 
 

--- a/scripts/test_task_registration.py
+++ b/scripts/test_task_registration.py
@@ -1,0 +1,118 @@
+"""Every bench task is either in the presubmit's TASKS array or excluded here.
+
+`hack/ci-eval-pr.sh` runs the tasks listed in its TASKS array, and only those:
+tasks under bench/tasks/ are not picked up automatically, the script's own
+comment says so, and nothing owned the difference between "left out on
+purpose" and "nobody remembered". That is how agent-kanban-smoke -- a task
+whose whole point is to smoke the deployed pipeline -- sat registered nowhere
+while the presubmit ran one task for months. A task nobody registered is the
+same failure as a domain nobody covered.
+
+This test owns that difference. A task passes by being named in TASKS (a
+commented-out entry counts: it is registered, pending activation, which is how
+scenarios wait for the seeded fleet), by declaring `tier: nightly` in its
+task.yaml, or by a reviewed entry in KNOWN_UNREGISTERED with the reason.
+
+TASKS is read from the script's text rather than by executing it: the script
+provisions clusters and reads secrets, so running it to ask a question is not
+an option. The parse is deliberately narrow -- the TASKS=( ... ) block only --
+and a parse that finds nothing fails loudly rather than passing vacuously.
+"""
+
+import pathlib
+import re
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+EVAL_SCRIPT = REPO_ROOT / "hack" / "ci-eval-pr.sh"
+TASKS_DIR = REPO_ROOT / "bench" / "tasks"
+
+# Tasks that are neither in TASKS nor nightly-tiered, on purpose, for now.
+# Every entry carries its reason; an entry without one should not survive
+# review. Delete an entry once its task is registered -- staleness is only
+# enforced for tasks that no longer exist, because an in-flight branch
+# registering a task must not red main the day it merges.
+KNOWN_UNREGISTERED = {
+    # Registration lands with the exact-verifiers branch (the two-speed gate),
+    # which also stops exporting BENCH_NO_INFRA so the task's tool_called
+    # check actually runs. Until that merges, this entry is the record.
+    "agent-kanban-smoke": "registered by the exact-verifiers branch, in flight",
+    # Provisions its own cluster, so registering it costs every pull request
+    # a second multi-minute provision. Whether it belongs in presubmit or
+    # nightly is a tier decision nobody has made; this entry is the record
+    # that the omission is known rather than accidental.
+    "cluster-provision-kanban": "cluster-scoped provisioning task, tier decision pending",
+}
+
+
+def registered_tasks():
+    """Task names in the TASKS array, commented entries included."""
+    text = EVAL_SCRIPT.read_text()
+    match = re.search(r"^TASKS=\((.*?)\)", text, re.M | re.S)
+    if match is None:
+        return None
+    return set(re.findall(r"tasks/([A-Za-z0-9_-]+)/task\.yaml", match.group(1)))
+
+
+def declared_tier(task_yaml):
+    """The task's top-level tier field, or None."""
+    match = re.search(r"^tier:\s*[\"']?([A-Za-z0-9_-]+)", task_yaml.read_text(), re.M)
+    return match.group(1) if match else None
+
+
+def bench_tasks():
+    return {p.parent.name: p for p in sorted(TASKS_DIR.glob("*/task.yaml"))}
+
+
+class TestEveryTaskIsRegistered(unittest.TestCase):
+    def test_every_task_is_in_tasks_or_nightly_or_excluded_by_name(self):
+        registered = registered_tasks()
+        self.assertIsNotNone(
+            registered,
+            "Could not find a TASKS=( ... ) array in hack/ci-eval-pr.sh -- "
+            "the script changed shape and this test's parse needs updating.",
+        )
+        orphans = sorted(
+            name
+            for name, yaml_path in bench_tasks().items()
+            if name not in registered
+            and declared_tier(yaml_path) != "nightly"
+            and name not in KNOWN_UNREGISTERED
+        )
+        self.assertEqual(
+            orphans,
+            [],
+            "\n\nThese bench tasks are registered nowhere and never run:\n  "
+            + "\n  ".join(orphans)
+            + "\n\nEither add each to TASKS in hack/ci-eval-pr.sh (a commented "
+            "entry counts as registered, pending activation), declare "
+            "`tier: nightly` in its task.yaml, or add it to KNOWN_UNREGISTERED "
+            "in this file with the reason it must not run.",
+        )
+
+    def test_the_exclusion_list_does_not_rot(self):
+        # An entry whose task directory is gone is stale noise. Entries whose
+        # task has since been registered are pruned in review, not enforced
+        # here -- see the comment above KNOWN_UNREGISTERED for why.
+        existing = bench_tasks()
+        stale = sorted(name for name in KNOWN_UNREGISTERED if name not in existing)
+        self.assertEqual(
+            stale,
+            [],
+            "\n\nThese KNOWN_UNREGISTERED entries match no bench task any "
+            "more; delete them:\n  " + "\n  ".join(stale),
+        )
+
+    def test_the_parse_reads_a_nonempty_array(self):
+        # If the TASKS parse ever comes back empty the first test would call
+        # every task an orphan; fail with the real story instead.
+        registered = registered_tasks()
+        self.assertTrue(
+            registered,
+            "The TASKS array in hack/ci-eval-pr.sh parsed to no tasks -- "
+            "either the array is empty or this test's parse has drifted.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_task_registration.py
+++ b/scripts/test_task_registration.py
@@ -16,12 +16,13 @@ exemption yet: no nightly runner exists anywhere in the tree, and an
 exemption into a runner that does not exist is an exemption into nothing.
 It returns with the nightly tier (testing implementation plan, Phase 4).
 
-Pending is not covered: scripts/test_domain_coverage.py counts a domain
-covered only when its task's path is an ACTIVE, uncommented TASKS entry, so
-a scenario parked here as commented-out keeps its domain on that lint's
-allowlist until someone activates it. The two lints ratchet together --
-this one guarantees every task is at least registered, that one guarantees
-a registered-but-dormant task never counts as coverage.
+Today this lint and scripts/test_domain_coverage.py are independent: that
+one counts a domain covered when any task carries its slug and a non-empty
+verification_spec, without reading TASKS at all. The feat/domain-scenarios
+branch redefines covered to require an ACTIVE, uncommented TASKS entry;
+once that lands, the two lints ratchet together -- this one guarantees
+every task is at least registered, that one guarantees a
+registered-but-dormant task never counts as coverage.
 
 TASKS is read from the script's text rather than by executing it: the script
 provisions clusters and reads secrets, so running it to ask a question is not

--- a/scripts/test_test_discovery.py
+++ b/scripts/test_test_discovery.py
@@ -51,8 +51,11 @@ EXCLUDED = {
     "tests/memory": "hermes-agent dependency, decision pending",
 }
 
-# Directory names that are never test homes, at any depth.
-IGNORED_NAMES = {".venv", "node_modules", "__pycache__", ".git", ".coverage-data"}
+# Directory names that are never test homes, at any depth. .terraform holds
+# provider and module downloads (an initialized module can carry its own
+# upstream test files), so a worktree where tofu init ever ran would
+# otherwise red this guard on vendored tests.
+IGNORED_NAMES = {".venv", "node_modules", "__pycache__", ".git", ".coverage-data", ".terraform"}
 
 
 def discovered_dirs():


### PR DESCRIPTION
## Summary

Two hardening items for the behavioural presubmit. A new lint makes "a bench task exists but never runs" a named, reviewed state instead of an accident: every `bench/tasks/*/task.yaml` must appear in `ci-eval-pr.sh`'s `TASKS` array (commented entries count as registered-pending) or sit in an explicit exclusion dict with a reason. And the gpu task's synthetic-log seeding now waits until Cloud Logging can actually return the planted entries before the evaluation starts, converting the suite's known ingestion-lag flake into a loud provision-time failure with the real error attached.

## Why This Change

The `TASKS` array is manual, and the repository has already lived the failure this lint prevents: `agent-kanban-smoke` — a task literally named for the smoke test — sat registered nowhere from the day it was written. A task nobody registered is the same silent gap as a domain nobody covered, and the existing discovery and domain lints don't see it. On the flake: the eval's fixture is two log entries written seconds before the agent is asked to find them; Cloud Logging ingestion is asynchronous, so the agent could query before the fixture existed and score an honest-looking zero. The fix moves that failure to where it belongs — the provisioning step, loudly.

## What Changed

- `scripts/test_task_registration.py` — parses the `TASKS` block by regex (never executes the script, which provisions clusters and reads secrets); the parse fails loud in the red direction on every drift it can detect, including a single-declaration assertion and a lone-`)` block terminator that survived hostile-shape testing against the in-flight sibling branches. A `tier: nightly` escape was considered and deliberately left out until a nightly runner exists
- `bench/tf/prebuilt/gpu-stress-test/main.tf` — the poll: filtered on the seeded `logName`, this run's unique cluster name, and both message strings (so system-container chatter cannot crowd the window), 5s/120s bound, three consecutive gcloud failures fail fast with the captured stderr and an IAM hint, timeout prints the last error
- `bench/CUSTOM-TASKS.md` — the registration requirement documented where a task author will look first, beside the existing domain-lint paragraph
- Drive-by: `.terraform` added to the discovery guard's ignore list (its absence tripped two reviewers' local `tofu init` artifacts)

## Context

Part of the Phase 2 testing-strategy work. Composes with the in-flight branches by verification rather than hope: the lint was executed against main, `feat/exact-verifiers`, and `feat/domain-scenarios` (which stacks both) — green in all three states, with the parse confirmed reading that branch's 2 active + 10 commented entries. The "commented forever" concern is closed from the other side: the domain-coverage lint (as fixed on `feat/domain-scenarios`) counts a domain covered only when its task is *actively* registered, so a dormant scenario keeps its domain visibly uncovered — the two lints ratchet together, and the docstrings cross-reference each other.

This PR was generated with the help of Claude.

## Testing

- Full `scripts/` discovery: 133 tests green; the new lint's negative checks executed in a throwaway copy (an unregistered task reds naming it; a vanished exclusion entry reds the rot check; hostile array shapes land red, and the two shapes that could have landed silently green now trip the single-declaration assert — which caught two bugs in its own parse during development)
- The poll exercised against a stubbed gcloud in all modes: entries on the third poll → success; persistent PERMISSION_DENIED → fail-fast printing the IAM error; transient 503 then empty → correctly not a fail-fast, times out on the ingestion path
- `sh -n`/`bash -n` clean on the extracted heredoc (TF escaping audited, `$$` throughout); `tofu validate` and `fmt -check` clean; `make docs-check` green; prettier clean

### Live validation

Not live-tested against real GCP: the poll's trigger conditions (actual ingestion lag, the caller's `logging.logEntries.list` grant in the Prow environment) were reasoned from GKE defaults and exercised via stub, not observed live. The first real Prow run of the gpu task after merge is the live check, and the poll's output is designed to make that run self-explaining in either direction.

## Self-Review

Adversarial + docs-drift passes by a separate reviewer context that did not write the change. Verdict was one Blocking, four Should-fix, one Nit — all fixed before opening:

- **Blocking, fixed:** the original poll filtered only on cluster name with `--limit=10` newest-first — GKE's system containers log under the same cluster, so during ingestion lag the fixture pair could be crowded permanently out of the window, timing out a healthy apply: a new flake worse than the one being fixed. The filter now pins logName + cluster + message strings
- **Fixed:** a gcloud read failure was indistinguishable from not-yet-ingested and its stderr destroyed — now surfaced with fail-fast on consecutive errors; the `tier: nightly` escape exempted tasks into a runner that does not exist — removed; the registration requirement was undocumented where authors look — added; the reviewer's suggested activation-forcing rule was investigated and **not** added, with evidence: the sibling branch's domain-lint fix already closes that hole, and a redundant rule here would have red their merge
- **Reviewer-verified clean:** the lint fails red on every constructible parse-miss; POSIX portability; timeout math; the write and read stamps agree on the resource labels

## Risk & Rollout

The lint is additive and green on every current and in-flight state of the tree; its failure mode is a red unit test naming exactly what to do. The poll can only make the provisioning step stricter; its failure mode is a loud provision-time error where there used to be a quiet judged zero. Revert is a clean revert of the commits.
