### PR TITLE
ci(eval): profile the eval presubmit's steps and each devops-bench phase

### DIFF
--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -13,15 +13,187 @@
 
 set -euo pipefail
 
+# ─── Step timing profiler ────────────────────────────────────────────────────
+# Contiguous named spans: each profile_begin closes the previous span and opens
+# the next, so the report's percentages always sum to 100% of the wall clock
+# between script start and the report. python3 is already a hard dependency of
+# the gate below, so it is what supplies millisecond epochs.
+PROFILE_ROWS=()
+PROFILE_CURRENT=""
+_now_ms() { python3 -c 'import time; print(int(time.time() * 1000))'; }
+PROFILE_T0="$(_now_ms)"
+PROFILE_LAST="${PROFILE_T0}"
+
+profile_begin() {
+  local now
+  now="$(_now_ms)"
+  if [ -n "${PROFILE_CURRENT}" ]; then
+    PROFILE_ROWS+=("${PROFILE_CURRENT}|$((PROFILE_LAST - PROFILE_T0))|$((now - PROFILE_LAST))")
+  fi
+  PROFILE_CURRENT="$1"
+  PROFILE_LAST="${now}"
+  echo "--- [PROFILE $(date -u +'%Y-%m-%dT%H:%M:%SZ')] step: $1 ---"
+}
+
+profile_report() {
+  local exit_code="$1" now
+  now="$(_now_ms)"
+  if [ -n "${PROFILE_CURRENT}" ]; then
+    PROFILE_ROWS+=("${PROFILE_CURRENT}|$((PROFILE_LAST - PROFILE_T0))|$((now - PROFILE_LAST))")
+    PROFILE_CURRENT=""
+  fi
+  PROFILE_DATA="$(printf '%s\n' ${PROFILE_ROWS[@]+"${PROFILE_ROWS[@]}"})" \
+  PROFILE_EXIT_CODE="${exit_code}" python3 <<'PY' || true
+import os
+
+rows = []
+for line in os.environ.get("PROFILE_DATA", "").splitlines():
+    if not line.strip():
+        continue
+    name, start_ms, dur_ms = line.rsplit("|", 2)
+    rows.append((name, int(start_ms), int(dur_ms)))
+total = sum(d for _, _, d in rows)
+print(f"\n=== Step timing profile (exit code {os.environ['PROFILE_EXIT_CODE']}) ===")
+if not rows or total <= 0:
+    print("no profiled spans recorded")
+else:
+    # Largest-remainder rounding in tenths of a percent, so the printed
+    # column sums to exactly 100.0 instead of drifting with row count.
+    tenths, rems = [], []
+    for _, _, d in rows:
+        q, r = divmod(d * 1000, total)
+        tenths.append(q)
+        rems.append(r)
+    for i in sorted(range(len(rows)), key=lambda i: rems[i], reverse=True)[: 1000 - sum(tenths)]:
+        tenths[i] += 1
+    print(f"{'start(s)':>10} {'dur(s)':>10} {'%':>7}  step")
+    for (name, start_ms, dur_ms), t in zip(rows, tenths):
+        print(f"{start_ms / 1000:10.1f} {dur_ms / 1000:10.1f} {t / 10:6.1f}%  {name}")
+    print(f"{'':>10} {total / 1000:10.1f} {'100.0':>6}%  TOTAL")
+PY
+}
+
+# Prefix every line flowing through with "[TS <epoch.ms>]". devops-bench's own
+# logger is never configured by its CLI (NullHandler swallows the INFO phase
+# lines), so the wrapper stamps wall-clock time onto the subprocess's output
+# itself and the phase analyzer below keys on content markers instead.
+_ts_lines() {
+  python3 -u -c 'import sys, time
+for line in iter(sys.stdin.readline, ""):
+    sys.stdout.write("[TS %.3f] " % time.time() + line)
+    sys.stdout.flush()'
+}
+
+# Per-task deep dive: split one devops-bench invocation into phases using the
+# [TS ...] stamps and the phase-boundary text the run actually prints (tofu
+# apply/destroy, the first DeepEval judge banner), plus the agent latency the
+# results.json record carries. Informational — the top-level profile table is
+# the one whose steps sum to 100% of the script's span; this table sums to
+# 100% of the single task's devops-bench run.
+analyze_eval_phases() {
+  EVAL_PHASE_LOG="$1" EVAL_PHASE_START_MS="$2" EVAL_PHASE_END_MS="$3" \
+  EVAL_PHASE_TASK="$4" EVAL_PHASE_RESULT="${5:-}" python3 <<'PY' || true
+import json
+import os
+import re
+
+log = os.environ["EVAL_PHASE_LOG"]
+start = int(os.environ["EVAL_PHASE_START_MS"]) / 1000.0
+end = int(os.environ["EVAL_PHASE_END_MS"]) / 1000.0
+task = os.environ["EVAL_PHASE_TASK"]
+result = os.environ.get("EVAL_PHASE_RESULT", "")
+
+latency = None
+if result and os.path.exists(result):
+    try:
+        data = json.load(open(result))
+        rec = data[0] if isinstance(data, list) else data
+        latency = float(rec.get("latency") or 0) or None
+    except Exception:
+        pass
+
+# Ordered phase-opening markers; a match is only accepted at or after the
+# last matched position, so a stray earlier occurrence cannot reorder phases.
+# Markers absent from a run (noop deployer, crash) collapse their phase into
+# the neighbour's.
+MARKERS = [
+    ("Initializing the backend", "provision (tofu init + apply)"),
+    ("Apply complete!", "scenario setup + agent execution"),
+    (": Destroying...", "teardown (tofu destroy)"),
+    ("You're running DeepEval", "scoring (LLM judge) + persist"),
+]
+ts_re = re.compile(r"^\[TS (\d+(?:\.\d+)?)\] (.*)$")
+found = []
+idx = 0
+try:
+    with open(log, errors="replace") as fh:
+        for line in fh:
+            if idx >= len(MARKERS):
+                break
+            m = ts_re.match(line)
+            if not m:
+                continue
+            t, content = float(m.group(1)), m.group(2)
+            for j in range(idx, len(MARKERS)):
+                if MARKERS[j][0] in content:
+                    found.append((MARKERS[j][1], min(max(t, start), end)))
+                    idx = j + 1
+                    break
+except OSError as exc:
+    print(f"    phase breakdown unavailable: {exc}")
+    raise SystemExit(0)
+
+# The agent's own span is recorded, not logged: results.json carries its
+# latency. With infrastructure, anchor it forward from "Apply complete!" and
+# split what follows into the drain; without (noop deployer), work backward
+# from where scoring begins — the agent runs immediately before it.
+labels = [label for label, _ in found]
+if latency:
+    if "scenario setup + agent execution" in labels:
+        i = labels.index("scenario setup + agent execution")
+        nxt = found[i + 1][1] if i + 1 < len(found) else end
+        cut = min(found[i][1] + latency, nxt)
+        if cut < nxt:
+            found.insert(i + 1, ("post-agent drain (verify/metrics, record)", cut))
+    elif "scoring (LLM judge) + persist" in labels:
+        i = labels.index("scoring (LLM judge) + persist")
+        found.insert(i, ("agent execution", max(found[i][1] - latency, start)))
+
+print(f"    ── devops-bench phase breakdown for {task} ──")
+if not found:
+    print("    no phase markers found in the log; cannot split the run")
+else:
+    bounds = [("harness startup (uv sync, imports, task load)", start)] + found + [("(end)", end)]
+    total = max(end - start, 1e-9)
+    for (label, t0), (_, t1) in zip(bounds, bounds[1:]):
+        d = max(t1 - t0, 0.0)
+        print(f"    {d:9.1f}s {100 * d / total:6.1f}%  {label}")
+    print(f"    {total:9.1f}s  100.0%  total devops-bench run")
+    if latency:
+        print(f"    (agent latency from results.json: {latency:.1f}s)")
+PY
+}
+
 # 1. Target Cluster Context
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+profile_begin "bootstrap: source ci-env.sh"
 source "${SCRIPT_DIR}/ci-env.sh"
-trap dump_prow_artifacts_on_failure EXIT
+
+# Print the profile on every exit — success, gate failure, or a set -e death —
+# then hand the original exit code to the artifact dumper ci-env.sh provides.
+profile_and_dump_on_exit() {
+  local exit_code=$?
+  profile_report "${exit_code}"
+  (exit "${exit_code}")
+  dump_prow_artifacts_on_failure
+}
+trap profile_and_dump_on_exit EXIT
 
 START_TIME=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
 
 # 2. Cluster Auth
+profile_begin "cluster-auth: gcloud get-credentials"
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Authenticating to GKE Cluster ==="
 gke_dns_endpoint_flag "$HOST_CLUSTER_NAME" "$REGION" "$PROJECT_ID"
@@ -64,6 +236,7 @@ echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 # environmental failure -- no fleet in this project, a cluster that will not
 # answer, a fixture that was never planted -- returns 0 with a warning of its
 # own and leaves the affected roles' files absent, which is the whole design.
+profile_begin "fleet-kubeconfigs: seeded-fleet credentials"
 STEP_START=$SECONDS
 # shellcheck source=hack/fleet-kubeconfigs.sh
 source "${SCRIPT_DIR}/fleet-kubeconfigs.sh"
@@ -71,6 +244,7 @@ write_fleet_kubeconfigs || echo "WARNING: the seeded-fleet catalog or output dir
 echo "✓ Seeded-fleet credentials finished in $((SECONDS - STEP_START))s"
 
 # 3. Agent & Harness Configuration
+profile_begin "config: env, platform-agent token fetch, prereqs"
 # Configures devops-bench runner to target deployed platform-agent service
 export BENCH_AGENT_TYPE="cli"
 export AGENT_TARGET="kubeagents"
@@ -274,6 +448,7 @@ INFRA_FAILED_TASKS=()
 
 for TASK in "${TASKS[@]}"; do
   TASK_NAME="$(basename "$(dirname "${TASK}")")"
+  profile_begin "task ${TASK_NAME}: devops-bench run"
   TASK_START=$SECONDS
   echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running Task: ${TASK_NAME} (${TASK}) <<<"
 
@@ -293,7 +468,11 @@ for TASK in "${TASKS[@]}"; do
   PRE_RUNS="$(ls -d "${BENCH_DIR}/results/run_"* 2>/dev/null | sort || true)"
   EVAL_LOG="/tmp/eval_${TASK_NAME}.log"
 
-  (cd "${BENCH_DIR}" && uv run devops-bench "${TASK}" --agent-type kubeagents 2>&1 | tee "${EVAL_LOG}") || true
+  RUN_START_MS="$(_now_ms)"
+  (cd "${BENCH_DIR}" && uv run devops-bench "${TASK}" --agent-type kubeagents 2>&1 | _ts_lines | tee "${EVAL_LOG}") || true
+  RUN_END_MS="$(_now_ms)"
+
+  profile_begin "task ${TASK_NAME}: classify + gate"
 
   # Use set difference (comm -13) to isolate the brand new directory created strictly by THIS task run.
   # If devops-bench crashed before or during execution without completing results.json, NEW_RUN_DIR will be empty.
@@ -301,6 +480,8 @@ for TASK in "${TASKS[@]}"; do
   NEW_RUN_DIR="$(comm -13 <(echo "${PRE_RUNS}") <(echo "${POST_RUNS}") | head -n 1)"
   LATEST_RESULT=""
   [ -n "${NEW_RUN_DIR}" ] && LATEST_RESULT="${NEW_RUN_DIR}/results.json"
+
+  analyze_eval_phases "${EVAL_LOG}" "${RUN_START_MS}" "${RUN_END_MS}" "${TASK_NAME}" "${LATEST_RESULT}"
 
   # Classify the run. Three outcomes, because they route differently:
   #   INFRA  -- devops-bench died before evaluating anything, on a task that
@@ -469,6 +650,7 @@ else:
   fi
 done
 
+profile_begin "final gate + summary"
 TOTAL_DURATION=$((SECONDS - START_TIME))
 if [ "${#INFRA_FAILED_TASKS[@]}" -gt 0 ]; then
   echo "⚠️ [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Infrastructure failed for tasks (not counted against the PR): ${INFRA_FAILED_TASKS[*]}"


### PR DESCRIPTION
## Summary

Instruments `hack/ci-eval-pr.sh` — the Prow eval presubmit — with timing observability. A step profiler prints a table on every exit (success, gate failure, or a `set -e` death) whose contiguous named spans sum to exactly 100% of the script's wall clock, and each `devops-bench` invocation is additionally split into its internal phases (harness startup, tofu provision, agent execution, verify drain, teardown, judge scoring). Observability only: gate logic, run classification, and exit codes are unchanged.

This PR was generated with the help of Claude.

## Why This Change

The presubmit prints one total duration, so where the ~55 minutes go is invisible from the Prow log. A profiled run shows the answer is lopsided: agent execution is ~73% of the whole job and GKE provision+teardown ~25% of the infra task, while everything the script itself does (auth, config, classification, gating) is under 0.2%. Optimizing the job needs these numbers per run, not reconstructed after the fact from GKE operation timestamps.

## What Changed

- `profile_begin`/`profile_report`: contiguous spans (each mark closes the previous span), largest-remainder rounding so the printed percentages sum to exactly 100.0. The report prints from the EXIT trap, which then chains to the existing `dump_prow_artifacts_on_failure` with the original exit code preserved.
- `_ts_lines`: stamps `[TS <epoch>]` onto every line of devops-bench output. The pinned devops-bench CLI never configures its package logger (a NullHandler swallows its INFO phase lines), so the wrapper supplies the timestamps its output lacks. Eval-log artifacts now carry these prefixes.
- `analyze_eval_phases`: splits one run at boundary text the run actually prints (`Initializing the backend`, `Apply complete!`, `: Destroying...`, the first DeepEval banner), ordered-match so a stray earlier occurrence cannot reorder phases, with the agent's span anchored by the `latency` field the `results.json` record already carries (forward from apply for tofu tasks, backward from scoring for noop tasks).
- Every existing step gets a span, including the recently added seeded-fleet credentials step (2b).

## Context

- Overlaps (merge-conflict warning, not competing work): #925 rewrites the verdict logic in this same file; #939/#944/#844 also touch `hack/ci-eval-pr.sh`/`ci-env.sh` for fleet and teardown concerns. None adds timing instrumentation.
- Follow-up issues filed from the first profiled run's numbers: #948 (agent execution is ~73% of the job) and #949 (GKE provision+teardown ~830s, ~470s of it serial teardown ahead of scoring).

## Testing

- `bash -n` on the script.
- `make docs-check` clean (generated regions, links, terminology, doc map, context budget).
- The profiler and analyzer were exercised standalone against synthetic inputs: a tofu-path log (provision/agent/drain/teardown/scoring all present) and a noop-path log (backward-anchored agent span), plus an empty-marker log (degrades to "no phase markers found").

### Live validation

Install: `platform-agent-host` (GKE, `us-central1`, project `haoxuw-gke-dev`), namespace `kubeagents-system`, operator and agent as deployed 2026-08-25 (11-day-old install, chart-managed). Ran the full script locally against it (`PROJECT_ID=haoxuw-gke-dev REGION=us-central1 ./hack/ci-eval-pr.sh`), which provisioned and tore down eval cluster `eval-pr0-haoxuw` (g2-standard-4, `us-west4-a`) for real:

- Total 3270.2s, profile printed on the exit-1 path (the gpu task legitimately failed the deterministic gate at `VerificationCorrectness=0.0` — an eval outcome, not a defect of this change — which proves the report fires on failure, the case that matters in CI):

```
=== Step timing profile (exit code 1) ===
  start(s)     dur(s)       %  step
       0.0        0.0    0.0%  bootstrap: source ci-env.sh
       0.1        2.4    0.1%  cluster-auth: gcloud get-credentials
       2.5        0.6    0.0%  config: env, platform-agent token fetch, prereqs
       3.1     2704.2   82.7%  task gpu-stress-test-diagnosis: devops-bench run
    2707.3        0.2    0.0%  task gpu-stress-test-diagnosis: classify + gate
    2707.5      562.5   17.2%  task agent-kanban-smoke: devops-bench run
    3270.0        0.2    0.0%  task agent-kanban-smoke: classify + gate
    3270.2        0.0    0.0%  final gate + summary
               3270.2  100.0%  TOTAL
```

- The phase markers the analyzer keys on were taken from that run's real eval log (`Apply complete!` at its line 403, `Destroy complete!` at 1173, first DeepEval banner at 1174), and the reconstructed phases agree with the GKE operation timestamps (`CREATE_CLUSTER` 14:07:33–14:11:19, destroy ops 14:44:14–14:52:02) and the recorded agent latencies (1829.4s gpu, 559.5s kanban).

Not covered, and why: the live run used the pre-rebase revision of this branch — its top-level profiler is byte-identical, but the `[TS]` stamping, the marker-based analyzer, and the span for the new seeded-fleet step (which landed on `main` after the run) have only the synthetic-log validation above, not a second 55-minute paid GKE run. The seeded-fleet step itself was a no-op in this project (no fleet applied). Cleanup: the eval cluster and its node service account were destroyed by the run's own teardown (verified via `gcloud container clusters list`); one "devops-bench smoke probe" kanban card was created on the platform agent by the smoke task itself.

## Self-Review

- Mechanical gate: `make docs-check` clean.
- `review-docs-drift`: ran in a subagent handed only the diff range. No Blocking, no Advisory findings. It verified every page stating a fact about this script (`bench/README.md`, `bench/tasks/DRAFTS.md`, `bench/CUSTOM-TASKS.md`, `bench/tf/fleet/README.md`, `docs/README.md` map row) still holds at HEAD, ran `scripts/test_task_registration.py` against the modified file (4 tests OK), and grepped all docs for anchors on eval-log line content that the `[TS]` prefixes could break — none exist.
- `review-adversarial`: launched in a subagent handed only the diff range, and stopped by a human before it reported. **No adversarial pass completed against this branch** — this section claims no more than that, and a `/review` pass from the bot is the next hostile read this diff gets.

## Risk & Rollout

Presubmit-only shell script; no runtime code paths, charts, or operator behavior touched. New failure modes are confined to observability: the timestamper and analyzer run inside the existing `(... ) || true` / `|| true` guards, so their failure degrades to missing tables, not a red job; eval-log artifacts now carry `[TS]` prefixes, which nothing in-tree parses (checked by the docs-drift pass). Revert = revert the one commit.
