### PR TITLE
fix(entrypoint): invalidate local MCP server schema caches on startup

### DIFF
--- a/agents/platform/scripts/invalidate_mcp_cache.py
+++ b/agents/platform/scripts/invalidate_mcp_cache.py
@@ -19,6 +19,14 @@ from pathlib import Path
 KNOWN_LOCAL_MCP_SERVERS = frozenset({"platform_control", "router"})
 
 
+class CacheInvalidationError(RuntimeError):
+    """Raised when one or more MCP schema caches could not be invalidated cleanly."""
+
+    def __init__(self, message: str, results: dict[str, list[str]] | None = None):
+        super().__init__(message)
+        self.results = results or {}
+
+
 def is_local_mcp_server(server_name: str, config: dict | None = None) -> bool:
     """Return True if the MCP server is locally hosted rather than a remote proxy."""
     if server_name in KNOWN_LOCAL_MCP_SERVERS:
@@ -65,7 +73,7 @@ def invalidate_cache_file(cache_file: Path, mcp_configs: dict[str, dict] | None 
     with open(cache_file, "r", encoding="utf-8") as f:
         data = json.load(f)
     if not isinstance(data, dict):
-        return []
+        raise ValueError(f"schema cache {cache_file} root is not a JSON object")
 
     removed: list[str] = []
     for server_name in list(data.keys()):
@@ -89,33 +97,55 @@ def invalidate_cache_file(cache_file: Path, mcp_configs: dict[str, dict] | None 
 def invalidate_all_mcp_caches(target_dir: Path) -> dict[str, list[str]]:
     """Scan root and all profile directories under target_dir and invalidate local MCP caches."""
     results: dict[str, list[str]] = {}
+    failed = False
 
-    # 1. Root / default profile cache
+    targets: list[tuple[str, Path, dict[str, dict]]] = []
     root_cache = target_dir / "cache" / "mcp_schema_cache.json"
-    root_configs = get_profile_mcp_configs(target_dir)
-    removed_root = invalidate_cache_file(root_cache, root_configs)
-    if removed_root:
-        results["default"] = removed_root
+    if root_cache.is_file():
+        targets.append(("default", root_cache, get_profile_mcp_configs(target_dir)))
 
-    # 2. Named profiles under profiles/
     profiles_dir = target_dir / "profiles"
     if profiles_dir.is_dir():
         for p in sorted(profiles_dir.iterdir()):
             if p.is_dir():
                 p_cache = p / "cache" / "mcp_schema_cache.json"
-                p_configs = get_profile_mcp_configs(p)
-                removed_p = invalidate_cache_file(p_cache, p_configs)
-                if removed_p:
-                    results[p.name] = removed_p
+                if p_cache.is_file():
+                    targets.append((p.name, p_cache, get_profile_mcp_configs(p)))
+
+    for profile_name, cache_file, configs in targets:
+        try:
+            removed = invalidate_cache_file(cache_file, configs)
+            if removed:
+                results[profile_name] = removed
+        except (json.JSONDecodeError, ValueError, OSError) as e:
+            print(f"unreadable cache {cache_file}: {e}; deleting", file=sys.stderr)
+            try:
+                cache_file.unlink(missing_ok=True)
+            except OSError as unlink_err:
+                print(f"could not delete corrupt cache {cache_file}: {unlink_err}", file=sys.stderr)
+            failed = True
+
+    if failed:
+        raise CacheInvalidationError("failed to invalidate one or more MCP schema caches", results=results)
 
     return results
 
 
-def main():
+def main() -> None:
     target_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(os.environ.get("PLATFORM_AGENT_HOME", "/opt/data"))
-    results = invalidate_all_mcp_caches(target_path)
+    results: dict[str, list[str]] = {}
+    failed = False
+    try:
+        results = invalidate_all_mcp_caches(target_path)
+    except CacheInvalidationError as e:
+        results = e.results
+        failed = True
+
     for profile, servers in results.items():
         print(f"[ENTRYPOINT] Invalidated local MCP schema cache for profile '{profile}': {', '.join(servers)}")
+
+    if failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/invalidate_mcp_cache.py
+++ b/agents/platform/scripts/invalidate_mcp_cache.py
@@ -62,12 +62,9 @@ def invalidate_cache_file(cache_file: Path, mcp_configs: dict[str, dict] | None 
     """Remove local MCP server entries from a single mcp_schema_cache.json file."""
     if not cache_file.is_file():
         return []
-    try:
-        with open(cache_file, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        if not isinstance(data, dict):
-            return []
-    except Exception:
+    with open(cache_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
         return []
 
     removed: list[str] = []
@@ -78,13 +75,14 @@ def invalidate_cache_file(cache_file: Path, mcp_configs: dict[str, dict] | None 
             removed.append(server_name)
 
     if removed:
+        tmp_file = cache_file.with_suffix(".tmp")
         try:
-            tmp_file = cache_file.with_suffix(".tmp")
             with open(tmp_file, "w", encoding="utf-8") as f:
                 json.dump(data, f, indent=2)
             os.replace(tmp_file, cache_file)
-        except Exception:
-            pass
+        finally:
+            if tmp_file.exists():
+                tmp_file.unlink(missing_ok=True)
     return removed
 
 

--- a/agents/platform/scripts/invalidate_mcp_cache.py
+++ b/agents/platform/scripts/invalidate_mcp_cache.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""
+Invalidate local stdio MCP server schemas in on-disk mcp_schema_cache.json files.
+
+When container images upgrade, new tools in local scripts (e.g. platform_mcp_server.py,
+router_server.py) must be discovered on first use instead of being shadowed by stale
+schema caches on persistent storage (Issue #854).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Known local stdio MCP servers in kube-agents whose tool definitions
+# are backed by image-provided local scripts.
+KNOWN_LOCAL_MCP_SERVERS = frozenset({"platform_control", "router"})
+
+
+def is_local_mcp_server(server_name: str, config: dict | None = None) -> bool:
+    """Return True if the MCP server is locally hosted rather than a remote proxy."""
+    if server_name in KNOWN_LOCAL_MCP_SERVERS:
+        return True
+    if not config or not isinstance(config, dict):
+        return False
+    # Remote servers have a direct URL or use mcp-remote proxy to an https:// endpoint
+    if config.get("url"):
+        return False
+    args = config.get("args") or []
+    for arg in args:
+        if isinstance(arg, str):
+            if "/opt/mcp-remote" in arg or arg.startswith("https://") or arg.startswith("http://"):
+                return False
+    # If it's a command like python / script inside scripts/ or local file, it's local
+    command = str(config.get("command") or "")
+    if "python" in command or any(str(a).endswith(".py") or "scripts/" in str(a) for a in args):
+        return True
+    return False
+
+
+def get_profile_mcp_configs(profile_dir: Path) -> dict[str, dict]:
+    """Try to read mcp_servers from a profile's config.yaml or template."""
+    config_file = profile_dir / "config.yaml"
+    if not config_file.is_file():
+        return {}
+    try:
+        import yaml  # type: ignore
+        with open(config_file, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+            if isinstance(data, dict):
+                servers = data.get("mcp_servers")
+                if isinstance(servers, dict):
+                    return servers
+    except Exception:
+        pass
+    return {}
+
+
+def invalidate_cache_file(cache_file: Path, mcp_configs: dict[str, dict] | None = None) -> list[str]:
+    """Remove local MCP server entries from a single mcp_schema_cache.json file."""
+    if not cache_file.is_file():
+        return []
+    try:
+        with open(cache_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return []
+    except Exception:
+        return []
+
+    removed: list[str] = []
+    for server_name in list(data.keys()):
+        cfg = (mcp_configs or {}).get(server_name)
+        if is_local_mcp_server(server_name, cfg):
+            del data[server_name]
+            removed.append(server_name)
+
+    if removed:
+        try:
+            tmp_file = cache_file.with_suffix(".tmp")
+            with open(tmp_file, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp_file, cache_file)
+        except Exception:
+            pass
+    return removed
+
+
+def invalidate_all_mcp_caches(target_dir: Path) -> dict[str, list[str]]:
+    """Scan root and all profile directories under target_dir and invalidate local MCP caches."""
+    results: dict[str, list[str]] = {}
+
+    # 1. Root / default profile cache
+    root_cache = target_dir / "cache" / "mcp_schema_cache.json"
+    root_configs = get_profile_mcp_configs(target_dir)
+    removed_root = invalidate_cache_file(root_cache, root_configs)
+    if removed_root:
+        results["default"] = removed_root
+
+    # 2. Named profiles under profiles/
+    profiles_dir = target_dir / "profiles"
+    if profiles_dir.is_dir():
+        for p in sorted(profiles_dir.iterdir()):
+            if p.is_dir():
+                p_cache = p / "cache" / "mcp_schema_cache.json"
+                p_configs = get_profile_mcp_configs(p)
+                removed_p = invalidate_cache_file(p_cache, p_configs)
+                if removed_p:
+                    results[p.name] = removed_p
+
+    return results
+
+
+def main():
+    target_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(os.environ.get("PLATFORM_AGENT_HOME", "/opt/data"))
+    results = invalidate_all_mcp_caches(target_path)
+    for profile, servers in results.items():
+        print(f"[ENTRYPOINT] Invalidated local MCP schema cache for profile '{profile}': {', '.join(servers)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/platform/scripts/test_invalidate_mcp_cache.py
+++ b/agents/platform/scripts/test_invalidate_mcp_cache.py
@@ -1,0 +1,147 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from invalidate_mcp_cache import (
+    invalidate_all_mcp_caches,
+    invalidate_cache_file,
+    is_local_mcp_server,
+    main,
+)
+
+
+class InvalidateMcpCacheTest(unittest.TestCase):
+    def test_is_local_mcp_server_known_servers(self):
+        self.assertTrue(is_local_mcp_server("platform_control"))
+        self.assertTrue(is_local_mcp_server("router"))
+
+    def test_is_local_mcp_server_remote_proxy(self):
+        remote_config = {
+            "command": "node",
+            "args": [
+                "/opt/mcp-remote/dist/proxy.js",
+                "https://developerknowledge.googleapis.com/mcp",
+            ],
+        }
+        self.assertFalse(is_local_mcp_server("developer_knowledge", remote_config))
+
+        remote_url_config = {
+            "url": "https://mcp.example.com/sse",
+            "transport": "sse",
+        }
+        self.assertFalse(is_local_mcp_server("custom_remote", remote_url_config))
+
+    def test_is_local_mcp_server_local_script(self):
+        local_config = {
+            "command": "/opt/hermes/.venv/bin/python3",
+            "args": ["${HERMES_HOME}/scripts/custom_server.py"],
+        }
+        self.assertTrue(is_local_mcp_server("custom_local", local_config))
+
+    def test_invalidate_cache_file_removes_local_and_keeps_remote(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "mcp_schema_cache.json"
+            initial_data = {
+                "platform_control": {
+                    "fingerprint": "abc12345",
+                    "tools": [{"name": "verify_gke_cluster"}],
+                },
+                "developer_knowledge": {
+                    "fingerprint": "def67890",
+                    "tools": [{"name": "search_docs"}],
+                },
+                "gke": {
+                    "fingerprint": "ghi12345",
+                    "tools": [{"name": "get_cluster"}],
+                },
+            }
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump(initial_data, f)
+
+            removed = invalidate_cache_file(cache_file)
+            self.assertEqual(["platform_control"], removed)
+
+            with open(cache_file, "r", encoding="utf-8") as f:
+                updated_data = json.load(f)
+
+            self.assertNotIn("platform_control", updated_data)
+            self.assertIn("developer_knowledge", updated_data)
+            self.assertIn("gke", updated_data)
+
+    def test_invalidate_cache_file_non_existent(self):
+        non_existent = Path("/tmp/non_existent_cache_dir_12345/mcp_schema_cache.json")
+        self.assertEqual([], invalidate_cache_file(non_existent))
+
+    def test_invalidate_cache_file_corrupted_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "mcp_schema_cache.json"
+            cache_file.write_text("invalid-json{", encoding="utf-8")
+            self.assertEqual([], invalidate_cache_file(cache_file))
+
+    def test_invalidate_all_mcp_caches_scans_root_and_profiles(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # 1. Root cache (holds router and gke)
+            root_cache_dir = root / "cache"
+            root_cache_dir.mkdir(parents=True)
+            root_cache_file = root_cache_dir / "mcp_schema_cache.json"
+            with open(root_cache_file, "w", encoding="utf-8") as f:
+                json.dump({"router": {"fingerprint": "111"}, "gke": {"fingerprint": "222"}}, f)
+
+            # 2. Platform profile cache (holds platform_control and developer_knowledge)
+            platform_cache_dir = root / "profiles" / "platform" / "cache"
+            platform_cache_dir.mkdir(parents=True)
+            platform_cache_file = platform_cache_dir / "mcp_schema_cache.json"
+            with open(platform_cache_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "platform_control": {"fingerprint": "333"},
+                        "developer_knowledge": {"fingerprint": "444"},
+                    },
+                    f,
+                )
+
+            # 3. Cluster profile cache (holds only remote gke)
+            cluster_cache_dir = root / "profiles" / "cluster-alpha" / "cache"
+            cluster_cache_dir.mkdir(parents=True)
+            cluster_cache_file = cluster_cache_dir / "mcp_schema_cache.json"
+            with open(cluster_cache_file, "w", encoding="utf-8") as f:
+                json.dump({"gke": {"fingerprint": "555"}}, f)
+
+            results = invalidate_all_mcp_caches(root)
+
+            self.assertEqual({"default": ["router"], "platform": ["platform_control"]}, results)
+
+            # Verify contents
+            with open(root_cache_file, "r", encoding="utf-8") as f:
+                self.assertEqual({"gke": {"fingerprint": "222"}}, json.load(f))
+
+            with open(platform_cache_file, "r", encoding="utf-8") as f:
+                self.assertEqual({"developer_knowledge": {"fingerprint": "444"}}, json.load(f))
+
+            with open(cluster_cache_file, "r", encoding="utf-8") as f:
+                self.assertEqual({"gke": {"fingerprint": "555"}}, json.load(f))
+
+    def test_main_cli(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_dir = root / "cache"
+            cache_dir.mkdir(parents=True)
+            cache_file = cache_dir / "mcp_schema_cache.json"
+            with open(cache_file, "w", encoding="utf-8") as f:
+                json.dump({"router": {"fingerprint": "111"}}, f)
+
+            with patch.object(sys, "argv", ["invalidate_mcp_cache.py", str(root)]):
+                main()
+
+            with open(cache_file, "r", encoding="utf-8") as f:
+                self.assertEqual({}, json.load(f))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agents/platform/scripts/test_invalidate_mcp_cache.py
+++ b/agents/platform/scripts/test_invalidate_mcp_cache.py
@@ -76,11 +76,12 @@ class InvalidateMcpCacheTest(unittest.TestCase):
         non_existent = Path("/tmp/non_existent_cache_dir_12345/mcp_schema_cache.json")
         self.assertEqual([], invalidate_cache_file(non_existent))
 
-    def test_invalidate_cache_file_corrupted_json(self):
+    def test_invalidate_cache_file_corrupted_json_raises(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_file = Path(tmpdir) / "mcp_schema_cache.json"
             cache_file.write_text("invalid-json{", encoding="utf-8")
-            self.assertEqual([], invalidate_cache_file(cache_file))
+            with self.assertRaises(json.JSONDecodeError):
+                invalidate_cache_file(cache_file)
 
     def test_invalidate_all_mcp_caches_scans_root_and_profiles(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/agents/platform/scripts/test_invalidate_mcp_cache.py
+++ b/agents/platform/scripts/test_invalidate_mcp_cache.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import sys
@@ -9,6 +10,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from invalidate_mcp_cache import (
+    CacheInvalidationError,
     invalidate_all_mcp_caches,
     invalidate_cache_file,
     is_local_mcp_server,
@@ -85,6 +87,13 @@ class InvalidateMcpCacheTest(unittest.TestCase):
             with self.assertRaises(json.JSONDecodeError):
                 invalidate_cache_file(cache_file)
 
+    def test_invalidate_cache_file_non_dict_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_file = Path(tmpdir) / "mcp_schema_cache.json"
+            cache_file.write_text("[\"item\"]", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                invalidate_cache_file(cache_file)
+
     def test_invalidate_all_mcp_caches_scans_root_and_profiles(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -130,6 +139,43 @@ class InvalidateMcpCacheTest(unittest.TestCase):
             with open(cluster_cache_file, "r", encoding="utf-8") as f:
                 self.assertEqual({"gke": {"fingerprint": "555"}}, json.load(f))
 
+    def test_invalidate_all_mcp_caches_corrupted_file_deletes_and_continues(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+
+            # 1. Corrupted root cache
+            root_cache_dir = root / "cache"
+            root_cache_dir.mkdir(parents=True)
+            root_cache_file = root_cache_dir / "mcp_schema_cache.json"
+            root_cache_file.write_text("corrupted-json{", encoding="utf-8")
+
+            # 2. Healthy platform profile cache
+            platform_cache_dir = root / "profiles" / "platform" / "cache"
+            platform_cache_dir.mkdir(parents=True)
+            platform_cache_file = platform_cache_dir / "mcp_schema_cache.json"
+            with open(platform_cache_file, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "platform_control": {"fingerprint": "333"},
+                        "developer_knowledge": {"fingerprint": "444"},
+                    },
+                    f,
+                )
+
+            err_stream = io.StringIO()
+            with patch("sys.stderr", err_stream):
+                with self.assertRaises(CacheInvalidationError) as ctx:
+                    invalidate_all_mcp_caches(root)
+
+            # Assert root cache was unlinked and stderr logged
+            self.assertFalse(root_cache_file.exists())
+            self.assertIn("unreadable cache", err_stream.getvalue())
+
+            # Assert platform profile cache was still processed despite root cache error
+            self.assertEqual({"platform": ["platform_control"]}, ctx.exception.results)
+            with open(platform_cache_file, "r", encoding="utf-8") as f:
+                self.assertEqual({"developer_knowledge": {"fingerprint": "444"}}, json.load(f))
+
     def test_main_cli(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
@@ -144,6 +190,23 @@ class InvalidateMcpCacheTest(unittest.TestCase):
 
             with open(cache_file, "r", encoding="utf-8") as f:
                 self.assertEqual({}, json.load(f))
+
+    def test_main_cli_corrupted_cache_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cache_dir = root / "cache"
+            cache_dir.mkdir(parents=True)
+            cache_file = cache_dir / "mcp_schema_cache.json"
+            cache_file.write_text("corrupted{", encoding="utf-8")
+
+            err_stream = io.StringIO()
+            with patch("sys.stderr", err_stream):
+                with patch.object(sys, "argv", ["invalidate_mcp_cache.py", str(root)]):
+                    with self.assertRaises(SystemExit) as cm:
+                        main()
+                    self.assertEqual(cm.exception.code, 1)
+
+            self.assertFalse(cache_file.exists())
 
 
 if __name__ == "__main__":

--- a/agents/platform/scripts/test_invalidate_mcp_cache.py
+++ b/agents/platform/scripts/test_invalidate_mcp_cache.py
@@ -6,6 +6,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
 from invalidate_mcp_cache import (
     invalidate_all_mcp_caches,
     invalidate_cache_file,

--- a/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
+++ b/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
@@ -697,6 +697,11 @@ def build_parser() -> argparse.ArgumentParser:
             # did not, and saying which is what `_check_claim` verifies. A
             # refusal never claims a change, so it is not asked.
             claim = cmd.add_mutually_exclusive_group(required=True)
+            # default=None ensures an explicitly passed `--verify-commit ""`
+            # is recognized by argparse as supplied (since `"" is not None`) rather
+            # than comparing equal to default and failing the mutually-exclusive
+            # group required check. This allows empty SHAs to reach `_check_claim`'s
+            # explicit empty-value safety guard.
             claim.add_argument(
                 "--verify-commit",
                 default=None,

--- a/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
+++ b/agents/platform/skills/pr-conversation/scripts/pr_conversation.py
@@ -697,11 +697,6 @@ def build_parser() -> argparse.ArgumentParser:
             # did not, and saying which is what `_check_claim` verifies. A
             # refusal never claims a change, so it is not asked.
             claim = cmd.add_mutually_exclusive_group(required=True)
-            # default=None ensures an explicitly passed `--verify-commit ""`
-            # is recognized by argparse as supplied (since `"" is not None`) rather
-            # than comparing equal to default and failing the mutually-exclusive
-            # group required check. This allows empty SHAs to reach `_check_claim`'s
-            # explicit empty-value safety guard.
             claim.add_argument(
                 "--verify-commit",
                 default=None,

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -433,6 +433,25 @@ if [ -d "/opt/defaults/scripts" ]; then
         || echo "WARN: could not refresh $TARGET_DIR/scripts from the image; runtime profile scaffolding may run stale code" >&2
 fi
 
+# 2c. Invalidate locally-hosted MCP server schemas from each profile's on-disk cache.
+#
+# Why: Hermes caches tool definitions from `mcp_servers` in `<profile>/cache/mcp_schema_cache.json`
+# so lazy startup can register tools without spawning subprocesses on every turn.
+# However, Hermes keys the cache entry only on `config_fingerprint` (command/args/url),
+# which does not change when an image update modifies the contents of a local script
+# (e.g. platform_mcp_server.py or router_server.py).
+# When an upgraded container image starts over an existing PVC, the stale cached tool list
+# shadows newly added or modified tools indefinitely (Issue #854).
+# Dropping local server entries forces Hermes to re-discover tools on first connect.
+# Remote servers (e.g. developer_knowledge, gke) are preserved to avoid unnecessary
+# network round-trips.
+INVALIDATE_MCP_SCRIPT="/opt/defaults/scripts/invalidate_mcp_cache.py"
+[ -f "$INVALIDATE_MCP_SCRIPT" ] || INVALIDATE_MCP_SCRIPT="$TARGET_DIR/scripts/invalidate_mcp_cache.py"
+if [ -f "$INVALIDATE_MCP_SCRIPT" ]; then
+    python3 "$INVALIDATE_MCP_SCRIPT" "$TARGET_DIR" 2>/dev/null \
+        || echo "WARN: could not invalidate local MCP schema caches; upgraded tools may not be discovered" >&2
+fi
+
 # Where the operator mounts its per-profile overlay ConfigMap (the operator's
 # profileOverlayDir), and the script that consumes what it holds. Resolved here rather
 # than at step 2.7, its only consumer, so the two paths sit next to the step 2d comment

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -448,7 +448,9 @@ fi
 INVALIDATE_MCP_SCRIPT="/opt/defaults/scripts/invalidate_mcp_cache.py"
 [ -f "$INVALIDATE_MCP_SCRIPT" ] || INVALIDATE_MCP_SCRIPT="$TARGET_DIR/scripts/invalidate_mcp_cache.py"
 if [ -f "$INVALIDATE_MCP_SCRIPT" ]; then
-    python3 "$INVALIDATE_MCP_SCRIPT" "$TARGET_DIR" 2>/dev/null \
+    PYTHON="python3"
+    [ -x "$INSTALL_DIR/.venv/bin/python3" ] && PYTHON="$INSTALL_DIR/.venv/bin/python3"
+    "$PYTHON" "$INVALIDATE_MCP_SCRIPT" "$TARGET_DIR" 2>/dev/null \
         || echo "WARN: could not invalidate local MCP schema caches; upgraded tools may not be discovered" >&2
 fi
 

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -450,7 +450,7 @@ INVALIDATE_MCP_SCRIPT="/opt/defaults/scripts/invalidate_mcp_cache.py"
 if [ -f "$INVALIDATE_MCP_SCRIPT" ]; then
     PYTHON="python3"
     [ -x "$INSTALL_DIR/.venv/bin/python3" ] && PYTHON="$INSTALL_DIR/.venv/bin/python3"
-    "$PYTHON" "$INVALIDATE_MCP_SCRIPT" "$TARGET_DIR" 2>/dev/null \
+    "$PYTHON" "$INVALIDATE_MCP_SCRIPT" "$TARGET_DIR" \
         || echo "WARN: could not invalidate local MCP schema caches; upgraded tools may not be discovered" >&2
 fi
 

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -27,9 +27,11 @@ instead, which only the gated steps below create.
 """
 
 import ast
+import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -1379,6 +1381,51 @@ class PlatformFrontDoorTest(unittest.TestCase):
         proc = self._run("platform_sync_items >/dev/null\necho SURVIVED\n")
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn("SURVIVED", proc.stdout)
+
+    def test_step_2c_invalidates_local_mcp_schema_cache(self):
+        """Step 2c drops local MCP server cache entries on startup so new tools appear."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            defaults = root / "defaults" / "scripts"
+            defaults.mkdir(parents=True)
+            invalidate_src = pathlib.Path(__file__).resolve().parent.parent / "agents" / "platform" / "scripts" / "invalidate_mcp_cache.py"
+            shutil.copy(invalidate_src, defaults / "invalidate_mcp_cache.py")
+
+            data = root / "data"
+            (data / "scripts").mkdir(parents=True)
+            shutil.copy(invalidate_src, data / "scripts" / "invalidate_mcp_cache.py")
+            cache_dir = data / "profiles" / "platform" / "cache"
+            cache_dir.mkdir(parents=True)
+            cache_file = cache_dir / "mcp_schema_cache.json"
+            cache_file.write_text(
+                json.dumps({
+                    "platform_control": {"fingerprint": "abc", "tools": [{"name": "verify_gke_cluster"}]},
+                    "developer_knowledge": {"fingerprint": "def", "tools": [{"name": "search_docs"}]},
+                }),
+                encoding="utf-8",
+            )
+
+            lines = _ENTRYPOINT.read_text(encoding="utf-8").splitlines()
+            start = next(i for i, line in enumerate(lines) if line.startswith('# 2c. Invalidate locally-hosted MCP server schemas'))
+            end = next(i for i in range(start, len(lines)) if lines[i] == "fi")
+            block = "\n".join(lines[start : end + 1])
+
+            proc = subprocess.run(
+                ["sh", "-c", "set -e\n" + block],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env={
+                    "PATH": "/usr/bin:/bin",
+                    "TARGET_DIR": str(data),
+                    "PYTHONPATH": str(defaults),
+                },
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            updated = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertNotIn("platform_control", updated)
+            self.assertIn("developer_knowledge", updated)
 
 
 class ApiKeyPinCheckTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Invalidates cached tool schemas for locally-hosted MCP servers (such as `platform_control` and `router`) during container entrypoint startup (Step 2c), ensuring newly added, renamed, or modified tools appear immediately after an image upgrade over an existing data volume.

## Why This Change

Hermes caches tool definitions from `mcp_servers` in `<profile>/cache/mcp_schema_cache.json` to enable lazy server registration without spawning subprocesses on every turn. However, cache entries are keyed solely by `config_fingerprint` (which hashes command, args, and transport), which does not change when an image update modifies the underlying Python script (e.g. `platform_mcp_server.py` or `router_server.py`).

When an upgraded agent image starts over an existing PVC, the stale cached tool list on persistent storage shadows new tools indefinitely (Issue #854). For example, `report_to_chat` (added in #731) and finding registration tools were unavailable to workers because the cached schema remained frozen at 7 tools rather than the current 15.

## What Changed

- **`agents/platform/scripts/invalidate_mcp_cache.py`**:
  - Implemented entrypoint cache invalidator that scans the root profile and all named profile directories under `$TARGET_DIR` (`$TARGET_DIR/cache/mcp_schema_cache.json` and `$TARGET_DIR/profiles/*/cache/mcp_schema_cache.json`).
  - Identifies and drops locally-hosted stdio MCP server entries (`platform_control`, `router`, and local script-backed servers) while preserving remote proxies (`developer_knowledge`, `gke`) to avoid redundant network discovery overhead.
  - Isolates error handling per cache file: unreadable or corrupt JSON caches (`json.JSONDecodeError`, non-dict roots, `OSError`) are unlinked and reported to stderr so subsequent profile caches are not blocked, raising `CacheInvalidationError` on completion so `main()` exits nonzero and entrypoint startup warnings fire honestly.
  - Uses atomic file replace with temporary file cleanup in a `finally` block.
- **`deploy/shared/docker-entrypoint.sh`**:
  - Added step 2c to execute `invalidate_mcp_cache.py` using `$INSTALL_DIR/.venv/bin/python3` during container startup right after force-syncing `/opt/defaults/scripts/`.
  - Preserves invalidator stderr (no `2>/dev/null`) so specific file errors and tracebacks are logged during failures.
- **`agents/platform/scripts/test_invalidate_mcp_cache.py`**:
  - Added unit test suite covering local vs remote server classification, cache file parsing, atomic updates, non-dict root handling, corrupt JSON error isolation and unlinking, multi-profile scanning, and nonzero CLI exit codes.
- **`tests/test_docker_entrypoint.py`**:
  - Added `test_step_2c_invalidates_local_mcp_schema_cache` to verify step 2c invalidation during entrypoint execution.

## Context

Closes #854.

## Testing

- `python3 -m unittest agents/platform/scripts/test_invalidate_mcp_cache.py`: 11 tests passed in 0.004s.
- `python3 -m unittest tests/test_docker_entrypoint.py`: 59 tests passed in 7.74s.
- `make docs-check`: Passed all link checks, terminology checks, map coverage, and context budget.

### Live validation

**Live-tested on GKE cluster `kyber-test` (GKE Standard `v1.35.6-gke.1641000`, `northamerica-northeast2-b`) in `kubeagents-system`:**

- **Environment and Images:**
  - Cluster: `kyber-test` (`10.188.0.3`, private endpoint, `northamerica-northeast2-b`).
  - Operator: `us-east4-docker.pkg.dev/bnaylor-kagents-dev/kube-agents/k8s-operator:dev-pr724b`.
  - Platform Agent: `us-east4-docker.pkg.dev/bnaylor-kagents-dev/kube-agents/platform-agent:latest`.
- **Observed Execution on Live Container:**
  1. Staged simulated warm schema cache in `/opt/data/profiles/platform/cache/mcp_schema_cache.json` containing stale `platform_control` and warm remote `developer_knowledge` entries.
  2. Executed `/opt/hermes/.venv/bin/python3 /opt/data/scripts/invalidate_mcp_cache.py /opt/data` inside `platform-agent-gateway`.
  3. Output:
     ```text
     [ENTRYPOINT] Invalidated local MCP schema cache for profile 'default': router
     [ENTRYPOINT] Invalidated local MCP schema cache for profile 'platform': platform_control
     ```
  4. Inspected `/opt/data/profiles/platform/cache/mcp_schema_cache.json`: verified `platform_control` was evicted while `developer_knowledge` remained intact.
  5. Verified cleanup: removed all simulated test artifacts from the live PVC volume.
- **What Was Not Covered Live:**
  - Remote MCP server endpoints (`developer_knowledge`, `gke`) were verified preserved in the cache structure, but outbound live requests to their external API endpoints were not triggered during this test.

## Self-Review

Passes executed in fresh isolated subagent context:
- **Adversarial code review (`review-adversarial`):**
  - Finding: Initial implementation swallowed file write errors in a `try/except: pass` block. Resolved in commit `684cac4` by letting write/replace exceptions bubble up so the entrypoint warning handler fires honestly, while ensuring `.tmp` files are cleaned up in a `finally` block.
  - Finding: `invalidate_all_mcp_caches` previously aborted on the first corrupted cache without isolating per file, and `docker-entrypoint.sh` silenced stderr with `2>/dev/null`. Resolved in `e593962` by catching `(json.JSONDecodeError, ValueError, OSError)` per file, unlinking corrupted cache files, continuing to process remaining profiles, preserving stderr output in entrypoint step 2c, and exiting nonzero.
  - Finding: Standalone execution of `test_invalidate_mcp_cache.py` required `PYTHONPATH`. Resolved in commit `c92c791` by adding `sys.path.insert(0, ...)` at the top of the test file.
- **Docs-drift review (`review-docs-drift`):**
  - Checked `docs/site/src/content/docs/reference/config.md` and `deploy/shared/defaults/config.yaml` to ensure lazy MCP cache documentation accurately describes the entrypoint invalidation behavior. Concluded all documentation remains accurate and consistent with source.

## Risk and Rollout

Low risk: Scoped to entrypoint cache invalidation of local stdio MCP servers on container boot. Re-discovery happens transparently on first tool call. Revert by reverting the commit.

---
*Generated with the help of Gemini.*