### PR TITLE
chore(bench): drop the unused L4 accelerator from the gpu-stress-test stack

### DIFF
--- a/bench/tasks/gpu-stress-test-diagnosis/task.yaml
+++ b/bench/tasks/gpu-stress-test-diagnosis/task.yaml
@@ -19,9 +19,17 @@ infrastructure:
   provider: "gcp"
   stack: "prebuilt/gpu-stress-test"
   teardown: true
+  # The task_id and the stack path are historical names, kept because
+  # hack/ci-eval-pr.sh, testgrid history and docs all reference them. No GPU
+  # is involved: the incident is seeded as Cloud Logging entries by the
+  # stack's write_synthetic_logs, no workload has ever run on this cluster
+  # (see the read-only-in-a-post-incident-task safeguard below), and
+  # "hypercomputer-agent" is a string inside a log line, not a deployment.
+  # Do not move this back to a g2-*/a2-* type: the gke module infers an
+  # accelerator from the machine family alone.
   variables:
     node_count: 1
-    machine_type: "g2-standard-4"
+    machine_type: "e2-standard-4"
 # Question 2 asks for the workload's own pod-scaling ceiling and says in as
 # many words that node-pool and cluster capacity are not the subject. Both
 # halves have to stay. It used to ask for "any cluster or workload autoscaling

--- a/bench/tf/prebuilt/gpu-stress-test/main.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/main.tf
@@ -51,6 +51,34 @@ provider "google" {
 
 provider "kind" {}
 
+# The directory name is historical and is deliberately NOT being changed:
+# hack/ci-eval-pr.sh's TASKS list, testgrid history and the task.yaml
+# `stack:` reference all point at "prebuilt/gpu-stress-test", and a rename
+# costs far more than it buys. Nothing here is GPU-backed and nothing ever
+# was in anger. The whole incident is seeded by null_resource
+# .write_synthetic_logs below as two Cloud Logging entries; the cluster runs
+# no workloads at all -- the task's own `read-only-in-a-post-incident-task`
+# safeguard asserts exactly that ("still no Deployments in the default
+# namespace"). The node hosts the GKE system pods and nothing else, so it
+# takes a plain general-purpose machine type and no accelerator.
+#
+# gpu_type / gpu_count are omitted rather than set: the module defaults
+# gpu_type to "" and the gke submodule's `enable_gpu` local is false for a
+# non-g2/non-a2 machine type, so its `dynamic "guest_accelerator"` block
+# emits nothing.
+#
+# The cluster itself cannot go away, even though nothing schedules onto it.
+# devops-bench (pinned at 4670d76 in bench/pyproject.toml) calls
+# `deployer.get_cluster_info()` unconditionally after `up()` for any
+# non-noop deployer -- evalharness/default.py -- and TFDeployer's
+# implementation reads the `cluster_name` and `cluster_location` outputs
+# below and hands them to `GCPProvider.ensure_cluster_credentials`, which
+# shells out to `gcloud container clusters get-credentials` with
+# `check=True`. A logging-only stack therefore either raises ConfigError on
+# the missing outputs or SubprocessError on credentials for a cluster that
+# does not exist; both red the task for every PR. Making this stack
+# cluster-free needs an upstream change (an opt-out for get_cluster_info),
+# not a change here.
 module "cluster" {
   source = "../../modules/cluster"
 
@@ -61,8 +89,6 @@ module "cluster" {
   machine_type    = var.machine_type
   project_id      = var.project_id
   kubeconfig_path = var.kubeconfig_path
-  gpu_type        = "l4"
-  gpu_count       = 1
 }
 
 # The task is a post-incident analysis, so the incident is seeded rather than

--- a/bench/tf/prebuilt/gpu-stress-test/variables.tf
+++ b/bench/tf/prebuilt/gpu-stress-test/variables.tf
@@ -37,10 +37,16 @@ variable "node_count" {
   default     = 1
 }
 
+# General-purpose on purpose. The node runs the GKE system pods and nothing
+# else -- the incident this stack stands up is seeded into Cloud Logging, not
+# scheduled onto the cluster -- so an accelerator machine family bought
+# nothing but cost and a stockout surface. Keep this off the g2-*/a2-*
+# families: the gke submodule infers a GPU from the machine family alone
+# (`local.is_g2`), so putting one back here re-attaches an L4 silently.
 variable "machine_type" {
   type        = string
   description = "VM instance type"
-  default     = "g2-standard-4"
+  default     = "e2-standard-4"
 }
 
 variable "project_id" {


### PR DESCRIPTION
## What this stops provisioning

`bench/tf/prebuilt/gpu-stress-test/` stood up a `g2-standard-4` node with one
`nvidia-l4` attached, for a task that has never scheduled a single pod.

| | before | after |
|---|---|---|
| machine type | `g2-standard-4` | `e2-standard-4` |
| accelerator | 1 × `nvidia-l4` | none |
| node shape | 4 vCPU / 16 GB | 4 vCPU / 16 GB |
| approx. on-demand rate | ~$0.71/hr | ~$0.13/hr |

Same CPU/memory shape, so the single node's GKE system pods schedule exactly
as they did. What goes away is the L4 line item and the dependency on L4
capacity being available in the run's zone. Provisioning time is roughly
unchanged — sampled across the 70 most recent presubmit builds the GPU node
pool created in 51 s in 14 of them, so the accelerator was costing money and
a capacity dependency, not wall-clock.

## Why removing it is safe

- The entire planted incident is the two `gcloud logging write` calls in
  `null_resource.write_synthetic_logs`: GCS FUSE buffer exhaustion, and HPA
  max-replica saturation at limit 10.
- The task prompt says in as many words that the live workload is gone and
  the investigation must come from Cloud Logging history rather than live
  cluster state.
- Both `report_contains` objectives grade the agent's report text
  (`gcs fuse`/`gcsfuse`, `HPA`/`HorizontalPodAutoscaler`). Neither reads the
  cluster.
- The only cluster-state check is the catastrophic safeguard
  `read-only-in-a-post-incident-task` — `resource_property`, `kind: deployment`,
  `namespace: default`, `op: absent`. Its own comment states the cluster runs
  no workloads by design.
- No objective references a GPU. `hypercomputer-agent` is a string inside a
  log line, not a Deployment.

## The accelerator gate was already conditional

`bench/tf/modules/cluster/gke/main.tf` guards the accelerator with

```hcl
dynamic "guest_accelerator" {
  for_each = local.enable_gpu ? [1] : []
```

and `local.enable_gpu = var.gpu_type != "" || local.is_g2 || local.is_a2`. With
`gpu_type` left at its `""` default and a machine type outside the `g2-*` /
`a2-*` families, the block emits nothing. That is a real conditional, not a
provider quirk, so the module needed no change — the stack simply stops
passing `gpu_type` / `gpu_count`.

Note the second half of that expression: **the module infers an L4 from the
machine family alone.** Putting a `g2-*` type back in `variables.tf` or the
task's `infrastructure.variables` would silently re-attach the accelerator
even with no `gpu_type` argument. Both sites carry a comment saying so.

## Names deliberately unchanged

`gpu-stress-test-diagnosis` and `prebuilt/gpu-stress-test` keep their names.
They are referenced by `hack/ci-eval-pr.sh`'s `TASKS`, by testgrid history and
by `docs/designs/domains.yaml`; a rename is a much larger blast radius than
this change earns. Comments at the stack and at the task record that the name
is historical. No prose in `bench/README.md`, `bench/CUSTOM-TASKS.md` or
`docs/` describes this stack as GPU-based, so there was nothing to correct
there.

## The abort investigation: L4 stockout is not the cause

The hypothesis was that L4 stockout (`ZONE_RESOURCE_POOL_EXHAUSTED`,
`GCE_STOCKOUT`, insufficient regional quota) was failing the deploy or burning
the 85-minute `decoration_config.timeout` into an abort. **It is not. The
hypothesis is wrong.**

Method: the 70 most recent `pull-kube-agents-smoke-test` builds from
`gs://kube-agents-prow/pr-logs/directory/pull-kube-agents-smoke-test/`
(2026-08-22 → 2026-08-25), reading `started.json`, `finished.json` and the full
`build-log.txt` for each.

Outcome mix — 68 with a parseable `finished.json`:

| result | count |
|---|---|
| SUCCESS | 17 |
| FAILURE | 28 |
| ABORTED | 23 (34%) |

The abort rate is real and matches the earlier 3-of-6 sweep. The cause is not
capacity:

1. **Zero stockout signatures.** Grepping all 70 build logs for
   `ZONE_RESOURCE_POOL_EXHAUSTED`, `STOCKOUT`, `RESOURCE_EXHAUSTED`,
   `QUOTA_EXCEEDED`, `Insufficient regional quota`,
   `does not have enough resources available` and `resource pool exhausted`
   returns **no hits at all**. Nor does any build log contain
   `RESOURCE_PREPARATION_FAILED`, the marker `hack/ci-eval-pr.sh` prints for an
   OpenTofu infrastructure failure.
2. **No abort is a timeout.** Longest aborted run was 58.2 min against an
   85-min budget. The distribution is 0.5 – 58.2 min, median ~16 min. A
   stockout burning the timeout would pile up at ~85 min; nothing is close.
3. **Every abort is Prow's own SIGINT.** All 23 end with
   `Entrypoint received interrupt: terminated` from
   `sigs.k8s.io/prow/pkg/entrypoint`, i.e. the ProwJob was cancelled, not
   failed.
4. **All 23 are explained by PR lifecycle.** 17 had a newer build on the same
   PR *start before the older one's abort* — the classic supersede-on-push. The
   other 6 line up with the PR merging or closing, to the second:

   | build | PR | abort | PR event |
   |---|---|---|---|
   | 2091932551944867840 | 692 | 17:32:54 | merged 17:32:52 |
   | 2091947471335854080 | 870 | 18:20:09 | merged 18:20:07 |
   | 2091968777250934784 | 874 | 19:27:30 | merged 19:27:28 |
   | 2091982202618253312 | 924 | 20:26:52 | closed 20:26:50 |
   | 2092241937204514816 | 879 | 14:05:11 | merged 14:00:08 |
   | 2091979099357581312 | 923 | 20:08:21 | head force-pushed, PR then closed |

5. **Aborts are not concentrated on the GPU stack.** By the stage the log was
   in when the interrupt arrived: 5 during container image build/push, 4 during
   chart deploy or `platform-agent` rollout/port-forward, 2 during `go mod`
   download, 2 during deepeval scoring, 3 already in CI teardown, 1 unclassified
   — and 6 inside a tofu run. Of those 6, **three** were creating the GKE
   *control plane* (`google_container_cluster.primary: Still creating` at 40 s,
   2 m 0 s and 3 m 0 s elapsed — no node pool, no accelerator involved yet) and
   **three** were in `destroy` during teardown. **Not one abort landed during
   GPU node-pool creation, and not one carried a capacity error.**

**Conclusion: this PR is a cost and blast-radius win only. It fixes no aborts,
because there were no stockout aborts to fix.** The aborts are Prow correctly
cancelling superseded and merged-out runs; on that reading a 34% abort rate on
a job this slow (median ~19 min, up to 58) is expected behaviour for an active
repo rather than a defect. If the abort rate is nonetheless considered a
problem, the lever is job duration and `max_concurrency`, not capacity. **The
"unexplained abort" question is closed, not open — but nothing here was the
cause.**

## A logging-only stack is not currently possible

Worth recording, since it is the obvious next question: this stack cannot drop
the GKE cluster and keep only the two `gcloud logging write` calls, not on the
pinned harness.

`devops_bench/evalharness/default.py` calls `deployer.get_cluster_info()`
unconditionally right after `deployer.up()` for any non-`noop` deployer.
`TFDeployer.get_cluster_info()` reads the stack's `cluster_name` and
`cluster_location` outputs (raising `ConfigError` if either is missing) and
hands them to `GCPProvider.ensure_cluster_credentials()`, which shells out to
`gcloud container clusters get-credentials` via a `run(..., check=True)` helper
that raises `SubprocessError` on a non-zero exit. A cluster-free stack
therefore fails either on the missing outputs or on credentials for a cluster
that does not exist — reddening the task on every PR in the repo. This is
visible in any green build log: `kubeconfig entry generated for
eval-pr<N>-<build-id>` immediately after the apply.

`deployer: noop` is the only supported no-cluster path and it skips OpenTofu
entirely, so the synthetic log entries would never be written. Making this
stack logging-only needs an opt-out for `get_cluster_info` in
kubernetes-sigs/devops-bench (pinned at `4670d76` in `bench/pyproject.toml`),
not a change in this repo. That also means the
`read-only-in-a-post-incident-task` safeguard keeps working unchanged here: the
`get-credentials` call above leaves the ambient kubeconfig pointing at this
run's own eval cluster, which is exactly what the safeguard should read.

## Verification

- `tofu init -backend=false && tofu validate` on the stack: `Success! The configuration is valid.`
- `tofu fmt -check -recursive bench/tf/`: clean.
- `make test-python`: OK.
- `make test-bench` (uv fallback): 191 passed.
- `make docs-check`: all checks pass; context budget 35.7k / 38,000 chars.
- prettier 3.9.6 `--check` on the changed YAML: clean. (19 pre-existing
  warnings under `.agents/`, untouched by this PR.)
- No `tofu apply`, `plan` against credentials, or `destroy` was run. All cloud
  access for the investigation was read-only `gcloud storage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
