### PR TITLE
feat(terraform): let a second install in a project name its own agent service account

### DIFF
--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -200,6 +200,51 @@ equivalent set exists). Deliberately no admin list is pre-staged in
 `terraform.tfvars.example` — widening access should be an explicit, reviewed
 choice.
 
+### A second install in the same project (`agent_service_account_id`)
+
+Two installs in one GCP project must not share the agent's service account.
+The name is `agent_service_account_id`, default `kubeagents-platform-gsa`, and
+it is a project-wide resource: nothing about it is scoped to the cluster, the
+namespace, or the state file.
+
+Leave it at the default for a second install and Terraform will do two things,
+the second of them destructive:
+
+1. `google_service_account.agent` fails to create — the account already
+   exists. The apply stops there, so nothing downstream of it is created and
+   this failure on its own is harmless.
+2. The harm is in the obvious way past it. `terraform import` on that address
+   is the move a 409 invites, and it is the wrong one here: it adopts the
+   **running** agent's service account into the second install's state. The
+   `google_project_iam_member` entries are keyed on that account's email, so
+   Terraform then believes it owns bindings that belong to a live agent — and
+   `terraform destroy` at teardown revokes them, and deletes the account
+   itself. Nothing warns you; the first install simply starts failing every
+   GCP call.
+
+So the first failure is a wall, not a hazard. Do not climb it by importing.
+
+So give a second install its own identity, and its own key ring — which
+collides in the same way, for the same reason:
+
+```bash
+TF_VAR_agent_service_account_id=kubeagents-pr786-gsa \
+TF_VAR_kms_keyring_name=pr786-keyring \
+  ./terraform/examples/full-install/lifecycle.sh apply
+```
+
+`TF_VAR_` is read only where `terraform.tfvars` is silent, and the generated
+tfvars names neither variable, so the environment wins for both. The chart
+consumes `module.kube_agents_iam.service_account_email`, so the override
+reaches the KSA annotation with nothing further to set.
+
+One thing it does not reach: `githubMinter.allowedServiceAccount`, which the
+chart derives from `platformAgent.harness.projectId` and so still spells the
+default name. If the second install enables the GitHub minter, set that value
+explicitly to match — otherwise the minty rule rejects the very agent it is
+there to serve. Every other consumer of the name reads it from the module's
+output.
+
 ### Backups
 
 `enable_backup_agent` (default `true`) turns on the Backup for GKE addon. It

--- a/terraform/examples/full-install/main.tf
+++ b/terraform/examples/full-install/main.tf
@@ -219,9 +219,16 @@ module "gke_backup_plan" {
 module "kube_agents_iam" {
   source = "../../modules/kube-agents-iam"
 
-  project_id    = var.project_id
-  namespace     = var.namespace
-  project_roles = local.agent_project_roles
+  project_id = var.project_id
+  # Passed rather than left to the module default, so a second install in an
+  # occupied project can be given its own identity. Without this the name is
+  # fixed at kubeagents-platform-gsa for every install in the project, and the
+  # second one's IAM bindings attach to the first one's service account --
+  # making its terraform destroy revoke project roles from a live agent. See
+  # the variable's own description.
+  service_account_id = var.agent_service_account_id
+  namespace          = var.namespace
+  project_roles      = local.agent_project_roles
 
   depends_on = [google_project_service.required]
 }

--- a/terraform/examples/full-install/variables.tf
+++ b/terraform/examples/full-install/variables.tf
@@ -90,6 +90,31 @@ variable "namespace" {
   default     = "kubeagents-system"
 }
 
+variable "agent_service_account_id" {
+  description = <<-EOT
+    Account ID of the agent's GCP service account. Change it only to stand up a
+    SECOND install in a project that already has one -- a PR test cluster
+    alongside a live agent, say. Two installs that share this name share the
+    identity: the second apply fails to create the service account because it
+    already exists, and its google_project_iam_member entries resolve to the
+    FIRST install's service account, so tearing the second one down revokes
+    project roles from the agent still running. Give the second install its own
+    name (and its own kms_keyring_name, which collides the same way).
+
+    The default is the only name any single-install project has ever used;
+    leaving it alone keeps existing state unchanged.
+  EOT
+  type        = string
+  default     = "kubeagents-platform-gsa"
+
+  # Mirrors the module's own validation so a bad name fails at plan time here,
+  # naming this variable, rather than inside kube-agents-iam naming its own.
+  validation {
+    condition     = can(regex("^[a-z]([-a-z0-9]{4,28}[a-z0-9])$", var.agent_service_account_id))
+    error_message = "agent_service_account_id must be 6-30 characters, start with a lowercase letter, and contain only lowercase letters, digits, and hyphens."
+  }
+}
+
 variable "permission_set" {
   description = "Which GCP IAM role bundle the agent's service account gets: read-only, gke-admin, or custom (custom requires project_roles). Ignored when project_roles is set explicitly."
   type        = string


### PR DESCRIPTION
## Summary

`terraform/examples/full-install` never passed `service_account_id` up to `module.kube-agents-iam`, so the agent's GCP service account was hardcoded to `kubeagents-platform-gsa` for every install in a project. This adds an `agent_service_account_id` variable to the composition and wires it through, defaulting to the existing name so no current install moves. It is a two-line functional change plus a variable and its documentation.

## Why This Change

A project can hold exactly one kube-agents install today, and nothing in the composition says so — you find out by hitting it.

`google_service_account.agent` takes `account_id` from the module's default, so a second install asks GCP for a name that already exists and the apply stops with a 409. That failure is loud and, by itself, harmless: the `google_project_iam_member` entries are keyed on `google_service_account.agent.email`, so with the account resource never created they are never created either, and a `terraform destroy` of the wreckage revokes nothing.

The hazard is the way past the wall. `terraform import` is what a 409 invites, and this repo has already normalized that reflex — `lifecycle.sh` adopts pre-existing KMS resources for exactly this reason. Import here adopts the **running** agent's service account into the second install's state. The IAM bindings then attach to a live identity, everything applies cleanly, nothing looks wrong, and teardown revokes those project roles and deletes the account. In `agentic-harness-demo` that is nine roles including `container.viewer`, `logging.viewer` and `monitoring.viewer` — the live agent loses sight of its own cluster, from a Terraform run that was never pointed at it.

So the fix is worth having for the plain reason first: a second install is impossible without it, and #786 needed one. That it also removes the incentive to reach for `import` is the part that would have cost someone a live agent.

The KMS keyring collides identically and is already survivable, because `kms_keyring_name` *is* a composition variable. This gives the service account the same handle the keyring already has.

## What Changed

- `variables.tf` — new `agent_service_account_id`, default `kubeagents-platform-gsa`. The description is written for the person who will need it, which is someone about to create a second install, and says plainly what happens if they do not set it. Validation mirrors the IAM module's own regex so a bad name fails at plan time naming *this* variable, rather than surfacing from inside the module.
- `main.tf` — passes it to `module.kube_agents_iam`. Note this is the only identity in the composition that was left to a module default; the LiteLLM service account a few lines down is already named explicitly.
- `README.md` — a section on running a second install in an occupied project: the 409 wall, why `terraform import` is the wrong way over it, the `TF_VAR_agent_service_account_id` + `TF_VAR_kms_keyring_name` pair needed together, and the one consumer the override does not reach (`githubMinter.allowedServiceAccount`).

`TF_VAR_` is the intended entry point here rather than `terraform.tfvars`: the installer generates the tfvars file, and Terraform reads `TF_VAR_*` only for variables the tfvars file is silent about (`installer_common.sh:585`). So this variable is deliberately **not** added to `terraform.tfvars.example` — adding it there, even commented, invites someone to uncomment it and quietly disable the override path. `kms_keyring_name` is absent from that file for the same reason, and this follows it.

## Context

Fixes #919. Related to #831 but not covered by it. Discovered while standing up the `kube-agents-pr786` test cluster for #874.

## Testing

- `terraform fmt -check -recursive` — exit 0.
- `terraform init -backend=false && terraform validate` — "Success! The configuration is valid."
- `prettier --check` on the README — passes.
- Default-preservation is by construction, not by claim: the new default is byte-identical to the module's existing default, so an existing install's plan cannot move. No state was available to me to diff a plan against, which is why I am resting this on the value rather than on a run.

### Live validation

This change is the productionized form of a local patch that was already exercised against real infrastructure, and the evidence outlived the cluster.

On 2026-08-21 the `kube-agents-pr786` install was created in `agentic-harness-demo`, a project that already contained the live `kage-management` agent, using a local two-file patch semantically identical to this diff (same variable, same wiring; this version adds the validation block and the docs). It was applied with:

```
TF_VAR_agent_service_account_id=kubeagents-pr786-gsa
TF_VAR_kms_keyring_name=pr786-keyring
```

Observed at the time: the override reached the IAM module, `kubeagents-pr786-gsa` was created as a distinct identity, and it reached the workload layer too — the chart consumes `module.kube_agents_iam.service_account_email`, so the KSA's `iam.gke.io/gcp-service-account` annotation carried the new name. That is the "set something distinctly different" the template asks for: the value used was nothing like the default, and it showed up end to end.

The revert half is the part I can still show today, after that install was destroyed:

```
$ gcloud iam service-accounts list --project agentic-harness-demo | grep -E 'pr786|platform-gsa'
kubeagents-platform-gsa@agentic-harness-demo.iam.gserviceaccount.com

$ gcloud projects get-iam-policy agentic-harness-demo \
    --flatten='bindings[].members' \
    --filter='bindings.members:kubeagents-platform-gsa@...' --format='value(bindings.role)' | wc -l
9
```

`kubeagents-pr786-gsa` is gone, cleaned up by its own destroy, and the live agent still holds all nine project roles. So a second install was created and torn down in an occupied project with the running agent's identity and IAM untouched — the outcome this variable exists to make possible. Stated precisely: this shows the override works end to end and tears down cleanly. It does not show that the default would have destroyed anything, because without the override there would have been no second install to tear down.

Not covered, and I would rather name it than round it off:

- I have not run a second install *without* the override to watch the 409, nor imported past it to watch the teardown strip the live agent. The second experiment destroys the thing it measures, on a cluster in use. Both are argued from the resource graph — `google_project_iam_member.agent_roles` keying on `google_service_account.agent.email` — not demonstrated.
- `terraform apply` has not run against this exact diff, only against the semantically equivalent patch. I have `validate`, not a fresh install; standing up a second project to get one was not worth the spend for a defaulted variable.
- The `githubMinter.allowedServiceAccount` gap is documented, not exercised. The pr786 install had the minter disabled.

## Self-Review

Passes run: adversarial read of the diff, and a docs-drift check. Both ran in **this** session — the one that wrote the change — not in a fresh context. My harness does not spawn subagents unless asked, so `/pr-preflight`'s isolated passes were unavailable. That is a real weakening of what a Self-Review is for; I will re-run them in a clean context on request.

- **Can this move an existing install's state?** The default equals the module's existing default, so a plan on an untouched install is empty. This is the load-bearing claim of the PR and it rests on a value comparison I checked directly, not on a plan run — flagged as such in Testing.
- **Is `main.tf` the only place the name leaks?** This is the pass that found something. Traced `service_account_id` through `modules/kube-agents-iam` to `service_account_email`, then grepped the whole repo for the literal `kubeagents-platform-gsa`. The load-bearing consumer is fine: `main.tf:456` sets the KSA's `iam.gke.io/gcp-service-account` annotation from the module output, so Workload Identity follows the override. But `charts/kube-agents/templates/github-minter.yaml:23` derives `allowedServiceAccount` from `platformAgent.harness.projectId` and spells the default name, so a renamed agent would be rejected by its own minty rule. It is overridable via `githubMinter.allowedServiceAccount`, and the composition does not set it. Documented in the README rather than wired: plumbing a Terraform output into a chart value that CI-pool installs deliberately derive per-project is a larger change than this PR, and the minter is off in the case this variable exists for. The remaining hits are docs and module READMEs describing the default, which is still the default.
- **Was the original justification for this fix right?** Partly, and I corrected it rather than shipping it. I had recorded this as "a second install's destroy silently revokes the live agent's roles." Re-reading the graph, the plain second apply fails at the 409 and never creates the bindings, so nothing is revoked. The revocation needs someone to `terraform import` first. Checked whether the installer does that automatically — `lifecycle.sh` imports KMS resources only, not the service account — so it is a human step, not an automatic one. Why This Change and the README both say the weaker, true version now.
- **Does the validation regex match the module's?** Copied deliberately rather than rewritten, so the two cannot disagree about what is legal. Duplicated on purpose: catching it here names the variable the user actually set.
- **Should this go in `terraform.tfvars.example`?** Considered and rejected, with the reasoning in What Changed — adding it would break the `TF_VAR_` path it exists to enable. Checked that `kms_keyring_name` sets the same precedent; it does.
- **Does the keyring need the same treatment?** No — it is already a composition variable. The README documents the pair together, since setting one without the other still fails.
- **Is the description honest about scope?** It tells the reader not to change it unless they are doing a second install, which is the failure mode worth guarding: someone renaming it on an existing install would strand the old GSA's bindings. Said explicitly.
- **Docs drift:** grepped the repo for prose naming `kubeagents-platform-gsa` as fixed or unconfigurable. The installer docs and the IAM module README describe the GSA but do not assert it is unchangeable, so no correction is owed elsewhere; the new README section is the only doc this change requires.
- **No findings** on: unused variables, provider version constraints, and whether the new block breaks `checkov` — `validate` and `fmt` are clean and the change introduces no new resource.

## Risk & Rollout

Low, and bounded by the default. Every existing install keeps the name it has because the default is the name it has; the new code path only activates for someone who deliberately sets the variable. The new failure mode is a second install being given a name that collides with something else in the project, which fails at plan time via the validation rather than at apply. Revert is a plain revert — the variable would simply stop being available, and any install using a non-default name would need it restored before its next apply. Nothing to coordinate at merge time.
