### PR TITLE
test(scripts): add __main__ guard to test_gke_endpoint_parity.py

### DIFF
--- a/agents/platform/scripts/test_gke_endpoint_parity.py
+++ b/agents/platform/scripts/test_gke_endpoint_parity.py
@@ -227,3 +227,7 @@ class PredicateParity(unittest.TestCase):
         self.assertEqual(1, len([c for c in calls if "--help" in c]), calls)
         # Each cluster still gets its own describe: that answer is per-cluster.
         self.assertEqual(3, len([c for c in calls if "describe" in c]), calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds the missing `if __name__ == "__main__": unittest.main()` guard to `test_gke_endpoint_parity.py` so that executing the file directly discovers and runs its tests rather than exiting silently.

## Why This Change

Direct invocation of test files is a standard way developers (and agents) run a focused subset of tests. Because the guard was missing, `python3 test_gke_endpoint_parity.py` simply parsed the file and exited 0 without running any tests, giving a false sense of success. This brings the file into parity with the rest of the `test_*.py` suite in `agents/platform/scripts/`.

## What Changed

- Added the standard `unittest.main()` execution guard to the bottom of `agents/platform/scripts/test_gke_endpoint_parity.py`.

## Context

Closes #851.

## Testing

- Ran `python3 agents/platform/scripts/test_gke_endpoint_parity.py` directly; verified that it now runs 4 tests in 0.110s instead of silently exiting.
- (Note: `make verify` could not be run locally as the sandbox lacks a Go toolchain, but the change is isolated to a single Python test file and does not affect the operator.)

### Live validation

Not live-tested: this is a test-suite-only change that does not ship to a running installation.

## Self-Review

- **Adversarial Pass:** Run in a fresh, independent subagent that had no context on why the code was written. The subagent was handed only the PR diff (`gh pr diff 880`) and verified that the `__main__` guard correctly isolates execution without any `sys.path` or working-directory side effects. Finding: Clean.
- **Docs-Drift Pass:** Run in the same fresh, independent subagent context via `make docs-check`. Finding: Clean (no terminology or documentation map drift).

## Risk & Rollout

Low risk, test-only change. Revert by reverting the commit.
