### PR TITLE
fix(ci): authenticate GA release steps with release bot token

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           ref: refs/heads/main
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - name: Calculate Next Release Version
         id: calculate-version
@@ -61,7 +62,7 @@ jobs:
           RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
           SKIP_RC_VALIDATION: ${{ inputs.skip_rc_validation }}
           EMERGENCY_OVERRIDE_REASON: ${{ inputs.emergency_override_reason }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/verify_release_eligibility.sh
 
       - name: Set up Docker Buildx
@@ -104,7 +105,7 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
           RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           GH_USER: ${{ github.actor }}
         run: ./scripts/release/publish_helm_chart.sh
 
@@ -113,14 +114,13 @@ jobs:
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
           RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/tag_ga_release.sh
 
-      # Note: If repository tag/release protection rules restrict github-actions[bot],
-      # this step or git tag push may fail with 403 unless GITHUB_TOKEN has bypass permissions.
       - name: Publish GitHub Release
         if: steps.verify-eligibility.outputs.skip_release != 'true'
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
           RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/publish_github_release.sh

--- a/tests/testing/common.py
+++ b/tests/testing/common.py
@@ -106,7 +106,7 @@ def get_isolated_test_env(overrides=None, bin_dir=None):
     env = {
         k: v
         for k, v in os.environ.items()
-        if not k.startswith(("GITHUB_", "RUNNER_")) and k not in ("CI", "CONTINUOUS_INTEGRATION")
+        if not k.startswith(("GITHUB_", "RUNNER_")) and k not in ("CI", "CONTINUOUS_INTEGRATION", "GH_TOKEN")
     }
     if bin_dir:
         env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"


### PR DESCRIPTION
## Summary

Authenticates all GitHub Actions steps in the GA release publication workflow (`release-publish.yml`) with `RELEASE_BOT_TOKEN` so that git tag push operations satisfy repository tag protection rulesets (`kube-agents-tag-protection`), matching the authentication convention used by RC tag creation workflows. Also adds `GH_TOKEN` to `get_isolated_test_env`'s environment strip list in `tests/testing/common.py` to ensure hermetic offline test execution when `GH_TOKEN` is exported in local developer shells.

## Why This Change

Running the GA release workflow failed during `tag_ga_release.sh` with `GH013: Repository rule violations found for refs/tags/0.1.0` because `kube-agents-tag-protection` restricts tag creation exclusively to authorized bypass actors, rejecting the default unprivileged `GITHUB_TOKEN`. In addition, running python unit tests locally with `GH_TOKEN` exported caused `test_verify_release_eligibility.py` to attempt live unmocked queries against `gke-labs/kube-agents`, failing test execution.

## What Changed

- **`.github/workflows/release-publish.yml`**:
  - Configured `actions/checkout` with `token: ${{ secrets.RELEASE_BOT_TOKEN }}` so `git push` in `tag_ga_release.sh` executes with bypass permissions.
  - Supplied `GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}` to `verify-eligibility`, `publish-helm-chart`, `tag-ga-release`, and `publish-github-release` steps.
- **`tests/testing/common.py`**:
  - Added `"GH_TOKEN"` to the list of stripped environment variables in `get_isolated_test_env()` to maintain strict test hermeticity.

## Context

- Follow-up fix to GA release orchestration workflow (#803).
- Addresses failed GA release run: https://github.com/gke-labs/kube-agents/actions/runs/32482743352/job/96772478049.

## Testing

- `python3 -m unittest discover -s tests` (all 272 unit tests passed).
- `GH_TOKEN="test_token_123" python3 -m unittest discover -s tests` (verified 272/272 tests pass hermetically even with `GH_TOKEN` exported).
- `make docs-check && make chart-check` (passed, 253 Markdown files checked).

### Live validation

- **Not live-tested on release publishing**: Workflow change addressing CI pipeline authentication and tag push permissions under repository rulesets. The fix was validated by comparing with the existing working tag push implementation in `rc-create-tag.yml` and `rc-tag-validated.yml`, and by reproducing and resolving the `GH_TOKEN` leak in `test_verify_release_eligibility.py`.

## Self-Review

- Verified least-privilege scoping remains intact (`contents: read` at top level, `github.ref == refs/heads/main` ref guard).
- Confirmed `RELEASE_BOT_TOKEN` secret is configured in the upstream `gke-labs/kube-agents` repository.
- Verified test suite passes cleanly with zero environment pollution.

## Risk & Rollout

- **Low risk**: Modifies CI workflow authentication and test fixture environment isolation without touching runtime agent or operator code.