### PR TITLE
test(platform): pin the invariant _run_env's safety depends on

### DIFF
--- a/agents/platform/scripts/agent_common_server.py
+++ b/agents/platform/scripts/agent_common_server.py
@@ -61,22 +61,29 @@ def _run_env(extra: dict[str, str] | None = None) -> dict[str, str]:
 
     1. The sandbox container holds no credentials. The operator gives it exactly
        two Secret-backed variables — SESSION_KV_API_KEY and SESSION_KV_SALT,
-       both pod-scoped and useless off this pod's loopback — and its
-       API_SERVER_KEY is the non-secret sentinel `cluster-internal-trusted`. The
-       real credentials live in the credential-proxy container. That allowlist
-       is enforced on the Go side by TestBuildDeployment in
-       platformagent_manifests_test.go, and mirrored here by
-       TestRunEnvInheritanceContract in test_agent_common_server.py so that a
-       change to it also goes loud next to the code that depends on it.
+       both pod-scoped: neither authenticates nor pseudonymises anything outside
+       this Pod. Its API_SERVER_KEY is the non-secret sentinel
+       `cluster-internal-trusted`, and the real credentials live in the
+       credential-proxy container. See docs/credential-isolation-design.md,
+       "The loopback-only exception", which owns this and is the page to change
+       if it moves. The allowlist is enforced on the Go side by
+       TestBuildDeployment in platformagent_manifests_test.go, and pinned here
+       by TestRunEnvInheritanceContract in test_agent_common_server.py, which
+       also covers the envFrom bulk-mount the Go loop cannot see.
 
     2. No call site crosses a privilege boundary. Callers are either an MCP
        child, whose own environment Hermes has already narrowed to an allowlist
        (`_build_safe_env` in hermes tools/mcp_tool.py, and the `env:` blocks in
-       agents/platform/config.yaml), or session_kv_server, which does hold the
-       whole container environment but spawns `hermes send` as the same UID in
-       the same container — a child that could read /proc/self/environ anyway.
+       agents/platform/config.yaml), or session_kv_server spawning `hermes send`
+       as the same UID in the same container — a child that could read
+       /proc/self/environ anyway. Note that session_kv_server has two shapes:
+       the uvicorn instance the entrypoint backgrounds holds the whole container
+       environment, while the fallback instance platform_mcp_server spawns
+       inherits the stdio MCP allowlist instead, which names SESSION_KV_API_KEY
+       and not the salt. Narrower, so the argument holds either way — but do not
+       read this docstring as a promise that the salt is always present.
 
-    A new caller that spawns across a UID or container boundary, or a fourth
+    A new caller that spawns across a UID or container boundary, or a third
     variable added to the sandbox's Secret allowlist, invalidates this. Narrow
     the environment explicitly at that call site rather than reaching for this.
     """

--- a/agents/platform/scripts/agent_common_server.py
+++ b/agents/platform/scripts/agent_common_server.py
@@ -52,7 +52,34 @@ DOTENV_PATH = os.environ.get("PLATFORM_AGENT_DOTENV_PATH", "/opt/data/.env")
 # test_agent_common_server.py.
 
 def _run_env(extra: dict[str, str] | None = None) -> dict[str, str]:
-    """Build a subprocess env with HOME redirected to /tmp for GKE container compatibility."""
+    """Build a subprocess env with HOME redirected to /tmp for GKE container compatibility.
+
+    This hands the child *the caller's entire environment*. That is safe today,
+    but it is safe because of two facts outside this file rather than anything
+    this function does, and both are worth stating because the day either stops
+    holding, every call site here becomes a credential leak at once.
+
+    1. The sandbox container holds no credentials. The operator gives it exactly
+       two Secret-backed variables — SESSION_KV_API_KEY and SESSION_KV_SALT,
+       both pod-scoped and useless off this pod's loopback — and its
+       API_SERVER_KEY is the non-secret sentinel `cluster-internal-trusted`. The
+       real credentials live in the credential-proxy container. That allowlist
+       is enforced on the Go side by TestBuildDeployment in
+       platformagent_manifests_test.go, and mirrored here by
+       TestRunEnvInheritanceContract in test_agent_common_server.py so that a
+       change to it also goes loud next to the code that depends on it.
+
+    2. No call site crosses a privilege boundary. Callers are either an MCP
+       child, whose own environment Hermes has already narrowed to an allowlist
+       (`_build_safe_env` in hermes tools/mcp_tool.py, and the `env:` blocks in
+       agents/platform/config.yaml), or session_kv_server, which does hold the
+       whole container environment but spawns `hermes send` as the same UID in
+       the same container — a child that could read /proc/self/environ anyway.
+
+    A new caller that spawns across a UID or container boundary, or a fourth
+    variable added to the sandbox's Secret allowlist, invalidates this. Narrow
+    the environment explicitly at that call site rather than reaching for this.
+    """
     return {**os.environ, "HOME": "/tmp", **(extra or {})}
 
 

--- a/agents/platform/scripts/test_agent_common_server.py
+++ b/agents/platform/scripts/test_agent_common_server.py
@@ -167,5 +167,92 @@ class TestResolveAgentCredentials(unittest.TestCase):
         self.assertTrue(endpoint.startswith("https://"))
 
 
+class TestRunEnvInheritanceContract(unittest.TestCase):
+    """`_run_env` hands a child the caller's whole environment.
+
+    Sound only while the sandbox container holds no credentials worth passing
+    on. The operator is what makes that true and
+    platformagent_manifests_test.go is what enforces it, but neither is next to
+    the code that relies on it: a fourth Secret-backed variable added to the
+    sandbox would pass every Go test and silently widen what every `_run_env`
+    call site leaks into `gcloud`, `kubectl` and `hermes send`.
+
+    So this asserts the same invariant from the Python side, against the
+    rendered golden rather than the builder, and fails with a message that says
+    what to do about it. Widening the allowlist is allowed — it is a decision,
+    and this makes someone take it deliberately and narrow the call sites in
+    the same change.
+    """
+
+    # Both are pod-scoped: one authenticates callers of the Session KV server
+    # on this pod's loopback, the other is the HMAC salt for pseudonymising
+    # chat identities, which has to be here because the hashing is here.
+    EXPECTED = {"SESSION_KV_API_KEY", "SESSION_KV_SALT"}
+    SANDBOX_CONTAINER = "platform-agent"
+    GOLDEN = (
+        Path(__file__).resolve().parents[3]
+        / "k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml"
+    )
+
+    def _sandbox_container(self):
+        import yaml
+
+        with self.GOLDEN.open() as handle:
+            docs = [d for d in yaml.safe_load_all(handle) if d]
+        deployments = [d for d in docs if d.get("kind") == "Deployment"]
+        self.assertEqual(
+            len(deployments), 1,
+            f"expected one Deployment in {self.GOLDEN.name}, found {len(deployments)}")
+        containers = deployments[0]["spec"]["template"]["spec"]["containers"]
+        for container in containers:
+            if container.get("name") == self.SANDBOX_CONTAINER:
+                return container
+        self.fail(
+            f"no container named {self.SANDBOX_CONTAINER!r} in the golden; found "
+            f"{[c.get('name') for c in containers]}. If the sandbox container was "
+            "renamed, update SANDBOX_CONTAINER — do not delete this test.")
+
+    def test_the_sandbox_holds_only_the_two_pod_scoped_secrets(self):
+        secret_backed = {
+            env["name"]
+            for env in self._sandbox_container().get("env", [])
+            if (env.get("valueFrom") or {}).get("secretKeyRef")
+        }
+        self.assertEqual(
+            secret_backed, self.EXPECTED,
+            "The sandbox container's Secret-backed environment changed. "
+            "_run_env in agent_common_server.py passes the whole environment to "
+            "every gcloud/kubectl/hermes child it spawns, and its docstring "
+            "cites this exact set as the reason that is safe. If the new "
+            "variable is genuinely pod-scoped, add it to EXPECTED here and to "
+            "the allowlist in platformagent_manifests_test.go. If it is a real "
+            "credential, it belongs in the credential-proxy container, or "
+            "_run_env's call sites need an explicit allowlist.")
+
+    def test_the_credential_proxy_is_where_real_credentials_live(self):
+        # The other half of the invariant: this asserts the credential-proxy
+        # container does hold Secret-backed values, so a refactor that emptied
+        # it -- moving credentials into the sandbox -- cannot leave the test
+        # above passing against a container that simply has no secrets at all.
+        with self.GOLDEN.open() as handle:
+            import yaml
+            docs = [d for d in yaml.safe_load_all(handle) if d]
+        deployment = next(d for d in docs if d.get("kind") == "Deployment")
+        proxies = [
+            c for c in deployment["spec"]["template"]["spec"]["containers"]
+            if c.get("name") == "envoy-credential-proxy"
+        ]
+        self.assertEqual(len(proxies), 1, "credential-proxy container not found in golden")
+        secret_backed = {
+            env["name"]
+            for env in proxies[0].get("env", [])
+            if (env.get("valueFrom") or {}).get("secretKeyRef")
+        }
+        self.assertTrue(
+            secret_backed,
+            "the credential-proxy container has no Secret-backed environment; "
+            "if credentials moved, they must not have moved into the sandbox")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/agents/platform/scripts/test_agent_common_server.py
+++ b/agents/platform/scripts/test_agent_common_server.py
@@ -183,8 +183,10 @@ class TestRunEnvInheritanceContract(unittest.TestCase):
     substitute for either. It buys two narrower things:
 
     - `envFrom.secretRef` bulk-mounts an entire Secret and is invisible to that
-      loop, which only walks `env`. One line in the operator would put every
-      key of platform-agent-secrets into the sandbox with every Go test green.
+      loop, which only walks `env`. TestAgentsGolden does catch the render
+      diff -- but as a golden mismatch, which `go test ./internal/testing
+      -update` absorbs. Add one line to the operator, regenerate, and every key
+      of platform-agent-secrets is in the sandbox with the whole Go suite green.
       That is the hole checked below.
     - When someone does widen the allowlist deliberately -- change the
       operator, update the Go list, regenerate the golden with

--- a/agents/platform/scripts/test_agent_common_server.py
+++ b/agents/platform/scripts/test_agent_common_server.py
@@ -20,6 +20,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import yaml
+
 # Add the directory containing agent_common_server.py to sys.path so it can be imported.
 sys.path.insert(0, str(Path(__file__).parent.absolute()))
 
@@ -171,32 +173,52 @@ class TestRunEnvInheritanceContract(unittest.TestCase):
     """`_run_env` hands a child the caller's whole environment.
 
     Sound only while the sandbox container holds no credentials worth passing
-    on. The operator is what makes that true and
-    platformagent_manifests_test.go is what enforces it, but neither is next to
-    the code that relies on it: a fourth Secret-backed variable added to the
-    sandbox would pass every Go test and silently widen what every `_run_env`
-    call site leaks into `gcloud`, `kubectl` and `hermes send`.
+    on. The canonical statement of why that holds is
+    docs/credential-isolation-design.md, "The loopback-only exception".
 
-    So this asserts the same invariant from the Python side, against the
-    rendered golden rather than the builder, and fails with a message that says
-    what to do about it. Widening the allowlist is allowed — it is a decision,
-    and this makes someone take it deliberately and narrow the call sites in
-    the same change.
+    The Go side already guards the obvious version of this: TestBuildDeployment
+    in platformagent_manifests_test.go walks the sandbox container's `env` and
+    fails on any entry whose `valueFrom` names a secretKeyRef outside the
+    two-name allowlist, and TestAgentsGolden fails alongside it. This is not a
+    substitute for either. It buys two narrower things:
+
+    - `envFrom.secretRef` bulk-mounts an entire Secret and is invisible to that
+      loop, which only walks `env`. One line in the operator would put every
+      key of platform-agent-secrets into the sandbox with every Go test green.
+      That is the hole checked below.
+    - When someone does widen the allowlist deliberately -- change the
+      operator, update the Go list, regenerate the golden with
+      `go test ./internal/testing -update` -- three green edits currently leave
+      no signal beside the Python that depends on the invariant. This fails
+      there, next to `_run_env`, and says what to do about it.
+
+    Widening is allowed. It is a decision, and this makes someone take it
+    where the call sites are.
     """
 
     # Both are pod-scoped: one authenticates callers of the Session KV server
     # on this pod's loopback, the other is the HMAC salt for pseudonymising
     # chat identities, which has to be here because the hashing is here.
+    # Neither grants access to any external system.
     EXPECTED = {"SESSION_KV_API_KEY", "SESSION_KV_SALT"}
     SANDBOX_CONTAINER = "platform-agent"
+    PROXY_CONTAINER = "envoy-credential-proxy"
+    # A credential the proxy holds and the sandbox must never see. Named
+    # rather than counted: SESSION_KV_API_KEY is on both containers, so
+    # "the proxy has some Secret-backed env" is satisfied by a pod-scoped
+    # value and would stay true after the last real credential left.
+    PROXY_CREDENTIAL = "API_SERVER_EXTERNAL_KEY"
     GOLDEN = (
         Path(__file__).resolve().parents[3]
         / "k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml"
     )
 
-    def _sandbox_container(self):
-        import yaml
-
+    def _container(self, name):
+        if not self.GOLDEN.exists():
+            self.fail(
+                f"golden manifest not found at {self.GOLDEN}. This test reads the "
+                "operator's testdata from Python; if that tree moved, update GOLDEN "
+                "— do not delete this test.")
         with self.GOLDEN.open() as handle:
             docs = [d for d in yaml.safe_load_all(handle) if d]
         deployments = [d for d in docs if d.get("kind") == "Deployment"]
@@ -205,21 +227,25 @@ class TestRunEnvInheritanceContract(unittest.TestCase):
             f"expected one Deployment in {self.GOLDEN.name}, found {len(deployments)}")
         containers = deployments[0]["spec"]["template"]["spec"]["containers"]
         for container in containers:
-            if container.get("name") == self.SANDBOX_CONTAINER:
+            if container.get("name") == name:
                 return container
         self.fail(
-            f"no container named {self.SANDBOX_CONTAINER!r} in the golden; found "
-            f"{[c.get('name') for c in containers]}. If the sandbox container was "
-            "renamed, update SANDBOX_CONTAINER — do not delete this test.")
+            f"no container named {name!r} in the golden; found "
+            f"{[c.get('name') for c in containers]}. If it was renamed, update the "
+            "constant on this class — do not delete this test.")
 
-    def test_the_sandbox_holds_only_the_two_pod_scoped_secrets(self):
-        secret_backed = {
+    @staticmethod
+    def _secret_backed(container):
+        return {
             env["name"]
-            for env in self._sandbox_container().get("env", [])
+            for env in container.get("env", [])
             if (env.get("valueFrom") or {}).get("secretKeyRef")
         }
+
+    def test_the_sandbox_holds_only_the_two_pod_scoped_secrets(self):
         self.assertEqual(
-            secret_backed, self.EXPECTED,
+            self._secret_backed(self._container(self.SANDBOX_CONTAINER)),
+            self.EXPECTED,
             "The sandbox container's Secret-backed environment changed. "
             "_run_env in agent_common_server.py passes the whole environment to "
             "every gcloud/kubectl/hermes child it spawns, and its docstring "
@@ -229,29 +255,33 @@ class TestRunEnvInheritanceContract(unittest.TestCase):
             "credential, it belongs in the credential-proxy container, or "
             "_run_env's call sites need an explicit allowlist.")
 
-    def test_the_credential_proxy_is_where_real_credentials_live(self):
-        # The other half of the invariant: this asserts the credential-proxy
-        # container does hold Secret-backed values, so a refactor that emptied
-        # it -- moving credentials into the sandbox -- cannot leave the test
-        # above passing against a container that simply has no secrets at all.
-        with self.GOLDEN.open() as handle:
-            import yaml
-            docs = [d for d in yaml.safe_load_all(handle) if d]
-        deployment = next(d for d in docs if d.get("kind") == "Deployment")
-        proxies = [
-            c for c in deployment["spec"]["template"]["spec"]["containers"]
-            if c.get("name") == "envoy-credential-proxy"
+    def test_the_sandbox_bulk_mounts_no_secret(self):
+        # The half the Go allowlist loop cannot see: it walks `env` only, so an
+        # `envFrom.secretRef` puts every key of a Secret into this container
+        # with TestBuildDeployment still green.
+        bulk = [
+            source for source in self._container(self.SANDBOX_CONTAINER).get("envFrom", [])
+            if source.get("secretRef")
         ]
-        self.assertEqual(len(proxies), 1, "credential-proxy container not found in golden")
-        secret_backed = {
-            env["name"]
-            for env in proxies[0].get("env", [])
-            if (env.get("valueFrom") or {}).get("secretKeyRef")
-        }
-        self.assertTrue(
-            secret_backed,
-            "the credential-proxy container has no Secret-backed environment; "
-            "if credentials moved, they must not have moved into the sandbox")
+        self.assertEqual(
+            bulk, [],
+            "The sandbox container bulk-mounts a Secret through envFrom, which "
+            "puts every key in it into the environment _run_env hands to each "
+            "child. Name the variables individually under `env` so the allowlist "
+            "above and the Go one both see them.")
+
+    def test_the_credential_proxy_is_where_real_credentials_live(self):
+        # Keeps the test above from passing for the wrong reason. If a refactor
+        # moved credentials out of the proxy, the next question is whether they
+        # landed in the sandbox, and the sandbox assertion alone reads the same
+        # either way.
+        secret_backed = self._secret_backed(self._container(self.PROXY_CONTAINER))
+        self.assertIn(
+            self.PROXY_CREDENTIAL, secret_backed,
+            f"{self.PROXY_CREDENTIAL} is no longer Secret-backed on the "
+            f"{self.PROXY_CONTAINER} container (found {sorted(secret_backed)}). "
+            "If credentials moved, they must not have moved into the sandbox; "
+            "update PROXY_CREDENTIAL to whichever one now anchors this.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`_run_env()` in `agent_common_server.py` hands a child process the caller's entire environment.
That is safe in this repository today, but it is safe because of facts that live in other files
— the operator keeps the sandbox container's Secret-backed environment to two pod-scoped
Session KV values, and no current caller spawns across a UID or container boundary — and
neither was stated where the helper is. This adds the docstring that states them, pointing at
`docs/credential-isolation-design.md` for the canonical version, and a Python-side guard over
the rendered golden manifest. No runtime behaviour changes; `_run_env`'s body is untouched.

## Why This Change

The helper reads as an ordinary convenience wrapper, so the natural way to add a caller is to
reach for it. That is correct as long as the sandbox holds nothing worth leaking. The day a
third Secret-backed variable is added to that container, or a caller spawns something across a
privilege boundary, every existing call site becomes a credential leak at once — and nothing in
this file said so.

The concrete gap the guard closes is `envFrom`. `TestBuildDeployment` already fails on a third
`secretKeyRef` in the sandbox, so that much is covered on the Go side. But its loop walks
`container.Env` only, so a single `envFrom.secretRef` in the operator passes it while
bulk-mounting every key of `platform-agent-secrets` into the sandbox — Slack tokens, `api-key` —
and `_run_env` hands the lot to every `gcloud`, `kubectl` and `hermes send` child.

`TestAgentsGolden` does catch that mutation, but only as a golden mismatch, and the routine
response to a golden mismatch is `go test ./internal/testing -update`. Regenerate, and the whole
Go suite passes with the bulk mount in place. The test added here is what is left standing at
that point. The operator uses no `EnvFrom` today; this keeps it that way.

This is a regression guard, not a fix. There is no vulnerability here now.

## What Changed

- `agents/platform/scripts/agent_common_server.py` — `_run_env`'s docstring states the two
  properties its safety rests on, names the code enforcing each, links the design doc that owns
  the fact, and says what a new caller should do instead. Body unchanged.
- `agents/platform/scripts/test_agent_common_server.py` — `TestRunEnvInheritanceContract` reads
  the golden manifest at
  `k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml` and asserts
  three things about the rendered Deployment: the `platform-agent` container's `secretKeyRef`
  environment is exactly `SESSION_KV_API_KEY` and `SESSION_KV_SALT`; that container bulk-mounts
  no Secret through `envFrom`; and `API_SERVER_EXTERNAL_KEY` is still Secret-backed on
  `envoy-credential-proxy`, so credentials leaving the proxy cannot go unnoticed. Each failure
  message names `_run_env` and the dispositions available to whoever trips it.

## Context

**Conflicts with #735.** That PR rewrites the same `_run_env` docstring line to pin
`HERMES_HOME`, so whichever merges second needs a manual resolution. The changes are compatible
in substance — #735 changes the body, this changes the prose around it — and the resolution is
to keep both.

This came out of triaging bnaylor's security audit. It is not one of that report's findings:
MCP-003, which it started as, turned out to already be closed by the credential-proxy split.
This is what was left once that premise was withdrawn.

Generated with the help of Claude.

## Testing

- `python3 -m unittest test_agent_common_server`: 10 tests, all passing (3 new).
- Mutation-tested, three mutations, each killing exactly one test and no others: a third
  `secretKeyRef` in the sandbox container of the golden →
  `test_the_sandbox_holds_only_the_two_pod_scoped_secrets`; an `envFrom.secretRef` on the same
  container → `test_the_sandbox_bulk_mounts_no_secret`; renaming `API_SERVER_EXTERNAL_KEY` on
  the proxy → `test_the_credential_proxy_is_where_real_credentials_live`. The fixture was
  restored and the suite re-run green.
- Mutated the operator itself, not just the golden: `EnvFrom` with a `secretRef` on
  `platform-agent-secrets` added to the sandbox container in `platformagent_manifests.go`.
  `TestBuildDeployment` passes, `TestAgentsGolden` fails; after
  `go test ./internal/testing -update` the entire Go suite passes and only
  `test_the_sandbox_bulk_mounts_no_secret` fails. `platformagent_manifests.go` and all three
  regenerated goldens were restored, and `go test ./...` plus the Python suite re-run green.
- `make docs-check` passes.

### Live validation

Not live-tested, and not testable against a running installation: the diff is a docstring and
three assertions over a checked-in test fixture. Nothing here executes in a pod, and no
behaviour reaches one.

The facts the docstring asserts were verified against `platformagent_manifests.go`, the golden
manifest, `platformagent_manifests_test.go`, and `agents/platform/config.yaml` rather than
against a cluster. One claim could not be closed from this repository at all: `_build_safe_env`
lives in hermes (`tools/mcp_tool.py`), which is neither checked in nor vendored here, so the
statement that Hermes narrows an MCP child's environment to an allowlist rests on this repo's
own prose — `agents/platform/config.yaml:45` and the site's `reference/config.md` — rather than
on the source. Flagging it because verifying identifiers against docs instead of source is
exactly what AGENTS.md warns against, and a reviewer with the hermes tree can settle it in a
minute. No test artifacts were created on any cluster.

## Self-Review

Adversarial and docs-drift, each run by a subagent given only the diff range and the skill file
— no plan, no reasoning, no summary from the session that wrote the change. Angles covered:
line-by-line reading, docstring claims traced to source, mutation testing of every assertion
(mutating both the golden and the operator itself), vacuous-pass analysis, path arithmetic,
cross-language coupling, reuse, ops/security scope, altitude, and repository conventions.
`kube-agents-bot` then reviewed the result and found a false claim both earlier passes had let
through; its finding and the mutation run that confirmed it are the first bullet below.

Dispositions:

- **The docstring's "with every Go test green" was false, and this body repeated it twice.**
  Raised by `kube-agents-bot`. I had run `TestBuildDeployment` against an operator mutated to add
  `envFrom.secretRef` on the sandbox container, seen it pass, and written that up as "Go tests
  stayed green" — but never ran the golden test on that mutation. Re-run properly:
  `TestBuildDeployment` does pass (its loop walks `container.Env` only, so the `envFrom` blindness
  is real), while `TestAgentsGolden` **fails**, printing the `+ envFrom: - secretRef: name:
  platform-agent-secrets` diff. The claim was also self-contradictory — four lines earlier the
  same docstring concedes `TestAgentsGolden` fails alongside `TestBuildDeployment` for the `env`
  case. **Fixed** in the docstring and in both body claims above.

  The narrower claim is true and is what the text now says: run
  `go test ./internal/testing -update`, the routine response to a golden mismatch, and the golden
  absorbs the bulk mount. I verified this end to end — after regenerating, `go test ./...` across
  the operator is entirely green (`api/v1alpha1`, `cmd/k8s-event-watcher`, `internal/controller`,
  `internal/testing`, `internal/webhook` all `ok`) with every key of `platform-agent-secrets`
  mounted into the sandbox, and `test_the_sandbox_bulk_mounts_no_secret` is the only thing that
  fails. Both fixtures were restored and both suites re-run green.
- **The test class claimed a third Secret-backed variable "would pass every Go test".** It would
  not. Adding a third `secretKeyRef` to the operator and running `go test` fails
  `TestBuildDeployment` with `sandbox must not receive Secret-backed environment variable
  GITHUB_TOKEN`, and `TestAgentsGolden` fails alongside it. The claim also contradicted the
  docstring four lines away in the same diff, which cites that test as the enforcement. **Fixed**
  in aa0da02c — replaced with what the test actually buys, which reframes this PR from "mirror
  the Go guard" to "close the `envFrom` hole the Go guard cannot see, and put a signal beside the
  Python that depends on the invariant".
- **Neither test saw `envFrom.secretRef`, so the invariant the docstring asserted was not
  actually enforced.** **Fixed** — `test_the_sandbox_bulk_mounts_no_secret`, which is now the
  coverage this branch uniquely adds. See the review-round correction below for what the
  mutation evidence actually shows; the original bullet here overstated it.
- **`test_the_credential_proxy_is_where_real_credentials_live` did not test what its comment
  claimed.** It asserted only that the proxy has some Secret-backed environment, which
  `SESSION_KV_API_KEY` satisfies — and that value is pod-scoped and also on the sandbox, so
  deleting the proxy's last real credential left the test green. Confirmed by mutation.
  **Fixed** — asserts `API_SERVER_EXTERNAL_KEY` by name.
- **Off-by-one: the docstring said "a fourth variable" where the allowlist holds two.**
  **Fixed.**
- **`SESSION_KV_SALT` described as "useless off this pod's loopback".** It is an HMAC salt;
  leaking it grants no access but enables offline de-pseudonymisation of stored identity hashes.
  **Fixed** — uses the design doc's wording, which is correct for both values. Docs-drift raised
  this independently.
- **A fourth copy of a fact whose canonical home is `docs/credential-isolation-design.md`, with
  no link, where the equivalent Go comment already links it.** Both passes raised this.
  **Fixed** — the docstring now points at "The loopback-only exception".
- **"session_kv_server holds the whole container environment" is true of only one of its two
  spawn shapes** — the MCP-spawned fallback inherits the stdio allowlist, which names
  `SESSION_KV_API_KEY` and not the salt. The safety argument survives (narrower is safer) but the
  premise was stated as universal. **Fixed** — stated, with the warning not to read it as a
  promise that the salt is present.
- **Duplicated golden loading, `import yaml` twice inside method bodies, and an asymmetric guard
  between the two tests.** **Fixed** — one `_container()` helper, module-scope import, and a
  directed failure when the golden file itself has moved.
- **`docs/credential-isolation-design.md:381` now under-describes its own enforcement** — it says
  "the assertion enumerates them" where there are now two enumerating assertions. Non-blocking,
  and nothing it says becomes false. **Not fixed**: the doc is accurate as written, and editing a
  design document to mention a test is the kind of coupling that goes stale next. If a reviewer
  wants the clause, it is one line.

Docs-drift: no Blocking findings, `make docs-check` green. Neither branch adds or moves a
Markdown file, so no `docs/README.md` entry is owed.

## Risk & Rollout

Low: no runtime code path changes. The one new failure mode is CI — a legitimate future addition
to the sandbox's Secret allowlist now fails this Python test as well as the Go one, which is the
intent, and the message says what to do. The test reads a Go-side fixture from a Python suite,
which is established practice here (`test_gke_endpoint_parity.py` does the same with the same
`parents[3]` idiom), but moving that testdata tree breaks it; the failure names the file.
Reverting the two commits removes the docstring and the guard together.
