### PR TITLE
fix(ci): grant logging and artifact registry roles in WIF admin setup

### DIFF
--- a/k8s-operator/scripts/dev/README.md
+++ b/k8s-operator/scripts/dev/README.md
@@ -10,9 +10,9 @@ The `setup-gcp-github-wif.sh` script automates the creation and configuration of
 
 ### What it does
 
-1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, `pubsub`, `gkebackup`) are enabled on your GCP project.
+1. **Enables Required APIs**: Ensures fundamental APIs (`iamcredentials`, `cloudresourcemanager`, `container`, `storage`, `pubsub`, `gkebackup`, `logging`, `artifactregistry`) are enabled on your GCP project.
 2. **Creates a Service Account**: Provisions a dedicated GCP Service Account for GitHub Actions to impersonate.
-3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, `roles/compute.viewer`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`).
+3. **Assigns IAM Roles**: Grants necessary permissions (`roles/cloudkms.admin`, `roles/container.admin`, `roles/compute.viewer`, etc.) to the new service account. When run with `--admin`, grants extended lifecycle administration roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`, `roles/logging.configWriter`, `roles/artifactregistry.admin`) required for full install/uninstall cycles (`install.sh` / `uninstall.sh`) and automated E2E testing.
 4. **Configures WIF**: Creates a Workload Identity Pool and an OIDC Provider linked to GitHub (`https://token.actions.githubusercontent.com`).
 5. **Secures Access**: Configures attribute mapping and conditions so that _only_ your specific GitHub Repository is authorized to authenticate via this pool.
 6. **Grants WIF Principal Role**: Grants the `roles/serviceusage.serviceUsageConsumer` role to the WIF principal to allow it to consume service quota.
@@ -28,7 +28,7 @@ Before running the script, you must have the Google Cloud CLI (`gcloud`) install
 
 #### Options
 
-- `--admin`: Grants extended IAM roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`) for full autonomous install/uninstall lifecycle operations.
+- `--admin`: Grants extended IAM roles (`roles/iam.serviceAccountAdmin`, `roles/resourcemanager.projectIamAdmin`, `roles/pubsub.admin`, `roles/gkebackup.admin`, `roles/storage.admin`, `roles/logging.configWriter`, `roles/artifactregistry.admin`) for full autonomous install/uninstall lifecycle and E2E test operations.
 - `ADMIN=true`: Environment variable alternative to `--admin`.
 
 > **Note:** IAM role grants made with `--admin` are additive and remain assigned to the service account in your GCP project until manually revoked.

--- a/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
+++ b/k8s-operator/scripts/dev/setup-gcp-github-wif.sh
@@ -77,6 +77,8 @@ gcloud services enable iamcredentials.googleapis.com \
   storage.googleapis.com \
   pubsub.googleapis.com \
   gkebackup.googleapis.com \
+  logging.googleapis.com \
+  artifactregistry.googleapis.com \
   --project="${PROJECT_ID}"
 
 # 3. Create Service Account
@@ -89,9 +91,16 @@ gcloud iam service-accounts create "${SA_NAME}" \
 echo "Granting necessary roles to the Service Account..."
 # Base roles required for standard CI deployments:
 ROLES=(
+  # Cloud KMS keyring and CryptoKey management for GKE CMEK database encryption, Backup for GKE, and GitHub Token Minter key provisioning
   "roles/cloudkms.admin"
+
+  # Full GKE cluster lifecycle management (cluster provisioning, node pools, and gVisor sandbox configuration)
   "roles/container.admin"
+
+  # Read-only Compute Engine and VPC inspection for GKE node-pool instance groups, machine types, reservations, and quota advice
   "roles/compute.viewer"
+
+  # Enabling and consuming required Google Cloud APIs across the platform
   "roles/serviceusage.serviceUsageAdmin"
   "roles/serviceusage.serviceUsageConsumer"
 )
@@ -114,6 +123,12 @@ if [ "$IS_ADMIN" = true ]; then
 
     # Terraform remote state management (creating and managing gs://<project>-kube-agents-tfstate)
     "roles/storage.admin"
+
+    # Cloud Logging sink creation and filter routing for event and autoscaler log ingestion into Pub/Sub
+    "roles/logging.configWriter"
+
+    # Artifact Registry repository creation and image management for agent plugin extensions
+    "roles/artifactregistry.admin"
   )
 fi
 

--- a/tests/test_setup_gcp_github_wif.py
+++ b/tests/test_setup_gcp_github_wif.py
@@ -1,0 +1,140 @@
+"""Tests for k8s-operator/scripts/dev/setup-gcp-github-wif.sh.
+
+Asserts that required GCP APIs and IAM roles (for both standard CI and extended
+--admin E2E pipelines) remain consistent and complete.
+"""
+
+import pathlib
+import re
+import subprocess
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_WIF_SCRIPT = _REPO_ROOT / "k8s-operator" / "scripts" / "dev" / "setup-gcp-github-wif.sh"
+
+
+_EXPECTED_APIS = [
+    "iamcredentials.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "container.googleapis.com",
+    "storage.googleapis.com",
+    "pubsub.googleapis.com",
+    "gkebackup.googleapis.com",
+    "logging.googleapis.com",
+    "artifactregistry.googleapis.com",
+]
+
+_STANDARD_ROLES = [
+    "roles/cloudkms.admin",
+    "roles/container.admin",
+    "roles/compute.viewer",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/serviceusage.serviceUsageConsumer",
+]
+
+_ADMIN_ROLES = [
+    "roles/iam.serviceAccountAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/pubsub.admin",
+    "roles/gkebackup.admin",
+    "roles/storage.admin",
+    "roles/logging.configWriter",
+    "roles/artifactregistry.admin",
+]
+
+
+class SetupGcpGithubWifTest(unittest.TestCase):
+    def setUp(self):
+        self.assertTrue(_WIF_SCRIPT.is_file(), f"WIF script not found at {_WIF_SCRIPT}")
+        self.script_content = _WIF_SCRIPT.read_text()
+
+    def _get_enabled_services_invocation(self) -> str:
+        match = re.search(r"gcloud services enable\s+([\s\S]*?)--project=", self.script_content)
+        self.assertIsNotNone(match, "Could not find 'gcloud services enable ... --project=' invocation")
+        return match.group(1)
+
+    def _split_script_by_admin_boundary(self) -> tuple[str, str]:
+        boundary = 'echo "Admin mode selected.'
+        self.assertIn(boundary, self.script_content, "Admin branch boundary not found in script")
+        base_part, admin_part = self.script_content.split(boundary, 1)
+        return base_part, admin_part
+
+    def test_missing_required_env_vars_fails(self):
+        """Executing the script without required env vars should fail with an informative message."""
+        env = get_isolated_test_env(
+            overrides={
+                "PROJECT_ID": "",
+                "SA_NAME": "",
+                "GITHUB_REPO": "",
+            }
+        )
+        proc = subprocess.run(
+            ["bash", str(_WIF_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Please set the required variables", proc.stdout)
+
+    def test_required_services_enabled_in_invocation(self):
+        """Ensures all required APIs are explicitly present in the gcloud services enable call."""
+        invocation = self._get_enabled_services_invocation()
+        active_tokens = [
+            line.strip().rstrip("\\").strip()
+            for line in invocation.splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ]
+        for api in _EXPECTED_APIS:
+            self.assertIn(
+                api,
+                active_tokens,
+                f"Expected API '{api}' missing from gcloud services enable invocation in {_WIF_SCRIPT}",
+            )
+        self.assertEqual(len(active_tokens), len(_EXPECTED_APIS))
+
+    def test_standard_roles_defined_in_base_tier_only(self):
+        """Verifies base standard CI roles are in base ROLES array and admin roles are excluded."""
+        base_part, _ = self._split_script_by_admin_boundary()
+        base_roles_match = re.search(r"^\s*ROLES=\(\s*\n([\s\S]*?)^\s*\)", base_part, re.MULTILINE)
+        self.assertIsNotNone(base_roles_match, "Base ROLES array definition not found")
+        base_block = base_roles_match.group(1)
+
+        for role in _STANDARD_ROLES:
+            self.assertIn(
+                f'"{role}"',
+                base_block,
+                f"Standard role '{role}' missing in base ROLES array of {_WIF_SCRIPT}",
+            )
+        for role in _ADMIN_ROLES:
+            self.assertNotIn(
+                f'"{role}"',
+                base_block,
+                f"Admin role '{role}' unexpectedly found in base ROLES array of {_WIF_SCRIPT}",
+            )
+
+    def test_admin_extended_roles_defined_in_admin_tier_only(self):
+        """Verifies extended admin roles are in admin ROLES+= array and base roles are excluded."""
+        _, admin_part = self._split_script_by_admin_boundary()
+        admin_roles_match = re.search(r"^\s*ROLES\+=\(\s*\n([\s\S]*?)^\s*\)", admin_part, re.MULTILINE)
+        self.assertIsNotNone(admin_roles_match, "Admin ROLES+= array definition not found")
+        admin_block = admin_roles_match.group(1)
+
+        for role in _ADMIN_ROLES:
+            self.assertIn(
+                f'"{role}"',
+                admin_block,
+                f"Admin lifecycle role '{role}' missing in ROLES+= array of {_WIF_SCRIPT}",
+            )
+        for role in _STANDARD_ROLES:
+            self.assertNotIn(
+                f'"{role}"',
+                admin_block,
+                f"Base role '{role}' unexpectedly found in admin ROLES+= array of {_WIF_SCRIPT}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `roles/logging.configWriter` and `roles/artifactregistry.admin` to the extended `--admin` role bundle in `k8s-operator/scripts/dev/setup-gcp-github-wif.sh` and ensures the `logging.googleapis.com` and `artifactregistry.googleapis.com` APIs are enabled during GCP Workload Identity Federation (WIF) setup.

## Why This Change

In the automated RC Release E2E Pipeline ([Run #32866087154](https://github.com/gke-labs/kube-agents/actions/runs/32866087154/job/97863070669)), `test_stockout_investigation.py` failed during extension setup with:
```text
ERROR: (gcloud.logging.sinks.create) [github-deploy-sa@kube-agents-rc.iam.gserviceaccount.com]
Permission 'logging.sinks.create' denied on resource '//logging.googleapis.com/projects/kube-agents-rc/sinks/gke-stockout-alerts-sink'
reason: IAM_PERMISSION_DENIED
```
While running E2E suites and plugin lifecycle operations, the GitHub Actions deployment service account requires:
1. `roles/logging.configWriter` to create and update Cloud Logging sinks routing autoscaler and cluster error events to Pub/Sub.
2. `roles/artifactregistry.admin` to create Artifact Registry Docker repositories (`gcloud artifacts repositories create`) and publish plugin images in `agentplugins/lib/plugin_image.sh`.

## What Changed

- **`k8s-operator/scripts/dev/setup-gcp-github-wif.sh`**:
  - Adds `roles/logging.configWriter` and `roles/artifactregistry.admin` to the `--admin` extended role array.
  - Adds `logging.googleapis.com` and `artifactregistry.googleapis.com` to the enabled service APIs.
  - Expands comments for all assigned roles to provide comprehensive, infrastructure-first descriptions of their platform lifecycle scope.
- **`k8s-operator/scripts/dev/README.md`**:
  - Updates the list of enabled APIs and `--admin` roles.
- **`tests/test_setup_gcp_github_wif.py`**:
  - Adds a unit test asserting that required APIs, standard roles, and admin roles remain consistent and covered.

## Context

Fixes CI permission gaps uncovered during E2E promotion testing in release candidate verification.

## Testing

- `python3 -m unittest tests/test_setup_gcp_github_wif.py` (All 4 unit tests pass).
- `python3 -m unittest discover -s tests` (All 322 project tests pass).
- `make docs-check` (All 263 documentation files verified, links resolve, terminology checks pass).

## Risk & Rollout

Low risk. Confined to developer WIF onboarding scripts, documentation, and test assertions. Does not affect runtime operator or agent controller logic.