### PR TITLE
refactor(scripts): share one GitHub API client between repository scripts

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1084,7 +1084,7 @@ COPY --chown=hermes:hermes deploy/shared/defaults/ /opt/defaults/
 
 
 # 5.5. Install and enable hermes-otel plugin in /opt/defaults
-RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel && \
+RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel/hermes_otel && \
     HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins enable hermes_otel && \
     /opt/hermes/.venv/bin/python3 -c "import yaml, pathlib; p = pathlib.Path('/opt/defaults/plugins/hermes_otel/config.yaml'); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; c['backends'] = [{'name': 'gke-managed-otel', 'type': 'otlp', 'endpoint': 'http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces'}]; p.write_text(yaml.safe_dump(c))"
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1084,7 +1084,7 @@ COPY --chown=hermes:hermes deploy/shared/defaults/ /opt/defaults/
 
 
 # 5.5. Install and enable hermes-otel plugin in /opt/defaults
-RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel/hermes_otel && \
+RUN HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins install briancaffey/hermes-otel && \
     HOME=/opt/defaults HERMES_HOME=/opt/defaults /opt/hermes/.venv/bin/hermes plugins enable hermes_otel && \
     /opt/hermes/.venv/bin/python3 -c "import yaml, pathlib; p = pathlib.Path('/opt/defaults/plugins/hermes_otel/config.yaml'); c = yaml.safe_load(p.read_text()) or {} if p.exists() else {}; c['backends'] = [{'name': 'gke-managed-otel', 'type': 'otlp', 'endpoint': 'http://opentelemetry-collector.gke-managed-otel.svc.cluster.local:4318/v1/traces'}]; p.write_text(yaml.safe_dump(c))"
 

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -1,0 +1,140 @@
+"""github_api.py — shared GitHub API client for repository maintenance scripts.
+
+Combines bounded retries on transient errors (5xx, 429, secondary rate limit 403)
+with automatic list endpoint pagination (`get_all`), so callers neither drop
+writes on transient blips nor silently truncate multi-page lists.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_ROOT = "https://api.github.com"
+API_VERSION = "2022-11-28"
+DEFAULT_USER_AGENT = "kube-agents-scripts"
+
+REQUEST_ATTEMPTS = 3
+REQUEST_RETRY_SECONDS = 5
+REQUEST_RETRY_CEILING = 60
+PER_PAGE = 100
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def _rate_limited(error: urllib.error.HTTPError) -> bool:
+    """Whether a 403 is GitHub throttling rather than refusing.
+
+    A secondary rate limit comes back as 403, not 429, and is the one 4xx worth
+    retrying on a write path. It carries `Retry-After`, or an exhausted primary
+    quota; a permissions 403 carries neither, so this does not turn a missing
+    permission into fifteen seconds of retries.
+    """
+    headers = getattr(error, "headers", None) or {}
+    return headers.get("Retry-After") is not None or headers.get("x-ratelimit-remaining") == "0"
+
+
+def _retry_delay(error: urllib.error.HTTPError) -> int:
+    """`Retry-After` when GitHub names one, capped, else the fixed backoff."""
+    headers = getattr(error, "headers", None) or {}
+    requested = headers.get("Retry-After")
+    if requested and str(requested).strip().isdigit():
+        return min(int(str(requested).strip()), REQUEST_RETRY_CEILING)
+    return REQUEST_RETRY_SECONDS
+
+
+class GitHubAPI:
+    def __init__(
+        self,
+        repo: str,
+        token: str,
+        root: str = API_ROOT,
+        user_agent: str = DEFAULT_USER_AGENT,
+        opener=urllib.request.urlopen,
+        sleep=time.sleep,
+    ):
+        self.repo = repo
+        self.token = token
+        self.root = root
+        self.user_agent = user_agent
+        self.opener = opener
+        self.sleep = sleep
+
+    def request(self, method: str, path: str, payload=None, tolerate=()):
+        """One API call, retried on the failures that are worth retrying.
+
+        A dropped write is the failure this whole client exists to prevent — so
+        a 5xx, a 429, and the 403 form of a secondary rate limit each get three
+        attempts, honouring `Retry-After` when GitHub sends one. A 403 that is
+        really a missing permission is not retried. `tolerate` names status
+        codes the caller has a meaning for; they come back as None instead of
+        raising.
+        """
+        body = None if payload is None else json.dumps(payload).encode()
+        for attempt in range(1, REQUEST_ATTEMPTS + 1):
+            request = urllib.request.Request(
+                f"{self.root}{path}",
+                method=method,
+                data=body,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {self.token}",
+                    "Content-Type": "application/json",
+                    "User-Agent": self.user_agent,
+                    "X-GitHub-Api-Version": API_VERSION,
+                },
+            )
+            try:
+                with self.opener(request) as response:
+                    raw = response.read()
+                return json.loads(raw) if raw else None
+            except urllib.error.HTTPError as error:
+                if error.code in tolerate:
+                    return None
+                retryable = (
+                    error.code == 429
+                    or 500 <= error.code < 600
+                    or (error.code == 403 and _rate_limited(error))
+                )
+                if not retryable or attempt == REQUEST_ATTEMPTS:
+                    raise
+                log(f"{method} {path} returned {error.code}; retrying ({attempt}/{REQUEST_ATTEMPTS})")
+                delay = _retry_delay(error)
+            except urllib.error.URLError as error:
+                if attempt == REQUEST_ATTEMPTS:
+                    raise
+                log(f"{method} {path} unreachable ({error.reason}); retrying ({attempt}/{REQUEST_ATTEMPTS})")
+                delay = REQUEST_RETRY_SECONDS
+            self.sleep(delay)
+
+    def get(self, path: str, tolerate=()):
+        return self.request("GET", path, tolerate=tolerate)
+
+    def get_all(self, path: str, per_page: int = PER_PAGE):
+        """Every page of a list endpoint. A truncated list reads as complete."""
+        separator = "&" if "?" in path else "?"
+        items = []
+        page = 1
+        while True:
+            batch = self.request("GET", f"{path}{separator}per_page={per_page}&page={page}")
+            if not isinstance(batch, list):
+                return items
+            items.extend(batch)
+            if len(batch) < per_page:
+                return items
+            page += 1
+
+    def post(self, path: str, payload=None, tolerate=()):
+        return self.request("POST", path, payload, tolerate=tolerate)
+
+    def patch(self, path: str, payload=None, tolerate=()):
+        return self.request("PATCH", path, payload, tolerate=tolerate)
+
+    def delete(self, path: str, tolerate=()):
+        return self.request("DELETE", path, tolerate=tolerate)

--- a/scripts/notify_broken_main.py
+++ b/scripts/notify_broken_main.py
@@ -71,7 +71,16 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-API_ROOT = "https://api.github.com"
+from github_api import (
+    API_ROOT,
+    REQUEST_ATTEMPTS,
+    REQUEST_RETRY_CEILING,
+    REQUEST_RETRY_SECONDS,
+    GitHubAPI as BaseGitHubAPI,
+    _rate_limited,
+    _retry_delay,
+    log,
+)
 
 # How a run says "main does not build". `cancelled` and `skipped` are not here:
 # the first is the concurrency group superseding a run, the second a path filter
@@ -374,59 +383,24 @@ def render_comment(notification, repo):
 # --------------------------------------------------------------------------- #
 
 
-class GitHubAPI:
-    def __init__(self, repo, token, root=API_ROOT, opener=urllib.request.urlopen, sleep=time.sleep):
-        self.repo = repo
-        self.token = token
-        self.root = root
-        self.opener = opener
-        self.sleep = sleep
-
-    def request(self, method, path, payload=None, tolerate=()):
-        """One API call, retried on the failures that are worth retrying.
-
-        A dropped write is the failure this whole script exists to prevent -- an
-        issue that never opened, or worse, one that never closed -- so a 5xx, a
-        429, and the 403 form of a secondary rate limit each get three attempts,
-        honouring `Retry-After` when GitHub sends one. A 403 that is really a
-        missing permission is not retried. `tolerate` names status codes the
-        caller has a meaning for; they come back as None instead of raising.
-        """
-        body = None if payload is None else json.dumps(payload).encode()
-        for attempt in range(1, REQUEST_ATTEMPTS + 1):
-            request = urllib.request.Request(
-                f"{self.root}{path}",
-                method=method,
-                data=body,
-                headers={
-                    "Accept": "application/vnd.github+json",
-                    "Authorization": f"Bearer {self.token}",
-                    "Content-Type": "application/json",
-                    "User-Agent": "kube-agents-notify-broken-main",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-            )
-            try:
-                with self.opener(request) as response:
-                    raw = response.read()
-                return json.loads(raw) if raw else None
-            except urllib.error.HTTPError as error:
-                if error.code in tolerate:
-                    return None
-                retryable = error.code == 429 or 500 <= error.code < 600 or (error.code == 403 and _rate_limited(error))
-                if not retryable or attempt == REQUEST_ATTEMPTS:
-                    raise
-                log(f"{method} {path} returned {error.code}; retrying ({attempt}/{REQUEST_ATTEMPTS})")
-                delay = _retry_delay(error)
-            except urllib.error.URLError as error:
-                if attempt == REQUEST_ATTEMPTS:
-                    raise
-                log(f"{method} {path} unreachable ({error.reason}); retrying ({attempt}/{REQUEST_ATTEMPTS})")
-                delay = REQUEST_RETRY_SECONDS
-            self.sleep(delay)
-
-    def get(self, path):
-        return self.request("GET", path)
+class GitHubAPI(BaseGitHubAPI):
+    def __init__(
+        self,
+        repo,
+        token,
+        root=API_ROOT,
+        user_agent="kube-agents-notify-broken-main",
+        opener=urllib.request.urlopen,
+        sleep=time.sleep,
+    ):
+        super().__init__(
+            repo=repo,
+            token=token,
+            root=root,
+            user_agent=user_agent,
+            opener=opener,
+            sleep=sleep,
+        )
 
     def run(self, run_id):
         return self.get(f"/repos/{self.repo}/actions/runs/{run_id}")

--- a/scripts/notify_broken_main.py
+++ b/scripts/notify_broken_main.py
@@ -104,36 +104,6 @@ LABEL = "ci:main-broken"
 LABEL_COLOR = "d73a4a"
 LABEL_DESCRIPTION = "A required check is failing on main"
 
-REQUEST_ATTEMPTS = 3
-REQUEST_RETRY_SECONDS = 5
-# A `Retry-After` GitHub asks for is honoured up to this; beyond it the job would
-# sit burning runner minutes for news that the next run will carry anyway.
-REQUEST_RETRY_CEILING = 60
-
-
-def log(message):
-    print(message, file=sys.stderr, flush=True)
-
-
-def _rate_limited(error):
-    """Whether a 403 is GitHub throttling rather than refusing.
-
-    A secondary rate limit comes back as 403, not 429, and is the one 4xx worth
-    retrying on a write path. It carries `Retry-After`, or an exhausted primary
-    quota; a permissions 403 carries neither, so this does not turn a missing
-    `issues: write` into fifteen seconds of retries.
-    """
-    headers = error.headers or {}
-    return headers.get("Retry-After") is not None or headers.get("x-ratelimit-remaining") == "0"
-
-
-def _retry_delay(error):
-    """`Retry-After` when GitHub names one, capped, else the fixed backoff."""
-    requested = (error.headers or {}).get("Retry-After")
-    if requested and str(requested).strip().isdigit():
-        return min(int(str(requested).strip()), REQUEST_RETRY_CEILING)
-    return REQUEST_RETRY_SECONDS
-
 
 # --------------------------------------------------------------------------- #
 # Deciding whether there is anything to say

--- a/scripts/request_reviewers.py
+++ b/scripts/request_reviewers.py
@@ -38,6 +38,8 @@ import urllib.request
 
 import yaml
 
+from github_api import API_ROOT, PER_PAGE, GitHubAPI, log
+
 # The `AI Review` check run comes from the kube-agents-bot GitHub App. The name
 # alone is not enough of an identity check: any App may post a check run with
 # any name, and this one decides who gets pinged.
@@ -50,9 +52,6 @@ DEFAULT_IGNORED_KEYWORDS = ["DO NOT REVIEW"]
 # Review states that mean a person has actually reviewed. `COMMENTED` is not one
 # of them: GitHub files a `COMMENTED` review for a reply to a review thread.
 HUMAN_VERDICT_STATES = {"APPROVED", "CHANGES_REQUESTED"}
-
-API_ROOT = "https://api.github.com"
-PER_PAGE = 100
 
 # Config keys the action supports and this port does not. Silently ignoring one
 # would hand the reviewer selection a rule nobody applied, so they are refused.
@@ -326,59 +325,6 @@ def ai_review_block_reason(check_run, author_is_bot):
     return f"{AI_REVIEW_CHECK_NAME} concluded {conclusion}{detail}, not success"
 
 
-# --------------------------------------------------------------------------- #
-# GitHub API
-# --------------------------------------------------------------------------- #
-
-
-class GitHubAPI:
-    def __init__(self, repo, token, root=API_ROOT):
-        self.repo = repo
-        self.token = token
-        self.root = root
-
-    def _request(self, method, path, body=None):
-        request = urllib.request.Request(
-            f"{self.root}{path}",
-            method=method,
-            data=json.dumps(body).encode() if body is not None else None,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {self.token}",
-                "Content-Type": "application/json",
-                "User-Agent": "kube-agents-request-reviewers",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-        )
-        with urllib.request.urlopen(request) as response:
-            payload = response.read()
-        return json.loads(payload) if payload else None
-
-    def get(self, path):
-        return self._request("GET", path)
-
-    def get_all(self, path):
-        """Every page of a list endpoint. A truncated list reads as complete."""
-        separator = "&" if "?" in path else "?"
-        items = []
-        page = 1
-        while True:
-            batch = self._request("GET", f"{path}{separator}per_page={PER_PAGE}&page={page}")
-            items.extend(batch)
-            if len(batch) < PER_PAGE:
-                return items
-            page += 1
-
-    def post(self, path, body):
-        return self._request("POST", path, body)
-
-    def patch(self, path, body):
-        return self._request("PATCH", path, body)
-
-    def delete(self, path):
-        return self._request("DELETE", path)
-
-
 def resolve_pull_request(api, head_sha):
     """Find the open pull request the commit `head_sha` belongs to.
 
@@ -494,7 +440,7 @@ def main(argv=None):
         return 1
 
     config = load_config(args.config)
-    api = GitHubAPI(args.repo, token)
+    api = GitHubAPI(args.repo, token, user_agent="kube-agents-request-reviewers")
 
     triggering_check_run = None
     if args.check_run_id:

--- a/scripts/test_github_api.py
+++ b/scripts/test_github_api.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tests for github_api.py — shared GitHub API client for repository scripts."""
+
+import json
+import sys
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import github_api
+
+
+def _response(raw):
+    """What `urlopen` returns: a context manager yielding something with `read`."""
+    return mock.MagicMock(
+        __enter__=mock.Mock(return_value=mock.Mock(read=lambda: raw)),
+        __exit__=mock.Mock(return_value=False),
+    )
+
+
+class GitHubAPITest(unittest.TestCase):
+    def _api(self, responses, **kwargs):
+        calls = []
+
+        def opener(request):
+            calls.append(request)
+            if not responses:
+                return _response(b"{}")
+            idx = len(calls) - 1
+            if idx < len(responses):
+                outcome = responses[idx]
+            else:
+                outcome = responses[-1]
+            if isinstance(outcome, Exception):
+                raise outcome
+            if isinstance(outcome, bytes):
+                return _response(outcome)
+            return _response(json.dumps(outcome).encode())
+
+        api = github_api.GitHubAPI(
+            "gke-labs/kube-agents",
+            "test-token",
+            opener=opener,
+            sleep=lambda _: None,
+            **kwargs,
+        )
+        return api, calls
+
+    def test_headers_and_auth_are_configured(self):
+        api, calls = self._api([{"ok": True}], user_agent="test-agent")
+        res = api.get("/user")
+        self.assertEqual(res, {"ok": True})
+        self.assertEqual(len(calls), 1)
+        req = calls[0]
+        self.assertEqual(req.get_header("Authorization"), "Bearer test-token")
+        self.assertEqual(req.get_header("User-agent"), "test-agent")
+        self.assertEqual(req.get_header("Accept"), "application/vnd.github+json")
+        self.assertEqual(req.get_header("X-github-api-version"), "2022-11-28")
+
+    def test_get_all_paginates_until_short_page(self):
+        page1 = [{"id": 1}, {"id": 2}]
+        page2 = [{"id": 3}]
+        api, calls = self._api([page1, page2])
+        items = api.get_all("/items", per_page=2)
+        self.assertEqual(items, [{"id": 1}, {"id": 2}, {"id": 3}])
+        self.assertEqual(len(calls), 2)
+        self.assertIn("per_page=2&page=1", calls[0].full_url)
+        self.assertIn("per_page=2&page=2", calls[1].full_url)
+
+    def test_get_all_with_existing_query_params(self):
+        page1 = [{"id": 1}]
+        api, calls = self._api([page1])
+        items = api.get_all("/items?state=open", per_page=10)
+        self.assertEqual(items, [{"id": 1}])
+        self.assertEqual(len(calls), 1)
+        self.assertIn("/items?state=open&per_page=10&page=1", calls[0].full_url)
+
+    def test_5xx_is_retried(self):
+        error_503 = urllib.error.HTTPError("https://api.github.com/test", 503, "Service Unavailable", {}, None)  # type: ignore[arg-type]
+        api, calls = self._api([error_503, {"status": "ok"}])
+        res = api.post("/test", {"data": 123})
+        self.assertEqual(res, {"status": "ok"})
+        self.assertEqual(len(calls), 2)
+
+    def test_secondary_rate_limit_403_is_retried(self):
+        throttled = urllib.error.HTTPError(
+            "https://api.github.com/test",
+            403,
+            "Rate Limited",
+            {"Retry-After": "2"},  # type: ignore[arg-type]
+            None,
+        )
+        api, calls = self._api([throttled, {"status": "ok"}])
+        res = api.post("/test", {"data": 123})
+        self.assertEqual(res, {"status": "ok"})
+        self.assertEqual(len(calls), 2)
+
+    def test_normal_403_is_not_retried(self):
+        permission_error = urllib.error.HTTPError(
+            "https://api.github.com/test",
+            403,
+            "Forbidden",
+            {},  # type: ignore[arg-type]
+            None,
+        )
+        api, calls = self._api([permission_error])
+        with self.assertRaises(urllib.error.HTTPError):
+            api.get("/test")
+        self.assertEqual(len(calls), 1)
+
+    def test_tolerate_status_codes(self):
+        exists_error = urllib.error.HTTPError(
+            "https://api.github.com/labels",
+            422,
+            "Unprocessable Entity",
+            {},  # type: ignore[arg-type]
+            None,
+        )
+        api, calls = self._api([exists_error])
+        res = api.post("/labels", {"name": "test"}, tolerate=(422,))
+        self.assertIsNone(res)
+        self.assertEqual(len(calls), 1)
+
+    def test_methods_patch_and_delete(self):
+        api, calls = self._api([{"patched": True}, None])
+        patch_res = api.patch("/item/1", {"name": "new"})
+        self.assertEqual(patch_res, {"patched": True})
+        self.assertEqual(calls[0].get_method(), "PATCH")
+
+        delete_res = api.delete("/item/1")
+        self.assertIsNone(delete_res)
+        self.assertEqual(calls[1].get_method(), "DELETE")
+
+    def test_url_error_is_retried(self):
+        url_error = urllib.error.URLError("Connection refused")
+        api, calls = self._api([url_error, {"status": "ok"}])
+        res = api.get("/test")
+        self.assertEqual(res, {"status": "ok"})
+        self.assertEqual(len(calls), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_github_api.py
+++ b/scripts/test_github_api.py
@@ -88,6 +88,19 @@ class GitHubAPITest(unittest.TestCase):
         self.assertEqual(res, {"status": "ok"})
         self.assertEqual(len(calls), 2)
 
+    def test_429_is_retried(self):
+        error_429 = urllib.error.HTTPError(
+            "https://api.github.com/test",
+            429,
+            "Too Many Requests",
+            {"Retry-After": "1"},  # type: ignore[arg-type]
+            None,
+        )
+        api, calls = self._api([error_429, {"status": "ok"}])
+        res = api.post("/test", {"data": 123})
+        self.assertEqual(res, {"status": "ok"})
+        self.assertEqual(len(calls), 2)
+
     def test_secondary_rate_limit_403_is_retried(self):
         throttled = urllib.error.HTTPError(
             "https://api.github.com/test",

--- a/scripts/test_notify_broken_main.py
+++ b/scripts/test_notify_broken_main.py
@@ -14,10 +14,16 @@ recovers, which does the same thing more slowly.
 
 import json
 import re
+import sys
 import unittest
 import urllib.error
 import urllib.parse
+from pathlib import Path
 from unittest import mock
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
 
 import notify_broken_main as notifier
 

--- a/scripts/test_request_reviewers.py
+++ b/scripts/test_request_reviewers.py
@@ -18,7 +18,13 @@ to stop.
 
 import random
 import re
+import sys
 import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
 
 import request_reviewers as rr
 


### PR DESCRIPTION
## Summary

Extracts a shared GitHub API client (`scripts/github_api.py`) combining automatic list endpoint pagination (`get_all`) and bounded retries on transient errors (5xx, 429, and secondary rate limits) across repository maintenance scripts (`scripts/request_reviewers.py` and `scripts/notify_broken_main.py`).

## Why This Change

Previously, `scripts/request_reviewers.py` and `scripts/notify_broken_main.py` each maintained duplicate implementations of `GitHubAPI` that diverged:
- `request_reviewers.py` implemented pagination via `get_all`, but lacked retry logic, causing dropped writes on 503s or secondary rate limits that left pull requests without assigned reviewers.
- `notify_broken_main.py` implemented bounded retries for 5xx, 429, and 403 secondary rate limits (fixed 5s delay or `Retry-After`), but lacked pagination.
- Sharing one unified client gives all repository scripts resilient retry handling and complete pagination.

## What Changed

- **`scripts/github_api.py`**:
  - Created shared module containing `GitHubAPI` with `request`, `get`, `get_all`, `post`, `patch`, and `delete`.
  - Configured bounded retries on 5xx, 429, secondary rate limit 403 (`Retry-After` / `x-ratelimit-remaining: 0`), and transient `URLError` network failures (using `Retry-After` capped at 60s or fixed 5s delay).
  - Implemented `get_all` automatic pagination across multi-page list endpoints.
  - Added configurable `user_agent` support with fallback to `kube-agents-scripts`.
- **`scripts/request_reviewers.py`**:
  - Replaced local `GitHubAPI` class with `from github_api import API_ROOT, PER_PAGE, GitHubAPI, log`.
  - Configured `user_agent="kube-agents-request-reviewers"`.
- **`scripts/notify_broken_main.py`**:
  - Replaced duplicate base request and retry definitions with `class GitHubAPI(BaseGitHubAPI)`.
  - Removed duplicate shadow definitions of `REQUEST_ATTEMPTS`, `REQUEST_RETRY_SECONDS`, `REQUEST_RETRY_CEILING`, `_rate_limited`, and `_retry_delay` so the shared client's knobs are live.
  - Preserved script-specific domain helpers (`run`, `history`, `open_issues_for_workflow`, `ensure_label`, `create_issue`, `update_issue`, `comment`, `close_issue`).
- **`scripts/test_github_api.py`**:
  - Added unit test suite covering header injection, `get_all` pagination across single and multiple pages, 5xx retries, 429 rate-limit retries, 403 secondary rate-limit retries, non-retried 403s, `tolerate` handling, and HTTP verbs.
- **`scripts/test_notify_broken_main.py` & `scripts/test_request_reviewers.py`**:
  - Added standalone `sys.path` bootstrapping for isolated test execution.

## Context

Closes #838.

## Testing

- `python3 -m unittest scripts/test_github_api.py`: 10 tests passed.
- `python3 -m unittest scripts/test_notify_broken_main.py`: 70 tests passed.
- `python3 -m unittest scripts/test_request_reviewers.py`: 48 tests passed.
- `python3 -m unittest discover -s scripts -p 'test_*.py'`: 362 tests passed.
- `make docs-check`: Passed all link checks, terminology checks, map coverage, and instruction budgets.

### Live validation

Not live-tested against a live cluster or running deployment. Changes are strictly confined to deterministic helper extraction in repository scripts (`scripts/github_api.py`) and unit test fixtures.

## Self-Review

Passes executed in fresh isolated subagent context (`sa-0-0d9dd69b`):
- **Adversarial code review (`review-adversarial`):**
  - Verified that `GitHubAPI` subclassing in `notify_broken_main.py` leaves `github_api`'s retry configuration authoritative and removes dead shadow variables.
  - Verified that `get_all` pagination termination condition (`len(batch) < per_page`) handles empty, single-page, and multi-page responses without infinite loops.
  - Verified that out-of-scope production image modifications were removed to keep the pull request strictly scoped.
  - Verified retry policy uses bounded fixed delay (5s) or `Retry-After` capped at 60s without unbacked claims of exponential backoff.
- **Docs-drift review (`review-docs-drift`):**
  - Verified that `scripts/` documentation headers and execution instructions remain accurate.

## Risk & Rollout

Low risk: Scoped entirely to repository maintenance automation scripts under `scripts/`. Revert by reverting the commit.

---
*Generated with the help of Gemini.*