### PR TITLE
fix(operator): give each parallel subtest its own Scheme so the fake clients stop racing

### DIFF
--- a/k8s-operator/internal/controller/netpolprofile_test.go
+++ b/k8s-operator/internal/controller/netpolprofile_test.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
@@ -31,12 +30,11 @@ import (
 func TestResolveNetpolProfile(t *testing.T) {
 	t.Parallel()
 
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = agentv1alpha1.AddToScheme(scheme)
-
 	t.Run("DefaultValues", func(t *testing.T) {
 		t.Parallel()
+		// Per-subtest, not hoisted into the parent: a Scheme shared across
+		// parallel fake clients is a data race. See internal/testing/golden_test.go.
+		scheme := setupScheme()
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()
 		r := &PlatformAgentReconciler{Client: client, Scheme: scheme}
 		agent := &agentv1alpha1.PlatformAgent{
@@ -54,6 +52,7 @@ func TestResolveNetpolProfile(t *testing.T) {
 
 	t.Run("DiscoveryKubeDNS", func(t *testing.T) {
 		t.Parallel()
+		scheme := setupScheme()
 		kubeDNSSvc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-dns"},
 			Spec:       corev1.ServiceSpec{ClusterIP: "34.118.224.10"},
@@ -75,6 +74,7 @@ func TestResolveNetpolProfile(t *testing.T) {
 
 	t.Run("OperatorOverrideWinsOverDiscovery", func(t *testing.T) {
 		t.Parallel()
+		scheme := setupScheme()
 		kubeDNSSvc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-dns"},
 			Spec:       corev1.ServiceSpec{ClusterIP: "34.118.224.10"},
@@ -101,6 +101,7 @@ func TestResolveNetpolProfile(t *testing.T) {
 
 	t.Run("AnnotationWinsOverOperatorOverride", func(t *testing.T) {
 		t.Parallel()
+		scheme := setupScheme()
 		kubeDNSSvc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-dns"},
 			Spec:       corev1.ServiceSpec{ClusterIP: "34.118.224.10"},
@@ -134,6 +135,7 @@ func TestResolveNetpolProfile(t *testing.T) {
 
 	t.Run("InvalidInputsIgnored", func(t *testing.T) {
 		t.Parallel()
+		scheme := setupScheme()
 		kubeDNSSvc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "kube-dns"},
 			Spec:       corev1.ServiceSpec{ClusterIP: "34.118.224.10"},

--- a/k8s-operator/internal/testing/golden_test.go
+++ b/k8s-operator/internal/testing/golden_test.go
@@ -19,18 +19,45 @@ import (
 	"github.com/gke-labs/kube-agents/k8s-operator/internal/testing/testutil"
 )
 
-var (
-	update     = flag.Bool("update", false, "update golden files")
-	testScheme = runtime.NewScheme()
-)
+var update = flag.Bool("update", false, "update golden files")
 
-func init() {
-	_ = agentv1alpha1.AddToScheme(testScheme)
-	_ = corev1.AddToScheme(testScheme)
-	_ = appsv1.AddToScheme(testScheme)
-	_ = networkingv1.AddToScheme(testScheme)
-	_ = policyv1.AddToScheme(testScheme)
-	_ = rbacv1.AddToScheme(testScheme)
+// newTestScheme builds a Scheme for one subtest. Per-subtest and not a shared
+// package-level var, because a Scheme is not safe to hand to concurrent fake
+// clients: controller-runtime's fake client lazily registers types it has not
+// seen (fake.(*fakeClient).addToSchemeIfUnknownAndUnstructuredOrPartial calls
+// Scheme.AddKnownTypeWithName). That function does take c.schemeLock, which is
+// why this looks safe at a glance -- but schemeLock is a field on the client,
+// so it orders writes within one fake client and nothing at all across the
+// three siblings here that were handed the same Scheme.
+//
+// The readers are wider than the writers. Every SSA Create rebuilds a
+// RESTMapper over the Scheme (testrestmapper.TestOnlyStaticRESTMapper ->
+// Scheme.PrioritizedVersionsForGroup), so a single lazy write races the whole
+// of every sibling's reconcile, not just their own lazy writes. Measured on the
+// parent commit: 23 of 25 race-detector runs report it, and 7 of 40 plain runs
+// die outright with `fatal error: concurrent map writes`.
+//
+// A fatal error is not a recoverable panic: it killed the whole binary and
+// printed whichever goroutine happened to be mid-reconcile, so it read as a
+// defect in whatever the reader had just touched rather than as test-harness
+// contention (#918).
+//
+// Registering more types up front is the tempting narrower fix, and for today's
+// code it does work -- FQDNNetworkPolicy is the only type the golden path
+// reaches lazily, and pre-registering it takes the race to 0 of 25. It is not
+// the fix taken, because it holds only until the next unregistered type, and
+// the lazy path fires precisely on the types nobody thought to register.
+// Isolation does not depend on that guess: a Scheme reachable from one
+// goroutine cannot be raced on.
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = agentv1alpha1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	_ = networkingv1.AddToScheme(s)
+	_ = policyv1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
+	return s
 }
 
 func TestAgentsGolden(t *testing.T) {
@@ -80,7 +107,7 @@ func TestAgentsGolden(t *testing.T) {
 				tt.inputPath,
 				tt.expectedPath,
 				*update,
-				testScheme,
+				newTestScheme(),
 				tt.newAgent,
 				tt.newReconciler,
 			)


### PR DESCRIPTION
## Summary

The operator's golden tests run their subtests with `t.Parallel()` but handed every one of them the same package-level `runtime.Scheme`. A `Scheme` is not safe to share with concurrent fake clients: controller-runtime's fake client registers types it has not seen lazily, so each subtest was writing that Scheme's maps while its siblings read them. This replaces the shared variable with a `newTestScheme()` called once per subtest. No production code, no golden fixture, and no assertion changes — only who owns the Scheme.

## Why This Change

The race was showing up as `fatal error: concurrent map writes` in roughly one in five `go test ./...` runs. A Go fatal error is not a recoverable panic: it kills the test binary outright and prints whichever goroutine happened to be mid-reconcile at the time. So the failure never named the golden tests. It named a reconcile path, on whatever PR happened to be running, and every person who hit it spent time deciding whether they had just broken the operator. That is the real cost — not the red run, but that the red run pointed at the wrong file.

The mechanism, precisely: `fake.(*fakeClient).addToSchemeIfUnknownAndUnstructuredOrPartial` calls `Scheme.AddKnownTypeWithName` for any type the Scheme does not already know. It holds `c.schemeLock` while doing it, which is why the code reads as safe — but `schemeLock` is a field on the *client*, so it orders writes within one fake client and nothing across the three siblings sharing the Scheme. `RunOperatorReconcile` builds a fresh client per subtest and was passing them all one Scheme.

The reader side is wider than the writer side, which is why the hit rate was as high as it was: every SSA `Create` rebuilds a RESTMapper over the Scheme (`testrestmapper.TestOnlyStaticRESTMapper` → `Scheme.PrioritizedVersionsForGroup`), so a single lazy write races the whole of every sibling's reconcile, not just their own lazy writes.

Worth being accurate about the alternative, because my first draft of this PR was not: registering more types up front **does** fix today's instance. `FQDNNetworkPolicy` is the only type the golden path reaches lazily, and pre-registering it takes the measured race to 0 of 25 runs. It is not the fix taken because it holds only until the next unregistered type, and the lazy path fires precisely on the ones nobody thought to register. Isolation does not depend on that guess — a Scheme reachable from one goroutine cannot be raced on.

## What Changed

- `k8s-operator/internal/testing/golden_test.go` — the package-level `testScheme` var and its `init()` become `newTestScheme()`, called at the one call site inside the parallel subtest. The comment on it records the mechanism, so the next person to hoist it back out has the reason in front of them.
- `k8s-operator/internal/controller/netpolprofile_test.go` — same construct: one Scheme built in the parent, five `t.Parallel()` subtests each building a fake client from it. This is **not** the test that was failing, and I could not make it fail (see Testing). It is here because it is one unregistered type away from the same outcome, and fixing the pattern in only one of its two instances leaves the next occurrence to be rediagnosed from scratch. It calls the package's existing `setupScheme()` (already fresh per call, and a superset of what this test registered) rather than adding a second factory beside it.

## Context

Fixes #918. Found while working on #786 / #874, where this flake fired on an unrelated PR and cost a round of investigation before it was clear the operator change was not at fault.

## Testing

Measured on the build host (Go is not installed on my workstation), fresh process per run:

| variant | data races | `fatal error: concurrent map writes` |
|---|---|---|
| parent commit, `-race`, 25 runs | 23/25 | 1/25 |
| parent commit, plain, 40 runs | — | **7/40 (17.5%)** |
| this branch, `-race`, 25 runs | **0/25** | 0/25 |
| this branch, plain, 25 runs | — | **0/25** |
| `./internal/controller/`, `-race`, 20 runs before and after | 0/20 both | — |

The captured race stack is the claimed path and not an inference from the fatal error (which by construction points elsewhere): write via `addToSchemeIfUnknownAndUnstructuredOrPartial` ← `fakeClient.Delete` ← `reconcileNetworkPolicy` (the FQDNNetworkPolicy cleanup), against a read via `Scheme.PrioritizedVersionsForGroup` ← `TestOnlyStaticRESTMapper` ← `fakeClient.Create` ← `applyManaged`.

Also: `go vet ./...` clean; `go test -race -count=5 ./...` green across all five packages; golden fixtures unchanged and passing without `-update`, which is the check that per-subtest Schemes did not alter any rendered manifest.

### Live validation

Not live-tested, and not live-testable: the change is confined to `_test.go` files. Nothing here compiles into the operator binary or any image, so there is no CR status, Deployment env, or in-pod file for it to touch. The equivalent proof for a test-harness fix is the before/after flake rate, which is in Testing above and was measured rather than asserted.

No cluster artifacts were created, so there is nothing to clean up.

## Self-Review

Two passes, adversarial and docs-drift, both run by a **subagent in a fresh context** handed the diff range and nothing else — no access to my reasoning, and instructed to try to break the change. It compiled and ran the suite on the build host independently. It found five things; three changed the diff.

- **Fixed — the comment stated something false.** My rationale claimed "registering every type up front would not fix this." The reviewer tested it: adding `FQDNNetworkPolicy` to the *old shared* scheme takes the race to 0/25, because `addToSchemeIfUnknownAndUnstructuredOrPartial` is guarded by `if !c.scheme.Recognizes(gvk)` and that is the only type the golden path reaches lazily. The class argument survives, the factual claim did not. Both the comment and the commit message now say pre-registration works today and is rejected for holding only until the next unregistered type. This is the finding that justified the pass: 20 lines of load-bearing rationale that future readers would have trusted, and the "no doc describes this" result from the docs pass is exactly why — the comment *is* the documentation.
- **Fixed — the comment sent readers to a mutex and did not explain it.** `addToSchemeIfUnknownAndUnstructuredOrPartial` opens with `c.schemeLock.Lock()`, so a skeptical reader who follows the pointer concludes the comment is wrong. The missing half-sentence is that `schemeLock` is a field on the *client*, so it serialises nothing across the three siblings. That is the crux of the bug and it was the one thing omitted. Added.
- **Fixed — duplicated an existing helper.** My `newNetpolTestScheme()` sat in a package that already has `setupScheme()` (`platformagent_controller_test.go:56`, 20+ call sites, already fresh per call, and a strict superset — `clientgoscheme` covers `corev1`). Now calls it; the diff is five lines shorter and introduces no new symbol.
- **Incorporated, not a defect — the reader surface is wider than I described.** The racing reader is not a sibling's lazy write but `Scheme.PrioritizedVersionsForGroup` via the RESTMapper that the managed-field tracker rebuilds on *every* SSA Create. That is why the rate was 17.5% and not vanishing. Comment and PR body now say so.
- **Reported, deliberately not fixed — CI never runs `-race`.** Repo-wide, zero `-race` in `.github/`, `Makefile`, `scripts/`; `make -C k8s-operator test` is the CI entry point. So this exact bug can be reintroduced silently — the pre-fix failure was a 17.5% crash, meaning CI passed >80% of the time, which is how it survived long enough to become folklore. Out of scope for a one-commit fix and it belongs to whoever owns the workflow, but worth noting that `-race` on `./internal/testing/` alone would have caught it and takes about a second. Happy to file it if wanted.

Checked and clean, per the same pass: completeness (only three files in the repo call `t.Parallel()`; the third, `webhook_port_test.go`, touches no Scheme — every other `runtime.NewScheme()` site audited and fine, so the fix is complete); no assertion became vacuous (identical groups registered, `-update` path unaffected, and the factories are evaluated *after* `t.Parallel()` inside each subtest goroutine, so the isolation is real and not accidentally hoisted); no golden output change — in fact isolation removes a pre-existing run-order dependency on which subtest happened to register `FQDNNetworkPolicy` first; and the "roughly a fifth of runs" claim measured out at 7/40.

Docs-drift pass: **no findings.** It searched `AGENTS.md`, `CLAUDE.md`, `docs/contributing.md`, `k8s-operator/README.md` and `docs/pull-request-workflow.md` for `parallel|scheme|flake|race` (zero hits), and every `*.md`/`*.mdx`/`*.yaml` for `golden test|-update|testScheme|RunGoldenTest|testdata/platform`. The only hits are unrelated GKE "golden path" skills and the `.checkov.yaml` / `.trivyignore.yaml` path excludes for `k8s-operator/internal/testing/**`, which are path-based and unaffected. No contributor doc describes the golden tests' Scheme setup at all.

One finding I raised myself and am still not fixing: `gofmt -l` flags `internal/controller/manifest_helpers.go` on this branch and equally on `main`, since the diff does not touch it. Pre-existing drift; folding an unreviewed reformat into a flake fix is not what a reviewer of this PR is checking for.

## Risk & Rollout

Low. Test-only, no runtime code paths touched, nothing to sequence at merge time. The failure mode if I am wrong is that the operator tests stay flaky, which is the status quo; there is no way for this to make a passing test fail silently, because a per-subtest Scheme that registered too little would fail the golden comparison loudly. Revert is a plain revert of the single commit.
