### PR TITLE
feat(portal): project task results, typed evidence, and artifacts

### DIFF
--- a/admin_console/agent_runtime.py
+++ b/admin_console/agent_runtime.py
@@ -225,6 +225,56 @@ def tasks(session_id, limit):
                 (session_id, limit + 1),
             )
         ]
+        for row in rows:
+            # tasks.result predates this reader, but a rebuilt store may lack
+            # it; the typed tables ship with the worker-side recorder patch and
+            # are absent on older images. Missing sources read as empty rather
+            # than failing the whole projection.
+            try:
+                found = connection.execute(
+                    "SELECT result FROM tasks WHERE id = ?", (row["id"],)
+                ).fetchone()
+                row["result"] = (found["result"] if found else None) or ""
+            except sqlite3.OperationalError:
+                row["result"] = ""
+            try:
+                row["evidence"] = [
+                    {
+                        "type": item["type"],
+                        "status": item["status"],
+                        "apiMethod": item["api_method"],
+                        "request": json.loads(item["request_json"] or "{}"),
+                        "analysis": json.loads(item["analysis_json"] or "{}"),
+                        "executionRef": item["execution_ref"],
+                    }
+                    for item in connection.execute(
+                        """
+                        SELECT type, status, api_method, request_json,
+                               analysis_json, execution_ref
+                        FROM task_evidence WHERE task_id = ? ORDER BY id
+                        """,
+                        (row["id"],),
+                    )
+                ]
+            except (sqlite3.OperationalError, ValueError):
+                row["evidence"] = []
+            try:
+                row["artifacts"] = [
+                    {
+                        "type": item["type"],
+                        "manifest": json.loads(item["manifest_json"] or "{}"),
+                        "pairId": item["pair_id"],
+                    }
+                    for item in connection.execute(
+                        """
+                        SELECT type, manifest_json, pair_id
+                        FROM task_artifacts WHERE task_id = ? ORDER BY id
+                        """,
+                        (row["id"],),
+                    )
+                ]
+            except (sqlite3.OperationalError, ValueError):
+                row["artifacts"] = []
     return {"tasks": rows[:limit], "truncated": len(rows) > limit}
 
 
@@ -596,6 +646,9 @@ class AgentTaskUpdate:
     latest_event: str = ""
     latest_event_at: datetime | None = None
     previous_error: str = ""
+    result: str = ""
+    evidence: tuple[dict, ...] = ()
+    artifacts: tuple[dict, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -753,6 +806,13 @@ class CronSnapshot:
     jobs_truncated: bool
     executions_truncated: bool
     read_at: datetime
+
+
+def _typed_records(value: object, limit: int = 32) -> tuple[dict, ...]:
+    """Bound the typed evidence and artifact records a task may carry."""
+    if not isinstance(value, list):
+        return ()
+    return tuple(item for item in value if isinstance(item, dict))[:limit]
 
 
 def _timestamp(value: object) -> datetime:
@@ -1012,6 +1072,9 @@ class AgentRuntimeProvider:
                 latest_event=str(row.get("latest_event") or ""),
                 latest_event_at=_optional_timestamp(row.get("latest_event_at")),
                 previous_error=redact_evidence(row.get("previous_error") or ""),
+                result=redact_evidence(row.get("result") or ""),
+                evidence=_typed_records(row.get("evidence")),
+                artifacts=_typed_records(row.get("artifacts")),
             )
             for row in payload.get("tasks", [])
         )

--- a/admin_console/chat/models.py
+++ b/admin_console/chat/models.py
@@ -52,6 +52,9 @@ class TaskProjection:
     summary: str = ""
     error: str = ""
     run_count: int = 0
+    result: str = ""
+    evidence: tuple[dict[str, Any], ...] = ()
+    artifacts: tuple[dict[str, Any], ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -62,6 +65,9 @@ class TaskProjection:
             "summary": self.summary,
             "error": self.error,
             "runCount": self.run_count,
+            "result": self.result,
+            "evidence": [dict(item) for item in self.evidence],
+            "artifacts": [dict(item) for item in self.artifacts],
         }
 
 

--- a/admin_console/chat/service.py
+++ b/admin_console/chat/service.py
@@ -25,6 +25,10 @@ from admin_console.telemetry import redact_evidence
 ACTIVE_TASK_STATUSES = {"triage", "todo", "ready", "scheduled", "running", "review"}
 FAILED_TASK_STATUSES = {"blocked", "cancelled", "crashed", "failed"}
 TASK_READ_ERROR_LIMIT = 3
+# Bounds the composed terminal output: the root acknowledgment plus every
+# specialist report. Large enough for a full design report, small enough that
+# one runaway worker cannot balloon the projection every poller receives.
+FINAL_OUTPUT_LIMIT = 65536
 NONTERMINAL_INTERACTION_STATUSES = frozenset(
     {
         InteractionStatus.QUEUED,
@@ -415,6 +419,9 @@ class ChatService:
                         interaction_id,
                         frozenset({InteractionStatus.WAITING_FOR_TASKS}),
                         status=InteractionStatus.COMPLETED,
+                        output=self._compose_final_output(
+                            interaction.output, tasks
+                        ),
                     )
                     if updated is not None:
                         self.store.append_event(interaction_id, "interaction.completed")
@@ -444,9 +451,34 @@ class ChatService:
                 summary=task.summary,
                 error=task.error,
                 run_count=task.run_count,
+                result=task.result,
+                evidence=task.evidence,
+                artifacts=task.artifacts,
             )
             for task in result.tasks
         )
+
+    @staticmethod
+    def _compose_final_output(root_output: str, tasks: tuple[TaskProjection, ...]) -> str:
+        """Fold the specialists' reports into the answer the user receives.
+
+        Workers are required to close their card with a full report in
+        ``result``, and the notifier posts it to the chat thread — but the
+        interaction's terminal ``output`` used to stay frozen at the root
+        run's delegation acknowledgment, so portal callers never saw the
+        answer they asked for.
+        """
+        reports = [task.result.strip() for task in tasks if task.result.strip()]
+        if not reports:
+            return root_output
+        combined = "\n\n".join([root_output.strip(), *reports]).strip()
+        if len(combined) > FINAL_OUTPUT_LIMIT:
+            combined = (
+                combined[:FINAL_OUTPUT_LIMIT]
+                + "\n\n[Truncated: the full report exceeds the portal output "
+                "limit; the complete text is on the task record.]"
+            )
+        return combined
 
     @staticmethod
     def _merge_tool_evidence(

--- a/admin_console/tests/test_agent_runtime.py
+++ b/admin_console/tests/test_agent_runtime.py
@@ -482,6 +482,85 @@ class EmbeddedReadScriptTest(unittest.TestCase):
         self.assertFalse(exact["truncated"])
         self.assertEqual(len(overflow["tasks"]), 100)
         self.assertTrue(overflow["truncated"])
+        # The fixture predates tasks.result and the typed record tables, so
+        # every row must degrade to empty values rather than fail the read.
+        self.assertEqual(exact["tasks"][0]["result"], "")
+        self.assertEqual(exact["tasks"][0]["evidence"], [])
+        self.assertEqual(exact["tasks"][0]["artifacts"], [])
+
+    def test_tasks_carry_result_and_typed_records_when_present(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with closing(sqlite3.connect(root / "kanban.db")) as connection, connection:
+                connection.executescript(
+                    """
+                    CREATE TABLE tasks (
+                        id TEXT PRIMARY KEY, title TEXT, assignee TEXT, status TEXT,
+                        session_id TEXT, created_at REAL, started_at REAL,
+                        completed_at REAL, last_heartbeat_at REAL,
+                        last_failure_error TEXT, result TEXT
+                    );
+                    CREATE TABLE task_runs (
+                        id INTEGER PRIMARY KEY, task_id TEXT, summary TEXT, error TEXT
+                    );
+                    CREATE TABLE task_events (
+                        id INTEGER PRIMARY KEY, task_id TEXT, kind TEXT, created_at REAL
+                    );
+                    CREATE TABLE task_evidence (
+                        id INTEGER PRIMARY KEY, task_id TEXT, type TEXT,
+                        status TEXT, api_method TEXT, request_json TEXT,
+                        analysis_json TEXT, execution_ref TEXT, created_at REAL
+                    );
+                    CREATE TABLE task_artifacts (
+                        id INTEGER PRIMARY KEY, task_id TEXT, type TEXT,
+                        manifest_json TEXT, pair_id TEXT, created_at REAL
+                    );
+                    """
+                )
+                connection.execute(
+                    "INSERT INTO tasks VALUES ('task-1', 'Design', 'platform', "
+                    "'done', 'portal_session', 1, NULL, 2, NULL, '', "
+                    "'Full capacity design report.')"
+                )
+                connection.execute(
+                    "INSERT INTO task_evidence VALUES (1, 'task-1', "
+                    "'advice_service_capacity', 'completed', "
+                    "'compute.beta.AdviceService.Capacity', "
+                    "'{\"region\": \"us-central1\"}', "
+                    "'{\"availableQuantity\": 8}', 'exec-7', 3)"
+                )
+                connection.execute(
+                    "INSERT INTO task_artifacts VALUES (1, 'task-1', "
+                    "'computeclass', '{\"kind\": \"ComputeClass\"}', 'pair-1', 3)"
+                )
+
+            payload = self._run_script(root, "tasks", "portal_session", "10")
+
+        row = payload["tasks"][0]
+        self.assertEqual(row["result"], "Full capacity design report.")
+        self.assertEqual(
+            row["evidence"],
+            [
+                {
+                    "type": "advice_service_capacity",
+                    "status": "completed",
+                    "apiMethod": "compute.beta.AdviceService.Capacity",
+                    "request": {"region": "us-central1"},
+                    "analysis": {"availableQuantity": 8},
+                    "executionRef": "exec-7",
+                }
+            ],
+        )
+        self.assertEqual(
+            row["artifacts"],
+            [
+                {
+                    "type": "computeclass",
+                    "manifest": {"kind": "ComputeClass"},
+                    "pairId": "pair-1",
+                }
+            ],
+        )
 
     def test_task_detail_returns_newest_runs_and_total_count(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/admin_console/tests/test_interaction_api.py
+++ b/admin_console/tests/test_interaction_api.py
@@ -19,7 +19,7 @@ from admin_console.agent_chat import ChatRunResult, MAX_HISTORY_MESSAGES
 from admin_console.agent_runtime import AgentTaskUpdate, TaskUpdateResult
 from admin_console.api.authorization import portal_api_headers
 from admin_console.api.app import create_app
-from admin_console.chat.service import ChatService
+from admin_console.chat.service import FINAL_OUTPUT_LIMIT, ChatService
 from admin_console.chat.models import Interaction, InteractionStatus, TaskProjection
 from admin_console.chat.store import SQLiteInteractionStore
 from admin_console.clients.portal_api import PortalApiClient, PortalApiError
@@ -30,7 +30,15 @@ from admin_console.project_config import (
 )
 
 
-def task(task_id: str, status: str, *, error: str = "") -> AgentTaskUpdate:
+def task(
+    task_id: str,
+    status: str,
+    *,
+    error: str = "",
+    result: str = "",
+    evidence: tuple[dict, ...] = (),
+    artifacts: tuple[dict, ...] = (),
+) -> AgentTaskUpdate:
     now = datetime.now(UTC)
     return AgentTaskUpdate(
         task_id=task_id,
@@ -41,6 +49,9 @@ def task(task_id: str, status: str, *, error: str = "") -> AgentTaskUpdate:
         updated_at=now,
         summary="Capacity checked" if status == "done" else "",
         error=error,
+        result=result,
+        evidence=evidence,
+        artifacts=artifacts,
     )
 
 
@@ -231,6 +242,98 @@ class InteractionApiTest(unittest.TestCase):
             ],
         )
         self.assertGreaterEqual(backend.task_reads, 3)
+
+    def test_completed_interaction_output_carries_specialist_reports(self):
+        report = (
+            "Quota is separate from live capacity: 32 A100 GPUs fit the "
+            "regional quota, and Spot obtainability in us-central1-c is 0.9."
+        )
+        backend = ScriptedBackend(
+            task_snapshots=[
+                TaskUpdateResult((task("task-1", "running"),), False),
+                TaskUpdateResult((task("task-1", "done", result=report),), False),
+            ]
+        )
+        client, _ = client_for(backend)
+        interaction_id = self.start(client)
+
+        result = self.wait_for_terminal(client, interaction_id)
+
+        self.assertEqual(result["status"], "completed")
+        # The user-facing answer is the root acknowledgment plus the report,
+        # not the acknowledgment alone.
+        self.assertTrue(result["output"].startswith("The cluster is healthy."))
+        self.assertIn(report, result["output"])
+        self.assertEqual(result["tasks"][0]["result"], report)
+
+    def test_task_projection_carries_typed_evidence_and_artifacts(self):
+        evidence = (
+            {
+                "type": "advice_service_capacity",
+                "status": "completed",
+                "apiMethod": "compute.beta.AdviceService.Capacity",
+                "request": {"region": "us-central1"},
+                "analysis": {"availableQuantity": 8},
+                "executionRef": "exec-1",
+            },
+        )
+        artifacts = (
+            {
+                "type": "computeclass",
+                "manifest": {"kind": "ComputeClass", "apiVersion": "cloud.google.com/v1"},
+                "pairId": "design-1",
+            },
+        )
+        backend = ScriptedBackend(
+            task_snapshots=[
+                TaskUpdateResult(
+                    (
+                        task(
+                            "task-1",
+                            "done",
+                            evidence=evidence,
+                            artifacts=artifacts,
+                        ),
+                    ),
+                    False,
+                )
+            ]
+        )
+        client, _ = client_for(backend)
+        interaction_id = self.start(client)
+
+        result = self.wait_for_terminal(client, interaction_id)
+
+        projected = result["tasks"][0]
+        self.assertEqual(projected["evidence"], [dict(evidence[0])])
+        self.assertEqual(projected["artifacts"], [dict(artifacts[0])])
+
+    def test_tasks_without_typed_records_project_empty_lists_not_absence(self):
+        # The CUJ evaluators distinguish "the portal cannot show evidence"
+        # from "evidence was shown and is empty"; the keys must always exist.
+        backend = ScriptedBackend(
+            task_snapshots=[TaskUpdateResult((task("task-1", "done"),), False)]
+        )
+        client, _ = client_for(backend)
+        interaction_id = self.start(client)
+
+        result = self.wait_for_terminal(client, interaction_id)
+
+        projected = result["tasks"][0]
+        self.assertEqual(projected["evidence"], [])
+        self.assertEqual(projected["artifacts"], [])
+        self.assertEqual(projected["result"], "")
+
+    def test_final_output_is_bounded_with_a_visible_truncation_marker(self):
+        oversized = "capacity report line\n" * 5000
+        composed = ChatService._compose_final_output(
+            "Delegated to the platform agent.",
+            (task("task-1", "done", result=oversized),),
+        )
+        self.assertLessEqual(
+            len(composed), FINAL_OUTPUT_LIMIT + 200, "bound must hold"
+        )
+        self.assertIn("[Truncated:", composed)
 
     def test_interaction_defaults_to_canonical_agent_and_chat_profile(self):
         backend = ScriptedBackend()


### PR DESCRIPTION
## Summary

First product slice of #804: the portal now projects each delegated task's `result`, typed `evidence`, and `artifacts`, and a completed interaction's terminal `output` carries the specialists' reports instead of only the root run's delegation acknowledgment.

## Why This Change

Workers are already required to close their card with a full report in `tasks.result` (the result-required patch enforces it; the notifier posts it into the chat thread) — but portal API callers never saw it: the interaction's `output` stayed frozen at "Delegated to the platform agent…", and `TaskProjection` carried seven fields with no room for what the worker actually did. Live CUJ1 runs against a stock install reproduce this exactly: the task summary shows a completed quota/availability assessment while the terminal output holds only the acknowledgment, so every evidence-scored criterion reports `portal task projection omits evidence/artifacts`.

## What Changed

- The in-pod reader returns `tasks.result` plus typed records from the `task_evidence` and `task_artifacts` tables (schema: type, status, api_method, request_json, analysis_json, execution_ref / type, manifest_json, pair_id). All three sources degrade to empty values on stores that predate them, so older images keep projecting.
- `TaskProjection` gains `result`, `evidence`, and `artifacts`. The keys are always present: callers can tell "projected and empty" apart from "cannot be shown", which is the distinction the CUJ evaluators report on.
- On the `waiting_for_tasks → completed` transition, the terminal `output` is composed from the root output plus every non-empty task report, bounded at 64 KiB with a visible truncation marker.

The worker-side recorder that populates the typed tables (`record_evidence` / `attach_artifact` tools, loaded-skill capture, worker tool-call normalization for `toolEvidenceComplete`) is the follow-up slice.

## Testing

- `make test-python` — green across every directory, including four new interaction-API tests (report folded into terminal output; typed records projected; empty-vs-absent distinction; truncation bound) and an embedded-read-script test against a real SQLite fixture with and without the new tables.
- Legacy-store compatibility covered by the pre-existing fixture, which lacks `tasks.result` and the typed tables and now asserts the empty-value degradation.

## Risk & Rollout

Additive projection fields and an output composition that only changes interactions whose tasks carry non-empty reports. Older agent images project empty values; no schema migration; revert is a clean rollback.
