### PR TITLE
fix(gitops): fail with named GitOpsRepoEmpty error on repositories with no commits

### DIFF
--- a/agents/platform/scripts/gitops_workspace.py
+++ b/agents/platform/scripts/gitops_workspace.py
@@ -123,6 +123,10 @@ def default_settings_path() -> str:
 # which is only when there is no clone to ask yet. See `resolve_base_branch`.
 DEFAULT_BASE_BRANCH = "main"
 
+
+class GitOpsRepoEmpty(RuntimeError):
+    """Raised when a GitOps repository has no commits on any branch."""
+
 # Tolerates the operator's Markdown bullet and bold markers, and the literal
 # `None` when the CR leaves it unset.
 SETTINGS_REPO_RE = re.compile(r"^\s*[-*]?\s*\**Git Repo:\**\s*(\S+)\s*$", re.M)
@@ -543,6 +547,28 @@ def ensure_workspace(
     # Resolved here rather than defaulted in the signature: it takes a `git` in
     # the clone, and the clone is what the lines above just established.
     base_branch = base_branch or resolve_base_branch(target, runner)
+
+    # An empty repository has no commits on any branch, so origin/<base_branch>
+    # cannot exist. Probe before checkout rather than dying on raw git fatal output.
+    ref_check = runner(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/remotes/origin/{base_branch}"],
+        cwd=str(target),
+        check=False,
+    )
+    if getattr(ref_check, "returncode", 1) != 0:
+        all_commits = runner(
+            ["git", "rev-list", "-n", "1", "--all"],
+            cwd=str(target),
+            check=False,
+        )
+        if (
+            getattr(all_commits, "returncode", 1) != 0
+            or not (getattr(all_commits, "stdout", "") or "").strip()
+        ):
+            raise GitOpsRepoEmpty(
+                f"{repo} has no commits on any branch; the audit cannot open a remediation branch"
+            )
+        raise RuntimeError(f"{repo} has no remote branch origin/{base_branch}")
 
     runner(["git", "reset", "--hard", "--quiet"], cwd=str(target), check=False)
     runner(["git", "clean", "-fdq"], cwd=str(target), check=False)

--- a/agents/platform/scripts/gitops_workspace.py
+++ b/agents/platform/scripts/gitops_workspace.py
@@ -515,6 +515,9 @@ def ensure_workspace(
     until the remediation branch stages them, so a `git clean -fd` on the way
     into `finish` deletes every fix the audit just produced and the run reports
     them all as "the file was never written".
+
+    Raises `GitOpsRepoEmpty` if the target repository has zero commits on any
+    branch, preventing dispatch runs from crashing on raw git fatal errors.
     """
     root = Path(root if root is not None else default_root())
     lease = sanitize_lease(lease)

--- a/agents/platform/scripts/test_gitops_workspace.py
+++ b/agents/platform/scripts/test_gitops_workspace.py
@@ -515,6 +515,60 @@ class TestResolveBaseBranch(WorkspaceTestCase):
         )
         self.assertEqual(head.stdout.strip(), "master")
 
+    def test_a_real_empty_repository_raises_gitops_repo_empty(self):
+        if shutil.which("git") is None:  # pragma: no cover
+            self.skipTest("git is not on PATH")
+
+        def real(cmd, *, cwd=None, check=True):
+            return subprocess.run(
+                cmd, cwd=cwd, check=check, capture_output=True, text=True
+            )
+
+        origin = seed_empty_origin(self.tmp_path, branch="main")
+        with self.assertRaises(gitops_workspace.GitOpsRepoEmpty) as ctx:
+            gitops_workspace.ensure_workspace(
+                "acme/fleet", real, lease=LEASE, root=self.root, remote_url=str(origin), reset=True
+            )
+        self.assertIn("has no commits on any branch", str(ctx.exception))
+
+    def test_ensure_workspace_raises_gitops_repo_empty_on_unborn_remote(self):
+        def runner(cmd, *, cwd=None, check=True):
+            self.calls.append(list(cmd))
+            if cmd[:2] == ["git", "clone"]:
+                (Path(cmd[-1]) / ".git").mkdir(parents=True, exist_ok=True)
+            if cmd[1:2] == ["symbolic-ref"]:
+                return CompletedProcess(cmd, 1, "", "")
+            if cmd[1:3] == ["rev-parse", "--verify"]:
+                return CompletedProcess(cmd, 1, "", "")
+            if cmd[1:3] == ["rev-list", "-n"]:
+                return CompletedProcess(cmd, 0, "", "")
+            return CompletedProcess(cmd, 0, "", "")
+
+        with self.assertRaises(gitops_workspace.GitOpsRepoEmpty) as ctx:
+            gitops_workspace.ensure_workspace(
+                "acme/fleet", runner, lease=LEASE, root=self.root, reset=True
+            )
+        self.assertIn("has no commits on any branch", str(ctx.exception))
+
+    def test_ensure_workspace_raises_runtime_error_when_branch_missing_but_repo_has_commits(self):
+        def runner(cmd, *, cwd=None, check=True):
+            self.calls.append(list(cmd))
+            if cmd[:2] == ["git", "clone"]:
+                (Path(cmd[-1]) / ".git").mkdir(parents=True, exist_ok=True)
+            if cmd[1:2] == ["symbolic-ref"]:
+                return CompletedProcess(cmd, 0, "origin/main\n", "")
+            if cmd[1:3] == ["rev-parse", "--verify"]:
+                return CompletedProcess(cmd, 1, "", "")
+            if cmd[1:3] == ["rev-list", "-n"]:
+                return CompletedProcess(cmd, 0, "abc12345\n", "")
+            return CompletedProcess(cmd, 0, "", "")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            gitops_workspace.ensure_workspace(
+                "acme/fleet", runner, lease=LEASE, root=self.root, reset=True
+            )
+        self.assertIn("has no remote branch origin/main", str(ctx.exception))
+
 
 class TestReaper(WorkspaceTestCase):
     def age(self, path, hours):
@@ -670,6 +724,17 @@ def seed_origin(tmp_path: Path, branch: str = "main") -> Path:
         ["git", "push", "--quiet", "origin", branch],
     ):
         subprocess.run(cmd, cwd=seed, check=True, capture_output=True)
+    return origin
+
+
+def seed_empty_origin(tmp_path: Path, branch: str = "main") -> Path:
+    """A local bare repository with zero commits."""
+    origin = tmp_path / f"empty_origin_{branch}.git"
+    subprocess.run(
+        ["git", "init", "--quiet", "--bare", f"--initial-branch={branch}", str(origin)],
+        check=True,
+        capture_output=True,
+    )
     return origin
 
 


### PR DESCRIPTION
## Summary

Probes for an unborn HEAD / empty repository in `agents/platform/scripts/gitops_workspace.py:ensure_workspace()` before checkout and raises a named `GitOpsRepoEmpty` exception, preventing dispatch runs from crashing on raw git fatal output and improvising workarounds against gateway safety policies (Issue #570).

## Why This Change

1. **Unborn HEAD Crash on Fresh GitOps Repos (#570):**
   When initializing a workspace against a brand-new GitOps repository with zero commits:
   - `_origin_head()` returned `None` because `refs/remotes/origin/HEAD` does not exist.
   - `_detect_base_branch()` ran `git remote set-head origin --auto`, which failed and returned `None`.
   - `resolve_base_branch()` fell back to `DEFAULT_BASE_BRANCH = "main"`.
   - `ensure_workspace()` executed `git checkout -B main origin/main`, which crashed with `fatal: 'origin/main' is not a commit and a branch 'main' cannot be created from it`.
   - When dispatch audit runs (e.g. `dispatch-compliance-audit`) encountered this raw git fatal error, models attempted to improvise by calling `audit_report.py` directly, triggering gateway safety blocks.

2. **Actionable Precondition Error:**
   By checking whether `refs/remotes/origin/{base_branch}` exists and verifying whether the repository holds any commits via `git rev-list -n 1 --all`, `ensure_workspace()` now raises `GitOpsRepoEmpty: <repo> has no commits on any branch; the audit cannot open a remediation branch`.

## What Changed

- **`agents/platform/scripts/gitops_workspace.py`**:
  - Added `GitOpsRepoEmpty(RuntimeError)` exception class.
  - In `ensure_workspace()`, added pre-checkout verification:
    - Runs `git rev-parse --verify --quiet refs/remotes/origin/{base_branch}`.
    - If non-zero, inspects `git rev-list -n 1 --all`.
    - If the repository has zero commits across all branches, raises `GitOpsRepoEmpty`.
    - If other branches exist but `origin/{base_branch}` is missing, raises `RuntimeError(f"{repo} has no remote branch origin/{base_branch}")`.
  - Updated `ensure_workspace()` docstring to document `GitOpsRepoEmpty`.
- **`agents/platform/scripts/test_gitops_workspace.py`**:
  - Added `seed_empty_origin()` helper creating bare repositories with 0 commits.
  - Added `test_a_real_empty_repository_raises_gitops_repo_empty` executing real git against an empty bare remote.
  - Added `test_ensure_workspace_raises_gitops_repo_empty_on_unborn_remote` testing mock runner with unborn remote.
  - Added `test_ensure_workspace_raises_runtime_error_when_branch_missing_but_repo_has_commits` testing missing base branch when other commits exist.

## Context

Closes #570.

## Testing

- `python3 -m unittest discover -s agents/platform/scripts -p 'test_gitops_workspace.py' -v`: All 63 tests passed.
- `make test-python`: Passed across all 11 test suites (1,415+ tests).
- `make docs-check`: Passed all link checks, terminology checks, map coverage, and instruction budgets.

### Live validation

- **Not live-tested on a live GKE cluster**: Changes are strictly confined to deterministic git workspace inspection in Python (`gitops_workspace.py`) and test fixtures.
- **Deterministic Mechanism Verification**: Verified via real git executions against a local bare repository (`git init --bare`) with zero commits (`seed_empty_origin`), confirming that `ensure_workspace()` raises `GitOpsRepoEmpty: acme/fleet has no commits on any branch; the audit cannot open a remediation branch` instead of raw git fatal output.

## Self-Review

Passes executed in fresh isolated subagent context (`sa-0-c048aaca`):
- **Adversarial code review (`review-adversarial`):**
  - Verified that `ensure_workspace` distinguishes between completely empty repositories (`GitOpsRepoEmpty`) and populated repositories where only the specified base branch is missing (`RuntimeError`).
  - Verified that `reset=False` paths (used between `start` and `finish` to preserve untracked remediation manifests) remain completely unhindered.
- **Docs-drift review (`review-docs-drift`):**
  - Verified that `gitops_workspace.py:ensure_workspace()` docstring documents the `GitOpsRepoEmpty` raise condition.

## Risk & Rollout

Low risk: Scoped to workspace initialization and branch validation in `gitops_workspace.py`. Revert by reverting the commit.

---
*Generated with the help of Gemini.*