### PR TITLE
fix(auth): add bounded retry with backoff to github_token_refresh

### DIFF
--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -1668,9 +1668,13 @@ class CredentialProxyHandler(BaseHTTPRequestHandler):
                 result.exit_code,
                 f": {detail[:1000]}" if detail else "",
             )
-            self._json(
-                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
-            )
+            # Differentiate policy refusal / client error from upstream gateway failure
+            status = HTTPStatus.BAD_GATEWAY
+            if "HTTP 403" in detail or "HTTP 401" in detail:
+                status = HTTPStatus.FORBIDDEN
+            elif "HTTP 400" in detail or "HTTP 404" in detail:
+                status = HTTPStatus.BAD_REQUEST
+            self._json(status, {"error": "GitHub credential refresh failed"})
             return
         self._json(HTTPStatus.OK, {"status": "refreshed"})
 

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -1668,13 +1668,9 @@ class CredentialProxyHandler(BaseHTTPRequestHandler):
                 result.exit_code,
                 f": {detail[:1000]}" if detail else "",
             )
-            # Differentiate policy refusal / client error from upstream gateway failure
-            status = HTTPStatus.BAD_GATEWAY
-            if "HTTP 403" in detail or "HTTP 401" in detail:
-                status = HTTPStatus.FORBIDDEN
-            elif "HTTP 400" in detail or "HTTP 404" in detail:
-                status = HTTPStatus.BAD_REQUEST
-            self._json(status, {"error": "GitHub credential refresh failed"})
+            self._json(
+                HTTPStatus.BAD_GATEWAY, {"error": "GitHub credential refresh failed"}
+            )
             return
         self._json(HTTPStatus.OK, {"status": "refreshed"})
 

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -20,7 +20,7 @@ import urllib.request
 
 def log(msg: str):
     timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-    print(f"[{timestamp}] [SRE-AUTH] {msg}", flush=True)
+    print(f"[{timestamp}] [SRE-AUTH] {msg}", file=sys.stderr, flush=True)
 
 
 TOKEN_BROKER_URL = os.getenv(
@@ -214,6 +214,9 @@ def refresh_git_credentials(
 
     # 3. Configure gh CLI authentication and Git credentials
     try:
+        env = os.environ.copy()
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("GH_TOKEN", None)
         subprocess.run(
             ["gh", "auth", "login", "--with-token"],
             input=token,
@@ -221,12 +224,14 @@ def refresh_git_credentials(
             check=True,
             capture_output=True,
             timeout=15,
+            env=env,
         )
         subprocess.run(
             ["gh", "auth", "setup-git"],
             check=True,
             capture_output=True,
             timeout=15,
+            env=env,
         )
         log(
             f"GitHub authentication successfully configured for repository: {repository}"

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -11,20 +11,31 @@ import os
 import subprocess
 import sys
 import time
-import urllib.request
 import urllib.error
+import urllib.request
 
-TOKEN_BROKER_URL = os.getenv("TOKEN_BROKER_URL", "http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token")
+TOKEN_BROKER_URL = os.getenv(
+    "TOKEN_BROKER_URL",
+    "http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token",
+)
+
 
 def log(msg: str):
-    print(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] [SRE-AUTH] {msg}", file=sys.stderr, flush=True)
+    print(
+        f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] [SRE-AUTH] {msg}",
+        file=sys.stderr,
+        flush=True,
+    )
+
 
 def get_current_git_repo() -> str:
     """Extract repository name (owner/repo) from local git config."""
     try:
         res = subprocess.run(
             ["git", "config", "--get", "remote.origin.url"],
-            capture_output=True, text=True, check=True
+            capture_output=True,
+            text=True,
+            check=True,
         )
         url = res.stdout.strip().strip("/")
         # Parse owner/repo from URL (supports HTTPS and SSH formats)
@@ -37,7 +48,7 @@ def get_current_git_repo() -> str:
         # If SSH format, split by ':' (e.g. git@github.com:owner/repo)
         if "@" in url and ":" in url:
             url = url.split(":", 1)[1]
-        
+
         parts = url.split("/")
         if len(parts) >= 2:
             return f"{parts[-2]}/{parts[-1]}"
@@ -45,7 +56,14 @@ def get_current_git_repo() -> str:
         log(f"WARNING: Could not parse repository from git config: {e}")
     return None
 
-def refresh_git_credentials(target_repo: str = None) -> str:
+
+def refresh_git_credentials(
+    target_repo: str | None = None,
+    *,
+    max_attempts: int = 3,
+    initial_delay: float = 1.0,
+    backoff_factor: float = 2.0,
+) -> str:
     """Query local Minty, retrieve token, and cache inside git credentials."""
     repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
     if not repository or "/" not in repository:
@@ -53,39 +71,91 @@ def refresh_git_credentials(target_repo: str = None) -> str:
 
     proxy_url = os.getenv("CREDENTIAL_PROXY_URL", "").strip()
     if proxy_url:
+        url = proxy_url.rstrip("/") + "/v1/github/refresh"
         request = urllib.request.Request(
-            proxy_url.rstrip("/") + "/v1/github/refresh",
+            url,
             data=json.dumps({"repository": repository}).encode("utf-8"),
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        try:
-            with urllib.request.urlopen(request, timeout=30) as response:
-                if response.status != 200:
-                    raise RuntimeError("credential sidecar rejected refresh")
-        except Exception as exc:
-            raise RuntimeError("Credential sidecar failed to refresh GitHub auth") from exc
-        log(f"GitHub credentials refreshed in credential sidecar for {repository}.")
-        return ""
+        last_exc = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                with urllib.request.urlopen(request, timeout=30) as response:
+                    if response.status == 200:
+                        log(
+                            f"GitHub credentials refreshed in credential sidecar for {repository}."
+                        )
+                        return ""
+                    if response.status >= 500:
+                        raise urllib.error.HTTPError(
+                            url,
+                            response.status,
+                            f"HTTP {response.status}",
+                            response.headers,
+                            None,
+                        )
+                    raise RuntimeError(
+                        f"Credential sidecar rejected refresh: HTTP {response.status}"
+                    )
+            except urllib.error.HTTPError as exc:
+                last_exc = exc
+                if exc.code >= 500:
+                    if attempt < max_attempts:
+                        delay = initial_delay * (backoff_factor ** (attempt - 1))
+                        log(
+                            f"Credential sidecar returned HTTP {exc.code} on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                        )
+                        time.sleep(delay)
+                        continue
+                raise RuntimeError(
+                    f"Credential sidecar failed to refresh GitHub auth: HTTP {exc.code}"
+                ) from exc
+            except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as exc:
+                last_exc = exc
+                if attempt < max_attempts:
+                    delay = initial_delay * (backoff_factor ** (attempt - 1))
+                    log(
+                        f"Credential sidecar transport error ({exc}) on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                    )
+                    time.sleep(delay)
+                    continue
+                raise RuntimeError(
+                    f"Credential sidecar failed to refresh GitHub auth: {exc}"
+                ) from exc
+            except Exception as exc:
+                raise RuntimeError(
+                    "Credential sidecar failed to refresh GitHub auth"
+                ) from exc
+
+        raise RuntimeError(
+            "Credential sidecar failed to refresh GitHub auth"
+        ) from last_exc
 
     # 1. Retrieve Google OIDC identity token via gcloud external command
     oidc_token = None
     try:
         oidc_token = subprocess.run(
             ["gcloud", "auth", "print-identity-token", f"--audiences={TOKEN_BROKER_URL}"],
-            capture_output=True, text=True, check=True,
-            timeout=10
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
         ).stdout.strip()
     except Exception as e1:
         # If --audiences fails (e.g., when running with human user credentials), retry without flags
         try:
             oidc_token = subprocess.run(
                 ["gcloud", "auth", "print-identity-token"],
-                capture_output=True, text=True, check=True,
-                timeout=10
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=10,
             ).stdout.strip()
         except Exception as e2:
-            raise RuntimeError(f"Failed to retrieve Google OIDC token via gcloud: {e2}") from e2
+            raise RuntimeError(
+                f"Failed to retrieve Google OIDC token via gcloud: {e2}"
+            ) from e2
 
     if not oidc_token:
         raise RuntimeError("Retrieved Google OIDC token via gcloud is empty")
@@ -95,48 +165,107 @@ def refresh_git_credentials(target_repo: str = None) -> str:
 
     headers = {
         "Content-Type": "application/json",
-        "X-OIDC-Token": oidc_token
+        "X-OIDC-Token": oidc_token,
     }
     body = {
         "org_name": org_name,
         "repositories": [repo_name],
-        "scope": "platform-agent-scope"
+        "scope": "platform-agent-scope",
     }
     req_data = json.dumps(body).encode("utf-8")
 
-    log(f"Requesting scoped installation token from Minty for repository: {org_name}/{repo_name}...")
-    
-    try:
-        req = urllib.request.Request(
-            TOKEN_BROKER_URL,
-            data=req_data,
-            headers=headers,
-            method="POST"
-        )
-        with urllib.request.urlopen(req, timeout=10) as response:
-            token = response.read().decode("utf-8").strip()
-    except urllib.error.HTTPError as e:
-        error_body = e.read().decode("utf-8")
-        raise RuntimeError(f"Minty returned error (HTTP {e.code}): {error_body}") from e
-    except Exception as e:
-        raise RuntimeError(f"Failed to connect to Minty at {TOKEN_BROKER_URL}: {e}") from e
+    log(
+        f"Requesting scoped installation token from Minty for repository: {org_name}/{repo_name}..."
+    )
+
+    token = None
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            req = urllib.request.Request(
+                TOKEN_BROKER_URL,
+                data=req_data,
+                headers=headers,
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as response:
+                if response.status == 200:
+                    token = response.read().decode("utf-8").strip()
+                    break
+                if response.status >= 500:
+                    raise urllib.error.HTTPError(
+                        TOKEN_BROKER_URL,
+                        response.status,
+                        f"HTTP {response.status}",
+                        response.headers,
+                        None,
+                    )
+                error_body = response.read().decode("utf-8").strip()
+                raise RuntimeError(
+                    f"Minty returned error (HTTP {response.status}): {error_body}"
+                )
+        except urllib.error.HTTPError as e:
+            last_exc = e
+            error_body = ""
+            try:
+                error_body = e.read().decode("utf-8")
+            except Exception:
+                pass
+            if e.code >= 500:
+                if attempt < max_attempts:
+                    delay = initial_delay * (backoff_factor ** (attempt - 1))
+                    log(
+                        f"Minty returned HTTP {e.code} on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                    )
+                    time.sleep(delay)
+                    continue
+            raise RuntimeError(
+                f"Minty returned error (HTTP {e.code}): {error_body}"
+            ) from e
+        except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+            last_exc = e
+            if attempt < max_attempts:
+                delay = initial_delay * (backoff_factor ** (attempt - 1))
+                log(
+                    f"Minty transport error ({e}) on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                )
+                time.sleep(delay)
+                continue
+            raise RuntimeError(
+                f"Failed to connect to Minty at {TOKEN_BROKER_URL}: {e}"
+            ) from e
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to connect to Minty at {TOKEN_BROKER_URL}: {e}"
+            ) from e
 
     if not token:
+        if last_exc:
+            raise RuntimeError(
+                f"Failed to obtain token from Minty: {last_exc}"
+            ) from last_exc
         raise RuntimeError("Token received from Minty is empty")
 
-    # 2. Configure GitHub CLI to securely cache the token in its internal state.
+    # 3. Configure GitHub CLI to securely cache the token in its internal state.
     env = os.environ.copy()
     if "GITHUB_TOKEN" in env:
         del env["GITHUB_TOKEN"]
     if "GH_TOKEN" in env:
         del env["GH_TOKEN"]
-    subprocess.run(["gh", "auth", "login", "--with-token"], input=token, text=True, env=env, check=True)
-    
-    # 3. Configure Git to use gh as the credential helper
+    subprocess.run(
+        ["gh", "auth", "login", "--with-token"],
+        input=token,
+        text=True,
+        env=env,
+        check=True,
+    )
+
+    # 4. Configure Git to use gh as the credential helper
     subprocess.run(["gh", "auth", "setup-git"], env=env, check=True)
-    
+
     log("Git credentials store successfully refreshed from Token Broker! Token cached.")
     return token
+
 
 def main():
     try:
@@ -145,6 +274,7 @@ def main():
     except Exception as e:
         log(f"FATAL: Failed to refresh git credentials: {e}")
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -3,9 +3,12 @@
 GKE Platform Agent — Secure GitHub Token Refresher (Broker Client)
 
 In the agent sandbox this script asks the credential sidecar to refresh. Only
-the sidecar queries Minty and caches the short-lived repository-scoped token.
+the sidecar queries the token broker (Minty) directly. Standalone/legacy
+deployments continue to use the direct path.
 """
 
+import email.message
+import io
 import json
 import os
 import subprocess
@@ -14,22 +17,19 @@ import time
 import urllib.error
 import urllib.request
 
+
+def log(msg: str):
+    timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{timestamp}] [SRE-AUTH] {msg}", flush=True)
+
+
 TOKEN_BROKER_URL = os.getenv(
     "TOKEN_BROKER_URL",
     "http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token",
 )
 
 
-def log(msg: str):
-    print(
-        f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] [SRE-AUTH] {msg}",
-        file=sys.stderr,
-        flush=True,
-    )
-
-
-def get_current_git_repo() -> str:
-    """Extract repository name (owner/repo) from local git config."""
+def get_current_git_repo() -> str | None:
     try:
         res = subprocess.run(
             ["git", "config", "--get", "remote.origin.url"],
@@ -37,23 +37,14 @@ def get_current_git_repo() -> str:
             text=True,
             check=True,
         )
-        url = res.stdout.strip().strip("/")
-        # Parse owner/repo from URL (supports HTTPS and SSH formats)
-        # e.g., git@github.com:owner/repo.git or https://github.com/owner/repo.git
-        if url.endswith(".git"):
-            url = url[:-4]
-        # Remove protocol prefix if present (e.g. https://)
-        if "://" in url:
-            url = url.split("://", 1)[1]
-        # If SSH format, split by ':' (e.g. git@github.com:owner/repo)
-        if "@" in url and ":" in url:
-            url = url.split(":", 1)[1]
-
-        parts = url.split("/")
-        if len(parts) >= 2:
-            return f"{parts[-2]}/{parts[-1]}"
-    except Exception as e:
-        log(f"WARNING: Could not parse repository from git config: {e}")
+        url = res.stdout.strip()
+        if "github.com" in url:
+            path = url.split("github.com")[-1].lstrip(":").lstrip("/")
+            if path.endswith(".git"):
+                path = path[:-4]
+            return path
+    except Exception:
+        pass
     return None
 
 
@@ -64,20 +55,19 @@ def refresh_git_credentials(
     initial_delay: float = 0.5,
     backoff_factor: float = 2.0,
 ) -> str:
-    """Query local Minty, retrieve token, and cache inside git credentials."""
     repository = target_repo.strip().strip("/") if target_repo else get_current_git_repo()
+
     if not repository or "/" not in repository:
-        raise RuntimeError("Could not identify target repository as owner/name")
+        raise RuntimeError(
+            f"Could not identify target repository '{repository}'. Must be in 'owner/repo' format."
+        )
 
     proxy_url = os.getenv("CREDENTIAL_PROXY_URL", "").strip()
     if proxy_url:
-        # Client leg (agent sandbox -> sidecar proxy over loopback).
-        # The sidecar runs the internal helper which already does bounded retry
-        # against Minty (budgeted at ~20s max). The client uses a 45s socket timeout
-        # to allow the sidecar to finish its attempts. If the sidecar answers with
-        # an HTTP status (200, 4xx, or 502), the client accepts it immediately
-        # without nested retries. It only retries if the loopback connection itself drops
-        # (e.g. sidecar restart).
+        # In the agent sandbox: delegate to the credential sidecar.
+        # The sidecar manages bounded retries against Minty internally.
+        # The client uses a 60s timeout to allow the sidecar's retry budget
+        # to finish, and fails fast on any error without re-triggering retries.
         url = proxy_url.rstrip("/") + "/v1/github/refresh"
         request = urllib.request.Request(
             url,
@@ -85,80 +75,62 @@ def refresh_git_credentials(
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        last_exc = None
-        proxy_attempts = 2
-        for attempt in range(1, proxy_attempts + 1):
-            try:
-                with urllib.request.urlopen(request, timeout=45) as response:
-                    if response.status == 200:
-                        log(
-                            f"GitHub credentials refreshed in credential sidecar for {repository}."
-                        )
-                        return ""
-                    raise RuntimeError(
-                        f"Credential sidecar rejected refresh: HTTP {response.status}"
-                    )
-            except urllib.error.HTTPError as exc:
-                # The sidecar returned an HTTP error response. The sidecar has already
-                # executed its retries internally. Fail fast with the sidecar's status.
-                raise RuntimeError(
-                    f"Credential sidecar failed to refresh GitHub auth: HTTP {exc.code}"
-                ) from exc
-            except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as exc:
-                last_exc = exc
-                if attempt < proxy_attempts:
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                if response.status == 200:
                     log(
-                        f"Credential sidecar transport error ({exc}) on attempt {attempt}/{proxy_attempts}; retrying in {initial_delay:.1f}s..."
+                        f"GitHub credentials refreshed in credential sidecar for {repository}."
                     )
-                    time.sleep(initial_delay)
-                    continue
+                    return ""
                 raise RuntimeError(
-                    f"Credential sidecar failed to refresh GitHub auth: {exc}"
-                ) from exc
-            except Exception as exc:
-                raise RuntimeError(
-                    "Credential sidecar failed to refresh GitHub auth"
-                ) from exc
-
-        raise RuntimeError(
-            "Credential sidecar failed to refresh GitHub auth"
-        ) from last_exc
+                    f"Credential sidecar rejected refresh: HTTP {response.status}"
+                )
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Credential sidecar failed to refresh GitHub auth: HTTP {exc.code}"
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                f"Credential sidecar failed to refresh GitHub auth: {exc}"
+            ) from exc
 
     # 1. Retrieve Google OIDC identity token via gcloud external command
     oidc_token = None
     try:
-        oidc_token = subprocess.run(
-            ["gcloud", "auth", "print-identity-token", f"--audiences={TOKEN_BROKER_URL}"],
+        res = subprocess.run(
+            [
+                "gcloud",
+                "auth",
+                "print-identity-token",
+                f"--audiences={TOKEN_BROKER_URL}",
+            ],
             capture_output=True,
             text=True,
             check=True,
             timeout=5,
-        ).stdout.strip()
-    except Exception as e1:
-        # If --audiences fails (e.g., when running with human user credentials), retry without flags
+        )
+        oidc_token = res.stdout.strip()
+    except Exception:
         try:
-            oidc_token = subprocess.run(
+            res = subprocess.run(
                 ["gcloud", "auth", "print-identity-token"],
                 capture_output=True,
                 text=True,
                 check=True,
                 timeout=5,
-            ).stdout.strip()
-        except Exception as e2:
+            )
+            oidc_token = res.stdout.strip()
+        except Exception as e:
             raise RuntimeError(
-                f"Failed to retrieve Google OIDC token via gcloud: {e2}"
-            ) from e2
+                f"Failed to retrieve Google OIDC token via gcloud: {e}"
+            ) from e
 
     if not oidc_token:
-        raise RuntimeError("Retrieved Google OIDC token via gcloud is empty")
+        raise RuntimeError("Retrieved Google OIDC token via gcloud is empty.")
 
-    # 2. Dynamically identify target repository from workspace git remote or parameter
+    # 2. Query Minty Token Broker with bounded retries
     org_name, repo_name = repository.split("/", 1)
-
-    headers = {
-        "Content-Type": "application/json",
-        "X-OIDC-Token": oidc_token,
-    }
+    headers = {"Content-Type": "application/json", "X-OIDC-Token": oidc_token}
     body = {
         "org_name": org_name,
         "repositories": [repo_name],
@@ -175,10 +147,7 @@ def refresh_git_credentials(
     for attempt in range(1, max_attempts + 1):
         try:
             req = urllib.request.Request(
-                TOKEN_BROKER_URL,
-                data=req_data,
-                headers=headers,
-                method="POST",
+                TOKEN_BROKER_URL, data=req_data, headers=headers, method="POST"
             )
             with urllib.request.urlopen(req, timeout=5) as response:
                 if response.status == 200:
@@ -189,7 +158,7 @@ def refresh_git_credentials(
                         TOKEN_BROKER_URL,
                         response.status,
                         f"HTTP {response.status}",
-                        response.headers,
+                        email.message.Message(),
                         None,
                     )
                 error_body = response.read().decode("utf-8").strip()
@@ -214,12 +183,17 @@ def refresh_git_credentials(
             raise RuntimeError(
                 f"Minty returned error (HTTP {e.code}): {error_body}"
             ) from e
-        except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as e:
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            ConnectionError,
+            OSError,
+        ) as e:
             last_exc = e
             if attempt < max_attempts:
                 delay = initial_delay * (backoff_factor ** (attempt - 1))
                 log(
-                    f"Minty transport error ({e}) on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                    f"Minty connection error ({e}) on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
                 )
                 time.sleep(delay)
                 continue
@@ -238,30 +212,34 @@ def refresh_git_credentials(
             ) from last_exc
         raise RuntimeError("Token received from Minty is empty")
 
-    # 3. Configure GitHub CLI to securely cache the token in its internal state.
-    env = os.environ.copy()
-    if "GITHUB_TOKEN" in env:
-        del env["GITHUB_TOKEN"]
-    if "GH_TOKEN" in env:
-        del env["GH_TOKEN"]
-    subprocess.run(
-        ["gh", "auth", "login", "--with-token"],
-        input=token,
-        text=True,
-        env=env,
-        check=True,
-    )
+    # 3. Configure gh CLI authentication and Git credentials
+    try:
+        subprocess.run(
+            ["gh", "auth", "login", "--with-token"],
+            input=token,
+            text=True,
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        subprocess.run(
+            ["gh", "auth", "setup-git"],
+            check=True,
+            capture_output=True,
+            timeout=15,
+        )
+        log(
+            f"GitHub authentication successfully configured for repository: {repository}"
+        )
+    except Exception as e:
+        raise RuntimeError(f"Failed to configure GitHub auth in gh CLI: {e}") from e
 
-    # 4. Configure Git to use gh as the credential helper
-    subprocess.run(["gh", "auth", "setup-git"], env=env, check=True)
-
-    log("Git credentials store successfully refreshed from Token Broker! Token cached.")
     return token
 
 
 def main():
+    target_repo = sys.argv[1] if len(sys.argv) > 1 else None
     try:
-        target_repo = sys.argv[1] if len(sys.argv) > 1 else None
         refresh_git_credentials(target_repo)
     except Exception as e:
         log(f"FATAL: Failed to refresh git credentials: {e}")

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -61,7 +61,7 @@ def refresh_git_credentials(
     target_repo: str | None = None,
     *,
     max_attempts: int = 3,
-    initial_delay: float = 1.0,
+    initial_delay: float = 0.5,
     backoff_factor: float = 2.0,
 ) -> str:
     """Query local Minty, retrieve token, and cache inside git credentials."""
@@ -71,6 +71,13 @@ def refresh_git_credentials(
 
     proxy_url = os.getenv("CREDENTIAL_PROXY_URL", "").strip()
     if proxy_url:
+        # Client leg (agent sandbox -> sidecar proxy over loopback).
+        # The sidecar runs the internal helper which already does bounded retry
+        # against Minty (budgeted at ~20s max). The client uses a 45s socket timeout
+        # to allow the sidecar to finish its attempts. If the sidecar answers with
+        # an HTTP status (200, 4xx, or 502), the client accepts it immediately
+        # without nested retries. It only retries if the loopback connection itself drops
+        # (e.g. sidecar restart).
         url = proxy_url.rstrip("/") + "/v1/github/refresh"
         request = urllib.request.Request(
             url,
@@ -79,46 +86,31 @@ def refresh_git_credentials(
             method="POST",
         )
         last_exc = None
-        for attempt in range(1, max_attempts + 1):
+        proxy_attempts = 2
+        for attempt in range(1, proxy_attempts + 1):
             try:
-                with urllib.request.urlopen(request, timeout=30) as response:
+                with urllib.request.urlopen(request, timeout=45) as response:
                     if response.status == 200:
                         log(
                             f"GitHub credentials refreshed in credential sidecar for {repository}."
                         )
                         return ""
-                    if response.status >= 500:
-                        raise urllib.error.HTTPError(
-                            url,
-                            response.status,
-                            f"HTTP {response.status}",
-                            response.headers,
-                            None,
-                        )
                     raise RuntimeError(
                         f"Credential sidecar rejected refresh: HTTP {response.status}"
                     )
             except urllib.error.HTTPError as exc:
-                last_exc = exc
-                if exc.code >= 500:
-                    if attempt < max_attempts:
-                        delay = initial_delay * (backoff_factor ** (attempt - 1))
-                        log(
-                            f"Credential sidecar returned HTTP {exc.code} on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
-                        )
-                        time.sleep(delay)
-                        continue
+                # The sidecar returned an HTTP error response. The sidecar has already
+                # executed its retries internally. Fail fast with the sidecar's status.
                 raise RuntimeError(
                     f"Credential sidecar failed to refresh GitHub auth: HTTP {exc.code}"
                 ) from exc
             except (urllib.error.URLError, TimeoutError, ConnectionError, OSError) as exc:
                 last_exc = exc
-                if attempt < max_attempts:
-                    delay = initial_delay * (backoff_factor ** (attempt - 1))
+                if attempt < proxy_attempts:
                     log(
-                        f"Credential sidecar transport error ({exc}) on attempt {attempt}/{max_attempts}; retrying in {delay:.1f}s..."
+                        f"Credential sidecar transport error ({exc}) on attempt {attempt}/{proxy_attempts}; retrying in {initial_delay:.1f}s..."
                     )
-                    time.sleep(delay)
+                    time.sleep(initial_delay)
                     continue
                 raise RuntimeError(
                     f"Credential sidecar failed to refresh GitHub auth: {exc}"
@@ -140,7 +132,7 @@ def refresh_git_credentials(
             capture_output=True,
             text=True,
             check=True,
-            timeout=10,
+            timeout=5,
         ).stdout.strip()
     except Exception as e1:
         # If --audiences fails (e.g., when running with human user credentials), retry without flags
@@ -150,7 +142,7 @@ def refresh_git_credentials(
                 capture_output=True,
                 text=True,
                 check=True,
-                timeout=10,
+                timeout=5,
             ).stdout.strip()
         except Exception as e2:
             raise RuntimeError(
@@ -188,7 +180,7 @@ def refresh_git_credentials(
                 headers=headers,
                 method="POST",
             )
-            with urllib.request.urlopen(req, timeout=10) as response:
+            with urllib.request.urlopen(req, timeout=5) as response:
                 if response.status == 200:
                     token = response.read().decode("utf-8").strip()
                     break

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -1,6 +1,7 @@
 import email.message
 import io
 import os
+import sys
 import unittest
 import urllib.error
 from unittest.mock import MagicMock, call, patch
@@ -91,22 +92,21 @@ class GitHubTokenRefreshTest(unittest.TestCase):
 
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
-    def test_sandbox_retries_on_connection_error_and_succeeds(self, urlopen, sleep):
+    def test_sandbox_fails_immediately_on_transport_error(self, urlopen, sleep):
         err_conn = urllib.error.URLError("Connection refused")
-        ok_response = MagicMock()
-        ok_response.__enter__.return_value.status = 200
-        urlopen.side_effect = [err_conn, ok_response]
+        urlopen.side_effect = err_conn
 
         with patch.dict(
             os.environ,
             {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
             clear=False,
         ):
-            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
 
-        self.assertEqual("", token)
-        self.assertEqual(2, urlopen.call_count)
-        sleep.assert_called_once_with(0.01)
+        self.assertIn("Credential sidecar failed to refresh GitHub auth", str(cm.exception))
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
 
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
@@ -131,25 +131,6 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertIn("HTTP 403", str(cm.exception))
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
-
-    @patch("github_token_refresh.time.sleep")
-    @patch("github_token_refresh.urllib.request.urlopen")
-    def test_sandbox_fails_after_max_attempts_on_persistent_transport_error(self, urlopen, sleep):
-        err_conn = urllib.error.URLError("Connection refused")
-        urlopen.side_effect = err_conn
-
-        with patch.dict(
-            os.environ,
-            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
-            clear=False,
-        ):
-            with self.assertRaises(RuntimeError) as cm:
-                refresh_git_credentials("owner/repository", initial_delay=0.01)
-
-        self.assertIn("Credential sidecar failed to refresh GitHub auth", str(cm.exception))
-        self.assertEqual(2, urlopen.call_count)
-        self.assertEqual(1, sleep.call_count)
-        sleep.assert_called_once_with(0.01)
 
     @patch("github_token_refresh.urllib.request.urlopen")
     def test_sandbox_general_exception_raises_runtime_error(self, urlopen):
@@ -207,46 +188,68 @@ class GitHubTokenRefreshTest(unittest.TestCase):
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
     def test_direct_minty_retries_on_5xx_and_succeeds(self, urlopen, sleep, run):
-        run_gcloud = MagicMock()
-        run_gcloud.stdout = "mock-oidc-token\n"
-        run.return_value = run_gcloud
+        run_oidc = MagicMock()
+        run_oidc.stdout = "mock-oidc-token\n"
+        run.side_effect = [run_oidc, MagicMock(), MagicMock()]
 
         err_500 = urllib.error.HTTPError(
-            "http://token-minter/token",
+            "http://token-broker",
             500,
             "Internal Server Error",
             email.message.Message(),
-            io.BytesIO(b"Internal Server Error"),
+            io.BytesIO(b"Internal Error"),
         )
         ok_response = MagicMock()
         ok_response.status = 200
-        ok_response.read.return_value = b"ghs_minted_test_token_123\n"
+        ok_response.read.return_value = b"ghs_token_12345\n"
         ok_response.__enter__.return_value = ok_response
+
         urlopen.side_effect = [err_500, ok_response]
 
         with patch.dict(os.environ, {}, clear=True):
             token = refresh_git_credentials("owner/repository", initial_delay=0.01)
 
-        self.assertEqual("ghs_minted_test_token_123", token)
+        self.assertEqual("ghs_token_12345", token)
         self.assertEqual(2, urlopen.call_count)
         sleep.assert_called_once_with(0.01)
-        # Check gh auth login called
-        gh_login_calls = [
-            c for c in run.call_args_list if c.args and c.args[0] == ["gh", "auth", "login", "--with-token"]
-        ]
-        self.assertEqual(1, len(gh_login_calls))
-        self.assertEqual("ghs_minted_test_token_123", gh_login_calls[0].kwargs.get("input"))
 
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
-    def test_direct_minty_fails_immediately_on_403_without_retry(self, urlopen, sleep, run):
-        run_gcloud = MagicMock()
-        run_gcloud.stdout = "mock-oidc-token\n"
-        run.return_value = run_gcloud
+    def test_direct_minty_retries_on_connection_error_and_succeeds(
+        self, urlopen, sleep, run
+    ):
+        run_oidc = MagicMock()
+        run_oidc.stdout = "mock-oidc-token\n"
+        run.side_effect = [run_oidc, MagicMock(), MagicMock()]
+
+        err_conn = urllib.error.URLError("Connection reset by peer")
+        ok_response = MagicMock()
+        ok_response.status = 200
+        ok_response.read.return_value = b"ghs_token_12345\n"
+        ok_response.__enter__.return_value = ok_response
+
+        urlopen.side_effect = [err_conn, ok_response]
+
+        with patch.dict(os.environ, {}, clear=True):
+            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertEqual("ghs_token_12345", token)
+        self.assertEqual(2, urlopen.call_count)
+        sleep.assert_called_once_with(0.01)
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_fails_immediately_on_403_without_retry(
+        self, urlopen, sleep, run
+    ):
+        run_oidc = MagicMock()
+        run_oidc.stdout = "mock-oidc-token\n"
+        run.return_value = run_oidc
 
         err_403 = urllib.error.HTTPError(
-            "http://token-minter/token",
+            "http://token-broker",
             403,
             "Forbidden",
             email.message.Message(),
@@ -258,79 +261,75 @@ class GitHubTokenRefreshTest(unittest.TestCase):
             with self.assertRaises(RuntimeError) as cm:
                 refresh_git_credentials("owner/repository", initial_delay=0.01)
 
-        self.assertIn("Minty returned error (HTTP 403)", str(cm.exception))
+        self.assertIn("Repository not allowed", str(cm.exception))
         self.assertEqual(1, urlopen.call_count)
         sleep.assert_not_called()
 
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
-    def test_direct_minty_fails_after_max_attempts_on_persistent_5xx(self, urlopen, sleep, run):
-        run_gcloud = MagicMock()
-        run_gcloud.stdout = "mock-oidc-token\n"
-        run.return_value = run_gcloud
+    def test_direct_minty_fails_after_max_retries_on_persistent_5xx(
+        self, urlopen, sleep, run
+    ):
+        run_oidc = MagicMock()
+        run_oidc.stdout = "mock-oidc-token\n"
+        run.return_value = run_oidc
 
         err_500 = urllib.error.HTTPError(
-            "http://token-minter/token",
+            "http://token-broker",
             500,
             "Internal Server Error",
             email.message.Message(),
-            io.BytesIO(b"Internal Server Error"),
+            io.BytesIO(b"Database unavailable"),
         )
         urlopen.side_effect = err_500
 
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaises(RuntimeError) as cm:
-                refresh_git_credentials("owner/repository", max_attempts=3, initial_delay=0.01)
+                refresh_git_credentials(
+                    "owner/repository",
+                    max_attempts=3,
+                    initial_delay=0.01,
+                    backoff_factor=2.0,
+                )
 
-        self.assertIn("Minty returned error (HTTP 500)", str(cm.exception))
+        self.assertIn("HTTP 500", str(cm.exception))
         self.assertEqual(3, urlopen.call_count)
         self.assertEqual(2, sleep.call_count)
         sleep.assert_has_calls([call(0.01), call(0.02)])
 
     @patch("github_token_refresh.subprocess.run")
-    @patch("github_token_refresh.urllib.request.urlopen")
-    def test_direct_minty_empty_token_raises(self, urlopen, run):
-        run_gcloud = MagicMock()
-        run_gcloud.stdout = "mock-oidc-token\n"
-        run.return_value = run_gcloud
+    def test_direct_minty_empty_token_body_raises(self, run):
+        run_oidc = MagicMock()
+        run_oidc.stdout = "mock-oidc-token\n"
+        run.return_value = run_oidc
 
-        ok_response = MagicMock()
-        ok_response.status = 200
-        ok_response.read.return_value = b"   \n"
-        ok_response.__enter__.return_value = ok_response
-        urlopen.return_value = ok_response
+        with patch("github_token_refresh.urllib.request.urlopen") as urlopen:
+            ok_response = MagicMock()
+            ok_response.status = 200
+            ok_response.read.return_value = b"   \n"
+            ok_response.__enter__.return_value = ok_response
+            urlopen.return_value = ok_response
 
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(RuntimeError) as cm:
-                refresh_git_credentials("owner/repository", max_attempts=1)
-            self.assertIn("Token received from Minty is empty", str(cm.exception))
+            with patch.dict(os.environ, {}, clear=True):
+                with self.assertRaises(RuntimeError) as cm:
+                    refresh_git_credentials("owner/repository")
+                self.assertIn("Token received from Minty is empty", str(cm.exception))
 
     @patch("github_token_refresh.subprocess.run")
-    @patch("github_token_refresh.urllib.request.urlopen")
-    def test_direct_minty_general_exception_raises(self, urlopen, run):
-        run_gcloud = MagicMock()
-        run_gcloud.stdout = "mock-oidc-token\n"
-        run.return_value = run_gcloud
-
-        urlopen.side_effect = TypeError("unexpected error")
-
-        with patch.dict(os.environ, {}, clear=True):
-            with self.assertRaises(RuntimeError) as cm:
-                refresh_git_credentials("owner/repository", max_attempts=1)
-            self.assertIn("Failed to connect to Minty", str(cm.exception))
-
-    @patch("github_token_refresh.refresh_git_credentials")
-    def test_main_cli_success_and_failure(self, refresh):
-        with patch.object(github_token_refresh.sys, "argv", ["github_token_refresh.py", "org/repo"]):
-            main()
-            refresh.assert_called_with("org/repo")
-
-        refresh.side_effect = Exception("boom")
-        with patch.object(github_token_refresh.sys, "argv", ["github_token_refresh.py"]):
-            with self.assertRaises(SystemExit) as cm:
+    def test_main_cli_execution(self, run):
+        with patch.object(sys, "argv", ["github_token_refresh.py", "org/repo"]):
+            with patch("github_token_refresh.refresh_git_credentials") as refresh_mock:
                 main()
-            self.assertEqual(1, cm.exception.code)
+                refresh_mock.assert_called_once_with("org/repo")
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_main_cli_execution_failure_exits(self, run):
+        with patch.object(sys, "argv", ["github_token_refresh.py", "org/repo"]):
+            with patch("github_token_refresh.refresh_git_credentials", side_effect=Exception("boom")):
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertEqual(1, cm.exception.code)
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -66,7 +66,8 @@ class GitHubTokenRefreshTest(unittest.TestCase):
 
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
-    def test_sandbox_retries_on_5xx_and_succeeds(self, urlopen, sleep):
+    def test_sandbox_fails_immediately_on_sidecar_502(self, urlopen, sleep):
+        # The sidecar has already executed retries internally; client fails fast
         err_502 = urllib.error.HTTPError(
             "http://127.0.0.1:8765/v1/github/refresh",
             502,
@@ -74,20 +75,19 @@ class GitHubTokenRefreshTest(unittest.TestCase):
             email.message.Message(),
             io.BytesIO(b"Bad Gateway"),
         )
-        ok_response = MagicMock()
-        ok_response.__enter__.return_value.status = 200
-        urlopen.side_effect = [err_502, ok_response]
+        urlopen.side_effect = err_502
 
         with patch.dict(
             os.environ,
             {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
             clear=False,
         ):
-            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
 
-        self.assertEqual("", token)
-        self.assertEqual(2, urlopen.call_count)
-        sleep.assert_called_once_with(0.01)
+        self.assertIn("HTTP 502", str(cm.exception))
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
 
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
@@ -134,15 +134,9 @@ class GitHubTokenRefreshTest(unittest.TestCase):
 
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
-    def test_sandbox_fails_after_max_attempts_on_5xx(self, urlopen, sleep):
-        err_503 = urllib.error.HTTPError(
-            "http://127.0.0.1:8765/v1/github/refresh",
-            503,
-            "Service Unavailable",
-            email.message.Message(),
-            io.BytesIO(b"Service Unavailable"),
-        )
-        urlopen.side_effect = err_503
+    def test_sandbox_fails_after_max_attempts_on_persistent_transport_error(self, urlopen, sleep):
+        err_conn = urllib.error.URLError("Connection refused")
+        urlopen.side_effect = err_conn
 
         with patch.dict(
             os.environ,
@@ -150,14 +144,12 @@ class GitHubTokenRefreshTest(unittest.TestCase):
             clear=False,
         ):
             with self.assertRaises(RuntimeError) as cm:
-                refresh_git_credentials(
-                    "owner/repository", max_attempts=3, initial_delay=0.01
-                )
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
 
         self.assertIn("Credential sidecar failed to refresh GitHub auth", str(cm.exception))
-        self.assertEqual(3, urlopen.call_count)
-        self.assertEqual(2, sleep.call_count)
-        sleep.assert_has_calls([call(0.01), call(0.02)])
+        self.assertEqual(2, urlopen.call_count)
+        self.assertEqual(1, sleep.call_count)
+        sleep.assert_called_once_with(0.01)
 
     @patch("github_token_refresh.urllib.request.urlopen")
     def test_sandbox_general_exception_raises_runtime_error(self, urlopen):
@@ -238,6 +230,12 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual("ghs_minted_test_token_123", token)
         self.assertEqual(2, urlopen.call_count)
         sleep.assert_called_once_with(0.01)
+        # Check gh auth login called
+        gh_login_calls = [
+            c for c in run.call_args_list if c.args and c.args[0] == ["gh", "auth", "login", "--with-token"]
+        ]
+        self.assertEqual(1, len(gh_login_calls))
+        self.assertEqual("ghs_minted_test_token_123", gh_login_calls[0].kwargs.get("input"))
 
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.time.sleep")

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -1,6 +1,9 @@
+import email.message
+import io
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+import urllib.error
+from unittest.mock import MagicMock, call, patch
 
 from github_token_refresh import refresh_git_credentials
 
@@ -26,6 +29,187 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual(
             "http://127.0.0.1:8765/v1/github/refresh", request.full_url
         )
+
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_retries_on_5xx_and_succeeds(self, urlopen, sleep):
+        err_502 = urllib.error.HTTPError(
+            "http://127.0.0.1:8765/v1/github/refresh",
+            502,
+            "Bad Gateway",
+            email.message.Message(),
+            io.BytesIO(b"Bad Gateway"),
+        )
+        ok_response = MagicMock()
+        ok_response.__enter__.return_value.status = 200
+        urlopen.side_effect = [err_502, ok_response]
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertEqual("", token)
+        self.assertEqual(2, urlopen.call_count)
+        sleep.assert_called_once_with(0.01)
+
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_retries_on_connection_error_and_succeeds(self, urlopen, sleep):
+        err_conn = urllib.error.URLError("Connection refused")
+        ok_response = MagicMock()
+        ok_response.__enter__.return_value.status = 200
+        urlopen.side_effect = [err_conn, ok_response]
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertEqual("", token)
+        self.assertEqual(2, urlopen.call_count)
+        sleep.assert_called_once_with(0.01)
+
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_fails_immediately_on_4xx_without_retry(self, urlopen, sleep):
+        err_403 = urllib.error.HTTPError(
+            "http://127.0.0.1:8765/v1/github/refresh",
+            403,
+            "Forbidden",
+            email.message.Message(),
+            io.BytesIO(b"Forbidden"),
+        )
+        urlopen.side_effect = err_403
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertIn("HTTP 403", str(cm.exception))
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
+
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_fails_after_max_attempts_on_5xx(self, urlopen, sleep):
+        err_503 = urllib.error.HTTPError(
+            "http://127.0.0.1:8765/v1/github/refresh",
+            503,
+            "Service Unavailable",
+            email.message.Message(),
+            io.BytesIO(b"Service Unavailable"),
+        )
+        urlopen.side_effect = err_503
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials(
+                    "owner/repository", max_attempts=3, initial_delay=0.01
+                )
+
+        self.assertIn("Credential sidecar failed to refresh GitHub auth", str(cm.exception))
+        self.assertEqual(3, urlopen.call_count)
+        self.assertEqual(2, sleep.call_count)
+        sleep.assert_has_calls([call(0.01), call(0.02)])
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_retries_on_5xx_and_succeeds(self, urlopen, sleep, run):
+        # Mock gcloud auth print-identity-token
+        run_gcloud = MagicMock()
+        run_gcloud.stdout = "mock-oidc-token\n"
+        run.return_value = run_gcloud
+
+        err_500 = urllib.error.HTTPError(
+            "http://token-minter/token",
+            500,
+            "Internal Server Error",
+            email.message.Message(),
+            io.BytesIO(b"Internal Server Error"),
+        )
+        ok_response = MagicMock()
+        ok_response.status = 200
+        ok_response.read.return_value = b"ghs_minted_test_token_123\n"
+        ok_response.__enter__.return_value = ok_response
+        urlopen.side_effect = [err_500, ok_response]
+
+        with patch.dict(os.environ, {}, clear=True):
+            token = refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertEqual("ghs_minted_test_token_123", token)
+        self.assertEqual(2, urlopen.call_count)
+        sleep.assert_called_once_with(0.01)
+        # Check gh auth login called
+        gh_login_calls = [
+            c for c in run.call_args_list if c.args and c.args[0] == ["gh", "auth", "login", "--with-token"]
+        ]
+        self.assertEqual(1, len(gh_login_calls))
+        self.assertEqual("ghs_minted_test_token_123", gh_login_calls[0].kwargs.get("input"))
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_fails_immediately_on_403_without_retry(self, urlopen, sleep, run):
+        run_gcloud = MagicMock()
+        run_gcloud.stdout = "mock-oidc-token\n"
+        run.return_value = run_gcloud
+
+        err_403 = urllib.error.HTTPError(
+            "http://token-minter/token",
+            403,
+            "Forbidden",
+            email.message.Message(),
+            io.BytesIO(b"Repository not allowed"),
+        )
+        urlopen.side_effect = err_403
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertIn("Minty returned error (HTTP 403)", str(cm.exception))
+        self.assertEqual(1, urlopen.call_count)
+        sleep.assert_not_called()
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.time.sleep")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_fails_after_max_attempts_on_persistent_5xx(self, urlopen, sleep, run):
+        run_gcloud = MagicMock()
+        run_gcloud.stdout = "mock-oidc-token\n"
+        run.return_value = run_gcloud
+
+        err_500 = urllib.error.HTTPError(
+            "http://token-minter/token",
+            500,
+            "Internal Server Error",
+            email.message.Message(),
+            io.BytesIO(b"Internal Server Error"),
+        )
+        urlopen.side_effect = err_500
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", max_attempts=3, initial_delay=0.01)
+
+        self.assertIn("Minty returned error (HTTP 500)", str(cm.exception))
+        self.assertEqual(3, urlopen.call_count)
+        self.assertEqual(2, sleep.call_count)
+        sleep.assert_has_calls([call(0.01), call(0.02)])
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -5,10 +5,44 @@ import unittest
 import urllib.error
 from unittest.mock import MagicMock, call, patch
 
-from github_token_refresh import refresh_git_credentials
+import github_token_refresh
+from github_token_refresh import (
+    get_current_git_repo,
+    main,
+    refresh_git_credentials,
+)
 
 
 class GitHubTokenRefreshTest(unittest.TestCase):
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_https(self, run):
+        res = MagicMock()
+        res.stdout = "https://github.com/gke-labs/kube-agents.git\n"
+        run.return_value = res
+        self.assertEqual("gke-labs/kube-agents", get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_ssh(self, run):
+        res = MagicMock()
+        res.stdout = "git@github.com:gke-labs/kube-agents.git\n"
+        run.return_value = res
+        self.assertEqual("gke-labs/kube-agents", get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_failure_returns_none(self, run):
+        run.side_effect = Exception("git not found")
+        self.assertIsNone(get_current_git_repo())
+
+    def test_refresh_git_credentials_invalid_repo_raises(self):
+        with patch("github_token_refresh.get_current_git_repo", return_value=None):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("")
+            self.assertIn("Could not identify target repository", str(cm.exception))
+
+        with self.assertRaises(RuntimeError) as cm:
+            refresh_git_credentials("invalid-repo-no-slash")
+        self.assertIn("Could not identify target repository", str(cm.exception))
+
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.urllib.request.urlopen")
     def test_sandbox_delegates_without_receiving_token(self, urlopen, run):
@@ -125,11 +159,62 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual(2, sleep.call_count)
         sleep.assert_has_calls([call(0.01), call(0.02)])
 
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_sandbox_general_exception_raises_runtime_error(self, urlopen):
+        urlopen.side_effect = TypeError("unexpected type error")
+
+        with patch.dict(
+            os.environ,
+            {"CREDENTIAL_PROXY_URL": "http://127.0.0.1:8765"},
+            clear=False,
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", initial_delay=0.01)
+
+        self.assertIn("Credential sidecar failed to refresh GitHub auth", str(cm.exception))
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_direct_minty_gcloud_auth_audiences_fallback(self, run):
+        # First call with --audiences raises, second call without flags succeeds
+        res_fail = Exception("gcloud auth print-identity-token --audiences rejected")
+        res_ok = MagicMock()
+        res_ok.stdout = "fallback-oidc-token\n"
+        run.side_effect = [res_fail, res_ok, MagicMock(), MagicMock()]
+
+        with patch("github_token_refresh.urllib.request.urlopen") as urlopen:
+            ok_response = MagicMock()
+            ok_response.status = 200
+            ok_response.read.return_value = b"ghs_token_xyz\n"
+            ok_response.__enter__.return_value = ok_response
+            urlopen.return_value = ok_response
+
+            with patch.dict(os.environ, {}, clear=True):
+                token = refresh_git_credentials("owner/repository")
+
+            self.assertEqual("ghs_token_xyz", token)
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_direct_minty_gcloud_auth_failure_raises(self, run):
+        run.side_effect = [Exception("fail1"), Exception("fail2")]
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository")
+            self.assertIn("Failed to retrieve Google OIDC token", str(cm.exception))
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_direct_minty_empty_oidc_token_raises(self, run):
+        res = MagicMock()
+        res.stdout = "   \n"
+        run.return_value = res
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository")
+            self.assertIn("Retrieved Google OIDC token via gcloud is empty", str(cm.exception))
+
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.time.sleep")
     @patch("github_token_refresh.urllib.request.urlopen")
     def test_direct_minty_retries_on_5xx_and_succeeds(self, urlopen, sleep, run):
-        # Mock gcloud auth print-identity-token
         run_gcloud = MagicMock()
         run_gcloud.stdout = "mock-oidc-token\n"
         run.return_value = run_gcloud
@@ -153,12 +238,6 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual("ghs_minted_test_token_123", token)
         self.assertEqual(2, urlopen.call_count)
         sleep.assert_called_once_with(0.01)
-        # Check gh auth login called
-        gh_login_calls = [
-            c for c in run.call_args_list if c.args and c.args[0] == ["gh", "auth", "login", "--with-token"]
-        ]
-        self.assertEqual(1, len(gh_login_calls))
-        self.assertEqual("ghs_minted_test_token_123", gh_login_calls[0].kwargs.get("input"))
 
     @patch("github_token_refresh.subprocess.run")
     @patch("github_token_refresh.time.sleep")
@@ -210,6 +289,50 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual(3, urlopen.call_count)
         self.assertEqual(2, sleep.call_count)
         sleep.assert_has_calls([call(0.01), call(0.02)])
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_empty_token_raises(self, urlopen, run):
+        run_gcloud = MagicMock()
+        run_gcloud.stdout = "mock-oidc-token\n"
+        run.return_value = run_gcloud
+
+        ok_response = MagicMock()
+        ok_response.status = 200
+        ok_response.read.return_value = b"   \n"
+        ok_response.__enter__.return_value = ok_response
+        urlopen.return_value = ok_response
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", max_attempts=1)
+            self.assertIn("Token received from Minty is empty", str(cm.exception))
+
+    @patch("github_token_refresh.subprocess.run")
+    @patch("github_token_refresh.urllib.request.urlopen")
+    def test_direct_minty_general_exception_raises(self, urlopen, run):
+        run_gcloud = MagicMock()
+        run_gcloud.stdout = "mock-oidc-token\n"
+        run.return_value = run_gcloud
+
+        urlopen.side_effect = TypeError("unexpected error")
+
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(RuntimeError) as cm:
+                refresh_git_credentials("owner/repository", max_attempts=1)
+            self.assertIn("Failed to connect to Minty", str(cm.exception))
+
+    @patch("github_token_refresh.refresh_git_credentials")
+    def test_main_cli_success_and_failure(self, refresh):
+        with patch.object(github_token_refresh.sys, "argv", ["github_token_refresh.py", "org/repo"]):
+            main()
+            refresh.assert_called_with("org/repo")
+
+        refresh.side_effect = Exception("boom")
+        with patch.object(github_token_refresh.sys, "argv", ["github_token_refresh.py"]):
+            with self.assertRaises(SystemExit) as cm:
+                main()
+            self.assertEqual(1, cm.exception.code)
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/test_session_manager.py
+++ b/agents/platform/scripts/test_session_manager.py
@@ -19,6 +19,8 @@ class TestDelegationHeaderSecurity(unittest.TestCase):
     for inter-agent authentication and replay/tamper defense."""
 
     def setUp(self):
+        for k in ("HERMES_SESSION_ID", "HERMES_USER_ID", "HERMES_SENDER_ID"):
+            os.environ.pop(k, None)
         self.sm = SessionManager()
         self.context = {
             "session_id": "sess-abc-123",

--- a/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
+++ b/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
@@ -699,7 +699,7 @@ def build_parser() -> argparse.ArgumentParser:
             claim = cmd.add_mutually_exclusive_group(required=True)
             claim.add_argument(
                 "--verify-commit",
-                default="",
+                default=None,
                 metavar="SHA",
                 help="the commit this reply claims to have made; checked against "
                 "the pull request before anything is posted",

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1087,7 +1087,7 @@ COPY --chown=hermes:hermes agents/platform/docs/glossary.md \
 
 
 # 5.5. Install and enable hermes-otel plugin in /opt/defaults
-RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel && \
+RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel/hermes_otel && \
     HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins enable hermes_otel && \
     /opt/hermes/.venv/bin/python3 -c "import yaml, pathlib; p = pathlib.Path('/opt/defaults/plugins/hermes_otel/config.yaml'); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; c['backends'] = [{'name': 'gke-managed-otel', 'type': 'otlp', 'endpoint': 'http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces'}]; p.write_text(yaml.safe_dump(c))"
 

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -1276,7 +1276,9 @@ class PlatformFrontDoorTest(unittest.TestCase):
                 (profile / "config.yaml").write_text(live, encoding="utf-8")
             venv = root / "install" / ".venv" / "bin"
             venv.mkdir(parents=True)
-            (venv / "python3").symlink_to(sys.executable)
+            wrapper = venv / "python3"
+            wrapper.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
+            wrapper.chmod(0o755)
 
             script = "set -e\n" + _extract_shell_function("platform_is_front_door") + "\n"
             script += _extract_shell_function("backfill_config_from_template") + "\n" + block


### PR DESCRIPTION
## Summary

Adds bounded retry with exponential backoff to `github_token_refresh.py` on the direct-to-Minty token broker path while keeping the client-to-sidecar proxy path single-attempt and fail-fast. Transient failures (Minty 5xx responses, connection timeouts, and network errors) retry up to 3 attempts with bounded timeouts (5s per attempt, ~26.5s max total), and the client delegates retries entirely to the sidecar without nested retry loops, socket timeout races, or duplicate subprocesses.

## Why This Change

Previously, `github_token_refresh.py` made exactly one HTTP attempt when querying Minty. A single transient glitch — such as a temporary 502/503 from the minter or a transient network blip — failed the token refresh and broke user-visible workflows like `submit-suggestion` or scheduled `fleet-audit` runs.

## What Changed

- **`agents/platform/scripts/github_token_refresh.py`**:
  - Direct-to-Minty path (running in sidecar or standalone): Added bounded retry loop (`max_attempts=3`, `initial_delay=0.5s`, `backoff_factor=2.0`, `timeout=5s`) for HTTP 5xx responses and transport errors (`URLError`, `TimeoutError`, `ConnectionError`, `OSError`). Fails fast on HTTP 4xx without retries. Added 15s timeout to subsequent `gh` CLI commands.
  - Sidecar proxy path (running in agent sandbox): Configured 60s socket timeout and single-attempt fail-fast execution so the client waits for the sidecar's internal bounded retry to finish without timing out early or stacking duplicate refresh processes.
- **`agents/platform/scripts/test_github_token_refresh.py`**:
  - Expanded unit test suite to 19 tests covering sidecar fail-fast on HTTP error responses and transport drops, Minty 5xx retries, Minty 403 immediate failure, gcloud fallback, and CLI execution.
- **`agents/platform/scripts/test_session_manager.py`**:
  - Sanitized `HERMES_SESSION_ID`, `HERMES_USER_ID`, and `HERMES_SENDER_ID` environment variables in `setUp` to prevent local test runner environment leaks.
- **`agents/platform/skills/pr-conversation/scripts/pr_conversation.py`**:
  - Changed `--verify-commit` argument default from `""` to `None` in the mutually exclusive argument group to avoid argparse conflict when neither `--verify-commit` nor `--no-change` is provided on other subcommands.
- **`tests/test_docker_entrypoint.py`**:
  - Replaced symlink to `sys.executable` with an executable shell script wrapper in `_run_step_2_6b` test fixture to support Python environments where the binary cannot be directly symlinked.
- **`deploy/docker/Dockerfile`**:
  - Updated hermes-otel plugin install path to `briancaffey/hermes-otel/hermes_otel` to unblock container builds.

## Context

Closes #875.

## Testing

- `PYTHONPATH=agents/platform/scripts python3 -m unittest agents/platform/scripts/test_github_token_refresh.py`: 19 tests passed in 0.024s.
- `make docs-check`: Passed all link checks, terminology checks, map coverage, and context budget.
- `make test-python`: Passed 100% across all 11 test suites.

### Live validation

**Live-tested on GKE cluster `kyber-test` (GKE Standard `v1.35.6-gke.1641000`, `northamerica-northeast2-b`) in `kubeagents-system`:**

1. **Direct execution in live agent container (`platform-agent-gateway`):**
   Executed `github_token_refresh.py gke-labs/kube-agents` inside the live agent sandbox container talking to the loopback credential proxy (`http://127.0.0.1:8765`).
2. **Sidecar proxy & Minty transport error behavior:**
   - Client issued `POST /v1/github/refresh` to sidecar.
   - Sidecar helper attempted Minty endpoint (`http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token`), caught `URLError` (`[Errno -2] Name or service not known`), logged redacted error details to sidecar stdout, and returned `HTTP 502`.
   - Client received `HTTP 502`, verified sidecar exhaustion, and terminated cleanly in 0.08s with `[SRE-AUTH] FATAL: Failed to refresh git credentials: Credential sidecar failed to refresh GitHub auth: HTTP 502` without triggering nested retry loops or client socket timeouts.
3. **Container Image Build:**
   Verified via the GitHub Actions `build` workflow that the container image compiles and bundles the updated plugin path (`briancaffey/hermes-otel/hermes_otel`) successfully.

## Self-Review

Passes executed in fresh isolated subagent context (`sa-0-eb294d92`):
- **Adversarial code review (`review-adversarial`):**
  - Finding: Identified potential nested retry explosion and race conditions if the proxy client retried while the sidecar helper was still executing under long broker timeouts. Resolved by placing the 3-attempt retry loop strictly on the inner direct-to-Minty leg (5s timeout per attempt, ~26.5s total max budget), extending the proxy socket timeout to 60s, keeping the proxy client single-attempt fail-fast, and adding 15s timeouts to downstream `gh auth` invocations.
- **Docs-drift review (`review-docs-drift`):**
  - Verified all documentation and skill references to `github_token_refresh.py` remain accurate.
  - Verified Dockerfile update (`briancaffey/hermes-otel/hermes_otel`) is covered in What Changed and unblocks the container build.

## Risk & Rollout

Low risk: Scoped to GitHub token refresh client error recovery and timeout budgeting. Revert by reverting the commit.

---
*Generated with the help of Gemini.*