### PR TITLE
fix(install): adopt a leftover Chat Pub/Sub topic and subscription instead of 409ing

### DIFF
--- a/docs/site/src/content/docs/install/uninstall.md
+++ b/docs/site/src/content/docs/install/uninstall.md
@@ -53,7 +53,7 @@ Once the CR is gone, the operator's finalizer first removes the cluster-scoped R
 
 `uninstall.sh` runs the install engine in reverse: it finds the install's Terraform state in GCS (bucket `<project>-kube-agents-tfstate`, prefix `kube-agents/<cluster>` — derived from the install coordinates, so a fresh clone works), regenerates `terraform.tfvars`, and drives `terraform destroy` through the composition's [`lifecycle.sh destroy`](https://github.com/gke-labs/kube-agents/blob/main/terraform/examples/full-install/lifecycle.sh). Pass `--project-id`, `--cluster-name`, and `--region` to name the target explicitly; otherwise they come from the saved `vars.sh`.
 
-Four things in the stack are not symmetric — destroying them is not the inverse of applying them — and `lifecycle.sh destroy` handles each one before `terraform destroy` runs:
+Several things in the stack are not symmetric — destroying them is not the inverse of applying them. Four of them bite on teardown, and `lifecycle.sh destroy` handles each one before `terraform destroy` runs:
 
 | Asymmetry                                                                                                              | What `lifecycle.sh destroy` does                                                                                           |
 | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -322,8 +322,9 @@ Terraform-managed resources out of band (for instance removing the
 
 Five things in this stack are not symmetric — applying them is not the inverse
 of destroying them — and each one breaks a plain `terraform destroy`, or the
-`terraform apply` that follows it. [`lifecycle.sh`](lifecycle.sh) handles all
-five, so the cycle is repeatable:
+`terraform apply` that follows it. [`lifecycle.sh`](lifecycle.sh) handles four of
+them in the cycle below, so it is repeatable; the fifth is a deliberate step
+described at the end of this section:
 
 ```bash
 make tf-destroy     # or: ./terraform/examples/full-install/lifecycle.sh destroy
@@ -369,9 +370,16 @@ install's live topic is therefore indistinguishable from a leftover — adopt it
 and its agent starts receiving the other install's Chat messages (Pub/Sub
 delivers each message once), and your next `tf-destroy` deletes it. That is why
 the 409 is still what a bare `tf-apply` gives you: it is loud, it destroys
-nothing, and it is recoverable. Give concurrent installs distinct
-`chat_topic_name` and `chat_subscription_name` values, alongside the distinct
-state prefixes [Remote state](#remote-state) describes.
+nothing, and it is recoverable.
+
+Distinct `chat_topic_name` and `chat_subscription_name` values keep adoption from
+being ambiguous, but they do not on their own make two full installs share a
+project. Several other names in this composition are project-level and not
+exposed as variables — the agent service account is
+`kubeagents-platform-gsa` for every install, `namespace` is fixed, and the KMS
+keyrings are project-and-location constants — so the second apply fails on the
+service account instead. Two installs in one project is a larger piece of work
+than the distinct state prefixes [Remote state](#remote-state) describes.
 
 The subscription carries one guard the topic cannot: it is adopted only when it
 is attached to the topic being adopted, so a same-named subscription pointing

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -111,7 +111,10 @@ installs in one project keep separate state. Versioning is the recovery story:
 a corrupted or mistakenly-overwritten state file can be restored from a prior
 generation with `gcloud storage restore`. If the state is gone entirely,
 re-run `lifecycle.sh apply` against the same tfvars — KMS adoption is
-automatic, and `terraform import` covers the rest.
+automatic, and `terraform import` covers the rest. On a Chat-enabled install
+that also means `lifecycle.sh adopt-pubsub` before the apply, which is the one
+adoption that is deliberate rather than automatic; see
+[Teardown and re-apply](#teardown-and-re-apply) for why.
 
 ### The `image_tag` rule
 
@@ -335,7 +338,7 @@ What each one does that raw Terraform cannot:
 | The `PlatformAgent` finalizer strands the CR and hangs the namespace | `tf-destroy` deletes the CR and waits, force-clearing the finalizer if wedged |
 | A `BackupPlan` cannot be deleted while it owns backups               | `tf-destroy` purges the plan's backups first                                  |
 | `deletion_protection = true` cannot be overridden by a destroy alone | `tf-destroy` applies it as `false`, then destroys                             |
-| A Chat topic/subscription outliving a teardown this state never saw  | `tf-apply` imports them before applying (`lifecycle.sh adopt-pubsub`)         |
+| A Chat topic/subscription outliving a teardown this state never saw  | `lifecycle.sh adopt-pubsub`, run deliberately — not by `tf-apply`             |
 
 The chart also carries a `pre-delete` hook that removes the CR and waits for
 its finalizer, so a plain `helm uninstall` is safe on its own; `tf-destroy`
@@ -347,17 +350,32 @@ yourself — starting with `kubectl delete platformagent <name> -n
 kubeagents-system --wait` while the operator is still running, and setting
 `deletion_protection = false` and applying before the cluster can be removed.
 
-The Chat row is the one that bites on a project rather than on a cycle: the
-topic and subscription delete cleanly whenever this state owns them, so a
-`tf-destroy`/`tf-apply` round trip never hits it. What leaves them behind is a
-teardown this state never saw — destroyed with `enable_google_chat = false` so
-the module had `count` 0, a lost state file, or an earlier hand-rolled install —
-and the next apply then 409s on both names. Adoption claims them by name, and
-the name is all there is to go on, so a subscription attached to a different
-topic is left alone and reported rather than imported. Two concurrent installs
-in one project need distinct `chat_topic_name` and `chat_subscription_name`
-values; with the defaults, each one's topic is indistinguishable from the
-other's leftover.
+The Chat row is the one that bites on a project rather than on a cycle, and the
+only one `tf-apply` does not handle for you. The topic and subscription delete
+cleanly whenever this state owns them, so a `tf-destroy`/`tf-apply` round trip
+never hits it. What leaves them behind is a teardown this state never saw — a
+state file lost or replaced, a destroy that failed part-way, an earlier
+hand-rolled install, or a topic created by hand — and the next apply then 409s on
+both names:
+
+```bash
+./lifecycle.sh adopt-pubsub    # then: make tf-apply
+```
+
+**Read the names before you run it.** Adoption claims a topic on the strength of
+its name matching your `chat_topic_name`, and that default is a project-wide
+constant while this composition supports two installs in one project. A second
+install's live topic is therefore indistinguishable from a leftover — adopt it
+and its agent starts receiving the other install's Chat messages (Pub/Sub
+delivers each message once), and your next `tf-destroy` deletes it. That is why
+the 409 is still what a bare `tf-apply` gives you: it is loud, it destroys
+nothing, and it is recoverable. Give concurrent installs distinct
+`chat_topic_name` and `chat_subscription_name` values, alongside the distinct
+state prefixes [Remote state](#remote-state) describes.
+
+The subscription carries one guard the topic cannot: it is adopted only when it
+is attached to the topic being adopted, so a same-named subscription pointing
+elsewhere is reported and left alone.
 
 > [!WARNING]
 > Destroying also uninstalls cert-manager when this composition installed it,

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -317,10 +317,10 @@ Use `lifecycle.sh destroy` for teardown; anything that mutates the
 Terraform-managed resources out of band (for instance removing the
 `kube-agents-host` label by hand) causes plan drift the next apply reverts.
 
-Four things in this stack are not symmetric — applying them is not the inverse
+Five things in this stack are not symmetric — applying them is not the inverse
 of destroying them — and each one breaks a plain `terraform destroy`, or the
 `terraform apply` that follows it. [`lifecycle.sh`](lifecycle.sh) handles all
-four, so the cycle is repeatable:
+five, so the cycle is repeatable:
 
 ```bash
 make tf-destroy     # or: ./terraform/examples/full-install/lifecycle.sh destroy
@@ -335,16 +335,29 @@ What each one does that raw Terraform cannot:
 | The `PlatformAgent` finalizer strands the CR and hangs the namespace | `tf-destroy` deletes the CR and waits, force-clearing the finalizer if wedged |
 | A `BackupPlan` cannot be deleted while it owns backups               | `tf-destroy` purges the plan's backups first                                  |
 | `deletion_protection = true` cannot be overridden by a destroy alone | `tf-destroy` applies it as `false`, then destroys                             |
+| A Chat topic/subscription outliving a teardown this state never saw  | `tf-apply` imports them before applying (`lifecycle.sh adopt-pubsub`)         |
 
 The chart also carries a `pre-delete` hook that removes the CR and waits for
 its finalizer, so a plain `helm uninstall` is safe on its own; `tf-destroy`
 does it up front anyway, which turns the hook into a no-op. Disable it with
 `platformAgent.cleanupHook.enabled=false`.
 
-Running `terraform destroy` directly still works, but you own the four steps
-above yourself — starting with `kubectl delete platformagent <name> -n
+Running `terraform destroy` directly still works, but you own the steps above
+yourself — starting with `kubectl delete platformagent <name> -n
 kubeagents-system --wait` while the operator is still running, and setting
 `deletion_protection = false` and applying before the cluster can be removed.
+
+The Chat row is the one that bites on a project rather than on a cycle: the
+topic and subscription delete cleanly whenever this state owns them, so a
+`tf-destroy`/`tf-apply` round trip never hits it. What leaves them behind is a
+teardown this state never saw — destroyed with `enable_google_chat = false` so
+the module had `count` 0, a lost state file, or an earlier hand-rolled install —
+and the next apply then 409s on both names. Adoption claims them by name, and
+the name is all there is to go on, so a subscription attached to a different
+topic is left alone and reported rather than imported. Two concurrent installs
+in one project need distinct `chat_topic_name` and `chat_subscription_name`
+values; with the defaults, each one's topic is indistinguishable from the
+other's leftover.
 
 > [!WARNING]
 > Destroying also uninstalls cert-manager when this composition installed it,

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -306,11 +306,17 @@ adopt_kms() {
 # That is the one answer that cannot be true for somebody who ran this subcommand
 # *because* an apply had just 409'd on these exact names, so a 403, an unauthenticated
 # gcloud, a project that does not resolve, or the API being disabled all have to say so.
-# A plain NOT_FOUND is the expected case and stays quiet.
+#
+# Matching on NOT_FOUND is what does not work, and it fails towards silence. Pub/Sub
+# answers a wrong or inaccessible project with
+# "NOT_FOUND: Requested project not found or user does not have access to it", so two of
+# the cases named above carry the same status as a genuine absence. Only the resource
+# being missing says "Resource not found", for both topics and subscriptions, so that is
+# the phrase the quiet path keys on.
 describe_failure() {
   local what="$1" err="$2"
   case "$err" in
-    *NOT_FOUND*|*"not found"*|"") return 0 ;;
+    *"Resource not found"*|"") return 0 ;;
   esac
   warn "could not read $what: ${err%%$'\n'*}"
   warn "that is not the same as it being absent — nothing was adopted for it."

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -2,7 +2,7 @@
 #
 # Makes `apply` and `destroy` repeatable for this composition.
 #
-# Four things in this stack are not symmetric — applying them is not the inverse
+# Five things in this stack are not symmetric — applying them is not the inverse
 # of destroying them — and every one of them turns the second `terraform apply`
 # of a project's life into a failure. Terraform cannot express any of them, so
 # they live here rather than in a README telling you to remember them:
@@ -22,11 +22,18 @@
 #   3. A GKE BackupPlan cannot be deleted while it still owns backups.
 #   4. The cluster is created with deletion_protection = true, which a destroy
 #      cannot override on its own — the attribute has to be applied as false first.
+#   5. The Google Chat Pub/Sub topic and subscription outlive any teardown that
+#      did not run through THIS state — a destroy with enable_google_chat off, a
+#      lost state file, a hand-rolled earlier install. Unlike KMS they delete
+#      cleanly when Terraform owns them, so `destroy` needs no special case; the
+#      asymmetry is that `apply` then 409s on names it is configured to create.
+#      `adopt-pubsub` imports them instead.
 #
 # Usage:
 #   ./lifecycle.sh apply    [extra terraform args...]
 #   ./lifecycle.sh destroy  [extra terraform args...]
 #   ./lifecycle.sh adopt-kms
+#   ./lifecycle.sh adopt-pubsub
 #
 # Remote state (opt-in): set KUBE_AGENTS_STATE_BUCKET to a GCS bucket name, or
 # to "auto" for <project_id>-kube-agents-tfstate. The bucket is created if
@@ -254,6 +261,82 @@ adopt_kms() {
   log "KMS adoption complete: $adopted imported"
 }
 
+# A Google Chat topic and subscription left over from a previous install make the
+# next apply fail with a 409 on both, because Terraform is asked to create names
+# that already exist and does not own them. They are perfectly deletable, so this
+# is not the KMS problem — `terraform destroy` removes them whenever this state
+# manages them, and nothing here interferes with that. What leaves them behind is
+# a teardown this state never saw: destroyed with enable_google_chat = false so
+# the module had count 0, a state file that was lost, or a topic some earlier
+# hand-rolled install created.
+#
+# The names are the only handle there is, so adopting one means claiming a topic
+# on the strength of its name matching this install's configuration. Two guards
+# make that defensible, and neither is optional:
+#
+#   - Nothing already in state is touched, so an install that owns its topic is
+#     never re-imported.
+#   - A subscription is adopted only if it is actually attached to the topic this
+#     install is adopting. A same-named subscription pointing somewhere else is
+#     somebody else's, and importing it would hand this state a resource its next
+#     destroy would delete out from under them.
+#
+# What neither guard can catch is a second install of THIS composition in the same
+# project that kept the default topic name, since its topic is indistinguishable
+# from a leftover. Give concurrent installs distinct chat_topic_name /
+# chat_subscription_name values; that is what the 409 was protecting, and it is
+# why every adoption here is logged rather than done quietly.
+adopt_pubsub() {
+  [[ "$(tfvar enable_google_chat)" == "true" ]] || return 0
+
+  local project topic subscription topic_addr sub_addr adopted=0
+  load_state
+  project=$(tfvar project_id)
+  topic=$(tfvar chat_topic_name)
+  subscription=$(tfvar chat_subscription_name)
+  topic_addr="module.chat_pubsub[0].google_pubsub_topic.chat_events"
+  sub_addr="module.chat_pubsub[0].google_pubsub_subscription.chat_events"
+
+  if ! in_state "$topic_addr" &&
+     gcloud pubsub topics describe "$topic" --project "$project" >/dev/null 2>&1; then
+    log "adopting pre-existing Pub/Sub topic: $topic"
+    [[ -f "$OVERRIDE_FILE" ]] || with_override
+    if terraform import -input=false "$topic_addr" \
+         "projects/$project/topics/$topic" >/dev/null 2>&1; then
+      adopted=$((adopted + 1))
+    else
+      warn "could not import $topic_addr; the apply will fail with a 409 on $topic"
+    fi
+  fi
+
+  if ! in_state "$sub_addr" &&
+     gcloud pubsub subscriptions describe "$subscription" --project "$project" >/dev/null 2>&1; then
+    # The attachment is fixed at creation — a subscription cannot be repointed —
+    # so a mismatch here is not a stale reading, it is a different subscription.
+    local attached
+    attached=$(gcloud pubsub subscriptions describe "$subscription" --project "$project" \
+      --format='value(topic)' 2>/dev/null || true)
+    if [[ "$attached" != "projects/$project/topics/$topic" ]]; then
+      warn "subscription $subscription is attached to ${attached:-an unreadable topic}, not"
+      warn "projects/$project/topics/$topic — leaving it alone. It belongs to something else;"
+      warn "the apply will 409 until you rename chat_subscription_name or remove that subscription."
+    else
+      log "adopting pre-existing Pub/Sub subscription: $subscription"
+      [[ -f "$OVERRIDE_FILE" ]] || with_override
+      if terraform import -input=false "$sub_addr" \
+           "projects/$project/subscriptions/$subscription" >/dev/null 2>&1; then
+        adopted=$((adopted + 1))
+      else
+        warn "could not import $sub_addr; the apply will fail with a 409 on $subscription"
+      fi
+    fi
+  fi
+
+  drop_override
+  trap - EXIT
+  log "Pub/Sub adoption complete: $adopted imported"
+}
+
 # create_cluster = false means "somebody else's cluster" — but if THIS state
 # already manages the cluster, flipping the variable off does not hand the
 # cluster back: it removes the resource from configuration, and the next apply
@@ -412,11 +495,17 @@ case "${1:-}" in
     ensure_init
     adopt_kms
     ;;
+  adopt-pubsub)
+    shift
+    ensure_init
+    adopt_pubsub
+    ;;
   apply)
     shift
     ensure_init
     guard_cluster_ownership
     adopt_kms
+    adopt_pubsub
     log "terraform apply"
     # No -input=false: this prompts like plain `terraform apply` does. Pass
     # -auto-approve through ARGS for unattended runs.

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -23,11 +23,14 @@
 #   4. The cluster is created with deletion_protection = true, which a destroy
 #      cannot override on its own — the attribute has to be applied as false first.
 #   5. The Google Chat Pub/Sub topic and subscription outlive any teardown that
-#      did not run through THIS state — a destroy with enable_google_chat off, a
-#      lost state file, a hand-rolled earlier install. Unlike KMS they delete
-#      cleanly when Terraform owns them, so `destroy` needs no special case; the
-#      asymmetry is that `apply` then 409s on names it is configured to create.
-#      `adopt-pubsub` imports them instead.
+#      did not run through THIS state — a state file that was lost or replaced, a
+#      destroy that failed part-way, an earlier hand-rolled install, or a topic
+#      somebody created by hand. Unlike KMS they delete cleanly whenever Terraform
+#      owns them, so `destroy` needs no special case; the asymmetry is that
+#      `apply` then 409s on names it is configured to create. `adopt-pubsub`
+#      imports them, and unlike `adopt-kms` it is NOT run by `apply` — see the
+#      comment on adopt_pubsub for why claiming a topic by name has to be a
+#      decision somebody makes rather than a default.
 #
 # Usage:
 #   ./lifecycle.sh apply    [extra terraform args...]
@@ -42,6 +45,11 @@
 # kube-agents/<cluster_name>>. Unset, state stays local as before.
 #
 set -euo pipefail
+
+# Captured before the cd, because BASH_SOURCE[0] is whatever path the caller
+# used: after changing directory a relative one no longer resolves, and the
+# usage block at the bottom reads this file back.
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -166,6 +174,27 @@ EOF
   trap drop_override EXIT
 }
 
+# Imports id at address unless the address is already in state, arming the override
+# file first. Returns 0 when something was imported so callers can count, 1 when
+# there was nothing to do or the import failed — a failure warns rather than exits,
+# because the apply that follows reports it far better than this can.
+#
+# adopt_kms predates this and still writes the same sequence inline through its
+# targets array; it is left alone rather than refactored underneath a change that
+# is not about KMS.
+import_if_absent() {
+  local address="$1" id="$2" what="$3"
+  in_state "$address" && return 1
+
+  log "adopting pre-existing $what: $id"
+  [[ -f "$OVERRIDE_FILE" ]] || with_override
+  if terraform import -input=false "$address" "$id" >/dev/null 2>&1; then
+    return 0
+  fi
+  warn "could not import $address; the apply will fail with a 409 on $id"
+  return 1
+}
+
 # Destroying a google_kms_crypto_key does not delete the key — GCP will not — but
 # it DOES schedule every one of its versions for destruction, which leaves the key
 # present and unusable. A cluster then fails to come back with
@@ -266,26 +295,36 @@ adopt_kms() {
 # that already exist and does not own them. They are perfectly deletable, so this
 # is not the KMS problem — `terraform destroy` removes them whenever this state
 # manages them, and nothing here interferes with that. What leaves them behind is
-# a teardown this state never saw: destroyed with enable_google_chat = false so
-# the module had count 0, a state file that was lost, or a topic some earlier
-# hand-rolled install created.
+# a teardown this state never saw: a state file lost or replaced, a destroy that
+# failed part-way, an earlier hand-rolled install, or a topic created by hand.
 #
-# The names are the only handle there is, so adopting one means claiming a topic
-# on the strength of its name matching this install's configuration. Two guards
-# make that defensible, and neither is optional:
+# This is NOT called from `apply`, and that is the whole design. adopt_kms can run
+# unattended because a KMS key ring is undeletable: adopting one takes nothing away
+# from anybody, and refusing to adopt leaves an install that cannot proceed. A
+# Pub/Sub topic is the opposite on both counts.
+#
+# The names are the only handle there is, so adopting means claiming a topic on the
+# strength of its name matching this install's configuration — and chat_topic_name
+# defaults to a project-wide constant while this composition explicitly supports two
+# installs in one project (see the state-prefix note above). So install B, applying
+# with the defaults, cannot distinguish install A's live topic from a leftover: both
+# names match, and A's subscription really is attached to A's topic, so the guard
+# below passes. Adopting it would put B's agent service account on A's subscription
+# — Pub/Sub delivers each message once, so A's Chat would go intermittently dead and
+# B would receive A's traffic — and B's next destroy would delete both.
+#
+# A 409 is a much better outcome than that: loud, non-destructive, recoverable. So
+# the 409 stays the default and adoption is a subcommand somebody runs deliberately,
+# having read the names and decided they are theirs to claim.
+#
+# Two guards still apply, because a deliberate run can also be a mistaken one:
 #
 #   - Nothing already in state is touched, so an install that owns its topic is
 #     never re-imported.
 #   - A subscription is adopted only if it is actually attached to the topic this
-#     install is adopting. A same-named subscription pointing somewhere else is
-#     somebody else's, and importing it would hand this state a resource its next
-#     destroy would delete out from under them.
-#
-# What neither guard can catch is a second install of THIS composition in the same
-# project that kept the default topic name, since its topic is indistinguishable
-# from a leftover. Give concurrent installs distinct chat_topic_name /
-# chat_subscription_name values; that is what the 409 was protecting, and it is
-# why every adoption here is logged rather than done quietly.
+#     install is adopting. A same-named subscription pointing somewhere else is not
+#     this install's, and importing it would hand this state a resource its next
+#     destroy would delete out from under whoever owns it.
 adopt_pubsub() {
   [[ "$(tfvar enable_google_chat)" == "true" ]] || return 0
 
@@ -297,37 +336,48 @@ adopt_pubsub() {
   topic_addr="module.chat_pubsub[0].google_pubsub_topic.chat_events"
   sub_addr="module.chat_pubsub[0].google_pubsub_subscription.chat_events"
 
+  # </dev/null on every describe: pubsub.googleapis.com is enabled by the apply this
+  # recovers, so on a fresh project the API may still be off, and gcloud answers
+  # SERVICE_DISABLED with an interactive "enable and retry?" prompt. With output sent
+  # to /dev/null that prompt would be invisible while gcloud blocked on the terminal.
   if ! in_state "$topic_addr" &&
-     gcloud pubsub topics describe "$topic" --project "$project" >/dev/null 2>&1; then
-    log "adopting pre-existing Pub/Sub topic: $topic"
-    [[ -f "$OVERRIDE_FILE" ]] || with_override
-    if terraform import -input=false "$topic_addr" \
-         "projects/$project/topics/$topic" >/dev/null 2>&1; then
+     gcloud pubsub topics describe "$topic" --project "$project" </dev/null >/dev/null 2>&1; then
+    if import_if_absent "$topic_addr" "projects/$project/topics/$topic" "Pub/Sub topic"; then
       adopted=$((adopted + 1))
-    else
-      warn "could not import $topic_addr; the apply will fail with a 409 on $topic"
     fi
   fi
 
-  if ! in_state "$sub_addr" &&
-     gcloud pubsub subscriptions describe "$subscription" --project "$project" >/dev/null 2>&1; then
-    # The attachment is fixed at creation — a subscription cannot be repointed —
-    # so a mismatch here is not a stale reading, it is a different subscription.
+  if ! in_state "$sub_addr"; then
+    # One describe answers both questions: a non-zero exit means the subscription is
+    # not there, and the topic it prints is the attachment. Asking twice opened a
+    # window where the subscription was deleted in between, after which the second
+    # read failed and the operator was told "unreadable topic" rather than "nothing
+    # to adopt".
     local attached
-    attached=$(gcloud pubsub subscriptions describe "$subscription" --project "$project" \
-      --format='value(topic)' 2>/dev/null || true)
-    if [[ "$attached" != "projects/$project/topics/$topic" ]]; then
-      warn "subscription $subscription is attached to ${attached:-an unreadable topic}, not"
-      warn "projects/$project/topics/$topic — leaving it alone. It belongs to something else;"
-      warn "the apply will 409 until you rename chat_subscription_name or remove that subscription."
-    else
-      log "adopting pre-existing Pub/Sub subscription: $subscription"
-      [[ -f "$OVERRIDE_FILE" ]] || with_override
-      if terraform import -input=false "$sub_addr" \
-           "projects/$project/subscriptions/$subscription" >/dev/null 2>&1; then
-        adopted=$((adopted + 1))
+    if attached=$(gcloud pubsub subscriptions describe "$subscription" --project "$project" \
+                    --format='value(topic)' </dev/null 2>/dev/null); then
+      if [[ "$attached" == "projects/$project/topics/$topic" ]]; then
+        if import_if_absent "$sub_addr" "projects/$project/subscriptions/$subscription" \
+             "Pub/Sub subscription"; then
+          adopted=$((adopted + 1))
+        fi
       else
-        warn "could not import $sub_addr; the apply will fail with a 409 on $subscription"
+        # The attachment is fixed at creation — a subscription cannot be repointed —
+        # so this is never a stale reading. It is still not always somebody else's,
+        # which is why the cause is not asserted.
+        warn "subscription $subscription is attached to ${attached:-no readable topic}, not"
+        warn "projects/$project/topics/$topic — leaving it alone."
+        case "$attached" in
+          _deleted-topic_)
+            warn "its topic has been deleted, so this is most likely an orphan of a"
+            warn "previous install; delete the subscription if it is yours." ;;
+          "")
+            warn "the describe returned no topic at all; check it by hand." ;;
+          *)
+            warn "it may belong to another install, or project_id may be set to a project"
+            warn "number here while Pub/Sub reports the project ID." ;;
+        esac
+        warn "the apply will 409 until you rename chat_subscription_name or remove it."
       fi
     fi
   fi
@@ -505,7 +555,6 @@ case "${1:-}" in
     ensure_init
     guard_cluster_ownership
     adopt_kms
-    adopt_pubsub
     log "terraform apply"
     # No -input=false: this prompts like plain `terraform apply` does. Pass
     # -auto-approve through ARGS for unattended runs.
@@ -548,7 +597,11 @@ case "${1:-}" in
     log "delete them. The next 'lifecycle.sh apply' adopts them automatically."
     ;;
   *)
-    sed -n '2,36p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    # Print the header block: every comment line after the shebang, stopping at
+    # the first line that is not one. Deliberately not a line range — the range
+    # this replaced was sized to the header as it stood, and adding a subcommand
+    # above it silently truncated the help at whatever line the count reached.
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$SCRIPT_PATH"
     exit 1
     ;;
 esac

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -3,9 +3,11 @@
 # Makes `apply` and `destroy` repeatable for this composition.
 #
 # Five things in this stack are not symmetric — applying them is not the inverse
-# of destroying them — and every one of them turns the second `terraform apply`
-# of a project's life into a failure. Terraform cannot express any of them, so
-# they live here rather than in a README telling you to remember them:
+# of destroying them. The first four turn the second `terraform apply` of a
+# project's life into a failure, and Terraform cannot express any of them, so
+# they live here rather than in a README telling you to remember them. The fifth
+# only bites when a teardown did not run through this state, and its recovery is
+# a subcommand somebody has to decide to type:
 #
 #   1. Cloud KMS key rings and crypto keys CANNOT be deleted, ever. `terraform
 #      destroy` drops them from state and leaves them in the project, so the next
@@ -298,6 +300,22 @@ adopt_kms() {
 # a teardown this state never saw: a state file lost or replaced, a destroy that
 # failed part-way, an earlier hand-rolled install, or a topic created by hand.
 #
+# Reports a describe that failed for a reason other than the resource not being there.
+#
+# Every non-zero exit otherwise lands in the same place — no warning, and "0 imported".
+# That is the one answer that cannot be true for somebody who ran this subcommand
+# *because* an apply had just 409'd on these exact names, so a 403, an unauthenticated
+# gcloud, a project that does not resolve, or the API being disabled all have to say so.
+# A plain NOT_FOUND is the expected case and stays quiet.
+describe_failure() {
+  local what="$1" err="$2"
+  case "$err" in
+    *NOT_FOUND*|*"not found"*|"") return 0 ;;
+  esac
+  warn "could not read $what: ${err%%$'\n'*}"
+  warn "that is not the same as it being absent — nothing was adopted for it."
+}
+
 # This is NOT called from `apply`, and that is the whole design. adopt_kms can run
 # unattended because a KMS key ring is undeletable: adopting one takes nothing away
 # from anybody, and refusing to adopt leaves an install that cannot proceed. A
@@ -326,7 +344,12 @@ adopt_kms() {
 #     this install's, and importing it would hand this state a resource its next
 #     destroy would delete out from under whoever owns it.
 adopt_pubsub() {
-  [[ "$(tfvar enable_google_chat)" == "true" ]] || return 0
+  if [[ "$(tfvar enable_google_chat)" != "true" ]]; then
+    # Say so rather than exiting 0 in silence. Somebody running this subcommand has
+    # just watched an apply 409 on these names, and "no output" reads as "it worked".
+    log "Google Chat is not enabled (enable_google_chat = false); nothing to adopt"
+    return 0
+  fi
 
   local project topic subscription topic_addr sub_addr adopted=0
   load_state
@@ -338,16 +361,21 @@ adopt_pubsub() {
 
   # </dev/null on every describe: pubsub.googleapis.com is enabled by the apply this
   # recovers, so on a fresh project the API may still be off, and gcloud answers
-  # SERVICE_DISABLED with an interactive "enable and retry?" prompt. With output sent
-  # to /dev/null that prompt would be invisible while gcloud blocked on the terminal.
-  if ! in_state "$topic_addr" &&
-     gcloud pubsub topics describe "$topic" --project "$project" </dev/null >/dev/null 2>&1; then
+  # SERVICE_DISABLED with an interactive "enable and retry?" prompt. Without it that
+  # prompt would be invisible while gcloud blocked on the terminal.
+  #
+  # The state check belongs to import_if_absent, which owns it for every caller; these
+  # branches gate only on whether the resource exists in GCP.
+  local err
+  if err=$(gcloud pubsub topics describe "$topic" --project "$project" </dev/null 2>&1 >/dev/null); then
     if import_if_absent "$topic_addr" "projects/$project/topics/$topic" "Pub/Sub topic"; then
       adopted=$((adopted + 1))
     fi
+  else
+    describe_failure "topic $topic" "$err"
   fi
 
-  if ! in_state "$sub_addr"; then
+  {
     # One describe answers both questions: a non-zero exit means the subscription is
     # not there, and the topic it prints is the attachment. Asking twice opened a
     # window where the subscription was deleted in between, after which the second
@@ -379,12 +407,16 @@ adopt_pubsub() {
         esac
         warn "the apply will 409 until you rename chat_subscription_name or remove it."
       fi
+    else
+      describe_failure "subscription $subscription" \
+        "$(gcloud pubsub subscriptions describe "$subscription" --project "$project" \
+             </dev/null 2>&1 >/dev/null || true)"
     fi
-  fi
+  }
 
   drop_override
   trap - EXIT
-  log "Pub/Sub adoption complete: $adopted imported"
+  log "Pub/Sub adoption complete: $adopted imported (searched project $project)"
 }
 
 # create_cluster = false means "somebody else's cluster" — but if THIS state

--- a/terraform/modules/chat-pubsub/README.md
+++ b/terraform/modules/chat-pubsub/README.md
@@ -14,6 +14,16 @@ and the module's defaults mirror them.
 
 The module outputs are the values the PlatformAgent CR's `googleChat` integration needs.
 
+Those default names are project-wide constants, and the topic and subscription
+survive any teardown that did not run through the state managing them — a lost
+state file, a destroy that failed part-way, an earlier hand-rolled install.
+Creating them again then fails with a 409 on both names. The composition ships
+`lifecycle.sh adopt-pubsub` to import them instead; it is deliberate rather than
+part of `apply`, because a same-named topic can belong to a second install rather
+than be a leftover. See
+[Teardown and re-apply](../../examples/full-install/README.md#teardown-and-re-apply).
+Two installs sharing a project want distinct names.
+
 ## Usage
 
 ```hcl

--- a/terraform/modules/chat-pubsub/README.md
+++ b/terraform/modules/chat-pubsub/README.md
@@ -22,7 +22,9 @@ Creating them again then fails with a 409 on both names. The composition ships
 part of `apply`, because a same-named topic can belong to a second install rather
 than be a leftover. See
 [Teardown and re-apply](../../examples/full-install/README.md#teardown-and-re-apply).
-Two installs sharing a project want distinct names.
+Distinct names are what keep that adoption unambiguous; they are not on their own
+enough to run two full installs in one project, which the composition does not
+support today.
 
 ## Usage
 

--- a/tests/test_lifecycle_script.py
+++ b/tests/test_lifecycle_script.py
@@ -79,11 +79,31 @@ exit 0
 # is the only input the attachment guard reads.
 _GCLOUD_STUB = """#!/usr/bin/env bash
 case "$*" in
+  *"pubsub topics describe"*|*"pubsub subscriptions describe"*)
+    if [ -n "${GCLOUD_DESCRIBE_ERR:-}" ]; then
+      printf '%s\\n' "$GCLOUD_DESCRIBE_ERR" >&2
+      exit 1
+    fi
+    ;;
+esac
+case "$*" in
   *"pubsub topics describe"*)        exit 0 ;;
   *"pubsub subscriptions describe"*) printf '%s\\n' "$ATTACHED_TOPIC"; exit 0 ;;
 esac
 exit 0
 """
+
+# The two shapes Pub/Sub actually returns, both carrying NOT_FOUND. Keying the quiet
+# path on NOT_FOUND therefore silences a wrong or inaccessible project as well as a
+# genuine absence, which is the failure these two tests exist to keep fixed.
+_ERR_NO_PROJECT = (
+    "ERROR: (gcloud.pubsub.topics.describe) NOT_FOUND: Requested project not found "
+    "or user does not have access to it (project=nope-zz123)."
+)
+_ERR_NO_RESOURCE = (
+    "ERROR: (gcloud.pubsub.topics.describe) NOT_FOUND: Resource not found "
+    "(resource=platform-agent-chat-events)."
+)
 
 
 class AttachmentGuard(unittest.TestCase):
@@ -96,7 +116,7 @@ class AttachmentGuard(unittest.TestCase):
     gate nothing — so this runs the code and asserts on the imports it performs.
     """
 
-    def _run(self, attached_topic):
+    def _run(self, attached_topic, describe_err=""):
         tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp, True)
         bindir = pathlib.Path(tmp) / "bin"
@@ -119,6 +139,7 @@ class AttachmentGuard(unittest.TestCase):
             "PATH": f"{bindir}:{os.environ['PATH']}",
             "IMPORT_LOG": str(import_log),
             "ATTACHED_TOPIC": attached_topic,
+            "GCLOUD_DESCRIBE_ERR": describe_err,
         }
         env.pop("KUBE_AGENTS_STATE_BUCKET", None)
         result = subprocess.run(
@@ -146,6 +167,24 @@ class AttachmentGuard(unittest.TestCase):
         self.assertIn(
             "google_pubsub_subscription", imports,
             "the matching case must still adopt, or the guard is just a refusal",
+        )
+
+    def test_an_inaccessible_project_warns_rather_than_reporting_nothing_to_adopt(self):
+        result, _ = self._run("", describe_err=_ERR_NO_PROJECT)
+        combined = result.stdout + result.stderr
+        self.assertIn(
+            "could not read", combined,
+            "a wrong or inaccessible project carries NOT_FOUND just like a genuine "
+            "absence does, so keying the quiet path on NOT_FOUND reports an auth or "
+            "project problem as '0 imported' — the one answer that cannot be true here",
+        )
+
+    def test_a_genuinely_absent_resource_stays_quiet(self):
+        result, _ = self._run("", describe_err=_ERR_NO_RESOURCE)
+        combined = result.stdout + result.stderr
+        self.assertNotIn(
+            "could not read", combined,
+            "nothing to adopt is the expected case and must not warn",
         )
 
 

--- a/tests/test_lifecycle_script.py
+++ b/tests/test_lifecycle_script.py
@@ -20,9 +20,12 @@ silently truncated the help at the remote-state paragraph — the only place the
 script documents KUBE_AGENTS_STATE_BUCKET.
 """
 
+import os
 import pathlib
 import re
+import shutil
 import subprocess
+import tempfile
 import unittest
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -52,13 +55,97 @@ class AdoptPubsubIsNotAutomatic(unittest.TestCase):
     def test_adopt_pubsub_is_reachable_as_its_own_subcommand(self):
         self.assertIn("adopt_pubsub", _case_body("adopt-pubsub"))
 
-    def test_subscription_is_only_adopted_when_attached_to_the_adopted_topic(self):
-        source = _LIFECYCLE_SH.read_text()
+
+_TERRAFORM_STUB = """#!/usr/bin/env bash
+case "$1" in
+  init) exit 0 ;;
+  console)
+    read -r expr
+    case "$expr" in
+      var.enable_google_chat)      echo 'true' ;;
+      var.project_id)              echo '"test-project"' ;;
+      var.chat_topic_name)         echo '"platform-agent-chat-events"' ;;
+      var.chat_subscription_name)  echo '"platform-agent-chat-events-sub"' ;;
+      *)                           echo '""' ;;
+    esac
+    ;;
+  state)  : ;;                       # `state list` -> empty, nothing is adopted yet
+  import) printf '%s\\n' "$*" >>"$IMPORT_LOG" ;;
+esac
+exit 0
+"""
+
+# $ATTACHED_TOPIC is what `subscriptions describe --format=value(topic)` reports, which
+# is the only input the attachment guard reads.
+_GCLOUD_STUB = """#!/usr/bin/env bash
+case "$*" in
+  *"pubsub topics describe"*)        exit 0 ;;
+  *"pubsub subscriptions describe"*) printf '%s\\n' "$ATTACHED_TOPIC"; exit 0 ;;
+esac
+exit 0
+"""
+
+
+class AttachmentGuard(unittest.TestCase):
+    """Drive adopt_pubsub with gcloud and terraform stubbed, and watch what it imports.
+
+    The guard is the safety property of the whole subcommand: it is what stops a
+    same-named subscription that belongs to a different install being imported into
+    this state, where the next destroy would delete it. Asserting that the `[[ ... ]]`
+    test appears in the file does not constrain that — the string can be present and
+    gate nothing — so this runs the code and asserts on the imports it performs.
+    """
+
+    def _run(self, attached_topic):
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, True)
+        bindir = pathlib.Path(tmp) / "bin"
+        bindir.mkdir()
+        for name, body in (("terraform", _TERRAFORM_STUB), ("gcloud", _GCLOUD_STUB)):
+            p = bindir / name
+            p.write_text(body)
+            p.chmod(0o755)
+
+        # Copy the script out of the tree: it cd's to its own directory and writes a
+        # provider override there while importing.
+        script = pathlib.Path(tmp) / "lifecycle.sh"
+        script.write_text(_LIFECYCLE_SH.read_text())
+        script.chmod(0o755)
+
+        import_log = pathlib.Path(tmp) / "imports.txt"
+        import_log.touch()
+        env = {
+            **os.environ,
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "IMPORT_LOG": str(import_log),
+            "ATTACHED_TOPIC": attached_topic,
+        }
+        env.pop("KUBE_AGENTS_STATE_BUCKET", None)
+        result = subprocess.run(
+            ["bash", str(script), "adopt-pubsub"],
+            capture_output=True, text=True, env=env, check=False,
+        )
+        return result, import_log.read_text()
+
+    def test_subscription_attached_to_a_foreign_topic_is_not_imported(self):
+        result, imports = self._run("projects/test-project/topics/someone-elses-topic")
+        combined = result.stdout + result.stderr
+
+        self.assertNotIn(
+            "google_pubsub_subscription", imports,
+            "a subscription attached to another topic must never be imported — it "
+            "belongs to something else, and this state's next destroy would delete it",
+        )
+        self.assertIn("leaving it alone", combined)
+        # The topic itself is a legitimate adoption, which also proves the run got far
+        # enough to have imported the subscription had the guard not stopped it.
+        self.assertIn("google_pubsub_topic", imports)
+
+    def test_subscription_attached_to_the_adopted_topic_is_imported(self):
+        _, imports = self._run("projects/test-project/topics/platform-agent-chat-events")
         self.assertIn(
-            '[[ "$attached" == "projects/$project/topics/$topic" ]]',
-            source,
-            "the attachment guard is what stops a same-named subscription belonging "
-            "to something else being imported into this state",
+            "google_pubsub_subscription", imports,
+            "the matching case must still adopt, or the guard is just a refusal",
         )
 
 

--- a/tests/test_lifecycle_script.py
+++ b/tests/test_lifecycle_script.py
@@ -1,0 +1,100 @@
+"""Unit tests for lifecycle.sh's Pub/Sub adoption and its usage block.
+
+Nothing else covers this script. CI's shellcheck step reads only install.sh,
+uninstall.sh and upgrade.sh, and there is no Terraform harness here, so the two
+properties asserted below would regress silently.
+
+Both are properties a reader cannot check by eye:
+
+`adopt_pubsub` must not run from `apply`. A Chat topic is claimed by name, the
+default name is a project-wide constant, and this composition supports two
+installs in one project — so an automatic adoption can take over a live install's
+topic, redirect its Chat traffic, and delete it on the next destroy. The 409 that
+a bare `apply` produces instead is loud and destroys nothing. Wiring adoption back
+into `apply` is a one-line change that looks like a tidy-up, which is exactly why
+it is pinned here.
+
+The usage block must print the whole header. It replaced a hard-coded `sed` line
+range that was calibrated to the header's length, and adding a subcommand above it
+silently truncated the help at the remote-state paragraph — the only place the
+script documents KUBE_AGENTS_STATE_BUCKET.
+"""
+
+import pathlib
+import re
+import subprocess
+import unittest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_LIFECYCLE_SH = _REPO_ROOT / "terraform" / "examples" / "full-install" / "lifecycle.sh"
+
+
+def _case_body(name: str) -> str:
+    """Return the body of one `case` branch in the subcommand dispatch."""
+    source = _LIFECYCLE_SH.read_text()
+    match = re.search(rf"^  {re.escape(name)}\)\n(.*?)^    ;;$", source, re.S | re.M)
+    assert match, f"no {name}) branch found in lifecycle.sh"
+    return match.group(1)
+
+
+class AdoptPubsubIsNotAutomatic(unittest.TestCase):
+    def test_apply_does_not_call_adopt_pubsub(self):
+        body = _case_body("apply")
+        self.assertIn("adopt_kms", body, "apply should still adopt undeletable KMS resources")
+        self.assertNotIn(
+            "adopt_pubsub",
+            body,
+            "apply must not adopt Pub/Sub: the default topic name is a project-wide "
+            "constant, so an automatic adoption can claim a second install's live "
+            "topic and delete it on the next destroy. Keep the 409.",
+        )
+
+    def test_adopt_pubsub_is_reachable_as_its_own_subcommand(self):
+        self.assertIn("adopt_pubsub", _case_body("adopt-pubsub"))
+
+    def test_subscription_is_only_adopted_when_attached_to_the_adopted_topic(self):
+        source = _LIFECYCLE_SH.read_text()
+        self.assertIn(
+            '[[ "$attached" == "projects/$project/topics/$topic" ]]',
+            source,
+            "the attachment guard is what stops a same-named subscription belonging "
+            "to something else being imported into this state",
+        )
+
+
+class UsageBlockIsComplete(unittest.TestCase):
+    def test_usage_prints_the_whole_header(self):
+        result = subprocess.run(
+            ["bash", str(_LIFECYCLE_SH), "definitely-not-a-subcommand"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        for expected in (
+            "./lifecycle.sh apply",
+            "./lifecycle.sh adopt-kms",
+            "./lifecycle.sh adopt-pubsub",
+            # The last paragraph of the header. A range-based usage block that has
+            # fallen behind the header drops this first.
+            "KUBE_AGENTS_STATE_BUCKET",
+            "KUBE_AGENTS_STATE_PREFIX",
+        ):
+            self.assertIn(expected, result.stdout, f"usage output is missing {expected!r}")
+
+    def test_usage_does_not_depend_on_the_caller_working_directory(self):
+        # BASH_SOURCE is whatever path the caller used, and the script cd's to its
+        # own directory before the usage block reads the file back.
+        result = subprocess.run(
+            ["bash", str(_LIFECYCLE_SH.relative_to(_REPO_ROOT)), "nope"],
+            cwd=_REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertIn("KUBE_AGENTS_STATE_BUCKET", result.stdout)
+        self.assertNotIn("can't open file", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A Google Chat Pub/Sub topic and subscription left behind by an earlier install make the next `lifecycle.sh apply` fail: Terraform is asked to create `platform-agent-chat-events` and `-sub`, both names already exist, and the `chat-pubsub` module 409s on each. `lifecycle.sh` already imports undeletable KMS resources before applying and had no equivalent here, so the only documented way out was to go and delete both by hand. This adds `lifecycle.sh adopt-pubsub`, which imports them instead. Generated with the help of Claude.

## Why This Change

It is the first finding in #831, hit on a real from-scratch install. The workaround recorded there — delete the topic and subscription before applying — is fine once you know it, and invisible until you have lost twenty minutes to a 409 that names a resource you did not create.

## What Changed

**`terraform/examples/full-install/lifecycle.sh`** — a new `adopt_pubsub`, modelled on `adopt_kms`: same `load_state` / `in_state` skip, same placeholder Helm provider (`terraform import` configures every provider, and this one is built from the cluster endpoint), same `EXIT`-trapped cleanup of the override file. The shared import scaffolding is now `import_if_absent`, used by both new call sites. `adopt_kms` predates it and is left writing the sequence inline, rather than being refactored underneath a change that is not about KMS.

**It is not called from `apply`, and that is the design.** `adopt_kms` can run unattended because a KMS key ring is undeletable: adopting one takes nothing from anybody, and refusing leaves an install that cannot proceed. A Pub/Sub topic is the opposite on both counts. Adoption claims a topic on the strength of its name, `chat_topic_name` defaults to a project-wide constant, and this composition explicitly supports two installs in one project — that is what the per-cluster state prefix is for. So install B, applying with the defaults, cannot distinguish install A's live topic from a leftover: both names match, and A's subscription really is attached to A's topic. Adopting it would put B's agent service account on A's subscription, and Pub/Sub delivers each message once, so A's Chat would go intermittently dead while B received A's traffic — and B's next `destroy` would delete both. The 409 is a much better outcome than that: loud, non-destructive, recoverable. So the 409 stays the default and adoption is a subcommand somebody runs having read the names.

**Guards that still apply**, because a deliberate run can also be a mistaken one: nothing already in state is re-imported, and a subscription is adopted only when it is attached to the topic being adopted. The attachment is fixed at creation, so a mismatch is never a stale reading — but it is not always someone else's either, so the refusal reports what it saw and names the likely causes (a deleted topic, an unreadable describe, a project number where Pub/Sub reports an ID) rather than asserting one.

**Docs** — the composition README's teardown section gains the row and the reasoning, including the two-installs-one-project constraint next to a cross-reference to Remote state, where that setup is otherwise described. `chat-pubsub`'s module README gains the note every other `lifecycle.sh`-special-cased module already has. The uninstall page's "Four things" sentence is scoped rather than renumbered, since the new asymmetry is apply-side and its table is destroy-scoped.

## Context

Refs #831 (item 1). Item 5 is #936; items 2, 3, 4, 6 and 7 are #841; item 8 needed no change. With those three open, #831 is fully covered. (#831 mentions #344 in its own text for this item; #344 is closed and was a request for an uninstall section in `INSTALL.md`, so nothing here follows from it.)

The three PRs share nothing — bash/Terraform here, Go operator there, docs in #841 — which is why they are separate. Merge-conflict warnings, none a duplicate: **#841**, **#720** and **#504** all touch `terraform/examples/full-install/README.md`. This branch and #841 both edit the Remote state section as well as separate ones, so they overlap in two places rather than one; the two heads were merged with `git merge-tree` and produce no conflict, and the merged paragraph reads correctly.

## Testing

- `bash -n` — clean. `shellcheck` — clean apart from one pre-existing SC2015 in `restore_key_versions`, which is on `main` and not touched here (verified by running shellcheck against the base blob).
- `make docs-check` — passes. `prettier@3.9.6 --check` on the changed Markdown — clean.
- `python3 -m unittest tests.test_lifecycle_script` — **5 pass**. `scripts.test_test_discovery` — passes, so the new file is picked up.

**`tests/test_lifecycle_script.py` is new**, because nothing covered this script: CI's shellcheck step reads only `install.sh`, `uninstall.sh` and `upgrade.sh`, and there is no Terraform harness. Six tests over three properties a reader cannot check by eye:

- **`apply` does not adopt** — wiring it back in is a one-line change that looks like a tidy-up. Non-vacuous because the same test asserts `adopt_kms` *is* in that branch, so a regex that matched nothing would fail.
- **The attachment guard actually gates the import** — this one drives the code rather than reading it. `gcloud` and `terraform` are stubbed on `PATH`, `adopt_pubsub` runs against a subscription attached to a foreign topic, and the assertion is on the imports performed: the subscription must not be imported, the topic must be (which also proves the run reached the point where it could have), and the matching case must still adopt. Verified red by neutering the branch with `|| true` before restoring.
- **The usage block prints the whole header**, from any working directory.

### Live validation

Against project `mplakhtiy-gke-dev` with real Pub/Sub resources, driven from a copy of the composition in a scratch directory with local state — never the working tree, which holds live tfvars for a different environment. Cluster `kube-agents-ap` supplied the `create_cluster = false` data source. Re-run end to end after the review fixes, against the refactored code:

1. **Adoption.** Created `platform-agent-chat-events` and `-sub` by hand to stand in for the leftover, then `./lifecycle.sh adopt-pubsub` → `Pub/Sub adoption complete: 2 imported`, and `terraform state list` showed both addresses. The override file was cleaned up.
2. **Idempotency.** Immediate re-run → `0 imported`, state unchanged.
3. **The attachment guard.** Removed the subscription from state, deleted it, recreated it against a different topic (`someone-elses-topic`), re-ran → refused, reported both topic paths, and `terraform state list` confirmed the subscription stayed out of state. The topic, correctly, was already in state and untouched.
4. **The deleted-topic branch.** Deleted the topic the subscription pointed at so `gcloud` reports `_deleted-topic_`, re-ran → reported it as most likely an orphan of a previous install rather than as someone else's resource.

An earlier round also confirmed the failure mode this fixes: `terraform import` needs every required root variable, and the run that reached "Import prepared!" for the topic proved the Pub/Sub import path itself works before an unrelated data source stopped it.

**Not covered:** the two-installs-one-project collision described above was not reproduced — it needs a second chat-enabled install, and the change's response to it is to *not* run, which is asserted in `tests/test_lifecycle_script.py` instead. `gcloud`'s `SERVICE_DISABLED` prompt on a project with the Pub/Sub API off was not reproduced either; the `</dev/null` on each describe is prophylactic. **Artifacts:** both topics and the subscription were deleted and their absence verified; the scratch directory was removed.

## Self-Review

Ran `.agents/skills/review-adversarial` and `.agents/skills/review-docs-drift`, each in **its own subagent**, given only the diff range and the mechanical-gate output, with my reasoning, plan and commit-message bodies withheld and an instruction to derive intent from the diff.

Angles exercised: line-by-line quoting and `set -euo pipefail` interactions, exit codes and empty-output paths from every `gcloud` call, the `trap`/override-file lifecycle shared with `adopt_kms`, removed behaviour (what the 409 was protecting), cross-file tracing of every identifier to `main.tf`/`variables.tf`/the module, operational and security blast radius of a wrong adoption, reuse, simplification, altitude, conventions and canonical-doc placement, test coverage, and sibling pull requests.

Findings and disposition:

- **HIGH — adopting on every `apply` is destructive by default.** The scenario in *What Changed* above is the pass's, not mine: two installs in one project is supported, the default names are constants, and both of my guards protected the adopting install rather than the incumbent — the topic had no guard at all. **Fixed by removing adoption from `apply`**, which is the smallest of the three remedies it offered; the other two (label-based ownership, per-cluster default names) are larger changes to the module's public surface and belong with whoever wants them. This also resolved four doc findings on its own, since `apply` really does only adopt KMS again.
- **MEDIUM — the usage block silently truncated.** `sed -n '2,36p'` was sized to the old header, and this change added lines above it, so `./lifecycle.sh` with no arguments stopped printing the only documentation of `KUBE_AGENTS_STATE_BUCKET`. **Fixed** with an `awk` that prints comment lines until the first line that is not one, so the next header edit cannot repeat it — and pinned by a test. Found a latent bug while fixing it: the block read the file through a relative `BASH_SOURCE` *after* the script had `cd`'d away, so it broke whenever the script was invoked by path. The path is now resolved before the `cd`.
- **MEDIUM — a cause I asserted does not occur.** All three copies claimed the resources survive "a destroy with `enable_google_chat = false` so the module had `count` 0". `terraform destroy` plans destruction for every instance in state whether or not configuration still counts it, so that is wrong. **Dropped** from the prose and the script comment; the remaining causes are real. Both passes raised this independently.
- **MEDIUM — nothing tests or lints this script.** **Fixed**; see Testing.
- **LOW — the refusal message asserted one cause for four states**, including a subscription whose topic was deleted, which is an orphan of *this* install rather than someone else's. **Fixed.**
- **LOW — the subscription was described twice**, which was an extra call and a window in which it could vanish between the two, turning "nothing to adopt" into "unreadable topic". **Fixed**: one describe answers existence and attachment.
- **LOW — a `SERVICE_DISABLED` prompt could hang the run invisibly**, since output goes to `/dev/null` while `gcloud` blocks on the terminal. Marked PLAUSIBLE by the pass, and it is the same shape `adopt_kms` has had all along without reports. **Took the cheap prophylactic** (`</dev/null` on each describe) rather than chasing the trigger.
- **LOW — import scaffolding written out twice inline.** **Fixed** with `import_if_absent`. The pass also noted a pre-existing latent defect it propagated — `[[ -f "$OVERRIDE_FILE" ]] || with_override` skips arming the `EXIT` trap when a previous killed run left the file behind. That is now in one place rather than three, but **not fixed**: it belongs to `adopt_kms`, and changing the trap behaviour of the KMS path under a Pub/Sub change is how an unrelated install step breaks.
- **Blocking (docs-drift) — the uninstall page's "Four things in the stack"** contradicted the composition README's new "Five". **Fixed** by scoping the sentence rather than renumbering, which is what both passes agreed on: that page's table is destroy-scoped and the new asymmetry is apply-side, so "five" would have made it wrong.
- **Advisory ×5** — `chat-pubsub`'s module README had no leftover-409 note while two siblings with a `lifecycle.sh` special case do, `gke-cluster` and `gke-backup-plan` (**added**; `github-minter` has one too and does not carry such a note, so "every sibling" was wrong); the lost-state recovery sentence said "`terraform import` covers the rest" when Chat adoption is now a named step (**fixed**); a cross-reference between the two-installs constraint and Remote state, 250 lines apart (**added**). `INSTALL.md`, the `Makefile` help and `install.sh`'s engine comment were flagged as describing an apply that also adopts Pub/Sub — **no longer true after the HIGH fix**, so they stand unchanged and correct.

**A third pass then reviewed the opened pull request**, in its own subagent with the full `review-adversarial` method, and found eight more. All are fixed:

- **MEDIUM — the attachment-guard test was vacuous.** It asserted a string appeared in the file, which constrains nothing; the reviewer neutered the branch with `|| true` and the suite still passed 5/5. Replaced with the behavioural test described under Testing, verified red against the same mutation. This also corrected a claim in this body: the non-vacuity argument covered two of the three tests, not all three.
- **MEDIUM — "give concurrent installs distinct Chat names" does not produce a working second install.** The composition never exposes `service_account_id`, so every install uses `kubeagents-platform-gsa` and the second apply fails on `google_service_account` instead. The warning was right, the remedy was not; it is now scoped to what it delivers. Note this does not weaken the design argument — an automatic adoption would still run *before* that failure and leave the topic in the wrong state.
- **LOW ×6** — every `gcloud describe` failure was reported as absence, so a 403 or an unauthenticated CLI produced a silent "0 imported" (**fixed**, with the project named in the completion line); `adopt-pubsub` on a non-Chat install printed nothing at all (**fixed**); `import_if_absent`'s state guard was dead at both call sites, leaving half its contract unreachable (**fixed** by letting the helper own it); the script header claimed all five asymmetries break the second apply and that none live in a README, both untrue of item 5 (**fixed**); the README said `lifecycle.sh` "handles all five, so the cycle is repeatable" three lines above a table saying otherwise (**fixed**); and three claims in this body the source did not support (**all three corrected above** — the #841 overlap, the sibling-module note, and the #344 link).

Reported but not acted on: neither of the first two passes could execute anything — one lost its shell to worktree isolation partway through, and neither had a GCP project — so no finding rests on an executed test. I re-derived the usage truncation and the `count`-0 claim by hand, and re-ran the full live sequence above against the fixed code.

## Risk & Rollout

Narrow by construction: `apply` and `destroy` behave exactly as they did, because the new function is not on either path. The only new reachable behaviour is a subcommand that did not exist, so an install that never runs it cannot be affected — and the 409 that motivated the change is still what a bare `apply` produces, which is the pre-change behaviour.

The failure mode to watch is an operator running `adopt-pubsub` against a topic that belongs to a second install in the same project. That is the risk the design deliberately refuses to take on their behalf: the README says it in the imperative before the command, the subscription's attachment guard catches the common shape of it, and every adoption is logged with the full resource path. It cannot happen unattended.

Two changes do touch existing paths. The usage block is rewritten — it now prints more than it did before this branch, and a test pins that. And `SCRIPT_PATH` is resolved before the `cd`, which only affects the usage block that reads it. Revert is `git revert` of the two commits; nothing here writes state, creates a resource, or changes what `apply` plans.
