### PR TITLE
fix(platform): select Slack from a variable the sandbox container actually has

### DIFF
--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -428,28 +428,42 @@ def get_active_platform() -> str:
             return "google_chat"
     except Exception as exc:
         logger.error(f"Failed to parse config.yaml for active platform: {exc}")
-    # Reached only when the block above found nothing: no config.yaml, an
-    # unparseable one, or a revision that predates the operator rendering
-    # `platforms` (renderConfigYAML in platformagent_manifests.go). On the
-    # healthy path the config answers and this line never runs.
+    # This is the selector on an operator-managed pod, not a corner case.
+    # CONFIG_PATH is $PLATFORM_AGENT_HOME/config.yaml — the agent's own
+    # writable file, seeded from agents/chat/config.yaml. The operator's
+    # `platforms.<p>.enabled` does not go there: renderConfigYAML writes it to
+    # the managed scope mounted read-only at /etc/hermes, which Hermes overlays
+    # per leaf key inside its own config loader rather than merging to disk
+    # (docker-entrypoint.sh, "The pins do NOT come through this file"; the
+    # template block at agents/chat/config.yaml:257 says the same from the
+    # other side). The open() above therefore reads a `platforms` subtree with
+    # no `enabled` key at all, both branches fall through, and control arrives
+    # here on every alert.
     #
-    # SLACK_RELAY_URL carries this, not SLACK_BOT_TOKEN. The token is a
-    # credential, so it lives in the credential-proxy container and never in
-    # this one — the sandbox's Secret-backed env is the two pod-scoped Session
-    # KV values and nothing else, pinned by TestBuildDeployment in
-    # platformagent_manifests_test.go. Asking for it here was asking a question
-    # whose answer in a deployed pod is always "no", so a Slack-only install
-    # that fell this far called itself google_chat and lost the alert to a
+    # So SLACK_RELAY_URL is not a better fallback signal, it is the answer.
+    # SLACK_BOT_TOKEN never reaches this container — it is a credential, so it
+    # lives in the credential-proxy container, which is what
+    # TestBuildDeploymentSlackIntegration in platformagent_manifests_test.go
+    # pins (TestBuildDeployment holds the general "no Secret-backed env in the
+    # sandbox" rule, but its fixture configures Google Chat only and never
+    # renders a Slack variable to check). Asking for the token here was asking
+    # a question whose answer in a deployed pod is always "no", so every
+    # Slack-only install called itself google_chat and lost the alert to a
     # `hermes send` against a platform that is not configured. SLACK_RELAY_URL
-    # is set on this container unconditionally, exactly when
-    # spec.integration.slack.enabled is true.
+    # is set on this container exactly when spec.integration.slack.enabled is.
+    #
+    # Slack-before-Google-Chat matches the try block above, so an install with
+    # both integrations enabled resolves the same way whichever branch answers.
+    # That is a routing change for a dual-platform install, which until now
+    # always landed on google_chat here; see Risk & Rollout on the PR.
     #
     # The token is still accepted rather than replaced: it is the signal that
     # works for a bare `docker run` off the image, where no operator has
     # rendered anything and an exported token is all there is.
-    # platform_mcp_server.py's copy of this test pairs SLACK_BOT_TOKEN with
-    # SLACK_HOME_CHANNEL for the same reason; that one is optional on the CR,
-    # so the relay URL is the stronger of the two signals to add here.
+    # platform_mcp_server.py:690 is the same test with the same wrong signal
+    # and is deliberately left alone here — open PR #735 fixes that copy, and
+    # it needs the MCP env allowlist widened to pass SLACK_RELAY_URL through,
+    # which is that PR's to do.
     if os.environ.get("SLACK_RELAY_URL") or os.environ.get("SLACK_BOT_TOKEN"):
         return "slack"
     return "google_chat"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -460,10 +460,15 @@ def get_active_platform() -> str:
     # The token is still accepted rather than replaced: it is the signal that
     # works for a bare `docker run` off the image, where no operator has
     # rendered anything and an exported token is all there is.
-    # platform_mcp_server.py:690 is the same test with the same wrong signal
-    # and is deliberately left alone here — open PR #735 fixes that copy, and
-    # it needs the MCP env allowlist widened to pass SLACK_RELAY_URL through,
-    # which is that PR's to do.
+    # platform_mcp_server.py:690 leans on the same absent SLACK_BOT_TOKEN, but
+    # it is not as badly off: it also accepts SLACK_HOME_CHANNEL, which the
+    # operator does render on this container when spec.integration.slack
+    # .homeChannel is set and which is allowlisted into that child
+    # (agents/platform/config.yaml). So it misroutes only on a Slack install
+    # with no home channel anywhere — an install whose sends have no
+    # destination in any case. It is deliberately left alone here — open PR
+    # #735 fixes that copy, and it needs the MCP env allowlist widened to pass
+    # SLACK_RELAY_URL through, which is that PR's to do.
     if os.environ.get("SLACK_RELAY_URL") or os.environ.get("SLACK_BOT_TOKEN"):
         return "slack"
     return "google_chat"

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -428,7 +428,29 @@ def get_active_platform() -> str:
             return "google_chat"
     except Exception as exc:
         logger.error(f"Failed to parse config.yaml for active platform: {exc}")
-    if os.environ.get("SLACK_BOT_TOKEN"):
+    # Reached only when the block above found nothing: no config.yaml, an
+    # unparseable one, or a revision that predates the operator rendering
+    # `platforms` (renderConfigYAML in platformagent_manifests.go). On the
+    # healthy path the config answers and this line never runs.
+    #
+    # SLACK_RELAY_URL carries this, not SLACK_BOT_TOKEN. The token is a
+    # credential, so it lives in the credential-proxy container and never in
+    # this one — the sandbox's Secret-backed env is the two pod-scoped Session
+    # KV values and nothing else, pinned by TestBuildDeployment in
+    # platformagent_manifests_test.go. Asking for it here was asking a question
+    # whose answer in a deployed pod is always "no", so a Slack-only install
+    # that fell this far called itself google_chat and lost the alert to a
+    # `hermes send` against a platform that is not configured. SLACK_RELAY_URL
+    # is set on this container unconditionally, exactly when
+    # spec.integration.slack.enabled is true.
+    #
+    # The token is still accepted rather than replaced: it is the signal that
+    # works for a bare `docker run` off the image, where no operator has
+    # rendered anything and an exported token is all there is.
+    # platform_mcp_server.py's copy of this test pairs SLACK_BOT_TOKEN with
+    # SLACK_HOME_CHANNEL for the same reason; that one is optional on the CR,
+    # so the relay URL is the stronger of the two signals to add here.
+    if os.environ.get("SLACK_RELAY_URL") or os.environ.get("SLACK_BOT_TOKEN"):
         return "slack"
     return "google_chat"
 

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -458,6 +458,69 @@ class TestSessionRoutingRecordsThePlatform(unittest.TestCase):
         self.assertEqual(self._read()["origin"], "k8s-watcher")
 
 
+class TestActivePlatformFallback(unittest.TestCase):
+    """`get_active_platform` when config.yaml does not answer.
+
+    The healthy path reads `platforms.<p>.enabled` out of the rendered
+    config.yaml and never reaches the environment at all. These cover the
+    degraded one -- no config, an unparseable config, or a revision predating
+    the operator rendering `platforms` -- where getting it wrong sends the
+    alert to a platform the install does not have and loses it.
+    """
+
+    _KEYS = ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN")
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self._KEYS}
+        for key in self._KEYS:
+            os.environ.pop(key, None)
+        # A path that cannot parse, so every test here lands in the fallback.
+        self._config = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False)
+        self._config.write("platforms: [this is not a mapping\n")
+        self._config.close()
+        self._config_patch = patch.object(
+            session_kv_server, "CONFIG_PATH", self._config.name)
+        self._config_patch.start()
+
+    def tearDown(self):
+        self._config_patch.stop()
+        os.unlink(self._config.name)
+        for key, value in self._saved.items():
+            os.environ.pop(key, None)
+            if value is not None:
+                os.environ[key] = value
+
+    def test_the_relay_url_the_operator_sets_selects_slack(self):
+        # What a Slack-enabled sandbox container actually holds: the relay URL
+        # is emitted unconditionally alongside spec.integration.slack.enabled.
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8642"
+        self.assertEqual(session_kv_server.get_active_platform(), "slack")
+
+    def test_the_bot_token_still_selects_slack(self):
+        # Never present in the deployed sandbox -- it is a credential and lives
+        # in the credential-proxy container -- but it is the only signal a bare
+        # `docker run` off the image has, so it stays accepted.
+        os.environ["SLACK_BOT_TOKEN"] = "xoxb-not-a-real-token"
+        self.assertEqual(session_kv_server.get_active_platform(), "slack")
+
+    def test_an_install_with_neither_falls_back_to_google_chat(self):
+        self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
+
+    def test_the_config_decides_when_it_names_a_platform(self):
+        # The fallback must stay a fallback: a parseable config naming Slack
+        # wins even though no Slack variable is set in the environment.
+        with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".yaml", delete=False) as handle:
+            handle.write("platforms:\n  slack:\n    enabled: true\n")
+            named = handle.name
+        try:
+            with patch.object(session_kv_server, "CONFIG_PATH", named):
+                self.assertEqual(session_kv_server.get_active_platform(), "slack")
+        finally:
+            os.unlink(named)
+
+
 class TestAlertDailyQuota(unittest.TestCase):
     """The per-severity daily ceiling enforced in /sessions/{id}/inject."""
 

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -459,42 +459,57 @@ class TestSessionRoutingRecordsThePlatform(unittest.TestCase):
 
 
 class TestActivePlatformFallback(unittest.TestCase):
-    """`get_active_platform` when config.yaml does not answer.
+    """`get_active_platform` when config.yaml does not name a platform.
 
-    The healthy path reads `platforms.<p>.enabled` out of the rendered
-    config.yaml and never reaches the environment at all. These cover the
-    degraded one -- no config, an unparseable config, or a revision predating
-    the operator rendering `platforms` -- where getting it wrong sends the
-    alert to a platform the install does not have and loses it.
+    Which is every operator-managed pod: `platforms.<p>.enabled` is rendered
+    into the managed scope at /etc/hermes and overlaid inside Hermes' config
+    loader, never written to the CONFIG_PATH file this function opens. So the
+    environment branch is the live selector, and getting it wrong sends every
+    alert to a platform the install does not have. The config branch is still
+    covered below because it answers for a `docker run` off the image and for
+    any install whose writable config was edited to name one -- and because
+    the ordering between the two is what keeps this a fallback.
     """
 
     _KEYS = ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN")
 
     def setUp(self):
-        self._saved = {k: os.environ.get(k) for k in self._KEYS}
+        # patch.dict restores the whole mapping, and addCleanup runs even if a
+        # later line of setUp raises -- a hand-rolled tearDown would not, and
+        # would leave both variables popped for the rest of the discovery run.
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
         for key in self._KEYS:
             os.environ.pop(key, None)
-        # A path that cannot parse, so every test here lands in the fallback.
+        # A path that cannot parse, so tests that do not override it land in
+        # the environment branch the way a deployed pod does.
         self._config = tempfile.NamedTemporaryFile(
             mode="w", suffix=".yaml", delete=False)
         self._config.write("platforms: [this is not a mapping\n")
         self._config.close()
-        self._config_patch = patch.object(
+        self.addCleanup(os.unlink, self._config.name)
+        config_patch = patch.object(
             session_kv_server, "CONFIG_PATH", self._config.name)
-        self._config_patch.start()
+        config_patch.start()
+        self.addCleanup(config_patch.stop)
 
-    def tearDown(self):
-        self._config_patch.stop()
-        os.unlink(self._config.name)
-        for key, value in self._saved.items():
-            os.environ.pop(key, None)
-            if value is not None:
-                os.environ[key] = value
+    def _with_config(self, text):
+        """Point CONFIG_PATH at a config with this content, for one test."""
+        with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".yaml", delete=False) as handle:
+            handle.write(text)
+            named = handle.name
+        self.addCleanup(os.unlink, named)
+        patcher = patch.object(session_kv_server, "CONFIG_PATH", named)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_the_relay_url_the_operator_sets_selects_slack(self):
-        # What a Slack-enabled sandbox container actually holds: the relay URL
-        # is emitted unconditionally alongside spec.integration.slack.enabled.
-        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8642"
+        # What a Slack-enabled sandbox container actually holds. The value is
+        # the credential proxy's loopback port (credentialProxyPort = 8765 in
+        # platformagent_manifests.go), not the Hermes gateway's 8642.
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
         self.assertEqual(session_kv_server.get_active_platform(), "slack")
 
     def test_the_bot_token_still_selects_slack(self):
@@ -504,21 +519,38 @@ class TestActivePlatformFallback(unittest.TestCase):
         os.environ["SLACK_BOT_TOKEN"] = "xoxb-not-a-real-token"
         self.assertEqual(session_kv_server.get_active_platform(), "slack")
 
+    def test_both_signals_together_still_select_slack(self):
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+        os.environ["SLACK_BOT_TOKEN"] = "xoxb-not-a-real-token"
+        self.assertEqual(session_kv_server.get_active_platform(), "slack")
+
     def test_an_install_with_neither_falls_back_to_google_chat(self):
         self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
 
+    def test_an_absent_config_falls_back_rather_than_raising(self):
+        # setUp writes an unparseable file; a missing one takes a different
+        # branch of the same `except` and must not escape to the caller.
+        missing = self._config.name + ".gone"
+        with patch.object(session_kv_server, "CONFIG_PATH", missing):
+            self.assertEqual(
+                session_kv_server.get_active_platform(), "google_chat")
+
     def test_the_config_decides_when_it_names_a_platform(self):
-        # The fallback must stay a fallback: a parseable config naming Slack
-        # wins even though no Slack variable is set in the environment.
-        with tempfile.NamedTemporaryFile(
-                mode="w", suffix=".yaml", delete=False) as handle:
-            handle.write("platforms:\n  slack:\n    enabled: true\n")
-            named = handle.name
-        try:
-            with patch.object(session_kv_server, "CONFIG_PATH", named):
-                self.assertEqual(session_kv_server.get_active_platform(), "slack")
-        finally:
-            os.unlink(named)
+        # The environment branch must stay second: a parseable config naming
+        # Slack wins even though no Slack variable is set.
+        self._with_config("platforms:\n  slack:\n    enabled: true\n")
+        self.assertEqual(session_kv_server.get_active_platform(), "slack")
+
+    def test_a_config_naming_google_chat_beats_the_slack_environment(self):
+        # The case the environment branch newly puts at risk. Before this
+        # signal was added the branch was inert on a deployed pod, so nothing
+        # pinned the ordering; now only statement order keeps a config that
+        # names Google Chat from being overridden by a Slack-shaped
+        # environment. A refactor that hoists the environment check above the
+        # config read fails here rather than silently rerouting alerts.
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+        self._with_config("platforms:\n  google_chat:\n    enabled: true\n")
+        self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
 
 
 class TestAlertDailyQuota(unittest.TestCase):


### PR DESCRIPTION
## Summary

`get_active_platform()` in `session_kv_server.py` decides where every k8s-watcher alert goes,
and on a Slack-only install it always answered `google_chat`. It tries `config.yaml` first and
falls back to the environment; the fallback tested `SLACK_BOT_TOKEN`, a variable the sandbox
container never receives — the token is a credential, so the operator puts it in the
`envoy-credential-proxy` container and keeps the sandbox's Secret-backed environment to the
two pod-scoped Session KV values. This tests `SLACK_RELAY_URL` instead, which the operator
does set on that container and sets exactly when `spec.integration.slack.enabled` is true, and
keeps the token alongside it.

The part worth knowing before reading the diff: the fallback is not a corner case. The
operator's `platforms.<p>.enabled` never reaches the file `get_active_platform()` opens, so
the environment branch runs on every operator-managed pod. That is spelled out below, and it
is not how I first understood this change.

## Why This Change

`CONFIG_PATH` is `$PLATFORM_AGENT_HOME/config.yaml` — the agent's own writable file, seeded
from `agents/chat/config.yaml`. The operator's `platforms.<p>.enabled` is not written there.
`renderConfigYAML` renders it into the managed scope mounted read-only at `/etc/hermes`, and
Hermes overlays that per leaf key inside its own config loader rather than merging it to disk.
The image template says the same thing from the other side (`agents/chat/config.yaml:257`:
"`enabled` is the operator's to set … the managed scope's copy is the one a deployed agent
obeys").

So the `platforms` subtree this function parses carries no `enabled` key, both `if`s fall
through, and control reaches the environment branch on every alert — where it then asked for a
variable that is never present. Every Slack-only install routed every alert to `hermes send
--to google_chat` on a pod where Google Chat was never configured, and the alert was lost
rather than failing loudly.

## What Changed

- `agents/platform/scripts/session_kv_server.py` — the branch now reads `SLACK_RELAY_URL or
  SLACK_BOT_TOKEN`. The token is added to, not replaced: it is the signal that works for a bare
  `docker run` off the image, where no operator has rendered anything and an exported token is
  all there is. The comment records why the relay URL is the variable that survives the
  credential split, and cites `TestBuildDeploymentSlackIntegration`, which is the test that
  actually pins the tokens out of the sandbox.
- `agents/platform/scripts/test_session_kv_server.py` — `TestActivePlatformFallback`, seven
  cases: relay URL only, token only, both, neither, absent config, a config naming Slack, and a
  config naming Google Chat against a Slack-shaped environment. The last pins the ordering
  between the two branches, which nothing covered while the environment branch was inert on a
  deployed pod.

**Behaviour change worth calling out:** an install with both `googleChat.enabled` and
`slack.enabled` resolved to `google_chat` here and now resolves to `slack`. That matches the
ordering the `config.yaml` branch already uses, so the two agree rather than diverging, but it
moves alerts for a dual-platform install. See Risk & Rollout.

## Context

No open pull request changes this function. #735 touches the same two files but its hunks start
below it, so the overlap is a possible merge conflict at worst, not duplicated work.

`platform_mcp_server.py:690` leans on the same absent variable but is not as badly off: its
test also accepts `SLACK_HOME_CHANNEL`, which the operator renders on the sandbox container
when `spec.integration.slack.homeChannel` is set and which the stdio MCP allowlist passes
through to the child. So the sibling already selects Slack on a Slack install with a home
channel, and misroutes only on one without — an install whose sends have no destination in any
case. It is deliberately left alone here. #735 already fixes that copy, and doing it properly
needs the allowlist widened so the child receives `SLACK_RELAY_URL` at all, which is that PR's
change to make. If #735 is closed rather than merged, that sibling needs its own follow-up.

This came out of triaging bnaylor's security audit. It is not one of that report's findings,
but was found next to one while establishing which environment variables the sandbox container
actually holds.

Generated with the help of Claude.

## Testing

- `TestActivePlatformFallback`: 7 tests, all passing. This environment cannot install
  `fastapi`/`mcp` (the package mirror is behind an airlock), so the class was run against
  stubs; the other tests in the file error on `fastapi.testclient` identically with and without
  this branch, and no `AssertionError` appears in either run.
- Mutation-tested twice. Reverting the source to `SLACK_BOT_TOKEN` alone fails exactly
  `test_the_relay_url_the_operator_sets_selects_slack`. Hoisting the environment check above
  the `config.yaml` read fails exactly
  `test_a_config_naming_google_chat_beats_the_slack_environment`. No other test moves in either
  case.
- `make docs-check` passes.

### Live validation

Not live-tested — no running kube-agents installation was reachable from this environment.

What that leaves unverified is the claim this change turns on: that a deployed pod's
`/opt/data/config.yaml` carries no `platforms.*.enabled`, and that `SLACK_RELAY_URL` is present
in the sandbox container while `SLACK_BOT_TOKEN` is not. Both were established by reading
`renderConfigYAML` and the ConfigMap keys it writes, `docker-entrypoint.sh`'s statement that the
pins do not come through that file, `TestRenderedConfigIsNotMountedOverTheAgentsOwn`, the image
template's own comment, and `TestBuildDeploymentSlackIntegration` — source and golden manifests
rather than a live pod.

One case reading cannot settle: a long-lived PVC created under the retired "rebuild config.yaml
from image + overlay" entrypoint shape could still hold a stale `platforms.*.enabled` on disk,
in which case the config branch answers on that install and neither the bug nor the routing
change applies there. Anyone with a cluster can close both questions in one command —
`kubectl exec` into the agent container, `grep -A3 '^platforms:' /opt/data/config.yaml`, and
`env | grep SLACK_`. No test artifacts were created on any cluster.

## Self-Review

Adversarial and docs-drift, each run by a subagent given only the diff range and the skill file
— no plan, no reasoning, no summary from the session that wrote the change. Angles covered:
line-by-line and enclosing-function reading, removed behaviour and CI, cross-file tracing of
every identifier the diff names, sibling symmetry, ops/security blast radius, reuse, altitude,
repository conventions, mutation testing, and overlap with open PRs.

The adversarial pass falsified the premise of my own comment, which is the main thing a
reviewer should know about this branch. Dispositions:

- **The comment said the environment branch runs only on a broken install. It runs on every
  operator-managed pod.** `renderConfigYAML` writes to the managed scope, not to the file
  `get_active_platform()` opens. Verified independently against `platformagent_manifests.go`
  (`managedConfigKey`), `docker-entrypoint.sh`, and `agents/chat/config.yaml:257`. **Fixed** in
  82b68237 — the comment, the test-class docstring, the commit message, and the framing of this
  body all changed. It makes the bug more serious, not less.
- **Adding `SLACK_RELAY_URL` reroutes a dual-platform install from Google Chat to Slack.** Live,
  given the finding above. **Not changed, disclosed instead**: it matches the ordering the
  `config.yaml` branch already uses, so making the environment branch disagree in order to
  preserve the old behaviour would leave the two halves of one function contradicting each
  other. Called out in What Changed, Risk & Rollout, and the source comment.
- **The comment cited `TestBuildDeployment` for pinning `SLACK_BOT_TOKEN` out of the sandbox.**
  That test's fixture configures Google Chat only, so it never renders a Slack variable;
  `TestBuildDeploymentSlackIntegration` is the real pin. A wrong citation would tell someone
  narrowing that test the invariant was still covered. **Fixed.**
- **The relay-URL fixture used `8642`, the Hermes gateway port, under a comment claiming it was
  the production value.** The real one is the credential proxy's `8765`. The assertion is
  unaffected, but it is a trap for the next person copying it. **Fixed.**
- **No test pinned the ordering between the two branches.** It did not matter while the
  environment branch was inert; it does now. **Fixed**, and mutation-tested by hoisting the
  environment check above the config read.
- **`setUp` hand-rolled environment save/restore, so a raise inside it would leak popped
  variables into the rest of the discovery run.** **Fixed** — `patch.dict` + `addCleanup`.
- **Bare truthiness rather than `.strip()`, where `slack_relay_patch.py` and `sitecustomize.py`
  both normalise `SLACK_RELAY_URL` first.** Marked PLAUSIBLE, not confirmed: no path was found
  that produces a whitespace value, and it is not reachable through the CR
  (`safeSandboxEnvOverrides` rejects it). **Reported, not fixed** — the argument for it is
  contract symmetry, and chasing an unconfirmed finding on my own change is how a self-review
  makes things worse. Worth a reviewer's opinion.
- **Reviewer finding (@jayantid): the comment overstated the sibling's brokenness.** It called
  `platform_mcp_server.py:690` "the same test with the same wrong signal"; that test also
  accepts `SLACK_HOME_CHANNEL`, which `platformagent_manifests.go` renders on the sandbox
  container when `spec.integration.slack.homeChannel` is set and which
  `agents/platform/config.yaml` allowlists into the MCP child. Verified both against source.
  A reader trusting the old wording would overestimate how urgent #735's copy is. **Fixed** —
  the source comment and the Context paragraph above now say the sibling misroutes only where
  no home channel is set.

Docs-drift: no Blocking findings. It searched every Markdown file for prose describing platform
selection and found none — nothing documents how the alert's target platform is chosen, so this
contradicts no page. It confirmed the "Slack tokens: sandbox No" row in
`docs/credential-isolation-design.md` still stands, since `SLACK_RELAY_URL` is a plain-valued
loopback URL rather than a token. One non-blocking note: `agent_common_server.py:49` names
`platform_mcp_server.get_active_platform`, a symbol that does not exist (the reader is
`get_enabled_platforms`). Pre-existing and in the file this PR deliberately leaves to #735, so
**not fixed here** — touching it would widen the diff into that PR's path.

## Risk & Rollout

Moderate, and concentrated in one place. On a Slack-only install this changes alert routing from
broken to correct. On a Google-Chat-only install nothing moves: neither variable is set, and the
answer is `google_chat` before and after. **On an install with both integrations enabled, alerts
move from Google Chat to Slack** — that is the real blast radius, it happens on the first pod
restart after upgrade with no CR change, and an operator watching a Google Chat space will
simply stop seeing alerts there. If that install also left `spec.integration.slack.homeChannel`
empty, `SLACK_HOME_CHANNEL` is not rendered and `hermes send --to slack` has no destination, so
the alert is lost rather than relocated. Anyone running both platforms should set a Slack home
channel before taking this, or expect the move.

No IAM, RBAC, NetworkPolicy, or credential path is touched, and nothing new is read from a
Secret. Reverting the two commits restores the previous behaviour exactly; there is nothing to
do at merge time.

