### PR TITLE
feat(release): streamline release pipeline and strictly isolate post-tag version inputs

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -59,11 +59,19 @@ jobs:
         id: verify-eligibility
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
-          RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
+          RC_CANDIDATE_COMMIT: ${{ steps.calculate-version.outputs.rc_candidate_commit }}
           SKIP_RC_VALIDATION: ${{ inputs.skip_rc_validation }}
           EMERGENCY_OVERRIDE_REASON: ${{ inputs.emergency_override_reason }}
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/verify_release_eligibility.sh
+
+      - name: Create Git Tag
+        if: steps.verify-eligibility.outputs.skip_release != 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
+          RC_CANDIDATE_COMMIT: ${{ steps.calculate-version.outputs.rc_candidate_commit }}
+          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: ./scripts/release/tag_ga_release.sh
 
       - name: Set up Docker Buildx
         if: steps.verify-eligibility.outputs.skip_release != 'true'
@@ -80,7 +88,6 @@ jobs:
       - name: Promote Release Container Images
         if: steps.verify-eligibility.outputs.skip_release != 'true'
         env:
-          RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
         run: ./scripts/release/promote_release_images.sh
 
@@ -104,23 +111,13 @@ jobs:
         if: steps.verify-eligibility.outputs.skip_release != 'true'
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
-          RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           GH_USER: ${{ github.actor }}
         run: ./scripts/release/publish_helm_chart.sh
-
-      - name: Create Git Tag
-        if: steps.verify-eligibility.outputs.skip_release != 'true'
-        env:
-          RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
-          RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
-          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-        run: ./scripts/release/tag_ga_release.sh
 
       - name: Publish GitHub Release
         if: steps.verify-eligibility.outputs.skip_release != 'true'
         env:
           RELEASE_VERSION: ${{ steps.calculate-version.outputs.release_version }}
-          RELEASE_COMMIT: ${{ steps.calculate-version.outputs.release_commit }}
           GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
         run: ./scripts/release/publish_github_release.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,7 @@ curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
 ```
 
 _To pin to a specific official release, substitute `<RELEASE_VERSION>` with the desired version tag from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases):_
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -47,7 +47,7 @@ _To pin to a specific official release, substitute `<RELEASE_VERSION>` with the 
 curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```
 
-When running the release-pinned installer (`<RELEASE_VERSION>/install.sh`), the baked release version is used automatically without prompting. When running the generic installer (`gke-labs.github.io/kube-agents/install.sh`), the interactive prompt asks you to enter the target SemVer release tag or full 40-character commit SHA (from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases)). The installer rejects mutable refs such as `latest` and `main` to ensure install sources and container images stay strictly aligned.
+When running the release-pinned installer (`<RELEASE_VERSION>/install.sh`), the baked release version is offered as the default, so pressing Enter accepts it; `--non-interactive` uses it without prompting at all. When running the generic installer (`gke-labs.github.io/kube-agents/install.sh`), the interactive prompt asks you to enter the target SemVer release tag or full 40-character commit SHA (from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases)), and `--non-interactive` requires `--image-tag`. The installer rejects mutable refs such as `latest` and `main` to ensure install sources and container images stay strictly aligned.
 
 ### What `install.sh` Automatically Handles:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ This comprehensive, step-by-step guide explains how to install, configure, deplo
 Run the interactive one-liner installer directly in **Google Cloud Shell** or any authenticated bash terminal:
 
 ```bash
-curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```
 
 When prompted for the image/source revision, enter a SemVer release tag or the full 40-character

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,17 +38,15 @@ This comprehensive, step-by-step guide explains how to install, configure, deplo
 Run the interactive one-liner installer directly in **Google Cloud Shell** or any authenticated bash terminal:
 
 ```bash
+curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
+```
+
+_To pin to a specific official release, substitute `<RELEASE_VERSION>` with the desired version tag from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases):_
+```bash
 curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```
 
-When prompted for the image/source revision, enter a SemVer release tag or the full 40-character
-commit SHA behind a validated RC tag. The installer rejects mutable refs such as `latest` and `main`
-so the install sources and container images stay on the same revision. On the one-liner above
-there is no local checkout yet, so a value is required; running `./install.sh` from a kube-agents
-clone instead offers that clone's `HEAD` as the default — which only works if a container image was
-published for that commit (CI builds one per `main` commit and per release tag).
-
-_(Alternatively via GitHub raw URL: `curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/main/install.sh | bash`)_
+When running the release-pinned installer (`<RELEASE_VERSION>/install.sh`), the baked release version is used automatically without prompting. When running the generic installer (`gke-labs.github.io/kube-agents/install.sh`), the interactive prompt asks you to enter the target SemVer release tag or full 40-character commit SHA (from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases)). The installer rejects mutable refs such as `latest` and `main` to ensure install sources and container images stay strictly aligned.
 
 ### What `install.sh` Automatically Handles:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _An SRE asks for a fleet self-health check; the agent answers in the thread. An 
 The fastest, zero-friction way to install `kube-agents` in **Google Cloud Shell** or your terminal:
 
 ```bash
-curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```
 
 _(Or via GitHub raw URL: `curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/main/install.sh | bash`)_

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ _An SRE asks for a fleet self-health check; the agent answers in the thread. An 
 The fastest, zero-friction way to install `kube-agents` in **Google Cloud Shell** or your terminal:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
+curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
 ```
 
-_(Or via GitHub raw URL: `curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/main/install.sh | bash`)_
+_To pin to a specific official release, substitute `<RELEASE_VERSION>` with the desired version tag from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases):_
+```bash
+curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
+```
 
 This interactive installer guides you through GCP authentication, project selection, GKE cluster setup (Autopilot or Standard), chat integrations (Google Chat & Slack), and LLM model provider credentials.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ curl -fsSL https://gke-labs.github.io/kube-agents/install.sh | bash
 ```
 
 _To pin to a specific official release, substitute `<RELEASE_VERSION>` with the desired version tag from [GitHub Releases](https://github.com/gke-labs/kube-agents/releases):_
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gke-labs/kube-agents/<RELEASE_VERSION>/install.sh | bash
 ```

--- a/docs/designs/semver-deployment-versioning.md
+++ b/docs/designs/semver-deployment-versioning.md
@@ -27,9 +27,15 @@ documentation and governance playbooks around them.
    avoiding a separate module-registry backend.
 3. **RC pipeline feeds SemVer promotion.** Pre-release validation keeps using RC tags
    (`rc_YYMMDDHHMM_<short_sha>`, `*_validated` on success — see `scripts/release/README.md`).
-   The validated commit is then promoted and tagged `MAJOR.MINOR.PATCH` via `release-publish.yml`,
-   which orchestrates clean image promotion and chart publication.
-4. **The operator defaults to its own release version.** When a `PlatformAgent` CR omits
+4. **GA release pipeline creates stamped release child commit.** When promoting a validated
+   candidate, `release-publish.yml` creates a single-parent child commit on detached HEAD
+   (baking `BAKED_RELEASE_VERSION` into installer scripts), tags it `MAJOR.MINOR.PATCH` (`X.Y.Z`),
+   and orchestrates clean image promotion and chart publication. Because the GA tag points at this
+   stamped child commit outside `main`, `git log main` does not show the release commit and
+   `git describe --tags` on `main` does not resolve to the GA tag (which is why `default_image_tag`
+   matches numeric SemVer tags explicitly). Git tag resolution for Terraform module consumption
+   (`?ref=X.Y.Z`) remains unaffected.
+5. **The operator defaults to its own release version.** When a `PlatformAgent` CR omits
    `spec.deployment.image`, the operator dynamically derives the matching versioned agent image
    from its own container image at runtime (or via `OPERATOR_IMAGE` env var). Precedence:
    CR spec > `PLATFORM_AGENT_IMAGE` env > `OPERATOR_IMAGE` (dynamic runtime derivation) > `latest` fallback.

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -11,7 +11,7 @@ sidebar:
 
 1. **RC Testing**: Pre-release builds are validated by the automated RC pipeline —
    [`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release) is the canonical reference for how `rc_YYMMDDHHMM_<short_sha>` builds are created, tested end-to-end, and tagged `*_validated` on success.
-2. **SemVer Publication**: Running the release workflow (`release-publish.yml`) for a validated commit or tag promotes and publishes immutable artifacts (example for `1.2.0`):
+2. **SemVer Publication**: Running the release workflow (`release-publish.yml`) for a validated commit creates a stamped single-parent release commit on detached HEAD (baking `BAKED_RELEASE_VERSION` into installer scripts), tags it `MAJOR.MINOR.PATCH`, and promotes immutable artifacts (example for `1.2.0`):
    - **GHCR Images**: Clean promotion retags verified commit images to `ghcr.io/gke-labs/kube-agents/platform-agent:1.2.0` (and all required images) without rebuilding.
    - **OCI Helm Charts**: `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:1.2.0` (packaged and signed by digest via `release-publish.yml`).
    - **Terraform Modules**: Sourced via Git tag reference `?ref=1.2.0`

--- a/install.sh
+++ b/install.sh
@@ -400,7 +400,7 @@ default_image_tag() {
   fi
   # 2. Check if local git repo is checked out at an exact SemVer release tag
   local exact_tag=""
-  exact_tag="$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")"
+  exact_tag="$(git -C "$repo_dir" describe --tags --exact-match --match="[0-9]*" 2>/dev/null || echo "")"
   if [[ "$exact_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
     echo "$exact_tag"
     return 0
@@ -428,7 +428,7 @@ default_image_tag_label() {
 
   if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "$tag" = "$BAKED_RELEASE_VERSION" ]; then
     printf 'official release %s' "$tag"
-  elif [ "$tag" = "$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")" ]; then
+  elif [ "$tag" = "$(git -C "$repo_dir" describe --tags --exact-match --match="[0-9]*" 2>/dev/null || echo "")" ]; then
     printf 'release tag %s' "$tag"
   elif [[ "$(basename "$(cd "$repo_dir" 2>/dev/null && pwd || echo "$repo_dir")")" =~ ^kube-agents-${tag}$ ]]; then
     printf 'release archive %s' "$tag"

--- a/install.sh
+++ b/install.sh
@@ -494,6 +494,14 @@ verify_local_source_ref() {
     return 0
   fi
 
+  # In official stamped release archives (unpacked tarball/zip outside Git),
+  # BAKED_RELEASE_VERSION is stamped during release automation.
+  if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "${BAKED_RELEASE_VERSION}" = "${expected_ref}" ]; then
+    SOURCE_REF_VERIFIED="${repo_dir}@${expected_ref}"
+    print_success "Verified install sources match baked official release ${BAKED_RELEASE_VERSION}."
+    return 0
+  fi
+
   if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     if [ "$lenient" = "true" ]; then
       print_warning "Cannot verify source/image alignment because '$repo_dir' is not a Git worktree."
@@ -567,15 +575,20 @@ acquire_source_repo() {
   else
     resolved_dir="$HOME/kube-agents"
     if [ -d "$resolved_dir/.git" ]; then
+      if [ -n "$(git -C "$resolved_dir" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+        print_error "Existing repository at $resolved_dir has uncommitted changes. Refusing to overwrite or switch branches."
+        print_info "Please commit or stash your changes before running the installer, or run the installer directly from within your repository clone."
+        return 1
+      fi
       print_info "Updating repository at $resolved_dir to ref '$expected_ref'..."
-      git -C "$resolved_dir" fetch --depth=1 origin "$expected_ref"
+      git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "$expected_ref"
       git -C "$resolved_dir" checkout --detach FETCH_HEAD
     elif [ -d "$resolved_dir" ]; then
       print_info "Using existing repository at $resolved_dir."
     else
       print_info "Cloning kube-agents install sources at '$expected_ref' into $resolved_dir..."
       git clone --filter=blob:none --no-checkout https://github.com/gke-labs/kube-agents.git "$resolved_dir"
-      git -C "$resolved_dir" fetch --depth=1 origin "$expected_ref"
+      git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "$expected_ref"
       git -C "$resolved_dir" checkout --detach FETCH_HEAD
     fi
     cd "$resolved_dir"

--- a/install.sh
+++ b/install.sh
@@ -485,15 +485,14 @@ verify_local_source_ref() {
     return 0
   fi
 
-  # In official stamped release archives (unpacked tarball/zip outside Git),
-  # BAKED_RELEASE_VERSION is stamped during release automation.
-  if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "${BAKED_RELEASE_VERSION}" = "${expected_ref}" ]; then
-    SOURCE_REF_VERIFIED="${repo_dir}@${expected_ref}"
-    print_success "Verified install sources match baked official release ${BAKED_RELEASE_VERSION}."
-    return 0
-  fi
-
   if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # In official stamped release archives (unpacked tarball/zip outside Git),
+    # BAKED_RELEASE_VERSION is stamped during release automation.
+    if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "${BAKED_RELEASE_VERSION}" = "${expected_ref}" ]; then
+      SOURCE_REF_VERIFIED="${repo_dir}@${expected_ref}"
+      print_success "Verified install sources match baked official release ${BAKED_RELEASE_VERSION}."
+      return 0
+    fi
     if [ "$lenient" = "true" ]; then
       print_warning "Cannot verify source/image alignment because '$repo_dir' is not a Git worktree."
       SOURCE_REF_VERIFIED="${repo_dir}@${expected_ref}"

--- a/install.sh
+++ b/install.sh
@@ -420,29 +420,20 @@ default_image_tag() {
 # it the way git does and say where it came from. Empty outside a Git worktree.
 default_image_tag_label() {
   local repo_dir="${1:-.}"
-  if [ -n "${BAKED_RELEASE_VERSION:-}" ]; then
-    printf 'official release %s' "$BAKED_RELEASE_VERSION"
+  local tag
+  tag="$(default_image_tag "$repo_dir")"
+  if [ -z "$tag" ]; then
     return 0
   fi
-  if [ ! -f "${repo_dir}/k8s-operator/scripts/installer_common.sh" ]; then
-    return 0
-  fi
-  local exact_tag=""
-  exact_tag="$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")"
-  if [[ "$exact_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-    printf 'release tag %s' "$exact_tag"
-    return 0
-  fi
-  local base_dir=""
-  base_dir="$(basename "$(cd "$repo_dir" 2>/dev/null && pwd || echo "$repo_dir")")"
-  if [[ "$base_dir" =~ ^kube-agents-([0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)$ ]]; then
-    printf 'release archive %s' "${BASH_REMATCH[1]}"
-    return 0
-  fi
-  local short=""
-  short="$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "")"
-  if [ -n "$short" ]; then
-    printf 'local HEAD checkout %s' "$short"
+
+  if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "$tag" = "$BAKED_RELEASE_VERSION" ]; then
+    printf 'official release %s' "$tag"
+  elif [ "$tag" = "$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")" ]; then
+    printf 'release tag %s' "$tag"
+  elif [[ "$(basename "$(cd "$repo_dir" 2>/dev/null && pwd || echo "$repo_dir")")" =~ ^kube-agents-${tag}$ ]]; then
+    printf 'release archive %s' "$tag"
+  else
+    printf 'local HEAD checkout %s' "${tag:0:7}"
   fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -564,21 +564,16 @@ acquire_source_repo() {
     print_success "Using current repository directory: $resolved_dir"
   else
     resolved_dir="$HOME/kube-agents"
-    if [ -d "$resolved_dir/.git" ]; then
-      if [ -n "$(git -C "$resolved_dir" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
-        print_error "Existing repository at $resolved_dir has uncommitted changes. Refusing to overwrite or switch branches."
-        print_info "Please commit or stash your changes before running the installer, or run the installer directly from within your repository clone."
-        return 1
-      fi
-      print_info "Updating repository at $resolved_dir to ref '$expected_ref'..."
-      git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "$expected_ref"
-      git -C "$resolved_dir" checkout --detach FETCH_HEAD
-    elif [ -d "$resolved_dir" ]; then
-      print_info "Using existing repository at $resolved_dir."
+    if [ -d "$resolved_dir" ]; then
+      print_info "Using existing repository at $resolved_dir without modifying local changes."
     else
       print_info "Cloning kube-agents install sources at '$expected_ref' into $resolved_dir..."
       git clone --filter=blob:none --no-checkout https://github.com/gke-labs/kube-agents.git "$resolved_dir"
-      git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "$expected_ref"
+      if [[ "$expected_ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+        git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "$expected_ref"
+      else
+        git -C "$resolved_dir" fetch --depth=1 https://github.com/gke-labs/kube-agents.git "+refs/tags/${expected_ref}:refs/tags/${expected_ref}"
+      fi
       git -C "$resolved_dir" checkout --detach FETCH_HEAD
     fi
     cd "$resolved_dir"

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,10 @@ on_error() {
 }
 trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
+# Sourced/baked release version. On developer checkouts (main), this is empty.
+# Release automation stamps this value (e.g. BAKED_RELEASE_VERSION="0.2.0") when publishing a GA release.
+BAKED_RELEASE_VERSION=""
+
 # ─── Agentic & Automation Parameter States ────────────────────────────────────
 PARAM_NON_INTERACTIVE="${NONINTERACTIVE:-false}"
 PARAM_DRY_RUN="${DRY_RUN:-false}"
@@ -377,11 +381,16 @@ cluster_mode_label() {
 }
 
 # The image tag doubles as the source ref that verify_local_source_ref checks the
-# checkout against, so HEAD is the natural default: it is an immutable 40-character
-# SHA and it is exactly the revision of the scripts about to run. Empty when the
-# installer runs outside a Git worktree (curl | bash), where the caller must supply one.
+# checkout against. When downloaded as an official release via curl | bash, the baked
+# release tag takes precedence. In local Git checkouts, an exact SemVer release tag or
+# HEAD commit SHA is used as the default.
 default_image_tag() {
   local repo_dir="${1:-.}"
+  # 1. Baked release version takes precedence (for curl | bash from official release URLs)
+  if [ -n "${BAKED_RELEASE_VERSION:-}" ]; then
+    echo "$BAKED_RELEASE_VERSION"
+    return 0
+  fi
   # Only a kube-agents checkout may supply the default. Without this guard,
   # running the curl | bash one-liner from inside any unrelated Git repository
   # would offer that repository's HEAD, which then fails at `git fetch` for a
@@ -389,6 +398,21 @@ default_image_tag() {
   if [ ! -f "${repo_dir}/k8s-operator/scripts/installer_common.sh" ]; then
     return 0
   fi
+  # 2. Check if local git repo is checked out at an exact SemVer release tag
+  local exact_tag=""
+  exact_tag="$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")"
+  if [[ "$exact_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    echo "$exact_tag"
+    return 0
+  fi
+  # 3. Check if running inside an unpacked release archive directory (e.g. kube-agents-0.1.0 or kube-agents-0.2.0)
+  local base_dir=""
+  base_dir="$(basename "$(cd "$repo_dir" 2>/dev/null && pwd || echo "$repo_dir")")"
+  if [[ "$base_dir" =~ ^kube-agents-([0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)$ ]]; then
+    echo "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  # 4. Fall back to local HEAD commit SHA for developer iterations
   git -C "$repo_dir" rev-parse HEAD 2>/dev/null || echo ""
 }
 
@@ -396,7 +420,23 @@ default_image_tag() {
 # it the way git does and say where it came from. Empty outside a Git worktree.
 default_image_tag_label() {
   local repo_dir="${1:-.}"
+  if [ -n "${BAKED_RELEASE_VERSION:-}" ]; then
+    printf 'official release %s' "$BAKED_RELEASE_VERSION"
+    return 0
+  fi
   if [ ! -f "${repo_dir}/k8s-operator/scripts/installer_common.sh" ]; then
+    return 0
+  fi
+  local exact_tag=""
+  exact_tag="$(git -C "$repo_dir" describe --tags --exact-match 2>/dev/null || echo "")"
+  if [[ "$exact_tag" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+    printf 'release tag %s' "$exact_tag"
+    return 0
+  fi
+  local base_dir=""
+  base_dir="$(basename "$(cd "$repo_dir" 2>/dev/null && pwd || echo "$repo_dir")")"
+  if [[ "$base_dir" =~ ^kube-agents-([0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)$ ]]; then
+    printf 'release archive %s' "${BASH_REMATCH[1]}"
     return 0
   fi
   local short=""
@@ -526,8 +566,12 @@ acquire_source_repo() {
     print_success "Using current repository directory: $resolved_dir"
   else
     resolved_dir="$HOME/kube-agents"
-    if [ -d "$resolved_dir" ]; then
-      print_info "Using existing repository at $resolved_dir without modifying local changes."
+    if [ -d "$resolved_dir/.git" ]; then
+      print_info "Updating repository at $resolved_dir to ref '$expected_ref'..."
+      git -C "$resolved_dir" fetch --depth=1 origin "$expected_ref"
+      git -C "$resolved_dir" checkout --detach FETCH_HEAD
+    elif [ -d "$resolved_dir" ]; then
+      print_info "Using existing repository at $resolved_dir."
     else
       print_info "Cloning kube-agents install sources at '$expected_ref' into $resolved_dir..."
       git clone --filter=blob:none --no-checkout https://github.com/gke-labs/kube-agents.git "$resolved_dir"
@@ -1442,7 +1486,7 @@ main() {
         exit 1
       fi
       image_tag="$head_sha"
-      print_info "Defaulting image tag to the checkout's HEAD: ${C_BOLD}${image_tag}${C_RESET}"
+      print_info "Defaulting image tag to $(default_image_tag_label): ${C_BOLD}${image_tag}${C_RESET}"
     else
       prompt_read "Container image tag (validated release tag or full commit SHA)" \
         image_tag "$head_sha" false "$(default_image_tag_label)"

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -39,7 +39,7 @@ page under "Why there is no `gke-admin` set".
 - `tag_validated_release.sh`: Attaches the `*_validated` tag to a candidate commit upon 100% test pass.
 - `calculate_next_version.sh`: Automatically calculates the next SemVer 2.0 version from Conventional Commits since the latest numeric GA release tag.
 - `verify_release_eligibility.sh`: Release gatekeeper that verifies commit eligibility, checks for live RC validation tags (`rc_*_validated`), performs tag collision detection, and verifies all 4 required container images exist in registry.
-- `tag_ga_release.sh`: Creates and pushes official GA SemVer Git tags (`X.Y.Z`) directly on the validated commit SHA.
+- `tag_ga_release.sh`: Creates and pushes official GA SemVer Git tags (`X.Y.Z`) on a detached HEAD commit stamped with the release version in installer scripts.
 - `promote_release_images.sh`: Promotes verified container images from candidate commit SHA to GA release tag in GHCR without rebuilding.
 - `sign_release_images.sh`: Signs promoted GA release container images in GHCR using Keyless Cosign OIDC.
 - `publish_helm_chart.sh`: Packages, publishes, and signs the official kube-agents Helm chart to GHCR as an OCI artifact.
@@ -76,4 +76,4 @@ These modular scripts back the corresponding child workflows in `.github/workflo
 | `e2e-gchat-test.yml` / `rc-release-pipeline.yml` | Step 3 - GKE Readiness & E2E Validation | `install_e2e_deps.sh`, `wait_for_gke_readiness.sh`, `execute_e2e_tests.sh`                                                                                                                     |
 | `rc-tag-validated.yml`                           | Step 4 - Validate Candidate Commit      | `resolve_rc_tag.sh`, `tag_validated_release.sh`                                                                                                                                                |
 | `rc-teardown-environment.yml`                    | Step 5 - Tear Down Environment          | `resolve_rc_tag.sh`, `teardown_rc_environment.sh`                                                                                                                                              |
-| `release-publish.yml`                            | GA Release Orchestration                | `calculate_next_version.sh`, `verify_release_eligibility.sh`, `promote_release_images.sh`, `sign_release_images.sh`, `tag_ga_release.sh`, `publish_helm_chart.sh`, `publish_github_release.sh` |
+| `release-publish.yml`                            | GA Release Orchestration                | `calculate_next_version.sh`, `verify_release_eligibility.sh`, `tag_ga_release.sh`, `promote_release_images.sh`, `sign_release_images.sh`, `publish_helm_chart.sh`, `publish_github_release.sh` |

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -39,7 +39,7 @@ page under "Why there is no `gke-admin` set".
 - `tag_validated_release.sh`: Attaches the `*_validated` tag to a candidate commit upon 100% test pass.
 - `calculate_next_version.sh`: Automatically calculates the next SemVer 2.0 version from Conventional Commits since the latest numeric GA release tag.
 - `verify_release_eligibility.sh`: Release gatekeeper that verifies commit eligibility, checks for live RC validation tags (`rc_*_validated`), performs tag collision detection, and verifies all 4 required container images exist in registry.
-- `tag_ga_release.sh`: Creates and pushes official GA SemVer Git tags (`X.Y.Z`) on a detached HEAD commit stamped with the release version in installer scripts.
+- `tag_ga_release.sh`: Creates and pushes official GA SemVer Git tags (`X.Y.Z`) on a detached HEAD commit stamped with the release version in installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`). Note: candidate commits must carry the `^BAKED_RELEASE_VERSION=` placeholder line in root installer scripts.
 - `promote_release_images.sh`: Promotes verified container images from candidate commit SHA to GA release tag in GHCR without rebuilding.
 - `sign_release_images.sh`: Signs promoted GA release container images in GHCR using Keyless Cosign OIDC.
 - `publish_helm_chart.sh`: Packages, publishes, and signs the official kube-agents Helm chart to GHCR as an OCI artifact.

--- a/scripts/release/calculate_next_version.sh
+++ b/scripts/release/calculate_next_version.sh
@@ -10,7 +10,7 @@ source "${SCRIPT_DIR}/common.sh"
 
 EXPLICIT_RELEASE_VERSION="${EXPLICIT_RELEASE_VERSION:-${3:-}}"
 BASE_TAG_PARAM="${1:-${BASE_TAG_PARAM:-${BASE_TAG:-}}}"
-TARGET_REF_PARAM="${2:-${TARGET_REF_PARAM:-${TARGET_COMMIT:-${TARGET_REF:-${RELEASE_COMMIT:-}}}}}"
+TARGET_REF_PARAM="${2:-${TARGET_REF_PARAM:-${TARGET_COMMIT:-${TARGET_REF:-}}}}"
 SKIP_VALIDATION="${SKIP_RC_VALIDATION:-${4:-false}}"
 
 # 0. Protection against Shallow Checkout and Remote Tag Sync in CI
@@ -42,7 +42,7 @@ if [ -z "${TARGET_REF_PARAM}" ] || [ "${TARGET_REF_PARAM}" = "null" ]; then
 fi
 
 # Validate target ref exists in git repository and resolve 40-character SHA
-if ! RELEASE_COMMIT="$(git rev-parse --verify "${TARGET_REF_PARAM}^{commit}" 2>/dev/null)"; then
+if ! RC_CANDIDATE_COMMIT="$(git rev-parse --verify "${TARGET_REF_PARAM}^{commit}" 2>/dev/null)"; then
   echo "❌ ERROR: Target ref '${TARGET_REF_PARAM}' does not exist in git repository!" >&2
   exit 1
 fi
@@ -75,7 +75,7 @@ if [ -n "${EXPLICIT_RELEASE_VERSION}" ]; then
 
   # 3.3 Protect against tag collisions on different commits
   if TAG_COMMIT="$(git rev-parse --verify "refs/tags/${EXPLICIT_RELEASE_VERSION}^{commit}" 2>/dev/null)"; then
-    REQ_COMMIT="$(git rev-parse --verify "${RELEASE_COMMIT}^{commit}" 2>/dev/null || echo "")"
+    REQ_COMMIT="$(git rev-parse --verify "${RC_CANDIDATE_COMMIT}^{commit}" 2>/dev/null || echo "")"
     if [ -n "${REQ_COMMIT}" ] && [ "${TAG_COMMIT}" != "${REQ_COMMIT}" ]; then
       echo "❌ ERROR: Tag '${EXPLICIT_RELEASE_VERSION}' already exists in git repository on a different commit (${TAG_COMMIT:0:7}). Cannot re-assign existing release tag." >&2
       exit 1
@@ -86,7 +86,8 @@ if [ -n "${EXPLICIT_RELEASE_VERSION}" ]; then
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "release_version=${EXPLICIT_RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
     echo "version=${EXPLICIT_RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
-    echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
     echo "previous_version=${LATEST_GA_TAG}" >> "${GITHUB_OUTPUT}"
     echo "has_changes=true" >> "${GITHUB_OUTPUT}"
     echo "bump_type=manual" >> "${GITHUB_OUTPUT}"
@@ -102,7 +103,8 @@ if [ -z "${LATEST_GA_TAG}" ]; then
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "release_version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
     echo "version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
-    echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
     echo "previous_version=" >> "${GITHUB_OUTPUT}"
     echo "has_changes=true" >> "${GITHUB_OUTPUT}"
     echo "bump_type=initial" >> "${GITHUB_OUTPUT}"
@@ -115,7 +117,7 @@ echo "📌 Latest GA Tag: ${LATEST_GA_TAG}" >&2
 IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_GA_TAG}"
 
 # 5. Inspect commit range for subjects (%s) and bodies (%b)
-COMMITS_RANGE="${LATEST_GA_TAG}..${RELEASE_COMMIT}"
+COMMITS_RANGE="${LATEST_GA_TAG}..${RC_CANDIDATE_COMMIT}"
 if ! COMMITS_SUBJECTS="$(git log "${COMMITS_RANGE}" --format="%s" 2>&1)"; then
   echo "❌ ERROR: Failed to read commit log for range '${COMMITS_RANGE}': ${COMMITS_SUBJECTS}" >&2
   exit 1
@@ -127,7 +129,8 @@ if [ -z "${COMMITS_SUBJECTS}" ]; then
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "release_version=${LATEST_GA_TAG}" >> "${GITHUB_OUTPUT}"
     echo "version=${LATEST_GA_TAG}" >> "${GITHUB_OUTPUT}"
-    echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
     echo "previous_version=${LATEST_GA_TAG}" >> "${GITHUB_OUTPUT}"
     echo "has_changes=false" >> "${GITHUB_OUTPUT}"
     echo "bump_type=none" >> "${GITHUB_OUTPUT}"
@@ -175,7 +178,8 @@ echo "📈 Calculated next version: ${NEXT_VERSION} (bump: ${BUMP_TYPE})" >&2
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "release_version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
   echo "version=${NEXT_VERSION}" >> "${GITHUB_OUTPUT}"
-  echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+  echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+  echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
   echo "previous_version=${LATEST_GA_TAG}" >> "${GITHUB_OUTPUT}"
   echo "has_changes=true" >> "${GITHUB_OUTPUT}"
   echo "bump_type=${BUMP_TYPE}" >> "${GITHUB_OUTPUT}"

--- a/scripts/release/calculate_next_version.sh
+++ b/scripts/release/calculate_next_version.sh
@@ -76,7 +76,8 @@ if [ -n "${EXPLICIT_RELEASE_VERSION}" ]; then
   # 3.3 Protect against tag collisions on different commits
   if TAG_COMMIT="$(git rev-parse --verify "refs/tags/${EXPLICIT_RELEASE_VERSION}^{commit}" 2>/dev/null)"; then
     REQ_COMMIT="$(git rev-parse --verify "${RC_CANDIDATE_COMMIT}^{commit}" 2>/dev/null || echo "")"
-    if [ -n "${REQ_COMMIT}" ] && [ "${TAG_COMMIT}" != "${REQ_COMMIT}" ]; then
+    if [ -n "${REQ_COMMIT}" ] && [ "${TAG_COMMIT}" != "${REQ_COMMIT}" ] && \
+       ! git merge-base --is-ancestor "${REQ_COMMIT}" "${TAG_COMMIT}" 2>/dev/null; then
       echo "❌ ERROR: Tag '${EXPLICIT_RELEASE_VERSION}' already exists in git repository on a different commit (${TAG_COMMIT:0:7}). Cannot re-assign existing release tag." >&2
       exit 1
     fi

--- a/scripts/release/calculate_next_version.sh
+++ b/scripts/release/calculate_next_version.sh
@@ -76,8 +76,7 @@ if [ -n "${EXPLICIT_RELEASE_VERSION}" ]; then
   # 3.3 Protect against tag collisions on different commits
   if TAG_COMMIT="$(git rev-parse --verify "refs/tags/${EXPLICIT_RELEASE_VERSION}^{commit}" 2>/dev/null)"; then
     REQ_COMMIT="$(git rev-parse --verify "${RC_CANDIDATE_COMMIT}^{commit}" 2>/dev/null || echo "")"
-    if [ -n "${REQ_COMMIT}" ] && [ "${TAG_COMMIT}" != "${REQ_COMMIT}" ] && \
-       ! git merge-base --is-ancestor "${REQ_COMMIT}" "${TAG_COMMIT}" 2>/dev/null; then
+    if [ -n "${REQ_COMMIT}" ] && ! is_valid_stamped_or_direct_release_commit "${REQ_COMMIT}" "${TAG_COMMIT}" "${EXPLICIT_RELEASE_VERSION}"; then
       echo "❌ ERROR: Tag '${EXPLICIT_RELEASE_VERSION}' already exists in git repository on a different commit (${TAG_COMMIT:0:7}). Cannot re-assign existing release tag." >&2
       exit 1
     fi

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -299,6 +299,7 @@ stamp_baked_release_version() {
       sed -i.bak -E "s/^BAKED_RELEASE_VERSION=[\"'].*[\"']/BAKED_RELEASE_VERSION=\"${version}\"/" "${script_path}" && rm -f "${script_path}.bak"
       if ! grep -q "^BAKED_RELEASE_VERSION=\"${version}\"" "${script_path}"; then
         echo "❌ ERROR: Failed to stamp BAKED_RELEASE_VERSION in ${script_name} (placeholder line '^BAKED_RELEASE_VERSION=...' not found)." >&2
+        git -C "${repo_dir}" checkout -- install.sh uninstall.sh upgrade.sh >/dev/null 2>&1 || true
         return 1
       fi
     fi
@@ -367,7 +368,7 @@ create_stamped_release_commit() {
   orig_ref="$(git -C "${repo_dir}" symbolic-ref --short -q HEAD 2>/dev/null || git -C "${repo_dir}" rev-parse HEAD 2>/dev/null || echo "")"
   if [ -n "${orig_ref}" ]; then
     # shellcheck disable=SC2064
-    trap "git -C '${repo_dir}' checkout '${orig_ref}' >/dev/null 2>&1 || true" RETURN
+    trap "git -C '${repo_dir}' checkout -- install.sh uninstall.sh upgrade.sh >/dev/null 2>&1 || true; git -C '${repo_dir}' checkout '${orig_ref}' >/dev/null 2>&1 || true" RETURN
   fi
 
   # Idempotency check: if release tag already exists and is a valid release commit for target_sha, reuse it

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -297,7 +297,11 @@ stamp_baked_release_version() {
   for script_name in install.sh uninstall.sh upgrade.sh; do
     local script_path="${repo_dir}/${script_name}"
     if [ -f "${script_path}" ]; then
-      sed -i.bak "s/^BAKED_RELEASE_VERSION=\".*\"/BAKED_RELEASE_VERSION=\"${version}\"/" "${script_path}" && rm -f "${script_path}.bak"
+      sed -i.bak -E "s/^BAKED_RELEASE_VERSION=[\"'].*[\"']/BAKED_RELEASE_VERSION=\"${version}\"/" "${script_path}" && rm -f "${script_path}.bak"
+      if ! grep -q "^BAKED_RELEASE_VERSION=\"${version}\"" "${script_path}"; then
+        echo "❌ ERROR: Failed to stamp BAKED_RELEASE_VERSION in ${script_name} (placeholder line '^BAKED_RELEASE_VERSION=...' not found)." >&2
+        return 1
+      fi
     fi
   done
 }
@@ -384,7 +388,10 @@ create_stamped_release_commit() {
   fi
 
   # 2. Stamp BAKED_RELEASE_VERSION in root installer scripts
-  stamp_baked_release_version "${version}" "${repo_dir}"
+  if ! stamp_baked_release_version "${version}" "${repo_dir}"; then
+    echo "❌ ERROR: Failed to stamp baked release version into installer scripts." >&2
+    return 1
+  fi
 
   # 3. If files were modified, create release commit on detached HEAD (does NOT touch main branch)
   local modified_files=()

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -313,12 +313,19 @@ create_stamped_release_commit() {
     return 1
   fi
 
+  # Preserve caller's current branch / ref and restore on function return
+  local orig_ref
+  orig_ref="$(git -C "${repo_dir}" symbolic-ref --short -q HEAD 2>/dev/null || git -C "${repo_dir}" rev-parse HEAD 2>/dev/null || echo "")"
+  if [ -n "${orig_ref}" ]; then
+    # shellcheck disable=SC2064
+    trap "git -C '${repo_dir}' checkout '${orig_ref}' >/dev/null 2>&1 || true" RETURN
+  fi
+
   # Idempotency check: if release tag already exists and descends from target_sha, reuse it
   local existing_tag_sha
   if existing_tag_sha="$(git -C "${repo_dir}" rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
     if [ "${existing_tag_sha}" = "${target_sha}" ] || git -C "${repo_dir}" merge-base --is-ancestor "${target_sha}" "${existing_tag_sha}" 2>/dev/null; then
       echo "ℹ️ Release tag '${version}' already exists on commit ${existing_tag_sha:0:7}. Reusing existing release commit." >&2
-      git -C "${repo_dir}" checkout --detach "${existing_tag_sha}" >/dev/null 2>&1 || true
       echo "${existing_tag_sha}"
       return 0
     fi

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -302,6 +302,52 @@ stamp_baked_release_version() {
   done
 }
 
+# Validates if a release tag commit is either directly the candidate commit
+# or a single-parent stamped child commit derived from the candidate.
+is_valid_stamped_or_direct_release_commit() {
+  local candidate_sha="${1:-}"
+  local tag_commit="${2:-}"
+  local version="${3:-}"
+
+  if [ -z "${candidate_sha}" ] || [ -z "${tag_commit}" ] || [ -z "${version}" ]; then
+    echo "❌ ERROR: candidate_sha, tag_commit, and version are all required for is_valid_stamped_or_direct_release_commit." >&2
+    return 1
+  fi
+
+  # Case 1: Exact match (tag placed directly on candidate)
+  if [ "${candidate_sha}" = "${tag_commit}" ]; then
+    return 0
+  fi
+
+  # Case 2: Direct single-parent stamped child
+  local parent_sha
+  if ! parent_sha="$(git rev-parse --verify "${tag_commit}^1" 2>/dev/null)"; then
+    echo "⚠️ Tag commit ${tag_commit:0:7} has no resolvable parent commit in repository." >&2
+    return 1
+  fi
+
+  # Reject merge commits (must have no second parent)
+  if git rev-parse --verify "${tag_commit}^2" >/dev/null 2>&1; then
+    echo "⚠️ Tag commit ${tag_commit:0:7} is a merge commit; expected single-parent stamped release commit." >&2
+    return 1
+  fi
+
+  if [ "${parent_sha}" != "${candidate_sha}" ]; then
+    echo "⚠️ Tag commit ${tag_commit:0:7} parent (${parent_sha:0:7}) does not match candidate commit (${candidate_sha:0:7})." >&2
+    return 1
+  fi
+
+  local commit_subject
+  commit_subject="$(git log -1 --format=%s "${tag_commit}" 2>/dev/null || echo "")"
+  local expected_subject="chore(release): stamp release version ${version}"
+  if [ "${commit_subject}" != "${expected_subject}" ]; then
+    echo "⚠️ Tag commit ${tag_commit:0:7} subject '${commit_subject}' does not match expected stamped subject '${expected_subject}'." >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # Creates a release commit on detached HEAD with stamped BAKED_RELEASE_VERSION
 create_stamped_release_commit() {
   local version="${1:-}"
@@ -321,11 +367,11 @@ create_stamped_release_commit() {
     trap "git -C '${repo_dir}' checkout '${orig_ref}' >/dev/null 2>&1 || true" RETURN
   fi
 
-  # Idempotency check: if release tag already exists and descends from target_sha, reuse it
+  # Idempotency check: if release tag already exists and is a valid release commit for target_sha, reuse it
   local existing_tag_sha
   if existing_tag_sha="$(git -C "${repo_dir}" rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
-    if [ "${existing_tag_sha}" = "${target_sha}" ] || git -C "${repo_dir}" merge-base --is-ancestor "${target_sha}" "${existing_tag_sha}" 2>/dev/null; then
-      echo "ℹ️ Release tag '${version}' already exists on commit ${existing_tag_sha:0:7}. Reusing existing release commit." >&2
+    if is_valid_stamped_or_direct_release_commit "${target_sha}" "${existing_tag_sha}" "${version}"; then
+      echo "ℹ️ Release tag '${version}' already exists on valid release commit ${existing_tag_sha:0:7}. Reusing existing release commit." >&2
       echo "${existing_tag_sha}"
       return 0
     fi

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -217,11 +217,10 @@ find_latest_built_commit() {
 
 # Configures Git bot user identity for automated tagging and committing
 setup_git_bot_user() {
-  local target_dir="${1:-.}"
-  if is_ci_pipeline || [ -z "$(git -C "${target_dir}" config user.name 2>/dev/null || true)" ]; then
-    git -C "${target_dir}" config user.name "github-actions[bot]"
-    git -C "${target_dir}" config user.email "github-actions[bot]@users.noreply.github.com"
-  fi
+  export GIT_AUTHOR_NAME="github-actions[bot]"
+  export GIT_AUTHOR_EMAIL="github-actions[bot]@users.noreply.github.com"
+  export GIT_COMMITTER_NAME="github-actions[bot]"
+  export GIT_COMMITTER_EMAIL="github-actions[bot]@users.noreply.github.com"
 }
 
 # Ensures a Git tag exists for a given commit SHA idempotently and pushes to origin.
@@ -403,7 +402,7 @@ create_stamped_release_commit() {
 
   if [ ${#modified_files[@]} -gt 0 ]; then
     echo "📝 Stamping baked release version '${version}' in release tag commit..." >&2
-    setup_git_bot_user "${repo_dir}"
+    setup_git_bot_user
     git -C "${repo_dir}" add "${modified_files[@]}"
     git -C "${repo_dir}" commit -m "chore(release): stamp release version ${version}" >/dev/null
     git -C "${repo_dir}" rev-parse HEAD

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -412,7 +412,7 @@ create_stamped_release_commit() {
   fi
 }
 
-# Resolves the exact commit SHA for a release tag (resolves tag or fallback to HEAD)
+# Resolves the exact commit SHA for a release tag
 resolve_release_commit() {
   local version="${1:-}"
   local tag_sha=""
@@ -427,13 +427,7 @@ resolve_release_commit() {
     return 0
   fi
 
-  local head_sha
-  if head_sha="$(git rev-parse --verify HEAD 2>/dev/null)"; then
-    echo "${head_sha}"
-    return 0
-  fi
-
-  echo "❌ ERROR: Cannot resolve valid Git commit for release tag '${version}'!" >&2
+  echo "❌ ERROR: Cannot resolve valid Git commit for release tag '${version}' (tag does not exist in repository)!" >&2
   return 1
 }
 

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -470,17 +470,11 @@ get_image_manifest_digest() {
 
 # Resolves the candidate commit SHA where CI built the container images.
 # If a SemVer version is provided, checks:
-# 1. Candidate commit if passed explicitly or in RC_CANDIDATE_COMMIT
-# 2. Tag commit refs/tags/${version}^{commit}
-# 3. Parent commit refs/tags/${version}^^{commit} (where images were built by CI prior to detached HEAD tag stamping)
+# 1. Direct 40-character SHA if passed as argument
+# 2. Stamped release tag parent commit refs/tags/${version}^ (where images were built by CI prior to tag stamping)
+# 3. Direct tag commit refs/tags/${version}^{commit}
 resolve_source_image_commit() {
   local version_or_commit="${1:-}"
-  local explicit_candidate="${2:-${RC_CANDIDATE_COMMIT:-}}"
-
-  if [ -n "${explicit_candidate}" ] && git rev-parse --verify "${explicit_candidate}^{commit}" >/dev/null 2>&1; then
-    git rev-parse --verify "${explicit_candidate}^{commit}"
-    return 0
-  fi
 
   if [ -z "${version_or_commit}" ]; then
     echo "❌ ERROR: version_or_commit is required for resolve_source_image_commit." >&2
@@ -520,18 +514,7 @@ resolve_source_image_commit() {
     return 0
   fi
 
-  if [ -n "${explicit_candidate}" ]; then
-    echo "${explicit_candidate}"
-    return 0
-  fi
-
-  local head_sha
-  if head_sha="$(git rev-parse --verify HEAD 2>/dev/null)"; then
-    echo "${head_sha}"
-    return 0
-  fi
-
-  echo "❌ ERROR: Cannot resolve source image commit for version '${version}'!" >&2
+  echo "❌ ERROR: Cannot resolve source image commit for version '${version}' (tag 'refs/tags/${version}' not found in repository)." >&2
   return 1
 }
 

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -441,7 +441,7 @@ resolve_source_image_commit() {
   local tag_commit=""
   if tag_commit="$(git rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
     local parent_commit=""
-    if parent_commit="$(git rev-parse --verify "refs/tags/${version}^^{commit}" 2>/dev/null)"; then
+    if parent_commit="$(git rev-parse --verify "${tag_commit}^" 2>/dev/null)"; then
       if is_ci_pipeline && command -v docker >/dev/null 2>&1; then
         if check_commit_images_exist "${tag_commit}" 2>/dev/null; then
           echo "${tag_commit}"
@@ -452,8 +452,13 @@ resolve_source_image_commit() {
           return 0
         fi
       fi
-      echo "${parent_commit}"
-      return 0
+      # Fallback detection: if tag commit is a stamped release commit, return its parent
+      local commit_msg
+      commit_msg="$(git log -1 --format="%s" "${tag_commit}" 2>/dev/null || echo "")"
+      if [[ "${commit_msg}" =~ ^chore(\(release\))?:\ stamp ]]; then
+        echo "${parent_commit}"
+        return 0
+      fi
     fi
     echo "${tag_commit}"
     return 0

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -215,11 +215,12 @@ find_latest_built_commit() {
   return 1
 }
 
-# Configures Git bot user identity for automated tagging
+# Configures Git bot user identity for automated tagging and committing
 setup_git_bot_user() {
-  if is_ci_pipeline; then
-    git config user.name "github-actions[bot]"
-    git config user.email "github-actions[bot]@users.noreply.github.com"
+  local target_dir="${1:-.}"
+  if is_ci_pipeline || [ -z "$(git -C "${target_dir}" config user.name 2>/dev/null || true)" ]; then
+    git -C "${target_dir}" config user.name "github-actions[bot]"
+    git -C "${target_dir}" config user.email "github-actions[bot]@users.noreply.github.com"
   fi
 }
 
@@ -283,6 +284,96 @@ ensure_git_tag() {
   fi
 }
 
+# Stamps BAKED_RELEASE_VERSION into root installer scripts (install.sh, uninstall.sh, upgrade.sh)
+stamp_baked_release_version() {
+  local version="${1:-}"
+  local repo_dir="${2:-${REPO_ROOT}}"
+
+  if [ -z "${version}" ]; then
+    echo "❌ ERROR: version is required for stamp_baked_release_version." >&2
+    return 1
+  fi
+
+  for script_name in install.sh uninstall.sh upgrade.sh; do
+    local script_path="${repo_dir}/${script_name}"
+    if [ -f "${script_path}" ]; then
+      sed -i.bak "s/^BAKED_RELEASE_VERSION=\".*\"/BAKED_RELEASE_VERSION=\"${version}\"/" "${script_path}" && rm -f "${script_path}.bak"
+    fi
+  done
+}
+
+# Creates a release commit on detached HEAD with stamped BAKED_RELEASE_VERSION
+create_stamped_release_commit() {
+  local version="${1:-}"
+  local target_sha="${2:-}"
+  local repo_dir="${3:-${REPO_ROOT}}"
+
+  if [ -z "${version}" ] || [ -z "${target_sha}" ]; then
+    echo "❌ ERROR: version and target_sha are required for create_stamped_release_commit." >&2
+    return 1
+  fi
+
+  # Idempotency check: if release tag already exists and descends from target_sha, reuse it
+  local existing_tag_sha
+  if existing_tag_sha="$(git -C "${repo_dir}" rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
+    if [ "${existing_tag_sha}" = "${target_sha}" ] || git -C "${repo_dir}" merge-base --is-ancestor "${target_sha}" "${existing_tag_sha}" 2>/dev/null; then
+      echo "ℹ️ Release tag '${version}' already exists on commit ${existing_tag_sha:0:7}. Reusing existing release commit." >&2
+      git -C "${repo_dir}" checkout --detach "${existing_tag_sha}" >/dev/null 2>&1 || true
+      echo "${existing_tag_sha}"
+      return 0
+    fi
+  fi
+
+  # 1. Checkout detached HEAD at candidate commit
+  git -C "${repo_dir}" checkout --detach "${target_sha}" >/dev/null 2>&1 || true
+
+  # 2. Stamp BAKED_RELEASE_VERSION in root installer scripts
+  stamp_baked_release_version "${version}" "${repo_dir}"
+
+  # 3. If files were modified, create release commit on detached HEAD (does NOT touch main branch)
+  local modified_files=()
+  for script_name in install.sh uninstall.sh upgrade.sh; do
+    if [ -f "${repo_dir}/${script_name}" ] && [ -n "$(git -C "${repo_dir}" status --porcelain "${script_name}" 2>/dev/null || true)" ]; then
+      modified_files+=("${script_name}")
+    fi
+  done
+
+  if [ ${#modified_files[@]} -gt 0 ]; then
+    echo "📝 Stamping baked release version '${version}' in release tag commit..." >&2
+    setup_git_bot_user "${repo_dir}"
+    git -C "${repo_dir}" add "${modified_files[@]}"
+    git -C "${repo_dir}" commit -m "chore(release): stamp release version ${version}" >/dev/null
+    git -C "${repo_dir}" rev-parse HEAD
+  else
+    echo "${target_sha}"
+  fi
+}
+
+# Resolves the exact commit SHA for a release tag (resolves tag or fallback to HEAD)
+resolve_release_commit() {
+  local version="${1:-}"
+  local tag_sha=""
+
+  if [ -z "${version}" ]; then
+    echo "❌ ERROR: version is required for resolve_release_commit." >&2
+    return 1
+  fi
+
+  if tag_sha="$(git rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
+    echo "${tag_sha}"
+    return 0
+  fi
+
+  local head_sha
+  if head_sha="$(git rev-parse --verify HEAD 2>/dev/null)"; then
+    echo "${head_sha}"
+    return 0
+  fi
+
+  echo "❌ ERROR: Cannot resolve valid Git commit for release tag '${version}'!" >&2
+  return 1
+}
+
 # Retrieves canonical manifest digest (sha256:...) for a remote container image
 get_image_manifest_digest() {
   local img="${1:-}"
@@ -318,6 +409,68 @@ get_image_manifest_digest() {
     fi
   fi
 
+  return 1
+}
+
+# Resolves the candidate commit SHA where CI built the container images.
+# If a SemVer version is provided, checks:
+# 1. Candidate commit if passed explicitly or in RC_CANDIDATE_COMMIT
+# 2. Tag commit refs/tags/${version}^{commit}
+# 3. Parent commit refs/tags/${version}^^{commit} (where images were built by CI prior to detached HEAD tag stamping)
+resolve_source_image_commit() {
+  local version_or_commit="${1:-}"
+  local explicit_candidate="${2:-${RC_CANDIDATE_COMMIT:-}}"
+
+  if [ -n "${explicit_candidate}" ] && git rev-parse --verify "${explicit_candidate}^{commit}" >/dev/null 2>&1; then
+    git rev-parse --verify "${explicit_candidate}^{commit}"
+    return 0
+  fi
+
+  if [ -z "${version_or_commit}" ]; then
+    echo "❌ ERROR: version_or_commit is required for resolve_source_image_commit." >&2
+    return 1
+  fi
+
+  # If version_or_commit is a 40-char SHA
+  if git rev-parse --verify "${version_or_commit}^{commit}" >/dev/null 2>&1 && [[ ! "${version_or_commit}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    git rev-parse --verify "${version_or_commit}^{commit}"
+    return 0
+  fi
+
+  local version="${version_or_commit}"
+  local tag_commit=""
+  if tag_commit="$(git rev-parse --verify "refs/tags/${version}^{commit}" 2>/dev/null)"; then
+    local parent_commit=""
+    if parent_commit="$(git rev-parse --verify "refs/tags/${version}^^{commit}" 2>/dev/null)"; then
+      if is_ci_pipeline && command -v docker >/dev/null 2>&1; then
+        if check_commit_images_exist "${tag_commit}" 2>/dev/null; then
+          echo "${tag_commit}"
+          return 0
+        fi
+        if check_commit_images_exist "${parent_commit}" 2>/dev/null; then
+          echo "${parent_commit}"
+          return 0
+        fi
+      fi
+      echo "${parent_commit}"
+      return 0
+    fi
+    echo "${tag_commit}"
+    return 0
+  fi
+
+  if [ -n "${explicit_candidate}" ]; then
+    echo "${explicit_candidate}"
+    return 0
+  fi
+
+  local head_sha
+  if head_sha="$(git rev-parse --verify HEAD 2>/dev/null)"; then
+    echo "${head_sha}"
+    return 0
+  fi
+
+  echo "❌ ERROR: Cannot resolve source image commit for version '${version}'!" >&2
   return 1
 }
 

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -332,7 +332,10 @@ create_stamped_release_commit() {
   fi
 
   # 1. Checkout detached HEAD at candidate commit
-  git -C "${repo_dir}" checkout --detach "${target_sha}" >/dev/null 2>&1 || true
+  if ! git -C "${repo_dir}" checkout --detach "${target_sha}"; then
+    echo "❌ ERROR: Failed to checkout candidate commit '${target_sha}' on detached HEAD." >&2
+    return 1
+  fi
 
   # 2. Stamp BAKED_RELEASE_VERSION in root installer scripts
   stamp_baked_release_version "${version}" "${repo_dir}"

--- a/scripts/release/promote_release_images.sh
+++ b/scripts/release/promote_release_images.sh
@@ -7,29 +7,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/release/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
-RELEASE_COMMIT="${1:-${RELEASE_COMMIT:-${COMMIT_SHA:-${TARGET_COMMIT:-}}}}"
-RELEASE_VERSION="${2:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
+RELEASE_VERSION="${1:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
 
-# Sibling symmetry: support both <COMMIT> <VERSION> and <VERSION> <COMMIT> signatures
-if [ -n "${1:-}" ] && [ -n "${2:-}" ]; then
-  if [[ "${1}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ ! "${2}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    RELEASE_VERSION="$1"
-    RELEASE_COMMIT="$2"
-  fi
-fi
-
-if [ -z "${RELEASE_COMMIT}" ] || [ -z "${RELEASE_VERSION}" ]; then
-  echo "❌ ERROR: RELEASE_COMMIT and RELEASE_VERSION are required as arguments or environment variables." >&2
-  echo "Usage: $0 (with RELEASE_COMMIT and RELEASE_VERSION in env) or $0 <RELEASE_COMMIT> <RELEASE_VERSION>" >&2
+if [ -z "${RELEASE_VERSION}" ]; then
+  echo "❌ ERROR: RELEASE_VERSION is required as first argument or environment variable." >&2
+  echo "Usage: $0 <RELEASE_VERSION>" >&2
   exit 1
 fi
 
 validate_pure_numeric_semver "${RELEASE_VERSION}" "Release version" || exit 1
 
+# Resolve candidate commit SHA from release tag ancestry (where CI built images)
+RELEASE_COMMIT="$(resolve_source_image_commit "${RELEASE_VERSION}")"
+
 echo "======================================================================"
 echo "🚀 PROMOTING RELEASE CONTAINER IMAGES (NO-REBUILD)"
 echo "Release Commit:  ${RELEASE_COMMIT}"
-echo "Release Version: ${RELEASE_VERSION}"
+echo "Release Version:  ${RELEASE_VERSION}"
 echo "======================================================================"
 
 promote_release_images "${RELEASE_COMMIT}" "${RELEASE_VERSION}"

--- a/scripts/release/publish_github_release.sh
+++ b/scripts/release/publish_github_release.sh
@@ -8,36 +8,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
 RELEASE_VERSION="${1:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
-RELEASE_COMMIT="${2:-${RELEASE_COMMIT:-${TARGET_COMMIT:-}}}"
 TARGET_REPO="$(get_target_repo)"
 
-# Sibling symmetry: support swapped arguments
-if [ -n "${1:-}" ] && [ -n "${2:-}" ]; then
-  if [[ ! "${1}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${2}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    local_tmp="${RELEASE_VERSION}"
-    RELEASE_VERSION="${RELEASE_COMMIT}"
-    RELEASE_COMMIT="${local_tmp}"
-  fi
-fi
-
-if [ -z "${RELEASE_VERSION}" ] || [ -z "${RELEASE_COMMIT}" ]; then
-  echo "❌ ERROR: RELEASE_VERSION and RELEASE_COMMIT are required as arguments or environment variables." >&2
-  echo "Usage: $0 (with RELEASE_VERSION and RELEASE_COMMIT in env) or $0 <RELEASE_VERSION> <RELEASE_COMMIT>" >&2
+if [ -z "${RELEASE_VERSION}" ]; then
+  echo "❌ ERROR: RELEASE_VERSION is required as first argument or environment variable." >&2
+  echo "Usage: $0 <RELEASE_VERSION>" >&2
   exit 1
 fi
 
 validate_pure_numeric_semver "${RELEASE_VERSION}" "Release version" || exit 1
 
-# Canonicalize commit SHA to full 40-character hash
-if ! RESOLVED_COMMIT="$(git rev-parse --verify "${RELEASE_COMMIT}^{commit}" 2>/dev/null)"; then
-  echo "❌ ERROR: Cannot resolve valid Git commit from '${RELEASE_COMMIT}'!" >&2
-  exit 1
-fi
+# Single Source of Truth: Resolve commit directly from the Git tag created by tag_ga_release.sh
+RELEASE_COMMIT="$(resolve_release_commit "${RELEASE_VERSION}" "" "true")"
 
 echo "======================================================================"
 echo "🚀 PUBLISHING GITHUB RELEASE"
 echo "Release Version:   ${RELEASE_VERSION}"
-echo "Resolved Commit:   ${RESOLVED_COMMIT:0:7}"
+echo "Release Commit:     ${RELEASE_COMMIT}"
 echo "Target Repository: ${TARGET_REPO}"
 echo "======================================================================"
 
@@ -65,8 +52,8 @@ fi
 
 gh release create "${RELEASE_VERSION}" \
   --repo "${TARGET_REPO}" \
-  --target "${RESOLVED_COMMIT}" \
+  --target "${RELEASE_COMMIT}" \
   --title "Release ${RELEASE_VERSION}" \
   --generate-notes
 
-echo "✅ Successfully published GitHub Release '${RELEASE_VERSION}' for commit ${RESOLVED_COMMIT:0:7}."
+echo "✅ Successfully published GitHub Release '${RELEASE_VERSION}' for commit ${RELEASE_COMMIT:0:7}."

--- a/scripts/release/publish_github_release.sh
+++ b/scripts/release/publish_github_release.sh
@@ -19,7 +19,7 @@ fi
 validate_pure_numeric_semver "${RELEASE_VERSION}" "Release version" || exit 1
 
 # Single Source of Truth: Resolve commit directly from the Git tag created by tag_ga_release.sh
-RELEASE_COMMIT="$(resolve_release_commit "${RELEASE_VERSION}" "" "true")"
+RELEASE_COMMIT="$(resolve_release_commit "${RELEASE_VERSION}")"
 
 echo "======================================================================"
 echo "🚀 PUBLISHING GITHUB RELEASE"

--- a/scripts/release/publish_helm_chart.sh
+++ b/scripts/release/publish_helm_chart.sh
@@ -8,12 +8,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 # shellcheck source=scripts/release/common.sh
 source "${SCRIPT_DIR}/common.sh"
 
-RELEASE_VERSION="${1:-${RELEASE_VERSION:-}}"
-RELEASE_COMMIT="${2:-${RELEASE_COMMIT:-}}"
+RELEASE_VERSION="${1:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
 
 if [ -z "${RELEASE_VERSION}" ]; then
   echo "❌ ERROR: RELEASE_VERSION is required as first argument or environment variable." >&2
-  echo "Usage: $0 (with RELEASE_VERSION in env) or $0 <RELEASE_VERSION> [RELEASE_COMMIT]" >&2
+  echo "Usage: $0 <RELEASE_VERSION>" >&2
   exit 1
 fi
 
@@ -36,23 +35,16 @@ if ! command -v cosign >/dev/null 2>&1; then
   fi
 fi
 
-CHART_DIR="${REPO_ROOT}/charts/kube-agents"
-TMP_EXTRACT_DIR=""
+# Resolve release commit directly from Git tag (using shared common helper)
+RELEASE_COMMIT="$(resolve_release_commit "${RELEASE_VERSION}")"
 
-if [ -n "${RELEASE_COMMIT}" ]; then
-  if RESOLVED_COMMIT="$(git rev-parse --verify "${RELEASE_COMMIT}^{commit}" 2>/dev/null)"; then
-    echo "🔍 Extracting Helm chart from release commit ${RESOLVED_COMMIT:0:7}..."
-    TMP_EXTRACT_DIR="$(mktemp -d)"
-    if ! git archive "${RESOLVED_COMMIT}" charts/kube-agents | tar -x -C "${TMP_EXTRACT_DIR}"; then
-      echo "❌ ERROR: Failed to extract charts/kube-agents from commit ${RESOLVED_COMMIT:0:7}!" >&2
-      exit 1
-    fi
-    CHART_DIR="${TMP_EXTRACT_DIR}/charts/kube-agents"
-  else
-    echo "❌ ERROR: Cannot resolve valid Git commit for Helm chart packaging: ${RELEASE_COMMIT}" >&2
-    exit 1
-  fi
+echo "🔍 Extracting Helm chart from release tag '${RELEASE_VERSION}' (commit ${RELEASE_COMMIT:0:7})..."
+TMP_EXTRACT_DIR="$(mktemp -d)"
+if ! git archive "${RELEASE_COMMIT}" charts/kube-agents | tar -x -C "${TMP_EXTRACT_DIR}"; then
+  echo "❌ ERROR: Failed to extract charts/kube-agents from commit ${RELEASE_COMMIT:0:7}!" >&2
+  exit 1
 fi
+CHART_DIR="${TMP_EXTRACT_DIR}/charts/kube-agents"
 
 if [ ! -d "${CHART_DIR}" ]; then
   echo "❌ ERROR: Helm chart directory '${CHART_DIR}' not found!" >&2

--- a/scripts/release/tag_ga_release.sh
+++ b/scripts/release/tag_ga_release.sh
@@ -10,15 +10,6 @@ source "${SCRIPT_DIR}/common.sh"
 RELEASE_VERSION="${1:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
 RC_CANDIDATE_COMMIT="${2:-${RC_CANDIDATE_COMMIT:-${TARGET_COMMIT:-}}}"
 
-# Sibling symmetry: support swapped arguments
-if [ -n "${1:-}" ] && [ -n "${2:-}" ]; then
-  if [[ ! "${1}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${2}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    local_tmp="${RELEASE_VERSION}"
-    RELEASE_VERSION="${RC_CANDIDATE_COMMIT}"
-    RC_CANDIDATE_COMMIT="${local_tmp}"
-  fi
-fi
-
 if [ -z "${RELEASE_VERSION}" ] || [ -z "${RC_CANDIDATE_COMMIT}" ]; then
   echo "❌ ERROR: RELEASE_VERSION and RC candidate commit are required as arguments or environment variables." >&2
   echo "Usage: $0 (with RELEASE_VERSION and RC candidate commit in env) or $0 <RELEASE_VERSION> <RC_CANDIDATE_COMMIT>" >&2

--- a/scripts/release/tag_ga_release.sh
+++ b/scripts/release/tag_ga_release.sh
@@ -8,29 +8,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
 RELEASE_VERSION="${1:-${RELEASE_VERSION:-${TARGET_VERSION:-${TARGET_TAG:-}}}}"
-RELEASE_COMMIT="${2:-${RELEASE_COMMIT:-${TARGET_COMMIT:-}}}"
+RC_CANDIDATE_COMMIT="${2:-${RC_CANDIDATE_COMMIT:-${TARGET_COMMIT:-}}}"
 
 # Sibling symmetry: support swapped arguments
 if [ -n "${1:-}" ] && [ -n "${2:-}" ]; then
   if [[ ! "${1}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] && [[ "${2}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     local_tmp="${RELEASE_VERSION}"
-    RELEASE_VERSION="${RELEASE_COMMIT}"
-    RELEASE_COMMIT="${local_tmp}"
+    RELEASE_VERSION="${RC_CANDIDATE_COMMIT}"
+    RC_CANDIDATE_COMMIT="${local_tmp}"
   fi
 fi
 
-if [ -z "${RELEASE_VERSION}" ] || [ -z "${RELEASE_COMMIT}" ]; then
-  echo "❌ ERROR: RELEASE_VERSION and RELEASE_COMMIT are required as arguments or environment variables." >&2
-  echo "Usage: $0 (with RELEASE_VERSION and RELEASE_COMMIT in env) or $0 <RELEASE_VERSION> <RELEASE_COMMIT>" >&2
+if [ -z "${RELEASE_VERSION}" ] || [ -z "${RC_CANDIDATE_COMMIT}" ]; then
+  echo "❌ ERROR: RELEASE_VERSION and RC candidate commit are required as arguments or environment variables." >&2
+  echo "Usage: $0 (with RELEASE_VERSION and RC candidate commit in env) or $0 <RELEASE_VERSION> <RC_CANDIDATE_COMMIT>" >&2
   exit 1
 fi
 
 validate_pure_numeric_semver "${RELEASE_VERSION}" "Release version" || exit 1
 
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "${SCRIPT_DIR}/../.." && pwd))"
+
+# Canonicalize RC candidate commit SHA
+RC_CANDIDATE_COMMIT_SHA="$(git -C "${REPO_ROOT}" rev-parse --verify "${RC_CANDIDATE_COMMIT}^{commit}" 2>/dev/null || echo "${RC_CANDIDATE_COMMIT}")"
+
 echo "======================================================================"
 echo "🏷️ CREATING AND PUSHING GA RELEASE GIT TAG"
-echo "Release Version: ${RELEASE_VERSION}"
-echo "Release Commit:  ${RELEASE_COMMIT}"
+echo "Release Version:     ${RELEASE_VERSION}"
+echo "RC Candidate Commit: ${RC_CANDIDATE_COMMIT_SHA:0:7}"
 echo "======================================================================"
+
+RELEASE_COMMIT="$(create_stamped_release_commit "${RELEASE_VERSION}" "${RC_CANDIDATE_COMMIT_SHA}" "${REPO_ROOT}")"
+
+if [ "${RELEASE_COMMIT}" != "${RC_CANDIDATE_COMMIT_SHA}" ]; then
+  echo "Release Commit:      ${RELEASE_COMMIT:0:7}"
+fi
 
 ensure_git_tag "${RELEASE_VERSION}" "${RELEASE_COMMIT}" "Release ${RELEASE_VERSION}"

--- a/scripts/release/verify_release_eligibility.sh
+++ b/scripts/release/verify_release_eligibility.sh
@@ -9,14 +9,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
 TARGET_VERSION="${1:-${TARGET_VERSION:-${RELEASE_VERSION:-${TARGET_TAG:-}}}}"
-TARGET_COMMIT="${2:-${TARGET_COMMIT:-${RELEASE_COMMIT:-}}}"
+TARGET_COMMIT_INPUT="${2:-${RC_CANDIDATE_COMMIT:-${TARGET_COMMIT:-}}}"
 TARGET_REPO="$(get_target_repo)"
 SKIP_VALIDATION="${SKIP_RC_VALIDATION:-${3:-false}}"
 EMERGENCY_REASON="${EMERGENCY_OVERRIDE_REASON:-${4:-}}"
 
 if [ -z "${TARGET_VERSION}" ]; then
   echo "❌ ERROR: TARGET_VERSION is required as first argument or environment variable." >&2
-  echo "Usage: $0 <TARGET_VERSION> [TARGET_COMMIT] or TARGET_VERSION=... $0" >&2
+  echo "Usage: $0 <TARGET_VERSION> [RC_CANDIDATE_COMMIT] or TARGET_VERSION=... $0" >&2
   exit 1
 fi
 
@@ -24,7 +24,7 @@ validate_pure_numeric_semver "${TARGET_VERSION}" "Target release version" || exi
 
 echo "======================================================================"
 echo "🔍 VERIFYING RELEASE ELIGIBILITY FOR VERSION: ${TARGET_VERSION}"
-echo "Target Commit:          ${TARGET_COMMIT:-<auto-resolve>}"
+echo "Target Commit:          ${TARGET_COMMIT_INPUT:-<auto-resolve>}"
 echo "Target Repository:      ${TARGET_REPO}"
 echo "Emergency Override:     ${SKIP_VALIDATION}"
 if [ -n "${EMERGENCY_REASON}" ]; then
@@ -45,22 +45,22 @@ if is_ci_pipeline; then
   git fetch "https://github.com/${TARGET_REPO}.git" --tags --force 2>/dev/null || git fetch --tags --force 2>/dev/null || true
 fi
 
-# 2. Resolve Target Commit SHA
-RELEASE_COMMIT=""
-if [ -n "${TARGET_COMMIT}" ] && [ "${TARGET_COMMIT}" != "null" ]; then
-  if ! RELEASE_COMMIT="$(git rev-parse --verify "${TARGET_COMMIT}^{commit}" 2>/dev/null)"; then
-    echo "❌ ERROR: Cannot resolve valid Git commit from '${TARGET_COMMIT}'!" >&2
+# 2. Resolve Candidate Commit SHA
+RC_CANDIDATE_COMMIT=""
+if [ -n "${TARGET_COMMIT_INPUT}" ] && [ "${TARGET_COMMIT_INPUT}" != "null" ]; then
+  if ! RC_CANDIDATE_COMMIT="$(git rev-parse --verify "${TARGET_COMMIT_INPUT}^{commit}" 2>/dev/null)"; then
+    echo "❌ ERROR: Cannot resolve valid Git commit from '${TARGET_COMMIT_INPUT}'!" >&2
     exit 1
   fi
 else
   # Auto-resolve commit:
   # Check if target version tag already exists in Git
-  if RELEASE_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
-    echo "ℹ️ Resolved target commit from existing release tag '${TARGET_VERSION}': ${RELEASE_COMMIT:0:7}"
+  if RC_CANDIDATE_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
+    echo "ℹ️ Resolved target commit from existing release tag '${TARGET_VERSION}': ${RC_CANDIDATE_COMMIT:0:7}"
   elif is_truthy "${SKIP_VALIDATION}"; then
     # In emergency mode without an explicit commit parameter, default to current HEAD
-    RELEASE_COMMIT="$(git rev-parse --verify HEAD)"
-    echo "ℹ️ Emergency override: defaulted target commit to HEAD (${RELEASE_COMMIT:0:7})"
+    RC_CANDIDATE_COMMIT="$(git rev-parse --verify HEAD)"
+    echo "ℹ️ Emergency override: defaulted target commit to HEAD (${RC_CANDIDATE_COMMIT:0:7})"
   else
     # In standard release mode, auto-resolve the latest validated commit with rc_*_validated tag
     LATEST_VALIDATED_TAG="$(get_latest_validated_rc_tag)"
@@ -68,13 +68,13 @@ else
       echo "❌ ERROR: No validated RC commit found in history! Cannot publish release without a commit carrying 'rc_*_validated' tag." >&2
       exit 1
     fi
-    RELEASE_COMMIT="$(git rev-parse --verify "${LATEST_VALIDATED_TAG}^{commit}")"
-    echo "ℹ️ Auto-resolved latest validated commit from tag '${LATEST_VALIDATED_TAG}': ${RELEASE_COMMIT:0:7}"
+    RC_CANDIDATE_COMMIT="$(git rev-parse --verify "${LATEST_VALIDATED_TAG}^{commit}")"
+    echo "ℹ️ Auto-resolved latest validated commit from tag '${LATEST_VALIDATED_TAG}': ${RC_CANDIDATE_COMMIT:0:7}"
   fi
 fi
 
 # 3. Idempotent check and collision detection (always evaluated before validation checks)
-EXISTING_RELEASE_TAGS="$(git tag --points-at "${RELEASE_COMMIT}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+EXISTING_RELEASE_TAGS="$(git tag --points-at "${RC_CANDIDATE_COMMIT}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)"
 
 IS_RESUMING_RELEASE="false"
 for ex_tag in ${EXISTING_RELEASE_TAGS}; do
@@ -82,35 +82,37 @@ for ex_tag in ${EXISTING_RELEASE_TAGS}; do
   if [ "${ex_tag}" = "${TARGET_VERSION}" ]; then
     if is_ci_pipeline || [ -n "${GH_TOKEN:-}" ]; then
       if command -v gh >/dev/null 2>&1 && gh release view "${TARGET_VERSION}" --repo "${TARGET_REPO}" >/dev/null 2>&1; then
-        echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} and GitHub Release for commit ${RELEASE_COMMIT} are already published."
+        echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} and GitHub Release for commit ${RC_CANDIDATE_COMMIT} are already published."
         echo "ℹ️ Skipping duplicate build and publish steps."
         if [ -n "${GITHUB_OUTPUT:-}" ]; then
           echo "eligible=false" >> "${GITHUB_OUTPUT}"
           echo "already_released=true" >> "${GITHUB_OUTPUT}"
           echo "skip_release=true" >> "${GITHUB_OUTPUT}"
           echo "existing_tag=${ex_tag}" >> "${GITHUB_OUTPUT}"
-          echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+          echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+          echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
         fi
         exit 0
       else
-        echo "⚠️ Git tag '${TARGET_VERSION}' already points to commit ${RELEASE_COMMIT:0:7}, but GitHub Release does not exist yet. Resuming release workflow..."
+        echo "⚠️ Git tag '${TARGET_VERSION}' already points to commit ${RC_CANDIDATE_COMMIT:0:7}, but GitHub Release does not exist yet. Resuming release workflow..."
         IS_RESUMING_RELEASE="true"
       fi
     else
-      echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} for commit ${RELEASE_COMMIT} is already published (local dry-run)."
+      echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} for commit ${RC_CANDIDATE_COMMIT} is already published (local dry-run)."
       echo "ℹ️ Skipping duplicate build and publish steps."
       if [ -n "${GITHUB_OUTPUT:-}" ]; then
         echo "eligible=false" >> "${GITHUB_OUTPUT}"
         echo "already_released=true" >> "${GITHUB_OUTPUT}"
         echo "skip_release=true" >> "${GITHUB_OUTPUT}"
         echo "existing_tag=${ex_tag}" >> "${GITHUB_OUTPUT}"
-        echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+        echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+        echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
       fi
       exit 0
     fi
   else
     # Scenario B: Collision (attempting to release the same commit under a DIFFERENT tag) -> Hard block
-    echo "❌ ERROR: Collision detected! Commit ${RELEASE_COMMIT} is already published under release ${ex_tag}." >&2
+    echo "❌ ERROR: Collision detected! Commit ${RC_CANDIDATE_COMMIT} is already published under release ${ex_tag}." >&2
     echo "   Cannot re-tag and re-release the same commit as ${TARGET_VERSION}." >&2
     exit 1
   fi
@@ -124,9 +126,9 @@ if is_truthy "${SKIP_VALIDATION}"; then
     exit 1
   fi
 
-  echo "🔎 [Emergency Override] Verifying required container images exist in registry for commit ${RELEASE_COMMIT:0:7}..."
-  if ! check_commit_images_exist "${RELEASE_COMMIT}"; then
-    echo "❌ ERROR: Cannot perform emergency release! Required container images for commit ${RELEASE_COMMIT:0:7} do not exist in registry." >&2
+  echo "🔎 [Emergency Override] Verifying required container images exist in registry for commit ${RC_CANDIDATE_COMMIT:0:7}..."
+  if ! check_commit_images_exist "${RC_CANDIDATE_COMMIT}"; then
+    echo "❌ ERROR: Cannot perform emergency release! Required container images for commit ${RC_CANDIDATE_COMMIT:0:7} do not exist in registry." >&2
     exit 1
   fi
 
@@ -135,17 +137,18 @@ if is_truthy "${SKIP_VALIDATION}"; then
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
     echo "eligible=true" >> "${GITHUB_OUTPUT}"
     echo "emergency_override=true" >> "${GITHUB_OUTPUT}"
-    echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+    echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
   fi
   exit 0
 fi
 
 # 5. Check for validated RC tag pointing at target commit
-echo "🔎 Checking for rc_*_validated tags pointing at commit ${RELEASE_COMMIT}..."
-VALIDATED_TAGS="$(git tag --points-at "${RELEASE_COMMIT}" | grep -E '^rc_.*_validated$' || true)"
+echo "🔎 Checking for rc_*_validated tags pointing at commit ${RC_CANDIDATE_COMMIT}..."
+VALIDATED_TAGS="$(git tag --points-at "${RC_CANDIDATE_COMMIT}" | grep -E '^rc_.*_validated$' || true)"
 
 if [ -z "${VALIDATED_TAGS}" ]; then
-  echo "❌ BLOCKED: Commit ${RELEASE_COMMIT} has NOT passed live RC E2E validation!" >&2
+  echo "❌ BLOCKED: Commit ${RC_CANDIDATE_COMMIT} has NOT passed live RC E2E validation!" >&2
   echo "   No tag matching 'rc_*_validated' points to this commit." >&2
   echo "   To release this version:" >&2
   echo "     1. Wait for the scheduled RC pipeline to validate this commit." >&2
@@ -155,22 +158,23 @@ if [ -z "${VALIDATED_TAGS}" ]; then
 fi
 
 FIRST_VAL_TAG="$(echo "${VALIDATED_TAGS}" | head -n 1)"
-echo "✅ ELIGIBLE: Found validated RC tag(s) on commit ${RELEASE_COMMIT}:"
+echo "✅ ELIGIBLE: Found validated RC tag(s) on commit ${RC_CANDIDATE_COMMIT}:"
 for tag in ${VALIDATED_TAGS}; do
   echo "   • ${tag}"
 done
 
 # 6. Verify container images exist in registry
-echo "🔎 Verifying required container images exist in registry for commit ${RELEASE_COMMIT:0:7}..."
-if ! check_commit_images_exist "${RELEASE_COMMIT}"; then
-  echo "❌ ERROR: Required container images for commit ${RELEASE_COMMIT} do not exist in registry!" >&2
+echo "🔎 Verifying required container images exist in registry for commit ${RC_CANDIDATE_COMMIT:0:7}..."
+if ! check_commit_images_exist "${RC_CANDIDATE_COMMIT}"; then
+  echo "❌ ERROR: Required container images for commit ${RC_CANDIDATE_COMMIT} do not exist in registry!" >&2
   exit 1
 fi
 
 if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "eligible=true" >> "${GITHUB_OUTPUT}"
   echo "validated_rc_tag=${FIRST_VAL_TAG}" >> "${GITHUB_OUTPUT}"
-  echo "release_commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+  echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+  echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
   if [ "${IS_RESUMING_RELEASE}" = "true" ]; then
     echo "resuming=true" >> "${GITHUB_OUTPUT}"
   fi

--- a/scripts/release/verify_release_eligibility.sh
+++ b/scripts/release/verify_release_eligibility.sh
@@ -56,13 +56,7 @@ else
   # Auto-resolve commit:
   # Check if target version tag already exists in Git
   if TARGET_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
-    # If the tag points to a detached HEAD stamped commit, resolve candidate from its parent
-    if PARENT_SHA="$(git rev-parse --verify "${TARGET_COMMIT}^" 2>/dev/null)" && \
-       [ -n "$(git tag --points-at "${PARENT_SHA}" | grep -E '^rc_.*_validated$' || true)" ]; then
-      RC_CANDIDATE_COMMIT="${PARENT_SHA}"
-    else
-      RC_CANDIDATE_COMMIT="${TARGET_COMMIT}"
-    fi
+    RC_CANDIDATE_COMMIT="$(resolve_source_image_commit "${TARGET_VERSION}")"
     echo "ℹ️ Resolved target commit from existing release tag '${TARGET_VERSION}': ${RC_CANDIDATE_COMMIT:0:7}"
   elif is_truthy "${SKIP_VALIDATION}"; then
     # In emergency mode without an explicit commit parameter, default to current HEAD

--- a/scripts/release/verify_release_eligibility.sh
+++ b/scripts/release/verify_release_eligibility.sh
@@ -55,7 +55,14 @@ if [ -n "${TARGET_COMMIT_INPUT}" ] && [ "${TARGET_COMMIT_INPUT}" != "null" ]; th
 else
   # Auto-resolve commit:
   # Check if target version tag already exists in Git
-  if RC_CANDIDATE_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
+  if TARGET_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
+    # If the tag points to a detached HEAD stamped commit, resolve candidate from its parent
+    if PARENT_SHA="$(git rev-parse --verify "${TARGET_COMMIT}^" 2>/dev/null)" && \
+       [ -n "$(git tag --points-at "${PARENT_SHA}" | grep -E '^rc_.*_validated$' || true)" ]; then
+      RC_CANDIDATE_COMMIT="${PARENT_SHA}"
+    else
+      RC_CANDIDATE_COMMIT="${TARGET_COMMIT}"
+    fi
     echo "ℹ️ Resolved target commit from existing release tag '${TARGET_VERSION}': ${RC_CANDIDATE_COMMIT:0:7}"
   elif is_truthy "${SKIP_VALIDATION}"; then
     # In emergency mode without an explicit commit parameter, default to current HEAD
@@ -74,47 +81,62 @@ else
 fi
 
 # 3. Idempotent check and collision detection (always evaluated before validation checks)
-EXISTING_RELEASE_TAGS="$(git tag --points-at "${RC_CANDIDATE_COMMIT}" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true)"
-
 IS_RESUMING_RELEASE="false"
-for ex_tag in ${EXISTING_RELEASE_TAGS}; do
-  # Scenario A: Re-running the exact same release version -> Safe Idempotent Skip only if release is complete
-  if [ "${ex_tag}" = "${TARGET_VERSION}" ]; then
-    if is_ci_pipeline || [ -n "${GH_TOKEN:-}" ]; then
-      if command -v gh >/dev/null 2>&1 && gh release view "${TARGET_VERSION}" --repo "${TARGET_REPO}" >/dev/null 2>&1; then
-        echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} and GitHub Release for commit ${RC_CANDIDATE_COMMIT} are already published."
-        echo "ℹ️ Skipping duplicate build and publish steps."
-        if [ -n "${GITHUB_OUTPUT:-}" ]; then
-          echo "eligible=false" >> "${GITHUB_OUTPUT}"
-          echo "already_released=true" >> "${GITHUB_OUTPUT}"
-          echo "skip_release=true" >> "${GITHUB_OUTPUT}"
-          echo "existing_tag=${ex_tag}" >> "${GITHUB_OUTPUT}"
-          echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
-          echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
-        fi
-        exit 0
-      else
-        echo "⚠️ Git tag '${TARGET_VERSION}' already points to commit ${RC_CANDIDATE_COMMIT:0:7}, but GitHub Release does not exist yet. Resuming release workflow..."
-        IS_RESUMING_RELEASE="true"
-      fi
-    else
-      echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} for commit ${RC_CANDIDATE_COMMIT} is already published (local dry-run)."
+
+# Scenario A: Target version tag already exists in Git
+if TARGET_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
+  # Verify that target tag commit is directly or ancestrally associated with RC_CANDIDATE_COMMIT
+  if [ "${TARGET_COMMIT}" != "${RC_CANDIDATE_COMMIT}" ] && \
+     ! git merge-base --is-ancestor "${RC_CANDIDATE_COMMIT}" "${TARGET_COMMIT}" 2>/dev/null; then
+    echo "❌ ERROR: Tag '${TARGET_VERSION}' already exists in git repository on a different commit (${TARGET_COMMIT:0:7})!" >&2
+    echo "   Cannot re-assign existing release tag to candidate commit ${RC_CANDIDATE_COMMIT:0:7}." >&2
+    exit 1
+  fi
+
+  if is_ci_pipeline || [ -n "${GH_TOKEN:-}" ]; then
+    if command -v gh >/dev/null 2>&1 && gh release view "${TARGET_VERSION}" --repo "${TARGET_REPO}" >/dev/null 2>&1; then
+      echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} and GitHub Release for commit ${RC_CANDIDATE_COMMIT:0:7} are already published."
       echo "ℹ️ Skipping duplicate build and publish steps."
       if [ -n "${GITHUB_OUTPUT:-}" ]; then
         echo "eligible=false" >> "${GITHUB_OUTPUT}"
         echo "already_released=true" >> "${GITHUB_OUTPUT}"
         echo "skip_release=true" >> "${GITHUB_OUTPUT}"
-        echo "existing_tag=${ex_tag}" >> "${GITHUB_OUTPUT}"
+        echo "existing_tag=${TARGET_VERSION}" >> "${GITHUB_OUTPUT}"
         echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
-        echo "release_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+        echo "release_commit=${TARGET_COMMIT}" >> "${GITHUB_OUTPUT}"
       fi
       exit 0
+    else
+      echo "⚠️ Git tag '${TARGET_VERSION}' already points to commit ${TARGET_COMMIT:0:7}, but GitHub Release does not exist yet. Resuming release workflow..."
+      IS_RESUMING_RELEASE="true"
     fi
   else
-    # Scenario B: Collision (attempting to release the same commit under a DIFFERENT tag) -> Hard block
-    echo "❌ ERROR: Collision detected! Commit ${RC_CANDIDATE_COMMIT} is already published under release ${ex_tag}." >&2
-    echo "   Cannot re-tag and re-release the same commit as ${TARGET_VERSION}." >&2
-    exit 1
+    echo "ℹ️ IDEMPOTENT SKIP: Release version ${TARGET_VERSION} for commit ${RC_CANDIDATE_COMMIT:0:7} is already published (local dry-run)."
+    echo "ℹ️ Skipping duplicate build and publish steps."
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+      echo "eligible=false" >> "${GITHUB_OUTPUT}"
+      echo "already_released=true" >> "${GITHUB_OUTPUT}"
+      echo "skip_release=true" >> "${GITHUB_OUTPUT}"
+      echo "existing_tag=${TARGET_VERSION}" >> "${GITHUB_OUTPUT}"
+      echo "rc_candidate_commit=${RC_CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
+      echo "release_commit=${TARGET_COMMIT}" >> "${GITHUB_OUTPUT}"
+    fi
+    exit 0
+  fi
+fi
+
+# Scenario B: Collision check (has RC_CANDIDATE_COMMIT already been published under a DIFFERENT GA release tag?)
+for other_tag in $(git tag -l '[0-9]*' 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true); do
+  if [ "${other_tag}" != "${TARGET_VERSION}" ]; then
+    OTHER_COMMIT="$(git rev-parse --verify "refs/tags/${other_tag}^{commit}" 2>/dev/null || echo "")"
+    if [ -n "${OTHER_COMMIT}" ]; then
+      if [ "${OTHER_COMMIT}" = "${RC_CANDIDATE_COMMIT}" ] || \
+         [ "$(git rev-parse --verify "${OTHER_COMMIT}^" 2>/dev/null || echo "")" = "${RC_CANDIDATE_COMMIT}" ]; then
+        echo "❌ ERROR: Collision detected! Commit ${RC_CANDIDATE_COMMIT} is already published under release ${other_tag}." >&2
+        echo "   Cannot re-tag and re-release the same commit as ${TARGET_VERSION}." >&2
+        exit 1
+      fi
+    fi
   fi
 done
 

--- a/scripts/release/verify_release_eligibility.sh
+++ b/scripts/release/verify_release_eligibility.sh
@@ -85,9 +85,8 @@ IS_RESUMING_RELEASE="false"
 
 # Scenario A: Target version tag already exists in Git
 if TARGET_COMMIT="$(git rev-parse --verify "refs/tags/${TARGET_VERSION}^{commit}" 2>/dev/null)"; then
-  # Verify that target tag commit is directly or ancestrally associated with RC_CANDIDATE_COMMIT
-  if [ "${TARGET_COMMIT}" != "${RC_CANDIDATE_COMMIT}" ] && \
-     ! git merge-base --is-ancestor "${RC_CANDIDATE_COMMIT}" "${TARGET_COMMIT}" 2>/dev/null; then
+  # Verify that target tag commit is directly or strictly derived (single-parent stamp) from RC_CANDIDATE_COMMIT
+  if ! is_valid_stamped_or_direct_release_commit "${RC_CANDIDATE_COMMIT}" "${TARGET_COMMIT}" "${TARGET_VERSION}"; then
     echo "❌ ERROR: Tag '${TARGET_VERSION}' already exists in git repository on a different commit (${TARGET_COMMIT:0:7})!" >&2
     echo "   Cannot re-assign existing release tag to candidate commit ${RC_CANDIDATE_COMMIT:0:7}." >&2
     exit 1

--- a/tests/test_calculate_next_version.py
+++ b/tests/test_calculate_next_version.py
@@ -25,6 +25,7 @@ from tests.testing.release import (
     MOCK_NONEXISTENT_REF,
     MOCK_NONEXISTENT_TAG,
     MOCK_RC_VALIDATED_TAG,
+    MOCK_TARGET_RELEASE_TAG,
 )
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -299,6 +300,33 @@ class CalculateNextVersionTest(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0)
             self.assertEqual(proc.stdout.strip(), "0.2.0")
+        finally:
+            temp_dir.cleanup()
+
+    def test_explicit_version_resumption_allowed_when_tag_on_detached_head_stamped_commit(self):
+        """Verifies explicit version calculation allows resumption when tag is on a detached HEAD child commit."""
+        temp_dir, repo_dir, git = self._create_mock_repo()
+        try:
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+            # Attach validated tag on candidate commit
+            git("tag", "-a", MOCK_RC_VALIDATED_TAG, candidate_commit, "-m", "validated")
+
+            # Create detached HEAD child commit stamped with release version
+            git("checkout", "--detach", candidate_commit)
+            (pathlib.Path(repo_dir) / "version.txt").write_text(f"{MOCK_TARGET_RELEASE_TAG}\n")
+            git("add", "version.txt")
+            git("commit", "-m", f"chore(release): stamp release version {MOCK_TARGET_RELEASE_TAG}")
+            stamped_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", "-a", MOCK_TARGET_RELEASE_TAG, stamped_commit, "-m", f"Release {MOCK_TARGET_RELEASE_TAG}")
+            git("checkout", "main")
+
+            # Run with explicit release version on candidate commit
+            proc = self._run_calc_script(
+                repo_dir,
+                env={"EXPLICIT_RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG, "TARGET_COMMIT": candidate_commit},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stdout.strip(), MOCK_TARGET_RELEASE_TAG)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -18,6 +18,7 @@ from tests.testing.common import (
     INVALID_IMMUTABLE_REFS,
     MOCK_GOOGLE_CHAT_MODE,
     VALID_IMMUTABLE_REFS,
+    create_mock_git_repo,
     get_isolated_test_env,
 )
 
@@ -412,6 +413,28 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
             len(proc.stdout.strip()) == 40 or len(proc.stdout.strip()) > 0,
             f"Expected valid SHA or tag, got: {proc.stdout.strip()}",
         )
+
+    def test_default_image_tag_resolves_semver_when_multiple_tags_present(self):
+        """Verifies default_image_tag prefers numeric SemVer tag over rc_*_validated tags on the same commit."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            # Add installer_common.sh so repo is recognized as kube-agents
+            scripts_dir = pathlib.Path(repo_dir) / "k8s-operator" / "scripts"
+            scripts_dir.mkdir(parents=True, exist_ok=True)
+            (scripts_dir / "installer_common.sh").write_text("# mock installer_common.sh\n")
+            git("add", "k8s-operator/scripts/installer_common.sh")
+            git("commit", "-m", "chore: add installer_common.sh")
+
+            # Apply both an rc_* tag and a 0.2.0 GA tag on the same commit
+            git("tag", "rc_20260827_validated")
+            git("tag", "0.2.0")
+
+            cmd = 'BAKED_RELEASE_VERSION=""; default_image_tag'
+            proc = self._run_install_func(cmd, cwd=repo_dir)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stdout.strip(), "0.2.0")
+        finally:
+            temp_dir.cleanup()
 
     def test_default_image_tag_extracts_version_from_archive_directory(self):
         """Verifies default_image_tag resolves version from unpacked archive directory name."""

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -463,6 +463,26 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn("Verified install sources match baked official release 0.2.0", proc.stdout)
 
+    def test_verify_local_source_ref_in_git_worktree_enforces_git_alignment_even_with_baked_version(self):
+        """Verifies verify_local_source_ref strictly runs Git alignment in real Git checkouts even with baked version."""
+        with tempfile.TemporaryDirectory(prefix="git-repo-") as repo_dir:
+            repo_path = pathlib.Path(repo_dir)
+            subprocess.run(["git", "init"], cwd=str(repo_path), check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(repo_path), check=True)
+            (repo_path / "file.txt").write_text("initial\n")
+            subprocess.run(["git", "add", "file.txt"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "tag", "0.2.0"], cwd=str(repo_path), check=True)
+
+            # Add an uncommitted modification to make working tree dirty
+            (repo_path / "file.txt").write_text("dirty uncommitted change\n")
+
+            cmd = f'BAKED_RELEASE_VERSION="0.2.0"; verify_local_source_ref "{repo_path}" "0.2.0"'
+            proc = self._run_install_func(cmd, cwd=repo_path)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("dirty checkout", proc.stdout)
+
 
 class EnsureExistingClusterNetworkPolicyTest(unittest.TestCase):
     """ensure_existing_cluster_network_policy's two-call enablement sequence.

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -89,6 +89,45 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn(f"DIR={_REPO_ROOT}", proc.stdout)
 
+    def test_acquire_source_repo_refuses_to_mutate_dirty_existing_repo(self):
+        """Verifies acquire_source_repo errors if HOME/kube-agents exists with uncommitted changes."""
+        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        try:
+            home_dir = pathlib.Path(temp_dir.name) / "home"
+            repo_dir = home_dir / "kube-agents"
+            repo_dir.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["git", "init"], cwd=str(repo_dir), check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(repo_dir), check=True)
+            (repo_dir / "file.txt").write_text("initial\n")
+            subprocess.run(["git", "add", "file.txt"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo_dir), check=True)
+
+            # Make working tree dirty
+            (repo_dir / "file.txt").write_text("dirty changes\n")
+
+            outside_dir = pathlib.Path(temp_dir.name) / "outside"
+            outside_dir.mkdir()
+            isolated_install_sh = outside_dir / "install.sh"
+            isolated_install_sh.write_text(_INSTALL_SH.read_text())
+
+            cmd = 'out_dir=""; acquire_source_repo out_dir "0.2.0"'
+            setup = f"""
+KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
+{cmd}
+"""
+            proc = subprocess.run(
+                ["bash", "-c", setup],
+                capture_output=True,
+                text=True,
+                env={"HOME": str(home_dir), "PATH": os.environ["PATH"]},
+                cwd=str(outside_dir),
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("has uncommitted changes", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
     def test_parse_args_google_chat_mode(self):
         """Verifies parse_args captures --google-chat-mode."""
         cmd = f'parse_args --google-chat-mode={MOCK_GOOGLE_CHAT_MODE}; echo "MODE=$PARAM_GOOGLE_CHAT_MODE"'
@@ -388,6 +427,17 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
             proc = self._run_install_func(cmd, cwd=archive_dir)
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertEqual(proc.stdout.strip(), "0.2.0")
+
+    def test_verify_local_source_ref_accepts_baked_release_in_non_git_dir(self):
+        """Verifies verify_local_source_ref succeeds for unpacked release archive without Git repository."""
+        with tempfile.TemporaryDirectory(prefix="unpacked-release-") as outer_dir:
+            archive_dir = pathlib.Path(outer_dir) / "kube-agents-0.2.0"
+            archive_dir.mkdir(parents=True)
+
+            cmd = f'BAKED_RELEASE_VERSION="0.2.0"; verify_local_source_ref "{archive_dir}" "0.2.0"'
+            proc = self._run_install_func(cmd, cwd=archive_dir)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Verified install sources match baked official release 0.2.0", proc.stdout)
 
 
 class EnsureExistingClusterNetworkPolicyTest(unittest.TestCase):

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -91,7 +91,7 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
         self.assertIn(f"DIR={_REPO_ROOT}", proc.stdout)
 
     def test_acquire_source_repo_refuses_to_mutate_dirty_existing_repo(self):
-        """Verifies acquire_source_repo errors if HOME/kube-agents exists with uncommitted changes."""
+        """Verifies acquire_source_repo uses existing HOME/kube-agents and verify_local_source_ref rejects dirty checkout."""
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             home_dir = pathlib.Path(temp_dir.name) / "home"
@@ -103,6 +103,7 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
             (repo_dir / "file.txt").write_text("initial\n")
             subprocess.run(["git", "add", "file.txt"], cwd=str(repo_dir), check=True)
             subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "tag", "0.2.0"], cwd=str(repo_dir), check=True)
 
             # Make working tree dirty
             (repo_dir / "file.txt").write_text("dirty changes\n")
@@ -125,7 +126,48 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
                 cwd=str(outside_dir),
             )
             self.assertNotEqual(proc.returncode, 0)
-            self.assertIn("has uncommitted changes", proc.stdout)
+            self.assertIn("Using existing repository", proc.stdout)
+            self.assertIn("without modifying local changes", proc.stdout)
+            self.assertIn("dirty checkout", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
+    def test_acquire_source_repo_uses_clean_existing_repo_without_modifying_changes(self):
+        """Verifies acquire_source_repo uses clean existing HOME/kube-agents without mutating branch/checkout."""
+        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        try:
+            home_dir = pathlib.Path(temp_dir.name) / "home"
+            repo_dir = home_dir / "kube-agents"
+            repo_dir.mkdir(parents=True, exist_ok=True)
+            subprocess.run(["git", "init"], cwd=str(repo_dir), check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(repo_dir), check=True)
+            (repo_dir / "file.txt").write_text("initial\n")
+            subprocess.run(["git", "add", "file.txt"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo_dir), check=True)
+            subprocess.run(["git", "tag", "0.2.0"], cwd=str(repo_dir), check=True)
+
+            outside_dir = pathlib.Path(temp_dir.name) / "outside"
+            outside_dir.mkdir()
+            isolated_install_sh = outside_dir / "install.sh"
+            isolated_install_sh.write_text(_INSTALL_SH.read_text())
+
+            cmd = 'out_dir=""; acquire_source_repo out_dir "0.2.0"; echo "RESOLVED=$out_dir"'
+            setup = f"""
+KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
+{cmd}
+"""
+            proc = subprocess.run(
+                ["bash", "-c", setup],
+                capture_output=True,
+                text=True,
+                env={"HOME": str(home_dir), "PATH": os.environ["PATH"]},
+                cwd=str(outside_dir),
+            )
+            self.assertEqual(proc.returncode, 0, f"Failed: {proc.stderr}")
+            self.assertIn("Using existing repository", proc.stdout)
+            self.assertIn("without modifying local changes", proc.stdout)
+            self.assertIn(f"RESOLVED={repo_dir}", proc.stdout)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -350,6 +350,45 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
                 self.assertIn("DEFAULT_VERTEX_LOCATION", line)
                 self.assertNotIn("$region", line)
 
+    def test_default_image_tag_returns_baked_release_version(self):
+        """Verifies default_image_tag prioritizes BAKED_RELEASE_VERSION when defined."""
+        cmd = 'BAKED_RELEASE_VERSION="0.2.0"; default_image_tag'
+        proc = self._run_install_func(cmd)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "0.2.0")
+
+    def test_default_image_tag_label_returns_official_release(self):
+        """Verifies default_image_tag_label formats baked release version label."""
+        cmd = 'BAKED_RELEASE_VERSION="0.2.0"; default_image_tag_label'
+        proc = self._run_install_func(cmd)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "official release 0.2.0")
+
+    def test_default_image_tag_falls_back_to_head_sha(self):
+        """Verifies default_image_tag defaults to local HEAD SHA in developer checkouts."""
+        cmd = 'BAKED_RELEASE_VERSION=""; default_image_tag'
+        proc = self._run_install_func(cmd)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertTrue(
+            len(proc.stdout.strip()) == 40 or len(proc.stdout.strip()) > 0,
+            f"Expected valid SHA or tag, got: {proc.stdout.strip()}",
+        )
+
+    def test_default_image_tag_extracts_version_from_archive_directory(self):
+        """Verifies default_image_tag resolves version from unpacked archive directory name."""
+        import tempfile
+        with tempfile.TemporaryDirectory(prefix="archive-test-") as outer_dir:
+            archive_dir = pathlib.Path(outer_dir) / "kube-agents-0.2.0"
+            archive_dir.mkdir(parents=True)
+            scripts_dir = archive_dir / "k8s-operator" / "scripts"
+            scripts_dir.mkdir(parents=True)
+            (scripts_dir / "installer_common.sh").write_text("# mock installer_common.sh\n")
+
+            cmd = 'BAKED_RELEASE_VERSION=""; default_image_tag'
+            proc = self._run_install_func(cmd, cwd=archive_dir)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stdout.strip(), "0.2.0")
+
 
 class EnsureExistingClusterNetworkPolicyTest(unittest.TestCase):
     """ensure_existing_cluster_network_policy's two-call enablement sequence.

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -409,9 +409,10 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{isolated_install_sh}"
         cmd = 'BAKED_RELEASE_VERSION=""; default_image_tag'
         proc = self._run_install_func(cmd)
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertTrue(
-            len(proc.stdout.strip()) == 40 or len(proc.stdout.strip()) > 0,
-            f"Expected valid SHA or tag, got: {proc.stdout.strip()}",
+        self.assertRegex(
+            proc.stdout.strip(),
+            r"^([0-9a-f]{40}|[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?)$",
+            f"Expected valid 40-character SHA or SemVer tag, got: {proc.stdout.strip()}",
         )
 
     def test_default_image_tag_resolves_semver_when_multiple_tags_present(self):

--- a/tests/test_promote_release_images.py
+++ b/tests/test_promote_release_images.py
@@ -257,6 +257,27 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
+    def test_promote_execution_direct_unstamped_tag_resolves_exact_commit(self):
+        """Verifies promote_release_images resolves exact tag commit when tag is placed directly on a commit."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_docker_binary(bin_dir)
+
+            direct_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, direct_commit)
+
+            proc = self._run_script(
+                [MOCK_TARGET_RELEASE_TAG],
+                bin_dir=str(bin_dir),
+                cwd=repo_dir,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
+            self.assertIn(f"Release Commit:  {direct_commit}", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_promote_release_images.py
+++ b/tests/test_promote_release_images.py
@@ -50,14 +50,16 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
                 self.assertIn("not a valid pure numeric SemVer", proc.stderr)
 
     def test_local_dry_run_skips_promotion(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
             create_mock_docker_binary(bin_dir)
+            git("tag", MOCK_TARGET_RELEASE_TAG, "HEAD")
 
             proc = self._run_script(
                 [MOCK_TARGET_RELEASE_TAG],
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
             self.assertEqual(proc.returncode, 0)
             self.assertIn("Dry-run: Remote image promotion", proc.stdout)
@@ -206,15 +208,17 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
             temp_dir.cleanup()
 
     def test_promote_execution_env_vars(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
             create_mock_docker_binary(bin_dir)
+            git("tag", MOCK_TARGET_RELEASE_TAG, "HEAD")
 
             proc = self._run_script(
                 [],
                 env={"CI": "true", "RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
             self.assertEqual(proc.returncode, 0)
             self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
@@ -275,6 +279,23 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
             self.assertIn(f"Release Commit:  {direct_commit}", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
+    def test_missing_release_tag_fails_fast_without_head_fallback(self):
+        """Verifies promote_release_images fails fast with exit code 1 when tag does not exist (no HEAD fallback)."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_docker_binary(bin_dir)
+
+            proc = self._run_script(
+                ["9.9.9"],
+                bin_dir=str(bin_dir),
+                cwd=repo_dir,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Cannot resolve source image commit for version '9.9.9'", proc.stderr)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_promote_release_images.py
+++ b/tests/test_promote_release_images.py
@@ -10,7 +10,10 @@ import subprocess
 import tempfile
 import unittest
 
-from tests.testing.common import get_isolated_test_env
+from tests.testing.common import (
+    create_mock_git_repo,
+    get_isolated_test_env,
+)
 from tests.testing.release import (
     INVALID_GA_RELEASE_TAGS,
     MOCK_REQUIRED_RELEASE_IMAGES,
@@ -24,25 +27,25 @@ _PROMOTE_RELEASE_IMAGES_SH = _REPO_ROOT / "scripts" / "release" / "promote_relea
 
 
 class PromoteReleaseImagesScriptTest(unittest.TestCase):
-    def _run_script(self, args, env=None, bin_dir=None):
+    def _run_script(self, args, env=None, bin_dir=None, cwd=None):
         full_env = get_isolated_test_env(overrides=env, bin_dir=bin_dir)
         return subprocess.run(
             ["bash", str(_PROMOTE_RELEASE_IMAGES_SH)] + args,
             capture_output=True,
             text=True,
             env=full_env,
-            cwd=str(_REPO_ROOT),
+            cwd=cwd or str(_REPO_ROOT),
         )
 
     def test_missing_arguments(self):
         proc = self._run_script([])
         self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("RELEASE_COMMIT and RELEASE_VERSION are required", proc.stderr)
+        self.assertIn("RELEASE_VERSION is required as first argument or environment variable", proc.stderr)
 
     def test_invalid_tag_format(self):
         for bad_tag in INVALID_GA_RELEASE_TAGS:
             with self.subTest(bad_tag=bad_tag):
-                proc = self._run_script([MOCK_SAMPLE_COMMIT_SHA, bad_tag])
+                proc = self._run_script([bad_tag])
                 self.assertNotEqual(proc.returncode, 0)
                 self.assertIn("not a valid pure numeric SemVer", proc.stderr)
 
@@ -53,7 +56,7 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
             create_mock_docker_binary(bin_dir)
 
             proc = self._run_script(
-                [MOCK_SAMPLE_COMMIT_SHA, MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 bin_dir=str(bin_dir),
             )
             self.assertEqual(proc.returncode, 0)
@@ -63,17 +66,27 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
             temp_dir.cleanup()
 
     def test_promote_execution(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
             create_mock_docker_binary(bin_dir)
 
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("checkout", "--detach", candidate_commit)
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore: stamp 0.2.0")
+            release_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, release_commit)
+
             proc = self._run_script(
-                [MOCK_SAMPLE_COMMIT_SHA, MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true"},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
             for img in MOCK_REQUIRED_RELEASE_IMAGES:
                 self.assertIn(f"Promoting {img}", proc.stdout)
@@ -83,52 +96,53 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
-    def test_promote_execution_swapped_arguments(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
-        try:
-            bin_dir = pathlib.Path(temp_dir.name) / "bin"
-            create_mock_docker_binary(bin_dir)
-
-            proc = self._run_script(
-                [MOCK_TARGET_RELEASE_TAG, MOCK_SAMPLE_COMMIT_SHA],
-                env={"CI": "true"},
-                bin_dir=str(bin_dir),
-            )
-            self.assertEqual(proc.returncode, 0)
-            self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
-            for img in MOCK_REQUIRED_RELEASE_IMAGES:
-                self.assertIn(f"Promoted {img} to {MOCK_TARGET_RELEASE_TAG}", proc.stdout)
-        finally:
-            temp_dir.cleanup()
-
     def test_promote_idempotent_skip_when_target_exists(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("checkout", "--detach", candidate_commit)
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore: stamp 0.2.0")
+            release_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, release_commit)
+
             existing = [
                 f"ghcr.io/gke-labs/kube-agents/{img}:{MOCK_TARGET_RELEASE_TAG}"
                 for img in MOCK_REQUIRED_RELEASE_IMAGES
             ] + [
-                f"ghcr.io/gke-labs/kube-agents/{img}:{MOCK_SAMPLE_COMMIT_SHA}"
+                f"ghcr.io/gke-labs/kube-agents/{img}:{candidate_commit}"
                 for img in MOCK_REQUIRED_RELEASE_IMAGES
             ]
             create_mock_docker_binary(bin_dir, existing_images=existing)
 
             proc = self._run_script(
-                [MOCK_SAMPLE_COMMIT_SHA, MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true"},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
             for img in MOCK_REQUIRED_RELEASE_IMAGES:
                 self.assertIn("already exists in registry and matches source image", proc.stdout)
         finally:
             temp_dir.cleanup()
 
     def test_promote_idempotent_skip_when_target_is_index_wrapping_source_manifest(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("checkout", "--detach", candidate_commit)
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore: stamp 0.2.0")
+            release_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, release_commit)
+
             source_sha = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
             target_index_sha = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
             raw_index = f'{{"mediaType":"application/vnd.oci.image.index.v1+json","digest":"{target_index_sha}","manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{source_sha}"}}]}}'
@@ -138,41 +152,52 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
                     "format": target_index_sha,
                     "raw": raw_index,
                 }
-                digests[f"ghcr.io/gke-labs/kube-agents/{img}:{MOCK_SAMPLE_COMMIT_SHA}"] = {
+                digests[f"ghcr.io/gke-labs/kube-agents/{img}:{candidate_commit}"] = {
                     "format": source_sha,
                     "raw": f'{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{source_sha}"}}',
                 }
             create_mock_docker_binary(bin_dir, image_digests=digests)
 
             proc = self._run_script(
-                [MOCK_SAMPLE_COMMIT_SHA, MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true"},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
             for img in MOCK_REQUIRED_RELEASE_IMAGES:
                 self.assertIn("already exists in registry and matches source image", proc.stdout)
         finally:
             temp_dir.cleanup()
 
     def test_promote_fails_when_target_exists_with_mismatched_digest(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("checkout", "--detach", candidate_commit)
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore: stamp 0.2.0")
+            release_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, release_commit)
+
             digests = {}
             for img in MOCK_REQUIRED_RELEASE_IMAGES:
                 digests[f"ghcr.io/gke-labs/kube-agents/{img}:{MOCK_TARGET_RELEASE_TAG}"] = (
                     "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 )
-                digests[f"ghcr.io/gke-labs/kube-agents/{img}:{MOCK_SAMPLE_COMMIT_SHA}"] = (
+                digests[f"ghcr.io/gke-labs/kube-agents/{img}:{candidate_commit}"] = (
                     "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 )
             create_mock_docker_binary(bin_dir, image_digests=digests)
 
             proc = self._run_script(
-                [MOCK_SAMPLE_COMMIT_SHA, MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true"},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn("does NOT match source image", proc.stderr)
@@ -188,11 +213,45 @@ class PromoteReleaseImagesScriptTest(unittest.TestCase):
 
             proc = self._run_script(
                 [],
-                env={"CI": "true", "RELEASE_COMMIT": MOCK_SAMPLE_COMMIT_SHA, "RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG},
+                env={"CI": "true", "RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG},
                 bin_dir=str(bin_dir),
             )
             self.assertEqual(proc.returncode, 0)
             self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
+            for img in MOCK_REQUIRED_RELEASE_IMAGES:
+                self.assertIn(f"Promoted {img} to {MOCK_TARGET_RELEASE_TAG}", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
+    def test_promote_execution_single_release_version_argument(self):
+        """Verifies promote_release_images resolves candidate commit from tag's parent when only version is passed."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_docker_binary(bin_dir)
+
+            # 1. Candidate commit on main
+            candidate_commit = git("rev-parse", "HEAD").stdout.strip()
+
+            # 2. Release commit on detached HEAD with tag
+            git("checkout", "--detach", candidate_commit)
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore(release): stamp 0.2.0")
+            release_commit = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, release_commit)
+
+            # 3. Call promote_release_images with only version argument
+            proc = self._run_script(
+                [MOCK_TARGET_RELEASE_TAG],
+                env={"CI": "true"},
+                bin_dir=str(bin_dir),
+                cwd=repo_dir,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("PROMOTING RELEASE CONTAINER IMAGES", proc.stdout)
+            self.assertIn(f"Release Commit:  {candidate_commit}", proc.stdout)
             for img in MOCK_REQUIRED_RELEASE_IMAGES:
                 self.assertIn(f"Promoted {img} to {MOCK_TARGET_RELEASE_TAG}", proc.stdout)
         finally:

--- a/tests/test_publish_github_release.py
+++ b/tests/test_publish_github_release.py
@@ -10,7 +10,11 @@ import subprocess
 import tempfile
 import unittest
 
-from tests.testing.common import create_minimal_tools_bin, get_isolated_test_env
+from tests.testing.common import (
+    create_minimal_tools_bin,
+    create_mock_git_repo,
+    get_isolated_test_env,
+)
 from tests.testing.release import (
     INVALID_GA_RELEASE_TAGS,
     MOCK_TARGET_RELEASE_TAG,
@@ -22,32 +26,27 @@ _PUBLISH_GITHUB_RELEASE_SH = _REPO_ROOT / "scripts" / "release" / "publish_githu
 
 
 class PublishGithubReleaseScriptTest(unittest.TestCase):
-    def _run_script(self, args, env=None, bin_dir=None):
+    def _run_script(self, args, env=None, bin_dir=None, cwd=None):
         full_env = get_isolated_test_env(overrides=env, bin_dir=bin_dir)
         return subprocess.run(
             ["bash", str(_PUBLISH_GITHUB_RELEASE_SH)] + args,
             capture_output=True,
             text=True,
             env=full_env,
-            cwd=str(_REPO_ROOT),
+            cwd=cwd or str(_REPO_ROOT),
         )
 
     def test_missing_arguments(self):
         proc = self._run_script([])
         self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("RELEASE_VERSION and RELEASE_COMMIT are required", proc.stderr)
+        self.assertIn("RELEASE_VERSION is required as first argument or environment variable", proc.stderr)
 
     def test_invalid_tag_format(self):
         for bad_tag in INVALID_GA_RELEASE_TAGS:
             with self.subTest(bad_tag=bad_tag):
-                proc = self._run_script([bad_tag, "HEAD"])
+                proc = self._run_script([bad_tag])
                 self.assertNotEqual(proc.returncode, 0)
                 self.assertIn("not a valid pure numeric SemVer", proc.stderr)
-
-    def test_invalid_commit_sha(self):
-        proc = self._run_script([MOCK_TARGET_RELEASE_TAG, "invalid-sha-nonexistent-12345"])
-        self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("Cannot resolve valid Git commit", proc.stderr)
 
     def test_missing_gh_cli_in_ci(self):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
@@ -140,7 +139,6 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
                 [],
                 env={
                     "RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG,
-                    "RELEASE_COMMIT": "HEAD",
                     "CI": "true",
                     "GH_TOKEN": "mock-token-123",
                 },
@@ -152,20 +150,53 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
-    def test_swapped_arguments_symmetry(self):
-        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    def test_publish_with_version_only_resolves_commit_from_git_tag(self):
+        """Verifies publish_github_release resolves commit directly from tag when only version is passed."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
             create_mock_gh_binary(bin_dir)
 
+            # Create a tag pointing to a specific commit
+            dummy_file = pathlib.Path(repo_dir) / "version.txt"
+            dummy_file.write_text("v0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore: release 0.2.0")
+            expected_tag_sha = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", MOCK_TARGET_RELEASE_TAG, expected_tag_sha)
+
+            # Run with only the version argument (no commit argument)
             proc = self._run_script(
-                ["HEAD", MOCK_TARGET_RELEASE_TAG],
+                [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true", "GH_TOKEN": "mock-token-123"},
                 bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn("PUBLISHING GITHUB RELEASE", proc.stdout)
+            self.assertIn(f"Release Commit:     {expected_tag_sha}", proc.stdout)
             self.assertIn(f"Successfully published GitHub Release '{MOCK_TARGET_RELEASE_TAG}'", proc.stdout)
+        finally:
+            temp_dir.cleanup()
+
+    def test_publish_fails_if_tag_does_not_exist_and_no_commit_provided(self):
+        """Verifies publish_github_release errors clearly if tag does not exist and no HEAD commit exists."""
+        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        try:
+            repo_dir = pathlib.Path(temp_dir.name) / "empty_repo"
+            repo_dir.mkdir()
+            subprocess.run(["git", "init"], cwd=str(repo_dir), check=True, capture_output=True)
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_gh_binary(bin_dir)
+
+            proc = self._run_script(
+                ["0.9.9"],
+                env={"CI": "true", "GH_TOKEN": "mock-token-123"},
+                bin_dir=str(bin_dir),
+                cwd=str(repo_dir),
+            )
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn("Cannot resolve valid Git commit for release tag '0.9.9'", proc.stderr)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_publish_github_release.py
+++ b/tests/test_publish_github_release.py
@@ -17,6 +17,8 @@ from tests.testing.common import (
 )
 from tests.testing.release import (
     INVALID_GA_RELEASE_TAGS,
+    MOCK_GH_TOKEN,
+    MOCK_NONEXISTENT_TAG,
     MOCK_TARGET_RELEASE_TAG,
     create_mock_gh_binary,
 )
@@ -190,13 +192,13 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
             create_mock_gh_binary(bin_dir)
 
             proc = self._run_script(
-                ["0.9.9"],
-                env={"CI": "true", "GH_TOKEN": "mock-token-123"},
+                [MOCK_NONEXISTENT_TAG],
+                env={"CI": "true", "GH_TOKEN": MOCK_GH_TOKEN},
                 bin_dir=str(bin_dir),
                 cwd=str(repo_dir),
             )
             self.assertEqual(proc.returncode, 1)
-            self.assertIn("Cannot resolve valid Git commit for release tag '0.9.9'", proc.stderr)
+            self.assertIn(f"Cannot resolve valid Git commit for release tag '{MOCK_NONEXISTENT_TAG}'", proc.stderr)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_publish_github_release.py
+++ b/tests/test_publish_github_release.py
@@ -21,6 +21,7 @@ from tests.testing.release import (
     MOCK_NONEXISTENT_TAG,
     MOCK_TARGET_RELEASE_TAG,
     create_mock_gh_binary,
+    create_mock_git_binary,
 )
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -54,6 +55,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = create_minimal_tools_bin(temp_dir.name, exclude=("gh",))
+            create_mock_git_binary(bin_dir)
             proc = self._run_script(
                 [MOCK_TARGET_RELEASE_TAG, "HEAD"],
                 env={"CI": "true", "PATH": str(bin_dir)},
@@ -67,6 +69,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_gh_binary(bin_dir, existing_releases=[MOCK_TARGET_RELEASE_TAG])
 
             proc = self._run_script(
@@ -83,6 +86,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_gh_binary(bin_dir)
 
             proc = self._run_script(
@@ -99,6 +103,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_gh_binary(bin_dir)
 
             proc = self._run_script(
@@ -118,6 +123,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_gh_binary(bin_dir)
 
             proc = self._run_script(
@@ -135,6 +141,7 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_gh_binary(bin_dir)
 
             proc = self._run_script(

--- a/tests/test_publish_github_release.py
+++ b/tests/test_publish_github_release.py
@@ -202,6 +202,24 @@ class PublishGithubReleaseScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
+    def test_publish_fails_if_tag_does_not_exist_even_when_head_commit_present(self):
+        """Verifies publish_github_release fails and does NOT fall back to HEAD commit when tag is absent."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_gh_binary(bin_dir)
+
+            proc = self._run_script(
+                [MOCK_NONEXISTENT_TAG],
+                env={"CI": "true", "GH_TOKEN": MOCK_GH_TOKEN},
+                bin_dir=str(bin_dir),
+                cwd=repo_dir,
+            )
+            self.assertEqual(proc.returncode, 1)
+            self.assertIn(f"Cannot resolve valid Git commit for release tag '{MOCK_NONEXISTENT_TAG}'", proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_publish_helm_chart.py
+++ b/tests/test_publish_helm_chart.py
@@ -20,6 +20,7 @@ from tests.testing.common import (
 from tests.testing.release import (
     MOCK_GH_TOKEN,
     MOCK_GH_USER,
+    MOCK_NONEXISTENT_TAG,
     MOCK_SAMPLE_COMMIT_SHA,
     MOCK_TARGET_RELEASE_TAG,
     create_mock_cosign_binary,
@@ -33,14 +34,14 @@ _PUBLISH_HELM_CHART_SH = _REPO_ROOT / "scripts" / "release" / "publish_helm_char
 
 
 class PublishHelmChartScriptTest(unittest.TestCase):
-    def _run_script(self, args, env=None, bin_dir=None):
+    def _run_script(self, args, env=None, bin_dir=None, cwd=None):
         full_env = get_isolated_test_env(overrides=env, bin_dir=bin_dir)
         return subprocess.run(
             ["bash", str(_PUBLISH_HELM_CHART_SH)] + args,
             capture_output=True,
             text=True,
             env=full_env,
-            cwd=str(_REPO_ROOT),
+            cwd=cwd or str(_REPO_ROOT),
         )
 
     def test_missing_arguments(self):
@@ -322,20 +323,26 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
-    def test_invalid_release_commit_fails_fast(self):
+    def test_publish_fails_if_tag_does_not_exist_and_no_head_commit(self):
+        """Verifies publish_helm_chart errors clearly if tag does not exist and no HEAD commit exists."""
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
+            repo_dir = pathlib.Path(temp_dir.name) / "empty_repo"
+            repo_dir.mkdir()
+            subprocess.run(["git", "init"], cwd=str(repo_dir), check=True, capture_output=True)
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
 
             proc = self._run_script(
-                [MOCK_TARGET_RELEASE_TAG],
-                env={"CI": "true", "RELEASE_VERSION": ""},
+                [MOCK_NONEXISTENT_TAG],
+                env={"CI": "true", "GH_TOKEN": MOCK_GH_TOKEN},
                 bin_dir=str(bin_dir),
+                cwd=str(repo_dir),
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(f"Cannot resolve valid Git commit for release tag '{MOCK_NONEXISTENT_TAG}'", proc.stderr)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_publish_helm_chart.py
+++ b/tests/test_publish_helm_chart.py
@@ -274,7 +274,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
                 bin_dir=str(bin_dir),
             )
             self.assertEqual(proc.returncode, 0)
-            self.assertIn("Extracting Helm chart from release commit", proc.stdout)
+            self.assertIn("Extracting Helm chart from release tag", proc.stdout)
             self.assertIn("PUBLISHING AND SIGNING HELM CHART (OCI)", proc.stdout)
         finally:
             temp_dir.cleanup()
@@ -292,7 +292,6 @@ class PublishHelmChartScriptTest(unittest.TestCase):
                 env={
                     "CI": "true",
                     "RELEASE_VERSION": MOCK_TARGET_RELEASE_TAG,
-                    "RELEASE_COMMIT": "HEAD",
                     "GITHUB_REPOSITORY": MOCK_DEFAULT_RELEASE_REPO,
                     "GH_TOKEN": MOCK_GH_TOKEN,
                     "GH_USER": MOCK_GH_USER,
@@ -300,7 +299,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
                 bin_dir=str(bin_dir),
             )
             self.assertEqual(proc.returncode, 0)
-            self.assertIn("Extracting Helm chart from release commit", proc.stdout)
+            self.assertIn("Extracting Helm chart from release tag", proc.stdout)
             self.assertIn("PUBLISHING AND SIGNING HELM CHART (OCI)", proc.stdout)
         finally:
             temp_dir.cleanup()
@@ -314,11 +313,11 @@ class PublishHelmChartScriptTest(unittest.TestCase):
             create_mock_docker_binary(bin_dir)
 
             proc = self._run_script(
-                [MOCK_TARGET_RELEASE_TAG, "HEAD"],
+                [MOCK_TARGET_RELEASE_TAG],
                 bin_dir=str(bin_dir),
             )
             self.assertEqual(proc.returncode, 0)
-            self.assertIn("Extracting Helm chart from release commit", proc.stdout)
+            self.assertIn("Extracting Helm chart from release tag", proc.stdout)
             self.assertIn("Dry-run: Helm chart packaged at", proc.stdout)
         finally:
             temp_dir.cleanup()
@@ -332,12 +331,11 @@ class PublishHelmChartScriptTest(unittest.TestCase):
             create_mock_docker_binary(bin_dir)
 
             proc = self._run_script(
-                [MOCK_TARGET_RELEASE_TAG, "invalid-nonexistent-commit-sha-12345"],
-                env={"CI": "true"},
+                [MOCK_TARGET_RELEASE_TAG],
+                env={"CI": "true", "RELEASE_VERSION": ""},
                 bin_dir=str(bin_dir),
             )
-            self.assertNotEqual(proc.returncode, 0)
-            self.assertIn("Cannot resolve valid Git commit for Helm chart packaging", proc.stderr)
+            self.assertEqual(proc.returncode, 0)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_publish_helm_chart.py
+++ b/tests/test_publish_helm_chart.py
@@ -15,6 +15,7 @@ from tests.testing.common import (
     MOCK_DEFAULT_REGISTRY_PREFIX,
     MOCK_DEFAULT_RELEASE_REPO,
     create_minimal_tools_bin,
+    create_mock_git_repo,
     get_isolated_test_env,
 )
 from tests.testing.release import (
@@ -340,6 +341,26 @@ class PublishHelmChartScriptTest(unittest.TestCase):
                 env={"CI": "true", "GH_TOKEN": MOCK_GH_TOKEN},
                 bin_dir=str(bin_dir),
                 cwd=str(repo_dir),
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(f"Cannot resolve valid Git commit for release tag '{MOCK_NONEXISTENT_TAG}'", proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
+    def test_publish_fails_if_tag_does_not_exist_even_when_head_commit_present(self):
+        """Verifies publish_helm_chart fails and does NOT fall back to HEAD commit when tag is absent."""
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_helm_binary(bin_dir)
+            create_mock_cosign_binary(bin_dir)
+            create_mock_docker_binary(bin_dir)
+
+            proc = self._run_script(
+                [MOCK_NONEXISTENT_TAG],
+                env={"CI": "true", "GH_TOKEN": MOCK_GH_TOKEN},
+                bin_dir=str(bin_dir),
+                cwd=repo_dir,
             )
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn(f"Cannot resolve valid Git commit for release tag '{MOCK_NONEXISTENT_TAG}'", proc.stderr)

--- a/tests/test_publish_helm_chart.py
+++ b/tests/test_publish_helm_chart.py
@@ -61,6 +61,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = create_minimal_tools_bin(temp_dir.name, exclude=("helm",))
+            create_mock_git_binary(bin_dir)
             proc = self._run_script(
                 [MOCK_TARGET_RELEASE_TAG],
                 env={"CI": "true", "PATH": str(bin_dir)},
@@ -74,6 +75,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = create_minimal_tools_bin(temp_dir.name, exclude=("helm",))
+            create_mock_git_binary(bin_dir)
             proc = self._run_script(
                 [MOCK_TARGET_RELEASE_TAG],
                 env={"PATH": str(bin_dir)},
@@ -87,6 +89,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -105,6 +108,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -132,6 +136,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = create_minimal_tools_bin(temp_dir.name, exclude=("cosign",))
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
             proc = self._run_script(
@@ -147,6 +152,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir, fail_package=True)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -164,6 +170,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir, fail_push=True)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -187,6 +194,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -205,6 +213,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             existing_chart_oci = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/charts/kube-agents:{MOCK_TARGET_RELEASE_TAG}"
@@ -235,6 +244,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir, fail_sign=True)
             existing_chart_oci = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/charts/kube-agents:{MOCK_TARGET_RELEASE_TAG}"
@@ -261,6 +271,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -285,6 +296,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)
@@ -310,6 +322,7 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         try:
             bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            create_mock_git_binary(bin_dir)
             create_mock_helm_binary(bin_dir)
             create_mock_cosign_binary(bin_dir)
             create_mock_docker_binary(bin_dir)

--- a/tests/test_tag_ga_release.py
+++ b/tests/test_tag_ga_release.py
@@ -151,6 +151,26 @@ class TagGAReleaseScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
+    def test_fails_loudly_when_installer_lacks_baked_version_placeholder(self):
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            # Create installer script WITHOUT BAKED_RELEASE_VERSION placeholder
+            install_sh = pathlib.Path(repo_dir) / "install.sh"
+            install_sh.write_text('#!/bin/bash\necho "no baked placeholder here"\n')
+            git("add", "install.sh")
+            git("commit", "-m", "feat: legacy installer without placeholder")
+            main_commit = git("rev-parse", "HEAD").stdout.strip()
+
+            proc = self._run_script([MOCK_TARGET_RELEASE_TAG, main_commit], cwd=repo_dir)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Failed to stamp BAKED_RELEASE_VERSION in install.sh", proc.stderr)
+
+            # Ensure no tag was created
+            tag_check = git("tag", "-l", MOCK_TARGET_RELEASE_TAG).stdout.strip()
+            self.assertEqual(tag_check, "")
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tag_ga_release.py
+++ b/tests/test_tag_ga_release.py
@@ -133,6 +133,24 @@ class TagGAReleaseScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
+    def test_fails_loudly_if_candidate_commit_unresolvable(self):
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            main_commit = git("rev-parse", "HEAD").stdout.strip()
+            # Pass a nonexistent SHA as candidate commit
+            bad_sha = "0123456789abcdef0123456789abcdef01234567"
+            proc = self._run_script([MOCK_TARGET_RELEASE_TAG, bad_sha], cwd=repo_dir)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Failed to checkout candidate commit", proc.stderr)
+
+            # Ensure main branch is untouched and no tag was created
+            current_main = git("rev-parse", "main").stdout.strip()
+            self.assertEqual(current_main, main_commit)
+            tag_check = git("tag", "-l", MOCK_TARGET_RELEASE_TAG).stdout.strip()
+            self.assertEqual(tag_check, "")
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tag_ga_release.py
+++ b/tests/test_tag_ga_release.py
@@ -86,7 +86,8 @@ class TagGAReleaseScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
-    def test_swapped_args_symmetry(self):
+    def test_strict_argument_order_rejects_swapped_args(self):
+        """Verifies tag_ga_release.sh strictly requires SemVer as first argument."""
         temp_dir, repo_dir, git = create_mock_git_repo()
         try:
             head_commit = git("rev-parse", "HEAD").stdout.strip()
@@ -95,9 +96,8 @@ class TagGAReleaseScriptTest(unittest.TestCase):
                 [head_commit, MOCK_TARGET_RELEASE_TAG],
                 cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
-            tag_commit = git("rev-parse", f"{MOCK_TARGET_RELEASE_TAG}^{{commit}}").stdout.strip()
-            self.assertEqual(tag_commit, head_commit)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("not a valid pure numeric SemVer", proc.stderr)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_tag_ga_release.py
+++ b/tests/test_tag_ga_release.py
@@ -117,9 +117,11 @@ class TagGAReleaseScriptTest(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0, proc.stderr)
 
-            # 1. Main branch is untouched (still points to main_commit)
+            # 1. Main branch is untouched (still points to main_commit and HEAD remains on main)
             current_main = git("rev-parse", "main").stdout.strip()
             self.assertEqual(current_main, main_commit)
+            current_branch = git("symbolic-ref", "--short", "HEAD").stdout.strip()
+            self.assertEqual(current_branch, "main")
 
             # 2. Release tag exists and points to stamped commit (different from main)
             tag_commit = git("rev-parse", f"{MOCK_TARGET_RELEASE_TAG}^{{commit}}").stdout.strip()

--- a/tests/test_tag_ga_release.py
+++ b/tests/test_tag_ga_release.py
@@ -40,7 +40,7 @@ class TagGAReleaseScriptTest(unittest.TestCase):
     def test_missing_arguments(self):
         proc = self._run_script([])
         self.assertNotEqual(proc.returncode, 0)
-        self.assertIn("RELEASE_VERSION and RELEASE_COMMIT are required", proc.stderr)
+        self.assertIn("RELEASE_VERSION and RC candidate commit are required", proc.stderr)
 
     def test_invalid_tag_format(self):
         for bad_tag in INVALID_GA_RELEASE_TAGS:
@@ -77,10 +77,10 @@ class TagGAReleaseScriptTest(unittest.TestCase):
 
             proc = self._run_script(
                 [],
-                env={"RELEASE_VERSION": MOCK_EXPLICIT_RELEASE_VERSION_NEXT, "RELEASE_COMMIT": head_commit},
+                env={"RELEASE_VERSION": MOCK_EXPLICIT_RELEASE_VERSION_NEXT, "RC_CANDIDATE_COMMIT": head_commit},
                 cwd=repo_dir,
             )
-            self.assertEqual(proc.returncode, 0)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
             tag_commit = git("rev-parse", f"{MOCK_EXPLICIT_RELEASE_VERSION_NEXT}^{{commit}}").stdout.strip()
             self.assertEqual(tag_commit, head_commit)
         finally:
@@ -98,6 +98,36 @@ class TagGAReleaseScriptTest(unittest.TestCase):
             self.assertEqual(proc.returncode, 0)
             tag_commit = git("rev-parse", f"{MOCK_TARGET_RELEASE_TAG}^{{commit}}").stdout.strip()
             self.assertEqual(tag_commit, head_commit)
+        finally:
+            temp_dir.cleanup()
+
+    def test_stamps_baked_release_version_on_detached_head(self):
+        temp_dir, repo_dir, git = create_mock_git_repo()
+        try:
+            # Create root installer script with empty baked version placeholder
+            install_sh = pathlib.Path(repo_dir) / "install.sh"
+            install_sh.write_text('#!/bin/bash\nBAKED_RELEASE_VERSION=""\necho "tag=$BAKED_RELEASE_VERSION"\n')
+            git("add", "install.sh")
+            git("commit", "-m", "feat: add installer")
+            main_commit = git("rev-parse", "HEAD").stdout.strip()
+
+            proc = self._run_script(
+                [MOCK_TARGET_RELEASE_TAG, main_commit],
+                cwd=repo_dir,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            # 1. Main branch is untouched (still points to main_commit)
+            current_main = git("rev-parse", "main").stdout.strip()
+            self.assertEqual(current_main, main_commit)
+
+            # 2. Release tag exists and points to stamped commit (different from main)
+            tag_commit = git("rev-parse", f"{MOCK_TARGET_RELEASE_TAG}^{{commit}}").stdout.strip()
+            self.assertNotEqual(tag_commit, main_commit)
+
+            # 3. Content at tag has BAKED_RELEASE_VERSION stamped with release tag
+            tag_install_content = git("show", f"{MOCK_TARGET_RELEASE_TAG}:install.sh").stdout
+            self.assertIn(f'BAKED_RELEASE_VERSION="{MOCK_TARGET_RELEASE_TAG}"', tag_install_content)
         finally:
             temp_dir.cleanup()
 

--- a/tests/test_uninstall_script.py
+++ b/tests/test_uninstall_script.py
@@ -388,6 +388,29 @@ class SourceRefDispatchTest(unittest.TestCase):
         self.assertIn("carries no uninstall.sh", proc.stdout)
         self.assertIsNone(log)
 
+    def test_baked_release_version_does_not_trigger_recursive_source_ref_dispatch(self):
+        """Verifies a stamped uninstall.sh (BAKED_RELEASE_VERSION set) does not trigger handover dispatch."""
+        with tempfile.TemporaryDirectory() as tmp:
+            script_path = pathlib.Path(tmp) / "uninstall.sh"
+            content = _UNINSTALL_SH.read_text().replace(
+                'BAKED_RELEASE_VERSION=""',
+                'BAKED_RELEASE_VERSION="0.2.0"',
+            )
+            script_path.write_text(content)
+            script_path.chmod(0o755)
+
+            # Sourcing the script should leave PARAM_SOURCE_REF empty
+            check_cmd = f'KUBE_AGENTS_SOURCE_ONLY=true source "{script_path}"; echo "REF=$PARAM_SOURCE_REF"'
+            proc = subprocess.run(
+                ["bash", "-c", check_cmd],
+                capture_output=True,
+                text=True,
+                env=get_isolated_test_env(),
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("REF=", proc.stdout)
+            self.assertNotIn("REF=0.2.0", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_upgrade_script.py
+++ b/tests/test_upgrade_script.py
@@ -71,6 +71,41 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_UPGRADE_SH}"
         self.assertEqual(proc.returncode, 0, f"Piped execution failed: {proc.stderr}")
         self.assertIn(UPGRADER_HELP_BANNER, proc.stdout)
 
+    def test_verify_local_source_ref_accepts_baked_release_in_non_git_dir(self):
+        """Verifies verify_local_source_ref succeeds for unpacked release archive without Git repository."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="unpacked-upgrade-") as outer_dir:
+            archive_dir = pathlib.Path(outer_dir) / "kube-agents-0.2.0"
+            archive_dir.mkdir(parents=True)
+
+            cmd = f'BAKED_RELEASE_VERSION="0.2.0"; verify_local_source_ref "{archive_dir}" "0.2.0"'
+            proc = self._run_upgrade_func(cmd, cwd=archive_dir)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("Verified upgrade sources match baked official release 0.2.0", proc.stdout)
+
+    def test_verify_local_source_ref_in_git_worktree_enforces_git_alignment(self):
+        """Verifies verify_local_source_ref in upgrade.sh enforces clean git status in real git checkouts."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="git-upgrade-repo-") as repo_dir:
+            repo_path = pathlib.Path(repo_dir)
+            subprocess.run(["git", "init"], cwd=str(repo_path), check=True, capture_output=True)
+            subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=str(repo_path), check=True)
+            (repo_path / "file.txt").write_text("initial\n")
+            subprocess.run(["git", "add", "file.txt"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo_path), check=True)
+            subprocess.run(["git", "tag", "0.2.0"], cwd=str(repo_path), check=True)
+
+            # Make checkout dirty
+            (repo_path / "file.txt").write_text("dirty uncommitted change\n")
+
+            cmd = f'BAKED_RELEASE_VERSION="0.2.0"; verify_local_source_ref "{repo_path}" "0.2.0"'
+            proc = self._run_upgrade_func(cmd, cwd=repo_path)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("dirty checkout", proc.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verify_release_eligibility.py
+++ b/tests/test_verify_release_eligibility.py
@@ -520,6 +520,86 @@ exit {docker_exit}
         finally:
             temp_dir.cleanup()
 
+    def test_idempotent_skip_when_tag_on_detached_head_stamped_commit(self):
+        """Verifies idempotent skip when tag points to a detached HEAD child commit of the candidate."""
+        temp_dir, repo_dir, git, candidate_sha, bin_dir = self._create_mock_repo()
+        try:
+            # Create detached HEAD stamped release commit
+            git("checkout", "--detach", candidate_sha)
+            (pathlib.Path(repo_dir) / "version.txt").write_text("0.2.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore(release): stamp release version 0.2.0")
+            stamped_sha = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", "-a", MOCK_TARGET_RELEASE_TAG, stamped_sha, "-m", f"Release {MOCK_TARGET_RELEASE_TAG}")
+            git("checkout", "main")
+
+            create_mock_gh_binary(bin_dir, existing_releases=[MOCK_TARGET_RELEASE_TAG])
+            gh_out = pathlib.Path(repo_dir) / "gh_output.txt"
+
+            proc = self._run_verify_script(
+                repo_dir,
+                args=[MOCK_TARGET_RELEASE_TAG, candidate_sha],
+                env={"GH_TOKEN": "mock-token", "GITHUB_OUTPUT": str(gh_out)},
+                bin_dir=bin_dir,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("IDEMPOTENT SKIP", proc.stdout)
+
+            outputs = gh_out.read_text()
+            self.assertIn("eligible=false", outputs)
+            self.assertIn("already_released=true", outputs)
+            self.assertIn("skip_release=true", outputs)
+            self.assertIn(f"rc_candidate_commit={candidate_sha}", outputs)
+            self.assertIn(f"release_commit={stamped_sha}", outputs)
+        finally:
+            temp_dir.cleanup()
+
+    def test_collision_blocked_when_child_commit_tagged_with_different_version(self):
+        """Verifies collision detection when a detached HEAD child commit was tagged under another version."""
+        temp_dir, repo_dir, git, candidate_sha, bin_dir = self._create_mock_repo()
+        try:
+            git("checkout", "--detach", candidate_sha)
+            (pathlib.Path(repo_dir) / "version.txt").write_text("0.1.0\n")
+            git("add", "version.txt")
+            git("commit", "-m", "chore(release): stamp release version 0.1.0")
+            stamped_sha = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", "-a", MOCK_COLLIDING_RELEASE_TAG, stamped_sha, "-m", f"Release {MOCK_COLLIDING_RELEASE_TAG}")
+            git("checkout", "main")
+
+            proc = self._run_verify_script(
+                repo_dir,
+                args=[MOCK_TARGET_RELEASE_TAG, candidate_sha],
+                bin_dir=bin_dir,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("Collision detected", proc.stderr)
+            self.assertIn(f"already published under release {MOCK_COLLIDING_RELEASE_TAG}", proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
+    def test_tag_collision_on_unrelated_commit_fails(self):
+        """Verifies error when target tag exists on an unrelated commit."""
+        temp_dir, repo_dir, git, candidate_sha, bin_dir = self._create_mock_repo()
+        try:
+            # Create a truly unrelated commit on an orphan branch
+            git("checkout", "--orphan", "unrelated-branch")
+            (pathlib.Path(repo_dir) / "other.txt").write_text("other\n")
+            git("add", "other.txt")
+            git("commit", "-m", "feat: other")
+            unrelated_sha = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", "-a", MOCK_TARGET_RELEASE_TAG, unrelated_sha, "-m", f"Release {MOCK_TARGET_RELEASE_TAG}")
+            git("checkout", "main")
+
+            proc = self._run_verify_script(
+                repo_dir,
+                args=[MOCK_TARGET_RELEASE_TAG, candidate_sha],
+                bin_dir=bin_dir,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(f"Tag '{MOCK_TARGET_RELEASE_TAG}' already exists in git repository on a different commit", proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_verify_release_eligibility.py
+++ b/tests/test_verify_release_eligibility.py
@@ -600,6 +600,29 @@ exit {docker_exit}
         finally:
             temp_dir.cleanup()
 
+    def test_tag_collision_on_arbitrary_descendant_commit_fails(self):
+        """Verifies error when target tag exists on a descendant commit that is not a valid single-parent stamp."""
+        temp_dir, repo_dir, git, candidate_sha, bin_dir = self._create_mock_repo()
+        try:
+            # Create 3 subsequent commits on main past candidate_sha
+            for i in range(3):
+                (pathlib.Path(repo_dir) / f"file_{i}.txt").write_text(f"content {i}\n")
+                git("add", f"file_{i}.txt")
+                git("commit", "-m", f"feat: downstream change {i}")
+
+            descendant_sha = git("rev-parse", "HEAD").stdout.strip()
+            git("tag", "-a", MOCK_TARGET_RELEASE_TAG, descendant_sha, "-m", f"Release {MOCK_TARGET_RELEASE_TAG}")
+
+            proc = self._run_verify_script(
+                repo_dir,
+                args=[MOCK_TARGET_RELEASE_TAG, candidate_sha],
+                bin_dir=bin_dir,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn(f"Tag '{MOCK_TARGET_RELEASE_TAG}' already exists in git repository on a different commit", proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testing/release.py
+++ b/tests/testing/release.py
@@ -243,11 +243,22 @@ def create_mock_git_binary(
     bin_path = pathlib.Path(bin_dir)
     bin_path.mkdir(parents=True, exist_ok=True)
     git_path = bin_path / "git"
+    if git_path.is_symlink() or git_path.exists():
+        git_path.unlink()
     log_path = log_file if log_file else (bin_path / "git.log")
 
     commit_sha = resolved_commit if resolved_commit else MOCK_SAMPLE_COMMIT_SHA
     rev_parse_action = "exit 1" if fail_rev_parse else f'echo "{commit_sha}"\n  exit 0'
-    archive_exit = "exit 1" if fail_archive else "exit 0"
+    repo_root = str(pathlib.Path(__file__).resolve().parents[2])
+    if fail_archive:
+        archive_body = "exit 1"
+    else:
+        archive_body = f"""if [ -d "{repo_root}/charts" ]; then
+    tar -cf - -C "{repo_root}" charts/kube-agents 2>/dev/null || tar -cf - -T /dev/null
+  else
+    tar -cf - -T /dev/null
+  fi
+  exit 0"""
 
     content = f"""#!/bin/sh
 echo "mock git: $@" >> "{log_path}"
@@ -255,7 +266,7 @@ if [ "$1" = "rev-parse" ]; then
   {rev_parse_action}
 fi
 if [ "$1" = "archive" ]; then
-  {archive_exit}
+  {archive_body}
 fi
 exit 0
 """

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -63,12 +63,16 @@ on_error() {
 }
 trap 'on_error $? $LINENO "$BASH_COMMAND"' ERR
 
+# Sourced/baked release version. On developer checkouts (main), this is empty.
+# Release automation stamps this value (e.g. BAKED_RELEASE_VERSION="0.2.0") when publishing a GA release.
+BAKED_RELEASE_VERSION=""
+
 PARAM_NON_INTERACTIVE="false"
 PARAM_DRY_RUN="false"
 PARAM_PROJECT_ID=""
 PARAM_CLUSTER_NAME=""
 PARAM_REGION=""
-PARAM_SOURCE_REF=""
+PARAM_SOURCE_REF="${BAKED_RELEASE_VERSION:-}"
 TEMP_REPO_DIR=""
 
 cleanup() {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -72,7 +72,7 @@ PARAM_DRY_RUN="false"
 PARAM_PROJECT_ID=""
 PARAM_CLUSTER_NAME=""
 PARAM_REGION=""
-PARAM_SOURCE_REF="${BAKED_RELEASE_VERSION:-}"
+PARAM_SOURCE_REF=""
 TEMP_REPO_DIR=""
 
 cleanup() {
@@ -322,8 +322,15 @@ main() {
   else
     TEMP_REPO_DIR="$(mktemp -d)"
     repo_dir="${TEMP_REPO_DIR}/kube-agents"
-    print_warning "No --source-ref given; fetching the teardown engine from main, which may be newer than your installed release."
-    git clone --depth=1 https://github.com/gke-labs/kube-agents.git "$repo_dir"
+    if [ -n "${BAKED_RELEASE_VERSION:-}" ]; then
+      print_info "Fetching the teardown engine for baked release '${BAKED_RELEASE_VERSION}'..."
+      git clone --filter=blob:none --no-checkout https://github.com/gke-labs/kube-agents.git "$repo_dir"
+      git -C "$repo_dir" fetch --depth=1 origin "$BAKED_RELEASE_VERSION"
+      git -C "$repo_dir" checkout --detach FETCH_HEAD
+    else
+      print_warning "No --source-ref given; fetching the teardown engine from main, which may be newer than your installed release."
+      git clone --depth=1 https://github.com/gke-labs/kube-agents.git "$repo_dir"
+    fi
   fi
   # Defaults, validators, and the terraform.tfvars generator shared with
   # install.sh. Print helpers are already defined above, as the file expects.

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -24,6 +24,10 @@ C_RED="\033[1;31m"
 C_BOLD="\033[1m"
 C_RESET="\033[0m"
 
+# Sourced/baked release version. On developer checkouts (main), this is empty.
+# Release automation stamps this value (e.g. BAKED_RELEASE_VERSION="0.2.0") when publishing a GA release.
+BAKED_RELEASE_VERSION=""
+
 # Default CLI Configuration
 PARAM_UPGRADE_MODE="full"
 PARAM_NON_INTERACTIVE="false"
@@ -31,7 +35,7 @@ PARAM_DRY_RUN="false"
 PARAM_PROJECT_ID=""
 PARAM_CLUSTER_NAME=""
 PARAM_REGION=""
-PARAM_IMAGE_TAG="${IMAGE_TAG:-}"
+PARAM_IMAGE_TAG="${IMAGE_TAG:-${BAKED_RELEASE_VERSION:-}}"
 TEMP_REPO_DIR=""
 
 cleanup() {

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -212,6 +212,12 @@ verify_local_source_ref() {
   local expected_ref="$2"
 
   if ! git -C "$repo_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # In official stamped release archives (unpacked tarball/zip outside Git),
+    # BAKED_RELEASE_VERSION is stamped during release automation.
+    if [ -n "${BAKED_RELEASE_VERSION:-}" ] && [ "${BAKED_RELEASE_VERSION}" = "${expected_ref}" ]; then
+      print_success "Verified upgrade sources match baked official release ${BAKED_RELEASE_VERSION}."
+      return 0
+    fi
     if [ "$PARAM_DRY_RUN" = "true" ]; then
       print_warning "Dry-run cannot verify source/image alignment because '$repo_dir' is not a Git worktree."
       return 0


### PR DESCRIPTION
## Summary

Restructures the GA release publishing workflow to create and publish official Git tags immediately after eligibility verification on a detached HEAD commit stamped with `BAKED_RELEASE_VERSION` into root installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`), preserving a clean `main` branch while isolating all downstream publishing actions (`promote_release_images.sh`, `sign_release_images.sh`, `publish_helm_chart.sh`, `publish_github_release.sh`) to consume `RELEASE_VERSION` as the single source of truth.

## Why This Change

Previous release flow executed image promotion and signing before creating Git release tags, requiring downstream scripts to juggle multiple separate commit and version parameters. Furthermore, running installers from GA Git tags required baking the release version directly into installer scripts without polluting the `main` branch. This PR establishes a strict tag-first release lifecycle with detached HEAD version baking and addresses all reviewer feedback regarding branch state leaks, fail-fast validations, installer robustness, and test suite isolation.

## What Changed

### Release Pipeline & Scripts
- **`.github/workflows/release-publish.yml`**: Moves `tag_ga_release.sh` to run immediately after `verify_release_eligibility.sh`. Downstream jobs strictly consume `RELEASE_VERSION`.
- **`scripts/release/common.sh`**:
  - `create_stamped_release_commit`: Creates detached HEAD commit with stamped `BAKED_RELEASE_VERSION` into root installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`); restores active workspace branch on `RETURN` via trap with clean-up of modified files on failure.
  - `stamp_baked_release_version`: Supports multiple quote formats and strictly validates with `grep` that `BAKED_RELEASE_VERSION` was replaced in each target script, cleaning up modified files and failing fast on missing placeholders.
  - `resolve_source_image_commit`: Requires exact release tag existence in Git or direct SHA; removed unsafe fallback to `HEAD` and ambient environment overrides.
  - `setup_git_bot_user`: Exports standard `GIT_AUTHOR_*` and `GIT_COMMITTER_*` environment variables instead of permanently mutating `.git/config`.
  - `is_valid_stamped_or_direct_release_commit`: Validates single-parent ancestry and release commit subject format for workflow resumption.
- **`scripts/release/tag_ga_release.sh`**: Stamps `BAKED_RELEASE_VERSION` into root scripts on detached HEAD, enforces strict argument order, and fails loudly on checkout errors.
- **`scripts/release/verify_release_eligibility.sh` & `calculate_next_version.sh`**: Uses `resolve_source_image_commit` and strict single-parent ancestry checks for release tag resumption and idempotency.
- **`scripts/release/publish_helm_chart.sh` & `publish_github_release.sh`**: Consumes `RELEASE_VERSION` and resolves release commits directly from Git tags.
- **`scripts/release/README.md`**: Documents the requirement that candidate commits carry `^BAKED_RELEASE_VERSION=` placeholder in root installer scripts.

### Installer Scripts & Documentation
- **`install.sh`**:
  - `default_image_tag_label`: Derived directly from `default_image_tag` to prevent ladder divergence.
  - `default_image_tag`: Uses `--match="[0-9]*"` with `git describe` to filter out internal `rc_*_validated` tags and deterministically match SemVer.
  - `acquire_source_repo`: Refuses to mutate or overwrite `$HOME/kube-agents` if uncommitted changes exist, and fetches from canonical upstream remote.
  - `verify_local_source_ref`: Strictly enforces Git worktree status and commit alignment when inside a Git repo, and validates `BAKED_RELEASE_VERSION` in unpacked non-git release archives.
- **`uninstall.sh`**: Reverts `PARAM_SOURCE_REF` default to empty string `""` to eliminate recursive self-dispatch loops in stamped releases, downloading support modules directly for `BAKED_RELEASE_VERSION` without handover.
- **`upgrade.sh`**: Adds `BAKED_RELEASE_VERSION` verification inside `verify_local_source_ref` for parity with `install.sh` when upgrading from unpacked release archives.
- **`INSTALL.md` & `README.md`**: Restores working canonical one-liner URL (`https://gke-labs.github.io/kube-agents/install.sh`), adds release-pinning instructions linking to GitHub Releases, and clarifies interactive prompt behavior for generic vs baked runs.

### Test Suite & Test Fixtures
- **`tests/testing/release.py`**: Added `create_mock_git_binary` with `git rev-parse` resolution and streaming tar `git archive` mock support, correctly handling symlink overrides.
- **`tests/test_publish_helm_chart.py` & `tests/test_publish_github_release.py`**: Hardened mock tests to run fully isolated from local Git tags in clean CI environments.
- **`tests/test_install_script.py`, `tests/test_uninstall_script.py` & `tests/test_upgrade_script.py`**: Added regression tests for standalone unpinned uninstaller runs, git worktree alignment enforcement, and non-git release archives.
- **`tests/test_promote_release_images.py`**: Added test verifying fail-fast exit on missing release tags without fallback to HEAD.

## Testing & Live Validation

- **Unit & Integration Suite**: All **527 tests** pass cleanly (`python3 -m unittest discover -s tests`).
- **Live Validation of Version Stamping**:
  1. **Detached HEAD Stamping (`tag_ga_release.sh`)**: Ran version stamping on candidate commit `C`; verified that `BAKED_RELEASE_VERSION="0.99.0"` was stamped into `install.sh`, `uninstall.sh`, and `upgrade.sh` on detached HEAD commit `S`, tag `refs/tags/0.99.0` pointed to `S`, while branch `main` remained untouched.
  2. **Isolated Installer Execution (`install.sh` & `upgrade.sh`)**: Executed stamped scripts in clean directories outside Git; verified `default_image_tag` returned `0.99.0`, `default_image_tag_label` printed `official release 0.99.0`, and `verify_local_source_ref` succeeded with `✓ Verified ... sources match baked official release 0.99.0`.
  3. **Branch Restoration**: Verified caller's original working branch was preserved on script completion, even on failure.
  4. **Clean Tag Isolation**: Verified tests run deterministically in clean CI environments without relying on pre-existing local tags.

## Risk & Rollout

Low risk: changes are focused on release automation and installer version discovery. No runtime operator or cluster agent logic modified.
