### PR TITLE
feat: publish screenshot evidence for PR live validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,11 @@ default, set something distinctly different, then revert and confirm it goes bac
 Say plainly what you could NOT cover and why, and confirm any test artifacts were
 cleaned up.
 
+For a genuinely graphical surface (admin console, docs site, chat), capture and link a
+screenshot with `scripts/pr_evidence_screenshot.sh` — it publishes the image and prints
+Markdown stamped with the commit and capture time. Command output stays as fenced text
+transcripts, not screenshots.
+
 If the change cannot reach a running installation — docs-only, a CI workflow, a path
 that needs infrastructure you do not have — write "Not live-tested" and say why.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,10 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
     confirm it goes back.
   - **Say what you could not cover, and why**, rather than implying full coverage. Clean up test
     artifacts, restore prior state, and note anything left behind.
+  - **Screenshots of graphical surfaces go through `scripts/pr_evidence_screenshot.sh`**, which
+    publishes the image where a PR body can render it and prints Markdown stamped with the
+    commit and capture time. Command output stays as fenced text transcripts — a screenshot of a
+    terminal is evidence degraded, not evidence.
   - **If the install is shared with other agents, take the lease.**
     `scripts/live_test_lease.py` holds it as a ConfigMap in the install's own namespace. Copy
     `.claude/settings.json.example` to `.claude/settings.json` once per checkout and its

--- a/docs/README.md
+++ b/docs/README.md
@@ -161,6 +161,7 @@ identifier appears, add its source here.
 | Hindsight endpoint (`HINDSIGHT_API_URL`, derived from the namespace) | `k8s-operator/internal/controller/platformagent_manifests.go` |
 | Admission webhook server port (`--webhook-port` default) | `DefaultPort` in `k8s-operator/internal/webhook/platformagent_webhook.go` |
 | Live-test lease: ConfigMap name, TTL, `vars.sh` keys read, which commands count as mutations | `scripts/live_test_lease.py` |
+| PR evidence screenshots: publish branch, file-name provenance, caption format | `scripts/pr_evidence_screenshot.sh` |
 | Context budget for the always-loaded agent instruction files (`AGENTS.md`, `CLAUDE.md`) | `BUDGET` in `scripts/check_context_budget.py` |
 
 ## 3. Documentation eras and status

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -93,6 +93,7 @@ What that section should say:
 - **What you observed at each layer the change touches** — the CR `.status`, the Deployment env, the file or process inside the pod. A change that claims to reach the pod is verified by reading it in the pod.
 - **Evidence the mechanism worked, not a coincidence.** If your new value happens to equal the previous default, observing it proves nothing. Set something distinctly different, confirm it lands, then revert and confirm it goes back.
 - **What you could not cover, and why.** An honest gap is more useful than an implied one.
+- **Screenshots for graphical surfaces** (admin console, docs site, chat) come from `scripts/pr_evidence_screenshot.sh`, which publishes the image and prints Markdown stamped with the commit and capture time. Command output stays as fenced text transcripts, not screenshots.
 - **Cleanup.** Remove test artifacts, restore prior state, and note anything left behind.
 
 Some changes can't reach a running installation — docs-only edits, CI workflow changes, code paths that need infrastructure you don't have. Write "Not live-tested" and say why. An empty section is not an answer.

--- a/scripts/pr_evidence_screenshot.sh
+++ b/scripts/pr_evidence_screenshot.sh
@@ -27,7 +27,8 @@
 # behind authenticated mirrors (the same failure AGENTS.md documents for
 # `npx prettier`). The second form publishes an image you already have — a
 # macOS `screencapture` of a surface headless Chromium cannot reach, for
-# example.
+# example; its caption says "Published" because the script can only vouch for
+# the publish time and the commit at publish, not when the image was taken.
 #
 # <slug> is a short kebab-case description that becomes part of the file name
 # and the image's alt text (e.g. `kanban-task-done`). --remote names the git
@@ -73,6 +74,11 @@ else
   [[ $# -eq 2 ]] || usage
   url="$1"
   shift
+  # Anything else would reach Chromium's argv as a switch, not a URL.
+  [[ "$url" =~ ^https?:// ]] || {
+    echo "error: url must start with http:// or https:// (got: $url)" >&2
+    exit 1
+  }
 fi
 slug="$1"
 [[ "$slug" =~ ^[a-z0-9][a-z0-9-]*$ ]] || {
@@ -100,13 +106,35 @@ if [[ -z "$remote" ]]; then
   fi
   remote="${candidates[0]}"
 fi
+# Re-check whatever remote we ended up with: an explicit --remote must not
+# bypass the fork rule, or the script pushes a pr-evidence branch upstream.
+if git remote get-url "$remote" | grep -q 'gke-labs/kube-agents'; then
+  echo "error: remote '$remote' is the upstream repository; evidence goes on your fork" >&2
+  exit 1
+fi
 fork_url="$(git remote get-url "$remote")"
+fork_push_url="$(git remote get-url --push "$remote")"
 # git@github.com:owner/repo.git and https://github.com/owner/repo(.git) both
-# reduce to owner/repo.
+# reduce to owner/repo. Refuse anything else rather than paste a broken — or,
+# for a token-embedded https remote, credential-leaking — raw URL.
 fork_slug="$(echo "$fork_url" | sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##')"
+[[ "$fork_slug" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] || {
+  echo "error: unrecognized URL shape on remote '$remote'; expected git@github.com:owner/repo or https://github.com/owner/repo" >&2
+  exit 1
+}
 
 workdir="$(mktemp -d)"
-trap 'rm -rf "$workdir"' EXIT
+cleanup() {
+  status=$?
+  # A capture that published nothing may show a state that cannot be
+  # reproduced; keep the image when exiting on a failure.
+  if [[ $status -ne 0 && -n "$url" && -s "${file:-}" ]]; then
+    keep="${TMPDIR:-/tmp}/$name"
+    mv "$file" "$keep" 2>/dev/null && echo "capture preserved at $keep" >&2
+  fi
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
 
 find_browser() {
   local candidate
@@ -135,28 +163,43 @@ if [[ -n "$url" ]]; then
     exit 1
   }
   source_line="headless-Chromium screenshot of $url (window ${viewport/,/x})"
+  verb="Captured"
 else
   source_line="pre-captured image ($(basename "$file"))"
+  # For a pre-captured image the timestamp is when it was published, and the
+  # commit is HEAD at publish — say so rather than claim a capture time.
+  verb="Published"
 fi
 
 # Publish on the orphan branch: clone it if the fork already has one,
-# otherwise start it from scratch. Only ever add files.
+# otherwise start it from scratch. Only ever add files. ls-remote first so a
+# network or auth failure is not misread as "branch does not exist" (which
+# would end in a baffling non-fast-forward rejection at the push).
 clone="$workdir/pr-evidence"
-if git clone --quiet --depth 1 --branch pr-evidence "$fork_url" "$clone" 2>/dev/null; then
-  :
-else
+set +e
+git ls-remote --exit-code "$fork_url" refs/heads/pr-evidence >/dev/null 2>&1
+have_branch=$?
+set -e
+case $have_branch in
+0) git clone --quiet --depth 1 --branch pr-evidence "$fork_url" "$clone" ;;
+2)
   git init --quiet "$clone"
   git -C "$clone" checkout --quiet --orphan pr-evidence
-fi
+  ;;
+*)
+  echo "error: cannot reach remote '$remote' (git ls-remote exit $have_branch)" >&2
+  exit 1
+  ;;
+esac
 cp "$file" "$clone/$name"
 git -C "$clone" add "$name"
 git -C "$clone" commit --quiet -m "evidence: $name"
-git -C "$clone" push --quiet "$fork_url" HEAD:refs/heads/pr-evidence
+git -C "$clone" push --quiet "$fork_push_url" HEAD:refs/heads/pr-evidence
 
 raw_url="https://raw.githubusercontent.com/${fork_slug}/pr-evidence/${name}"
 cat <<EOF
 
 ![${slug}](${raw_url})
 
-_Captured ${ts} at commit ${sha} — ${source_line}._
+_${verb} ${ts} at commit ${sha} — ${source_line}._
 EOF

--- a/scripts/pr_evidence_screenshot.sh
+++ b/scripts/pr_evidence_screenshot.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Publish a screenshot as linkable evidence for a pull request's Live
+# validation section.
+# ==============================================================================
+# PRs here are opened with `gh`, and no GitHub API accepts an image the way
+# browser drag-and-drop does — that upload path is session-authenticated and
+# browser-only. So a screenshot that proves a verification step has nowhere to
+# live unless something hosts it. This script hosts it on an orphan
+# `pr-evidence` branch of the author's fork: forks of this repository are
+# public, so `raw.githubusercontent.com` URLs from that branch render inline
+# in a PR body.
+#
+# The file name carries the provenance — the commit under test and a UTC
+# timestamp — and files are only ever added to the branch, never overwritten,
+# so a published URL keeps meaning what it meant when it was pasted.
+#
+# Usage:
+#   scripts/pr_evidence_screenshot.sh [--remote <name>] <url> <slug>
+#   scripts/pr_evidence_screenshot.sh [--remote <name>] --file <path> <slug>
+#
+# The first form captures <url> with a headless Chromium: the first of
+# $PR_EVIDENCE_BROWSER, $AGENT_BROWSER_EXECUTABLE_PATH (the agent runtime
+# exports this for its bundled Playwright Chromium — deploy/shared/
+# docker-entrypoint.sh), or an installed Chrome/Chromium. Driving the binary
+# directly avoids `npx playwright`, which needs a working npm and fails
+# behind authenticated mirrors (the same failure AGENTS.md documents for
+# `npx prettier`). The second form publishes an image you already have — a
+# macOS `screencapture` of a surface headless Chromium cannot reach, for
+# example.
+#
+# <slug> is a short kebab-case description that becomes part of the file name
+# and the image's alt text (e.g. `kanban-task-done`). --remote names the git
+# remote pointing at your fork; without it the script uses the one remote
+# that is not gke-labs/kube-agents and refuses if that is ambiguous.
+#
+# Output is the ready-to-paste Markdown: the inline image plus a caption line
+# recording when, from what, and at which commit it was captured.
+set -euo pipefail
+
+usage() {
+  sed -n '/^# Usage:/,/^set -euo/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+remote=""
+file=""
+url=""
+viewport="1280,800"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --remote)
+      remote="${2:?--remote needs a value}"
+      shift 2
+      ;;
+    --file)
+      file="${2:?--file needs a path}"
+      shift 2
+      ;;
+    -h | --help) usage ;;
+    *) break ;;
+  esac
+done
+
+if [[ -n "$file" ]]; then
+  [[ $# -eq 1 ]] || usage
+  [[ -f "$file" ]] || {
+    echo "error: no such file: $file" >&2
+    exit 1
+  }
+else
+  [[ $# -eq 2 ]] || usage
+  url="$1"
+  shift
+fi
+slug="$1"
+[[ "$slug" =~ ^[a-z0-9][a-z0-9-]*$ ]] || {
+  echo "error: slug must be kebab-case (got: $slug)" >&2
+  exit 1
+}
+
+# Provenance comes from the repository the script is run in, so run it from
+# the worktree whose code the screenshot is evidence for.
+sha="$(git rev-parse --short=12 HEAD)"
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+name="${slug}-${sha}-${ts}.png"
+
+# Find the fork. PR branches live on forks (AGENTS.md, Pull Request Hygiene),
+# so the fork is any remote that is not the upstream repository.
+if [[ -z "$remote" ]]; then
+  candidates=()
+  while read -r r; do
+    git remote get-url "$r" | grep -q 'gke-labs/kube-agents' || candidates+=("$r")
+  done < <(git remote)
+  if [[ ${#candidates[@]} -ne 1 ]]; then
+    echo "error: cannot pick a fork remote from: ${candidates[*]:-none}." >&2
+    echo "Pass --remote <name>." >&2
+    exit 1
+  fi
+  remote="${candidates[0]}"
+fi
+fork_url="$(git remote get-url "$remote")"
+# git@github.com:owner/repo.git and https://github.com/owner/repo(.git) both
+# reduce to owner/repo.
+fork_slug="$(echo "$fork_url" | sed -E 's#^(git@github\.com:|https://github\.com/)##; s#\.git$##')"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+find_browser() {
+  local candidate
+  for candidate in \
+    "${PR_EVIDENCE_BROWSER:-}" \
+    "${AGENT_BROWSER_EXECUTABLE_PATH:-}" \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+    "$(command -v chromium || true)" \
+    "$(command -v google-chrome || true)"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  echo "error: no Chromium found; set PR_EVIDENCE_BROWSER to a browser binary" >&2
+  return 1
+}
+
+if [[ -n "$url" ]]; then
+  browser="$(find_browser)"
+  file="$workdir/$name"
+  "$browser" --headless --disable-gpu --hide-scrollbars \
+    --window-size="$viewport" --screenshot="$file" "$url" >&2
+  [[ -s "$file" ]] || {
+    echo "error: capture produced no image" >&2
+    exit 1
+  }
+  source_line="headless-Chromium screenshot of $url (window ${viewport/,/x})"
+else
+  source_line="pre-captured image ($(basename "$file"))"
+fi
+
+# Publish on the orphan branch: clone it if the fork already has one,
+# otherwise start it from scratch. Only ever add files.
+clone="$workdir/pr-evidence"
+if git clone --quiet --depth 1 --branch pr-evidence "$fork_url" "$clone" 2>/dev/null; then
+  :
+else
+  git init --quiet "$clone"
+  git -C "$clone" checkout --quiet --orphan pr-evidence
+fi
+cp "$file" "$clone/$name"
+git -C "$clone" add "$name"
+git -C "$clone" commit --quiet -m "evidence: $name"
+git -C "$clone" push --quiet "$fork_url" HEAD:refs/heads/pr-evidence
+
+raw_url="https://raw.githubusercontent.com/${fork_slug}/pr-evidence/${name}"
+cat <<EOF
+
+![${slug}](${raw_url})
+
+_Captured ${ts} at commit ${sha} — ${source_line}._
+EOF


### PR DESCRIPTION
## Summary

Adds `scripts/pr_evidence_screenshot.sh`, which gives screenshot evidence a place to live in a
PR body. PRs here are opened with `gh`, and no GitHub API accepts an image the way browser
drag-and-drop does, so a screenshot proving a verification step currently has no path into the
Live validation section. The script captures a URL with a headless Chromium (or publishes an
image you already have), pushes it to an orphan `pr-evidence` branch on the author's fork —
public, so `raw.githubusercontent.com` renders inline — and prints ready-to-paste Markdown
stamped with the commit under test and the capture time. The PR template, AGENTS.md, and the
contributing guide now point at it, and keep fenced text transcripts as the rule for command
output.

This PR was generated with the help of Claude.

## Why This Change

Live validation evidence is prose today: a reviewer takes the author's word that the admin
console showed the task done or the docs page rendered. For graphical surfaces the honest
evidence is a picture, and without a publishing path each author either skips it or invents an
ad-hoc host. Without this change, screenshot evidence stays structurally impossible for
`gh`-opened PRs.

## What Changed

- `scripts/pr_evidence_screenshot.sh` (new): capture via the first of `$PR_EVIDENCE_BROWSER`,
  `$AGENT_BROWSER_EXECUTABLE_PATH` (the agent runtime's bundled Playwright Chromium), or an
  installed Chrome — driving the binary directly avoids `npx`, which AGENTS.md already
  documents as failing behind authenticated mirrors. Publishes add-only to the fork's
  `pr-evidence` branch; file names carry slug + commit + UTC timestamp. Refuses upstream
  remotes, unrecognized remote-URL shapes (which could otherwise leak a token-embedded remote
  URL into the printed Markdown), and non-http(s) URLs.
- `.github/PULL_REQUEST_TEMPLATE.md`, `AGENTS.md`, `docs/site/src/content/docs/contributing.md`:
  one pointer each in the Live validation contract (AGENTS.md is canonical; the other two are
  its named summaries). Text transcripts remain the rule for command output.
- `docs/README.md`: identifier-sources row for the new script.

## Context

No open or closed PR/issue covers this (searched screenshot/evidence/proof). #876 and #792
touch `contributing.md`/`AGENTS.md` — merge-conflict overlap only, nothing adjacent to this
feature.

## Testing

- `bash -n` on the script; shellcheck is not installed on this machine, so it was not run.
- `make docs-check` green (map, links, terminology, AGENTS.md context budget: 2.3k under).
- prettier 3.9.6 (the CI-pinned version) clean on all four changed Markdown files.

### Live validation

The change is a contributor-side helper plus doc pointers — it does not touch a running
install, so validation is running the tool itself, end to end, against the real fork:

All evidence below was produced from a worktree at `069bf3c` (an earlier round, run before the
commits existed and therefore stamped with main's tip, was superseded — the bot's review caught
that, and this section replaces it rather than stacking on it). A later rebase onto main
re-parented that commit as `4e34d8d` with an identical patch (`git range-diff` reports both
commits `=`), so the observations hold unchanged against the current head.

- URL mode: captured `https://gke-labs.github.io/kube-agents/` with headless Chrome and
  published to `pr-evidence` on adrianchung/kube-agents. The raw URL serves `200 image/png`
  (101,367 bytes) and the image is a full render of the docs home page:

  ![docs-site-home](https://raw.githubusercontent.com/adrianchung/kube-agents/pr-evidence/docs-site-home-069bf3cb94f6-20260824T012152Z.png)

  _Captured 20260824T012152Z at commit 069bf3cb94f6 — headless-Chromium screenshot of https://gke-labs.github.io/kube-agents/ (window 1280x800)._

- Rendered-in-PR proof, closing the loop: GitHub's rendered body
  (`Accept: application/vnd.github.html+json`) turns that Markdown into an `<img>` tag, and a
  headless-Chrome screenshot of this PR — published through the script's `--file` path, which
  also exercised the ls-remote → clone path for an existing branch and the "Published"
  caption — shows an evidence image rendering inline in this very section. The crop shows the
  body as it stood before this revision; what it evidences, inline rendering, does not depend
  on the body text:

  ![pr879-rendered-evidence](https://raw.githubusercontent.com/adrianchung/kube-agents/pr-evidence/pr879-rendered-evidence-069bf3cb94f6-20260824T011908Z.png)

  _Published 20260824T011908Z at commit 069bf3cb94f6 — pre-captured image (pr879-crop.png)._

- Guards observed failing correctly, re-run at `069bf3c`: `--remote origin` refused ("upstream
  repository"), `chrome://settings` refused (non-http(s) URL), bad slug and missing `--file`
  path refused.
- Not covered: the `$AGENT_BROWSER_EXECUTABLE_PATH` branch (needs the agent runtime image) and
  a Linux chromium/google-chrome PATH lookup — the resolution order is the only untested part
  of those. Test artifacts: the published evidence images stay on the fork's `pr-evidence`
  branch deliberately; this PR's body links one.

## Self-Review

Adversarial pass (`review-adversarial` angles) run by a subagent handed only the diff range,
plus a `review-docs-drift` pass, both fresh contexts that did not write the change.

- Adversarial: 1 High (unvalidated owner/repo derivation could paste a token-embedded remote
  URL into a public PR body), 1 Medium (`--remote` bypassed the not-upstream guard), 4 Low
  (clone failure misread as missing branch; `pushurl` ignored; a mistyped flag reaching
  Chromium's argv as a switch; captured image deleted when publish fails). All six fixed in
  069bf3c. Clean angles it reported: bash 3.2 / `set -euo pipefail` behavior (tested), the
  orphan add-only flow (exercised against a bare repo), stdout discipline, no weakened gates,
  no reusable helper missed, injection surfaces (slug regex, hex sha, constant refspec).
- Docs-drift: no Blocking; 2 Advisory, both addressed in 069bf3c (identifier-sources row in
  `docs/README.md`; "Captured" vs published time in `--file` mode). It could not run the
  docs-site build locally (broken npm on this machine) — the site change is one plain list
  item, and CI's docs build covers it.
- Known accepted gap: no unit tests for the script; the repo tests only its Python scripts.
  The pure-logic parts a test could pin (slug regex, remote detection, URL-shape validation)
  are now also guarded by hard failures at runtime.

## Risk & Rollout

Low: a standalone contributor-side script plus documentation pointers — no runtime, operator,
or CI code paths. Worst case is a bad evidence link in a PR body. Revert by deleting the
script and reverting the four doc edits; the orphan `pr-evidence` branches live on
contributors' forks, not here.
