### PR TITLE
fix(eval): make the two presubmit task prompts ask for what their checks verify

### DIFF
--- a/bench/tasks/agent-kanban-smoke/task.yaml
+++ b/bench/tasks/agent-kanban-smoke/task.yaml
@@ -7,11 +7,13 @@
 id: agent-kanban-smoke
 name: Agent kanban smoke test
 prompt: >-
-  Create a kanban task titled exactly "devops-bench smoke probe", then state in
-  one sentence the id that was assigned to it.
+  Create a kanban task titled exactly "devops-bench smoke probe", then reply
+  with one sentence that quotes that exact title and states the id the kanban
+  tooling assigned to it.
 expected_output: >-
   A kanban task titled "devops-bench smoke probe" is created via the kanban
-  tooling, and the final message states the id assigned to it.
+  tooling, and the final sentence quotes that exact title and states the id
+  assigned to it.
 infrastructure:
   deployer: noop
 validated: false
@@ -23,7 +25,31 @@ domain: chat-and-routing
 # We chose the title, so an exact match is fair. The kanban_create call is the
 # whole point of the probe: a green judge score with no kanban call would mean
 # the agent talked about creating a task instead of creating it.
+#
+# The prompt asks the closing sentence for the title AND the id on purpose, and
+# it has to keep asking for both. It used to ask for the id alone, which left
+# the title check below punishing the very answer the prompt requested: on
+# PR 890 (build 2091367133568045056) the agent filed the card with the exact
+# title and closed with "The id assigned is `t_faecff25`." -- kanban_create
+# succeeded, so the second objective passed, and the first failed for want of a
+# phrase nothing had asked the agent to repeat. VerificationCorrectness 0.5 at
+# VerificationCoverage 1.0, against the presubmit's floor of 1.0: a clean
+# single-objective miss, not an error. Shorten the prompt and you must delete
+# the check with it.
+#
+# The id itself is deliberately NOT checked here. It is minted per run
+# (t_faecff25 was that run's), so no literal phrase can match it, and
+# report_contains matches substrings only -- required_phrases, any_of_phrases,
+# forbidden_phrases, and a scope selector, with no regex or pattern field to
+# borrow. The one available bodge, requiring the substring "t_", would pass any
+# sentence that happens to contain those two characters and fail a correct
+# report that wrote the id some other way, so it would grade spelling rather
+# than the answer. The id stays a judged requirement via expected_output above;
+# turn it into an objective the day the verifier grows a pattern matcher.
 verification_spec:
+  # Named for what it proves and no more: the closing sentence carries the
+  # title we chose. That the same sentence carries the id is asked for in the
+  # prompt but graded only by the judge -- see the note above.
   - name: report-states-the-probe-title
     role: objective
     # assert, not the converge default: the transcript is immutable once the

--- a/bench/tasks/gpu-stress-test-diagnosis/task.yaml
+++ b/bench/tasks/gpu-stress-test-diagnosis/task.yaml
@@ -22,6 +22,24 @@ infrastructure:
   variables:
     node_count: 1
     machine_type: "g2-standard-4"
+# Question 2 asks for the workload's own pod-scaling ceiling and says in as
+# many words that node-pool and cluster capacity are not the subject. Both
+# halves have to stay. It used to ask for "any cluster or workload autoscaling
+# limitations identified during the event", and on PR 889 (build
+# 2091347335803047936) an agent took the offer the word "cluster" made: it
+# found the GCS FUSE bottleneck and cited the right cluster, then attributed
+# the autoscaling problem to the Cluster Autoscaler. The judge's own words were
+# "focuses entirely on Cluster Autoscaler limitations ... completely omits any
+# mention of Horizontal Pod Autoscaler", and report-names-the-autoscaling-limit
+# failed -- VerificationCorrectness 0.5 at VerificationCoverage 1.0, against a
+# presubmit floor of 1.0. The check was right and the prompt was wrong:
+# write_synthetic_logs in this task's own tofu stack plants HPA max-replica
+# saturation and nothing else, so the node pool never ran out of anything and a
+# Cluster Autoscaler finding is a wrong answer rather than a second valid one.
+# What the prompt must NOT do is name the controller or quote the planted line
+# back -- finding "HorizontalPodAutoscaler" in Cloud Logging IS the task, and a
+# prompt that hands it over leaves the objective measuring transcription.
+# Describe the shape of the answer; never supply its nouns.
 prompt: |
   An automated alert for high Time to First Token (TTFT) latency has triggered
   for the 'hypercomputer-agent' service in GKE cluster '{{CLUSTER_NAME}}' in
@@ -31,8 +49,11 @@ prompt: |
 
   Output an incident post-mortem report directly in your answer detailing:
   1. The primary storage bottleneck identified and its root cause.
-  2. Any cluster or workload autoscaling limitations identified during the
-     event.
+  2. The autoscaling limit the 'hypercomputer-agent' workload itself reached
+     during the event: which controller reported reaching it, which of that
+     controller's configured bounds was hit, and the value it was set to. This
+     is about the workload's own pod-scaling ceiling, not about node-pool or
+     cluster-level capacity.
   3. Recommended architectural remediation steps.
 expected_output: |
   critical requirements:
@@ -41,7 +62,10 @@ expected_output: |
   - Identify GCS FUSE buffer exhaustion as the primary storage bottleneck
     in the report.
   - Identify HorizontalPodAutoscaler (HPA) max-replica saturation (limit 10)
-    in the report.
+    in the report. The autoscaling finding must be the workload's pod-level
+    scaling ceiling: a report that attributes the limit to the Cluster
+    Autoscaler or to node-pool capacity has answered the wrong question, since
+    nothing in the logs shows node scaling failing.
   - Detail architectural recommendations (e.g., using Parallelstore/Lustre
     or optimizing FUSE cache settings and HPA limits).
 
@@ -91,6 +115,9 @@ verification_spec:
       type: report_contains
       # Either spelling of the autoscaler names the planted limit; all-of
       # required_phrases would punish a report for choosing the long form.
+      # This check stays exactly as strict as it is: when it and the prompt
+      # disagreed it was the prompt that was narrowed, for the reason
+      # recorded in the note above the prompt.
       any_of_phrases: ["HPA", "HorizontalPodAutoscaler"]
   # A post-incident analysis must not mutate anything. Checked against the
   # CLUSTER, not the tool trace, for two reasons: the trajectory holds only


### PR DESCRIPTION
## Summary

`hack/ci-eval-pr.sh` runs exactly two tasks today — `gpu-stress-test-diagnosis` and `agent-kanban-smoke` — and the other ten entries in its `TASKS` array are commented out pending A1–A5. Those two tasks are therefore the entire active presubmit matrix, and the job is being prepared to become a blocking merge gate. Both of them currently fail agents that do exactly what the prompt asks. This change makes each prompt agree with the checks that grade it: the kanban probe now asks the closing sentence for the card's title as well as its id, and the GPU diagnosis prompt's question 2 now asks for the workload's own pod-scaling ceiling instead of "any cluster or workload autoscaling limitations". Neither check is loosened; in both cases the prompt is what was wrong.

## Why This Change

A prompt that asks for one thing and a deterministic check that grades another produces red presubmits on correct agent behaviour. That is tolerable while the eval job is advisory and is not tolerable the day it starts holding merges — every failure it reports then has to be a real one, or the gate gets ignored and then disabled.

Both mismatches have already fired on real runs, and the arithmetic is unforgiving: with two objectives per task and `DETERMINISTIC_CORRECTNESS_FLOOR="1.0"`, one missed objective is `VerificationCorrectness = 0.5` and a red PR. Without this change, the two tasks that constitute the entire gate each carry a known way to fail an agent that did the work.

## What Changed

Two `task.yaml` files. No harness, verifier, or runtime code.

**`bench/tasks/agent-kanban-smoke/task.yaml` — the probe graded the wrong sentence.** The prompt asked the agent to "state in one sentence the id that was assigned to it", and then graded that sentence with an objective named `report-states-the-probe-title` that required the card's **title**. Nothing in the prompt ever asked the agent to repeat the title, and nothing anywhere checked the id — the one thing the prompt did ask for.

This is not theoretical. From `results_agent-kanban-smoke.json` on PR #890, build `2091367133568045056`: the card was created with the exactly correct title, `kanban_create` succeeded so `the-kanban-card-was-actually-filed` passed, the agent closed with "The id assigned is `t_faecff25`.", and the run scored `VerificationCorrectness = 0.5` at `VerificationCoverage = 1.0`. Coverage of 1.0 is what makes this diagnosable rather than noisy: both checks evaluated, one passed, one failed. It was a genuine miss on a genuinely correct run, and the judge said as much — "the actual output lacks a final text response stating the assigned task ID". Against `DETERMINISTIC_CORRECTNESS_FLOOR="1.0"` that is a red presubmit.

The prompt now asks the closing sentence for the title **and** the id together. That is the smallest change that makes the existing title check honest instead of accidental, and it leaves the probe testing the same thing it was always meant to test: that the deployed agent can be told to file a kanban card, files one, and can report back about it.

**Why the id itself is still not checked deterministically.** The obvious follow-on — add a second objective asserting the id was stated — is not available, and I decided against faking it. `report_contains` (`bench/kube_agents_bench/verifiers.py`) takes `required_phrases`, `forbidden_phrases`, `any_of_phrases` and `scope`, and nothing else; the model forbids extra keys, so a made-up `pattern:` field is a load-time `ValidationError`, and a spec entry that fails to parse counts as an unmet objective of weight 1.0. Inventing a matcher would red the task permanently rather than fix it. The regex operator that does exist in this repo, `resource_property`'s `matches`, reads cluster state and cannot see the transcript.

That leaves substring matching against an id minted fresh per run — `t_faecff25` was that run's, and the next run's will differ. The only substring available in advance is `t_`, which would pass on any sentence containing those two characters anywhere and fail a correct report that wrote the id without the prefix. That check would grade spelling, not correctness, and a misfiring check on a blocking gate is worse than an acknowledged gap. So the id remains a judged requirement via `expected_output`, and the task file now says plainly that it is asked for in the prompt, feeds the judge, and is not deterministically checked because the verifier has no pattern matcher. If `report_contains` ever grows one, the comment says what to do.

**`bench/tasks/gpu-stress-test-diagnosis/task.yaml` — the prompt invited the wrong answer.** `bench/tf/prebuilt/gpu-stress-test/main.tf`'s `write_synthetic_logs` plants exactly two log lines and then polls Cloud Logging until both are readable: GCS FUSE buffer exhaustion during checkpoint load, and `HorizontalPodAutoscaler: HPA max-replica saturation for deployment/hypercomputer-agent (max: 10)`. Those two defects are the whole incident. Nothing in the stack starves the node pool.

The prompt nevertheless asked for "any **cluster** or workload autoscaling limitations identified during the event", and on PR #889, build `2091347335803047936`, an agent took the offer that first word made. It found the GCS FUSE bottleneck, cited the right cluster, and then attributed the autoscaling problem to the Cluster Autoscaler. The judge: "focuses entirely on Cluster Autoscaler limitations ... completely omits any mention of Horizontal Pod Autoscaler." `VerificationCorrectness = 0.5`, `VerificationCoverage = 1.0` again.

I fixed the prompt rather than the check, deliberately. A report naming the Cluster Autoscaler is not a differently-worded right answer; it is a wrong diagnosis of a planted defect, and `any_of_phrases: ["HPA", "HorizontalPodAutoscaler"]` is right to reject it. Widening that check to admit "Cluster Autoscaler" would turn the only signal this objective carries into a check that the agent said the word "autoscaler".

The interesting constraint is the other side of it: the prompt must not hand over the answer. If it names the controller, or quotes the planted line back, the objective stops measuring diagnosis and starts measuring transcription — and finding `HorizontalPodAutoscaler` in Cloud Logging is precisely the work this task exists to test. So question 2 now asks for the autoscaling limit the `hypercomputer-agent` workload *itself* reached: which controller reported reaching it, which of that controller's configured bounds was hit, and what value it was set to — with an explicit note that this is the workload's own pod-scaling ceiling, not node-pool or cluster-level capacity. That rules out the wrong answer without supplying the right noun. The agent still has to read the logs. (The residual risk in that trade is recorded under Self-Review.)

`expected_output` is kept in step with both prompts, since it is what the judge grades against, and the GPU one now also states that attributing the limit to the Cluster Autoscaler is a wrong answer rather than a partial one.

Both task files carry a comment recording why the prompt and the spec are worded the way they now are, with the failing build IDs, so the next person editing either one does not quietly re-open the gap.

## Context

- The two failing runs this change is a response to: PR #890, build `2091367133568045056` (`agent-kanban-smoke`) and PR #889, build `2091347335803047936` (`gpu-stress-test-diagnosis`).
- The eval job is advisory today and is being prepared to become a blocking merge gate; that transition is what makes these mismatches urgent rather than cosmetic.
- The catastrophic `read-only-in-a-post-incident-task` safeguard and the `tool_called` check are unchanged. Both are correct as written.

Known follow-ups, deliberately not addressed here:

- **`DocRetrievalRate = 0.0`.** On the same PR #889 artifact the agent never fetched either URL in the task's `documentation:` block, and `GroundingAccuracy` came in at 2.5 ("Applied 1 out of 2 documented constraints"). That block is currently decorative. It is agent and harness behaviour rather than a task-definition bug, so it is out of scope here and wants its own change.
- **`DETERMINISTIC_CORRECTNESS_FLOOR="1.0"`.** With two objectives per task the floor leaves no slack at all — one missed objective is a red PR, which is how both of the failures above surfaced. That is a deliberate decision and I have not touched it; worth being aware of when the job goes blocking, because it means every objective on every active task must be one the agent can hit reliably.
- **`bench/tasks/cluster-provision-kanban/task.yaml` carries the identical unfixed mismatch** — see Self-Review, finding 5. Left alone here because it is not in the active matrix.

## Testing

Everything below was run in a clean worktree at `ad20351` and the output observed. `make test-bench` and `make docs-check` are the two Makefile targets that reach these files; the registration and domain lints are the two `scripts/` guards that read `bench/tasks/`.

- `python3 scripts/test_task_registration.py` — **Ran 4 tests, OK.** Neither task is added or removed, so the `TASKS` array and `KNOWN_UNREGISTERED` are untouched.
- `python3 scripts/test_domain_coverage.py` — **Ran 4 tests, OK.** `agent-kanban-smoke` keeps `domain: chat-and-routing` and its non-empty `verification_spec`, so the one covered domain of ten stays covered. `gpu-stress-test-diagnosis` still declares no domain, deliberately.
- `python -m pytest bench/tests/` (what `make test-bench` runs) — **153 passed in 30.90s.** Run in a throwaway venv with `pip install -e bench/ pytest`, because system Python has no `pytest`.
- `make docs-check` — **passed** (all five sub-targets: generated regions, 260 Markdown files link-checked, terminology, docs map over 230 tracked docs, context budget 35.3k of 38,000 chars). No Markdown changed, so this only proves nothing was broken.
- Both files parsed as YAML and both `verification_spec`s built through the real loader (`devops_bench.verification.spec.VerificationEntry` + `parse_node`): all five entries resolve to their verifier class — `ReportContainsVerifier` ×3, `ToolCalledVerifier`, `ResourcePropertyVerifier`. **This is the check that matters most here**, since a spec that fails to parse scores as a failed objective rather than an error.
- Grepped the whole tree for the two replaced prompt strings to find anything pinning the old wording. Only hit outside the diff is `bench/tasks/cluster-provision-kanban/task.yaml` (Self-Review finding 5). No doc, test, or golden file pins either prompt.

What none of the above covers: **no automated check in this repo reads a prompt and a `verification_spec` together and reports that they disagree.** That is the entire class of bug this PR fixes, and the lints above are all blind to it. The only thing that catches it today is a human reading the file, or a red eval run.

### Live validation

**Not live-tested.** This change has not been exercised by an eval run of any kind, and I could not run one: `hack/ci-eval-pr.sh` needs Prow, a leased GCP project (Boskos), a `platform-agent` deployed to the host cluster, and — for `gpu-stress-test-diagnosis` — an OpenTofu apply of `prebuilt/gpu-stress-test` on a `g2-standard-4` node. None of that is reachable from this environment.

To be explicit about the evidence in the sections above: `results_agent-kanban-smoke.json` from PR #890 build `2091367133568045056`, and the PR #889 build `2091347335803047936` artifact, are **prior** runs of the **old** prompts. They are the diagnosis this change responds to. They are not validation of it, and nothing here should be read as saying the new prompts have been observed to pass.

What would actually exercise this: the presubmit eval run against this PR itself, which runs both tasks against the deployed agent. The specific things to read out of it — and I have not read them — are `VerificationCorrectness = 1.0` at `VerificationCoverage = 1.0` on both tasks, and, on `gpu-stress-test-diagnosis`, whether the agent's report names the HPA *and* the max-replica value 10, since only the controller name is checked deterministically. One green run is weak evidence for a prompt change: the failure mode being fixed is a wording ambiguity an agent may or may not take on any given run.

No test artifacts were created, so there is nothing to clean up.

## Self-Review

Adversarial pass run by a subagent handed the diff (`gh pr diff 893`) and the repo, in a context that did not write the change and had not seen the reasoning behind it. Docs-drift pass folded in (the grep under Testing). What it looked for: whether each prompt now asks for every noun its `verification_spec` asserts; whether either prompt now leaks the answer so the check passes trivially; whether the `expected_output` edits changed what the judge grades in a way that pulls away from the deterministic checks; whether the comments claim more than the verifier does; whether the same mismatch exists elsewhere in the corpus.

1. **Coverage — clean.** Every phrase the specs assert is now something the prompt asks for. `gcs fuse`/`gcsfuse` ← question 1's "primary storage bottleneck"; `HPA`/`HorizontalPodAutoscaler` ← question 2's controller; the probe title ← "quotes that exact title"; `kanban_create` ← "create a kanban task"; the `read-only-in-a-post-incident-task` safeguard ← the prompt's "this is a post-incident analysis ... rather than from live kubectl/cluster state". The kanban id is the one requirement with no objective behind it, which is stated in the file and above.

2. **Leak, GPU — real, accepted, not fixed.** Question 2's new "the workload's own pod-scaling ceiling" plus "which controller reported reaching it" narrows the answer space enough that a model could name the HorizontalPodAutoscaler by inference, without ever reading Cloud Logging — and `report-names-the-autoscaling-limit` matches only the controller name, not the value 10. So against a guessing agent this objective is weaker than it was before the change. Not fixed, and the reason is that the alternative is worse in a way this PR exists to prevent: saying less re-opens the Cluster Autoscaler wrong answer, which is the failure that was actually observed rather than a hypothetical one. The value 10 remains judged via `expected_output`, and the storage-bottleneck objective on the same task is not guessable, so a log-free agent still cannot clear the task. Recorded here rather than in the file because it is a property of the trade, not of the wording.

3. **Leak, kanban — pre-existing, unchanged in kind.** `report-states-the-probe-title` requires a phrase the prompt supplies verbatim, so it is satisfiable by echo. That was already true; the change makes echoing the requested behaviour instead of an accident. It is not a hole, because the objective's job is "did the agent report back at all" and `the-kanban-card-was-actually-filed` (`tool_called` with `require_success: true`) is what proves work happened. Not fixed, deliberately.

4. **Judge drift — checked, both directions clean.** Both `expected_output` blocks changed, so the judge's rubric changed. Kanban: the judge now also wants the title in the final sentence, which is stricter and matches the prompt and the objective. GPU: an added clause makes a Cluster Autoscaler attribution a wrong answer rather than a partial one, which aligns the judge with `any_of_phrases`. Neither edit makes the judge grade something the deterministic checks contradict, and neither relaxes anything.

5. **Same bug, third task — found, reported, not fixed.** `bench/tasks/cluster-provision-kanban/task.yaml` has the unrepaired original shape: the prompt says "then state in one sentence the id that was assigned to it" while `report-states-the-onboard-title` requires `"onboard cluster"`. Identical mismatch, same failure mode. Left alone because it cannot red a presubmit today — it is absent from `TASKS` and listed in `KNOWN_UNREGISTERED` ("cluster-scoped provisioning task, tier decision pending") — and because fixing an unregistered task under a PR titled for the two presubmit tasks widens the diff past its title. It will fail the day the tier decision registers it; that is the change that should carry the fix.

6. **Comment overclaims the verifier — cosmetic, not fixed.** The new kanban comment describes the check as grading "the closing sentence". `report_contains` with the default `scope: final` reads the whole final message — and, on a delegated turn, the delivered card results and artifacts too. For this task the distinction is inert: `kanban_create` is the router's own call, so there is no delegated worker output folded in. Worth knowing before anyone reuses the sentence-level framing on a task that does delegate.

7. **Not independently verified.** The two Prow artifacts (`results_agent-kanban-smoke.json` on build `2091367133568045056`, and build `2091347335803047936`) are not reachable from this environment. Every number quoted from them is the author's reading, cited to the artifact, not something re-observed for this description.

## Risk & Rollout

Low risk. Two eval task definitions change and nothing else — no runtime code path, no operator, agent, chart, or CI logic, nothing shipped in an image. The blast radius is the eval job's own scoring: only `gpu-stress-test-diagnosis` and `agent-kanban-smoke`, which run only in `hack/ci-eval-pr.sh`, which is advisory today.

The new failure mode, if the change is wrong, is a task that keeps failing for a different reason than before, or a GPU objective an agent clears without reading the logs (Self-Review finding 2). Either shows up as a red or an implausibly-easy presubmit eval, in a job that gates nothing yet — which is the right order: this lands while the job is still advisory, and gets a few real runs before it goes blocking.

Revert is `git revert` of the single commit; there is no state, migration, or deployed artifact to unwind, and a revert takes effect on the next eval run. Nothing has to happen at merge time. The one thing to watch afterwards is the first presubmit eval run on any subsequent PR: it is the first real exercise of either new prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
