### PR TITLE
fix(skills): correct gcloud command spellings for compute advice and logging read

### DIFF
--- a/agents/cluster/skills/gke-workload-troubleshooting/SKILL.md
+++ b/agents/cluster/skills/gke-workload-troubleshooting/SKILL.md
@@ -84,7 +84,7 @@ Look for infrastructure, volume, image, or scheduling alerts in GKE.
 ```bash
 kubectl get events -n <workload_namespace> --sort-by='.metadata.creationTimestamp'
 # Or query Cloud Logging for historical GKE events within the time window:
-gcloud logging read "resource.type=\"k8s_cluster\" AND logName=\"projects/<project_id>/logs/events\" AND jsonPayload.involvedObject.namespace=\"<workload_namespace>\"" --start-time="[Start_Time]" --end-time="[End_Time]" --project="<project_id>"
+gcloud logging read "resource.type=\"k8s_cluster\" AND logName=\"projects/<project_id>/logs/events\" AND jsonPayload.involvedObject.namespace=\"<workload_namespace>\" AND timestamp>=\"[Start_Time]\" AND timestamp<=\"[End_Time]\"" --project="<project_id>"
 ```
 
 _Note: Retrieve the sorted events list and manually inspect the event timestamps (CreationTimestamp/LastSeen) to identify failures occurring within the `[Start_Time]` and `[End_Time]` window._

--- a/agents/platform/cron/jobs.json
+++ b/agents/platform/cron/jobs.json
@@ -2,78 +2,78 @@
   "jobs": [
     {
       "id": "compliance-audit",
-      "name": "Security & RBAC Posture Audit",
+      "name": "Fleet Compliance & Blueprint Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "20 6 * * *",
-        "display": "20 6 * * *"
+        "expr": "0 9 * * *",
+        "display": "0 9 * * *"
       },
-      "prompt": "Run the daily fleet security and RBAC posture audit. Read the SOP at 'governance/compliance_audit_sop.md' in your profile home — all 413 lines of it, before you run anything. Its eleven checks are section 2, lines 107-320, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
-      "skills": ["fleet-audit"],
-      "enabled": true,
-      "deliver": "chat"
-    },
-    {
-      "id": "obtainability-audit",
-      "name": "Workload Reliability Audit",
-      "schedule": {
-        "kind": "cron",
-        "expr": "50 6 * * *",
-        "display": "50 6 * * *"
-      },
-      "prompt": "Run the daily workload reliability audit. Read the SOP at 'governance/obtainability_audit_sop.md' in your profile home — all 288 lines of it, before you run anything. Its eleven checks are section 3, lines 91-220, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily fleet compliance and blueprint audit. Read the SOP at 'governance/compliance_audit_sop.md' in your profile home — all 171 lines of it, before you run anything. Its ten checks are section 3, lines 60-142, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "security-patch-orchestrator",
-      "name": "Upgrade & Patch Readiness Audit",
+      "name": "Security & Cluster Hardening Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "20 7 * * 1",
-        "display": "20 7 * * 1"
+        "expr": "0 10 * * *",
+        "display": "0 10 * * *"
       },
-      "prompt": "Run the weekly GKE upgrade and patch readiness audit. Read the SOP at 'governance/security_patch_orchestrator_sop.md' in your profile home — all 289 lines of it, before you run anything. Its ten checks are section 3, lines 119-223, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. This audit is read-only: never upgrade a cluster.",
+      "prompt": "Run the daily security and cluster hardening audit. Read the SOP at 'governance/security_patch_orchestrator_sop.md' in your profile home — all 210 lines of it, before you run anything. Its eight checks are section 3, lines 69-170, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "skills": ["fleet-audit"],
+      "enabled": true,
+      "deliver": "chat"
+    },
+    {
+      "id": "obtainability-audit",
+      "name": "Workload Obtainability & Quota Audit",
+      "schedule": {
+        "kind": "cron",
+        "expr": "0 11 * * *",
+        "display": "0 11 * * *"
+      },
+      "prompt": "Run the daily workload obtainability and quota audit. Read the SOP at 'governance/obtainability_audit_sop.md' in your profile home — all 144 lines of it, before you run anything. Its six checks are section 3, lines 52-117, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "fleet-wide-cost-analysis",
-      "name": "Fleet Waste Audit",
+      "name": "Fleet Cost & Waste Analysis",
       "schedule": {
         "kind": "cron",
-        "expr": "50 7 * * 1",
-        "display": "50 7 * * 1"
+        "expr": "0 12 * * *",
+        "display": "0 12 * * *"
       },
-      "prompt": "Run the weekly fleet waste audit. Read the SOP at 'governance/fleet_wide_cost_analysis_sop.md' in your profile home — all 268 lines of it, before you run anything. Its ten checks are section 3, lines 94-200, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. Report findings in resource units only — you have no pricing data.",
+      "prompt": "Run the daily fleet cost and waste analysis. Read the SOP at 'governance/fleet_wide_cost_analysis_sop.md' in your profile home — all 152 lines of it, before you run anything. Its six checks are section 3, lines 54-123, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "fleet-consistency-drift",
-      "name": "Fleet Consistency Drift Audit",
+      "name": "Fleet Consistency & Drift Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "20 8 * * 1",
-        "display": "20 8 * * 1"
+        "expr": "0 13 * * *",
+        "display": "0 13 * * *"
       },
-      "prompt": "Run the weekly fleet consistency drift audit. Read the SOP at 'governance/fleet_consistency_drift_sop.md' in your profile home — all 271 lines of it, before you run anything. Its nineteen facets are section 4, lines 96-201, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. The baseline is derived from the live fleet itself — never from an external blueprint.",
+      "prompt": "Run the daily fleet consistency and drift audit. Read the SOP at 'governance/fleet_consistency_drift_sop.md' in your profile home — all 170 lines of it, before you run anything. Its six checks are section 3, lines 60-141, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "ai-security-audit",
-      "name": "AI Workload Security Audit",
+      "name": "AI & GPU Workload Security Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "50 8 * * *",
-        "display": "50 8 * * *"
+        "expr": "0 14 * * *",
+        "display": "0 14 * * *"
       },
-      "prompt": "Run the daily AI workload security audit. Read the SOP at 'governance/ai_security_audit_sop.md' in your profile home — all 348 lines of it, before you run anything. Its six checks are section 3, lines 153-277, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Section 2 defines which workloads count as AI workloads; on a cluster running none the six checks still ran and matched nothing, so record all six in checks_run with the collection command — never leave checks_run empty, which the validator rejects. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily AI and GPU workload security audit. Read the SOP at 'governance/ai_security_audit_sop.md' in your profile home — all 149 lines of it, before you run anything. Its six checks are section 3, lines 55-121, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
@@ -86,51 +86,47 @@
         "expr": "20 9 * * *",
         "display": "20 9 * * *"
       },
-      "prompt": "Run the daily fleet stockout prevention and capacity audit. Read the SOP at 'governance/stockout_prevention_sop.md' in your profile home — all 268 lines of it, before you run anything. Its twelve checks are section 3, lines 84-216, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily fleet stockout prevention and capacity audit. Read the SOP at 'governance/stockout_prevention_sop.md' in your profile home — all 271 lines of it, before you run anything. Its twelve checks are section 3, lines 87-219, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "gcp-networking-fabric-audit",
-      "name": "GCP Networking Fabric & VPC IPAM Audit",
+      "name": "GCP Networking Fabric Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 8 * * *",
-        "display": "0 8 * * *"
+        "expr": "40 9 * * *",
+        "display": "40 9 * * *"
       },
-      "prompt": "Run the daily GCP networking fabric and VPC IPAM audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 209 lines of it, before you run anything. Its five checks are section 2, lines 38-77, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily GCP networking fabric audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 192 lines of it, before you run anything. Its ten checks are section 3, lines 60-156, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
-      "deliver": "all"
+      "deliver": "chat"
     },
     {
       "id": "github-repo-watcher",
       "name": "GitHub Repo Watcher",
       "schedule": {
         "kind": "cron",
-        "expr": "*/10 * * * *",
-        "display": "*/10 * * * *"
+        "expr": "* * * * *",
+        "display": "* * * * *"
       },
-      "prompt": "",
-      "skills": [],
-      "no_agent": true,
       "script": "github_scan_gate.py",
+      "no_agent": true,
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "eod-event-watcher-daily-report",
-      "name": "Event Watcher Daily Activity Recap",
+      "name": "k8s-event-watcher Daily Summary",
       "schedule": {
         "kind": "cron",
-        "expr": "0 21 * * 1-5",
-        "display": "0 21 * * 1-5"
+        "expr": "0 17 * * 1-5",
+        "display": "0 17 * * 1-5 (M-F 5pm)"
       },
-      "prompt": "",
-      "skills": [],
-      "no_agent": true,
       "script": "eod_report_generator.py",
+      "no_agent": true,
       "enabled": true,
       "deliver": "chat"
     }

--- a/agents/platform/cron/jobs.json
+++ b/agents/platform/cron/jobs.json
@@ -2,78 +2,78 @@
   "jobs": [
     {
       "id": "compliance-audit",
-      "name": "Fleet Compliance & Blueprint Audit",
+      "name": "Security & RBAC Posture Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 9 * * *",
-        "display": "0 9 * * *"
+        "expr": "20 6 * * *",
+        "display": "20 6 * * *"
       },
-      "prompt": "Run the daily fleet compliance and blueprint audit. Read the SOP at 'governance/compliance_audit_sop.md' in your profile home — all 171 lines of it, before you run anything. Its ten checks are section 3, lines 60-142, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
-      "skills": ["fleet-audit"],
-      "enabled": true,
-      "deliver": "chat"
-    },
-    {
-      "id": "security-patch-orchestrator",
-      "name": "Security & Cluster Hardening Audit",
-      "schedule": {
-        "kind": "cron",
-        "expr": "0 10 * * *",
-        "display": "0 10 * * *"
-      },
-      "prompt": "Run the daily security and cluster hardening audit. Read the SOP at 'governance/security_patch_orchestrator_sop.md' in your profile home — all 210 lines of it, before you run anything. Its eight checks are section 3, lines 69-170, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily fleet security and RBAC posture audit. Read the SOP at 'governance/compliance_audit_sop.md' in your profile home — all 413 lines of it, before you run anything. Its eleven checks are section 2, lines 107-320, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "obtainability-audit",
-      "name": "Workload Obtainability & Quota Audit",
+      "name": "Workload Reliability Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 11 * * *",
-        "display": "0 11 * * *"
+        "expr": "50 6 * * *",
+        "display": "50 6 * * *"
       },
-      "prompt": "Run the daily workload obtainability and quota audit. Read the SOP at 'governance/obtainability_audit_sop.md' in your profile home — all 144 lines of it, before you run anything. Its six checks are section 3, lines 52-117, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily workload reliability audit. Read the SOP at 'governance/obtainability_audit_sop.md' in your profile home — all 288 lines of it, before you run anything. Its eleven checks are section 3, lines 91-220, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "skills": ["fleet-audit"],
+      "enabled": true,
+      "deliver": "chat"
+    },
+    {
+      "id": "security-patch-orchestrator",
+      "name": "Upgrade & Patch Readiness Audit",
+      "schedule": {
+        "kind": "cron",
+        "expr": "20 7 * * 1",
+        "display": "20 7 * * 1"
+      },
+      "prompt": "Run the weekly GKE upgrade and patch readiness audit. Read the SOP at 'governance/security_patch_orchestrator_sop.md' in your profile home — all 289 lines of it, before you run anything. Its ten checks are section 3, lines 119-223, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. This audit is read-only: never upgrade a cluster.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "fleet-wide-cost-analysis",
-      "name": "Fleet Cost & Waste Analysis",
+      "name": "Fleet Waste Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 12 * * *",
-        "display": "0 12 * * *"
+        "expr": "50 7 * * 1",
+        "display": "50 7 * * 1"
       },
-      "prompt": "Run the daily fleet cost and waste analysis. Read the SOP at 'governance/fleet_wide_cost_analysis_sop.md' in your profile home — all 152 lines of it, before you run anything. Its six checks are section 3, lines 54-123, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the weekly fleet waste audit. Read the SOP at 'governance/fleet_wide_cost_analysis_sop.md' in your profile home — all 268 lines of it, before you run anything. Its ten checks are section 3, lines 94-200, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. Report findings in resource units only — you have no pricing data.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "fleet-consistency-drift",
-      "name": "Fleet Consistency & Drift Audit",
+      "name": "Fleet Consistency Drift Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 13 * * *",
-        "display": "0 13 * * *"
+        "expr": "20 8 * * 1",
+        "display": "20 8 * * 1"
       },
-      "prompt": "Run the daily fleet consistency and drift audit. Read the SOP at 'governance/fleet_consistency_drift_sop.md' in your profile home — all 170 lines of it, before you run anything. Its six checks are section 3, lines 60-141, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the weekly fleet consistency drift audit. Read the SOP at 'governance/fleet_consistency_drift_sop.md' in your profile home — all 271 lines of it, before you run anything. Its nineteen facets are section 4, lines 96-201, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run. The baseline is derived from the live fleet itself — never from an external blueprint.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "ai-security-audit",
-      "name": "AI & GPU Workload Security Audit",
+      "name": "AI Workload Security Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "0 14 * * *",
-        "display": "0 14 * * *"
+        "expr": "50 8 * * *",
+        "display": "50 8 * * *"
       },
-      "prompt": "Run the daily AI and GPU workload security audit. Read the SOP at 'governance/ai_security_audit_sop.md' in your profile home — all 149 lines of it, before you run anything. Its six checks are section 3, lines 55-121, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily AI workload security audit. Read the SOP at 'governance/ai_security_audit_sop.md' in your profile home — all 348 lines of it, before you run anything. Its six checks are section 3, lines 153-277, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Section 2 defines which workloads count as AI workloads; on a cluster running none the six checks still ran and matched nothing, so record all six in checks_run with the collection command — never leave checks_run empty, which the validator rejects. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "chat"
@@ -93,40 +93,44 @@
     },
     {
       "id": "gcp-networking-fabric-audit",
-      "name": "GCP Networking Fabric Audit",
+      "name": "GCP Networking Fabric & VPC IPAM Audit",
       "schedule": {
         "kind": "cron",
-        "expr": "40 9 * * *",
-        "display": "40 9 * * *"
+        "expr": "0 8 * * *",
+        "display": "0 8 * * *"
       },
-      "prompt": "Run the daily GCP networking fabric audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 192 lines of it, before you run anything. Its ten checks are section 3, lines 60-156, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily GCP networking fabric and VPC IPAM audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 209 lines of it, before you run anything. Its five checks are section 2, lines 38-77, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
-      "deliver": "chat"
+      "deliver": "all"
     },
     {
       "id": "github-repo-watcher",
       "name": "GitHub Repo Watcher",
       "schedule": {
         "kind": "cron",
-        "expr": "* * * * *",
-        "display": "* * * * *"
+        "expr": "*/10 * * * *",
+        "display": "*/10 * * * *"
       },
-      "script": "github_scan_gate.py",
+      "prompt": "",
+      "skills": [],
       "no_agent": true,
+      "script": "github_scan_gate.py",
       "enabled": true,
       "deliver": "chat"
     },
     {
       "id": "eod-event-watcher-daily-report",
-      "name": "k8s-event-watcher Daily Summary",
+      "name": "Event Watcher Daily Activity Recap",
       "schedule": {
         "kind": "cron",
-        "expr": "0 17 * * 1-5",
-        "display": "0 17 * * 1-5 (M-F 5pm)"
+        "expr": "0 21 * * 1-5",
+        "display": "0 21 * * 1-5"
       },
-      "script": "eod_report_generator.py",
+      "prompt": "",
+      "skills": [],
       "no_agent": true,
+      "script": "eod_report_generator.py",
       "enabled": true,
       "deliver": "chat"
     }

--- a/agents/platform/governance/stockout_prevention_sop.md
+++ b/agents/platform/governance/stockout_prevention_sop.md
@@ -74,8 +74,11 @@ gcloud compute reservations list --project=<project> --format=json > /opt/data/s
 # 3. Inspect GCP Regional Quotas for the cluster's region (e.g. us-central1)
 gcloud compute regions describe <region> --project=<project> --format="json(quotas)"
 
-# 4. Check Spot Capacity & Preemption Advice History
-gcloud beta compute advice capacity-history --region=<region> --instance-selection-machine-types="g2-standard-4,n4-standard-4,c3-standard-4" --size=1 --types=PREEMPTION,PRICE --format=json
+# 4. Check Spot Capacity & Preemption Advice History (repeat for target machine types, e.g. g2-standard-4, n4-standard-4, c3-standard-4)
+gcloud beta compute advice capacity-history --region=<region> --provisioning-model=SPOT --machine-type=<machine_type> --types=PREEMPTION,PRICE --format=json
+
+# Or check capacity obtainability for target machine types:
+gcloud beta compute advice capacity --region=<region> --provisioning-model=SPOT --size=1 --instance-selection-machine-types="g2-standard-4,n4-standard-4,c3-standard-4" --target-distribution-shape=any --format=json
 
 # 5. Autoscaler Visibility Logs (Stage 1 Triage Query)
 gcloud logging read 'log_id("container.googleapis.com/cluster-autoscaler-visibility") AND resource.labels.cluster_name="<cluster>" AND (jsonPayload.noDecisionStatus.noScaleUp:* OR jsonPayload.resultInfo.results.errorMsg:*)' --project=<project> --freshness=24h --limit=1000 --format="value(timestamp,resource.labels.cluster_name,jsonPayload.noDecisionStatus.noScaleUp.unhandledPodGroups[0].napFailureReasons[0].messageId)"
@@ -164,7 +167,7 @@ gcloud logging read 'log_id("container.googleapis.com/cluster-autoscaler-visibil
 #### 3.8 High preemption risk or low obtainability on Spot instances (`spot-scarcity-risk`)
 
 - **Reference:** `skills/gke-compute-classes/references/compute-class-prioritization.md`
-- **Command:** `gcloud beta compute advice capacity-history --region=<region> --instance-selection-machine-types="g2-standard-4,n4-standard-4,c3-standard-4" --size=1 --types=PREEMPTION,PRICE --format=json`
+- **Command:** `gcloud beta compute advice capacity-history --region=<region> --provisioning-model=SPOT --machine-type=<machine_type> --types=PREEMPTION,PRICE --format=json`
 - **Flag when:** Workloads or ComputeClasses request Spot VM shapes that have high historical preemption rates (>20%) or low obtainability scores in `compute advice`, without alternative family fallbacks.
 - **Do NOT flag:** Spot configurations that have high obtainability scores or comprehensive multi-family fallbacks; non-production environments.
 - **Severity:** `major`.

--- a/agents/platform/scripts/command_policy.py
+++ b/agents/platform/scripts/command_policy.py
@@ -285,7 +285,7 @@ GCLOUD_READ_COMMANDS: frozenset[tuple[str, ...]] = frozenset(
         ("config", "get-value"),
         ("config", "list"),
         # `beta` is a word like any other here, so a beta path has to be
-        # listed on its own -- the GA entry above it grants nothing. These two
+        # listed on its own -- the GA entry above it grants nothing. These
         # are the stockout SOP's capacity forecast; the data has no GA
         # spelling yet.
         ("beta", "compute", "advice", "calendar-mode"),

--- a/agents/platform/scripts/command_policy.py
+++ b/agents/platform/scripts/command_policy.py
@@ -289,6 +289,7 @@ GCLOUD_READ_COMMANDS: frozenset[tuple[str, ...]] = frozenset(
         # are the stockout SOP's capacity forecast; the data has no GA
         # spelling yet.
         ("beta", "compute", "advice", "calendar-mode"),
+        ("beta", "compute", "advice", "capacity"),
         ("beta", "compute", "advice", "capacity-history"),
         # Budget reads for the cost skills. list only: budgets are written
         # by humans, and `billing accounts list` is deliberately absent --
@@ -392,6 +393,8 @@ _GCLOUD_FLAGS_WITH_VALUE = frozenset(
         # machine-types list uses --zones (plural; --zone alone was listed).
         # An allowlist entry whose flags are not here is unreachable.
         "--instance-selection-machine-types", "--size", "--types", "--zones",
+        "--machine-type", "--provisioning-model", "--target-distribution-shape",
+        "--instance-selection",
         # `billing budgets list` requires it.
         "--billing-account",
         # `container ai profiles manifests create` selectors, from its gcloud

--- a/agents/platform/scripts/test_command_policy.py
+++ b/agents/platform/scripts/test_command_policy.py
@@ -963,9 +963,14 @@ class TheAllowlistCoversWhatTheProductActuallyRuns(unittest.TestCase):
         # were consulted. These are the SOP's spellings (lines 73 and 220).
         for argv, desc in (
             (["gcloud", "beta", "compute", "advice", "capacity-history",
-              "--region=r", "--instance-selection-machine-types=g2-standard-4",
-              "--size=1", "--types=PREEMPTION,PRICE", "--format=json"],
-             "capacity forecast as the SOP spells it"),
+              "--region=r", "--provisioning-model=SPOT", "--machine-type=g2-standard-4",
+              "--types=PREEMPTION,PRICE", "--format=json"],
+             "capacity-history as the SOP spells it"),
+            (["gcloud", "beta", "compute", "advice", "capacity",
+              "--region=r", "--provisioning-model=SPOT", "--size=1",
+              "--instance-selection-machine-types=g2-standard-4",
+              "--target-distribution-shape=any", "--format=json"],
+             "capacity advice as the SOP spells it"),
             (["gcloud", "compute", "machine-types", "list", "--zones=z"],
              "machine-types with --zones (plural)"),
             (["gcloud", "billing", "budgets", "list", "--billing-account=A",

--- a/agents/platform/skills/gke-workload-troubleshooting/SKILL.md
+++ b/agents/platform/skills/gke-workload-troubleshooting/SKILL.md
@@ -109,7 +109,7 @@ Look for infrastructure, volume, image, or scheduling alerts in GKE.
 ```bash
 kubectl get events -n {workload_namespace} --sort-by='.metadata.creationTimestamp'
 # Or query Cloud Logging for historical GKE events within the time window:
-gcloud logging read "resource.type=\"k8s_cluster\" AND logName=\"projects/{project_id}/logs/events\" AND jsonPayload.involvedObject.namespace=\"{workload_namespace}\"" --start-time="{start_time}" --end-time="{end_time}" --project="{project_id}"
+gcloud logging read "resource.type=\"k8s_cluster\" AND logName=\"projects/{project_id}/logs/events\" AND jsonPayload.involvedObject.namespace=\"{workload_namespace}\" AND timestamp>=\"{start_time}\" AND timestamp<=\"{end_time}\"" --project="{project_id}"
 ```
 
 *Note: Retrieve the sorted events list and manually inspect the event timestamps


### PR DESCRIPTION
## Summary

Corrects invalid `gcloud` flag spellings in the stockout prevention governance SOP and GKE workload troubleshooting skills. `beta compute advice capacity-history` and `beta compute advice capacity` now use their respective valid CLI flags (`--provisioning-model=SPOT`, `--machine-type`, `--target-distribution-shape`), and `gcloud logging read` queries embed time window constraints directly in the filter expression instead of non-existent `--start-time`/`--end-time` flags.

## Why This Change

Two shipped command patterns in the skills and governance SOPs were rejected by `gcloud` with unrecognized argument errors when executed:
1. `gcloud beta compute advice capacity-history`: The SOP previously passed `--instance-selection-machine-types` and `--size=1`, which belong to `gcloud beta compute advice capacity` rather than `capacity-history`, causing the daily stockout prevention cron job to fail to collect capacity forecast advice.
2. `gcloud logging read`: The workload troubleshooting skills passed `--start-time` and `--end-time` as CLI flags. `gcloud logging read` has no such flags; time window filtering must be placed in the filter expression (`timestamp>="..." AND timestamp<="..."`).

## What Changed

- **`agents/platform/governance/stockout_prevention_sop.md`**: Fixed `capacity-history` command to pass `--provisioning-model=SPOT --machine-type=<machine_type> --types=PREEMPTION,PRICE` and added the valid `beta compute advice capacity` variant.
- **`agents/platform/cron/jobs.json`**: Reconciled the line counts and section line numbers cited in the `stockout-prevention` job prompt (all 271 lines... section 3, lines 87-219).
- **`agents/platform/skills/gke-workload-troubleshooting/SKILL.md` & `agents/cluster/skills/gke-workload-troubleshooting/SKILL.md`**: Respelled `gcloud logging read` commands to include `AND timestamp>="..." AND timestamp<="..."` inside the log filter query string.
- **`agents/platform/scripts/command_policy.py`**: Added `("beta", "compute", "advice", "capacity")` to `GCLOUD_READ_COMMANDS` and registered `--machine-type`, `--provisioning-model`, `--target-distribution-shape`, and `--instance-selection` in `_GCLOUD_FLAGS_WITH_VALUE`.
- **`agents/platform/scripts/test_command_policy.py`**: Updated allowlist test cases to assert coverage for the corrected `capacity-history` and `capacity` command structures.

## Context

Closes #843.

## Testing

- `PYTHONPATH=agents/platform/scripts python3 -m unittest agents/platform/scripts/test_command_policy.py`: 77 tests passed.
- `PYTHONPATH=agents/platform/skills/fleet-audit/scripts python3 -m unittest agents/platform/skills/fleet-audit/scripts/test_audit_report.py`: 547 tests passed (including line-count assertions on `jobs.json`).
- `make docs-check`: Passed all relative links, terminology checks, map coverage, and context budget.

### Live validation

- Validated against real `gcloud` CLI:
  - Executed `gcloud beta compute advice capacity-history --help` and `gcloud beta compute advice capacity --help` to confirm required/optional flag contracts (`--provisioning-model=SPOT`, `--machine-type`, `--types=PREEMPTION,PRICE`, `--size`, `--target-distribution-shape`).
  - Executed `gcloud logging read --help` to confirm filter expression timestamp syntax.

## Self-Review

Passes executed in fresh isolated subagent context (`sa-0-85388364`):
- **Adversarial code review (`review-adversarial`):**
  - Verified that `command_policy.py` allowlists both `capacity` and `capacity-history` paths and registers all value-taking flags in `_GCLOUD_FLAGS_WITH_VALUE` so credentials proxy parsing behaves consistently for attached (`--flag=val`) and detached (`--flag val`) forms.
- **Docs-drift review (`review-docs-drift`):**
  - Finding: Line count changes in `stockout_prevention_sop.md` drifted from prompt string in `agents/platform/cron/jobs.json`. Fixed by reconciling line numbers (`all 271 lines... section 3, lines 87-219`).
  - Finding: Verified both platform and cluster copies of `gke-workload-troubleshooting/SKILL.md` were updated in sync.

## Risk & Rollout

Low risk: Documentation and CLI flag syntax corrections. Ensures agent cron jobs and troubleshooting skills execute valid `gcloud` invocations.

---
*Generated with the help of Gemini.*