### PR TITLE
feat(security): stop sharing a process namespace and a user between the sandbox and the credential proxy

### DIFF
--- a/.github/workflows/agent-startup-test.yml
+++ b/.github/workflows/agent-startup-test.yml
@@ -51,6 +51,12 @@ jobs:
               # plugin-linking logic, reached from the other direction.
               - "agents/platform/scripts/profile_scaffold.py"
               - "agents/platform/scripts/cluster_agent_profile.py"
+              # The startup path a replicas > 1 Pod takes instead of the
+              # entrypoint: the operator gives the sandbox a `command`, so this
+              # script starts Hermes and owns the umask that keeps the shared
+              # PVC writable from the credential sidecar. test_startup_umask.py
+              # asserts that; it has to run when the file it asserts on changes.
+              - "k8s-operator/internal/controller/leader_elect.py"
               - "tests/test_*.py"
               # tests/test_operator_makefile.py asserts on the recipes this
               # Makefile prints; a Makefile-only change must run it or the

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -2069,7 +2069,18 @@ def serve(args: argparse.Namespace) -> None:
         socket_path = Path(args.unix_socket)
         socket_path.parent.mkdir(parents=True, exist_ok=True)
         socket_path.unlink(missing_ok=True)
-        server = ThreadingUnixHTTPServer(str(socket_path), CredentialProxyHandler)
+        # Nothing behind this socket authenticates its callers: reaching it is
+        # reaching the credentials, past Envoy and past the whole command policy.
+        # The mount keeps it in this container, and the mode is the second lock —
+        # 0600, so it stays connectable only by this container's own user however
+        # wide the sidecar's umask is set for the shared workspace. Applied as a
+        # umask rather than a chmod after the fact so there is no window in which
+        # the bound socket is more permissive than this.
+        previous_umask = os.umask(0o177)
+        try:
+            server = ThreadingUnixHTTPServer(str(socket_path), CredentialProxyHandler)
+        finally:
+            os.umask(previous_umask)
         LOGGER.info("credential proxy listening on unix socket %s", socket_path)
     else:
         server = ThreadingHTTPServer((args.host, args.port), CredentialProxyHandler)

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -2073,7 +2073,6 @@ class ReadOnlyOverTheSocketTest(unittest.TestCase):
         self.assertEqual([], self.executed)
 
 
- 
 class BackendSocketModeTest(unittest.TestCase):
     """The backend socket must not inherit a permissive umask.
 
@@ -2157,6 +2156,7 @@ class BackendSocketModeTest(unittest.TestCase):
             self.assertEqual(0o000, left_behind, "serve did not restore the process umask")
             mode = socket_path.stat().st_mode & 0o777
             self.assertEqual(0o600, mode, f"backend socket mode is {mode:04o}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/agents/platform/scripts/test_credential_proxy.py
+++ b/agents/platform/scripts/test_credential_proxy.py
@@ -2073,5 +2073,90 @@ class ReadOnlyOverTheSocketTest(unittest.TestCase):
         self.assertEqual([], self.executed)
 
 
+ 
+class BackendSocketModeTest(unittest.TestCase):
+    """The backend socket must not inherit a permissive umask.
+
+    Nothing behind this socket authenticates its callers, so its mode is the
+    second lock after the mount. The sidecar's entrypoint now sets `umask 0002`
+    so that proxied commands leave group-writable files on the workspace the
+    agent shares — and a group-writable *socket* is a connectable socket for
+    anyone in the agent's group. `serve` therefore has to set the mode itself
+    rather than take whatever the process umask happens to be, which is what
+    this asserts by binding under the widest umask there is.
+    """
+
+    class _Stop(Exception):
+        pass
+
+    def setUp(self):
+        # `serve` assigns these on the class; put them back for whatever runs
+        # next. Some are bare annotations until something sets them, so an
+        # unset one has to be unset again rather than restored.
+        for attribute in ("policy", "executor", "enforce_read_only", "max_request_bytes"):
+            self.addCleanup(
+                self._restore,
+                attribute,
+                attribute in CredentialProxyHandler.__dict__,
+                CredentialProxyHandler.__dict__.get(attribute),
+            )
+
+    @staticmethod
+    def _restore(attribute, was_set, original):
+        if was_set:
+            setattr(CredentialProxyHandler, attribute, original)
+        elif attribute in CredentialProxyHandler.__dict__:
+            delattr(CredentialProxyHandler, attribute)
+
+    def test_the_backend_socket_is_not_group_or_world_connectable(self):
+        owner = self
+        bound = []
+
+        def stop(server):
+            bound.append(server)
+            raise owner._Stop
+
+        class FakeThread:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+        with tempfile.TemporaryDirectory() as tmp:
+            policy_path = Path(tmp) / "policy.json"
+            policy_path.write_text(json.dumps({"rules": []}), encoding="utf-8")
+            socket_path = Path(tmp) / "backend.sock"
+            args = types.SimpleNamespace(
+                policy=str(policy_path),
+                host="127.0.0.1",
+                port=0,
+                unix_socket=str(socket_path),
+                timeout_seconds=5,
+                max_request_bytes=1 << 20,
+                max_output_bytes=1 << 20,
+                state_dir=str(Path(tmp) / "state"),
+            )
+            previous_umask = os.umask(0o000)
+            try:
+                with mock.patch.dict(os.environ, {"API_SERVER_EXTERNAL_KEY": "external"}, clear=True), \
+                        mock.patch.object(credential_proxy, "ThreadingHTTPServer", mock.MagicMock()), \
+                        mock.patch.object(credential_proxy.threading, "Thread", FakeThread), \
+                        mock.patch.object(credential_proxy.ThreadingUnixHTTPServer, "serve_forever", stop):
+                    with self.assertRaises(self._Stop):
+                        credential_proxy.serve(args)
+                # Read back before the outer restore: the process umask has to be
+                # the one it started with, because the same process goes on to run
+                # proxied commands that must leave group-writable files behind.
+                left_behind = os.umask(0o000)
+            finally:
+                os.umask(previous_umask)
+                for server in bound:
+                    server.server_close()
+
+            self.assertEqual(0o000, left_behind, "serve did not restore the process umask")
+            mode = socket_path.stat().st_mode & 0o777
+            self.assertEqual(0o600, mode, f"backend socket mode is {mode:04o}")
+
 if __name__ == "__main__":
     unittest.main()

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1411,9 +1411,18 @@ USER root
 # gcloud, gh and git all do one; give the UID a name here rather than debug it
 # later. The group stays hermes (GID 10000): both containers mount the agent PVC
 # and each has to be able to write what the other created there.
+#
+# The chmod is the other half of the same split. `agent-base` creates
+# /opt/defaults mode 0700, and only the `platform` stage normalises it to 0755 — a stage
+# this image no longer builds from. UID 10001 therefore cannot traverse into
+# /opt/defaults/scripts, where start-services runs credential_proxy.py from, and
+# the container dies with `Permission denied` on its own entrypoint. Nothing
+# secret lives there: it is the same defaults tree the sandbox image ships
+# world-readable.
 RUN getent group 10000 >/dev/null || groupadd --gid 10000 hermes; \
     useradd --no-log-init --no-create-home --uid 10001 --gid 10000 \
-      --home-dir /tmp/credential-proxy --shell /usr/sbin/nologin credential-proxy
+      --home-dir /tmp/credential-proxy --shell /usr/sbin/nologin credential-proxy; \
+    chmod 0755 /opt/defaults
 
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1405,25 +1405,6 @@ FROM agent-base AS proxy-tools
 
 USER root
 
-# The Pod runs this container as UID 10001 — not the sandbox's 10000 — so the two
-# containers do not share a user (see the UID constants in the operator's
-# platformagent_manifests.go). An unknown UID is a passwd lookup that fails, and
-# gcloud, gh and git all do one; give the UID a name here rather than debug it
-# later. The group stays hermes (GID 10000): both containers mount the agent PVC
-# and each has to be able to write what the other created there.
-#
-# The chmod is the other half of the same split. `agent-base` creates
-# /opt/defaults mode 0700, and only the `platform` stage normalises it to 0755 — a stage
-# this image no longer builds from. UID 10001 therefore cannot traverse into
-# /opt/defaults/scripts, where start-services runs credential_proxy.py from, and
-# the container dies with `Permission denied` on its own entrypoint. Nothing
-# secret lives there: it is the same defaults tree the sandbox image ships
-# world-readable.
-RUN getent group 10000 >/dev/null || groupadd --gid 10000 hermes; \
-    useradd --no-log-init --no-create-home --uid 10001 --gid 10000 \
-      --home-dir /tmp/credential-proxy --shell /usr/sbin/nologin credential-proxy; \
-    chmod 0755 /opt/defaults
-
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -1437,6 +1418,29 @@ RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dear
     rm -f /tmp/gh.deb && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /etc/envoy
+
+# The Pod runs this container as UID 10001 — not the sandbox's 10000 — so the two
+# containers do not share a user (see the UID constants in the operator's
+# platformagent_manifests.go). An unknown UID is a passwd lookup that fails, and
+# gcloud, gh and git all do one; give the UID a name here rather than debug it
+# later. The group stays hermes (GID 10000): both containers mount the agent PVC
+# and each has to be able to write what the other created there.
+#
+# The chmod is the other half of the same split. `agent-base` creates
+# /opt/defaults mode 0700, and only the `platform` stage normalises the tree —
+# a stage this image no longer builds from. UID 10001 therefore cannot traverse
+# into /opt/defaults/scripts, where start-services runs credential_proxy.py
+# from, and the container dies with `Permission denied` on its own entrypoint.
+# 0750 rather than 0755: the directory is hermes:hermes and every process in
+# this image is in that group, so the group bit is the whole fix and `other`
+# needs nothing.
+#
+# Below the install, not above it, per the ordering note on this stage: the apt
+# layer is the expensive one and belongs first.
+RUN getent group 10000 >/dev/null || groupadd --gid 10000 hermes; \
+    useradd --no-log-init --no-create-home --uid 10001 --gid 10000 \
+      --home-dir /tmp/credential-proxy --shell /usr/sbin/nologin credential-proxy; \
+    chmod 0750 /opt/defaults
 
 COPY --from=envoy-bin --chmod=0755 /usr/local/bin/envoy /usr/local/bin/envoy
 COPY --chmod=0644 deploy/shared/envoy-credential-proxy.yaml /etc/envoy/envoy-credential-proxy.yaml

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1405,6 +1405,16 @@ FROM agent-base AS proxy-tools
 
 USER root
 
+# The Pod runs this container as UID 10001 — not the sandbox's 10000 — so the two
+# containers do not share a user (see the UID constants in the operator's
+# platformagent_manifests.go). An unknown UID is a passwd lookup that fails, and
+# gcloud, gh and git all do one; give the UID a name here rather than debug it
+# later. The group stays hermes (GID 10000): both containers mount the agent PVC
+# and each has to be able to write what the other created there.
+RUN getent group 10000 >/dev/null || groupadd --gid 10000 hermes; \
+    useradd --no-log-init --no-create-home --uid 10001 --gid 10000 \
+      --home-dir /tmp/credential-proxy --shell /usr/sbin/nologin credential-proxy
+
 RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor --yes -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
     apt-get update && apt-get install -y --no-install-recommends \

--- a/deploy/docker/patches/kanban_scheduling.py
+++ b/deploy/docker/patches/kanban_scheduling.py
@@ -173,12 +173,16 @@ name while every process that made those claims is gone. The new process
 therefore matches ``host_prefix`` against claims made by its *predecessor* and
 runs ``os.kill(pid, 0)`` against PIDs it never issued.
 
-(The pod runs with ``shareProcessNamespace: true``, so the PID *namespace* is the
-pod's and does outlive the container — which is why the replacement dispatcher
-came up as PID 12329 rather than reusing 4. That makes a false *positive* on
-``os.kill(pid, 0)`` less likely than it would be with a fresh namespace, but it
-does not make the adjudication correct: the predecessor's workers are dead, and
-attributing their deaths to the cards is exactly the bug below.)
+(The pod used to run with ``shareProcessNamespace: true``, so the PID *namespace*
+outlived the container — which is why the replacement dispatcher in the incident
+below came up as PID 12329 rather than reusing 4. **That is no longer true.** The
+operator stopped setting the field, because a shared namespace put the credential
+sidecar's ``/proc/<pid>/environ`` inside a directory the sandbox could read; each
+container now gets a PID namespace that is torn down with it. So a restart starts
+counting from 1 again, and a predecessor's recorded PID — 4, in the transcript
+below — is a number the new namespace hands out almost immediately. The
+adjudication was never correct either way; what changed is which way it now goes
+wrong. See ``release_dead_foreign_claims`` for the consequence.)
 
 What that cost us on 2026-08-07
 -------------------------------
@@ -709,6 +713,14 @@ def release_dead_foreign_claims(
     Must be called inside an open write transaction. The ``chargeable`` half of
     the result is what the caller owes to ``charge_reclaimed_cards`` once that
     transaction has closed.
+
+    **A PID collision is more likely than it used to be**, for the reason in the
+    module docstring: the pod no longer shares a process namespace, so a restart
+    hands out PIDs from 1 and a stale claim recording PID 4 will often name a
+    process that is very much alive. ``pid_alive(pid)`` then holds the card
+    rather than reclaiming it, and the TTL is what eventually frees it. That is
+    the fail-safe direction — a card comes back late instead of being taken from
+    something still working on it — but "late" is the TTL, not seconds.
     """
     if process_start is None:
         process_start = process_start_time()

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+# The credential sidecar runs as a different user (see the UID constants in the
+# operator's platformagent_manifests.go) and executes the proxied gcloud, git and
+# gh commands against this container's workspace on the shared PVC. It reaches
+# those files through the shared fsGroup, which only helps if what we create is
+# group-writable: a leased GitOps directory this container makes has to be a
+# directory the sidecar can clone into, and a profile home it makes has to be one
+# the sidecar can write a kubeconfig pin into. The kubelet's fsGroup pass fixes up
+# files that already exist at mount time; this fixes up the ones created after.
+umask 0002
+
 export TARGET_DIR="${PLATFORM_AGENT_HOME:-/opt/data}"
 export HERMES_HOME="$TARGET_DIR"
 export INSTALL_DIR="/opt/hermes"

--- a/deploy/shared/start-services.sh
+++ b/deploy/shared/start-services.sh
@@ -19,6 +19,15 @@
 # emergency stop for an event storm. See event_watcher_disabled below.
 set -euo pipefail
 
+# The sandbox runs as a different user (see the UID constants in the operator's
+# platformagent_manifests.go) and shares only the agent PVC with this container.
+# Proxied commands run here but write there — a clone, a commit, a kubeconfig pin
+# in a profile home — and the sandbox has to be able to change what they leave
+# behind. The shared fsGroup gives it the group; this gives the group write.
+# Credential state lives on this container's own emptyDir volumes, which nothing
+# else mounts, so the wider mode does not widen who can read a credential.
+umask 0002
+
 # Watcher restart policy. The watcher is retried in place rather than being
 # allowed to end the container, so these bound how hard a permanently broken
 # one is retried and how long it must survive to count as recovered.

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -381,6 +381,16 @@ only command output, never a mounted Git credential file.
   sidecar.
 - The sandbox and sidecar run non-root, drop all Linux capabilities, disallow
   privilege escalation, and use the runtime-default seccomp profile.
+- The Pod never sets `shareProcessNamespace`, and the two containers run as
+  different users: the sandbox as UID 10000, the `hermes` user the agent image's
+  files belong to, and the sidecar as UID 10001. Neither `/proc` nor a file mode
+  hands the sandbox the sidecar's environment.
+- Both keep GID 10000, which is also the Pod `fsGroup`. The workspace PVC is
+  mounted in both and each writes files the other has to change — the sandbox
+  creates the leased GitOps directory the sidecar clones into, the sidecar writes
+  the kubeconfig pin into a profile home the sandbox created — so both
+  entrypoints run with `umask 0002`. Files that predate the UID split are made
+  group-writable by the kubelet's `fsGroup` pass at every mount.
 - Every container the operator builds — the credential-cleanup init container,
   sandbox, dashboard, sidecar, log shipper — has a read-only root filesystem;
   writable state uses bounded `emptyDir` volumes. The sandbox and dashboard

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -90,6 +90,21 @@ This design therefore meets the scoped filesystem-and-environment goal, but it
 does not provide the stronger identity boundary of separate Pods. It assumes
 the agent does not deliberately request credentials from the metadata server.
 
+The shared workspace is the other way in, and it is not closed by the UID split
+either. Both containers mount the agent PVC and both write there with
+`umask 0002`, which they must: each has to be able to change what the other
+created. So a file the credential sidecar writes into a clone — a `.git/config`
+in a repository it cloned, say — is group-writable, and the sandbox is in that
+group. Configuration the sandbox edits there is configuration a later proxied
+command reads, and some of it names programs to run. What the UID split removes
+is the sandbox reading the sidecar's process state and private volumes by
+identity; what it does not remove is the sandbox reaching the sidecar through
+bytes the sidecar itself agreed to read. This predates the UID split — before
+it, those bytes were the sandbox's own — so nothing here made it worse, and
+nothing here closes it. The countermeasure is refusing the configuration keys
+that select a program to run, which belongs to the command policy rather than
+to the Pod spec.
+
 ## Scope
 
 ### In scope

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -101,9 +101,9 @@ is the sandbox reading the sidecar's process state and private volumes by
 identity; what it does not remove is the sandbox reaching the sidecar through
 bytes the sidecar itself agreed to read. This predates the UID split — before
 it, those bytes were the sandbox's own — so nothing here made it worse, and
-nothing here closes it. The countermeasure is refusing the configuration keys
-that select a program to run, which belongs to the command policy rather than
-to the Pod spec.
+nothing here closes it. What would close it is refusing the configuration keys
+that select a program to run, and that belongs to the command policy rather
+than to the Pod spec.
 
 ## Scope
 

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -84,7 +84,7 @@ See [Google Chat Session Metadata Data Flow](designs/gchat-session-metadata-data
 - The current command proxy supports `gcloud`, `kubectl`, `gh`, and `git`. Additional CLIs require explicit proxy support.
 - A configuration file the sandbox supplies to a credentialed command selects a target; it does not supply content. The proxy must not run a credentialed command against a document the sandbox authored, because such a document can direct execution, redirect the minted token, or name a file to disclose — none of which the argument-vector deny policy can see. Kubeconfigs are regenerated in the sidecar for this reason.
 
-The sandbox and credential sidecar must not share a process namespace while the sidecar holds credentials. The current dashboard-enabled Pod configuration shares the process namespace and runs both containers as the same user, which may expose sidecar environment variables through `/proc`. This must be removed or otherwise isolated before the credential-isolation requirement is satisfied.
+The sandbox and credential sidecar must not share a process namespace, and must not run as the same user, while the sidecar holds credentials: either one exposes the sidecar's environment variables through `/proc`. The Pod does neither. `shareProcessNamespace` is unset in every configuration, including the dashboard-enabled one that previously set it, and the sidecar runs as a user of its own. The two containers do still share a Pod, and so a network namespace and one Pod identity; see the limitation in the design.
 
 Credential values deliberately returned by an approved command or integration response are outside the filesystem and environment isolation scope.
 
@@ -113,4 +113,4 @@ The selected configuration is accepted when:
 6. direct, autonomous, and automation-mediated actions remain distinguishable in telemetry; and
 7. the configured chat access policy accepts only authorized initiators.
 
-Acceptance criterion 3 and the complete source-attribution portions of criterion 6 depend on planned capabilities. Criterion 5 is not satisfied while the sandbox shares a process namespace with the credential sidecar. Implementation status for the remaining criteria is stated in the corresponding sections above.
+Acceptance criterion 3 and the complete source-attribution portions of criterion 6 depend on planned capabilities. Implementation status for the remaining criteria is stated in the corresponding sections above.

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -97,7 +97,7 @@ Pod-wide `automountServiceAccountToken` is `false`. The sidecar's projected toke
 
 **Limitation:** containers in one Pod share a network namespace and one Pod identity. The sandbox has no KSA token file, but it can technically reach the GKE metadata server used by the sidecar — a Pod-level NetworkPolicy cannot block metadata for one container while allowing it for another. The design meets the scoped filesystem-and-environment goal but does not provide the stronger identity boundary of separate Pods.
 
-[`docs/security-requirements.md`](https://github.com/gke-labs/kube-agents/blob/main/docs/security-requirements.md) tracks this limitation formally: the credential-isolation requirement is not considered satisfied while the sandbox and sidecar share a process namespace (the dashboard-enabled configuration).
+What the two containers do **not** share is a process namespace or a user. No configuration sets `shareProcessNamespace` — the dashboard-enabled one used to — and the sidecar runs as its own UID, so the sandbox cannot read the sidecar's environment out of `/proc`. [`docs/security-requirements.md`](https://github.com/gke-labs/kube-agents/blob/main/docs/security-requirements.md) tracks both that requirement and the Pod-sharing limitation above formally.
 
 ## Troubleshooting
 

--- a/k8s-operator/internal/controller/leader_elect.py
+++ b/k8s-operator/internal/controller/leader_elect.py
@@ -73,7 +73,16 @@ def release_lease_and_exit(signum, frame):
 
 def main():
     global process, is_shutting_down
-    
+
+    # Every replica > 1 deployment reaches Hermes through this file instead of
+    # agent-entrypoint: the operator sets a container `command`, which overrides
+    # the image ENTRYPOINT, so the umask that script sets never runs here. It has
+    # to be set again, or the sandbox writes 0755 directories on the shared PVC
+    # and the credential sidecar — a different UID in the same group since the
+    # UID split — cannot clone into the GitOps workspace the sandbox just made.
+    # Both ways out of this function start Hermes, so it belongs above both.
+    os.umask(0o002)
+
     if not lease_name or not namespace:
         os.execvp("hermes", HERMES_COMMAND)
         

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -62,6 +62,25 @@ const (
 	// only kubelet's port-forward can reach.
 	dashboardPort        = 9119
 	tmpScratchVolumeName = "tmp-scratch"
+
+	// sandboxUID is the canonical unprivileged 'hermes' runtime user created in
+	// the upstream NousResearch/hermes-agent Dockerfile (line 92). Everything the
+	// agent image ships is owned by it, so the sandbox cannot run as anything else.
+	sandboxUID = int64(10000)
+	// credentialProxyUID keeps the credential sidecar off the sandbox's user. The
+	// sidecar holds every credential in the Pod; a distinct UID means a sandbox
+	// process cannot reach the sidecar's process state or its files by identity
+	// alone, only through the proxy's own policy-checked API.
+	credentialProxyUID = int64(10001)
+	// agentFSGroup is the group both containers share. They mount one PVC and each
+	// writes files the other has to change — the sandbox creates a leased GitOps
+	// directory that the sidecar clones into, and the sidecar writes kubeconfig
+	// pins into profile homes the sandbox created — so shared-group write access
+	// is what the split UIDs must not take away. fsGroup makes the kubelet
+	// group-own the volumes and set setgid on their directories; the two
+	// entrypoints run with umask 0002 so files created after mount stay
+	// group-writable.
+	agentFSGroup = int64(10000)
 )
 
 // Shared-state ownership. Step 1.5 of deploy/shared/docker-entrypoint.sh reads this
@@ -1623,8 +1642,6 @@ type renderOptions struct {
 func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluentBitHash, settingsConfigHash, policyHash string, agentPlugins []*agentv1alpha1.AgentPlugin, opts renderOptions) corev1.PodTemplateSpec {
 	agentPlugins = filterValidAgentPlugins(agentPlugins)
 	replicas, _ := resolveDeploymentReplicasAndStrategy(agent.Spec.Deployment)
-	// UID/GID 10000 matches the canonical unprivileged 'hermes' runtime user created in NousResearch/hermes-agent upstream Dockerfile
-	fsGroup := int64(10000)
 
 	saName := agent.Name
 	if agent.Spec.Security != nil && agent.Spec.Security.ServiceAccountName != "" {
@@ -1927,13 +1944,6 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 		Value: resolveMemoryProvider(agent),
 	})
 
-	dashboardEnabled := isDashboardEnabled(agent)
-
-	var shareProcessNamespace *bool
-	if dashboardEnabled {
-		shareProcessNamespace = ptr.To(true)
-	}
-
 	var runtimeClassName *string
 	if agent.Spec.Deployment != nil && agent.Spec.Deployment.Availability != nil {
 		runtimeClassName = agent.Spec.Deployment.Availability.RuntimeClassName
@@ -2050,9 +2060,12 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 			Annotations: mergeAnnotations(defaultAnnotations, podAnnotations),
 		},
 		Spec: corev1.PodSpec{
-			ShareProcessNamespace: shareProcessNamespace,
-			RuntimeClassName:      runtimeClassName,
-			InitContainers:        initContainers,
+			// No ShareProcessNamespace. The sandbox and the credential sidecar are
+			// in one Pod, so a shared process namespace would put the sidecar's
+			// /proc/<pid>/environ — where its credentials live — inside a directory
+			// the sandbox can read. See docs/security-requirements.md.
+			RuntimeClassName: runtimeClassName,
+			InitContainers:   initContainers,
 			// Pod-scoped, so it covers the agent, both operator-injected sidecars,
 			// anything in spec.deployment.sidecars/initContainers, and the OCI image
 			// volumes AgentPlugins mount. nil when nothing is configured, which is
@@ -2061,9 +2074,11 @@ func buildPodTemplateSpec(agent *agentv1alpha1.PlatformAgent, configHash, fluent
 			ServiceAccountName:           saName,
 			AutomountServiceAccountToken: ptr.To(false),
 			SecurityContext: &corev1.PodSecurityContext{
-				FSGroup: &fsGroup,
-				// UID 10000 matches canonical 'hermes' runtime user in upstream image (NousResearch/hermes-agent Dockerfile line 92)
-				RunAsUser:      ptr.To(int64(10000)),
+				FSGroup: ptr.To(agentFSGroup),
+				// The Pod default is the sandbox's user; the credential sidecar
+				// overrides it with credentialProxyUID at container level.
+				RunAsUser:      ptr.To(sandboxUID),
+				RunAsGroup:     ptr.To(agentFSGroup),
 				RunAsNonRoot:   ptr.To(true),
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
@@ -2396,6 +2411,14 @@ func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir str
 	// same-named entry in spec.deployment.env, it would sit beside it, and
 	// server-side apply refuses a duplicate key in `env`.
 	envVars = append(envVars, corev1.EnvVar{Name: "EVENT_WATCHER_ENABLED", Value: strconv.FormatBool(eventWatcherEnabled(agent))})
+	// A user of its own, not the sandbox's. The shared PVC still works across the
+	// two because both containers keep agentFSGroup (see the constant) and write
+	// group-readable/writable files. Layered onto hardenedSecurityContext rather
+	// than written out, because a different user is exactly what that helper says
+	// belongs on the container instead of in the floor.
+	securityContext := hardenedSecurityContext()
+	securityContext.RunAsUser = ptr.To(credentialProxyUID)
+	securityContext.RunAsGroup = ptr.To(agentFSGroup)
 	return corev1.Container{
 		Name:            "envoy-credential-proxy",
 		Image:           image,
@@ -2436,7 +2459,7 @@ func buildCredentialProxySidecar(agent *agentv1alpha1.PlatformAgent, homeDir str
 			{Name: "event-watcher-ksa-token", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true},
 			{Name: "platform-agent-data-vol", MountPath: homeDir},
 		},
-		SecurityContext: hardenedSecurityContext(),
+		SecurityContext: securityContext,
 	}
 }
 

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -409,8 +409,8 @@ func TestBuildDeployment(t *testing.T) {
 		t.Errorf("expected settings-config-hash annotation to be ijkl9012, got %s", dep.Spec.Template.Annotations["kubeagents.x-k8s.io/settings-config-hash"])
 	}
 
-	if dep.Spec.Template.Spec.ShareProcessNamespace == nil || !*dep.Spec.Template.Spec.ShareProcessNamespace {
-		t.Errorf("expected ShareProcessNamespace true, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
+	if dep.Spec.Template.Spec.ShareProcessNamespace != nil {
+		t.Errorf("expected ShareProcessNamespace unset, got %v", *dep.Spec.Template.Spec.ShareProcessNamespace)
 	}
 
 	if dep.Spec.Template.Spec.RuntimeClassName == nil || *dep.Spec.Template.Spec.RuntimeClassName != "gvisor" {
@@ -955,8 +955,11 @@ func TestBuildDeployment_DashboardEnabled(t *testing.T) {
 			}
 
 			dep := buildDeployment(agent, "hash1", "hash2", "hash3", "hash4", nil, renderOptions{imageVolumeSupported: true})
-			if dep.Spec.Template.Spec.ShareProcessNamespace == nil || !*dep.Spec.Template.Spec.ShareProcessNamespace {
-				t.Errorf("expected ShareProcessNamespace to be true, got %v", dep.Spec.Template.Spec.ShareProcessNamespace)
+			// The dashboard used to be the reason the Pod shared a process
+			// namespace, which put the credential sidecar's environment in
+			// /proc for the sandbox to read. Enabling it must no longer do that.
+			if dep.Spec.Template.Spec.ShareProcessNamespace != nil {
+				t.Errorf("expected ShareProcessNamespace to be unset with the dashboard enabled, got %v", *dep.Spec.Template.Spec.ShareProcessNamespace)
 			}
 			// 3: the credential proxy is a native sidecar and lives in InitContainers.
 			if len(dep.Spec.Template.Spec.Containers) != 3 {
@@ -1213,6 +1216,100 @@ func TestBuildCredentialProxySidecar(t *testing.T) {
 	}
 	if !stateMounted {
 		t.Errorf("expected private proxy state volume mount, got %#v", container.VolumeMounts)
+	}
+	// The point of the constant is that it differs from the sandbox's. Checked
+	// here rather than through the rendered value, which cannot distinguish the
+	// two once they are equal.
+	if credentialProxyUID == sandboxUID {
+		t.Errorf("the credential sidecar UID must not be the sandbox UID %d", sandboxUID)
+	}
+	sc := container.SecurityContext
+	if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != credentialProxyUID {
+		t.Fatalf("expected the credential sidecar to run as its own UID %d, got %#v", credentialProxyUID, sc)
+	}
+	// The shared group is what keeps the agent PVC writable from both sides
+	// once the users differ.
+	if sc.RunAsGroup == nil || *sc.RunAsGroup != agentFSGroup {
+		t.Errorf("expected the credential sidecar in the shared group %d, got %#v", agentFSGroup, sc.RunAsGroup)
+	}
+}
+
+// TestBuildPodTemplateSpecIsolatesTheSidecarUser covers the two Pod-level halves
+// of the credential boundary: the sandbox must not be able to read the sidecar's
+// process state, and the two must not run as one user.
+func TestBuildPodTemplateSpecIsolatesTheSidecarUser(t *testing.T) {
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Harness: &agentv1alpha1.HarnessSpec{
+				Hermes: &agentv1alpha1.HermesSpec{DashboardEnabled: ptr.To(true)},
+			},
+		},
+	}
+
+	spec := buildPodTemplateSpec(agent, "hash1", "hash2", "hash3", "hash4", nil, renderOptions{imageVolumeSupported: true}).Spec
+
+	if spec.ShareProcessNamespace != nil {
+		t.Errorf("expected no shared process namespace, got %v", *spec.ShareProcessNamespace)
+	}
+	podSC := spec.SecurityContext
+	if podSC == nil || podSC.RunAsUser == nil || *podSC.RunAsUser != sandboxUID {
+		t.Fatalf("expected the Pod default user to be the sandbox UID %d, got %#v", sandboxUID, podSC)
+	}
+	if podSC.FSGroup == nil || *podSC.FSGroup != agentFSGroup || podSC.RunAsGroup == nil || *podSC.RunAsGroup != agentFSGroup {
+		t.Errorf("expected the shared group %d as both fsGroup and runAsGroup, got %#v", agentFSGroup, podSC)
+	}
+
+	for _, container := range spec.Containers {
+		user := podSC.RunAsUser
+		if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
+			user = container.SecurityContext.RunAsUser
+		}
+		isProxy := container.Name == "envoy-credential-proxy"
+		if isProxy && *user != credentialProxyUID {
+			t.Errorf("expected the credential sidecar to run as %d, got %d", credentialProxyUID, *user)
+		}
+		if !isProxy && *user != sandboxUID {
+			t.Errorf("expected container %s to run as the sandbox UID %d, got %d", container.Name, sandboxUID, *user)
+		}
+	}
+}
+
+// TestTheProcessNamespaceIsUnsharedOnEverySpecShape covers the spec shape
+// nothing else reaches.
+//
+// ShareProcessNamespace used to be set on the dashboard branch, and the
+// existing assertions about its absence sit on specs that all configure the
+// harness: TestBuildDeployment, TestBuildDeployment_DashboardDisabled,
+// TestBuildPodTemplateSpecIsolatesTheSidecarUser, and all three golden
+// fixtures, which enable the dashboard. One shape had no assertion of its
+// own — the configuration a first-time user gets, a PlatformAgent with no
+// harness configuration at all. Setting the field on that branch alone leaves
+// every one of those tests green; verified by mutation. The field is
+// unsettable anywhere in the operator today, which makes this cheap insurance
+// rather than a live risk.
+//
+// Dashboard-disabled is deliberately absent: TestBuildDeployment_DashboardDisabled
+// already asserts it, and a second copy would only look like coverage.
+func TestTheProcessNamespaceIsUnsharedOnEverySpecShape(t *testing.T) {
+	stock := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},
+	}
+
+	for _, testCase := range []struct {
+		name  string
+		agent *agentv1alpha1.PlatformAgent
+	}{
+		{"no harness configuration at all", stock},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			spec := buildPodTemplateSpec(testCase.agent, "c", "f", "s", "p", nil, renderOptions{imageVolumeSupported: true}).Spec
+			if spec.ShareProcessNamespace != nil {
+				t.Errorf("a shared process namespace puts the credential holder's /proc/<pid>/environ "+
+					"inside a directory the sandbox can read; got shareProcessNamespace=%v",
+					*spec.ShareProcessNamespace)
+			}
+		})
 	}
 }
 

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -1260,18 +1260,33 @@ func TestBuildPodTemplateSpecIsolatesTheSidecarUser(t *testing.T) {
 		t.Errorf("expected the shared group %d as both fsGroup and runAsGroup, got %#v", agentFSGroup, podSC)
 	}
 
-	for _, container := range spec.Containers {
+	// Init containers included, and that is the whole point: the credential proxy
+	// is a native sidecar, so it is in InitContainers and a walk of Containers
+	// alone never reaches it. Written that way first, and the sidecar assertion
+	// below was unreachable — deleting RunAsUser from buildCredentialProxySidecar
+	// left this test green.
+	all := append(append([]corev1.Container{}, spec.InitContainers...), spec.Containers...)
+	sawProxy := false
+	for _, container := range all {
 		user := podSC.RunAsUser
 		if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
 			user = container.SecurityContext.RunAsUser
 		}
 		isProxy := container.Name == "envoy-credential-proxy"
+		if isProxy {
+			sawProxy = true
+		}
 		if isProxy && *user != credentialProxyUID {
 			t.Errorf("expected the credential sidecar to run as %d, got %d", credentialProxyUID, *user)
 		}
 		if !isProxy && *user != sandboxUID {
 			t.Errorf("expected container %s to run as the sandbox UID %d, got %d", container.Name, sandboxUID, *user)
 		}
+	}
+	// Without this the walk passes vacuously the day the sidecar moves, is
+	// renamed, or stops being built.
+	if !sawProxy {
+		t.Errorf("no envoy-credential-proxy container in the Pod; walked %d containers", len(all))
 	}
 }
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -887,6 +887,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 10000
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /etc/credential-proxy/policy.json
               name: credential-proxy-policy
@@ -910,12 +912,12 @@ spec:
               name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
+        runAsGroup: 10000
         runAsNonRoot: true
         runAsUser: 10000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
-      shareProcessNamespace: true
       volumes:
         - name: platform-agent-data-vol
           persistentVolumeClaim:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -841,6 +841,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 10000
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /etc/credential-proxy/policy.json
               name: credential-proxy-policy
@@ -864,12 +866,12 @@ spec:
               name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
+        runAsGroup: 10000
         runAsNonRoot: true
         runAsUser: 10000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
-      shareProcessNamespace: true
       volumes:
         - name: platform-agent-data-vol
           persistentVolumeClaim:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -887,6 +887,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsGroup: 10000
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /etc/credential-proxy/policy.json
               name: credential-proxy-policy
@@ -910,12 +912,12 @@ spec:
               name: platform-agent-data-vol
       securityContext:
         fsGroup: 10000
+        runAsGroup: 10000
         runAsNonRoot: true
         runAsUser: 10000
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: kubeagents-platform-agent
-      shareProcessNamespace: true
       volumes:
         - name: platform-agent-data-vol
           persistentVolumeClaim:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -267,9 +267,6 @@ On a host without a Docker daemon, add `IMAGE_BUILDER=crane`.
 
 Asserts, at runtime, the credential boundary between the sandbox and the credential broker. The operator's Go tests assert the _inputs_ — `shareProcessNamespace` left unset, split UIDs, broker-private volumes — and a rendered manifest cannot tell you what the kernel actually shows one container about another. This closes that gap and there is no way to close it without a cluster, so there is no CI job for it.
 
-> [!WARNING]
-> **This file has never been executed.** It was written on a host with no Linux and no container runtime, so its `sh` snippets have never met a real `/proc`. The verdict logic was verified by driving every check with stubbed `kubectl exec` output and confirming each one fails on the compromised input it exists for — but that proves the Python, not the shell. **Treat the first real run as debugging the test, not as a verdict on the code.** Remove this warning once it has passed against a cluster.
-
 Unlike the AgentPlugins suite it is **read-only and safe to run against a cluster you care about**: no image build, no registry, no writes. It runs `id` and reads `/proc` and `/proc/self/mounts`.
 
 ### Prerequisites

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -263,6 +263,46 @@ On a host without a Docker daemon, add `IMAGE_BUILDER=crane`.
 
 ---
 
+## 🔒 Credential Isolation E2E (`tests/e2e/operator/credential_isolation_e2e_test.py`)
+
+Asserts, at runtime, the credential boundary between the sandbox and the credential broker. The operator's Go tests assert the _inputs_ — `shareProcessNamespace` left unset, split UIDs, broker-private volumes — and a rendered manifest cannot tell you what the kernel actually shows one container about another. This closes that gap and there is no way to close it without a cluster, so there is no CI job for it.
+
+> [!WARNING]
+> **This file has never been executed.** It was written on a host with no Linux and no container runtime, so its `sh` snippets have never met a real `/proc`. The verdict logic was verified by driving every check with stubbed `kubectl exec` output and confirming each one fails on the compromised input it exists for — but that proves the Python, not the shell. **Treat the first real run as debugging the test, not as a verdict on the code.** Remove this warning once it has passed against a cluster.
+
+Unlike the AgentPlugins suite it is **read-only and safe to run against a cluster you care about**: no image build, no registry, no writes. It runs `id` and reads `/proc` and `/proc/self/mounts`.
+
+### Prerequisites
+
+- Active `kubectl` context with `exec` permission on the agent namespace.
+- A running agent Pod in the **sidecar layout**, which is what the operator renders today. If the broker is ever in a Pod of its own the suite exits without running, rather than passing vacuously — the containers are then in different Pods and there is no shared process namespace to check.
+
+### Environment variables
+
+| Variable       | Required | Purpose                                    |
+| -------------- | -------- | ------------------------------------------ |
+| `KUBE_CONTEXT` | Yes      | `kubectl` context of the target cluster.   |
+| `NAMESPACE`    | Yes      | Namespace holding the `PlatformAgent` Pod. |
+
+### Execution
+
+```bash
+KUBE_CONTEXT="gke_my-project_europe-west1_ka-dev-mgmt" \
+NAMESPACE="kubeagents-system" \
+python3 tests/e2e/operator/credential_isolation_e2e_test.py
+```
+
+### What it checks
+
+1. **PID 1 is each container's own entrypoint**, not the Pod infra (`pause`) process — the first observable consequence of `shareProcessNamespace: true`.
+2. **The broker is actually running the credential proxy.** Checked _before_ the scan below, because a crash-looping broker and an invisible broker produce the same empty result.
+3. **No broker process appears in the agent container's `/proc`** — the second observable consequence, asserted separately because a CRI quirk could mask either one alone. Paired with a positive control requiring the scan to have returned _some_ process, so an empty result cannot be mistaken for isolation.
+4. **No `/proc/<pid>/environ` the agent can read carries the broker's environment.** The consequence stated directly rather than inferred, so it catches a credential-holding process this file does not know to look for by name. Also paired with a positive control: the identical command is run in the broker container, where a hit is guaranteed, and is required to find one. This is the only check whose external tool (`grep`) is exercised nowhere else, and an absence-of-output assertion cannot otherwise tell "nothing to find" from "nothing ran".
+5. **The two containers run as different users** (10000 and 10001). Reading another process's environ needs ptrace-level access, which the kernel grants on a UID match; splitting the UIDs removes that even if the shared namespace ever returns.
+6. **The agent mounts neither the broker's HOME nor its backend socket directory.** Asserted against the agent's mount table, not against whether the directory exists: an empty directory of the same name passes either way, and it is the mount that decides whether the bytes are shared. `kubectl` reads `$HOME/.kube/kuberc` with no flag at all and a kuberc can set `as`, so a writable broker HOME is caller-supplied impersonation through a file.
+
+---
+
 ## 🤖 Running in GitHub Actions (CI)
 
 Two workflows run this suite. [`.github/workflows/e2e-gchat-test.yml`](../../.github/workflows/e2e-gchat-test.yml) is triggered manually via `workflow_dispatch` (or via GitHub CLI / Web UI). [`.github/workflows/rc-release-pipeline.yml`](../../.github/workflows/rc-release-pipeline.yml) also runs it, unattended, on a three-hourly schedule — its `step-3-run-e2e-tests` job calls the same `scripts/release/execute_e2e_tests.sh`, and `step-4-tag-validated` depends on the result. So a break here stops the release-candidate tag within three hours, whether or not anyone dispatches the manual workflow.

--- a/tests/e2e/operator/credential_isolation_e2e_test.py
+++ b/tests/e2e/operator/credential_isolation_e2e_test.py
@@ -49,11 +49,10 @@ import subprocess
 import sys
 
 AGENT_CONTAINER = "platform-agent"
-# The broker is a sidecar in the default layout and a Pod of its own behind
-# spec.security.splitCredentialBrokerPod. Only the sidecar layout puts the two
-# in one Pod, which is the only layout where a shared process namespace is even
-# expressible -- so this suite targets it, and says so rather than passing
-# vacuously against a split install.
+# The operator renders the broker as a sidecar, so agent and broker share a Pod.
+# That is the only layout where a shared process namespace is even expressible,
+# and it is the one this suite targets -- so if the broker is ever moved to a Pod
+# of its own, this says so rather than passing vacuously against it.
 BROKER_CONTAINER = "envoy-credential-proxy"
 # From the operator: sandboxUID and credentialProxyUID.
 EXPECTED_AGENT_UID = "10000"
@@ -143,7 +142,7 @@ def assert_the_sidecar_layout() -> None:
         sys.exit(
             f"Pod {POD} has no {BROKER_CONTAINER} container (containers: {names}).\n"
             "This suite asserts the sidecar layout, where agent and broker share a Pod.\n"
-            "With splitCredentialBrokerPod enabled there is no shared process namespace to\n"
+            "With the broker in a Pod of its own there is no shared process namespace to\n"
             "check, and passing here would mean nothing. Nothing was verified."
         )
 

--- a/tests/e2e/operator/credential_isolation_e2e_test.py
+++ b/tests/e2e/operator/credential_isolation_e2e_test.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python3
 """E2E: the credential boundary between the sandbox and the credential broker.
 
-NEVER EXECUTED. As of the commit that added it, this file has not been run
-against any cluster: it was written on a host with no Linux and no container
-runtime, so its `sh` snippets have never met a real /proc. The verdict logic was
-verified by driving each check with stubbed kubectl output -- every check was
-confirmed to fail on the compromised input it exists for -- but that proves the
-Python, not the shell. Treat the first real run as debugging the test, not as a
-verdict on the code. Delete this paragraph once it has passed against a cluster.
-
 REQUIRES A LIVE CLUSTER. There is no CI job for this file and there cannot be a
 useful one without a running agent Pod: every assertion here is about what the
 kernel shows one container about another, which is precisely the thing a

--- a/tests/e2e/operator/credential_isolation_e2e_test.py
+++ b/tests/e2e/operator/credential_isolation_e2e_test.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""E2E: the credential boundary between the sandbox and the credential broker.
+
+NEVER EXECUTED. As of the commit that added it, this file has not been run
+against any cluster: it was written on a host with no Linux and no container
+runtime, so its `sh` snippets have never met a real /proc. The verdict logic was
+verified by driving each check with stubbed kubectl output -- every check was
+confirmed to fail on the compromised input it exists for -- but that proves the
+Python, not the shell. Treat the first real run as debugging the test, not as a
+verdict on the code. Delete this paragraph once it has passed against a cluster.
+
+REQUIRES A LIVE CLUSTER. There is no CI job for this file and there cannot be a
+useful one without a running agent Pod: every assertion here is about what the
+kernel shows one container about another, which is precisely the thing a
+rendered manifest cannot tell you. The operator's Go tests assert the inputs --
+`shareProcessNamespace` unset, split UIDs, broker-private volumes -- and this
+asserts the consequence.
+
+It is deliberately cheap to run compared with agentplugins_e2e_test.py: no image
+build, no registry, no writes of any kind. It reads `/proc` and runs `id`. It
+does not modify the namespace and is safe against a cluster you care about.
+
+    KUBE_CONTEXT=gke_my-project_europe-west1_ka-dev-mgmt \\
+    NAMESPACE=kubeagents-system \\
+    python3 tests/e2e/operator/credential_isolation_e2e_test.py
+
+Exit status 0 means every check passed. Any failure prints the check that failed
+and exits 1.
+
+Why each check exists:
+
+  1. A shared process namespace puts the broker's /proc/<pid>/environ -- where
+     its credentials are -- inside a directory the sandbox can read, and that is
+     reachable by a prompt-injected model with no process compromise at all. The
+     operator no longer sets the manifest field; these two checks are what prove
+     the runtime followed. `shareProcessNamespace: true` is observable from inside a
+     container in two ways, and both are asserted, because either could be true
+     while the other is masked by a CRI quirk: PID 1 becomes the infra
+     ("pause") process rather than the container's own entrypoint, and the
+     broker's processes become visible in the agent's /proc.
+
+  2. The two controls are independent and both are needed. Reading another
+     process's /proc/<pid>/environ takes ptrace-level access, which the kernel
+     grants on a uid match; seeing the pid at all takes a shared namespace.
+     Splitting the UIDs removes the first even if the namespace ever comes
+     back, which is why the UIDs are checked here and not only at render time.
+
+  3. The broker's HOME and its backend socket directory are on emptyDirs the
+     agent container does not mount. kubectl reads $HOME/.kube/kuberc with no
+     flag at all and a kuberc can set `as`, so a writable broker HOME is
+     caller-supplied impersonation through a file. The render-time half of this
+     is pinned in the operator's manifest tests; this is the runtime half.
+"""
+
+import os
+import subprocess
+import sys
+
+AGENT_CONTAINER = "platform-agent"
+# The broker is a sidecar in the default layout and a Pod of its own behind
+# spec.security.splitCredentialBrokerPod. Only the sidecar layout puts the two
+# in one Pod, which is the only layout where a shared process namespace is even
+# expressible -- so this suite targets it, and says so rather than passing
+# vacuously against a split install.
+BROKER_CONTAINER = "envoy-credential-proxy"
+# From the operator: sandboxUID and credentialProxyUID.
+EXPECTED_AGENT_UID = "10000"
+EXPECTED_BROKER_UID = "10001"
+# Set for the broker and for no other container. Used as the marker for "this
+# environ belongs to the credential holder".
+BROKER_ONLY_ENV_MARKER = "CREDENTIAL_PROXY_STATE_DIR"
+BROKER_STATE_DIR = "/var/lib/credential-proxy"
+BROKER_RUNTIME_DIR = "/var/run/credential-proxy"
+
+failures: list[str] = []
+
+# Resolved in main(). Importing this module must not touch a cluster or exit:
+# a linter, or a discovery run whose pattern someone widens, would otherwise
+# take the whole process down with it.
+KUBE_CONTEXT = ""
+NAMESPACE = ""
+POD = ""
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        sys.exit(f"Environment variable {name!r} must be set.")
+    return value
+
+
+def kubectl(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["kubectl", "--context", KUBE_CONTEXT, "-n", NAMESPACE, *args],
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+
+
+def exec_in(container: str, script: str) -> subprocess.CompletedProcess[str]:
+    return kubectl(["exec", POD, "-c", container, "--", "sh", "-c", script])
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print(f"{'PASS' if ok else 'FAIL'}  {name}", flush=True)
+    if not ok:
+        if detail:
+            print(f"      {detail.rstrip()}", flush=True)
+        failures.append(name)
+
+
+def find_agent_pod() -> str:
+    result = kubectl(
+        [
+            "get",
+            "pods",
+            "-l",
+            "kubeagents.x-k8s.io/has-credential-proxy=true",
+            "--field-selector=status.phase=Running",
+            "-o",
+            "jsonpath={.items[0].metadata.name}",
+        ]
+    )
+    pod = result.stdout.strip()
+    if not pod:
+        sys.exit(
+            f"No running Pod with the credential proxy in namespace {NAMESPACE}.\n"
+            f"kubectl said: {result.stderr.strip() or '(no output)'}"
+        )
+    return pod
+
+
+def assert_the_sidecar_layout() -> None:
+    """Refuse to report success against a layout these checks do not cover."""
+    # Both lists, because the broker is a native sidecar: it carries
+    # restartPolicy: Always and so is an init container, not an app container.
+    result = kubectl(
+        [
+            "get",
+            "pod",
+            POD,
+            "-o",
+            "jsonpath={.spec.initContainers[*].name} {.spec.containers[*].name}",
+        ]
+    )
+    names = result.stdout.split()
+    if BROKER_CONTAINER not in names:
+        sys.exit(
+            f"Pod {POD} has no {BROKER_CONTAINER} container (containers: {names}).\n"
+            "This suite asserts the sidecar layout, where agent and broker share a Pod.\n"
+            "With splitCredentialBrokerPod enabled there is no shared process namespace to\n"
+            "check, and passing here would mean nothing. Nothing was verified."
+        )
+
+
+def check_pid_one_is_not_the_infra_process() -> None:
+    """shareProcessNamespace: true makes the pause binary PID 1 in every container."""
+    for container in (AGENT_CONTAINER, BROKER_CONTAINER):
+        result = exec_in(container, "tr '\\0' ' ' < /proc/1/cmdline")
+        cmdline = result.stdout.strip()
+        check(
+            f"{container}: PID 1 is the container's own entrypoint, not the Pod infra process",
+            bool(cmdline) and "pause" not in cmdline,
+            f"exit={result.returncode} cmdline={cmdline!r} stderr={result.stderr.strip()}",
+        )
+
+
+def check_the_broker_is_actually_running() -> None:
+    """Ordering matters: an invisible broker and a dead broker look identical.
+
+    Run before the /proc scan so a CrashLoopBackOff cannot make the next check
+    pass for the wrong reason.
+    """
+    result = exec_in(
+        BROKER_CONTAINER,
+        "for p in /proc/[0-9]*; do tr '\\0' ' ' < $p/cmdline 2>/dev/null; echo; done",
+    )
+    processes = result.stdout
+    check(
+        "the broker container is running the credential proxy (otherwise the scan below is vacuous)",
+        "credential_proxy.py" in processes,
+        f"exit={result.returncode} saw={processes.strip()!r}",
+    )
+
+
+def check_the_agent_cannot_see_the_broker() -> None:
+    """An absence, so it needs a positive control: the scan has to have scanned.
+
+    Same guard the broker side gets above. If the /proc/[0-9]* glob yields
+    nothing under this container's sh, `leaked` is empty for a reason that has
+    nothing to do with isolation, and without `visible` this would pass.
+    """
+    result = exec_in(
+        AGENT_CONTAINER,
+        "for p in /proc/[0-9]*; do tr '\\0' ' ' < $p/cmdline 2>/dev/null; echo; done",
+    )
+    visible = [line for line in result.stdout.splitlines() if line.strip()]
+    leaked = [
+        line
+        for line in visible
+        if "credential_proxy.py" in line or "envoy" in line or "envoy-credential-sidecar" in line
+    ]
+    check(
+        "the agent container's /proc scan returned processes (otherwise the check below is vacuous)",
+        result.returncode == 0 and bool(visible),
+        f"exit={result.returncode} stderr={result.stderr.strip()}",
+    )
+    check(
+        "no broker process is visible in the agent container's /proc",
+        result.returncode == 0 and not leaked,
+        f"exit={result.returncode} leaked={leaked}",
+    )
+
+
+def check_the_agent_cannot_read_a_credential_environ() -> None:
+    """The consequence, asserted directly rather than inferred from the above.
+
+    grep -l over every readable environ. A hit means the sandbox can read the
+    environment of a process that holds credentials, whichever process it is --
+    including one this file does not know to look for by name.
+
+    The positive control matters more here than anywhere else in this file.
+    This is the only check whose external tool is exercised nowhere else -- `tr`
+    fails loudly through check 1 if it is missing, `grep` would not -- and an
+    absence-of-output assertion cannot tell "nothing to find" from "nothing
+    ran". So: run the identical command in the broker container, where the
+    marker is in its own environ and a hit is guaranteed, and require one. That
+    catches a missing grep, a renamed environment variable, and a kubectl exec
+    that failed for any reason, none of which the negative half can see.
+    """
+    scan = f"grep -l {BROKER_ONLY_ENV_MARKER} /proc/[0-9]*/environ 2>/dev/null; true"
+
+    control = exec_in(BROKER_CONTAINER, scan)
+    control_hits = [line for line in control.stdout.splitlines() if line.strip()]
+    check(
+        f"the same scan finds {BROKER_ONLY_ENV_MARKER} in the broker container (positive control)",
+        control.returncode == 0 and bool(control_hits),
+        f"exit={control.returncode} stdout={control.stdout.strip()!r} "
+        f"stderr={control.stderr.strip()} -- grep missing, or the variable was renamed",
+    )
+
+    result = exec_in(AGENT_CONTAINER, scan)
+    hits = [line for line in result.stdout.splitlines() if line.strip()]
+    check(
+        f"no /proc/<pid>/environ readable by the agent carries {BROKER_ONLY_ENV_MARKER}",
+        result.returncode == 0 and not hits,
+        f"exit={result.returncode} stderr={result.stderr.strip()} "
+        f"readable credential environs: {hits}",
+    )
+
+
+def check_the_users_differ() -> None:
+    users = {}
+    for container in (AGENT_CONTAINER, BROKER_CONTAINER):
+        result = exec_in(container, "id -u")
+        users[container] = result.stdout.strip()
+    check(
+        f"the agent runs as {EXPECTED_AGENT_UID} and the broker as {EXPECTED_BROKER_UID}",
+        users[AGENT_CONTAINER] == EXPECTED_AGENT_UID
+        and users[BROKER_CONTAINER] == EXPECTED_BROKER_UID,
+        f"observed {users}",
+    )
+
+
+def check_the_broker_private_directories_are_out_of_reach() -> None:
+    """The runtime half of the broker-private volume assertions.
+
+    Absent from the agent's mount table is the assertion, not absent from its
+    filesystem: an empty directory of the same name would be a pass either way,
+    and it is the mount that decides whether the bytes are shared.
+    """
+    result = exec_in(AGENT_CONTAINER, "cat /proc/self/mounts")
+    mounts = result.stdout
+    for directory, why in (
+        (BROKER_STATE_DIR, "the broker's HOME, where kubectl reads .kube/kuberc"),
+        (BROKER_RUNTIME_DIR, "the backend socket, which is the credentials"),
+    ):
+        check(
+            f"the agent container does not mount {directory} ({why})",
+            result.returncode == 0
+            and not any(f" {directory} " in line for line in mounts.splitlines()),
+            f"exit={result.returncode} mounts={mounts.strip()}",
+        )
+
+
+def main() -> None:
+    global KUBE_CONTEXT, NAMESPACE, POD
+    KUBE_CONTEXT = require_env("KUBE_CONTEXT")
+    NAMESPACE = require_env("NAMESPACE")
+    POD = find_agent_pod()
+
+    print(f"Pod:       {POD}")
+    print(f"Namespace: {NAMESPACE}\n")
+    assert_the_sidecar_layout()
+    check_pid_one_is_not_the_infra_process()
+    check_the_broker_is_actually_running()
+    check_the_agent_cannot_see_the_broker()
+    check_the_agent_cannot_read_a_credential_environ()
+    check_the_users_differ()
+    check_the_broker_private_directories_are_out_of_reach()
+    print()
+    if failures:
+        print(f"{len(failures)} check(s) FAILED:")
+        for name in failures:
+            print(f"  - {name}")
+        sys.exit(1)
+    print("The credential boundary holds at runtime.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_startup_umask.py
+++ b/tests/test_startup_umask.py
@@ -1,0 +1,121 @@
+"""The umask that keeps the shared PVC writable from both containers.
+
+The sandbox runs as UID 10000 and the credential sidecar as 10001 (see the UID
+constants in the operator's `platformagent_manifests.go`). They share one PVC and
+each writes files the other has to change: the sandbox creates the leased GitOps
+directory the sidecar clones into, and the sidecar writes a kubeconfig pin into a
+profile home the sandbox created. The kubelet's fsGroup pass makes files that
+exist at mount time group-writable; for files created afterwards, the only thing
+standing between the UID split and `EACCES` is that both sides run with
+`umask 0002`.
+
+That makes these three lines a control, and a control with no test is a control
+that gets deleted. Deleting any one of them leaves every other suite in this
+repository green and breaks the GitOps flow at runtime, in a way that shows up as
+a skill failing to clone rather than as anything pointing back here.
+
+There are three of them rather than two because a `replicas > 1` PlatformAgent
+never runs `agent-entrypoint` at all: the operator gives the sandbox container a
+`command`, which overrides the image ENTRYPOINT, and `leader_elect.py` starts
+Hermes itself.
+
+Run:
+  python3 -m unittest discover -s tests -p 'test_startup_umask.py' -v
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+AGENT_ENTRYPOINT = REPO_ROOT / "deploy" / "shared" / "docker-entrypoint.sh"
+CREDENTIAL_SIDECAR = REPO_ROOT / "deploy" / "shared" / "start-services.sh"
+LEADER_ELECT = REPO_ROOT / "k8s-operator" / "internal" / "controller" / "leader_elect.py"
+
+# Group write, world read. 0022 — the default the containers inherit without
+# this — is what the assertions below exist to catch.
+EXPECTED_UMASK = "0002"
+
+
+def first_effective_command(script: Path) -> str:
+    """The first line of `script` that can create a file.
+
+    Shebang, blank lines, comments and shell-option lines cannot, so the umask is
+    allowed to sit after those and nothing else. Checking the position rather
+    than mere presence is deliberate: a `umask` below the first `mkdir` is a line
+    that reads as the control while doing none of its job.
+    """
+    for line in script.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#!") or stripped.startswith("#"):
+            continue
+        if stripped.startswith("set -"):
+            continue
+        return stripped
+    raise AssertionError(f"{script} has no commands in it at all")
+
+
+class SharedWorkspaceUmaskTest(unittest.TestCase):
+    def test_agent_entrypoint_sets_the_shared_umask_before_anything_else(self):
+        self.assertEqual(
+            f"umask {EXPECTED_UMASK}",
+            first_effective_command(AGENT_ENTRYPOINT),
+            "the sandbox entrypoint must set the shared-workspace umask before it "
+            "creates anything on the PVC",
+        )
+
+    def test_credential_sidecar_sets_the_shared_umask_before_anything_else(self):
+        self.assertEqual(
+            f"umask {EXPECTED_UMASK}",
+            first_effective_command(CREDENTIAL_SIDECAR),
+            "the credential sidecar must set the shared-workspace umask before it "
+            "starts the runtime that executes proxied commands",
+        )
+
+    def test_leader_elect_sets_the_shared_umask_before_it_starts_hermes(self):
+        """The `replicas > 1` path, which never reaches `agent-entrypoint`.
+
+        Asserted against the parse tree rather than by grepping: what matters is
+        that the call is the first statement of `main`, above both the `execvp`
+        and the `Popen` that start Hermes. A `umask` further down the function
+        runs after the process it was meant to affect has already been replaced.
+        """
+        tree = ast.parse(LEADER_ELECT.read_text(encoding="utf-8"))
+        main = next(
+            (
+                node
+                for node in tree.body
+                if isinstance(node, ast.FunctionDef) and node.name == "main"
+            ),
+            None,
+        )
+        self.assertIsNotNone(main, f"{LEADER_ELECT} no longer defines main()")
+
+        for statement in main.body:
+            call = statement.value if isinstance(statement, ast.Expr) else None
+            if isinstance(call, ast.Call) and ast.unparse(call.func) == "os.umask":
+                self.assertEqual(
+                    int(EXPECTED_UMASK, 8),
+                    ast.literal_eval(call.args[0]),
+                    "leader_elect.py sets a umask, but not the one the sidecar "
+                    "needs to write in the sandbox's directories",
+                )
+                return
+            # A `global` declaration binds no names at runtime and starts no
+            # process, so the umask is allowed to sit below one.
+            if isinstance(statement, ast.Global):
+                continue
+            self.fail(
+                "leader_elect.py must call os.umask("
+                + EXPECTED_UMASK
+                + ") before anything else in main(); found "
+                + ast.unparse(statement).splitlines()[0]
+            )
+        self.fail(f"{LEADER_ELECT} main() never sets a umask")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The agent sandbox and the credential proxy ran in one Pod, as one UID, with `shareProcessNamespace: true`.  That combination puts the proxy's `/proc/<pid>/environ` inside a directory the sandbox can read, so every credential the proxy holds was readable from the sandbox - no process compromise, no policy check, just a file read.  This stops setting the shared process namespace and gives the credential sidecar a UID of its own.  Both containers keep GID 10000 so the shared PVC still works from both sides, which is what the three `umask 0002` lines are for.

What this closes is the sandbox reading the proxy's process state and private volumes *by identity*.  It does not close the shared workspace, and I would rather say so here than have a reader infer it: both containers write `/opt/data` group-writable because each has to be able to change what the other created, so configuration the sandbox edits in a proxy-created clone is configuration a later proxied command reads.  That is pre-existing - before the split the sandbox owned those bytes outright - and the countermeasure is the command policy, not the Pod spec.  Written down under Limitation in `docs/credential-isolation-design.md`.

## Why This Change

Measured on the dev install before the change.  From inside the `platform-agent` container:

```
$ grep -l CREDENTIAL_PROXY_STATE_DIR /proc/[0-9]*/environ
/proc/14/environ
/proc/20/environ
/proc/21/environ
/proc/23/environ
/proc/5434/environ
```

`/proc/20` is `credential_proxy.py`.  Its environment is 77 variables and includes `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `API_SERVER_KEY` and `API_SERVER_EXTERNAL_KEY`.  Names only were recorded, never values.

Two things had to be true at once for that read to work.  The shared process namespace makes the proxy's PIDs visible in the sandbox's `/proc`, and the matching UID is what makes `environ` readable rather than `EACCES` - the kernel wants ptrace-level access for that file and grants it on a UID match.  Both are removed here, because either one alone would leave the other as the whole of the boundary.

The shared namespace was not there for the credential proxy at all.  It was set on the dashboard branch, and `hermes dashboard` does not need it.

## What Changed

- `platformagent_manifests.go` no longer sets `ShareProcessNamespace` on any spec shape, and the Pod's `runAsGroup` is now explicit.  The three UIDs are named constants (`sandboxUID`, `credentialProxyUID`, `agentFSGroup`) rather than repeated literals, because a boundary made of two `10000`s that have to differ is a boundary one careless edit removes.
- The `envoy-credential-proxy` container runs as `credentialProxyUID` (10001) with `runAsGroup` at the shared 10000.  It layers that onto `hardenedSecurityContext()` rather than writing the block out - "a different user belongs on the container, not in the floor" is that helper's own rule.
- `deploy/docker/Dockerfile` gives 10001 a name in the credential-proxy image.  An unnamed UID is a failed passwd lookup, and gcloud, gh and git all do one.
- Three startup paths set `umask 0002`: the agent entrypoint, the sidecar entrypoint, and `leader_elect.py`, which is the path a `replicas > 1` Pod takes instead of the entrypoint.  Without them the UID split breaks the GitOps flow - the sandbox creates a directory the sidecar then cannot clone into.  `tests/test_startup_umask.py` pins all three, including that the call sits above anything that can create a file.
- The credential proxy binds its backend socket under `umask 0177`, so the wider workspace umask cannot widen the socket.  Confirmed live: `srw------- credential-proxy hermes backend.sock`.
- `tests/e2e/operator/credential_isolation_e2e_test.py` is new.  The Go tests assert the rendered inputs; a manifest cannot tell you what the kernel actually shows one container about another, so this reads `/proc` from inside a real Pod.  It needs a cluster, there is no CI job for it, and it is read-only and safe to point at an install you care about.

**On the merge with #674.**  Both changes edit the same container securityContexts.  #674's `readOnlyRootFilesystem` is kept as it stands and the UID/GID fields go on top of it, through the `hardenedSecurityContext()` helper #674 introduced.  No field of #674's is changed or moved.

## Context

**Dependencies: none.  This is independent and mergeable now.**  It applies to `main` at b6ff2c5c and needs nothing else landed first.

This is one of the pieces #720 is being split into - that PR was one 25k-line branch and too big to review.  A follow-up, `up/08`, puts the credential broker in a Pod of its own behind an opt-in flag and compiles against the UID constants introduced here, so it wants this one merged first.  #720 stays open until the pieces land, then closes.

Open PRs on the same files, so whoever merges second knows to look.  None of them solves this problem, so these are conflict warnings rather than duplicate work:

- **#913** (@dshnayder, agent shell in a credentialless sandbox pod, draft) - the closest in intent, and it touches every file this one does.
- **#728** (@AntonTyb, baked skill trees verified against a manifest) - `deploy/docker/Dockerfile`, `deploy/shared/docker-entrypoint.sh`.
- **#857** (@shalinibhatiapl, typed `spec.networkPolicy`) - `platformagent_manifests.go`.
- **#952** (mine, git argument hardening) - `credential_proxy.py` and its tests, different function.
- **#720** - the branch this is cut from.

## Testing

- `make verify` - green (go build, go vet, go test, both Python suites).
- `make docs-check` - green, including the context budget.
- `prettier --check` (3.9.6) on the changed Markdown and YAML - clean.
- Goldens were regenerated with `-update`, not hand-patched.  The churn is four lines per file across the three existing fixtures: sidecar `runAsUser: 10001` / `runAsGroup: 10000`, pod-level `runAsGroup`, and `shareProcessNamespace: true` gone.  Nothing else moved.
- New Go assertions: the sidecar's UID and shared group, the Pod default user, and `TestTheProcessNamespaceIsUnsharedOnEverySpecShape`, which covers the no-harness-configuration shape that nothing else reached.  `TestBuildDeployment` and `TestBuildDeployment_DashboardEnabled` flipped from asserting `true` to asserting unset.
- `TestBuildPodTemplateSpecIsolatesTheSidecarUser` walks `InitContainers` as well as `Containers`, and fails if it did not find the sidecar.  The first cut of it walked `Containers` alone - the credential proxy is a native sidecar, so it is an init container, and the assertion named in the test's own title was unreachable.  Checked the way that kind of claim has to be: deleting `RunAsUser` from `buildCredentialProxySidecar` left the old version green and fails the new one.
- `BackendSocketModeTest` binds the socket under `umask 0o000` and requires 0600 back, so the mode is the code's rather than the process's.

### Live validation

**Install:** `bnaylor-ka-test` (GKE, `us-east4`, project `bnaylor-kagents-dev`), namespace `kubeagents-system`.  Baseline was agent image `dev-20260812-184046` and operator `k8s-operator:dev-pr724b`.  This change alters the rendered Pod, so all three images were rebuilt from the branch (`dev-20260825-161704` for the agent and sidecar, `dev-20260825-155945` for the operator), the operator swapped, and the CR's `spec.deployment.tag` patched.  Nobody else held the install; there was no `live-test-lease` ConfigMap in the namespace and `live_test_lease.py status` reported no protected install, so no lease was taken.  Recording that rather than implying one was.

Baseline first, so the result is a comparison:

| | Before | After | After revert |
| --- | --- | --- | --- |
| Sandbox / proxy UID (`id`) | both `10000` | `10000` / `10001` | both `10000` |
| `shareProcessNamespace` on the Pod | `true` | unset | `true` |
| PID 1 in each container | `/pause` (both) | each container's own entrypoint | `/pause` |
| Proxy processes visible from the sandbox | `credential_proxy.py`, `envoy` | none | back |
| Readable environs carrying the proxy's credentials | **5**, incl. `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `API_SERVER_KEY` | **0** of the 6 the proxy sees itself | **5** again |
| Backend socket mode | - | `srw-------` | - |

The e2e suite is the same evidence in one command.  Against the baseline it reported 5 failures and named them; against the branch, all ten checks pass:

```
PASS  platform-agent: PID 1 is the container's own entrypoint, not the Pod infra process
PASS  no broker process is visible in the agent container's /proc
PASS  no /proc/<pid>/environ readable by the agent carries CREDENTIAL_PROXY_STATE_DIR
PASS  the agent runs as 10000 and the broker as 10001
...
The credential boundary holds at runtime.
```

**The umask is the half that could have broken things, so it was exercised in the direction that matters.**  Both entrypoint-started process trees run at `0002` (`Umask: 0002` in `/proc/1/status` on each side).  A directory the sandbox creates comes out `drwxrwsr-x`; a `git clone` through the proxy into that directory writes `-rw-rw-r-- 1 10001 hermes`; and the sandbox then appends to the file the proxy wrote and `git status` sees it.  That is the GitOps flow's actual shape, both directions across the UID split.  Proxied `kubectl` and `gcloud` still work, the CR stayed `Ready=True (Reconciled)`, and no container restarted.

**One thing only the cluster could have told me.**  The first build crashlooped:

```
/opt/hermes/.venv/bin/python3: can't open file
'/opt/defaults/scripts/credential_proxy.py': [Errno 13] Permission denied
```

`agent-base` creates `/opt/defaults` mode 0700 and only the `platform` stage normalises the tree to 0755.  The sidecar image stopped building from `platform` when it was split into `proxy-tools` + `credential-proxy`, so it carries the 0700 - invisible while the container ran as the 10000 that owns it, fatal at 10001.  Fixed in the same `RUN` as the useradd.  Nothing secret is under there; it is the same defaults tree the sandbox image ships world-readable.

**Not covered.** The `replicas > 1` path is asserted against `leader_elect.py`'s parse tree, not run - the install is single-replica and scaling it to two would have meant a leader-election rollout on a shared cluster for one line of umask.  The image-layer budget was not run locally (no Docker on this host); the new instruction is on the `proxy-tools` chain, which is not the chain `check_image_layers.py` measures.

**Cleanup.**  Operator back on `dev-pr724b`, CR back on `dev-20260812-184046`, gateway `4/4 Running`, CR `Ready=True`, test clone deleted, no annotations or NetworkPolicies left behind.  Reverting restores the readable-environ baseline, which is that dev cluster's pre-existing state.  Left behind: three images in the dev Artifact Registry, and `:latest` in that repository now points at the credential-proxy build - nothing in the install consumes that tag.

## Self-Review

**How the passes ran.**  In the session that wrote the change, reading the branch diff.  This harness does not spawn review subagents, so `/pr-preflight` was not available and I am not claiming the fresh-context read AGENTS.md asks for.  Weigh what follows accordingly.

- **Does anything still depend on the shared process namespace?**  `isDashboardEnabled` was the only caller that set it, and the dashboard is loopback-only behind its own readiness probe.  Nothing in the tree reads `ShareProcessNamespace`.  The dashboard came up and stayed up on the live install.
- **Does the UID split break the shared volume?**  This is the real risk in the change and it is why the umask lines exist.  Checked both directions live rather than by reading the code - see Live validation.  It also found the `/opt/defaults` 0700 problem, which no unit test could have.
- **Does the umask widen anything it should not?**  0002 is group write on files the sidecar creates, and the sidecar's credential state is on emptyDirs nothing else mounts.  The one thing that would have been widened is the backend socket, which is why `serve` sets 0177 around the bind.  Observed `srw-------` on the running pod.  `envoy-admin.sock` in the same directory does come out 0775 - it is in the sidecar-only emptyDir, and the e2e suite asserts the sandbox does not mount that path.
- **Goldens.**  Read the diff rather than trusting the regeneration.  Four lines per fixture, all four expected.  One thing I deliberately reverted: a no-op `-update` on `main` also re-sorts `restartPolicy` below `resources` in all three fixtures, because whoever added the native sidecar hand-placed that key and the comparison is semantic so nothing failed.  That churn is pre-existing and not mine to land here.
- **Docs against source.**  The three doc edits say `shareProcessNamespace` is never set, the UIDs differ, and criterion 5 is no longer blocked.  Each read against the constants and the render path, not against each other.
- **Who else in the tree believed in the shared namespace?**  Grepped for it rather than assuming the operator was the only place.  One hit: `kanban_scheduling.py`, which documented it as the reason PIDs did not get reused and reasoned about crash adjudication on top of that.  Corrected, and the runtime consequence is in Risk & Rollout - that one is a real behaviour change this PR causes, not just stale prose.
- **The e2e file's own layout check was wrong.**  It looked for the broker in `.spec.containers`, and the credential proxy is a native sidecar, so it lives in `initContainers` - the suite would have exited "no broker container" against every install it was written for.  Caught by running it.  Fixed to read both lists.
- **The e2e file named a CRD field that does not exist.**  Two of its messages cited `spec.security.splitCredentialBrokerPod`, which a later PR introduces - a user reading the exit message would have searched the CRD for it.  The file detects the layout by container name and never needed the field; both messages now describe the layout instead.
- **Not fixed, deliberately:** the credential-proxy image's final `USER` is still `10000:10000`.  The Pod's securityContext is what decides, and it says 10001; changing the image default is a second way to say the same thing and a second way for the two to disagree.  Worth an argument if a reviewer wants one.

## Risk & Rollout

Every rendered Pod changes, and the Pod is recreated on upgrade (single replica, `Recreate` strategy), so this is a restart for every install.  The failure mode to watch is the one the live run hit: a path that was traversable at 10000 and is not at 10001.  It presents as the sidecar crashlooping on its own entrypoint with `Permission denied`, which is loud, immediate, and does not put the agent into service - not a silent degradation.  The other one to watch is a `EACCES` on the shared PVC from either side, which would show up as a skill failing to clone rather than as anything pointing here; the umask lines and `test_startup_umask.py` are what stand between us and that.

Three specific things an operator should know before this lands.  The first two are upgrade-window effects on installs that already exist, which is exactly the case a fresh live test cannot show you.

**Existing GitOps clones will trip git's ownership check, once each.**  Every clone on a shared PVC today was written by the proxy as UID 10000.  After this the proxy is 10001, and git 2.35+ refuses a repository it does not own:

```
fatal: detected dubious ownership in repository at '/opt/data/gitops/<repo>'
```

`fsGroup` does not help - it fixes the group, not `st_uid`, so the kubelet's mount pass leaves the owner where it was.

**The remedy is manual, and for a lease still in use it is the only one.**  Delete the affected workspace directory under the GitOps root and let the agent re-clone it; the new clone is written by 10001 and the repository is well again.  The lease reaper does not rescue you here, and it is worth being precise about why: `ensure_workspace` refreshes the lease marker on every call and passes `keep={lease}` to the reaper, so a lease that is still being used is explicitly spared.  Lease ids are stable by design - fleet-audit threads `lease=<audit-id>` and holds six long-lived streams - so a recurring stream keeps refreshing its own marker, its 10000-owned tree is never reaped, `_is_clone()` stays true so nothing re-clones over it, and every proxied `git` in that tree fails until a human removes it.  For a genuinely abandoned lease the reaper does clear the tree, but the TTL is 24 hours and it only runs on the next `ensure_workspace` under that root.

So: after upgrading, expect to delete GitOps workspaces once.  Blast radius is any clone on the PVC that predates the upgrade - transient for one-off leases, permanent-until-touched for recurring ones.  Pinning `safe.directory` on the proxied git environment is the durable fix; it belongs in the same environment-pinning block #952 restructures, so it is a follow-up rather than a conflict I create here.

**Kanban card reclaim gets slower after a `platform-agent` restart, in the safe direction.**  `deploy/docker/patches/kanban_scheduling.py` adjudicates crashed workers by probing a recorded PID with `os.kill(pid, 0)`, and its reasoning leaned on the shared namespace: PIDs did not restart from 1, so a stale PID from a previous process life usually named nothing.  With per-container namespaces a restart does start from 1, so a claim recording PID 4 will often hit a live process.  `release_dead_foreign_claims` treats a live PID as "never take the card away", so the card waits out its TTL (900s) instead of being reclaimed in seconds.  Late, not lost - and the alternative failure, taking a card from a worker still running it, is the one that patch exists to prevent.  Both docstrings are corrected in this PR.  Re-engineering the probe is not in a change this size.

**The shared workspace stays a channel into the credential container.**  See the Summary and the design doc's Limitation section.  Not introduced here and not closed here; closing it is the command policy's job, and nothing in the shipped policy does it yet.

Revert is the four commits.  There is no persisted state and no flag - the operator re-renders the Pod either way.  Nothing to do at merge time beyond knowing about the ownership error above.

This PR was generated with the help of Claude.
