### PR TITLE
fix(e2e): resolve GITHUB_REPO to owner/repo in the promotion fixtures

### DIFF
--- a/docs/designs/e2e-testing-harness.md
+++ b/docs/designs/e2e-testing-harness.md
@@ -91,6 +91,23 @@ The test runner `scripts/release/execute_e2e_tests.py` reads configuration from 
 | `STOCKOUT_SCENARIOS`  | Comma-separated scenario numbers or `all` | `04`                 |
 | `FLEET_AUDIT_STREAMS` | Specific audit stream names or `all`      | `all`                |
 | `E2E_ENV`             | Target environment selector               | `investigations-e2e` |
+| `GITHUB_ORG`          | Owner used to qualify `GITHUB_REPO`       | Config `env_vars`    |
+| `GITHUB_REPO`         | Repository the GitHub probes target       | Config `env_vars`    |
+
+The last two are read by the fixtures in `tests/e2e/conftest.py` rather than by the
+runner, which forwards the environment to pytest unchanged. `GITHUB_REPO` is required —
+`test_agent_fleet_audit.py` fails rather than skips without it. `GITHUB_ORG` is
+optional, and is only cross-checked against the owner the repository resolves to; where
+it is unset, the fixture takes it from that owner.
+
+The suites' `GITHUB_REPO` resolves to `owner/repo`: `test_agent_fleet_audit.py` asserts
+that shape and `agents/platform/scripts/github_token_refresh.py` refuses anything else.
+A bare repository name is accepted and qualified with `GITHUB_ORG`, because the CI
+variable behind it is bare — `vars.GH_REPO`, which the deploy workflows pass to the
+GitHub Token Minter alongside `vars.GH_ORG` rather than combined with it. That is the
+same spelling with a different meaning: the Token Minter's `GITHUB_REPO`
+([install variables](../site/src/content/docs/deploy/token-minter.md)) is the bare name,
+and only the E2E suites' one is the qualified form.
 
 ### Test Environments
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -158,12 +158,64 @@ def fleet_audit_streams() -> str:
     return str(env_vars.get("FLEET_AUDIT_STREAMS") or "all").strip().lower()
 
 
+def _clean(value: Optional[str]) -> Optional[str]:
+    """Trims surrounding whitespace, returning None when no name is left."""
+    text = str(value).strip() if value else ""
+    return text or None
+
+
+def _clean_owner(value: Optional[str]) -> Optional[str]:
+    """_clean for an owner, which carries no slash of its own.
+
+    Kept separate from _clean because stripping slashes off a *repository* would turn a
+    half-written 'owner/' into the bare name 'owner' and hide the missing half.
+    """
+    owner = _clean(value)
+    return _clean(owner.strip("/")) if owner else None
+
+
+def _resolve_github_org() -> Optional[str]:
+    """Resolves the GitHub owner from the environment or e2e_config.yaml.
+
+    Deliberately does not consult GITHUB_REPO, unlike the github_org fixture:
+    _qualify_repo calls this while it is still deciding what github_repo resolves to.
+    """
+    return _clean_owner(os.environ.get("GITHUB_ORG")) or _clean_owner(
+        _get_default_config_env().get("env_vars", {}).get("GITHUB_ORG")
+    )
+
+
+def _qualify_repo(repo: Optional[str]) -> Optional[str]:
+    """Prefixes a bare repository name with the owner.
+
+    GH_REPO is bare by repository convention -- reusable-deploy-integrations.yml passes
+    the org and the repo to the GitHub Token Minter as separate values -- while every
+    consumer of this fixture wants 'owner/repo': test_github_target_repository_configuration
+    asserts the shape, and github_token_refresh.py rejects anything else.
+
+    The owner comes from GITHUB_ORG or, failing that, e2e_config.yaml, which hard-codes
+    it for every e2e environment. So in CI a bare name is always composed, and the
+    owner it gets is that config default whenever nothing more specific is set.
+
+    Only a value with no slash in it is composed. Anything else is returned as the
+    caller gave it, trimmed of surrounding whitespace: 'owner/' and '/repo' stay as they
+    are and fail the caller's structure check naming the value, rather than being
+    reshaped into a repository that parses and does not exist. Whitespace alone
+    resolves to None for the same reason -- 'org/  ' passes both halves of that check.
+    """
+    repo = _clean(repo)
+    if not repo or "/" in repo:
+        return repo
+    org = _resolve_github_org()
+    return f"{org}/{repo}" if org else repo
+
+
 @pytest.fixture(scope="session")
 def github_repo(agent_namespace: str) -> Optional[str]:
     """Resolves the registered GitOps/Audit repository (owner/repo)."""
     val = os.environ.get("GITHUB_REPO") or os.environ.get("GITOPS_REPO")
     if val:
-        return val
+        return _qualify_repo(val)
 
     # Try reading from platform-agent-settings in the cluster
     try:
@@ -178,26 +230,32 @@ def github_repo(agent_namespace: str) -> Optional[str]:
                 if "Git Repo:" in line:
                     repo_cand = line.split("Git Repo:", 1)[1].strip().strip("*` ")
                     if repo_cand and repo_cand.lower() != "none":
-                        return repo_cand
+                        return _qualify_repo(repo_cand)
     except Exception:
         pass
 
     cfg = _get_default_config_env()
     env_vars = cfg.get("env_vars", {})
-    return env_vars.get("GITHUB_REPO") or env_vars.get("GITOPS_REPO")
+    return _qualify_repo(env_vars.get("GITHUB_REPO") or env_vars.get("GITOPS_REPO"))
 
 
 @pytest.fixture(scope="session")
 def github_org(github_repo: Optional[str]) -> Optional[str]:
-    """Resolves the GitHub Organization name."""
-    val = os.environ.get("GITHUB_ORG")
+    """Resolves the GitHub Organization name.
+
+    Every branch is normalised the same way github_repo's owner is, so that
+    GITHUB_ORG=' myorg' and GITHUB_REPO='myorg/repo' agree. Left un-normalised, the
+    two disagree on the whitespace and test_github_target_repository_configuration
+    fails on an owner mismatch instead of on the value that caused it.
+    """
+    val = _clean_owner(os.environ.get("GITHUB_ORG"))
     if val:
         return val
     if github_repo and "/" in github_repo:
-        return github_repo.split("/", 1)[0]
+        return _clean_owner(github_repo.split("/", 1)[0])
     cfg = _get_default_config_env()
     env_vars = cfg.get("env_vars", {})
-    return env_vars.get("GITHUB_ORG")
+    return _clean_owner(env_vars.get("GITHUB_ORG"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_e2e_github_repo_resolution.py
+++ b/tests/test_e2e_github_repo_resolution.py
@@ -1,0 +1,274 @@
+"""Unit tests for the owner/repo resolution in tests/e2e/conftest.py.
+
+GH_REPO is bare by repository convention -- reusable-deploy-integrations.yml hands the
+org and the repo to the GitHub Token Minter as separate values -- while the e2e suite
+needs 'owner/repo': test_agent_fleet_audit.py asserts the shape and
+agents/platform/scripts/github_token_refresh.py refuses anything else. The RC pipeline
+passed the bare name through and both of those failed on every scheduled run.
+
+Most of these rows are about when composition must not happen. Prefixing an owner onto a
+value that is not a repository name produces one that parses: 'test-org-kube-agent/  '
+and 'test-org-kube-agent/gke-labs' both satisfy the slash check and the non-empty-halves
+check in test_github_target_repository_configuration, so the helper written to surface a
+misconfiguration would bury it instead, and the run would fail later against a
+repository nobody configured.
+"""
+
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CONFTEST = _REPO_ROOT / "tests" / "e2e" / "conftest.py"
+
+
+def _pytest_stub() -> types.ModuleType:
+    """A stand-in for pytest, which requirements-test.txt does not install.
+
+    conftest.py touches exactly two pytest attributes at import time: the `fixture`
+    decorator and the `Config` annotation on pytest_configure. A third one added at
+    module scope later fails the import with an AttributeError naming it.
+    """
+    stub = types.ModuleType("pytest")
+    stub.fixture = lambda *args, **kwargs: (lambda func: func)
+    stub.Config = object
+    return stub
+
+
+def _load_conftest():
+    """Imports the e2e conftest by path -- tests/e2e is not an importable package.
+
+    The stub replaces pytest even when the real package is installed. `make test-python`
+    runs on an interpreter without pytest, so the stub is what makes the import possible
+    at all there; forcing it everywhere keeps the module the same shape in both places.
+    Under the real pytest the fixtures come back as FixtureFunctionDefinition objects
+    that raise when called directly, so the fixture tests below would pass on a checkout
+    with tests/e2e/requirements.txt installed and fail without it.
+
+    os.environ is snapshotted because the module calls load_dotenv on a repo-root .env
+    at import time, and sys.modules is restored so nothing that runs afterwards picks
+    the stub up as pytest.
+    """
+    with mock.patch.dict(sys.modules, {"pytest": _pytest_stub()}), mock.patch.dict(
+        os.environ, {}, clear=False
+    ):
+        spec = importlib.util.spec_from_file_location("e2e_conftest", _CONFTEST)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+class _ConftestTestCase(unittest.TestCase):
+    """Loads the module under test once and pins everything it reads."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.conftest = _load_conftest()
+
+    def _pinned(self, env=None, config_env_vars=None):
+        """Both of the helpers' inputs: the process environment and e2e_config.yaml."""
+        return (
+            mock.patch.dict(os.environ, env or {}, clear=True),
+            mock.patch.object(
+                self.conftest,
+                "_get_default_config_env",
+                return_value={"env_vars": config_env_vars or {}},
+            ),
+        )
+
+
+class QualifyRepoTest(_ConftestTestCase):
+    """_qualify_repo prefixes an owner onto a bare name, and onto nothing else."""
+
+    def _qualify(self, repo, env=None, config_env_vars=None):
+        env_patch, config_patch = self._pinned(env, config_env_vars)
+        with env_patch, config_patch:
+            return self.conftest._qualify_repo(repo)
+
+    def test_bare_repo_composed_with_env_org(self):
+        """The RC pipeline's case: GH_REPO='kube-agents', GH_ORG='gke-labs'."""
+        self.assertEqual(
+            self._qualify("kube-agents", env={"GITHUB_ORG": "gke-labs"}),
+            "gke-labs/kube-agents",
+        )
+
+    def test_bare_repo_composed_with_config_org(self):
+        """Nothing in the environment: the owner comes from e2e_config.yaml."""
+        self.assertEqual(
+            self._qualify("agents-repo", config_env_vars={"GITHUB_ORG": "test-org-kube-agent"}),
+            "test-org-kube-agent/agents-repo",
+        )
+
+    def test_environment_org_beats_config_org(self):
+        self.assertEqual(
+            self._qualify(
+                "kube-agents",
+                env={"GITHUB_ORG": "gke-labs"},
+                config_env_vars={"GITHUB_ORG": "test-org-kube-agent"},
+            ),
+            "gke-labs/kube-agents",
+        )
+
+    def test_qualified_repo_is_not_prefixed_twice(self):
+        """An already-qualified value passes through, whatever the org says."""
+        self.assertEqual(
+            self._qualify("test-org-kube-agent/agents-repo", env={"GITHUB_ORG": "gke-labs"}),
+            "test-org-kube-agent/agents-repo",
+        )
+
+    def test_surrounding_whitespace_is_trimmed_before_composing(self):
+        self.assertEqual(
+            self._qualify(" agents-repo ", env={"GITHUB_ORG": "myorg"}),
+            "myorg/agents-repo",
+        )
+
+    def test_blank_repo_is_never_composed(self):
+        """A value with no name in it must not acquire an owner.
+
+        'test-org-kube-agent/  ' satisfies both the slash check and the
+        non-empty-halves check in test_github_target_repository_configuration.
+        """
+        for blank in ("  ", "\t", "\n", ""):
+            with self.subTest(repo=blank):
+                self.assertIsNone(self._qualify(blank, env={"GITHUB_ORG": "test-org-kube-agent"}))
+
+    def test_half_written_repo_is_passed_through_not_composed(self):
+        """A missing half must reach the caller as the missing half.
+
+        Stripping the stray slash first would turn 'gke-labs/' into the bare name
+        'gke-labs' and compose 'test-org-kube-agent/gke-labs' -- a repository that
+        parses, belongs to the wrong owner, and first surfaces as a 404. Passed through,
+        'gke-labs/' fails the caller's structure check quoting the value.
+        """
+        for value, expected in (
+            ("/", "/"),
+            ("gke-labs/", "gke-labs/"),
+            ("gke-labs//", "gke-labs//"),
+            ("/kube-agents", "/kube-agents"),
+            ("  gke-labs/  ", "gke-labs/"),
+        ):
+            with self.subTest(repo=value):
+                result = self._qualify(value, env={"GITHUB_ORG": "test-org-kube-agent"})
+                self.assertEqual(result, expected)
+                self.assertNotIn("test-org-kube-agent", result)
+
+    def test_blank_org_is_not_an_org(self):
+        """An exported-but-empty GITHUB_ORG is the unset case, not a 'None/repo' prefix."""
+        self.assertEqual(self._qualify("kube-agents", env={"GITHUB_ORG": "  "}), "kube-agents")
+
+    def test_bare_repo_without_any_org_stays_bare(self):
+        """No owner anywhere -- the caller's shape assertion has to stay reachable.
+
+        Not a configuration CI can produce, since every e2e environment hard-codes
+        GITHUB_ORG.
+        """
+        result = self._qualify("kube-agents")
+        self.assertEqual(result, "kube-agents")
+        self.assertNotIn("/", result)
+
+    def test_missing_repo_passes_through(self):
+        self.assertIsNone(self._qualify(None, env={"GITHUB_ORG": "gke-labs"}))
+
+
+class ResolveGithubOrgTest(_ConftestTestCase):
+    """_resolve_github_org reads the owner without consulting GITHUB_REPO."""
+
+    def _resolve(self, env=None, config_env_vars=None):
+        env_patch, config_patch = self._pinned(env, config_env_vars)
+        with env_patch, config_patch:
+            return self.conftest._resolve_github_org()
+
+    def test_environment_wins_over_config(self):
+        self.assertEqual(
+            self._resolve(env={"GITHUB_ORG": "gke-labs"}, config_env_vars={"GITHUB_ORG": "other"}),
+            "gke-labs",
+        )
+
+    def test_falls_back_to_config(self):
+        self.assertEqual(self._resolve(config_env_vars={"GITHUB_ORG": "gke-labs"}), "gke-labs")
+
+    def test_whitespace_and_slashes_trimmed(self):
+        """An owner has no slash of its own, so a stray one is noise here."""
+        self.assertEqual(self._resolve(env={"GITHUB_ORG": " gke-labs/ "}), "gke-labs")
+
+    def test_blank_falls_through_to_config(self):
+        """A blank environment value must not shadow a real one in the config."""
+        self.assertEqual(
+            self._resolve(env={"GITHUB_ORG": "   "}, config_env_vars={"GITHUB_ORG": "gke-labs"}),
+            "gke-labs",
+        )
+        self.assertEqual(
+            self._resolve(env={"GITHUB_ORG": "/"}, config_env_vars={"GITHUB_ORG": "gke-labs"}),
+            "gke-labs",
+        )
+
+    def test_absent_everywhere_is_none(self):
+        self.assertIsNone(self._resolve())
+
+    def test_does_not_read_github_repo(self):
+        """The recursion guard: github_repo may still be mid-resolution."""
+        self.assertIsNone(self._resolve(env={"GITHUB_REPO": "gke-labs/kube-agents"}))
+
+
+class FixtureWiringTest(_ConftestTestCase):
+    """The fixtures apply the helpers -- deleting the calls has to fail something.
+
+    Only the environment branch of github_repo is exercised, which returns before the
+    kubectl lookup, so nothing here shells out.
+    """
+
+    def _repo(self, env=None, config_env_vars=None):
+        env_patch, config_patch = self._pinned(env, config_env_vars)
+        with env_patch, config_patch:
+            return self.conftest.github_repo("kubeagents-system")
+
+    def _org(self, repo, env=None, config_env_vars=None):
+        env_patch, config_patch = self._pinned(env, config_env_vars)
+        with env_patch, config_patch:
+            return self.conftest.github_org(repo)
+
+    def test_github_repo_qualifies_a_bare_environment_value(self):
+        self.assertEqual(
+            self._repo(env={"GITHUB_REPO": "kube-agents", "GITHUB_ORG": "gke-labs"}),
+            "gke-labs/kube-agents",
+        )
+
+    def test_github_repo_qualifies_gitops_repo_too(self):
+        self.assertEqual(
+            self._repo(env={"GITOPS_REPO": "kube-agents", "GITHUB_ORG": "gke-labs"}),
+            "gke-labs/kube-agents",
+        )
+
+    def test_github_repo_qualifies_the_config_value(self):
+        self.assertEqual(
+            self._repo(config_env_vars={"GITHUB_REPO": "agents-repo", "GITHUB_ORG": "test-org"}),
+            "test-org/agents-repo",
+        )
+
+    def test_github_repo_leaves_a_qualified_value_alone(self):
+        self.assertEqual(
+            self._repo(env={"GITHUB_REPO": "myorg/myrepo", "GITHUB_ORG": "gke-labs"}),
+            "myorg/myrepo",
+        )
+
+    def test_the_two_fixtures_agree_on_the_owner(self):
+        """What test_github_target_repository_configuration's last assertion compares."""
+        env = {"GITHUB_REPO": " kube-agents ", "GITHUB_ORG": " gke-labs "}
+        repo = self._repo(env=env)
+        self.assertEqual(repo, "gke-labs/kube-agents")
+        self.assertEqual(self._org(repo, env=env), repo.split("/", 1)[0])
+
+    def test_github_org_falls_back_to_the_repository_owner(self):
+        """Precedence: a qualified GITHUB_REPO outranks the config's GITHUB_ORG."""
+        self.assertEqual(
+            self._org("myorg/myrepo", config_env_vars={"GITHUB_ORG": "test-org-kube-agent"}),
+            "myorg",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The scheduled RC Release E2E Pipeline hands the e2e suite a bare repository name where the suite requires `owner/repo`, and two of the five failures on every run that reaches step 3 come from that one value. The fix composes the owner and the repository in `tests/e2e/conftest.py`, which is the single place every consumer of the value already goes through.

## Why This Change

`vars.GH_REPO` in the RC environment is `kube-agents`, and GH_REPO is bare there on purpose: `.github/workflows/reusable-deploy-integrations.yml` passes the org and the repo to the GitHub Token Minter as separate values. The e2e suite wants the qualified form, which the hardcoded fallback in the workflow (`test-org-kube-agent/agents-repo`) and the `rc-e2e` block of `tests/e2e/e2e_config.yaml` both state.

In run [32866087154](https://github.com/gke-labs/kube-agents/actions/runs/32866087154), job 97877916395:

- `test_github_target_repository_configuration` — `AssertionError: Expected GITHUB_REPO in 'owner/repo' format, got 'kube-agents'` (`tests/e2e/test_agent_fleet_audit.py:271`).
- `test_github_token_minting_and_connectivity` — the in-pod probe passes the value to `github_token_refresh.py`, which refuses it: `FATAL: Failed to refresh git credentials: Could not identify target repository 'kube-agents'. Must be in 'owner/repo' format.` The `gh api repos/kube-agents` call the probe makes next is unresolvable for the same reason.

Without this, both fail on every scheduled run and the release candidate never reaches step 4.

## What Changed

- `tests/e2e/conftest.py` — `_qualify_repo` prefixes a bare repository name with the owner from `GITHUB_ORG` or `e2e_config.yaml`, and returns anything else unchanged. It is applied at each of `github_repo`'s three resolution paths. The `github_org` fixture already derived the owner by splitting `github_repo`; this is the inverse, so the pair is symmetric. `_resolve_github_org` deliberately does not consult `GITHUB_REPO`, which keeps the inverse from recursing.
- Only a value with no slash in it is composed, and that boundary carries the safety. Prefixing an owner onto anything else produces a repository that parses: `test-org-kube-agent/  ` from a whitespace-only `GITHUB_REPO`, and `test-org-kube-agent/gke-labs` from a trailing-slash typo like `gke-labs/`, both satisfy the slash check and the non-empty-halves check in the configuration test, so the misconfiguration would surface as a 404 against a repository nobody configured rather than as an assertion quoting the value. `_clean` therefore trims whitespace only, `_qualify_repo` decides "already qualified" before any slash is normalised away, and `owner/` and `/repo` reach the caller as written. `_clean_owner` keeps the slash-stripping for the owner, which has no slash of its own. It also settles a disagreement between the two fixtures: with `GITHUB_ORG=' myorg'` against `GITHUB_REPO='myorg/repo'` the untrimmed owner and the split owner differed, so the test failed on an owner mismatch rather than on the whitespace behind it.
- `tests/test_e2e_github_repo_resolution.py` — 22 cases over both helpers and the two fixtures that call them, with the rows where composition must *not* happen as the point of the exercise. Covered by the existing `tests/test_*.py` glob in `PYTHON_TEST_DIRS`, so it runs on every pull request.
- `docs/designs/e2e-testing-harness.md` — the environment-contract table gains `GITHUB_ORG` and `GITHUB_REPO`, which it omitted despite `test_agent_fleet_audit.py` failing without `GITHUB_REPO`, plus a note on which `GITHUB_REPO` it means. The same spelling is the bare repository name on the Token Minter install path and the qualified form here.

No workflow is changed. All three that run the suite (`rc-release-pipeline.yml`, `e2e-nightly-matrix.yml`, `e2e-manual-runner.yml`) export `GITHUB_ORG` alongside `GITHUB_REPO`, so the fixture has what it needs, and it additionally reaches two paths no workflow can: a local run, and the repository read out of the cluster's `platform-agent-settings` ConfigMap.

## Context

Three of the five step-3 failures in that run have other causes and are untouched here: `test_platform_agent_api_health_ping`, `test_stockout_ingress_alert_smoke`, and `test_stockout_scenario[04-missing-zone-fallback]`.

Merge-conflict risk: another in-flight branch is changing the `port_forward_agent` fixture in `tests/e2e/conftest.py` (line 331). This change sits at lines 161–256 of the same file, so the two do not overlap textually, but they will need rebasing past each other.

## Testing

- `cd tests && PYTHONPATH=<repo root> python3 -m unittest discover -p "test_*.py"` — 395 tests, exit 0. This is the invocation `make test-python` uses for the directory.
- `python3 -m unittest tests.test_e2e_github_repo_resolution` — 22 tests, exit 0.
- The new suite was checked by mutation rather than assumed non-vacuous. Restoring the slash-stripping `_clean` → 5 failures; dropping `_qualify_repo`'s leading `_clean` → 7; reducing `_qualify_repo` to the identity, which is what deleting its three call sites in the fixture amounts to → 13. Unmutated, 0.
- `python3 -m unittest tests.test_execute_e2e_tests` — exit 0. It is the other suite that reads `tests/e2e/conftest.py`.
- `python3 -m py_compile` on both changed Python files — clean.
- `make docs-check` — exit 0 (generated regions, 266 files' relative links, terminology, map coverage, context budget).
- `prettier --write docs/designs/e2e-testing-harness.md` with prettier 3.9.6, the version `.github/workflows/prettier.yml` installs — unchanged, and the table diff is purely additive with no re-aligned rows.

### Live validation

Not live-tested. The fixtures this change touches execute only inside the e2e suites, which run from `rc-release-pipeline.yml`, `e2e-nightly-matrix.yml`, and `e2e-manual-runner.yml` — and none of those is reachable from here. `gcloud container clusters get-credentials` on the RC cluster returns 403 for this account, and the Actions repository variables that supply `GH_ORG` and `GH_REPO` are not visible either, so there is no way to observe the composed value in a real run or to prove the mechanism by setting the variable to something distinctly different and reverting it. No test artifacts were created anywhere, and no state was changed outside this branch.

Two things stand in for it, and neither is a substitute.

Both defects the reviews found have a genuine red-then-green, checked by putting the old code back. Restoring the `_qualify_repo` that did not trim `repo` turns 7 cases red, including `'  '` composing into `'test-org-kube-agent/  '`. Restoring the `_clean` that stripped slashes off repositories turns 5 red, including `'gke-labs/'` composing into `'test-org-kube-agent/gke-labs'`. Reducing `_qualify_repo` to the identity — what deleting its three call sites in the fixture amounts to — turns 13 red. All 22 pass unmutated, and the whole `tests/` directory is green at 395 tests under the invocation `make test-python` uses.

The premise this change rests on is inferred rather than read. `vars.GH_REPO = kube-agents` in the RC environment comes from the failing job log — the in-pod probe was handed `kube-agents` and `github_token_refresh.py` refused it — not from the environment settings themselves. **A reviewer with access to those settings should confirm it**, along with `GH_ORG = gke-labs`. If `GH_REPO` turns out to already carry an owner, this change is a no-op rather than a fix, and the failure has another cause.

## Self-Review

Three passes ran against the branch, each in a context that did not write the change — a separate reviewer handed a diff range and nothing else, with none of the reasoning behind it. Dispositions were decided afterwards with the author. The third pass was run because the branch changed shape after the first two: the workflow edits came out and a test file and a docs change went in, so what the first adversarial pass read is not what a reviewer sees now.

**Adversarial pass, first round** (whole diff, when it still edited three workflows). Angles covered: behaviour change against the pre-change baseline for every combination of the two inputs; duplication against rules the repository already expresses elsewhere; input validation on blank, whitespace, and already-qualified values; whether the change makes the test it exists to satisfy vacuous; accuracy of comments and docstrings against the code they describe; and test coverage. Seven findings, all confirmed, none High.

1. **Composing in the workflow discarded a configured value (Medium).** With `GH_REPO` set and `GH_ORG` unset or empty, both composing arms of the YAML expression were falsy and the result fell to the hardcoded `test-org-kube-agent/agents-repo`. Before the change that input produced the configured name and failed loudly, naming the variable to fix; after, it passed the shape assertion and would have failed later against a repository nobody configured. **Fixed** — the workflow edits are reverted; the diff no longer touches `.github/`.
2. **The workflow half bought nothing (Medium).** All three workflows already export `GITHUB_ORG`, which `_resolve_github_org` reads, so `_qualify_repo` alone produces the same final value in every combination except the one in finding 1, where the workflow was the losing side. It would also have been a third and fourth copy of a rule already written in `get_target_repo` (`scripts/release/common.sh`) and `_parse_repo` (`agents/platform/scripts/forge.py`). **Fixed** by the same revert. Before reverting, the assumption underneath it was checked directly: the only consumers of `GITHUB_REPO` on the e2e path are the `conftest.py` fixture and `tests/e2e/scripts/{provision,teardown}_ci_iam.sh`, which take it as a `--github-repo` flag and are invoked by no workflow. `execute_e2e_tests.py` never reads it — it merges `{**config_env_vars, **os.environ}` and hands the result to pytest.
3. **A blank repository acquired an owner (Medium).** `_qualify_repo` did not trim `repo`, so `'  '` survived the `if not repo` guard and became `'test-org-kube-agent/  '` — which passes both the slash check and the `len(owner) > 0 and len(repo_name) > 0` check in `test_github_target_repository_configuration`. The helper meant to surface a misconfiguration would have buried one. **Fixed**: `_clean` trims at the top of `_qualify_repo` and a blank resolves to `None`. The third pass found the same defect in a second shape; see finding 8.
4. **No automated coverage (Low).** **Fixed** — `tests/test_e2e_github_repo_resolution.py`, now 22 cases over both helpers and the two fixtures. The earlier decision to skip it was wrong about the cause: the obstacle was importing `tests/e2e/conftest.py`, which needs `pytest` at module scope, not the file's location. Conftest touches exactly two pytest attributes at import time, so the loader supplies a two-attribute stub, which is what lets it run under `make test-python` on an interpreter with no pytest. A third import-time attribute added later fails the import by name rather than silently.
5. **A docstring claimed a safety property the deployment does not have (Low).** It said a bare name is "left bare when no owner is available anywhere, so that assertion still reports the misconfiguration" — but every e2e environment in `e2e_config.yaml` hard-codes `GITHUB_ORG` and all three workflows default it, so in CI an owner is always available and that branch is unreachable. **Fixed**: the docstring states that a bare name is always composed in CI and that the owner is the config default whenever nothing more specific is set. It was narrowed again after finding 8.
6. **The two owner resolutions disagreed on whitespace (Low).** `_resolve_github_org` trimmed; the `github_org` fixture returned `os.environ["GITHUB_ORG"]` raw, so `GITHUB_ORG=' myorg'` made the test fail on an owner mismatch instead of on the whitespace. **Fixed, by a different remedy than the one suggested.** The suggestion was to route the fixture through `_resolve_github_org()`; that would reorder its precedence from env → split-`github_repo` → config to env → config → split, and the reorder breaks a case that works today: `GITHUB_REPO=myorg/myrepo` in the environment with `e2e_config.yaml`'s `GITHUB_ORG: "test-org-kube-agent"` underneath currently yields owner `myorg` from the split and passes, but would yield `test-org-kube-agent` and fail on a mismatch. The fixture instead routes each of its three branches through `_clean`, which fixes the whitespace disagreement and leaves precedence alone.
7. **A comment misdescribed `get_target_repo` (Low).** It claimed the shell helper "composes the pair the same way this does", which was wrong in exactly the arm the reader most needed to check — `get_target_repo` has no `contains('/')` arm and its fallbacks are real repositories rather than a placeholder. **Moot**: the comment went with the reverted workflow edits.

**Docs-drift pass.** Angles covered: whether prose still matches the source it describes, generated-region currency, relative-link resolution, identifiers verified against source rather than against other docs, and documentation-map coverage. No Blocking findings, and `make docs-check` is clean. One non-blocking finding, **fixed**: `GH_ORG` and `GH_REPO` were documented nowhere — zero hits across every Markdown file — while the bare-versus-qualified convention lived in code in three places. The environment-contract table in `docs/designs/e2e-testing-harness.md` was the canonical home per the Documentation Guidelines table, and it already omitted both variables. Both rows are added, scoped to the E2E suites' meaning and pointing at the Token Minter's bare `GITHUB_REPO` so the two spellings are not confused.

**Adversarial pass, second round** (the delta after the revert: the reworked helpers, the new test file, the docs rows — none of which the first pass had seen). Angles covered: the same defect class the branch exists to close, re-run against the new code; the boundary between normalising a value and reshaping it; whether the new tests can actually fail; whether the new doc prose matches source; and prose against the Documentation Guidelines. Four findings.

8. **The same defect, one shape along: a half-written repository acquired an owner (Medium).** `_clean`'s `.strip("/")` applied to a repository turned `'gke-labs/'` into the bare `'gke-labs'`, which `_qualify_repo` then composed into `'test-org-kube-agent/gke-labs'` — a repository that passes every assertion in the configuration test and 404s at the API call. On `main` that input fails immediately quoting `'gke-labs/'`. This is exactly the failure mode fixed for whitespace in finding 3 and reintroduced for a stray slash, and the docstring's guard claim overstated what the code did. **Fixed**: `_clean` trims whitespace only, `_clean_owner` keeps the slash-stripping for owners (which have no slash of their own), and `_qualify_repo` tests for a slash before anything normalises one away, so `'owner/'`, `'/repo'` and `'owner//'` pass through untouched. `test_half_written_repo_is_passed_through_not_composed` covers those and asserts the org is not prefixed. Verified: with the old `_clean` restored, 5 cases go red. One limit stated rather than papered over — `'owner//'` still satisfies the configuration test's structure check, exactly as it does on `main`; this change neither fixes nor worsens that, and the docstring claims the loud failure only for the two shapes that have it.
9. **The new doc rows were wrong about `GITHUB_ORG` (Low).** They said both variables are "required by `test_agent_fleet_audit.py`, which fails rather than skips without them". False for `GITHUB_ORG`: both configuration-gating `pytest.fail` calls name `github_repo` only, and `github_org`'s single use sits behind an `if github_org:` guard. It is also effectively never absent once `GITHUB_REPO` is set, because the fixture derives it from the resolved owner. Drift introduced by this branch, in prose this branch wrote. **Fixed**: `GITHUB_REPO` is documented as required and `GITHUB_ORG` as optional and only cross-checked.
10. **The fixture wiring had no regression test (Low).** Deleting all three `_qualify_repo(...)` call sites left all tests green, because nothing referenced the fixtures. **Fixed**, and the awkwardness the pass identified is fixed with it: the loader now installs the pytest stub unconditionally rather than preferring the real package, because under real pytest the fixtures are `FixtureFunctionDefinition` objects that raise when called directly, so fixture-level tests would pass in a checkout with `tests/e2e/requirements.txt` installed and fail in one without it. `FixtureWiringTest` calls `github_repo` and `github_org` directly — only the environment branch, which returns before the kubectl lookup, so nothing shells out. Reducing `_qualify_repo` to the identity now turns 13 cases red.
11. **Prose (Low).** **Fixed.** The 14-line docstring on a four-line function is down to eight and states behaviour instead of arguing with an unnamed reader; "this is not a helper that declines to guess" is gone, as is the "not X, but Y" framing in the test module's docstring and in the loader's. The claim that the release-script composer "is tested the same way" was **dropped rather than weakened** — it was false in both halves: `test_get_target_repo` has only happy-path rows, and `get_target_repo` composes unconditionally with no already-qualified passthrough, so it is not the same rule tested the same way.

The pass also verified, and these needed no action: the revert is exact (the `.github` tree object is byte-identical at the head and the merge base); the tests are non-vacuous by mutation; the loader leaves `sys.modules`, `os.environ` and `sys.meta_path` as it found them and `unittest discover` never descends into `tests/e2e/`; `execute_e2e_tests.py` does not read either variable and does not pin them, so the workflow env reaches pytest intact; and the docs table edit is purely additive with no existing row moved.

## Risk & Rollout

The blast radius is the e2e fixtures and one design document; no workflow, runtime code path, chart template, or operator behaviour is touched. The fixtures are exercised only by `tests/e2e/`, which runs in the RC pipeline and the nightly matrix, so the change cannot affect a pull request's own CI beyond the new unit test. Reverting is a revert of the single commit. Nothing has to happen at merge time; the next scheduled RC run picks it up.

---

This PR was generated with the help of Claude.
