### PR TITLE
feat(ci): classify every pull request's risk tier as a non-blocking check

### DIFF
--- a/.github/risk-rules.yml
+++ b/.github/risk-rules.yml
@@ -82,8 +82,8 @@ rules:
   - id: docs-site-only
     tier: low
     only_match:
-      - "docs/site/src/content/docs/**"
+      - "docs/site/src/content/docs/**/*.md"
       - "docs/designs/**"
       - "docs/README.md"
       - "README.md"
-    why: "narrative documentation; no runtime or agent-behavior path. Deliberately narrow: INSTALL.md is agent-executable, docs/architecture gates design decisions, and the rest of docs/site (manifests, astro config, components) executes in the docs-deploy build, so only the content tree is prose"
+    why: "narrative documentation; no runtime or agent-behavior path. Deliberately narrow: INSTALL.md is agent-executable, docs/architecture gates design decisions, and the rest of docs/site (manifests, astro config, components) executes in the docs-deploy build. Within the content tree only plain .md is prose -- .mdx accepts imports and JS expressions that run in that same build, so it falls through to medium"

--- a/.github/risk-rules.yml
+++ b/.github/risk-rules.yml
@@ -69,11 +69,21 @@ rules:
     patch_contains: ["^-.*\\bfunc Test", "^-.*\\bdef test_"]
     why: "a coverage regression is invisible in a green run"
 
+  - id: docs-site-build-inputs
+    tier: high
+    match:
+      - "docs/site/package.json"
+      - "docs/site/package-lock.json"
+      - "docs/site/astro.config.mjs"
+      - "docs/site/tsconfig.json"
+      - "docs/site/public/**"
+    why: "docs-deploy runs npm ci and the build on these and publishes the site users fetch install.sh from via curl|bash -- a dependency or config swap here is a supply-chain edit, the workflows-are-supply-chain reasoning one artifact downstream"
+
   - id: docs-site-only
     tier: low
     only_match:
-      - "docs/site/**"
+      - "docs/site/src/content/docs/**"
       - "docs/designs/**"
       - "docs/README.md"
       - "README.md"
-    why: "narrative documentation; no runtime or agent-behavior path. INSTALL.md and docs/architecture are deliberately absent: the install guide is agent-executable and the architecture docs gate design decisions"
+    why: "narrative documentation; no runtime or agent-behavior path. Deliberately narrow: INSTALL.md is agent-executable, docs/architecture gates design decisions, and the rest of docs/site (manifests, astro config, components) executes in the docs-deploy build, so only the content tree is prose"

--- a/.github/risk-rules.yml
+++ b/.github/risk-rules.yml
@@ -1,0 +1,79 @@
+# Risk rules for scripts/classify_risk.py (#818).
+#
+# Each rule names the evidence (`why`), ideally a past incident or an
+# architecture constraint. The classifier takes the highest tier among the
+# rules that trigger; when nothing triggers, `default_tier` applies -- an
+# unclassified path is not the same thing as a safe one.
+#
+# Selectors, one flavour per rule:
+#   match:          triggers when any changed file matches a glob. Combined
+#                   with patch_contains, the regex must also hit a matched
+#                   file's patch.
+#   patch_contains: alone, triggers when any file's patch matches. A file the
+#                   API returns no patch for (binary, or a very large diff)
+#                   never satisfies it, so rules that must not miss stay
+#                   path-only.
+#   only_match:     triggers only when EVERY changed file matches -- the shape
+#                   for `low`, so a mixed pull request never classifies low on
+#                   its safe half.
+#   all_of:         a list of glob groups; triggers when each group matches at
+#                   least one changed file.
+#
+# Globs follow the same minimatch subset as .github/auto_request_review.yml:
+# `*` and `**` never match a path segment that starts with a dot.
+
+default_tier: medium
+
+rules:
+  - id: workflows-are-supply-chain
+    tier: high
+    match: [".github/workflows/**"]
+    why: "CI runs with repository credentials; the SHA-pinning policy in AGENTS.md exists for the same reason"
+
+  - id: risk-rules-are-policy
+    tier: high
+    match: [".github/risk-rules.yml"]
+    why: "editing the rules is how a change buys itself a lower tier; the policy file classifies as high so a rules edit is always read"
+
+  - id: dockerfile-layer-budget
+    tier: high
+    match: ["deploy/docker/Dockerfile"]
+    patch_contains: ["^\\+\\s*(RUN|COPY)\\b"]
+    why: "#658 -- a layer added past the overlay2 budget passes every PR build and fails only in Cloud Build, after merge"
+
+  - id: iam-role-bundles
+    tier: high
+    match: ["k8s-operator/scripts/**", "terraform/**"]
+    patch_contains: ["^[+-].*\\broles/"]
+    why: "cross-scope/privilege change, a mandatory-gate class in docs/architecture/04-workflow-model.md section 2.2"
+
+  - id: agent-behavior-is-config-not-docs
+    tier: medium
+    match: ["agents/**/*.md", ".agents/skills/**", "AGENTS.md"]
+    why: "Markdown here is executable agent configuration, not documentation; a SKILL.md edit changes what a deployed agent does"
+
+  - id: image-pins
+    tier: medium
+    match: ["images.json"]
+    why: "a one-character error in a pin is invisible in review and breaks every install"
+
+  - id: multi-surface-touch
+    tier: medium
+    all_of:
+      - ["k8s-operator/scripts/**"]
+      - ["charts/**", "terraform/**"]
+    why: "the install surfaces drift apart silently; make iac-parity-check catches only the scalar subset"
+
+  - id: test-deletion
+    tier: medium
+    patch_contains: ["^-.*\\bfunc Test", "^-.*\\bdef test_"]
+    why: "a coverage regression is invisible in a green run"
+
+  - id: docs-site-only
+    tier: low
+    only_match:
+      - "docs/site/**"
+      - "docs/designs/**"
+      - "docs/README.md"
+      - "README.md"
+    why: "narrative documentation; no runtime or agent-behavior path. INSTALL.md and docs/architecture are deliberately absent: the install guide is agent-executable and the architecture docs gate design decisions"

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -10,14 +10,14 @@ name: Risk Classification
 # `GITHUB_TOKEN` that `permissions:` cannot raise, so it could post neither
 # the check run nor the label.
 #
-# zizmor: ignore[dangerous-triggers] - the job never checks out or executes
-# pull-request code. The checkout below is the base repository's default
-# branch (the script and its rules), and the diff arrives as text through the
-# API.
 # `edited` is in the list because the declared-vs-computed flag reads the pull
 # request body: without it, fixing the Risk & Rollout section would leave a
 # stale mismatch banner until the next push.
 on:
+  # zizmor: ignore[dangerous-triggers] - the job never checks out or executes
+  # pull-request code: the checkout below is the base repository's default
+  # branch (the script and its rules), and the diff arrives as text through
+  # the API, so no pull-request content reaches the write token's context.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, edited]
 

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -35,7 +35,10 @@ concurrency:
 
 jobs:
   classify:
-    name: Risk Classification
+    # Not "Risk Classification": the job's own check run takes this name, and
+    # sharing it with the script's check run put two same-named runs on every
+    # head SHA. The script's run carries the verdict; this one is plumbing.
+    name: classify
     runs-on: ubuntu-latest
     permissions:
       contents: read # check out the default branch: the script and its rules

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -1,0 +1,61 @@
+name: Risk Classification
+
+# Classifies every pull request's risk tier (low / medium / high) from its
+# diff, against the rules in .github/risk-rules.yml -- a non-blocking signal
+# for reviewers (#818). The verdict lands as a `Risk Classification` check run
+# that always concludes `success`, and a `risk:*` label.
+#
+# The trigger cannot be `pull_request`: every pull request here comes from a
+# fork, and on a fork `pull_request` hands the workflow a read-only
+# `GITHUB_TOKEN` that `permissions:` cannot raise, so it could post neither
+# the check run nor the label.
+#
+# zizmor: ignore[dangerous-triggers] - the job never checks out or executes
+# pull-request code. The checkout below is the base repository's default
+# branch (the script and its rules), and the diff arrives as text through the
+# API.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions: {}
+
+# One run per pull request, newest wins: a push supersedes the classification
+# of the commit it replaced.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: Risk Classification
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the default branch: the script and its rules
+      checks: write # post the Risk Classification check run
+      pull-requests: write # swap the risk:* label on the pull request
+      issues: write # create the risk:* labels the first time
+    steps:
+      # The default branch, never the pull request head: this job holds a
+      # writable token and must not run code from a fork.
+      - name: Checkout the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install the script's one third-party import
+        run: python3 -m pip install pyyaml
+
+      - name: Classify the pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Through the environment, not interpolated into the script: event
+          # fields are attacker-controlled input on a pull-request trigger.
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 scripts/classify_risk.py --pr "$PR_NUMBER"

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -14,9 +14,12 @@ name: Risk Classification
 # pull-request code. The checkout below is the base repository's default
 # branch (the script and its rules), and the diff arrives as text through the
 # API.
+# `edited` is in the list because the declared-vs-computed flag reads the pull
+# request body: without it, fixing the Risk & Rollout section would leave a
+# stale mismatch banner until the next push.
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions: {}
 

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -15,11 +15,15 @@ name: Risk Classification
 # stale mismatch banner until the next push.
 on:
   # zizmor: ignore[dangerous-triggers] - the job never checks out or executes
-  # pull-request code: the checkout below is the base repository's default
-  # branch (the script and its rules), and the diff arrives as text through
-  # the API, so no pull-request content reaches the write token's context.
+  # pull-request code: the checkout below pins `ref:` to the default branch
+  # (the script and its rules), and the diff arrives as text through the
+  # API, so no pull-request content reaches the write token's context.
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, edited]
+    # Like every other PR-triggered workflow here: without the filter, a PR
+    # based on a branch that predates this workflow would run against a tree
+    # where the classifier does not exist.
+    branches: [main]
 
 permissions: {}
 
@@ -40,10 +44,14 @@ jobs:
       issues: write # create the risk:* labels the first time
     steps:
       # The default branch, never the pull request head: this job holds a
-      # writable token and must not run code from a fork.
+      # writable token and must not run code from a fork. The `ref:` is
+      # explicit because on `pull_request_target` the fallback is the pull
+      # request's *base* branch -- an unreviewed ref that anyone with push
+      # access could point a PR at to serve this job their own classifier.
       - name: Checkout the default branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Python

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -69,7 +69,7 @@ RISK_SECTION = re.compile(
 # it misreads errs toward suppressing the mismatch flag rather than accusing
 # an author of a declaration they did not make.
 DECLARED_WORDS = {
-    "low": "low|none|no|minimal|negligible",
+    "low": "low|none|minimal|negligible",
     "medium": "medium|moderate",
     "high": "high",
 }
@@ -78,7 +78,11 @@ DECLARED = {
         # "<word> risk" / "<word>-risk", or "risk ... <word>" in one clause,
         # or the section opening with the bare word ("Low." / "Moderate,").
         # The lookahead keeps "High-level overview" from declaring high.
-        rf"(?<!not )(?<!not a )\b(?:{words})[- ]risk\b"
+        # "no" declares low ONLY in the literal "no risk" collocation: as a
+        # bare word near "risk" it is almost always a determiner ("there is
+        # no automated rollback"), and reading that as a declaration would
+        # accuse the author of claiming the opposite of what they wrote.
+        rf"(?<!not )(?<!not a )\b(?:{words}{'|no' if tier == 'low' else ''})[- ]risk\b"
         rf"|\brisk\b[^.!?\n]{{0,40}}?(?<!not )\b(?:{words})\b"
         rf"|\A[\s>*_-]*(?:\*\*)?(?:{words})(?=[\s.,:;!)])",
         re.IGNORECASE,

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -41,6 +41,12 @@ import yaml
 import request_reviewers as rr
 
 CHECK_NAME = "Risk Classification"
+# Stamped on every check run this script creates, and required of every run it
+# will update. The name cannot be the identity: Actions gives the workflow
+# *job's* check run whatever the job is called, under the same github-actions
+# app slug, on the same head SHA -- and puts the job GUID in its external_id,
+# so this constant can never collide with one.
+CHECK_EXTERNAL_ID = "risk-classify"
 DEFAULT_RULES_PATH = ".github/risk-rules.yml"
 
 TIER_ORDER = {"low": 0, "medium": 1, "high": 2}
@@ -380,11 +386,15 @@ def post_check_run(api, head_sha, result):
     SHA; a fresh POST each time would stack runs, leaving the stale verdict
     ("declares low") standing beside the corrected one with nothing marking
     which is current. So the existing run is PATCHed when there is one --
-    filtered to the github-actions app, because a name alone is not an
-    identity and PATCHing another app's run would 403 anyway.
+    filtered to the github-actions app AND this script's external_id. The app
+    slug alone is not enough: the workflow job's own check run is created by
+    the same app on the same SHA, and on a re-classification it is the newest
+    run in the listing, so matching by name-plus-app PATCHes the job's run and
+    leaves the stale verdict standing (853-F1).
     """
     payload = {
         "name": CHECK_NAME,
+        "external_id": CHECK_EXTERNAL_ID,
         "status": "completed",
         "conclusion": "success",
         "output": {"title": check_run_title(result), "summary": check_run_summary(result)},
@@ -394,7 +404,12 @@ def post_check_run(api, head_sha, result):
         f"/repos/{api.repo}/commits/{head_sha}/check-runs"
         f"?check_name={urllib.parse.quote(CHECK_NAME)}"
     )["check_runs"]
-    mine = [run for run in existing if (run.get("app") or {}).get("slug") == "github-actions"]
+    mine = [
+        run
+        for run in existing
+        if (run.get("app") or {}).get("slug") == "github-actions"
+        and run.get("external_id") == CHECK_EXTERNAL_ID
+    ]
 
     if mine:
         newest = max(mine, key=lambda run: run.get("id") or 0)

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -374,16 +374,33 @@ def check_run_summary(result):
 
 
 def post_check_run(api, head_sha, result):
-    api.post(
-        f"/repos/{api.repo}/check-runs",
-        {
-            "name": CHECK_NAME,
-            "head_sha": head_sha,
-            "status": "completed",
-            "conclusion": "success",
-            "output": {"title": check_run_title(result), "summary": check_run_summary(result)},
-        },
-    )
+    """Create or update THE check run for this commit.
+
+    `edited`, `reopened` and `ready_for_review` re-classify the same head
+    SHA; a fresh POST each time would stack runs, leaving the stale verdict
+    ("declares low") standing beside the corrected one with nothing marking
+    which is current. So the existing run is PATCHed when there is one --
+    filtered to the github-actions app, because a name alone is not an
+    identity and PATCHing another app's run would 403 anyway.
+    """
+    payload = {
+        "name": CHECK_NAME,
+        "status": "completed",
+        "conclusion": "success",
+        "output": {"title": check_run_title(result), "summary": check_run_summary(result)},
+    }
+
+    existing = api.get(
+        f"/repos/{api.repo}/commits/{head_sha}/check-runs"
+        f"?check_name={urllib.parse.quote(CHECK_NAME)}"
+    )["check_runs"]
+    mine = [run for run in existing if (run.get("app") or {}).get("slug") == "github-actions"]
+
+    if mine:
+        newest = max(mine, key=lambda run: run.get("id") or 0)
+        api.patch(f"/repos/{api.repo}/check-runs/{newest['id']}", payload)
+    else:
+        api.post(f"/repos/{api.repo}/check-runs", {**payload, "head_sha": head_sha})
 
 
 def _tolerate(status, call):

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -32,6 +32,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 
 import yaml
 
@@ -60,13 +61,15 @@ RISK_SECTION = re.compile(
 
 # What authors actually write in the section, from the open pull requests the
 # heuristic was replayed against: "Low risk, ...", "Risk: none to any running
-# system", and a bare leading verdict -- "Low. No runtime code paths" (#770),
-# "Moderate, and concentrated in one place" (#733). Deliberately loose in one
-# direction: when a section mentions more than one tier, the highest counts as
-# the declaration, so a cautious sentence ("high-risk paths are untouched")
-# only ever suppresses the mismatch flag, never raises a false one.
+# system", "No risk to running systems", and a bare leading verdict -- "Low.
+# No runtime code paths" (#770), "Moderate, and concentrated in one place"
+# (#733). A heuristic, loose in one direction by design: when a section
+# mentions more than one tier, the highest counts as the declaration, and the
+# lookbehinds guard only the common negations ("not low-risk"), so a phrasing
+# it misreads errs toward suppressing the mismatch flag rather than accusing
+# an author of a declaration they did not make.
 DECLARED_WORDS = {
-    "low": "low|none|minimal|negligible",
+    "low": "low|none|no|minimal|negligible",
     "medium": "medium|moderate",
     "high": "high",
 }
@@ -75,8 +78,8 @@ DECLARED = {
         # "<word> risk" / "<word>-risk", or "risk ... <word>" in one clause,
         # or the section opening with the bare word ("Low." / "Moderate,").
         # The lookahead keeps "High-level overview" from declaring high.
-        rf"\b(?:{words})[- ]risk\b"
-        rf"|\brisk\b[^.!?\n]{{0,40}}?\b(?:{words})\b"
+        rf"(?<!not )(?<!not a )\b(?:{words})[- ]risk\b"
+        rf"|\brisk\b[^.!?\n]{{0,40}}?(?<!not )\b(?:{words})\b"
         rf"|\A[\s>*_-]*(?:\*\*)?(?:{words})(?=[\s.,:;!)])",
         re.IGNORECASE,
     )
@@ -172,18 +175,28 @@ def _matching_paths(globs, paths):
     return [path for path in paths if any(regex.match(path) for regex in regexes)]
 
 
+def _entry_paths(entry):
+    """Both sides of a rename. Classifying only the destination would let a
+    rename out of a guarded tree buy a lower tier -- deleting a workflow by
+    renaming it into docs/site/ must still read as a workflow change."""
+    paths = [entry["filename"]]
+    if entry.get("previous_filename"):
+        paths.append(entry["previous_filename"])
+    return paths
+
+
 def rule_trigger(rule, files):
     """The changed files that trigger `rule`, or None when it does not.
 
-    `files` is the GitHub `pulls/{n}/files` shape: dicts with `filename` and,
-    for text diffs the API is willing to inline, `patch`. A file without a
-    patch never satisfies `patch_contains`.
+    `files` is the GitHub `pulls/{n}/files` shape: dicts with `filename`,
+    `previous_filename` on renames, and, for text diffs the API is willing to
+    inline, `patch`. A file without a patch never satisfies `patch_contains`.
     """
-    paths = [entry["filename"] for entry in files]
+    paths = [path for entry in files for path in _entry_paths(entry)]
 
     if "only_match" in rule:
         if paths and len(_matching_paths(rule["only_match"], paths)) == len(paths):
-            return paths
+            return [entry["filename"] for entry in files]
         return None
 
     if "all_of" in rule:
@@ -195,7 +208,7 @@ def rule_trigger(rule, files):
     candidates = files
     if "match" in rule:
         matched = set(_matching_paths(rule["match"], paths))
-        candidates = [entry for entry in files if entry["filename"] in matched]
+        candidates = [entry for entry in files if matched.intersection(_entry_paths(entry))]
         if not candidates:
             return None
 
@@ -212,14 +225,39 @@ def rule_trigger(rule, files):
     return [entry["filename"] for entry in candidates]
 
 
-def classify(config, files):
-    """The tier and the rules behind it: {tier, default_applied, rules}."""
+# Per rule, how many triggering paths the JSON block lists. Uncapped, a
+# 1500-file docs pull request renders a summary past GitHub's 65535-character
+# limit and the check-run POST 422s -- on exactly the pull requests a reviewer
+# most wants triaged. `file_count` always carries the real number.
+RULE_FILES_LISTED = 50
+
+# The files endpoint stops at 3000 entries however far you page. Past that the
+# list is a truncated view, and a `low` verdict from `only_match` over a
+# truncated list is a claim about files nobody read.
+API_FILES_CAP = 3000
+
+
+def classify(config, files, complete=True):
+    """The tier and the rules behind it: {tier, default_applied, rules}.
+
+    `complete=False` says `files` is a truncated view (the API's 3000-file
+    cap); `only_match` rules -- the only way to reach `low` -- are skipped,
+    because they quantify over every changed file.
+    """
     triggered = []
     for rule in config["rules"]:
+        if "only_match" in rule and not complete:
+            continue
         hits = rule_trigger(rule, files)
         if hits is not None:
             triggered.append(
-                {"id": rule["id"], "tier": rule["tier"], "why": rule["why"], "files": hits}
+                {
+                    "id": rule["id"],
+                    "tier": rule["tier"],
+                    "why": rule["why"],
+                    "files": hits[:RULE_FILES_LISTED],
+                    "file_count": len(hits),
+                }
             )
 
     if triggered:
@@ -234,7 +272,11 @@ def classify(config, files):
 
 def declared_tier(body):
     """The tier the Risk & Rollout section claims, or None without one."""
-    section = RISK_SECTION.search(body or "")
+    # HTML comments first: the PR template's own comment contains the literal
+    # phrase "Low risk, no runtime code paths touched", so an author who left
+    # the template unedited would otherwise declare low without writing a word.
+    body = re.sub(r"<!--.*?-->", "", body or "", flags=re.DOTALL)
+    section = RISK_SECTION.search(body)
     if not section:
         return None
     text = section.group("text")
@@ -242,14 +284,15 @@ def declared_tier(body):
     return max(found, key=TIER_ORDER.get) if found else None
 
 
-def build_result(config, files, body, pr_number=None, head_sha=None):
-    result = classify(config, files)
+def build_result(config, files, body, pr_number=None, head_sha=None, complete=True):
+    result = classify(config, files, complete=complete)
     declared = declared_tier(body)
     result.update(
         {
             "schema": SCHEMA_VERSION,
             "pr": pr_number,
             "head_sha": head_sha,
+            "file_list_complete": complete,
             "declared_tier": declared,
             "mismatch": declared == "low" and result["tier"] == "high",
         }
@@ -270,6 +313,14 @@ def check_run_title(result):
     return f"risk: {result['tier']} ({detail})"
 
 
+def _display_path(path):
+    """A filename, defanged for the markdown summary. Git permits backticks
+    and newlines in paths, and a crafted filename could otherwise open its own
+    fenced block ahead of the real JSON one and forge the machine-readable
+    verdict for anything that parses the first fence it sees."""
+    return re.sub(r"[`\r\n]", "?", path)
+
+
 def check_run_summary(result):
     lines = [f"## Risk: {result['tier']}", ""]
 
@@ -281,6 +332,14 @@ def check_run_summary(result):
             "",
         ]
 
+    if not result.get("file_list_complete", True):
+        lines += [
+            f"The API lists at most {API_FILES_CAP} files and this pull request "
+            "hit that cap, so the tier was computed on a truncated view and "
+            "`low` rules were not evaluated.",
+            "",
+        ]
+
     if result["default_applied"]:
         lines += [
             f"No rule in `{DEFAULT_RULES_PATH}` matched, so the default tier applies. "
@@ -289,8 +348,8 @@ def check_run_summary(result):
         ]
     else:
         for entry in result["rules"]:
-            files = ", ".join(f"`{path}`" for path in entry["files"][:5])
-            more = f" (+{len(entry['files']) - 5} more)" if len(entry["files"]) > 5 else ""
+            files = ", ".join(f"`{_display_path(path)}`" for path in entry["files"][:5])
+            more = f" (+{entry['file_count'] - 5} more)" if entry["file_count"] > 5 else ""
             lines.append(f"- `{entry['id']}` → **{entry['tier']}** — {entry['why']} ({files}{more})")
         lines.append("")
 
@@ -338,10 +397,15 @@ def sync_labels(api, pr_number, tier, current):
 
     for name in current:
         if name.startswith(LABEL_PREFIX) and name != desired:
-            # 404: someone removed it between our read and this call.
+            # 404: someone removed it between our read and this call. Quoted:
+            # a hand-created label like "risk: high" (space) would otherwise
+            # raise InvalidURL from the stdlib, which _tolerate does not catch,
+            # and fail every run until someone deleted the label.
             _tolerate(
                 404,
-                lambda name=name: api.delete(f"/repos/{api.repo}/issues/{pr_number}/labels/{name}"),
+                lambda name=name: api.delete(
+                    f"/repos/{api.repo}/issues/{pr_number}/labels/{urllib.parse.quote(name, safe='')}"
+                ),
             )
 
     if desired not in current:
@@ -412,7 +476,12 @@ def main(argv=None):
     files = api.get_all(f"/repos/{args.repo}/pulls/{args.pr}/files")
 
     result = build_result(
-        config, files, pull_request.get("body"), pr_number=args.pr, head_sha=head_sha
+        config,
+        files,
+        pull_request.get("body"),
+        pr_number=args.pr,
+        head_sha=head_sha,
+        complete=len(files) < API_FILES_CAP,
     )
     log(f"#{args.pr} at {head_sha[:7]}: {check_run_title(result)}")
     print(json.dumps(result, indent=2, sort_keys=True))

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Classify a pull request's risk tier from its diff, as a non-blocking signal.
+
+Reviewers get no signal about which pull requests are safe to clear quickly:
+the only risk information on a pull request is the template's Risk & Rollout
+section, author-asserted prose that nothing verifies (#818). This script
+computes a `low` / `medium` / `high` tier from the diff itself against the
+rules in `.github/risk-rules.yml`, then surfaces it three ways:
+
+  - a `Risk Classification` check run, always concluding `success` -- the tier
+    lives in the title, the triggered rules in the summary, and a fenced JSON
+    block carries the machine-readable contract for later consumers;
+  - a `risk:low|medium|high` label, swapped idempotently;
+  - a declared-vs-computed note when the Risk & Rollout section says "low
+    risk" and the rules say high -- the same contract reviewers apply to
+    Self-Review, where a claim the diff does not support is itself a finding.
+
+The tier is computed from the diff and the rules alone. The pull request's
+title, labels, and body are inputs only to the declared-vs-computed check,
+never to the tier, so wording cannot buy a lower classification.
+
+`.github/workflows/risk_classify.yml` runs this on `pull_request_target` and
+never checks out pull-request code: the diff arrives as text through the API.
+
+Run: python3 scripts/classify_risk.py --pr 812 --dry-run
+Test: cd scripts && python3 -m unittest test_classify_risk
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+
+import yaml
+
+# The API plumbing and the minimatch glob subset are request_reviewers.py's;
+# both scripts read globs the same way or the two configs drift apart.
+import request_reviewers as rr
+
+CHECK_NAME = "Risk Classification"
+DEFAULT_RULES_PATH = ".github/risk-rules.yml"
+
+TIER_ORDER = {"low": 0, "medium": 1, "high": 2}
+LABEL_PREFIX = "risk:"
+LABEL_COLORS = {"low": "0e8a16", "medium": "fbca04", "high": "d93f0b"}
+
+RULE_KEYS = {"id", "tier", "why", "match", "only_match", "all_of", "patch_contains"}
+SELECTOR_KEYS = {"match", "only_match", "all_of", "patch_contains"}
+
+# The version of the JSON block in the check-run summary. Bump it when a field
+# changes meaning; consumers pin against it.
+SCHEMA_VERSION = 1
+
+RISK_SECTION = re.compile(
+    r"^##\s*Risk\s*&\s*Rollout\s*$(?P<text>.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL | re.IGNORECASE,
+)
+
+# What authors actually write in the section, from the open pull requests the
+# heuristic was replayed against: "Low risk, ...", "Risk: none to any running
+# system", and a bare leading verdict -- "Low. No runtime code paths" (#770),
+# "Moderate, and concentrated in one place" (#733). Deliberately loose in one
+# direction: when a section mentions more than one tier, the highest counts as
+# the declaration, so a cautious sentence ("high-risk paths are untouched")
+# only ever suppresses the mismatch flag, never raises a false one.
+DECLARED_WORDS = {
+    "low": "low|none|minimal|negligible",
+    "medium": "medium|moderate",
+    "high": "high",
+}
+DECLARED = {
+    tier: re.compile(
+        # "<word> risk" / "<word>-risk", or "risk ... <word>" in one clause,
+        # or the section opening with the bare word ("Low." / "Moderate,").
+        # The lookahead keeps "High-level overview" from declaring high.
+        rf"\b(?:{words})[- ]risk\b"
+        rf"|\brisk\b[^.!?\n]{{0,40}}?\b(?:{words})\b"
+        rf"|\A[\s>*_-]*(?:\*\*)?(?:{words})(?=[\s.,:;!)])",
+        re.IGNORECASE,
+    )
+    for tier, words in DECLARED_WORDS.items()
+}
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Rules
+# --------------------------------------------------------------------------- #
+
+
+def load_rules(path):
+    with open(path, encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+
+    if not isinstance(config, dict):
+        raise ValueError(f"{path} does not parse to a mapping")
+
+    validate_rules(config)
+    return config
+
+
+def validate_rules(config):
+    """Refuse a config this script would misread. Silence here becomes a wrong
+    tier on every pull request, so anything unrecognised raises."""
+    default = config.get("default_tier", "medium")
+    if default not in TIER_ORDER:
+        raise ValueError(f"default_tier {default!r} is not one of {sorted(TIER_ORDER)}")
+
+    rules = config.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("rules must be a non-empty list")
+
+    seen = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            raise ValueError(f"rule {rule!r} is not a mapping")
+
+        unknown = set(rule) - RULE_KEYS
+        if unknown:
+            raise ValueError(f"rule {rule.get('id')!r} has unknown keys: {sorted(unknown)}")
+
+        for key in ("id", "tier", "why"):
+            if not rule.get(key):
+                raise ValueError(f"rule {rule.get('id')!r} is missing {key!r}")
+
+        if rule["id"] in seen:
+            raise ValueError(f"rule id {rule['id']!r} appears twice")
+        seen.add(rule["id"])
+
+        if rule["tier"] not in TIER_ORDER:
+            raise ValueError(f"rule {rule['id']!r} tier {rule['tier']!r} is not one of {sorted(TIER_ORDER)}")
+
+        selectors = SELECTOR_KEYS & set(rule)
+        if not selectors:
+            raise ValueError(f"rule {rule['id']!r} has no selector ({sorted(SELECTOR_KEYS)})")
+
+        # `only_match` and `all_of` decide on the whole file set; mixing them
+        # with the per-file selectors has no one obvious meaning, so refuse.
+        for whole in ("only_match", "all_of"):
+            if whole in rule and selectors != {whole}:
+                raise ValueError(f"rule {rule['id']!r} combines {whole!r} with other selectors")
+
+        # A low rule scoped to a subset of files would classify a mixed pull
+        # request low on the strength of its safe half.
+        if rule["tier"] == "low" and "only_match" not in rule:
+            raise ValueError(f"low rule {rule['id']!r} must use only_match")
+
+        for key in ("match", "only_match"):
+            for pattern in rule.get(key, []):
+                rr.glob_to_regex(pattern)
+        for group in rule.get("all_of", []):
+            if not isinstance(group, list) or not group:
+                raise ValueError(f"rule {rule['id']!r} all_of groups must be non-empty lists")
+            for pattern in group:
+                rr.glob_to_regex(pattern)
+        for pattern in rule.get("patch_contains", []):
+            re.compile(pattern)
+
+
+# --------------------------------------------------------------------------- #
+# Classification
+# --------------------------------------------------------------------------- #
+
+
+def _matching_paths(globs, paths):
+    regexes = [rr.glob_to_regex(pattern) for pattern in globs]
+    return [path for path in paths if any(regex.match(path) for regex in regexes)]
+
+
+def rule_trigger(rule, files):
+    """The changed files that trigger `rule`, or None when it does not.
+
+    `files` is the GitHub `pulls/{n}/files` shape: dicts with `filename` and,
+    for text diffs the API is willing to inline, `patch`. A file without a
+    patch never satisfies `patch_contains`.
+    """
+    paths = [entry["filename"] for entry in files]
+
+    if "only_match" in rule:
+        if paths and len(_matching_paths(rule["only_match"], paths)) == len(paths):
+            return paths
+        return None
+
+    if "all_of" in rule:
+        groups = [_matching_paths(group, paths) for group in rule["all_of"]]
+        if all(groups):
+            return sorted({path for group in groups for path in group})
+        return None
+
+    candidates = files
+    if "match" in rule:
+        matched = set(_matching_paths(rule["match"], paths))
+        candidates = [entry for entry in files if entry["filename"] in matched]
+        if not candidates:
+            return None
+
+    if "patch_contains" in rule:
+        regexes = [re.compile(pattern, re.MULTILINE) for pattern in rule["patch_contains"]]
+        candidates = [
+            entry
+            for entry in candidates
+            if any(regex.search(entry.get("patch") or "") for regex in regexes)
+        ]
+        if not candidates:
+            return None
+
+    return [entry["filename"] for entry in candidates]
+
+
+def classify(config, files):
+    """The tier and the rules behind it: {tier, default_applied, rules}."""
+    triggered = []
+    for rule in config["rules"]:
+        hits = rule_trigger(rule, files)
+        if hits is not None:
+            triggered.append(
+                {"id": rule["id"], "tier": rule["tier"], "why": rule["why"], "files": hits}
+            )
+
+    if triggered:
+        tier = max((entry["tier"] for entry in triggered), key=TIER_ORDER.get)
+        default_applied = False
+    else:
+        tier = config.get("default_tier", "medium")
+        default_applied = True
+
+    return {"tier": tier, "default_applied": default_applied, "rules": triggered}
+
+
+def declared_tier(body):
+    """The tier the Risk & Rollout section claims, or None without one."""
+    section = RISK_SECTION.search(body or "")
+    if not section:
+        return None
+    text = section.group("text")
+    found = [tier for tier, regex in DECLARED.items() if regex.search(text)]
+    return max(found, key=TIER_ORDER.get) if found else None
+
+
+def build_result(config, files, body, pr_number=None, head_sha=None):
+    result = classify(config, files)
+    declared = declared_tier(body)
+    result.update(
+        {
+            "schema": SCHEMA_VERSION,
+            "pr": pr_number,
+            "head_sha": head_sha,
+            "declared_tier": declared,
+            "mismatch": declared == "low" and result["tier"] == "high",
+        }
+    )
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Rendering
+# --------------------------------------------------------------------------- #
+
+
+def check_run_title(result):
+    if result["mismatch"]:
+        return f"risk: {result['tier']} — Risk & Rollout declares low"
+    count = len(result["rules"])
+    detail = "no rule matched" if result["default_applied"] else f"{count} rule{'s' if count != 1 else ''}"
+    return f"risk: {result['tier']} ({detail})"
+
+
+def check_run_summary(result):
+    lines = [f"## Risk: {result['tier']}", ""]
+
+    if result["mismatch"]:
+        lines += [
+            "**The Risk & Rollout section declares low risk; the diff classifies "
+            "high.** Read that section against the rules below before anything "
+            "else — a claim the diff does not support is itself a finding.",
+            "",
+        ]
+
+    if result["default_applied"]:
+        lines += [
+            f"No rule in `{DEFAULT_RULES_PATH}` matched, so the default tier applies. "
+            "An unclassified path is not the same thing as a safe one.",
+            "",
+        ]
+    else:
+        for entry in result["rules"]:
+            files = ", ".join(f"`{path}`" for path in entry["files"][:5])
+            more = f" (+{len(entry['files']) - 5} more)" if len(entry["files"]) > 5 else ""
+            lines.append(f"- `{entry['id']}` → **{entry['tier']}** — {entry['why']} ({files}{more})")
+        lines.append("")
+
+    lines += [
+        "This check is signal for the reviewer; it blocks nothing. "
+        f"Rules live in `{DEFAULT_RULES_PATH}` (#818).",
+        "",
+        "```json",
+        json.dumps(result, indent=2, sort_keys=True),
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# GitHub side effects
+# --------------------------------------------------------------------------- #
+
+
+def post_check_run(api, head_sha, result):
+    api.post(
+        f"/repos/{api.repo}/check-runs",
+        {
+            "name": CHECK_NAME,
+            "head_sha": head_sha,
+            "status": "completed",
+            "conclusion": "success",
+            "output": {"title": check_run_title(result), "summary": check_run_summary(result)},
+        },
+    )
+
+
+def _tolerate(status, call):
+    """Run an API call, swallowing exactly one expected HTTP status."""
+    try:
+        call()
+    except urllib.error.HTTPError as error:
+        if error.code != status:
+            raise
+
+
+def sync_labels(api, pr_number, tier, current):
+    """Make `risk:{tier}` the one risk label on the pull request."""
+    desired = f"{LABEL_PREFIX}{tier}"
+
+    for name in current:
+        if name.startswith(LABEL_PREFIX) and name != desired:
+            # 404: someone removed it between our read and this call.
+            _tolerate(
+                404,
+                lambda name=name: api.delete(f"/repos/{api.repo}/issues/{pr_number}/labels/{name}"),
+            )
+
+    if desired not in current:
+        # 422: the label already exists in the repository. Creating it first
+        # keeps the colours consistent; adding an unknown label name to an
+        # issue would otherwise invent one with a random colour.
+        _tolerate(
+            422,
+            lambda: api.post(
+                f"/repos/{api.repo}/labels",
+                {"name": desired, "color": LABEL_COLORS[tier], "description": f"computed by {CHECK_NAME} (#818)"},
+            ),
+        )
+        api.post(f"/repos/{api.repo}/issues/{pr_number}/labels", {"labels": [desired]})
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument("--pr", type=int, help="pull request number")
+    target.add_argument(
+        "--files-json",
+        help="offline: a JSON file in the pulls/{n}/files shape; classifies and prints, no API",
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "gke-labs/kube-agents"),
+        help="owner/name (default: $GITHUB_REPOSITORY)",
+    )
+    parser.add_argument("--rules", default=DEFAULT_RULES_PATH)
+    parser.add_argument("--body-file", help="with --files-json: the pull request body to parse")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="classify and print, but post no check run or label"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    config = load_rules(args.rules)
+
+    if args.files_json:
+        with open(args.files_json, encoding="utf-8") as handle:
+            files = json.load(handle)
+        body = ""
+        if args.body_file:
+            with open(args.body_file, encoding="utf-8") as handle:
+                body = handle.read()
+        print(json.dumps(build_result(config, files, body), indent=2, sort_keys=True))
+        return 0
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not token:
+        log("GITHUB_TOKEN (or GH_TOKEN) is not set")
+        return 1
+
+    api = rr.GitHubAPI(args.repo, token)
+    pull_request = api.get(f"/repos/{args.repo}/pulls/{args.pr}")
+    # The head from the API rather than the event payload: on a `synchronize`
+    # the payload's head can be a push behind by the time the job runs, and a
+    # check run on a superseded commit is invisible on the pull request.
+    head_sha = pull_request["head"]["sha"]
+    files = api.get_all(f"/repos/{args.repo}/pulls/{args.pr}/files")
+
+    result = build_result(
+        config, files, pull_request.get("body"), pr_number=args.pr, head_sha=head_sha
+    )
+    log(f"#{args.pr} at {head_sha[:7]}: {check_run_title(result)}")
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+    if args.dry_run:
+        return 0
+
+    post_check_run(api, head_sha, result)
+    sync_labels(api, args.pr, result["tier"], [label["name"] for label in pull_request.get("labels") or []])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/request_reviewers.py
+++ b/scripts/request_reviewers.py
@@ -372,6 +372,9 @@ class GitHubAPI:
     def post(self, path, body):
         return self._request("POST", path, body)
 
+    def delete(self, path):
+        return self._request("DELETE", path)
+
 
 def resolve_pull_request(api, head_sha):
     """Find the open pull request the commit `head_sha` belongs to.

--- a/scripts/request_reviewers.py
+++ b/scripts/request_reviewers.py
@@ -372,6 +372,9 @@ class GitHubAPI:
     def post(self, path, body):
         return self._request("POST", path, body)
 
+    def patch(self, path, body):
+        return self._request("PATCH", path, body)
+
     def delete(self, path):
         return self._request("DELETE", path)
 

--- a/scripts/test_classify_risk.py
+++ b/scripts/test_classify_risk.py
@@ -1,0 +1,255 @@
+"""Tests for classify_risk.py: rule evaluation, tier arithmetic, the declared-
+vs-computed parse, and that the repository's own rules file loads and
+classifies the shapes it was written for.
+
+Run: cd scripts && python3 -m unittest test_classify_risk
+"""
+
+import json
+import os
+import unittest
+
+import classify_risk
+
+
+def _file(filename, patch=None):
+    entry = {"filename": filename, "status": "modified"}
+    if patch is not None:
+        entry["patch"] = patch
+    return entry
+
+
+def _config(*rules, default_tier="medium"):
+    config = {"default_tier": default_tier, "rules": list(rules)}
+    classify_risk.validate_rules(config)
+    return config
+
+
+REPO_RULES = os.path.join(os.path.dirname(__file__), "..", ".github", "risk-rules.yml")
+
+
+class ValidateRulesTest(unittest.TestCase):
+    def test_low_rule_without_only_match_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "must use only_match"):
+            _config({"id": "x", "tier": "low", "why": "w", "match": ["docs/**"]})
+
+    def test_unknown_key_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "unknown keys"):
+            _config({"id": "x", "tier": "high", "why": "w", "match": ["a/**"], "paths": ["b"]})
+
+    def test_rule_without_selector_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "no selector"):
+            _config({"id": "x", "tier": "high", "why": "w"})
+
+    def test_only_match_combined_with_patch_contains_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "combines"):
+            _config(
+                {"id": "x", "tier": "high", "why": "w", "only_match": ["a/**"], "patch_contains": ["b"]}
+            )
+
+    def test_duplicate_id_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "appears twice"):
+            _config(
+                {"id": "x", "tier": "high", "why": "w", "match": ["a/**"]},
+                {"id": "x", "tier": "low", "why": "w", "only_match": ["b/**"]},
+            )
+
+    def test_bad_tier_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "not one of"):
+            _config({"id": "x", "tier": "critical", "why": "w", "match": ["a/**"]})
+
+    def test_bad_default_tier_is_refused(self):
+        with self.assertRaisesRegex(ValueError, "default_tier"):
+            _config(
+                {"id": "x", "tier": "high", "why": "w", "match": ["a/**"]},
+                default_tier="none",
+            )
+
+    def test_unsupported_glob_is_refused(self):
+        with self.assertRaises(ValueError):
+            _config({"id": "x", "tier": "high", "why": "w", "match": ["a/{b,c}/**"]})
+
+
+class RuleTriggerTest(unittest.TestCase):
+    def test_match_triggers_on_any_file(self):
+        rule = {"id": "x", "tier": "high", "why": "w", "match": [".github/workflows/**"]}
+        files = [_file(".github/workflows/ci.yml"), _file("README.md")]
+        self.assertEqual(classify_risk.rule_trigger(rule, files), [".github/workflows/ci.yml"])
+
+    def test_match_and_patch_contains_need_the_same_file(self):
+        rule = {
+            "id": "x",
+            "tier": "high",
+            "why": "w",
+            "match": ["deploy/docker/Dockerfile"],
+            "patch_contains": ["^\\+\\s*(RUN|COPY)\\b"],
+        }
+        added = [_file("deploy/docker/Dockerfile", patch="+RUN apt-get install jq")]
+        context_only = [_file("deploy/docker/Dockerfile", patch=" RUN existing\n+ENV FOO=1")]
+        elsewhere = [_file("scripts/x.sh", patch="+RUN not the dockerfile")]
+        self.assertEqual(classify_risk.rule_trigger(rule, added), ["deploy/docker/Dockerfile"])
+        self.assertIsNone(classify_risk.rule_trigger(rule, context_only))
+        self.assertIsNone(classify_risk.rule_trigger(rule, elsewhere))
+
+    def test_missing_patch_never_satisfies_patch_contains(self):
+        rule = {"id": "x", "tier": "medium", "why": "w", "patch_contains": ["anything"]}
+        self.assertIsNone(classify_risk.rule_trigger(rule, [_file("big.bin")]))
+
+    def test_only_match_requires_every_file(self):
+        rule = {"id": "x", "tier": "low", "why": "w", "only_match": ["docs/site/**", "README.md"]}
+        all_docs = [_file("docs/site/src/a.md"), _file("README.md")]
+        mixed = all_docs + [_file("agents/platform/skills/x/SKILL.md")]
+        self.assertEqual(len(classify_risk.rule_trigger(rule, all_docs)), 2)
+        self.assertIsNone(classify_risk.rule_trigger(rule, mixed))
+        self.assertIsNone(classify_risk.rule_trigger(rule, []))
+
+    def test_all_of_requires_every_group(self):
+        rule = {
+            "id": "x",
+            "tier": "medium",
+            "why": "w",
+            "all_of": [["k8s-operator/scripts/**"], ["charts/**", "terraform/**"]],
+        }
+        both = [_file("k8s-operator/scripts/common.sh"), _file("charts/kube-agents/values.yaml")]
+        one = [_file("k8s-operator/scripts/common.sh")]
+        self.assertEqual(
+            classify_risk.rule_trigger(rule, both),
+            ["charts/kube-agents/values.yaml", "k8s-operator/scripts/common.sh"],
+        )
+        self.assertIsNone(classify_risk.rule_trigger(rule, one))
+
+
+class ClassifyTest(unittest.TestCase):
+    def test_highest_tier_wins(self):
+        config = _config(
+            {"id": "med", "tier": "medium", "why": "w", "match": ["agents/**/*.md"]},
+            {"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]},
+        )
+        files = [_file("agents/platform/skills/x/SKILL.md"), _file(".github/workflows/ci.yml")]
+        result = classify_risk.classify(config, files)
+        self.assertEqual(result["tier"], "high")
+        self.assertEqual([entry["id"] for entry in result["rules"]], ["med", "hi"])
+        self.assertFalse(result["default_applied"])
+
+    def test_nothing_matched_falls_back_to_default(self):
+        config = _config({"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]})
+        result = classify_risk.classify(config, [_file("bench/run.py")])
+        self.assertEqual(result["tier"], "medium")
+        self.assertTrue(result["default_applied"])
+        self.assertEqual(result["rules"], [])
+
+
+class DeclaredTierTest(unittest.TestCase):
+    BODY = "## Summary\n\nwords\n\n## Risk & Rollout\n\n%s\n"
+
+    def test_template_low_risk_phrase(self):
+        body = self.BODY % "Low risk, no runtime code paths touched."
+        self.assertEqual(classify_risk.declared_tier(body), "low")
+
+    def test_highest_mentioned_tier_counts(self):
+        body = self.BODY % "Mostly low risk, but the migration itself is high risk."
+        self.assertEqual(classify_risk.declared_tier(body), "high")
+
+    def test_no_section_is_none(self):
+        self.assertIsNone(classify_risk.declared_tier("## Summary\n\nlow risk change"))
+
+    def test_bare_leading_verdict(self):
+        # The shapes real pull requests write: #770, #733, #721.
+        self.assertEqual(classify_risk.declared_tier(self.BODY % "Low. No runtime code paths."), "low")
+        self.assertEqual(
+            classify_risk.declared_tier(self.BODY % "Moderate, and concentrated in one place."),
+            "medium",
+        )
+        self.assertEqual(
+            classify_risk.declared_tier(self.BODY % "- **Risk: none to any running system.**"), "low"
+        )
+
+    def test_leading_compound_word_is_not_a_verdict(self):
+        body = self.BODY % "High-level summary: nothing changes at runtime."
+        self.assertIsNone(classify_risk.declared_tier(body))
+
+    def test_crlf_body_parses(self):
+        body = (self.BODY % "Low risk, nothing at runtime.").replace("\n", "\r\n")
+        self.assertEqual(classify_risk.declared_tier(body), "low")
+
+    def test_section_without_tier_word_is_none(self):
+        body = self.BODY % "Reverting this commit removes the page."
+        self.assertIsNone(classify_risk.declared_tier(body))
+
+    def test_mismatch_only_for_declared_low_computed_high(self):
+        config = _config({"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]})
+        files = [_file(".github/workflows/ci.yml")]
+        low = classify_risk.build_result(config, files, self.BODY % "Low risk.")
+        none = classify_risk.build_result(config, files, "")
+        self.assertTrue(low["mismatch"])
+        self.assertFalse(none["mismatch"])
+
+
+class RenderingTest(unittest.TestCase):
+    def _result(self):
+        config = _config({"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]})
+        return classify_risk.build_result(
+            config,
+            [_file(".github/workflows/ci.yml")],
+            "## Risk & Rollout\n\nLow risk.",
+            pr_number=1,
+            head_sha="a" * 40,
+        )
+
+    def test_title_leads_with_the_mismatch(self):
+        self.assertIn("declares low", classify_risk.check_run_title(self._result()))
+
+    def test_summary_carries_a_parseable_json_block(self):
+        summary = classify_risk.check_run_summary(self._result())
+        block = summary.split("```json\n", 1)[1].split("\n```", 1)[0]
+        parsed = json.loads(block)
+        self.assertEqual(parsed["schema"], classify_risk.SCHEMA_VERSION)
+        self.assertEqual(parsed["tier"], "high")
+        self.assertTrue(parsed["mismatch"])
+
+
+class RepositoryRulesTest(unittest.TestCase):
+    """The committed rules file, against the shapes it was written for."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = classify_risk.load_rules(REPO_RULES)
+
+    def classify(self, files):
+        return classify_risk.classify(self.config, files)
+
+    def test_docs_site_only_is_low(self):
+        result = self.classify([_file("docs/site/src/content/docs/concepts.md"), _file("README.md")])
+        self.assertEqual(result["tier"], "low")
+
+    def test_skill_md_is_not_docs(self):
+        result = self.classify(
+            [_file("docs/site/src/content/docs/concepts.md"), _file("agents/cluster/skills/x/SKILL.md")]
+        )
+        self.assertEqual(result["tier"], "medium")
+        self.assertIn("agent-behavior-is-config-not-docs", [entry["id"] for entry in result["rules"]])
+
+    def test_workflow_edit_is_high(self):
+        self.assertEqual(self.classify([_file(".github/workflows/tests.yml")])["tier"], "high")
+
+    def test_the_rules_file_itself_is_high(self):
+        self.assertEqual(self.classify([_file(".github/risk-rules.yml")])["tier"], "high")
+
+    def test_added_iam_role_is_high(self):
+        files = [_file("terraform/kube-agents-iam/main.tf", patch='+    "roles/container.admin",')]
+        self.assertEqual(self.classify(files)["tier"], "high")
+
+    def test_terraform_without_role_change_is_default_medium(self):
+        files = [_file("terraform/gke-cluster/variables.tf", patch="+variable \"zone\" {}")]
+        result = self.classify(files)
+        self.assertEqual(result["tier"], "medium")
+        self.assertTrue(result["default_applied"])
+
+    def test_deleted_go_test_is_medium(self):
+        files = [_file("k8s-operator/internal/controller/thing_test.go", patch="-func TestReconcile(t *testing.T) {")]
+        result = self.classify(files)
+        self.assertIn("test-deletion", [entry["id"] for entry in result["rules"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_classify_risk.py
+++ b/scripts/test_classify_risk.py
@@ -218,6 +218,17 @@ class DeclaredTierTest(unittest.TestCase):
             classify_risk.declared_tier(self.BODY % "No risk to running systems."), "low"
         )
 
+    def test_determiner_no_near_risk_is_not_a_declaration(self):
+        # "no" declares only in the literal "no risk" collocation; as a
+        # determiner in the same clause as "risk" it says nothing about tier.
+        body = self.BODY % (
+            "Risk: this rewrites the IAM bundle; there is no automated rollback."
+        )
+        self.assertIsNone(classify_risk.declared_tier(body))
+        self.assertIsNone(
+            classify_risk.declared_tier(self.BODY % "The risk is contained; no migration needed.")
+        )
+
     def test_section_without_tier_word_is_none(self):
         body = self.BODY % "Reverting this commit removes the page."
         self.assertIsNone(classify_risk.declared_tier(body))
@@ -352,6 +363,19 @@ class RepositoryRulesTest(unittest.TestCase):
     def test_docs_site_only_is_low(self):
         result = self.classify([_file("docs/site/src/content/docs/concepts.md"), _file("README.md")])
         self.assertEqual(result["tier"], "low")
+
+    def test_docs_site_build_inputs_are_high(self):
+        # The docs-deploy build executes these and publishes the install.sh
+        # users pipe to bash; a dependency bump is a supply-chain edit.
+        result = self.classify([_file("docs/site/package-lock.json"), _file("docs/site/package.json")])
+        self.assertEqual(result["tier"], "high")
+        self.assertIn("docs-site-build-inputs", [entry["id"] for entry in result["rules"]])
+
+    def test_docs_site_outside_the_content_tree_is_not_low(self):
+        # Components and build config execute at build time; only the content
+        # tree is prose.
+        result = self.classify([_file("docs/site/src/components/Hero.astro")])
+        self.assertEqual(result["tier"], "medium")
 
     def test_skill_md_is_not_docs(self):
         result = self.classify(

--- a/scripts/test_classify_risk.py
+++ b/scripts/test_classify_risk.py
@@ -375,8 +375,8 @@ class PostCheckRunTest(unittest.TestCase):
         # would leave the stale verdict beside the corrected one.
         api = FakeAPI(
             check_runs=[
-                {"id": 5, "app": {"slug": "github-actions"}},
-                {"id": 9, "app": {"slug": "github-actions"}},
+                {"id": 5, "app": {"slug": "github-actions"}, "external_id": "risk-classify"},
+                {"id": 9, "app": {"slug": "github-actions"}, "external_id": "risk-classify"},
             ]
         )
         classify_risk.post_check_run(api, "a" * 40, self._result())
@@ -389,6 +389,39 @@ class PostCheckRunTest(unittest.TestCase):
         api = FakeAPI(check_runs=[{"id": 5, "app": {"slug": "some-other-app"}}])
         classify_risk.post_check_run(api, "a" * 40, self._result())
         self.assertEqual(api.calls[-1][0:2], ("POST", "/repos/gke-labs/kube-agents/check-runs"))
+
+    def test_the_workflow_jobs_own_check_run_is_not_touched(self):
+        # Actions creates a check run for the job itself: same app slug, same
+        # SHA, and -- until the job was renamed -- the same name. Its
+        # external_id carries the runner's job GUID, which is how the script's
+        # runs are told apart. Matching it here would PATCH the job's run and
+        # leave the stale verdict standing (853-F1); the newest-id decoy is the
+        # exact shape of a re-classification, where the current run's job
+        # check run postdates the script's earlier POST.
+        api = FakeAPI(
+            check_runs=[
+                {"id": 5, "app": {"slug": "github-actions"}, "external_id": "risk-classify"},
+                {
+                    "id": 9,
+                    "app": {"slug": "github-actions"},
+                    "external_id": "0198f2f3-ab-job-guid",
+                },
+            ]
+        )
+        classify_risk.post_check_run(api, "a" * 40, self._result())
+        method, path, body = api.calls[-1]
+        self.assertEqual((method, path), ("PATCH", "/repos/gke-labs/kube-agents/check-runs/5"))
+        self.assertEqual(body["external_id"], "risk-classify")
+
+    def test_a_pre_external_id_run_falls_back_to_post(self):
+        # A run this script created before it stamped external_id no longer
+        # matches. One stacked pair on the transition is the accepted cost;
+        # asserting the POST keeps the fallback from silently PATCHing by name.
+        api = FakeAPI(check_runs=[{"id": 5, "app": {"slug": "github-actions"}}])
+        classify_risk.post_check_run(api, "a" * 40, self._result())
+        method, path, body = api.calls[-1]
+        self.assertEqual((method, path), ("POST", "/repos/gke-labs/kube-agents/check-runs"))
+        self.assertEqual(body["external_id"], "risk-classify")
 
 
 class RepositoryRulesTest(unittest.TestCase):
@@ -417,6 +450,20 @@ class RepositoryRulesTest(unittest.TestCase):
         # tree is prose.
         result = self.classify([_file("docs/site/src/components/Hero.astro")])
         self.assertEqual(result["tier"], "medium")
+
+    def test_mdx_in_the_content_tree_is_not_low(self):
+        # MDX accepts imports and JS expressions that execute in the
+        # docs-deploy build -- the build that publishes the install.sh users
+        # pipe to bash -- so it is not prose even inside the content tree
+        # (853-F2).
+        result = self.classify([_file("docs/site/src/content/docs/skills/index.mdx")])
+        self.assertEqual(result["tier"], "medium")
+
+    def test_top_level_content_page_is_still_low(self):
+        # `**/*.md` must match zero intermediate directories, or every page
+        # sitting directly under content/docs silently loses its low path.
+        result = self.classify([_file("docs/site/src/content/docs/contributing.md")])
+        self.assertEqual(result["tier"], "low")
 
     def test_skill_md_is_not_docs(self):
         result = self.classify(

--- a/scripts/test_classify_risk.py
+++ b/scripts/test_classify_risk.py
@@ -294,9 +294,10 @@ class SummaryHostileInputTest(unittest.TestCase):
 class FakeAPI:
     repo = "gke-labs/kube-agents"
 
-    def __init__(self, fail=None):
+    def __init__(self, fail=None, check_runs=None):
         self.calls = []
         self.fail = fail or {}
+        self.check_runs = check_runs or []
 
     def _record(self, method, path, body=None):
         self.calls.append((method, path) if body is None else (method, path, body))
@@ -304,8 +305,15 @@ class FakeAPI:
         if status:
             raise urllib.error.HTTPError(path, status, "", {}, None)
 
+    def get(self, path):
+        self._record("GET", path)
+        return {"check_runs": self.check_runs}
+
     def post(self, path, body):
         self._record("POST", path, body)
+
+    def patch(self, path, body):
+        self._record("PATCH", path, body)
 
     def delete(self, path):
         self._record("DELETE", path)
@@ -348,6 +356,39 @@ class SyncLabelsTest(unittest.TestCase):
         self.assertEqual(
             api.calls, [("DELETE", "/repos/gke-labs/kube-agents/issues/7/labels/risk%3A%20high")]
         )
+
+
+class PostCheckRunTest(unittest.TestCase):
+    def _result(self):
+        config = _config({"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]})
+        return classify_risk.build_result(config, [_file(".github/workflows/ci.yml")], "")
+
+    def test_first_classification_creates_the_run(self):
+        api = FakeAPI(check_runs=[])
+        classify_risk.post_check_run(api, "a" * 40, self._result())
+        method, path, body = api.calls[-1]
+        self.assertEqual((method, path), ("POST", "/repos/gke-labs/kube-agents/check-runs"))
+        self.assertEqual(body["head_sha"], "a" * 40)
+
+    def test_reclassifying_the_same_sha_updates_in_place(self):
+        # edited/reopened re-classify the same commit; stacking a fresh run
+        # would leave the stale verdict beside the corrected one.
+        api = FakeAPI(
+            check_runs=[
+                {"id": 5, "app": {"slug": "github-actions"}},
+                {"id": 9, "app": {"slug": "github-actions"}},
+            ]
+        )
+        classify_risk.post_check_run(api, "a" * 40, self._result())
+        method, path, body = api.calls[-1]
+        self.assertEqual((method, path), ("PATCH", "/repos/gke-labs/kube-agents/check-runs/9"))
+        self.assertNotIn("head_sha", body)
+
+    def test_another_apps_run_with_the_same_name_is_not_touched(self):
+        # A name is not an identity, and PATCHing another app's run 403s.
+        api = FakeAPI(check_runs=[{"id": 5, "app": {"slug": "some-other-app"}}])
+        classify_risk.post_check_run(api, "a" * 40, self._result())
+        self.assertEqual(api.calls[-1][0:2], ("POST", "/repos/gke-labs/kube-agents/check-runs"))
 
 
 class RepositoryRulesTest(unittest.TestCase):

--- a/scripts/test_classify_risk.py
+++ b/scripts/test_classify_risk.py
@@ -8,6 +8,7 @@ Run: cd scripts && python3 -m unittest test_classify_risk
 import json
 import os
 import unittest
+import urllib.error
 
 import classify_risk
 
@@ -103,6 +104,18 @@ class RuleTriggerTest(unittest.TestCase):
         self.assertIsNone(classify_risk.rule_trigger(rule, mixed))
         self.assertIsNone(classify_risk.rule_trigger(rule, []))
 
+    def test_rename_is_classified_by_both_paths(self):
+        # Renaming a workflow into docs/ must not buy the low tier.
+        rename = {
+            "filename": "docs/site/src/old-ci.txt",
+            "status": "renamed",
+            "previous_filename": ".github/workflows/ci.yml",
+        }
+        high = {"id": "hi", "tier": "high", "why": "w", "match": [".github/workflows/**"]}
+        low = {"id": "lo", "tier": "low", "why": "w", "only_match": ["docs/site/**"]}
+        self.assertEqual(classify_risk.rule_trigger(high, [rename]), ["docs/site/src/old-ci.txt"])
+        self.assertIsNone(classify_risk.rule_trigger(low, [rename]))
+
     def test_all_of_requires_every_group(self):
         rule = {
             "id": "x",
@@ -138,6 +151,21 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(result["default_applied"])
         self.assertEqual(result["rules"], [])
 
+    def test_incomplete_file_list_never_reaches_low(self):
+        # The API stops at 3000 files; only_match over a truncated list would
+        # be a claim about files nobody read.
+        config = _config({"id": "lo", "tier": "low", "why": "w", "only_match": ["docs/site/**"]})
+        files = [_file("docs/site/src/a.md")]
+        self.assertEqual(classify_risk.classify(config, files, complete=True)["tier"], "low")
+        self.assertEqual(classify_risk.classify(config, files, complete=False)["tier"], "medium")
+
+    def test_rule_file_list_is_capped_but_counted(self):
+        config = _config({"id": "lo", "tier": "low", "why": "w", "only_match": ["docs/site/**"]})
+        files = [_file(f"docs/site/src/{i}.md") for i in range(60)]
+        entry = classify_risk.classify(config, files)["rules"][0]
+        self.assertEqual(len(entry["files"]), classify_risk.RULE_FILES_LISTED)
+        self.assertEqual(entry["file_count"], 60)
+
 
 class DeclaredTierTest(unittest.TestCase):
     BODY = "## Summary\n\nwords\n\n## Risk & Rollout\n\n%s\n"
@@ -171,6 +199,24 @@ class DeclaredTierTest(unittest.TestCase):
     def test_crlf_body_parses(self):
         body = (self.BODY % "Low risk, nothing at runtime.").replace("\n", "\r\n")
         self.assertEqual(classify_risk.declared_tier(body), "low")
+
+    def test_unedited_template_comment_declares_nothing(self):
+        # The template's own HTML comment contains "Low risk, no runtime code
+        # paths touched"; leaving it in place is not a declaration.
+        body = self.BODY % (
+            '<!--\nBlast radius, any new failure mode, how to revert. "Low risk, no runtime\n'
+            'code paths touched" is a complete answer when it is true.\n-->'
+        )
+        self.assertIsNone(classify_risk.declared_tier(body))
+
+    def test_common_negations_do_not_declare(self):
+        self.assertIsNone(classify_risk.declared_tier(self.BODY % "This is not a low-risk change."))
+        self.assertIsNone(classify_risk.declared_tier(self.BODY % "The risk is not low here."))
+
+    def test_no_risk_phrasing_declares_low(self):
+        self.assertEqual(
+            classify_risk.declared_tier(self.BODY % "No risk to running systems."), "low"
+        )
 
     def test_section_without_tier_word_is_none(self):
         body = self.BODY % "Reverting this commit removes the page."
@@ -206,6 +252,91 @@ class RenderingTest(unittest.TestCase):
         self.assertEqual(parsed["schema"], classify_risk.SCHEMA_VERSION)
         self.assertEqual(parsed["tier"], "high")
         self.assertTrue(parsed["mismatch"])
+
+
+class SummaryHostileInputTest(unittest.TestCase):
+    def test_filename_cannot_forge_a_json_fence(self):
+        # Git permits backticks and newlines in paths; a crafted name must not
+        # open a fenced block ahead of the real one.
+        hostile = 'a``` ```json\n{"tier": "low"}\n```b.md'
+        config = _config({"id": "hi", "tier": "high", "why": "w", "match": ["a*"]})
+        result = classify_risk.build_result(config, [_file(hostile)], "")
+        summary = classify_risk.check_run_summary(result)
+        # A fence marker only counts at the start of a line (json.dumps keeps
+        # string content mid-line by escaping newlines). Exactly one fenced
+        # block must exist, it must be the JSON one, and it must carry the
+        # real tier.
+        fences = [line for line in summary.splitlines() if line.startswith("```")]
+        self.assertEqual(fences, ["```json", "```"])
+        block = summary.split("```json\n", 1)[1].split("\n```", 1)[0]
+        self.assertEqual(json.loads(block)["tier"], "high")
+
+    def test_wide_pr_summary_fits_the_api_limit(self):
+        # GitHub caps output.summary at 65535 characters; an uncapped file
+        # list 422s the check-run POST on exactly the widest pull requests.
+        config = _config({"id": "lo", "tier": "low", "why": "w", "only_match": ["docs/site/**"]})
+        files = [_file(f"docs/site/src/content/docs/some/long/path/page-{i}.md") for i in range(1500)]
+        summary = classify_risk.check_run_summary(classify_risk.build_result(config, files, ""))
+        self.assertLess(len(summary), 65535)
+
+
+class FakeAPI:
+    repo = "gke-labs/kube-agents"
+
+    def __init__(self, fail=None):
+        self.calls = []
+        self.fail = fail or {}
+
+    def _record(self, method, path, body=None):
+        self.calls.append((method, path) if body is None else (method, path, body))
+        status = self.fail.get((method, path))
+        if status:
+            raise urllib.error.HTTPError(path, status, "", {}, None)
+
+    def post(self, path, body):
+        self._record("POST", path, body)
+
+    def delete(self, path):
+        self._record("DELETE", path)
+
+
+class SyncLabelsTest(unittest.TestCase):
+    def test_swaps_the_stale_risk_label(self):
+        api = FakeAPI()
+        classify_risk.sync_labels(api, 7, "high", ["risk:low", "unrelated"])
+        self.assertEqual(
+            api.calls,
+            [
+                ("DELETE", "/repos/gke-labs/kube-agents/issues/7/labels/risk%3Alow"),
+                (
+                    "POST",
+                    "/repos/gke-labs/kube-agents/labels",
+                    {
+                        "name": "risk:high",
+                        "color": classify_risk.LABEL_COLORS["high"],
+                        "description": f"computed by {classify_risk.CHECK_NAME} (#818)",
+                    },
+                ),
+                ("POST", "/repos/gke-labs/kube-agents/issues/7/labels", {"labels": ["risk:high"]}),
+            ],
+        )
+
+    def test_noop_when_the_label_is_already_right(self):
+        api = FakeAPI()
+        classify_risk.sync_labels(api, 7, "medium", ["risk:medium", "unrelated"])
+        self.assertEqual(api.calls, [])
+
+    def test_existing_repository_label_is_tolerated(self):
+        api = FakeAPI(fail={("POST", "/repos/gke-labs/kube-agents/labels"): 422})
+        classify_risk.sync_labels(api, 7, "low", [])
+        self.assertEqual(api.calls[-1][1], "/repos/gke-labs/kube-agents/issues/7/labels")
+
+    def test_hand_created_label_with_a_space_is_deletable(self):
+        api = FakeAPI()
+        classify_risk.sync_labels(api, 7, "high", ["risk: high", "risk:high"])
+        self.assertEqual(
+            api.calls, [("DELETE", "/repos/gke-labs/kube-agents/issues/7/labels/risk%3A%20high")]
+        )
 
 
 class RepositoryRulesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Every pull request now gets a computed risk tier — `low`, `medium`, or `high` — derived from its diff against the rules in `.github/risk-rules.yml`, surfaced as a non-blocking `Risk Classification` check run and a `risk:*` label. The check always concludes `success`; it is signal for the reviewer, not a gate. When the body's Risk & Rollout section declares low risk and the diff classifies high, the check title and summary lead with that disagreement.

## Why This Change

Reviewers get no signal about which pull requests are safe to clear quickly. The only risk information on a PR today is the template's Risk & Rollout section — author-asserted prose that nothing verifies and no automation consumes. As of 2026-08-19 this repository had 43 ready-for-review PRs with zero approvals; a reviewer deciding where to spend the next half hour has to open each diff to learn that one renames a docs page and another rewrites an IAM role bundle. #818 has the full design; this implements its build-order steps 1–3 (deterministic rules, workflow with check + label, declared-vs-computed mismatch). The LLM content pass and any consumers of the tier are follow-ups.

## What Changed

- `.github/risk-rules.yml` — nine seed rules, each carrying its evidence: the #658 layer-budget incident, the privilege-change mandatory-gate class from `docs/architecture/04-workflow-model.md` §2.2, and this repository's specific inversion of "docs are low risk" (agent-behavior Markdown is executable configuration). The rules file classifies itself `high`: editing it is how a change would buy a lower tier.
- `scripts/classify_risk.py` — the classifier. Highest triggered tier wins; nothing triggering falls to `medium` (an unclassified path is not a safe one); `low` is reachable only through `only_match` rules that quantify over every changed file, including both sides of renames. The tier is computed from the diff and rules alone — title, labels, and body feed only the declared-vs-computed check, so wording cannot buy a lower classification. Reuses `request_reviewers.py`'s API client and minimatch glob subset so the two configs cannot drift; that module gains a 3-line `delete` method.
- `.github/workflows/risk_classify.yml` — `pull_request_target` (the write token fork PRs need), never checks out PR code: the diff arrives as text through the API. The check-run summary carries a fenced JSON block (`schema: 1`) as the contract for later consumers.
- `scripts/test_classify_risk.py` — 44 tests: rule evaluation, tier arithmetic, hostile filenames, the declared-tier parse against phrasings taken from real open PRs, the label-sync layer against a fake API, and the committed rules file against the shapes it was written for.

## Context

Closes #818. Related: #788 (PR review flow improvements, no body yet — this is a concrete piece of that space) and #721 (architecture doc 09, the capability envelope — if it lands risk-tier vocabulary for the product, `risk-rules.yml` should adopt it rather than keep a parallel one).

Replayed offline against 8 open PRs, the seed rules classify: 6 medium and 2 high — #770 (workflow edits, also the one genuine mismatch: it declares "Low." in Risk & Rollout) and #753 (Dependabot docs-site bump, high via the build-inputs rule the bot review prompted; it was the sample's one low before ac013d8).

This PR was generated with the help of Claude.

## Testing

- `cd scripts && python3 -m unittest test_classify_risk test_request_reviewers` — 92 tests pass.
- `make docs-check` passes; prettier 3.9.6 (CI's pin) clean on both new YAML files.
- actionlint not run locally (not installed); CI's actionlint job covers the workflow.

### Live validation

This is a CI workflow, so it cannot reach a kube-agents installation; the live target was a real GitHub repository instead: a scratch PR on the `adrianchung/kube-agents` fork (its #1, now closed), with this branch as base so the real workflow ran with a real Actions token.

- Docs-only diff with a "Low risk" body: classified `low`, `risk:low` label created (color, description) and attached — observed by reading the labels back through the API.
- Pushed a workflow edit to the same PR — the distinctly-different state: tier moved to `high`, the mismatch fired ("risk: high — Risk & Rollout declares low"), and the label swapped to `risk:high` with `risk:low` deleted.
- The `pull_request_target` run posted the check run under the Actions token: `Risk Classification` `completed/success`, title "risk: high — Risk & Rollout declares low", and the fenced JSON block in its summary parses back to `{schema: 1, tier: high, mismatch: true, rules: [workflows-are-supply-chain]}`.
- Two findings from the exercise: `pull_request_target` takes the workflow file from the repository's **default branch**, so this check starts running on upstream PRs only after this merges to `main` (the fork test temporarily pointed the fork's default branch at this branch, then restored it); and a user token gets 403 on the check-run POST (App tokens only), which is why the label path was also exercised manually and the check-run path under Actions.
- Not covered live: the 3000-file truncation path and the 404/422 label-tolerance paths (unit-tested against a fake API); the `edited` trigger (same handler as `synchronize`).
- Cleanup: scratch PR closed unmerged, both test branches deleted, the three `risk:*` labels deleted from the fork, fork default branch restored to `main`. Nothing left behind.

## Self-Review

- Ran `review-adversarial` in a fresh-context subagent handed only the diff range. It confirmed four Should-fix findings, all fixed in the second commit: renames were classified only by their destination path (renaming a workflow into `docs/site/` bought `low` — now both sides of a rename are matched); a crafted filename with backticks could open a fenced block ahead of the real JSON one (display paths are defanged; the JSON block itself was already safe because `json.dumps` escapes newlines and markdown fences must start a line); a 1500-file PR rendered a summary past GitHub's 65535-character cap and would 422 the check-run POST (per-rule file lists cap at 50 with `file_count` carrying the truth); and an unedited PR template declared "low" because the template's HTML comment contains the literal phrase — comments are stripped before parsing.
- Confirmed nits, also fixed: common negations ("not a low-risk change") no longer read as declarations; "No risk to running systems" now reads as low; label names are URL-quoted so a hand-created `risk: high` cannot fail every run; the label-sync layer is under test; `edited` triggers reclassification so a corrected body clears a stale mismatch banner.
- Its one suspicion-only finding (the files endpoint caps at 3000 entries, so `only_match` over a truncated list could report `low` on files nobody read) is mitigated rather than left open: `low` rules are skipped when the PR hits the cap, and the summary says so.
- Angles it ran with nothing found: nothing removed or weakened, correct reuse over re-implementation, `pull_request_target` hygiene (base checkout, `persist-credentials: false`, event data through env only, SHA-pinned actions, minimal permissions), and scope.
- Ran `review-docs-drift` in a second fresh context: no Blocking findings. No page inventories PR checks or labels, `.github/` is outside the documentation map, and `make docs-check` passes with zero doc edits. Its advisory suggestion to mention the check in the site's contributing guide is not taken: the check-run summary itself names the rules file and #818, and no existing page claims a complete list of automations. It also noted pre-existing drift in `docs/designs/design_537148738.md:89` ("all workflows set `permissions: contents: read`" — already false on `main`), which belongs in a separate fix.

## Risk & Rollout

High, by this change's own classifier — it adds a workflow and the policy file that decides every future tier. The failure modes are contained: the check always concludes `success` and gates nothing, so a classifier bug misleads a reviewer rather than blocking a merge, and a crashed run shows as a failed non-required job. The workflow holds a write token on `pull_request_target` but never checks out or executes PR code. Revert is deleting the workflow and rules file (the `risk:*` labels linger harmlessly and can be deleted by hand). Nothing has to happen at merge time; the labels create themselves on first use, and the check starts appearing on PRs once this is on `main`.

