### PR TITLE
fix(bench): retry the opening turn's transport and stop grading a 502

### DIFF
--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -73,11 +73,18 @@ from kube_agents_bench.parsing import (
     reported_statuses,
 )
 
-__all__ = ["KubeAgentsHarness"]
+__all__ = ["INFRA_FAILURE_MARKER", "KubeAgentsHarness"]
 
 _log = logging.getLogger("kube_agents_bench.harness")
 
 SERVICE_API_PORT = 8642
+
+# Prefix on ``AgentResult.errors[0]`` that marks a run as never having reached
+# the agent at all. ``hack/ci-eval-pr.sh`` matches this string in results.json
+# and classifies the task ``RUN_CLASS=INFRA``, so it lands in
+# ``INFRA_FAILED_TASKS`` instead of failing the pull request. The literal is the
+# contract between the two files: change it in both or in neither.
+INFRA_FAILURE_MARKER = "KUBE_AGENTS_INFRA_FAILURE"
 
 # Where hermes keeps per-card state in the agent's data volume. A card's
 # attachments hold the files its worker produced -- the deliverable itself on a
@@ -296,6 +303,34 @@ def _ensure_port_forward(local_port: int) -> None:
                 _PF_PROCESSES.pop(local_port, None)
             _stop_process(proc)
             raise
+
+
+def _reset_port_forward(local_port: int) -> None:
+    """Tear this process's forward down and stand a fresh one up.
+
+    ``_ensure_port_forward`` returns immediately when ``_port_open`` is true,
+    and an open local listener whose upstream is gone is exactly the state a
+    transport retry has to escape -- ``kubectl port-forward`` keeps accepting
+    on 127.0.0.1 after the pod behind it has been replaced. Probing the port
+    therefore proves nothing; the process has to go first.
+
+    A forward this process did not spawn is left alone (nothing is registered
+    to kill), and the re-establish is then a no-op -- someone else owns the
+    tunnel and terminating it is not ours to do.
+
+    Raises:
+        RuntimeError: The replacement forward could not be established.
+    """
+    with _port_establishment_lock(local_port):
+        with _PF_LOCK:
+            proc = _PF_PROCESSES.pop(local_port, None)
+        if proc is None:
+            _log.info("no port-forward owned on port %d; nothing to tear down", local_port)
+        else:
+            _log.info("tearing down the port-forward on port %d before retrying", local_port)
+            _stop_process(proc)
+    # Outside the lock: _ensure_port_forward takes the same non-reentrant one.
+    _ensure_port_forward(local_port)
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -595,8 +630,40 @@ class _TransportError(RuntimeError):
     """A turn that never reached the agent, or came back unreadable.
 
     Distinct from an agent that answered badly: the message is ready for
-    ``AgentResult.errors`` and the caller stops rather than retrying.
+    ``AgentResult.errors``.
+
+    ``retryable`` says whether issuing the same request again could plausibly
+    succeed. It is False by default so a new raise site has to opt in.
     """
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
+
+# Gateway statuses a proxy in front of the agent emits when the upstream is
+# gone or saturated -- the pod restarted, the tunnel died -- and which clear
+# once it is back. Every other status is an answer about the request itself and
+# repeating the request cannot change it, 500 included: a handler that raised
+# will raise again.
+_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+
+
+def _connection_dropped(exc: BaseException) -> bool:
+    """Whether ``exc`` is a connection lost in flight rather than a timeout.
+
+    A reset or a half-closed keepalive says the socket went away and a fresh
+    one may not; a timeout says the request may still be running on the other
+    end, and re-issuing it would spend the whole HTTP budget a second time for
+    a turn that could yet return. ``URLError`` wraps the real ``OSError`` in
+    ``reason``, so unwrap before testing.
+    """
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, BaseException):
+        exc = reason
+    if isinstance(exc, TimeoutError):
+        return False
+    return isinstance(exc, ConnectionError | http.client.IncompleteRead)
 
 
 def _post_turn(
@@ -619,16 +686,39 @@ def _post_turn(
             session_id = response.headers.get(_SESSION_ID_HEADER, "")
     except urllib.error.HTTPError as exc:
         raise _TransportError(
-            f"HTTP {exc.code} from agent endpoint: {_http_error_detail(exc)}"
+            f"HTTP {exc.code} from agent endpoint: {_http_error_detail(exc)}",
+            retryable=exc.code in _RETRYABLE_STATUSES,
         ) from exc
     except (OSError, http.client.HTTPException, ValueError) as exc:
         # Timeouts, resets, a mid-read protocol failure, and a body that is
         # neither UTF-8 nor JSON: transport, not agent, bugs.
-        raise _TransportError(f"{type(exc).__name__}: {exc}") from exc
+        raise _TransportError(
+            f"{type(exc).__name__}: {exc}", retryable=_connection_dropped(exc)
+        ) from exc
 
     if not isinstance(payload, dict):
         raise _TransportError(f"agent endpoint returned non-object JSON: {type(payload).__name__}")
     return parse_response(payload), session_id
+
+
+def _infra_failure(detail: str) -> AgentResult:
+    """A run that never reached the agent, recorded as infrastructure.
+
+    ``output`` is deliberately left empty. ``AgentResult.errored`` copies its
+    message into ``output``, which the eval harness writes to results.json as
+    the "Actual Output" the LLM judge grades -- and on build
+    2092339233527173120 that is how a proxy's HTTP 502 error page came to be
+    graded as the agent's answer to ``gpu-stress-test-diagnosis``
+    ("The Actual Output consists entirely of an HTTP 502 Bad Gateway",
+    OutcomeValidity 0.0). A transport failure has to set a run class, not an
+    output: the marker on ``errors[0]`` is what ``hack/ci-eval-pr.sh`` reads.
+    """
+    return AgentResult(
+        output="",
+        trajectory=[],
+        errors=[f"{INFRA_FAILURE_MARKER}: {detail}"],
+        metadata={"infra_failure": detail},
+    )
 
 
 class KubeAgentsHarness(AgentHarness):
@@ -706,10 +796,44 @@ class KubeAgentsHarness(AgentHarness):
             "input": prompt,
         }
 
-        try:
-            result, session_id = _post_turn(url, body, headers, timeout)
-        except _TransportError as exc:
-            return AgentResult.errored(str(exc))
+        # Same shape as the status-turn retry in _await_delegated_work: count
+        # the transport failures, log each one against the ceiling, and give up
+        # at _MAX_TRANSPORT_FAILURES. What differs is the escape between
+        # attempts -- there is no poll interval to back off over here, and the
+        # 502 this exists for is a live proxy over a dead upstream, so the
+        # tunnel is torn down and respawned rather than merely probed.
+        transport_failures = 0
+        while True:
+            try:
+                result, session_id = _post_turn(url, body, headers, timeout)
+                break
+            except _TransportError as exc:
+                # A 4xx, a 500, or a body that is not JSON says the endpoint
+                # answered; that is the agent's own failure and still belongs
+                # in front of the judge. Only a gateway status or a dropped
+                # connection is worth a second attempt.
+                if not exc.retryable:
+                    return AgentResult.errored(str(exc))
+                transport_failures += 1
+                _log.warning(
+                    "opening turn failed in transport (%d/%d): %s",
+                    transport_failures,
+                    _MAX_TRANSPORT_FAILURES,
+                    exc,
+                )
+                if transport_failures >= _MAX_TRANSPORT_FAILURES:
+                    # Not AgentResult.errored: see _infra_failure. This is the
+                    # run class, not an answer.
+                    return _infra_failure(
+                        f"the opening turn failed in transport {transport_failures} times "
+                        f"running; last failure: {exc}"
+                    )
+                try:
+                    _reset_port_forward(local_port)
+                except RuntimeError as pf_exc:
+                    # Counted, not returned: a forward that will not come back
+                    # is the same outage, and the loop's own ceiling ends it.
+                    _log.warning("port-forward respawn failed before retry: %s", pf_exc)
 
         if delegation_timeout > 0:
             session_id = (

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import threading
 import time
+import urllib.error
 from collections.abc import Generator
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.metadata import entry_points
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -186,7 +189,10 @@ class _StubAgentHandler(BaseHTTPRequestHandler):
         if self.server.session_id:
             headers["X-Hermes-Session-Id"] = self.server.session_id
         if len(self.server.requests) in self.server.fail_on:
-            self._respond(503, json.dumps({"error": {"message": "agent went away"}}).encode())
+            self._respond(
+                self.server.fail_on_status,
+                json.dumps({"error": {"message": "agent went away"}}).encode(),
+            )
         elif (
             self.server.fail_after is not None
             and len(self.server.requests) > self.server.fail_after
@@ -231,9 +237,12 @@ class _StubAgentServer(ThreadingHTTPServer):
     fail_with: int | None = None
     # Serve normally for this many requests, then 503 every later one.
     fail_after: int | None = None
-    # 1-based request ordinals that 503; every other request serves normally.
+    # 1-based request ordinals that fail; every other request serves normally.
     # Models a dropped keepalive rather than a dead endpoint.
     fail_on: frozenset[int] = frozenset()
+    # Status the ``fail_on`` ordinals answer with. 503 by default so the
+    # dropped-keepalive tests read as they did before 502 became interesting.
+    fail_on_status: int = 503
     raw_body: bytes | None = None
     session_id: str | None = _SESSION_ID
     session_row: dict[str, Any] = _SESSION_ROW
@@ -1113,6 +1122,233 @@ def test_a_pinned_port_forward_failure_stays_quiet_about_the_context(
     )
 
     assert harness._cluster_hint() == ""
+
+
+# --- the opening turn's transport retry --------------------------------------
+#
+# Build 2092339233527173120: the connectivity check passed at 20:07:13, the
+# agent answered a 502 at ~20:27:17 near the end of a 1283s task, and the judge
+# graded the proxy's error page -- "The Actual Output consists entirely of an
+# HTTP 502 Bad Gateway", OutcomeValidity 0.0. Two things were wrong. The
+# opening turn had no retry (the status-turn path already had one), and the
+# transport text was returned as the answer instead of as a run class.
+
+
+@pytest.fixture
+def recorded_pf_resets(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Record every tunnel respawn without spawning a real ``kubectl``."""
+    resets: list[int] = []
+    monkeypatch.setattr(harness, "_reset_port_forward", resets.append)
+    return resets
+
+
+def test_a_gateway_error_on_the_opening_turn_is_retried(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int]
+) -> None:
+    """A 502 on attempt one, the real answer on attempt two."""
+    stub_agent.fail_on = frozenset({1})
+    stub_agent.fail_on_status = 502
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == _FINAL_TEXT
+    assert len(stub_agent.requests) == 2
+    # The tunnel was replaced between the two, not merely probed.
+    assert recorded_pf_resets == [stub_agent.server_address[1]]
+
+
+@pytest.mark.parametrize("status", [502, 503, 504])
+def test_every_gateway_status_is_retried(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int], status: int
+) -> None:
+    """503 and 504 say the same thing a 502 does: the upstream is not there."""
+    stub_agent.fail_on = frozenset({1})
+    stub_agent.fail_on_status = status
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == _FINAL_TEXT
+
+
+def test_an_exhausted_retry_is_infrastructure_and_not_an_answer(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int]
+) -> None:
+    """A 502 on every attempt gives up, and gives up as a run class.
+
+    The output stays empty: whatever a dead proxy wrote is not the agent's
+    answer, and putting it in ``output`` is exactly what put an HTTP error page
+    in front of the judge on 2092339233527173120.
+    """
+    stub_agent.fail_with = 502
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
+    assert "HTTP 502" in result.errors[0]
+    assert result.output == ""
+    assert result.trajectory == []
+    assert len(stub_agent.requests) == harness._MAX_TRANSPORT_FAILURES
+    # One respawn between each pair of attempts, none after the last.
+    assert len(recorded_pf_resets) == harness._MAX_TRANSPORT_FAILURES - 1
+
+
+def test_an_agent_side_error_is_still_graded(stub_agent: _StubAgentServer) -> None:
+    """A 500 is the endpoint answering, so it keeps the old behaviour.
+
+    The INFRA class is for turns that never reached the agent. Widening it to
+    every failed request would take real agent faults off the gate: they are
+    not retried, they are not marked, and their text still reaches the judge.
+    """
+    stub_agent.fail_with = 500
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert result.has_errors()
+    assert harness.INFRA_FAILURE_MARKER not in result.errors[0]
+    assert "HTTP 500" in result.errors[0]
+    # Still in front of the judge, as before.
+    assert result.errors[0] in result.output
+    assert len(stub_agent.requests) == 1
+
+
+def test_a_well_formed_answer_that_reports_a_failure_is_untouched(
+    stub_agent: _StubAgentServer,
+) -> None:
+    """The agent saying "I could not do it" is a score, not an infra event."""
+    refusal = "I could not provision the operator: the project has no GPU quota."
+    stub_agent.raw_body = json.dumps(
+        {
+            **_RESPONSE,
+            "output": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": refusal}],
+                }
+            ],
+        }
+    ).encode()
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == refusal
+    assert len(stub_agent.requests) == 1
+
+
+def test_a_timeout_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The turn may still be running; a retry would spend the budget twice."""
+    assert harness._connection_dropped(TimeoutError("timed out")) is False
+    assert harness._connection_dropped(ConnectionResetError(104, "reset by peer")) is True
+    # urllib buries the real OSError in URLError.reason.
+    wrapped = urllib.error.URLError(ConnectionResetError(104, "reset by peer"))
+    assert harness._connection_dropped(wrapped) is True
+    assert harness._connection_dropped(urllib.error.URLError(TimeoutError())) is False
+
+
+def test_the_tunnel_is_torn_down_rather_than_probed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_ensure_port_forward`` alone cannot escape a live-listener outage.
+
+    ``kubectl port-forward`` keeps accepting on 127.0.0.1 after the pod behind
+    it is replaced, so ``_port_open`` stays true and the re-establish is a
+    no-op. The reset has to kill the process it owns first.
+    """
+    stopped: list[object] = []
+    established: list[int] = []
+    stale = object()
+    monkeypatch.setitem(harness._PF_PROCESSES, 4242, stale)  # type: ignore[arg-type]
+    monkeypatch.setattr(harness, "_stop_process", stopped.append)
+    monkeypatch.setattr(harness, "_ensure_port_forward", established.append)
+
+    harness._reset_port_forward(4242)
+
+    assert stopped == [stale]
+    assert established == [4242]
+    assert 4242 not in harness._PF_PROCESSES
+
+
+# --- the ci-eval-pr.sh contract ----------------------------------------------
+
+
+def _run_class_classifier(results_path: object, deployer: str) -> str:
+    """Run hack/ci-eval-pr.sh's RUN_CLASS snippet against a results.json.
+
+    The marker string is a contract between two files in two languages. Copying
+    it into an assertion here would only prove this test agrees with itself, so
+    the snippet is lifted out of the shell script and executed as written.
+    """
+    script = (Path(__file__).resolve().parents[2] / "hack" / "ci-eval-pr.sh").read_text()
+    body = script.split('RUN_CLASS=$(python3 -c "', 1)[1].split('\n" 2>/dev/null', 1)[0]
+    body = body.replace("${LATEST_RESULT}", str(results_path)).replace("${DEPLOYER}", deployer)
+    return subprocess.run(
+        [sys.executable, "-c", body], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture
+def results_json(tmp_path: Path) -> Any:
+    """Write a devops-bench-shaped record and hand back its path."""
+
+    def _write(result: AgentResult, *, scores: dict[str, Any] | None = None) -> Path:
+        dumped = result.to_dict()
+        path = tmp_path / "results.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "gpu-stress-test-diagnosis",
+                        "output": dumped["output"],
+                        "errors": dumped["errors"],
+                        "error": (dumped["errors"] or [None])[0],
+                        "scores": scores if scores is not None else {"OutcomeValidity": 0.0},
+                    }
+                ]
+            )
+        )
+        return path
+
+    return _write
+
+
+def test_the_marker_classifies_the_run_as_infra(results_json: Any) -> None:
+    """The whole point: INFRA_FAILED_TASKS, not FAILED_TASKS.
+
+    The record is scored -- the judge graded the empty output and returned 0.0
+    -- so the pre-existing "has scores" test would have called this OK and let
+    a pod restart red the pull request.
+    """
+    path = results_json(harness._infra_failure("HTTP 502 from agent endpoint"))
+
+    assert _run_class_classifier(path, "opentofu") == "INFRA"
+    # No noop carve-out: an unreachable agent endpoint is infrastructure
+    # whatever the task provisions.
+    assert _run_class_classifier(path, "noop") == "INFRA"
+
+
+def test_an_ordinary_scored_record_is_still_graded(results_json: Any) -> None:
+    path = results_json(
+        AgentResult(output="the node pool is out of GPU quota", trajectory=[]),
+        scores={"OutcomeValidity": 0.9},
+    )
+
+    assert _run_class_classifier(path, "opentofu") == "OK"
+
+
+def test_an_agent_error_without_the_marker_is_still_graded(results_json: Any) -> None:
+    """A 500 reaches the judge exactly as it did before this change."""
+    path = results_json(AgentResult.errored("HTTP 500 from agent endpoint: agent exploded"))
+
+    assert _run_class_classifier(path, "opentofu") == "OK"
+
+
+def test_a_scoreless_record_still_blocks(results_json: Any) -> None:
+    """The BROKEN branch must survive the marker check being inserted above it."""
+    path = results_json(AgentResult(output="", trajectory=[]), scores={})
+
+    assert _run_class_classifier(path, "opentofu") == "BROKEN"
 
 
 # --- delegated (kanban) work -------------------------------------------------

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -8,6 +8,7 @@ path the eval harness consumes.
 
 from __future__ import annotations
 
+import http.client
 import json
 import subprocess
 import sys
@@ -176,6 +177,15 @@ class _StubAgentHandler(BaseHTTPRequestHandler):
         self.server.last_request = json.loads(self.rfile.read(length))
         self.server.requests.append(self.server.last_request)
         self.server.last_auth = self.headers.get("Authorization")
+        if len(self.server.requests) in self.server.drop_on:
+            # Kill the socket before any status line goes out: the client
+            # sees the connection die in flight, not an HTTP answer.
+            self.close_connection = True
+            try:
+                self.wfile.close()
+            finally:
+                self.connection.close()
+            return
         if self.path != "/v1/responses":
             self.send_error(404)
             return
@@ -240,6 +250,9 @@ class _StubAgentServer(ThreadingHTTPServer):
     # 1-based request ordinals that fail; every other request serves normally.
     # Models a dropped keepalive rather than a dead endpoint.
     fail_on: frozenset[int] = frozenset()
+    # 1-based request ordinals whose socket is closed before any response
+    # bytes: a connection lost in flight, as distinct from a gateway status.
+    drop_on: frozenset[int] = frozenset()
     # Status the ``fail_on`` ordinals answer with. 503 by default so the
     # dropped-keepalive tests read as they did before 502 became interesting.
     fail_on_status: int = 503
@@ -1247,6 +1260,77 @@ def test_a_timeout_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:
     wrapped = urllib.error.URLError(ConnectionResetError(104, "reset by peer"))
     assert harness._connection_dropped(wrapped) is True
     assert harness._connection_dropped(urllib.error.URLError(TimeoutError())) is False
+    # The other half of the isinstance: a body cut off mid-read.
+    assert harness._connection_dropped(http.client.IncompleteRead(b"partial")) is True
+
+
+def test_a_connection_dropped_in_flight_is_retried(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int]
+) -> None:
+    """The socket dies before a status line; the retry gets the answer.
+
+    The gateway-status tests exercise ``retryable`` through the HTTPError arm
+    of ``_post_turn``; this one exercises the OSError arm, where the verdict
+    comes from ``_connection_dropped`` on the unwrapped exception.
+    """
+    stub_agent.drop_on = frozenset({1})
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == _FINAL_TEXT
+    assert len(stub_agent.requests) == 2
+    assert recorded_pf_resets == [stub_agent.server_address[1]]
+
+
+def test_a_failed_respawn_is_absorbed_and_the_ceiling_still_ends_the_run(
+    stub_agent: _StubAgentServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A tunnel that will not come back is the same outage, not a crash.
+
+    ``_reset_port_forward`` raises when the replacement forward cannot be
+    established -- a cluster that is fully down. If that escaped ``run()``,
+    the harness would die with no record at all and the task would land in
+    BROKEN (or worse, kill the eval loop) instead of INFRA: exactly the
+    un-graded death the retry exists to prevent.
+    """
+    respawn_attempts: list[int] = []
+
+    def _failing_reset(port: int) -> None:
+        respawn_attempts.append(port)
+        raise RuntimeError("port-forward did not become ready")
+
+    monkeypatch.setattr(harness, "_reset_port_forward", _failing_reset)
+    stub_agent.fail_with = 502
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
+    assert result.output == ""
+    # The failed respawns did not shortcut the ceiling: every attempt ran.
+    assert len(stub_agent.requests) == harness._MAX_TRANSPORT_FAILURES
+    assert len(respawn_attempts) == harness._MAX_TRANSPORT_FAILURES - 1
+
+
+def test_an_unowned_tunnel_is_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No registered process for the port: nothing killed, re-establish still runs.
+
+    The docstring's contract: a forward this process did not spawn is not ours
+    to terminate. The reset then degrades to the probe -- which no-ops on the
+    open listener -- so the retry loop spins to its ceiling and the run ends
+    INFRA rather than the harness reaching into someone else's tunnel.
+    """
+    stopped: list[object] = []
+    established: list[int] = []
+    monkeypatch.setattr(harness, "_stop_process", stopped.append)
+    monkeypatch.setattr(harness, "_ensure_port_forward", established.append)
+    assert 4243 not in harness._PF_PROCESSES
+
+    harness._reset_port_forward(4243)
+
+    assert stopped == []
+    assert established == [4243]
 
 
 def test_the_tunnel_is_torn_down_rather_than_probed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -490,11 +490,27 @@ for TASK in "${TASKS[@]}"; do
   #             for the infra owner. A noop-deployer task prepares nothing,
   #             so its pre-record death is never weather -- it is a harness
   #             or agent crash and classifies BROKEN instead.
+  #             Also: a scored record the harness marked with
+  #             KUBE_AGENTS_INFRA_FAILURE -- see below.
   #   BROKEN -- the run died somewhere no infrastructure excuse exists: a
   #             record with no scores (the scoring pass crashed), or any
   #             pre-record death on a noop task. BLOCKS -- treating these as
   #             infra would let a crash turn the whole gate green.
   #   OK     -- a record with scores; the gate below decides.
+  #
+  # KUBE_AGENTS_INFRA_FAILURE is the marker kube_agents_bench.harness puts on
+  # errors[0] when the agent endpoint failed in transport on every attempt, so
+  # no turn ever reached the agent. The record IS scored -- the judge grades
+  # the empty output and returns 0.0 -- but there is no answer in it to grade,
+  # and gating on that score reds the PR for a pod restart. The harness raises
+  # this only after exhausting its retries on a gateway status or a dropped
+  # connection; a 4xx, a 500, or any answer the agent actually returned stays
+  # OK and is graded normally.
+  #
+  # No noop carve-out here, unlike the two branches above: those infer infra
+  # from an absent record, which a noop task cannot honestly claim, whereas
+  # this marker is the harness stating what happened. An unreachable agent
+  # endpoint is infrastructure whatever the task's deployer provisions.
   RUN_CLASS=$(python3 -c "
 import json, os
 path = '${LATEST_RESULT}'
@@ -514,7 +530,13 @@ else:
             print('BROKEN' if deployer == 'noop' else 'INFRA')
         else:
             rec = data[0] if isinstance(data, list) else data
-            print('OK' if rec and isinstance(rec, dict) and rec.get('scores') else 'BROKEN')
+            rec = rec if isinstance(rec, dict) else {}
+            errors = rec.get('errors') or []
+            # Before the scores test: the record carries both.
+            if any('KUBE_AGENTS_INFRA_FAILURE' in str(e) for e in errors):
+                print('INFRA')
+            else:
+                print('OK' if rec.get('scores') else 'BROKEN')
     except Exception:
         print('BROKEN')
 " 2>/dev/null || echo "BROKEN")
@@ -532,15 +554,19 @@ else:
     fi
     FAILED_TASKS+=("${TASK_NAME} (run produced no scored record)")
   elif [ "${RUN_CLASS}" = "INFRA" ]; then
-    echo "⚠️ [RESOURCE_PREPARATION_FAILED] Evaluation task ${TASK_NAME} resource creation or teardown failed! (The evaluation is skipped)"
+    # RESOURCE_PREPARATION_FAILED is kept verbatim as the grep token even
+    # though the class now also covers an unreachable agent endpoint; the
+    # artifact below says which of the two it was.
+    echo "⚠️ [RESOURCE_PREPARATION_FAILED] Evaluation task ${TASK_NAME} resource creation, teardown, or agent transport failed! (The evaluation is skipped)"
     ARTIFACT_DIR="${ARTIFACTS:-/tmp/artifacts}"
     mkdir -p "${ARTIFACT_DIR}"
     cp "${EVAL_LOG}" "${ARTIFACT_DIR}/resource_prep_failure_${TASK_NAME}.log" 2>/dev/null || true
     [ -n "${NEW_RUN_DIR}" ] && cp "${EVAL_LOG}" "${NEW_RUN_DIR}/resource_prep_failure.log" 2>/dev/null || true
     echo "Saved resource preparation log to artifact: ${ARTIFACT_DIR}/resource_prep_failure_${TASK_NAME}.log"
-    echo "Task ${TASK_NAME} Result: [RESOURCE_PREPARATION_FAILED] Infrastructure setup/teardown error (Duration: ${TASK_DURATION}s)"
-    # Deliberately NOT appended to FAILED_TASKS: an OpenTofu stockout or a
-    # teardown race says nothing about the pull request under test, and
+    echo "Task ${TASK_NAME} Result: [RESOURCE_PREPARATION_FAILED] Infrastructure setup/teardown or agent transport error (Duration: ${TASK_DURATION}s)"
+    # Deliberately NOT appended to FAILED_TASKS: an OpenTofu stockout, a
+    # teardown race, or an agent pod that went away mid-task says nothing
+    # about the pull request under test, and
     # redding the job for it teaches people to ignore the job. The log line
     # above and the artifact are the record; whoever owns the eval
     # infrastructure greps for RESOURCE_PREPARATION_FAILED, not the PR author.


### PR DESCRIPTION
Part of #957 (flake A).

## What went wrong

On build `2092339233527173120`, `gpu-stress-test-diagnosis` scored `OutcomeValidity 0.0` and failed the pull request. The judge's stated reason:

> The Actual Output consists entirely of an HTTP 502 Bad Gateway

The connectivity check had passed 20 minutes earlier (`✓ Agent API Server responded successfully in 41s!` at 20:07:13); the 502 arrived at ~20:27:17, near the end of a 1283s task. We asked Gemini to grade a proxy error page and then failed the PR on the result.

Three defects, all fixed here.

## 1. The opening turn had no retry

`harness.py` caught `_TransportError` from the first `_post_turn` and gave up immediately. The delegation-poll path in `_await_delegated_work` already caught the identical error and retried up to `_MAX_TRANSPORT_FAILURES = 3`; the first turn was simply never wired to it. The new loop mirrors that path's counting and logging shape.

`_TransportError` now carries a `retryable` flag set at the raise site — a gateway status (502/503/504) or a connection dropped in flight — rather than the caller re-deriving it from the message text. A timeout is deliberately **not** retryable: the turn may still be running on the other end, and a second attempt would spend the whole `AGENT_HTTP_TIMEOUT` budget again.

## 2. A retry would have retried into the same hole

`_ensure_port_forward` returns immediately when `_port_open(local_port)` is true, and it is called once before the first turn. `kubectl port-forward` keeps accepting on 127.0.0.1 after the pod behind it has been replaced, which is exactly this outage — so probing the port proves nothing.

`_reset_port_forward` is the explicit teardown path: it pops the process this harness registered, `_stop_process`es it, and only then re-establishes. A forward this process did not spawn is left alone. A respawn that fails is counted as another attempt rather than returned, so the loop's own ceiling still ends it.

## 3. A transport error was returned as the agent's answer

`AgentResult.errored(msg)` copies `msg` into `output`, and the eval harness writes `output` to results.json as the "Actual Output" the judge grades. That is the mechanism above.

Exhausted retries now return `_infra_failure(...)`: **empty** output, and `errors[0]` prefixed with `KUBE_AGENTS_INFRA_FAILURE`.

### The shell-side change, and why it was needed

`hack/ci-eval-pr.sh` classifies a run purely from results.json, and its `INFRA` branch only fires when there is **no** scored record. A transport failure still produces one — devops-bench grades the (now empty) output and writes `OutcomeValidity 0.0` — so the existing "has scores" test would have called it `OK` and gated on the zero. There was no way to reach `RUN_CLASS=INFRA` from the harness without a small change on the shell side, so the classifier now checks `errors[]` for the marker **before** the scores test. Everything downstream of that (`INFRA_FAILED_TASKS`, the `resource_prep_failure_*.log` artifact, the `EVAL_INFRASTRUCTURE_DOWN` all-tasks-failed guard) is reused as-is.

Two smaller decisions there, both commented in the file:

- **No noop-deployer carve-out.** The two existing `INFRA` branches infer infrastructure from an *absent* record, which a noop task cannot honestly claim. This marker is the harness *stating* what happened, and an unreachable agent endpoint is infrastructure whatever the task provisions.
- The `RESOURCE_PREPARATION_FAILED` grep token is kept verbatim (people grep for it); only the prose around it gained "or agent transport".

## The class stays narrow

A 4xx, a 500, a non-JSON body, and any answer the agent actually returned are unretried, unmarked, and still graded. `test_an_agent_side_error_is_still_graded` and `test_a_well_formed_answer_that_reports_a_failure_is_untouched` pin that.

## Validation

Everything below was run at `a6e64924`.

**`cd bench && uv run pytest`** — 1 failed, 292 passed, 2 skipped.

```
FAILED cuj/test_00_agent_responsive.py::test_00_agent_live_and_responsive[platform-agent:default]
1 failed, 292 passed, 2 skipped in 56.41s
```

The one failure is `agent prerequisite failed: No verified portal connection is available` — a live-agent CUJ test with no cluster to talk to on this machine. It is **pre-existing**: stashing this branch's changes and running `uv run pytest cuj/test_00_agent_responsive.py` on a clean tree fails identically (`1 failed in 1.57s`). The two skips are the same prerequisite. `tests/test_harness.py` alone is 128 passed.

**`python3 scripts/validate_bench_cases.py`** — pass.

```
13 bench case(s) OK.
```

**`python3 scripts/test_task_registration.py`** — pass.

```
Ran 58 tests in 0.621s

OK
```

**`python3 scripts/test_domain_coverage.py`** — pass.

```
Ran 4 tests in 0.123s

OK
```

**`shellcheck -S warning hack/ci-eval-pr.sh`** — one warning, `SC2155` at line 310, pre-existing and untouched by this change. `bash -n hack/ci-eval-pr.sh` is clean.

## Tests added

In `bench/tests/test_harness.py`:

- `test_a_gateway_error_on_the_opening_turn_is_retried` — 502 on attempt one, the real answer on attempt two, and the tunnel replaced in between (not merely probed).
- `test_every_gateway_status_is_retried` — parametrised over 502/503/504.
- `test_an_exhausted_retry_is_infrastructure_and_not_an_answer` — 502 on every attempt: marker on `errors[0]`, `output == ""`, exactly `_MAX_TRANSPORT_FAILURES` requests, exactly two respawns.
- `test_an_agent_side_error_is_still_graded` — a 500 is unretried, unmarked, and its text still reaches `output`.
- `test_a_well_formed_answer_that_reports_a_failure_is_untouched` — the agent saying "I could not do it" is a score, not an infra event.
- `test_a_timeout_is_not_retried` — unit coverage of `_connection_dropped`, including the `URLError.reason` unwrap.
- `test_the_tunnel_is_torn_down_rather_than_probed` — `_reset_port_forward` stops the registered process and re-establishes.
- Four tests that **execute the actual `RUN_CLASS` snippet lifted out of `hack/ci-eval-pr.sh`** against a synthetic results.json. The marker is a contract between two files in two languages; copying it into an assertion would only prove the test agrees with itself. These cover: the marker → `INFRA` (both deployers), an ordinary scored record → `OK`, an unmarked agent error → `OK`, and a scoreless record → still `BROKEN`.

`_StubAgentServer` gained a `fail_on_status` (default 503, so the existing dropped-keepalive tests read unchanged).

## Not in scope

This makes a pod restart stop looking like a bad answer. It does not explain *why* the agent pod became unreachable 20 minutes into a task — the 502 body was the Python `http.server` error template, so a proxy in front of the agent was reporting an unreachable upstream. Per #957 that is a separate investigation.

Companion PR for flakes B and C: https://github.com/GoogleCloudPlatform/oss-test-infra/pull/2664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
