### PR TITLE
fix(operator): pin a gateway progress deadline and size the rollout gates to match

### DIFF
--- a/.github/workflows/reusable-deploy-agent.yml
+++ b/.github/workflows/reusable-deploy-agent.yml
@@ -131,8 +131,21 @@ jobs:
 
       - name: Verify Agent Deployment Rollout
         run: |
+          # This is the only step that waits for the agent to come up. The
+          # helm --wait above returns in seconds because the chart's resource
+          # is the PlatformAgent CR, not the Deployment: the CR is ready
+          # immediately and the operator reconciles it into
+          # platform-agent-gateway afterwards, so --wait never watches the
+          # slow part.
+          #
+          # 180s was under the cold-start cost and failed deploys that had
+          # actually succeeded. On Autopilot a rollout onto a scaled-down node
+          # pays node scale-up plus an agent image pull before the container
+          # even starts: measured 215s in autopush and 259s in staging, the
+          # latter spending 212s of it pre-Initialized. Both reported red
+          # while the pod went Ready moments later.
           echo "Waiting for rollout of platform-agent-gateway deployment..."
-          if ! kubectl rollout status deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} --timeout=180s; then
+          if ! kubectl rollout status deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} --timeout=600s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} || true
             kubectl get pods -n ${{ env.NAMESPACE }} -l app=platform-agent-gateway || true

--- a/.github/workflows/reusable-deploy-agent.yml
+++ b/.github/workflows/reusable-deploy-agent.yml
@@ -144,8 +144,17 @@ jobs:
           # even starts: measured 215s in autopush and 259s in staging, the
           # latter spending 212s of it pre-Initialized. Both reported red
           # while the pod went Ready moments later.
+          #
+          # 900s, and it has to stay inside the ordering tests/test_hindsight_probes.py
+          # records: startupProbe budget < rollout gate < progressDeadlineSeconds.
+          # The gateway's agentAPIProbe(10, 60) sanctions a 605s cold boot, and
+          # the repo's own derivation adds a 240s pull allowance on top, giving
+          # 845s; 900 rounds that up. The ceiling is the gateway Deployment's
+          # progressDeadlineSeconds, which the operator now pins at 1200s —
+          # above that the Deployment reports ProgressDeadlineExceeded and this
+          # wait returns early however long it was given.
           echo "Waiting for rollout of platform-agent-gateway deployment..."
-          if ! kubectl rollout status deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} --timeout=600s; then
+          if ! kubectl rollout status deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} --timeout=900s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/platform-agent-gateway -n ${{ env.NAMESPACE }} || true
             kubectl get pods -n ${{ env.NAMESPACE }} -l app=platform-agent-gateway || true

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -231,8 +231,12 @@ jobs:
 
       - name: Verify LiteLLM Deployment Rollout
         run: |
+          # 600s, not 180s: on Autopilot a rollout onto a scaled-down node pays
+          # node scale-up plus an image pull before the container starts, which
+          # measured over 180s on both installs. See the comment on the agent
+          # rollout in reusable-deploy-agent.yml for the numbers.
           echo "Waiting for rollout of LiteLLM deployment..."
-          if ! kubectl rollout status deployment/litellm -n "$NAMESPACE" --timeout=180s; then
+          if ! kubectl rollout status deployment/litellm -n "$NAMESPACE" --timeout=600s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/litellm -n "$NAMESPACE" || true
             kubectl get pods -n "$NAMESPACE" -l app=litellm || true
@@ -390,8 +394,9 @@ jobs:
 
       - name: Verify GitHub Token Minter Deployment Rollout
         run: |
+          # 600s for the same reason as the LiteLLM rollout above.
           echo "Waiting for rollout of github-token-minter deployment..."
-          if ! kubectl rollout status deployment/github-token-minter -n "$NAMESPACE" --timeout=180s; then
+          if ! kubectl rollout status deployment/github-token-minter -n "$NAMESPACE" --timeout=600s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/github-token-minter -n "$NAMESPACE" || true
             kubectl get pods -n "$NAMESPACE" -l app=github-token-minter || true

--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -231,12 +231,16 @@ jobs:
 
       - name: Verify LiteLLM Deployment Rollout
         run: |
-          # 600s, not 180s: on Autopilot a rollout onto a scaled-down node pays
+          # 420s, not 180s: on Autopilot a rollout onto a scaled-down node pays
           # node scale-up plus an image pull before the container starts, which
           # measured over 180s on both installs. See the comment on the agent
-          # rollout in reusable-deploy-agent.yml for the numbers.
+          # rollout in reusable-deploy-agent.yml for the numbers and the
+          # ordering this has to keep. litellm's startupProbe budget is 180s
+          # plus the repo's 240s pull allowance; 420s stays under this
+          # Deployment's 600s default progressDeadlineSeconds, which is the
+          # ceiling any wait here returns at.
           echo "Waiting for rollout of LiteLLM deployment..."
-          if ! kubectl rollout status deployment/litellm -n "$NAMESPACE" --timeout=600s; then
+          if ! kubectl rollout status deployment/litellm -n "$NAMESPACE" --timeout=420s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/litellm -n "$NAMESPACE" || true
             kubectl get pods -n "$NAMESPACE" -l app=litellm || true
@@ -394,9 +398,12 @@ jobs:
 
       - name: Verify GitHub Token Minter Deployment Rollout
         run: |
-          # 600s for the same reason as the LiteLLM rollout above.
+          # 420s for the same reason as the LiteLLM rollout above. The minter
+          # has no startupProbe and a small image, so this is pull allowance
+          # and headroom rather than a derived budget; it stays under the 600s
+          # default progressDeadlineSeconds either way.
           echo "Waiting for rollout of github-token-minter deployment..."
-          if ! kubectl rollout status deployment/github-token-minter -n "$NAMESPACE" --timeout=600s; then
+          if ! kubectl rollout status deployment/github-token-minter -n "$NAMESPACE" --timeout=420s; then
             echo "::error::Rollout failed! Printing debug logs..."
             kubectl describe deployment/github-token-minter -n "$NAMESPACE" || true
             kubectl get pods -n "$NAMESPACE" -l app=github-token-minter || true

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -1955,10 +1955,25 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 	}
 }
 
+// gatewayProgressDeadlineSeconds is the ceiling over every rollout wait on the
+// gateway Deployment, and it has to outlast both of the budgets under it:
+//
+//	startupProbe budget  <  rollout gate  <  progressDeadlineSeconds
+//
+// Past the deadline the Deployment reports ProgressDeadlineExceeded and any
+// caller's wait returns early however long it asked for, so a gate raised above
+// this number buys nothing. Kubernetes defaults it to 600s, which is *below*
+// the 605s cold boot agentAPIProbe(10, 60) already sanctions — the kubelet is
+// told to tolerate a boot the Deployment gives up on. 1200s clears the 900s
+// deploy gate in .github/workflows/reusable-deploy-agent.yml. hindsight-api
+// carries an explicit 900 for the same reason; see tests/test_hindsight_probes.py.
+const gatewayProgressDeadlineSeconds int32 = 1200
+
 // buildDeployment generates the Deployment manifest for the agent payload
 func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string, agentPlugins []*agentv1alpha1.AgentPlugin, opts renderOptions) *appsv1.Deployment {
 	replicas, strategy := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
 	podTemplate := buildPodTemplateSpec(agent, configHash, fluentBitHash, settingsConfigHash, policyHash, agentPlugins, opts)
+	progressDeadline := gatewayProgressDeadlineSeconds
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -1974,8 +1989,9 @@ func buildDeployment(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHa
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Strategy: strategy,
+			Replicas:                &replicas,
+			Strategy:                strategy,
+			ProgressDeadlineSeconds: &progressDeadline,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": agent.Name + "-gateway",

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -494,6 +494,7 @@ metadata:
       name: platformagent
       uid: ""
 spec:
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -459,6 +459,7 @@ metadata:
       name: platformagent
       uid: ""
 spec:
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -494,6 +494,7 @@ metadata:
       name: platformagent
       uid: ""
 spec:
+  progressDeadlineSeconds: 1200
   replicas: 1
   selector:
     matchLabels:

--- a/tests/test_gateway_rollout_budgets.py
+++ b/tests/test_gateway_rollout_budgets.py
@@ -1,0 +1,143 @@
+"""Tests for the platform-agent-gateway rollout budgets.
+
+The companion to test_hindsight_probes.py, for the Deployment the redeploy
+workflows actually gate on. The same three numbers have to stay in the same
+order:
+
+    startupProbe budget  <  rollout gate  <  progressDeadlineSeconds
+
+The upper bound is the hard one. Past the deadline the Deployment reports
+ProgressDeadlineExceeded and any caller's wait returns early however long it
+was given, so a gate at or above the deadline buys nothing.
+
+The gateway spent a long time violating this on both sides. Kubernetes
+defaults progressDeadlineSeconds to 600s, and nothing set it, while
+agentAPIProbe(10, 60) sanctions a 605s cold boot -- the kubelet was told to
+tolerate a boot the Deployment gives up on. The rollout gate sat at 180s,
+under both, and reported red on deploys that had succeeded: a gateway pod
+measured 215s to Ready in autopush and 259s in staging.
+
+Every number is read from the source that owns it rather than hardcoded here,
+so raising one cannot leave this suite asserting against a value no install
+uses.
+"""
+
+import pathlib
+import re
+import unittest
+
+_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_MANIFESTS_GO = _ROOT / "k8s-operator" / "internal" / "controller" / "platformagent_manifests.go"
+_AGENT_WORKFLOW = _ROOT / ".github" / "workflows" / "reusable-deploy-agent.yml"
+_INTEGRATIONS_WORKFLOW = _ROOT / ".github" / "workflows" / "reusable-deploy-integrations.yml"
+
+# What the gate must have over the startupProbe budget, in seconds, for the
+# node scale-up and image pull that precede the container starting at all.
+# Matches the allowance test_hindsight_probes.py derives its gate from.
+_PULL_ALLOWANCE_SECONDS = 240
+
+# Kubernetes' default when a Deployment does not set progressDeadlineSeconds.
+# The integrations Deployments below rely on it rather than setting their own.
+_DEFAULT_PROGRESS_DEADLINE_SECONDS = 600
+
+
+def _gateway_startup_budget_seconds():
+    """How long the gateway's startupProbe tolerates failure.
+
+    Both halves come from the Go source: the call site fixes periodSeconds and
+    failureThreshold, and agentAPIProbe fixes initialDelaySeconds. Counting the
+    initial delay matters -- omitting it under-reports the budget, which is the
+    direction that hides a violation.
+    """
+    text = _MANIFESTS_GO.read_text()
+
+    call = re.search(r"StartupProbe:\s*agentAPIProbe\((\d+),\s*(\d+)\)", text)
+    assert call, "could not find the gateway StartupProbe call to agentAPIProbe"
+    period, failure_threshold = int(call.group(1)), int(call.group(2))
+
+    body = re.search(r"func agentAPIProbe\([^)]*\)[^{]*\{.*?\n\}", text, re.DOTALL)
+    assert body, "could not find func agentAPIProbe"
+    initial = re.search(r"InitialDelaySeconds:\s*(\d+)", body.group(0))
+    assert initial, "could not find InitialDelaySeconds in agentAPIProbe"
+
+    return int(initial.group(1)) + period * failure_threshold
+
+
+def _gateway_progress_deadline_seconds():
+    """The ceiling the operator pins on the gateway Deployment."""
+    match = re.search(
+        r"const gatewayProgressDeadlineSeconds int32 = (\d+)", _MANIFESTS_GO.read_text()
+    )
+    assert match, "could not find gatewayProgressDeadlineSeconds in platformagent_manifests.go"
+    return int(match.group(1))
+
+
+def _rollout_gate_seconds(workflow, deployment):
+    """The --timeout on a `kubectl rollout status` for one Deployment."""
+    match = re.search(
+        rf"kubectl rollout status deployment/{re.escape(deployment)}\b[^\n]*?--timeout=(\d+)s",
+        workflow.read_text(),
+    )
+    assert match, f"could not find the rollout gate for {deployment} in {workflow.name}"
+    return int(match.group(1))
+
+
+class GatewayRolloutBudgetTest(unittest.TestCase):
+    """The three gateway budgets, and the order they have to stay in."""
+
+    def setUp(self):
+        self.startup = _gateway_startup_budget_seconds()
+        self.gate = _rollout_gate_seconds(_AGENT_WORKFLOW, "platform-agent-gateway")
+        self.deadline = _gateway_progress_deadline_seconds()
+
+    def test_the_gate_covers_the_startup_budget_and_the_image_pull(self):
+        self.assertGreaterEqual(
+            self.gate,
+            self.startup + _PULL_ALLOWANCE_SECONDS,
+            f"a {self.gate}s gate leaves {self.gate - self.startup}s for node scale-up and "
+            f"an image pull on top of a {self.startup}s startupProbe budget; the workflow "
+            "fails the deploy when it expires, so this reds a rollout that succeeded",
+        )
+
+    def test_the_progress_deadline_outlasts_the_gate(self):
+        # Without this the gate is decorative: kubectl rollout status returns
+        # "exceeded its progress deadline" the moment the Deployment gives up,
+        # however long the caller asked to wait.
+        self.assertGreater(
+            self.deadline,
+            self.gate,
+            f"a {self.gate}s gate against a {self.deadline}s progressDeadlineSeconds cannot "
+            "run its full length; raise the deadline in the operator, not just the gate",
+        )
+
+    def test_the_progress_deadline_outlasts_the_startup_budget(self):
+        # The inversion this file exists for: the kubelet tolerating a longer
+        # cold boot than the Deployment will wait for means a pod using its
+        # sanctioned startup time is failed by the Deployment regardless of
+        # what any gate says.
+        self.assertGreater(
+            self.deadline,
+            self.startup,
+            f"agentAPIProbe sanctions a {self.startup}s cold boot the Deployment abandons "
+            f"at {self.deadline}s",
+        )
+
+
+class IntegrationsRolloutGateTest(unittest.TestCase):
+    """The integrations gates rely on the default deadline, so they stay under it."""
+
+    def test_gates_stay_under_the_default_progress_deadline(self):
+        for deployment in ("litellm", "github-token-minter"):
+            with self.subTest(deployment=deployment):
+                gate = _rollout_gate_seconds(_INTEGRATIONS_WORKFLOW, deployment)
+                self.assertLess(
+                    gate,
+                    _DEFAULT_PROGRESS_DEADLINE_SECONDS,
+                    f"{deployment} sets no progressDeadlineSeconds, so it runs on the "
+                    f"{_DEFAULT_PROGRESS_DEADLINE_SECONDS}s default; a {gate}s gate cannot "
+                    "run its full length. Set an explicit deadline first, as the gateway does",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The three `kubectl rollout status` gates in the reusable deploy workflows waited 180s, which is
under what a cold start on Autopilot actually costs, and they were failing deploys that had
succeeded: the workflow reported red, and the image it had just deployed is the one the cluster
ended up running. Raising the gates alone turned out not to be enough — the gateway Deployment
had no `progressDeadlineSeconds`, so the Kubernetes default of 600s capped any wait regardless of
`--timeout`, and the operator was already sanctioning a 605s cold boot the Deployment abandons at
600s. This fixes the ordering as well as the numbers, and adds a test that holds it.

## Why This Change

`kubectl rollout status` is the only step in these workflows that waits for a workload to become
available. The `helm upgrade --wait --timeout 10m` above it looks like it should cover this, but
it returns in seconds: the chart's resource is the `PlatformAgent` CR, not the Deployment. The CR
reports ready as soon as it is applied, and the operator reconciles it into
`platform-agent-gateway` asynchronously afterwards — so `--wait` never watches the slow part.

That left 180s to absorb a full cold start. On Autopilot a rollout onto a scaled-down node pays
node scale-up plus an image pull before the container process starts. Measured time-to-Ready for
the gateway pod:

| Install | Time to Ready | Of which pre-`Initialized` |
| --- | --- | --- |
| autopush | 215s | 67s |
| staging (kube-agents-gkedemos) | 259s | 212s |

It presented as flakiness rather than a hard failure because a warm node lands well inside 180s —
2 of the last 6 `autopush-redeploy-agent` runs failed this way (`d36b1319`, `f4dba1ea`).

`tests/test_hindsight_probes.py` records the ordering these budgets have to keep:

```
startupProbe budget  <  rollout gate  <  progressDeadlineSeconds
```

Past the deadline the Deployment reports `ProgressDeadlineExceeded` and any caller's wait returns
early however long it asked for. Read off the live autopush cluster, only `hindsight-api` held
that ordering:

| Deployment | `progressDeadlineSeconds` | startupProbe budget |
| --- | --- | --- |
| `platform-agent-gateway` | 600 (k8s default, unset) | 605s |
| `litellm` | 600 (default, unset) | 180s |
| `github-token-minter` | 600 (default, unset) | none |
| `hindsight-api` | 900 (explicit) | 300s |

The gateway violated it on both sides. Its `agentAPIProbe(10, 60)` budget is 605s — the kubelet is
told to tolerate a cold boot the Deployment gives up on at 600s — an inversion that predates this
branch and that no gate value can work around.

## What Changed

- `k8s-operator/internal/controller/platformagent_manifests.go` — pin
  `gatewayProgressDeadlineSeconds = 1200` on the gateway Deployment, following the precedent
  `hindsight-api` sets with its explicit 900. This is the change that makes raising the gate mean
  anything.
- `.github/workflows/reusable-deploy-agent.yml` — gateway gate 180s → 900s. The repo's own
  derivation (`startup + 240s` pull allowance) gives 845; 900 rounds it up and sits under the new
  1200s deadline.
- `.github/workflows/reusable-deploy-integrations.yml` — `litellm` and `github-token-minter` gates
  180s → 420s, derived the same way and deliberately left under the 600s default deadline they
  still rely on, rather than giving them deadlines they do not need.
- `tests/test_gateway_rollout_budgets.py` — new, the companion to the hindsight suite. Asserts the
  full ordering for the gateway and that the integrations gates stay under the default deadline.
  Every number is read from the source that owns it, so raising one cannot leave the suite
  asserting against a value no install uses.

## Context

Found while checking whether a `staging/**` tag push would deploy correctly after
`kube-agents-gkedemos` was reinstalled onto the Terraform + Helm engine. It would have tripped
this gate, so the red would have said nothing about staging.

Adjacent to #836, which stopped deploys cancelling each other mid-upgrade and taught them to wait
out the Helm release lock. This is the next layer down: the deploy completes, but the verification
gate does not wait long enough to see it.

No open PR or issue covers this — searched open PRs for `rollout timeout` and open issues for
rollout/timeout/180/flaky.

## Testing

- `tests/test_gateway_rollout_budgets.py` — 4 tests, pass. Negative control run: reverting the
  gateway gate to the 600s of the first commit fails it with `600 not greater than or equal to 845
  ... leaves -5s for node scale-up and an image pull`.
- `tests/test_hindsight_probes.py` — 8 tests, still pass.
- `scripts/test_domain_coverage.py` — passes.
- `go build ./...`, `go vet ./internal/controller/`, `gofmt -l` — all clean.
- `make docs-check` — passes.
- `prettier --check` on both changed workflows — clean.

Not run locally: the operator Go test suite. Every locally built Go binary is SIGKILLed on this
machine, so `go test` cannot run here and CI's `Run Controller Tests` is the only runner for it.

**That gap produced a real miss.** I checked by hand for golden fixtures, looked in
`internal/controller/testdata`, found no such directory, and reported there were none. They live in
`internal/testing/testdata`. `TestAgentsGolden` renders the PlatformAgent manifests and diffs them
against checked-in YAML, so pinning `progressDeadlineSeconds` left all three platform goldens
stale and CI failed on the first push of 357d07ba. Fixed in 23568aeb by adding
`progressDeadlineSeconds: 1200` to the Deployment spec in `platformagent.yaml`,
`platformagent-telemetry.yaml`, and `platformagent-tagged.yaml` — written by hand, since
`go test -update` cannot run here either. `CompareGolden` parses both sides and diffs the parsed
objects, so only the value matters, but it is placed before `replicas` to match the serializer's
alphabetical key order.

The rest of that hand-check still holds and CI has now confirmed the parts it covers: no test in
`internal/controller` references `ProgressDeadlineSeconds`, and the ~20 `buildDeployment` call
sites assert on named fields rather than comparing whole structs.

`scripts/test_test_discovery.py` fails in my checkout, but only on 74 directories under
`.claude/worktrees/` — stale local review worktrees. No tracked path is implicated and CI checks
out clean.

### Live validation

Not live-tested as a change. A workflow edit only takes effect on a run of that workflow in
`gke-labs/kube-agents`, and these fire on push-to-main and `staging/**` tags rather than on a PR
branch; the operator change needs a controller image built from this commit, which is published on
merge to main.

The defect is live-observed, on two running installs:

- **autopush** (`platform-agent-host`, us-central1, image `d36b1319…`): run
  [32483093720](https://github.com/gke-labs/kube-agents/actions/runs/32483093720) logged
  `error: timed out waiting for the condition` at 12:45:37 having started the wait at 12:42:32.
  The pod's `Ready` condition flipped at 12:45:58 — 21s after the gate gave up. Off the pod:
  created 12:42:23, `Initialized` 12:43:32, `Ready` 12:45:58 = 215s. The Helm step in that same run
  logged `Release "kube-agents" has been upgraded` at 12:42:32, 9s after pod creation, which is the
  `--wait` behaviour described above. That install is now healthy on the very image the "failed"
  run deployed: gateway 3/3 `Running`, `readyReplicas: 1`, CR phase `Ready`.
- **staging** (`kube-agents-gkedemos`, us-central1): gateway pod created 12:39:21, `Ready`
  12:43:40 = 259s, of which 212s before `Initialized`.
- The `progressDeadlineSeconds` and startupProbe-budget table above was read off the live autopush
  cluster with `kubectl get deploy -o json`, not inferred from the manifests.

What this does not prove: that 900s/1200s are enough for every cold start, only that they clear
the two worst observed with room. If a rollout genuinely hangs, the agent job now takes up to 15
minutes to say so rather than 3.

No test artifacts created; nothing to clean up.

## Self-Review

**Neither required pass was run.** `/pr-preflight` spawns a subagent per pass, this harness
requires human approval for that, and the approval was declined. Per AGENTS.md I am recording that
rather than running the passes in the session that wrote the diff and reporting the result as a
self-review — that context re-derives its own reasoning instead of testing it.

That gap had a cost, and it is worth being concrete about it: the automated review caught, on the
first commit, exactly the class of thing an adversarial pass looks for — a number that is
locally plausible and globally wrong, contradicting an invariant the repo already writes down.
Everything below the first bullet is a consequence of `kube-agents-bot`'s finding, not of my own
review.

- **`kube-agents-bot`, 🟠 Medium, `reusable-deploy-agent.yml`** — 600s equals the default
  `progressDeadlineSeconds` and sits under the gateway's 605s startup budget, so it is the one
  value the gate cannot deliver. **Confirmed and fixed** in 357d07ba. I verified each claim
  independently against source and against the live cluster before acting: the ordering rule at
  `test_hindsight_probes.py:19`, `progressDeadlineSeconds` set in exactly one place repo-wide,
  `agentAPIProbe`'s `InitialDelaySeconds: 5` with a `(10, 60)` call site, and the four live
  Deployments' actual values. All held. Not adopted verbatim: the bot's derived ~845s gate, which
  I rounded to 900.
- **Docs drift** — mechanical only, via `make docs-check` (generated regions, links, terminology,
  map coverage): clean. Grepped for prose stating any rollout timeout or progress deadline and
  found none outside the tests and comments this PR updates. The skill's prose-vs-source check did
  not run.
- **Completeness** — all three `timeout=180s` occurrences changed; verified none remains in
  `.github/workflows/`.
- **Regression risk from the Go change** — checked by hand, since Go tests cannot run locally, and
  **I got it wrong**: I searched `internal/controller/testdata` for golden fixtures, found no such
  directory, and concluded there were none. The goldens are in `internal/testing/testdata` and
  `TestAgentsGolden` failed in CI on the first push of the operator change. Refreshed in 23568aeb.
  See Testing above. This is the second finding on this PR that a hand-check by the author missed
  and an independent reader caught.
- **Scope** — no chart template, CRD, or RBAC touched, so `make chart-check` parity is unaffected.

Still open for a reviewer, since no independent pass examined it: whether 1200s is the right
deadline rather than merely a sufficient one, and whether the litellm and minter gates should get
explicit deadlines now rather than continuing to rely on the 600s default. I derived their 420s
from their own startup budgets, but I measured the *gateway* pod on both installs — I did not
observe either of those two time out.

## Risk & Rollout

Moderate, and larger than the first commit. The workflow half is CI-only. The operator half adds
`progressDeadlineSeconds: 1200` to the gateway Deployment spec, so the first reconcile after the
new controller image lands will patch every existing `platform-agent-gateway` — a metadata-level
update that does not roll pods. Raising a progress deadline only widens the window before
Kubernetes declares a rollout failed; it cannot make a healthy rollout fail. The visible downside
is a genuinely stuck agent rollout now taking up to 15 minutes to report instead of 3, still
inside the 60-minute job cap.

Revert is the two commits, and the second is safe to revert alone if the operator change is
unwanted — though doing so puts the gate back above the default deadline, which the new test will
fail on rather than let through silently. Nothing needs to happen at merge time; the next
push-to-main deploy picks up the workflow change, and the controller image carries the operator
change.

---

Generated with the help of Claude.

