### PR TITLE
fix(e2e): reach the agent API through an exec relay, not a port-forward

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,21 @@ AGENT_NAMESPACE=kubeagents-system
 # GITHUB_REPO, FLEET_AUDIT_STREAMS, STOCKOUT_SCENARIOS -- silently resolves to nothing.
 # E2E_ENV=investigations-e2e
 
-# Optional: Override agent local port-forward port (default: 8642)
-AGENT_LOCAL_PORT=8642
+# Optional: pin the local port the agent-API tunnel listens on. The E2E suite
+# defaults to 0, an ephemeral port, and leaving it unset is the right choice:
+# the suite yields the bound URL to its tests, so nothing needs to know the
+# number, and a fixed port turns a listener left behind by an earlier run into
+# "address already in use" -- which reads like a broken agent.
+#
+# Do not set it to 0 here. bench (kube_agents_bench/harness.py) reads the same
+# variable, defaults it to 8642, and uses it as a fixed port for both its
+# port-forward and the URL it dials, so 0 breaks bench while helping nothing.
+# Uncomment with a real port only to attach something external to the tunnel.
+# AGENT_LOCAL_PORT=8642
+
+# Optional: how long (seconds) to wait for the agent API to answer over the
+# exec tunnel before failing Stage 2. Default 30.
+# AGENT_TUNNEL_TIMEOUT=30
 
 # Optional: Explicit platform agent token (if secret is not auto-read via kubectl)
 # PLATFORM_AGENT_TOKEN=

--- a/docs/designs/e2e-testing-harness.md
+++ b/docs/designs/e2e-testing-harness.md
@@ -40,7 +40,7 @@ Validates credential isolation, GitHub authentication, and audit watchdog capabi
 
 Verifies core platform agent responsiveness and Kubernetes operator controller reconciliation:
 
-- **Direct Agent API Health**: Sends a REST probe to `/v1/responses` via port-forwarding to verify agent process readiness and JSON schema response handling.
+- **Direct Agent API Health**: Sends a REST probe to `/v1/responses` to verify agent process readiness and JSON schema response handling. The probe reaches the credential-proxy sidecar through a `kubectl exec` relay (`scripts/exec_tunnel.py`), not `kubectl port-forward`: on a GKE Sandbox (gVisor) node pool the kubelet sets a forward up in the host-side netns and cannot see a listener inside the sandbox, so every port on the pod refuses the connection. [`platformagent-crd.md`](../site/src/content/docs/operator/platformagent-crd.md) is canonical on that constraint.
 - **Operator Plugin Reconciliation**: Deploys `AgentPlugin` Custom Resources to verify the Kubebuilder operator controller mounts plugin volumes into `platform-agent` pods and cleanly cleans up on CR deletion.
 
 ### Stage 3: Stockout Ingress & Incident Scenarios (`test_stockout_investigation.py`)

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -64,8 +64,10 @@ Reaching it means getting inside the pod's network namespace — `kubectl port-f
 9119:9119` on an ordinary node pool, and
 [`scripts/hermes-dashboard-tunnel.py`](https://github.com/gke-labs/kube-agents/blob/main/scripts/hermes-dashboard-tunnel.py)
 on a GKE Sandbox (gVisor) one, where port-forward is set up in the host-side netns and cannot see
-the sandbox's listener. That script is canonical on both the access path and why the loopback bind
-is deliberate. The container's readiness probe runs `curl` against loopback for the same reason a
+the sandbox's listener. That script is canonical on the dashboard's access path and on why the
+loopback bind is deliberate; the exec relay it uses to get inside the sandbox lives in
+[`scripts/exec_tunnel.py`](https://github.com/gke-labs/kube-agents/blob/main/scripts/exec_tunnel.py),
+shared with the E2E suite, which reaches the agent API the same way and for the same reason. The container's readiness probe runs `curl` against loopback for the same reason a
 `tcpSocket` probe cannot work here: kubelet dials the pod IP, and nothing is listening on it.
 
 `sessionKVApiKeySecretRef` is optional in the API but not in practice, and the `503` above is the

--- a/scripts/exec_tunnel.py
+++ b/scripts/exec_tunnel.py
@@ -1,0 +1,401 @@
+"""Relay a local TCP port to a pod-loopback listener through `kubectl exec`.
+
+This module is the canonical home for that mechanism and for why it is needed;
+`scripts/hermes-dashboard-tunnel.py` and the `port_forward_agent` fixture in
+`tests/e2e/conftest.py` both use it rather than restating it.
+
+`kubectl port-forward` is the obvious way to reach a listener bound to
+127.0.0.1 inside a pod, and on an ordinary node pool it works: the kubelet sets
+the forward up inside the pod's own network namespace. On a GKE Sandbox
+(gVisor) node pool it does not. The forward is established in the host-side CNI
+netns while the listener lives in the sandbox's own network stack, so every
+port on the pod refuses the connection --
+`docs/site/src/content/docs/operator/platformagent-crd.md` is canonical on that
+constraint. `kubectl exec` does enter the sandbox, so this relays bytes through
+an exec channel instead.
+
+Five things this has to get right, each of which broke it once:
+
+1. Under `bufsize=0` the subprocess pipes are raw FileIO. There is no
+   `.read1()` -- only `.read()`.
+2. Raw pipe `write()` may consume only part of the buffer and return a short
+   count. Discarding that count silently dropped 32-64KB chunks mid-stream and
+   truncated the SPA's 1.9MB entrypoint, so the module would not parse.
+3. The pod name changes on every redeploy. Pinning one produces a tunnel that
+   accepts connections and returns zero bytes (ERR_EMPTY_RESPONSE) the moment
+   the Deployment rolls. The pod is resolved by label and re-resolved whenever
+   an exec fails to come up.
+4. A terminated or killed child has to be waited on, and its pipes closed.
+   Without the reap the kubectl process becomes a zombie holding its end of the
+   exec stream, and since one connection is one exec, a caller that opens
+   several accumulates both zombies and descriptors.
+5. Resolution failures are not all empty output. A missing kubectl raises
+   OSError and an unreachable control plane raises TimeoutExpired, and a caller
+   that only expects RuntimeError gets a bare traceback instead of the message
+   naming the selector.
+"""
+
+import dataclasses
+import json
+import socket
+import socketserver
+import subprocess
+import threading
+from typing import Any, Callable, List, Optional, Set
+
+# The remote end writes READY (one NUL) as soon as it has actually connected to
+# the target port, before relaying anything. That single byte is what lets the
+# local side distinguish "container reachable and listener up" from a stale pod
+# name, without having to buffer and replay the client's request.
+REMOTE_RELAY = """
+import os, sys, socket, threading, time
+
+def write_all(fd, buf):
+    mv = memoryview(buf)
+    while mv:
+        mv = mv[os.write(fd, mv):]
+
+s = socket.create_connection(("127.0.0.1", {port}))
+os.write(1, b"\\x00")
+
+def up():
+    try:
+        while True:
+            d = os.read(0, 65536)
+            if not d:
+                break
+            s.sendall(d)
+    except Exception:
+        pass
+    try:
+        s.shutdown(socket.SHUT_WR)
+    except Exception:
+        pass
+
+threading.Thread(target=up, daemon=True).start()
+try:
+    while True:
+        d = s.recv(65536)
+        if not d:
+            break
+        write_all(1, d)
+except Exception:
+    pass
+finally:
+    # kubectl tears down the stdout stream when this process exits; give the
+    # final frames a moment to ship before we go away.
+    time.sleep(0.25)
+"""
+
+
+@dataclasses.dataclass
+class TunnelConfig:
+    """Where to exec, and what to connect to once inside."""
+
+    namespace: str = "kubeagents-system"
+    selector: str = "app=platform-agent-gateway"
+    pod: str = ""
+    container: str = "platform-agent-dashboard"
+    remote_port: int = 9119
+    python: str = "/opt/hermes/.venv/bin/python3"
+    # Bounds the wait for the remote end's READY byte. Without it a `kubectl
+    # exec` that connects but never returns -- an unschedulable pod, an API
+    # server that accepts the upgrade and stalls -- hangs the handler thread
+    # and leaks the child for the life of the process.
+    ready_timeout: float = 30.0
+    # A file object for kubectl's stderr. None inherits, which is what an
+    # interactive caller wants and a test harness does not.
+    stderr: Any = None
+    # Diagnostics go here. Callers that print should print to stderr: stdout is
+    # where a piped caller expects data, not commentary.
+    log: Callable[[str], None] = lambda message: None
+
+
+def write_all(fileobj, buf) -> None:
+    """Write every byte of buf, tolerating short writes on a raw pipe."""
+    mv = memoryview(buf)
+    while mv:
+        n = fileobj.write(mv)
+        if not n:
+            continue
+        mv = mv[n:]
+    fileobj.flush()
+
+
+def reap(proc: Optional[subprocess.Popen], timeout: float = 5.0) -> None:
+    """Terminate a child, wait for it, and close its pipes.
+
+    The wait is what stops a caller that tears tunnels down in a loop from
+    accumulating zombies; closing the pipes is what stops it running out of
+    descriptors, since one connection is one exec here.
+
+    Callers must not have a thread still writing to `proc.stdin` when they call
+    this -- `handle` joins its uploader first. Closing a descriptor another
+    thread is mid-write on risks that thread writing into whatever the fd
+    number gets reused for.
+    """
+    if proc is None:
+        return
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                pass
+    for pipe in (proc.stdin, proc.stdout, proc.stderr):
+        if pipe is None:
+            continue
+        try:
+            pipe.close()
+        except Exception:  # noqa: BLE001 - a closed or in-flight pipe is not an error here
+            pass
+
+
+class PodResolver:
+    """Cache the pod name; re-resolve by label when an exec fails to start."""
+
+    def __init__(self, cfg: TunnelConfig):
+        self.cfg = cfg
+        self.lock = threading.Lock()
+        self.pod = cfg.pod
+
+    def _list(self) -> List[dict]:
+        """Every Running pod matching the selector, or RuntimeError saying why not.
+
+        Every failure leaves by the same door. `kubectl` missing raises
+        OSError, a control plane behind a VPN raises TimeoutExpired, and a
+        cluster with no such pod returns success and an empty list -- three
+        very different causes that a caller can only sensibly treat one way,
+        and one of which used to escape as a bare traceback.
+        """
+        try:
+            out = subprocess.run(
+                ["kubectl", "get", "pods", "-n", self.cfg.namespace,
+                 "-l", self.cfg.selector,
+                 "--field-selector=status.phase=Running",
+                 "-o", "json"],
+                capture_output=True, text=True, timeout=60,
+            )
+        except OSError as exc:
+            raise RuntimeError(f"could not run kubectl: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"kubectl get pods -l {self.cfg.selector} timed out after 60s"
+            ) from exc
+        if out.returncode != 0:
+            raise RuntimeError(
+                f"kubectl get pods -l {self.cfg.selector} failed: "
+                f"{out.stderr.strip() or 'no stderr'}"
+            )
+        try:
+            return json.loads(out.stdout).get("items", []) or []
+        except ValueError as exc:
+            raise RuntimeError(f"kubectl returned unparseable JSON: {exc}") from exc
+
+    def get(self, refresh: bool = False) -> str:
+        with self.lock:
+            if self.pod and not refresh:
+                return self.pod
+            items = self._list()
+            if not items:
+                raise RuntimeError(
+                    f"no Running pod matches -l {self.cfg.selector} "
+                    f"in {self.cfg.namespace}"
+                )
+            # Ready first. Running only means the containers started; a pod
+            # still inside its startup probe is Running and not yet serving,
+            # and the agent's startup probe sanctions a cold boot of minutes.
+            name = next(
+                (
+                    pod["metadata"]["name"]
+                    for pod in items
+                    if any(
+                        condition.get("type") == "Ready" and condition.get("status") == "True"
+                        for condition in pod.get("status", {}).get("conditions", [])
+                    )
+                ),
+                items[0]["metadata"]["name"],
+            )
+            if name != self.pod:
+                self.cfg.log(f"  pod → {name}")
+            self.pod = name
+            return name
+
+
+class Handler(socketserver.BaseRequestHandler):
+    def _spawn(self, pod: str) -> Optional[subprocess.Popen]:
+        """Start an exec relay; return it only once it reports READY."""
+        cfg = self.server.cfg
+        cmd = [
+            "kubectl", "exec", "-i",
+            "-n", cfg.namespace, pod,
+            "-c", cfg.container,
+            "--", cfg.python, "-u", "-c",
+            REMOTE_RELAY.format(port=cfg.remote_port),
+        ]
+        try:
+            proc = subprocess.Popen(
+                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=cfg.stderr, bufsize=0,
+            )
+        except OSError as exc:
+            cfg.log(f"  exec failed: {exc}")
+            return None
+        # read(1) on a raw pipe has no timeout of its own, so the deadline is a
+        # timer that kills the child; the read then returns b"" and falls into
+        # the rejection path below.
+        fired = threading.Event()
+
+        def expire():
+            fired.set()
+            proc.kill()
+
+        watchdog = threading.Timer(cfg.ready_timeout, expire)
+        watchdog.daemon = True
+        watchdog.start()
+        try:
+            ready = proc.stdout.read(1)
+        finally:
+            watchdog.cancel()
+        # cancel() is a no-op once the timer thread has entered its callback, so
+        # a READY arriving in that window would otherwise hand back a relay that
+        # is already being killed. The flag is set before the kill, so it is
+        # true for the whole of that window -- poll() alone is not, since the
+        # process may not have died yet when it is read.
+        if ready != b"\x00" or fired.is_set() or proc.poll() is not None:
+            reap(proc)
+            return None
+        if not self.server.track(proc):
+            # The server was torn down between Popen and here, so nothing will
+            # come back for this one.
+            reap(proc)
+            return None
+        return proc
+
+    def handle(self) -> None:
+        resolver = self.server.resolver
+        cfg = self.server.cfg
+        proc = None
+        for refresh in (False, True):
+            try:
+                pod = resolver.get(refresh=refresh)
+            except RuntimeError as exc:
+                cfg.log(f"  {exc}")
+                return
+            proc = self._spawn(pod)
+            if proc:
+                break
+        if not proc:
+            return
+
+        def to_pod():
+            try:
+                while True:
+                    data = self.request.recv(65536)
+                    if not data:
+                        break
+                    write_all(proc.stdin, data)
+            except Exception:  # noqa: BLE001
+                pass
+            finally:
+                try:
+                    proc.stdin.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        uploader = threading.Thread(target=to_pod, daemon=True)
+        uploader.start()
+        try:
+            while True:
+                # raw FileIO: .read(n) is one read() syscall, no .read1()
+                data = proc.stdout.read(65536)
+                if not data:
+                    break
+                self.request.sendall(data)
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            try:
+                self.request.shutdown(socket.SHUT_WR)
+            except Exception:  # noqa: BLE001
+                pass
+            # Before reap, so the uploader is not mid-write on a descriptor
+            # reap is about to close. What ends it is the client closing its
+            # end: the shutdown(SHUT_WR) above does not interrupt a recv()
+            # blocked in another thread, so for a peer that holds the socket
+            # open the 5s timeout is the normal exit path rather than a
+            # backstop. Shortening it reopens the descriptor race.
+            uploader.join(timeout=5.0)
+            self.server.untrack(proc)
+            reap(proc)
+
+
+class Server(socketserver.ThreadingTCPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+    request_queue_size = 64
+
+    def __init__(self, *args, **kwargs):
+        # Handlers are daemon threads, so server_close() does not join them: a
+        # probe the caller abandoned leaves one waiting on its own exec. Track
+        # the children so close_relays() can end the exec sessions even when
+        # the threads outlive the caller.
+        self._relays: Set[subprocess.Popen] = set()
+        self._relay_lock = threading.Lock()
+        self._closing = False
+        super().__init__(*args, **kwargs)
+
+    def track(self, proc: subprocess.Popen) -> bool:
+        """Register a live relay. False once close_relays() has run.
+
+        The return value is what closes the window between a handler getting
+        past Popen and reaching here: without it, a relay registered after
+        close_relays() has taken its snapshot is never reaped, which is the
+        leak close_relays() exists to prevent.
+        """
+        with self._relay_lock:
+            if self._closing:
+                return False
+            self._relays.add(proc)
+            return True
+
+    def untrack(self, proc: subprocess.Popen) -> None:
+        with self._relay_lock:
+            self._relays.discard(proc)
+
+    def close_relays(self) -> None:
+        """Reap every exec session this server still holds. Idempotent."""
+        with self._relay_lock:
+            self._closing = True
+            outstanding = list(self._relays)
+            self._relays.clear()
+        for proc in outstanding:
+            reap(proc)
+
+
+def build_server(cfg: TunnelConfig, local_port: int, host: str = "127.0.0.1") -> Server:
+    """Bind the local listener. Pass local_port=0 for an ephemeral port.
+
+    The caller reads the bound port back from `server.server_address[1]`, which
+    is what a test wants: a fixed port turns two concurrent runs into an
+    `address already in use` that reads like a broken tunnel.
+    """
+    server = Server((host, local_port), Handler)
+    server.cfg = cfg
+    server.resolver = PodResolver(cfg)
+    return server
+
+
+def serve_background(cfg: TunnelConfig, local_port: int = 0, host: str = "127.0.0.1") -> Server:
+    """Bind and serve on a daemon thread.
+
+    The caller owns teardown: shutdown(), then close_relays(), then
+    server_close().
+    """
+    server = build_server(cfg, local_port, host)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server

--- a/scripts/hermes-dashboard-tunnel.py
+++ b/scripts/hermes-dashboard-tunnel.py
@@ -12,197 +12,27 @@ unauthenticated. The loopback bind is what keeps the dashboard usable, so
 reaching it means getting inside the pod's network namespace rather than
 changing how it listens.
 
-`kubectl port-forward` cannot do that on a GKE Sandbox (gVisor) node pool: the
-kubelet sets the forward up in the host-side CNI netns, while the listener
-lives in the sandbox's own network stack, so every port on the pod refuses the
-connection. `kubectl exec` does enter the sandbox correctly, so this relays
-bytes through an exec channel instead.
-
-Three things this has to get right, each of which broke it once:
-
-1. Under `bufsize=0` the subprocess pipes are raw FileIO. There is no
-   `.read1()` -- only `.read()`.
-2. Raw pipe `write()` may consume only part of the buffer and return a short
-   count. Discarding that count silently dropped 32-64KB chunks mid-stream and
-   truncated the SPA's 1.9MB entrypoint, so the module would not parse.
-3. The pod name changes on every redeploy. Pinning one produces a tunnel that
-   accepts connections and returns zero bytes (ERR_EMPTY_RESPONSE) the moment
-   the Deployment rolls. The pod is resolved by label and re-resolved whenever
-   an exec fails to come up.
+`kubectl port-forward` cannot do that on a GKE Sandbox (gVisor) node pool --
+docs/site/src/content/docs/operator/platformagent-crd.md is canonical on why --
+so this relays bytes through a `kubectl exec` channel instead. The relay, and
+everything it has to get right, moved to `scripts/exec_tunnel.py` when the E2E
+suite needed the same mechanism against the credential-proxy sidecar. What
+stays here is the dashboard's access path: its defaults, and why its loopback
+bind is deliberate.
 """
 
 import argparse
-import socket
-import socketserver
-import subprocess
+import pathlib
 import sys
-import threading
 
-# The remote end writes READY (one NUL) as soon as it has actually connected to
-# the dashboard, before relaying anything. That single byte is what lets the
-# local side distinguish "container reachable and dashboard listening" from a
-# stale pod name, without having to buffer and replay the client's request.
-REMOTE_RELAY = """
-import os, sys, socket, threading, time
+# Python already puts a script's own directory on sys.path, so this is only
+# needed under `python3 -P` or PYTHONSAFEPATH=1, which suppress that.
+sys.path.append(str(pathlib.Path(__file__).parent))
 
-def write_all(fd, buf):
-    mv = memoryview(buf)
-    while mv:
-        mv = mv[os.write(fd, mv):]
-
-s = socket.create_connection(("127.0.0.1", {port}))
-os.write(1, b"\\x00")
-
-def up():
-    try:
-        while True:
-            d = os.read(0, 65536)
-            if not d:
-                break
-            s.sendall(d)
-    except Exception:
-        pass
-    try:
-        s.shutdown(socket.SHUT_WR)
-    except Exception:
-        pass
-
-threading.Thread(target=up, daemon=True).start()
-try:
-    while True:
-        d = s.recv(65536)
-        if not d:
-            break
-        write_all(1, d)
-except Exception:
-    pass
-finally:
-    # kubectl tears down the stdout stream when this process exits; give the
-    # final frames a moment to ship before we go away.
-    time.sleep(0.25)
-"""
+from exec_tunnel import TunnelConfig, build_server  # noqa: E402
 
 
-def write_all(fileobj, buf):
-    """Write every byte of buf, tolerating short writes on a raw pipe."""
-    mv = memoryview(buf)
-    while mv:
-        n = fileobj.write(mv)
-        if not n:
-            continue
-        mv = mv[n:]
-    fileobj.flush()
-
-
-class PodResolver:
-    """Cache the pod name; re-resolve by label when an exec fails to start."""
-
-    def __init__(self, cfg):
-        self.cfg = cfg
-        self.lock = threading.Lock()
-        self.pod = cfg.pod
-
-    def get(self, refresh=False):
-        with self.lock:
-            if self.pod and not refresh:
-                return self.pod
-            out = subprocess.run(
-                ["kubectl", "get", "pods", "-n", self.cfg.namespace,
-                 "-l", self.cfg.selector,
-                 "--field-selector=status.phase=Running",
-                 "-o", "jsonpath={.items[0].metadata.name}"],
-                capture_output=True, text=True, timeout=60,
-            )
-            name = out.stdout.strip()
-            if not name:
-                raise RuntimeError(
-                    f"no Running pod matches -l {self.cfg.selector} "
-                    f"in {self.cfg.namespace}"
-                )
-            if name != self.pod:
-                print(f"  pod → {name}", flush=True)
-            self.pod = name
-            return name
-
-
-class Handler(socketserver.BaseRequestHandler):
-    def _spawn(self, pod):
-        """Start an exec relay; return it only once it reports READY."""
-        cmd = [
-            "kubectl", "exec", "-i",
-            "-n", self.server.cfg.namespace, pod,
-            "-c", self.server.cfg.container,
-            "--", self.server.cfg.python, "-u", "-c",
-            REMOTE_RELAY.format(port=self.server.cfg.remote_port),
-        ]
-        try:
-            proc = subprocess.Popen(
-                cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                stderr=None, bufsize=0,
-            )
-        except Exception as exc:  # noqa: BLE001
-            print(f"  exec failed: {exc}", file=sys.stderr, flush=True)
-            return None
-        if proc.stdout.read(1) != b"\x00":
-            proc.terminate()
-            return None
-        return proc
-
-    def handle(self):
-        resolver = self.server.resolver
-        proc = None
-        for refresh in (False, True):
-            try:
-                pod = resolver.get(refresh=refresh)
-            except Exception as exc:  # noqa: BLE001
-                print(f"  {exc}", file=sys.stderr, flush=True)
-                return
-            proc = self._spawn(pod)
-            if proc:
-                break
-        if not proc:
-            return
-
-        def to_pod():
-            try:
-                while True:
-                    data = self.request.recv(65536)
-                    if not data:
-                        break
-                    write_all(proc.stdin, data)
-            except Exception:  # noqa: BLE001
-                pass
-            finally:
-                try:
-                    proc.stdin.close()
-                except Exception:  # noqa: BLE001
-                    pass
-
-        threading.Thread(target=to_pod, daemon=True).start()
-        try:
-            while True:
-                # raw FileIO: .read(n) is one read() syscall, no .read1()
-                data = proc.stdout.read(65536)
-                if not data:
-                    break
-                self.request.sendall(data)
-        except Exception:  # noqa: BLE001
-            pass
-        finally:
-            try:
-                self.request.shutdown(socket.SHUT_WR)
-            except Exception:  # noqa: BLE001
-                pass
-            proc.terminate()
-
-
-class Server(socketserver.ThreadingTCPServer):
-    daemon_threads = True
-    allow_reuse_address = True
-    request_queue_size = 64
-
-
-def main():
+def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--namespace", default="kubeagents-system")
     ap.add_argument("--selector", default="app=platform-agent-gateway")
@@ -211,17 +41,24 @@ def main():
     ap.add_argument("--remote-port", type=int, default=9119)
     ap.add_argument("--local-port", type=int, default=9119)
     ap.add_argument("--python", default="/opt/hermes/.venv/bin/python3")
-    cfg = ap.parse_args()
+    args = ap.parse_args()
 
-    resolver = PodResolver(cfg)
-    resolver.get()
-
-    server = Server(("127.0.0.1", cfg.local_port), Handler)
-    server.cfg = cfg
-    server.resolver = resolver
-    print(f"Hermes dashboard → http://127.0.0.1:{cfg.local_port}", flush=True)
-    print(f"  via kubectl exec into -l {cfg.selector} "
-          f"({cfg.namespace}), Ctrl-C to stop", flush=True)
+    cfg = TunnelConfig(
+        namespace=args.namespace,
+        selector=args.selector,
+        pod=args.pod,
+        container=args.container,
+        remote_port=args.remote_port,
+        python=args.python,
+        # stderr, so the tunnel's commentary never lands in a pipe a caller is
+        # reading data from.
+        log=lambda message: print(message, file=sys.stderr, flush=True),
+    )
+    server = build_server(cfg, args.local_port)
+    server.resolver.get()
+    print(f"Hermes dashboard → http://127.0.0.1:{args.local_port}", flush=True)
+    print(f"  via kubectl exec into -l {args.selector} "
+          f"({args.namespace}), Ctrl-C to stop", flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/scripts/test_exec_tunnel.py
+++ b/scripts/test_exec_tunnel.py
@@ -1,0 +1,280 @@
+"""The exec relay, against a fake kubectl and a real loopback server.
+
+`tests/e2e` is a live-cluster suite that CI never imports
+(scripts/test_test_discovery.py records the exclusion), so the relay it depends
+on would otherwise be checked only by an RC run. It is separable from the
+cluster, though: everything specific to Kubernetes is the `kubectl` argv, so a
+`kubectl` on PATH that runs the relay's own remote half locally exercises the
+real code — the READY handshake, the short-write loop, pod re-resolution and
+the reap — over a real socket.
+
+The two cases that earn their keep are the ones the module docstring says broke
+it: a payload large enough to force short writes on the pipe, and a stale pod
+name that has to be re-resolved rather than retried against.
+"""
+
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import exec_tunnel  # noqa: E402
+
+# Big enough that the relay's pipe writes come back short, which is finding 2
+# in exec_tunnel's docstring. 1.9MB is the size that actually truncated the
+# dashboard's entrypoint.
+BIG_BODY = b"x" * (1900 * 1024)
+
+
+class _Upstream(BaseHTTPRequestHandler):
+    """Stands in for a loopback listener inside the pod."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):  # noqa: N802
+        body = BIG_BODY if self.path == "/big" else b'{"sessions": []}'
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+FAKE_KUBECTL = r'''"""Answers the two kubectl calls exec_tunnel makes, without a cluster."""
+import json, os, sys
+
+args = sys.argv[1:]
+
+
+def pod_item(name, ready=True):
+    return {
+        "metadata": {"name": name},
+        "status": {"conditions": [{"type": "Ready", "status": "True" if ready else "False"}]},
+    }
+
+
+if args[0] == "get" and args[1] == "pods":
+    if os.environ.get("FAKE_BROKEN"):
+        sys.stderr.write("Unable to connect to the server: dial tcp: i/o timeout\n")
+        sys.exit(1)
+    if os.environ.get("FAKE_EMPTY"):
+        items = []
+    elif os.environ.get("FAKE_NOTREADY_FIRST"):
+        items = [pod_item("running-pod", ready=False), pod_item("ready-pod")]
+    elif os.environ.get("FAKE_STALE"):
+        # The first resolve hands back a pod the exec refuses, so the caller
+        # has to re-resolve; the counter file makes the second call differ.
+        with open(os.environ["FAKE_STATE"], "a+") as fh:
+            fh.seek(0)
+            n = len(fh.read().split())
+            fh.write("x ")
+        items = [pod_item("stale-pod" if n == 0 else "good-pod")]
+    else:
+        items = [pod_item("good-pod")]
+    sys.stdout.write(json.dumps({"items": items}))
+    sys.exit(0)
+
+if args[0] == "exec":
+    # kubectl exec -i -n <ns> <pod> -c <container> -- ...
+    pod = args[args.index("-n") + 2]
+    if pod == "stale-pod":
+        sys.stderr.write("Error from server (NotFound): pods \"stale-pod\" not found\n")
+        sys.exit(1)
+    # Everything after "--" is the interpreter and its -u -c <program>.
+    tail = args[args.index("--") + 1:]
+    os.execvp(sys.executable, [sys.executable, "-u", "-c", tail[-1]])
+
+sys.stderr.write("fake kubectl: unhandled %r\n" % (args,))
+sys.exit(1)
+'''
+
+
+class ExecTunnelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        bin_dir = pathlib.Path(cls.tmp.name) / "bin"
+        bin_dir.mkdir()
+        kubectl = bin_dir / "kubectl"
+        # sys.executable, not `#!/usr/bin/env python3`: env resolves off the
+        # ambient PATH, so the fake would run whichever interpreter the shell
+        # happened to offer -- a different one from the module under test, and
+        # none at all under a stripped PATH.
+        kubectl.write_text("#!" + sys.executable + "\n" + FAKE_KUBECTL)
+        kubectl.chmod(0o755)
+        cls.bin_dir = str(bin_dir)
+
+        # For the "kubectl is not installed" case. An empty directory rather
+        # than the developer's real PATH: see test_a_missing_kubectl_*.
+        empty_bin = pathlib.Path(cls.tmp.name) / "empty-bin"
+        empty_bin.mkdir()
+        cls.empty_bin = str(empty_bin)
+
+        cls.upstream = ThreadingHTTPServer(("127.0.0.1", 0), _Upstream)
+        cls.upstream_port = cls.upstream.server_address[1]
+        threading.Thread(target=cls.upstream.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.upstream.shutdown()
+        cls.upstream.server_close()
+        cls.tmp.cleanup()
+
+    # Every knob the fake reads, cleared before and after each test so one
+    # case cannot leak a mode into the next.
+    FAKE_FLAGS = ("FAKE_STALE", "FAKE_EMPTY", "FAKE_BROKEN", "FAKE_NOTREADY_FIRST")
+
+    def setUp(self):
+        self._path = os.environ.get("PATH", "")
+        # The fake shadows any real kubectl, and no test ever falls back to the
+        # developer's PATH for a kubectl call.
+        os.environ["PATH"] = self.bin_dir + os.pathsep + self._path
+        state = tempfile.NamedTemporaryFile(delete=False)
+        state.close()
+        self._state = state.name
+        os.environ["FAKE_STATE"] = self._state
+        for flag in self.FAKE_FLAGS:
+            os.environ.pop(flag, None)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        os.environ["PATH"] = self._path
+        os.environ.pop("FAKE_STATE", None)
+        for flag in self.FAKE_FLAGS:
+            os.environ.pop(flag, None)
+        os.unlink(self._state)
+
+    def _temp_sink(self):
+        """A closed-and-removed-on-cleanup file for kubectl's stderr."""
+        sink = tempfile.NamedTemporaryFile(mode="w", delete=False)
+        self.addCleanup(os.unlink, sink.name)
+        self.addCleanup(sink.close)
+        return sink
+
+    def _tunnel(self, **overrides):
+        kwargs = dict(
+            namespace="ns",
+            selector="app=platform-agent-gateway",
+            container="envoy-credential-proxy",
+            remote_port=self.upstream_port,
+            python=sys.executable,
+            ready_timeout=30.0,
+            log=lambda message: None,
+        )
+        kwargs.update(overrides)
+        server = exec_tunnel.serve_background(exec_tunnel.TunnelConfig(**kwargs), local_port=0)
+        # Reverse order of registration, so: shutdown, close_relays, then close.
+        self.addCleanup(server.server_close)
+        self.addCleanup(server.close_relays)
+        self.addCleanup(server.shutdown)
+        return server.server_address[1]
+
+    def _get(self, port, path="/"):
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(f"http://127.0.0.1:{port}{path}", timeout=30) as response:
+            return response.status, response.read()
+
+    def test_relays_a_response(self):
+        status, body = self._get(self._tunnel())
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b'{"sessions": []}')
+
+    def test_relays_a_payload_larger_than_one_pipe_write(self):
+        status, body = self._get(self._tunnel(), "/big")
+        self.assertEqual(status, 200)
+        self.assertEqual(len(body), len(BIG_BODY), "short write truncated the stream")
+
+    def test_re_resolves_the_pod_when_the_first_exec_fails(self):
+        os.environ["FAKE_STALE"] = "1"
+        log = self._temp_sink()
+        status, _ = self._get(self._tunnel(stderr=log))
+        self.assertEqual(status, 200)
+        self.assertIn("stale-pod", pathlib.Path(log.name).read_text())
+
+    def _resolver(self):
+        return exec_tunnel.PodResolver(exec_tunnel.TunnelConfig(
+            namespace="ns", selector="app=platform-agent-gateway",
+            container="c", remote_port=self.upstream_port, python=sys.executable,
+        ))
+
+    def test_no_matching_pod_is_reported_not_raised(self):
+        os.environ["FAKE_EMPTY"] = "1"
+        with self.assertRaises(RuntimeError) as caught:
+            self._resolver().get()
+        self.assertIn("app=platform-agent-gateway", str(caught.exception))
+
+    def test_a_missing_kubectl_is_a_runtime_error(self):
+        # PATH is pointed at an EMPTY directory, never at the developer's real
+        # PATH. An earlier version of this test stripped the fake kubectl and
+        # left the rest in place, so on a machine with kubectl installed it
+        # resolved pods against whatever cluster the current context named --
+        # a PR-gating unit test making a live API call.
+        os.environ["PATH"] = self.empty_bin
+        with self.assertRaises(RuntimeError) as caught:
+            self._resolver().get()
+        self.assertIn("could not run kubectl", str(caught.exception))
+
+    def test_a_failing_kubectl_is_a_runtime_error(self):
+        os.environ["FAKE_BROKEN"] = "1"
+        with self.assertRaises(RuntimeError) as caught:
+            self._resolver().get()
+        self.assertIn("Unable to connect to the server", str(caught.exception))
+
+    def test_ready_pods_are_preferred_over_merely_running_ones(self):
+        os.environ["FAKE_NOTREADY_FIRST"] = "1"
+        self.assertEqual(self._resolver().get(), "ready-pod")
+
+    def test_track_refuses_after_close_and_close_is_idempotent(self):
+        server = exec_tunnel.build_server(exec_tunnel.TunnelConfig(), local_port=0)
+        self.addCleanup(server.server_close)
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        self.assertTrue(server.track(proc))
+        server.close_relays()
+        self.assertIsNotNone(proc.poll(), "close_relays did not reap the tracked child")
+
+        late = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        self.addCleanup(exec_tunnel.reap, late)
+        # A handler that got past Popen before the teardown and reaches track()
+        # after it must be told so, or its exec session is never reaped.
+        self.assertFalse(server.track(late))
+        server.close_relays()  # idempotent
+
+    def test_reap_waits_for_the_child(self):
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        exec_tunnel.reap(proc, timeout=5.0)
+        self.assertIsNotNone(proc.poll(), "reap left the child unwaited")
+
+    def test_ready_timeout_does_not_hang_on_a_listener_that_never_answers(self):
+        # A remote port nothing is bound to: the remote half raises before it
+        # writes READY, so _spawn must reject rather than block the handler.
+        dead = socket.socket()
+        dead.bind(("127.0.0.1", 0))
+        dead_port = dead.getsockname()[1]
+        dead.close()
+
+        port = self._tunnel(remote_port=dead_port, ready_timeout=5.0, stderr=self._temp_sink())
+        started = time.time()
+        with socket.create_connection(("127.0.0.1", port), timeout=10) as client:
+            client.sendall(b"GET / HTTP/1.0\r\n\r\n")
+            try:
+                # Clean close or reset both mean "no bytes and not hung", which
+                # is the property under test; which one depends on the platform.
+                self.assertEqual(client.recv(1), b"", "expected the relay to close, not answer")
+            except ConnectionResetError:
+                pass
+        self.assertLess(time.time() - started, 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,9 +5,13 @@ import json
 import os
 import pathlib
 import subprocess
+import sys
+import tempfile
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Generator
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -259,7 +263,16 @@ def ensure_cluster_credentials(
 
 @pytest.fixture(scope="session")
 def platform_agent_api_key(agent_namespace: str) -> Optional[str]:
-    """Retrieves API_SERVER_KEY from platform-agent-secrets in the cluster."""
+    """Retrieves API_SERVER_KEY from platform-agent-secrets in the cluster.
+
+    Returns None when there is no key to be had. It used to fall back to the
+    literal "cluster-internal-trusted", which is `loopbackAgentAPIKey` in
+    k8s-operator/internal/controller/platformagent_manifests.go — the in-pod
+    sentinel the agent container accepts on loopback, and deliberately *not*
+    the Secret the credential proxy checks. Substituting it turned a failed
+    Secret read into a suite that authenticated against a different listener
+    than the one under test and reported the result as the external path's.
+    """
     try:
         cmd = [
             "kubectl", "get", "secret", "platform-agent-secrets",
@@ -272,117 +285,385 @@ def platform_agent_api_key(agent_namespace: str) -> Optional[str]:
             return base64.b64decode(raw_key).decode("utf-8")
     except Exception:
         pass
-    return os.environ.get("PLATFORM_AGENT_TOKEN") or os.environ.get("API_SERVER_KEY") or "cluster-internal-trusted"
+    return os.environ.get("PLATFORM_AGENT_TOKEN") or os.environ.get("API_SERVER_KEY") or None
+
+
+# ---------------------------------------------------------------------------
+# Reaching the Platform Agent API from the test runner
+#
+# The transport is a `kubectl exec` relay, not `kubectl port-forward`, because
+# the RC environment runs the agent pod on a GKE Sandbox (gVisor) node pool
+# (`ENABLE_GVISOR=true`, against install.sh's `false` default) and port-forward
+# cannot see a listener inside a sandbox. scripts/exec_tunnel.py is canonical on
+# that constraint and owns the relay; it is shared with
+# scripts/hermes-dashboard-tunnel.py rather than written twice.
+#
+# It is used unconditionally rather than behind a gVisor detector: it works on
+# both kinds of node pool, and a detector's wrong answer is the failure being
+# fixed here -- guess "ordinary pool" on a sandboxed cluster and the suite is
+# back to an unexplained reset.
+#
+# Which port, and which key, verified against the operator source rather than
+# against another document:
+#
+#   * The Service the operator creates for the agent (buildPlatformService in
+#     k8s-operator/internal/controller/platformagent_manifests.go) publishes
+#     `api` on 8642 with targetPort 8643. 8643 is the credential-proxy sidecar's
+#     listener: it checks `Authorization: Bearer $API_SERVER_EXTERNAL_KEY` and
+#     re-signs the request to Hermes on the pod's 127.0.0.1:8642 with a
+#     different bearer.
+#   * API_SERVER_EXTERNAL_KEY comes from the API_SERVER_KEY entry of the
+#     platform-agent-secrets Secret, which is what platform_agent_api_key reads.
+#     Port 8643 plus that key is the pair an external caller presents, so it is
+#     the pair this fixture targets.
+#   * The agent container's own API_SERVER_KEY is a different value on purpose:
+#     `loopbackAgentAPIKey`, a non-secret in-pod sentinel. Relaying to
+#     127.0.0.1:8642 would reach Hermes directly, where the Secret's key is not
+#     accepted -- a path no external caller uses. That is the diagnostic below,
+#     never the transport.
+#
+# What this cannot cover is the Service VIP and endpoint hop: entering the
+# sandbox puts us on the pod's own loopback, past kube-proxy. Dialling the
+# Service from inside the pod is not an alternative either, because
+# buildNetworkPolicy grants the gateway no egress to 8642 or 8643 anywhere, so
+# the hairpin would be dropped on a healthy cluster. Read that policy rather
+# than trusting this sentence -- it is rewritten often.
+# ---------------------------------------------------------------------------
+
+# scripts/ is not a package, so the relay is imported off the repo root already
+# resolved at the top of this file. Appended rather than inserted: this runs at
+# import time and stays for the session, and prepending would let a stray
+# scripts/*.py shadow a stdlib module for every other import in the suite.
+sys.path.append(str(_REPO_ROOT / "scripts"))
+from exec_tunnel import TunnelConfig, serve_background  # noqa: E402
+
+# The PlatformAgent CR name, which is also the Service name and the prefix of
+# the `<name>-gateway` Deployment and its `app` label. Same env var
+# bench/kube_agents_bench/harness.py reads for the same value.
+_AGENT_NAME = os.environ.get("AGENT_SERVICE_NAME", "platform-agent")
+
+_PROXY_CONTAINER = "envoy-credential-proxy"
+_AGENT_CONTAINER = "platform-agent"
+
+# The interpreter the relay runs inside _PROXY_CONTAINER. Named here rather than
+# inherited from TunnelConfig's default, whose help text describes it as the
+# dashboard's: this is a real coupling to the image, and it holds because the
+# credential-proxy stage derives from proxy-tools -> agent-base
+# (deploy/docker/Dockerfile) and start-services.sh launches credential_proxy.py
+# with this same path.
+_PROXY_PYTHON = "/opt/hermes/.venv/bin/python3"
+
+# The credential-proxy sidecar's authenticated listener, and the Service's
+# targetPort for `api`.
+_PROXY_API_PORT = 8643
+_HERMES_API_PORT = 8642
+
+# Read-only, and the endpoint the operator's own readiness probe asks for
+# (agentAPIProbe in platformagent_manifests.go), so a pass here means what a
+# pass there means.
+_AGENT_API_PROBE_PATH = "/api/sessions?limit=1"
+
+
+def _numeric_env(name: str, default: str, cast: Any) -> Any:
+    """Read a numeric env var, naming it in the error rather than the value.
+
+    Matches the helper in bench/kube_agents_bench/harness.py, including the case
+    its regression test names: a variable that is present but empty, which a
+    bare `float(os.environ.get(...))` turns into an unattributed ValueError.
+    """
+    raw = os.environ.get(name) or default
+    try:
+        return cast(raw)
+    except ValueError:
+        raise ValueError(f"{name} must be numeric, got {raw!r}") from None
+
+
+def _probe_agent_api(port: int, api_key: str, timeout: float) -> Tuple[Optional[int], str]:
+    """Asks whatever is on the far end for one HTTP response.
+
+    Returns (status, detail), with status None when no HTTP response arrived at
+    all. That distinction is the point: a plain TCP connect to the local end of
+    a tunnel succeeds whether or not the far end exists, so it cannot tell a
+    working transport from a broken one.
+    """
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}{_AGENT_API_PROBE_PATH}",
+        headers={"Authorization": f"Bearer {api_key}"},
+        method="GET",
+    )
+    # ProxyHandler({}) rather than urlopen: urlopen reads http_proxy from the
+    # environment, and a runner that sets one would send this loopback probe to
+    # the proxy and report its answer as the agent's.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            response.read()
+            return response.status, f"HTTP {response.status}"
+    except urllib.error.HTTPError as exc:
+        # An HTTP status is a success for this probe: something on the far end
+        # spoke HTTP. Whether it is the right something is the caller's call.
+        exc.read()
+        return exc.code, f"HTTP {exc.code} {exc.reason}"
+    except Exception as exc:  # noqa: BLE001 - any transport failure is one answer
+        return None, f"{type(exc).__name__}: {exc}"
+
+
+def _read_log_tail(log: Any, limit: int = 800) -> str:
+    """Returns the tail of a captured kubectl log, flattened onto one line.
+
+    Re-opened by path rather than rewound: subprocess dups this handle's
+    descriptor into each child, so the two share one file offset and a seek(0)
+    here would send the next write to the top of the file.
+
+    Repeats are collapsed with a count. One connection is one exec, and the
+    probe retries for its whole budget, so a single persistent error otherwise
+    fills the tail with twenty copies of itself and pushes out everything that
+    was said only once.
+    """
+    try:
+        with open(log.name, "r", errors="replace") as handle:
+            text = handle.read()
+    except Exception:  # noqa: BLE001 - diagnostics must not raise
+        return "(kubectl output unavailable)"
+
+    seen: List[str] = []
+    counts: Dict[str, int] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line not in counts:
+            seen.append(line)
+            counts[line] = 0
+        counts[line] += 1
+    if not seen:
+        return "(kubectl printed nothing)"
+    rendered = " | ".join(
+        line if counts[line] == 1 else f"{line} (x{counts[line]})" for line in seen
+    )
+    return rendered[-limit:]
+
+
+def _discard_log(log: Any) -> None:
+    """Closes and removes a capture file, whatever state it is in."""
+    try:
+        log.close()
+    except Exception:  # noqa: BLE001 - cleanup must not mask a real failure
+        pass
+    try:
+        os.unlink(log.name)
+    except OSError:
+        pass
+
+
+def _gateway_pod_selector(namespace: str, note: Callable[[str], None]) -> str:
+    """The label selector the agent Service itself uses, or the plain fallback.
+
+    Not a hardcoded `app=<name>-gateway`. Above one replica the operator adds
+    `kubeagents.io/is-leader: "true"` to that Service's selector
+    (buildPlatformService), because only the leader runs `hermes gateway run` --
+    a standby still answers on 8643, where the credential proxy's API listener
+    is up, and the proxy then 502s trying to reach a Hermes that was never
+    started. Reading the selector off the Service means this transport lands
+    where a real caller lands, at any replica count, without restating the
+    operator's leader logic here.
+
+    Every fallback is announced through `note`. A silent one sends the reader
+    the wrong way: the failure downstream reads "no Running pod matches -l
+    app=<name>-gateway", which blames the pods when what actually failed was
+    reading the Service -- wrong namespace, missing RBAC, or a Service the
+    operator has not created yet.
+    """
+    fallback = f"app={_AGENT_NAME}-gateway"
+    try:
+        res = subprocess.run(
+            ["kubectl", "get", "service", _AGENT_NAME, "-n", namespace, "-o", "json"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except Exception as exc:  # noqa: BLE001 - the fallback is the documented shape
+        note(f"could not run kubectl to read svc/{_AGENT_NAME}: {type(exc).__name__}: {exc}; "
+             f"falling back to {fallback}")
+        return fallback
+    if res.returncode != 0:
+        note(f"reading svc/{_AGENT_NAME} failed rc={res.returncode} "
+             f"({res.stderr.strip() or 'no stderr'}); falling back to {fallback}")
+        return fallback
+    try:
+        selector = json.loads(res.stdout).get("spec", {}).get("selector") or {}
+    except ValueError as exc:
+        note(f"svc/{_AGENT_NAME} returned unparseable JSON: {exc}; falling back to {fallback}")
+        return fallback
+    if not selector:
+        note(f"svc/{_AGENT_NAME} has no selector; falling back to {fallback}")
+        return fallback
+    # Naive joining is safe: a Kubernetes label key or value cannot contain
+    # a comma or an equals sign.
+    return ",".join(f"{key}={value}" for key, value in sorted(selector.items()))
+
+
+def _diagnose_hermes(namespace: str) -> str:
+    """Separates "the agent is down" from "the credential proxy is broken".
+
+    Runs the operator's own readiness probe on demand: curl against Hermes on
+    pod loopback bearing the agent container's `$API_SERVER_KEY`, read inside
+    the pod and never printed, so no copy of the sentinel value lives here to
+    drift from platformagent_manifests.go.
+
+    `deployment/<name>-gateway` selects any Ready pod rather than the leader.
+    Above one replica that may be a standby, which never binds 8642 at all --
+    agentAPIProbe passes it anyway, tolerating curl's exit 7 when
+    `$ENABLE_LEADER_ELECTION` is `"true"` -- so read a failure here as "this pod
+    is not serving" rather than "the agent is down".
+    """
+    curl = (
+        'curl --silent --show-error --max-time 5 -o /dev/null -w "%{http_code}" '
+        '-H "Authorization: Bearer $API_SERVER_KEY" '
+        f"http://127.0.0.1:{_HERMES_API_PORT}{_AGENT_API_PROBE_PATH}"
+    )
+    try:
+        res = subprocess.run(
+            ["kubectl", "exec", "-n", namespace, f"deployment/{_AGENT_NAME}-gateway",
+             "-c", _AGENT_CONTAINER, "--", "sh", "-c", curl],
+            capture_output=True, text=True, timeout=60,
+        )
+    except Exception as exc:  # noqa: BLE001 - a diagnostic must not raise over the real failure
+        return f"DIAGNOSE Hermes on pod loopback: kubectl exec failed: {type(exc).__name__}: {exc}"
+
+    if res.returncode != 0:
+        return (
+            f"DIAGNOSE Hermes on pod loopback: curl rc={res.returncode} "
+            f"({res.stderr.strip() or 'no stderr'}). This pod is not serving "
+            f"{_AGENT_API_PROBE_PATH}, so the fault is at or below Hermes."
+        )
+
+    # There is no --fail on that curl, so a status came back and the branch is
+    # decided on the status rather than on the exit code. 4xx here is not the
+    # proxy's problem: it means the agent container's own $API_SERVER_KEY is not
+    # what its Hermes accepts, which is issue #786's shape.
+    code = res.stdout.strip()
+    if code.startswith("4"):
+        return (
+            f"DIAGNOSE Hermes on pod loopback: HTTP {code}. Hermes is serving but rejects the "
+            f"agent container's own $API_SERVER_KEY, so the two ends of the in-pod sentinel "
+            f"disagree -- the credential proxy is downstream of that and cannot succeed either."
+        )
+    if not code.startswith("2"):
+        return (
+            f"DIAGNOSE Hermes on pod loopback: HTTP {code}. Hermes answered but not with success, "
+            f"so the fault is at or below Hermes rather than in the credential proxy."
+        )
+    return (
+        f"DIAGNOSE Hermes on pod loopback: HTTP {code}. Hermes is serving, so the fault is the "
+        f"credential-proxy listener on {_PROXY_API_PORT} or the key it holds -- compare "
+        f"`kubectl exec -c {_PROXY_CONTAINER} -- printenv API_SERVER_EXTERNAL_KEY` against the "
+        f"platform-agent-secrets API_SERVER_KEY, which a pod that outlived a Secret rewrite "
+        f"will not match."
+    )
 
 
 @pytest.fixture(scope="session")
 def port_forward_agent(
     agent_namespace: str, platform_agent_api_key: Optional[str]
-) -> Generator[Optional[str], None, None]:
-    """Establishes background port-forward to the platform agent REST API with guaranteed cleanup."""
+) -> Generator[str, None, None]:
+    """Yields a local URL that reaches the agent API, or fails saying why.
+
+    Never yields None -- every path that cannot produce a working URL fails the
+    setup instead, which is why callers need no guard on the value.
+
+    The name is historical: the transport is an exec relay, not a port-forward.
+    """
     if not platform_agent_api_key:
-        yield None
-        return
+        pytest.fail(
+            "Platform Agent API key not found: platform-agent-secrets has no readable "
+            "API_SERVER_KEY, and neither PLATFORM_AGENT_TOKEN nor API_SERVER_KEY is set."
+        )
 
-    import socket
+    # 0 takes an ephemeral port. A fixed one turns a leftover listener from an
+    # earlier run into "address already in use", which reads like a broken agent.
+    local_port = _numeric_env("AGENT_LOCAL_PORT", "0", int)
+    budget = _numeric_env("AGENT_TUNNEL_TIMEOUT", "30", float)
 
-    port_str = os.environ.get("AGENT_LOCAL_PORT", "8642")
-    port = int(port_str)
-    url = f"http://127.0.0.1:{port}"
+    # kubectl's stderr, which is where a failed exec explains itself. A file
+    # rather than a pipe: nothing drains it for the life of the fixture, and a
+    # full pipe buffer would block the relay mid-session.
+    log = tempfile.NamedTemporaryFile(
+        mode="w", prefix="agent-exec-tunnel-", suffix=".log", delete=False
+    )
+    # Built before the selector is resolved, because resolving it can have
+    # something to say.
+    diary: List[str] = [f"Platform Agent API transport, namespace {agent_namespace}:"]
+    selector = _gateway_pod_selector(
+        agent_namespace, lambda message: diary.append(f"  {message}")
+    )
+    target = (
+        f"exec relay -> {_PROXY_CONTAINER}:{_PROXY_API_PORT} "
+        f"in a pod matching {selector}"
+    )
 
-    # Build prioritized candidate targets: services, deployments, pods
-    targets = [
-        "svc/platform-agent",
-        "svc/platform-agent-credential-proxy",
-        "deployment/platform-agent-gateway",
-    ]
-
-    # Dynamically discover agent deployments or pods in agent_namespace
+    server = None
     try:
-        res_dep = subprocess.run(
-            ["kubectl", "get", "deployments", "-n", agent_namespace, "-o", "jsonpath={.items[*].metadata.name}"],
-            capture_output=True,
-            text=True,
-            timeout=5,
+        server = serve_background(
+            TunnelConfig(
+                namespace=agent_namespace,
+                selector=selector,
+                container=_PROXY_CONTAINER,
+                remote_port=_PROXY_API_PORT,
+                python=_PROXY_PYTHON,
+                ready_timeout=budget,
+                stderr=log,
+                log=lambda message: diary.append(f"  {message.strip()}"),
+            ),
+            local_port=local_port,
         )
-        if res_dep.returncode == 0:
-            for dep in res_dep.stdout.split():
-                if "gateway" in dep or "platform" in dep or "agent" in dep:
-                    targets.append(f"deployment/{dep}")
+        port = server.server_address[1]
 
-        res_pods = subprocess.run(
-            [
-                "kubectl", "get", "pods", "-n", agent_namespace,
-                "-l", "kubeagents.x-k8s.io/has-credential-proxy=true",
-                "-o", "jsonpath={.items[*].metadata.name}",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if res_pods.returncode == 0:
-            for p in res_pods.stdout.split():
-                targets.append(f"pod/{p}")
-    except Exception:
-        pass
-
-    # Deduplicate targets preserving order
-    seen = set()
-    unique_targets = []
-    for t in targets:
-        if t not in seen:
-            seen.add(t)
-            unique_targets.append(t)
-
-    proc = None
-    connected = False
-
-    for target in unique_targets:
-        proc = subprocess.Popen(
-            [
-                "kubectl",
-                "port-forward",
-                target,
-                "-n",
-                agent_namespace,
-                f"{port}:8642",
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
-
-        deadline = time.time() + 8
-        while time.time() < deadline:
-            if proc.poll() is not None:
+        # 5xx is retried, everything else is final. The credential proxy answers
+        # 502 whenever its upstream dial fails (credential_proxy.py, the
+        # BAD_GATEWAY branch of AgentAPIProxyHandler._proxy), and its container
+        # is Ready long before Hermes binds 8642: the sidecar's readiness probe
+        # curls /healthz on 8765, which CredentialProxyHandler answers
+        # unconditionally and which depends on nothing Hermes does, while the
+        # agent's own startup probe sanctions a cold boot of several minutes.
+        # Treating that first 502 as the verdict hard-fails the suite against an
+        # agent that is merely still booting, with none of the budget spent.
+        #
+        # Each probe gets whatever is left of the budget rather than a fixed
+        # slice, so the client's deadline and the relay's ready_timeout are the
+        # same instant. A probe timeout shorter than ready_timeout is worse than
+        # useless: it abandons a handshake the relay is still waiting on, so an
+        # exec slower than the slice can never succeed however many times it is
+        # retried, and each abandoned attempt strands a `kubectl exec` for the
+        # rest of the session. A 502 costs nothing here -- it comes back as fast
+        # as the upstream dial fails, leaving the rest of the budget to retry.
+        deadline = time.time() + budget
+        status, detail = None, "no probe completed"
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
                 break
-            try:
-                with socket.create_connection(("127.0.0.1", port), timeout=1):
-                    connected = True
-                    break
-            except (OSError, ConnectionRefusedError):
-                time.sleep(0.3)
+            status, detail = _probe_agent_api(port, platform_agent_api_key, remaining)
+            if status is not None and status < 500:
+                break
+            time.sleep(0.5)
 
-        if connected:
-            break
+        if status is None or not 200 <= status < 300:
+            diary.append(f"  REJECT {target} -- probe {_AGENT_API_PROBE_PATH} got {detail}")
+            diary.append(f"  kubectl said: {_read_log_tail(log)}")
+            diary.append("  " + _diagnose_hermes(agent_namespace))
+            pytest.fail(
+                "The Platform Agent API did not answer over the exec relay.\n" + "\n".join(diary)
+            )
 
-        if proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=2)
-            except Exception:
-                proc.kill()
-        proc = None
-
-    if not connected or proc is None:
-        yield None
-        return
-
-    try:
-        yield url
+        diary.append(f"  USED   {target} -- probe {_AGENT_API_PROBE_PATH} answered {detail}")
+        print("\n".join(diary))
+        yield f"http://127.0.0.1:{port}"
     finally:
-        if proc and proc.poll() is None:
-            proc.terminate()
-            try:
-                proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proc.kill()
+        if server is not None:
+            server.shutdown()
+            # Handlers are daemon threads, so shutdown() does not join them and
+            # an abandoned probe would leave its `kubectl exec` running after
+            # the suite reported. close_relays() ends those sessions before the
+            # log they write to is unlinked.
+            server.close_relays()
+            server.server_close()
+        _discard_log(log)

--- a/tests/e2e/test_agent_api_health.py
+++ b/tests/e2e/test_agent_api_health.py
@@ -13,11 +13,10 @@ def test_platform_agent_api_health_ping(
     platform_agent_api_key: Optional[str],
 ) -> None:
     """Verifies that the deployed Platform Agent REST API is reachable, authenticated, and responsive."""
-    if not port_forward_agent:
-        pytest.fail("Cannot reach Platform Agent REST API on cluster: background port-forward could not connect to agent pod/gateway.")
-    if not platform_agent_api_key:
-        pytest.fail("Platform Agent API key (API_SERVER_KEY) not found in platform-agent-secrets or environment.")
-
+    # No guard on the fixtures here on purpose. port_forward_agent fails during
+    # setup, naming the transport it used and what the far end said, so a guard
+    # in the test body could only restate that less precisely — the message this
+    # one used to carry named a port-forward the suite no longer uses.
     url = f"{port_forward_agent}/v1/responses"
     payload = json.dumps({
         "model": "model-default",


### PR DESCRIPTION
## Summary

`tests/e2e/test_agent_api_health.py::test_platform_agent_api_health_ping` has failed on every RC Release E2E Pipeline run that reaches step 3, and the cause is the transport rather than anything about the agent. The RC environment runs the agent pod on a GKE Sandbox (gVisor) node pool, where `kubectl port-forward` is established in the host-side CNI netns while the listener lives in the sandbox's own network stack, so every port on the pod refuses the connection. This PR moves the exec relay that `scripts/hermes-dashboard-tunnel.py` already used for that exact reason into `scripts/exec_tunnel.py`, and has the E2E fixture reach the credential-proxy sidecar through it. Along the way the fixture stops deciding that a target works by opening a TCP socket to kubectl's own local listener — a connect that succeeds whether or not the far end exists, which is how a broken transport came to be reported as a broken agent.

## Why This Change

Runs 32866087154, 32883825538, 32900969147 and 32953137904 all fail the same test with the connection accepted and then closed carrying no HTTP response at all: `ECONNRESET` on the first three, `Remote end closed connection without response` on the last. No status code ever arrives, so nothing in the CI log says which hop broke, and step 3 has been red on every RC since.

Step 2's own provisioning log carries `ENABLE_GVISOR: true` — against `install.sh:80`'s `false` default — a `gvisor-pool` node pool, and `runtimeClassName = "gvisor"` on the Deployment. `docs/site/src/content/docs/operator/platformagent-crd.md` and `scripts/hermes-dashboard-tunnel.py` have both documented the consequence since the Hermes dashboard hit it. That explains the two things nothing else did: the stream is torn down with zero HTTP bytes, and every `kubectl exec`-based test in the same suite passes — `test_github_token_minter_credential_isolation`, and scenario 04's in-pod session poll for its full 360s — while the one port-forward test fails deterministically.

Four other hypotheses were eliminated on the way, and they are what make the conclusion trustworthy rather than merely plausible:

- **Two of the three port-forward targets could never have worked.** `svc/<name>-credential-proxy` does not exist — the operator deletes it on every reconcile in `deleteLegacyCredentialIsolationResources` (`platformagent_controller.go:517`, called from `:286`, with the Service at `:521`). And `deployment/<name>-gateway` reaches the pod's container port 8642, the loopback Hermes listener, whose bearer is `loopbackAgentAPIKey` (`platformagent_manifests.go:583`) rather than the Secret's value.
- **NetworkPolicy is not involved.** Ingress admits 8642/8643 from same-namespace pods, but port-forward never crosses it, and a policy drop presents as a timeout rather than an accept-then-close.
- **Leader election is not involved.** RC runs the default one replica, so the Service selector never gains `kubeagents.io/is-leader`.
- **The credential proxy's un-drained `send_error`** does turn a genuine 401 into an `ECONNRESET` for a request with a body, which fits the earlier runs. It is a real latent defect and it is not this one; it is filed in #971 rather than fixed here, because #955/#960/#963/#966 are all rewriting that region.

## What Changed

- **`scripts/exec_tunnel.py` (new)** is now the canonical home for the relay and for why it is needed. It was moved out of `scripts/hermes-dashboard-tunnel.py` rather than written a second time, and carries that script's three hard-won correctness notes (raw `FileIO` has no `.read1()`; a raw pipe `write()` can return a short count; a pinned pod name breaks the moment the Deployment rolls) plus two more this PR adds: children are waited on and their pipes closed, since one connection is one exec; and every resolution failure — missing kubectl, unreachable control plane, non-zero exit, unparseable JSON, no matching pod — leaves by the same `RuntimeError` door.
- **`scripts/hermes-dashboard-tunnel.py`** keeps the dashboard's access path, its defaults, and why its loopback bind is deliberate. Behaviour is preserved: all seven CLI flags and defaults identical, both banner lines verbatim, the relay program byte-for-byte. One fix in passing — its diagnostics go to stderr again, not stdout.
- **`tests/e2e/conftest.py`** uses that relay, **unconditionally rather than behind a gVisor detector**. It works on both kinds of node pool, and a detector's wrong answer is precisely the failure being fixed: guess "ordinary pool" on a sandboxed cluster and the suite is back to an unexplained reset.
  - **Target: `envoy-credential-proxy` at `127.0.0.1:8643`, with the `platform-agent-secrets` API_SERVER_KEY.** That is the port and key pair an external caller presents — the Service's `api` port 8642 has targetPort 8643, and `API_SERVER_EXTERNAL_KEY` is populated from that Secret entry.
  - **Success is an HTTP probe, not a TCP connect.** `GET /api/sessions?limit=1`, the endpoint `agentAPIProbe` uses; only a 2xx accepts the transport.
  - **5xx is retried for the whole budget; everything else is final.** The credential proxy answers 502 whenever its upstream dial fails, and its container is Ready long before Hermes binds 8642 — its readiness probe curls `/healthz` on 8765, which depends on nothing Hermes does, while the agent's own startup probe sanctions a cold boot of minutes. Treating the first 502 as the verdict hard-fails against an agent that is merely still booting.
  - **Each probe gets whatever is left of the budget**, so the client's deadline and the relay's handshake deadline are the same instant. A shorter probe slice abandons a handshake the relay is still waiting on, which makes any exec slower than the slice permanently unreachable however often it is retried, and strands a `kubectl exec` per attempt.
  - **The pod is selected with the agent Service's own selector**, read from the cluster. Above one replica that selector carries `kubeagents.io/is-leader`, and a standby still answers on 8643 with no Hermes behind it.
  - **The failure is legible.** A diary names the transport, the target, why any fallback was taken, and kubectl's own stderr with repeats collapsed; then a diagnostic runs the operator's readiness probe inside the pod using the agent container's own `$API_SERVER_KEY`, distinguishing a broken proxy listener, a key the pod has outlived, and a sentinel the agent's own Hermes rejects.
  - **`platform_agent_api_key` no longer falls back to `"cluster-internal-trusted"`.** That literal is `loopbackAgentAPIKey`, the in-pod sentinel. Substituting it for a failed Secret read authenticated against a different listener than the one under test and reported the result as the external path's.
  - **`AGENT_SERVICE_NAME`** replaces a second name for a knob `bench/kube_agents_bench/harness.py` already owns, and numeric env vars go through a helper matching bench's, including its present-but-empty case.
- **`.env.example`** pinned `AGENT_LOCAL_PORT=8642` uncommented, and conftest `load_dotenv()`s that file, so following the documented setup reintroduced the fixed-port collision the ephemeral default exists to prevent. Commented out, corrected, scoped so it cannot mislead a bench user, and `AGENT_TUNNEL_TIMEOUT` documented beside it.
- **`scripts/test_exec_tunnel.py` (new)** covers the relay in CI. **`tests/e2e/test_agent_api_health.py`** loses a dead guard whose message named a port-forward the suite no longer uses. **`docs/designs/e2e-testing-harness.md`** and **`platformagent-crd.md`** are reconciled to where each fact now lives.

## Context

Out-of-scope defects found while diagnosing this are filed as **#971** rather than listed here — the bench port-forward exposure, three docs missing the gVisor caveat, the kustomize `targetPort` mismatch, `hack/ci-deploy.sh`'s `nc -z` readiness gate, the credential proxy's undrained `send_error`, and the `AGENT_LOCAL_PORT` collision between this suite and bench.

**Open, not landed: #969.** That branch shares two files with this one and is still open, so whichever merges second needs rebasing past the other. In `tests/e2e/conftest.py` it changes the `github_repo` fixture and its helpers around lines 161–256, while this change is confined to `platform_agent_api_key` and everything below it. In `docs/designs/e2e-testing-harness.md` it extends the environment-variable table further down the page, while this change is the Stage 2 bullet near the top. No textual overlap in either file, so the rebase should be mechanical — but it is a live conflict to sequence, not one already resolved.

**Sibling PRs this collides with**, none of them blocking but all of them worth sequencing against:

- **#960** moves the credential broker into its own Pod. In that mode `envoy-credential-proxy` is not a container in the gateway Pod at all, so this fixture cannot resolve it and the target needs revisiting.
- **#960 and #963** both rewrite `buildNetworkPolicy`. This branch deliberately does not restate that policy's egress rules — it states the conclusion and tells the reader to go and read the policy — but the conclusion itself should be re-checked against whichever lands second.
- **#955** changes that container's user and process namespace, and touches the Dockerfile that currently guarantees the `/opt/hermes/.venv/bin/python3` the relay execs.

## Testing

- **`scripts/test_exec_tunnel.py`**, 11 tests, running on every pull request — `scripts/` is already in `PYTHON_TEST_DIRS`. It covers the READY handshake, a 1.9MB payload that forces short pipe writes, pod re-resolution after a stale name, Ready pods preferred over merely Running ones, a missing kubectl, a failing kubectl, no matching pod, the reap, `track()` refusing after teardown, `close_relays()` idempotence, and the ready timeout.
- **The gating suite is hermetic**, and that was verified rather than assumed — see Self-Review.
- Whole `scripts/` suite: **417 tests OK** under `python3 -m unittest discover`, which is how `make test-python` runs it. Also **10/10 green under `PATH=/nonexistent`**, confirming the suite does not depend on an interpreter or a binary it did not choose.
- The fixture itself was exercised end to end against a fake sandboxed cluster — a `kubectl` on `PATH` answering the secret read, the Service read, the pod resolve, the relay exec and the diagnostic exec, with real loopback HTTP servers behind them. Cases: healthy (0.8s); a **12s exec handshake against a 30s budget**, which passes in 12.6s and is exactly what the earlier split-deadline version could not do; a proxy that **502s for 4s while Hermes boots**, which now passes rather than hard-failing on the first probe; an **HA Service selector**, which resolves to `app=platform-agent-gateway,kubeagents.io/is-leader=true`; a **missing Service**, which records why it fell back; a **stale key** at the proxy, which now reports `HTTP 401 Unauthorized` plus the two commands that confirm it; **Hermes rejecting its own sentinel**; the proxy unreachable; and no key available. The harness was throwaway and is not in the diff.
- `make docs-check` clean. `prettier --check` clean on both changed Markdown files, using 3.9.6 — byte-identical to the version `.github/workflows/prettier.yml` pins. `py_compile` clean on all five Python files, no unused imports.
- **Coverage gap, stated rather than left implicit:** the conftest-local helpers (`_probe_agent_api`, `_read_log_tail`, `_numeric_env`, `_diagnose_hermes`, `_gateway_pod_selector`) have no CI coverage, because `tests/e2e` is excluded from `PYTHON_TEST_DIRS` by design (`scripts/test_test_discovery.py` records the exclusion). Moving e2e-specific policy into `scripts/` to buy coverage would put it in the wrong place. The relay was extracted and tested; those were not.

### Live validation

**Not live-tested.** I have no access to the RC cluster — `gcloud container clusters get-credentials` for `kube-agents-rc` returns 403 — and nothing in this branch was run against any live kube-agents installation. No test artifacts were created anywhere, because nothing reached a cluster.

The gVisor diagnosis therefore rests on the step-2 provisioning log of run 32866087154 (`ENABLE_GVISOR: true`, `gvisor-pool`, `runtimeClassName = "gvisor"`), on the behaviour `platformagent-crd.md` documents, and on `hermes-dashboard-tunnel.py` having solved the same problem the same way. It does not rest on an observation of this test passing.

What this branch can honestly claim beyond that: **the relay code path is now covered by CI** — the READY handshake, short writes, pod re-resolution, and every failure mode of resolution are exercised on every pull request against a fake kubectl and real sockets. **The cluster-facing wiring is not**: whether `envoy-credential-proxy` really exposes 8643 to an exec on the RC pod, whether the Secret's key really matches what that pod holds, and whether the relay's interpreter path really resolves inside that image are all read off source and unverified against a running install. The first RC run after merge is what settles them, and if it fails it will now say which of them failed.

## Self-Review

Four passes, each in a context that did not write the change: an adversarial subagent, a docs-drift subagent, and two coordinator re-verification rounds handed the diff range and nothing else. The gVisor root cause came out of the docs-drift pass as an *advisory* and became the entire change — the first two revisions of this branch only made the failure diagnosable.

**Angles covered.** Transport correctness under gVisor and under an ordinary node pool; the port/key pairing against operator source; retry and timeout budgets against the agent's real boot behaviour, including whether the client's and the relay's deadlines agree; pod selection at replicas > 1; subprocess lifecycle (zombies, descriptors, pipes, orphaned exec sessions, registration races); what a PR-gating unit test is allowed to touch; canonicity and duplication across the three files that now discuss the same mechanism; and whether every factual claim about the operator holds against the source.

**Proven, not asserted — the gating test is hermetic.** The fourth pass put a recording shim first on `PATH` that appends to a marker file before exec'ing the real `kubectl`, ran the suite, and confirmed the marker was never created. Eleven tests, ~2.5s, stable across three runs, no network, no cluster, no `KUBECONFIG` dependency.

**Verified correct, no change needed.** Eleven of twelve operator claims re-verified exact, including all five relay correctness notes as *implemented* rather than merely mentioned. One reviewer finding was itself wrong — `deleteLegacyCredentialIsolationResources` was reported absent from the repository; it is at `platformagent_controller.go:286`, `:517` and `:521`, so the claim stands and is repeated above. Also cleared: Service name derivation; label-selector joining (Kubernetes keys and values cannot contain `,` or `=`); the uploader join cannot deadlock; `addCleanup` LIFO ordering; `close_relays()` idempotence; `_relays` assigned before `super().__init__()` so a bind failure cannot half-construct the server; the wrapper working standalone, by relative path and via symlink; `_PROXY_PYTHON`'s Dockerfile derivation chain end to end; and `bench`'s port docstring.

**Fixed — HIGH.** A unit test in the PR-gating suite shelled out to the real `kubectl`. It raised `FileNotFoundError` for any contributor without kubectl, and *with* kubectl installed it made a live API call against the reviewer's current context, hitting a real cluster. `PATH` now points at the fake or at a purpose-made empty directory, never at the developer's own, and `PodResolver` translates `OSError` and `TimeoutExpired` into the `RuntimeError` its callers expect — which also removes a bare traceback from `hermes-dashboard-tunnel.py`, where `resolver.get()` is called uncaught.

**Fixed — the two deadlines disagreed.** `probe_timeout` was strictly less than the relay's `ready_timeout` at every budget above 15s, so the probe abandoned handshakes the relay was still waiting on: an exec slower than the slice could never succeed however often it was retried, and each abandoned attempt stranded a `kubectl exec` for the rest of the session. Each probe now gets whatever is left of the budget, making the two deadlines the same instant while keeping the 5xx retry, since a 502 returns as fast as the upstream dial fails. A 12s handshake against a 30s budget now passes in 12.6s; the previous revision failed it with "no probe completed".

**Fixed — two factual errors in my own comments, both inside a block whose banner advertises verification against operator source.** That is exactly why they are worth naming rather than quietly correcting. (1) I wrote that a standby "answers on 8643, where Envoy is up" — Envoy declares one listener, `127.0.0.1:8765`; 8643 is bound by `AgentAPIProxyHandler`, a Python `ThreadingHTTPServer`. (2) I wrote that "the sidecar's readiness probe checks the event watcher on 8765" — the probe curls `/healthz`, which `CredentialProxyHandler` answers unconditionally, and no event watcher is involved. The second error made the surrounding argument *weaker* than the truth: the probe depends on nothing Hermes does, so the sidecar really is Ready long before Hermes binds 8642. Both corrected in place.

**Fixed — behavioural.** 5xx retried rather than final. The pod selected with the agent Service's own selector rather than a hardcoded label, so an HA install reaches the leader. The diagnostic no longer overstates two things: `agentAPIProbe` tolerates curl's exit 7 only under `$ENABLE_LEADER_ELECTION`, and a 401 on pod loopback means the agent's own sentinel disagrees rather than that the credential proxy is at fault. `_gateway_pod_selector` no longer falls back silently — a failed Service read used to surface downstream as "no Running pod matches", blaming the pods for a Service problem.

**Fixed — lifecycle and hygiene.** Handler threads joined before their pipes are closed. A READY racing the ready-timeout kill rejected via a flag set inside the timer callback, since `poll()` alone can still return `None` in that window. Abandoned relays reaped at teardown, and `track()` refuses registration after teardown so a late handler cannot strand its exec. The unusable second CLI dropped. Diagnostics to stderr. `sys.path` appended rather than prepended in conftest, and the wrapper's path handling reduced to the one case that needs it (`python3 -P` / `PYTHONSAFEPATH=1`). A temp-file leak closed. The fake kubectl's shebang pinned to `sys.executable` rather than resolving `python3` off the ambient PATH.

**Fixed — documentation.** `.env.example`'s uncommented `AGENT_LOCAL_PORT=8642` (above). On the second look at that stanza the wording I had *replaced* it with was worse than imprecise — it invited the reader to uncomment `AGENT_LOCAL_PORT=0`, which would have broken bench, since `bench/kube_agents_bench/harness.py` reads the same variable as a *fixed* port for both its port-forward and the URL it dials. Rescoped to say the ephemeral default is the E2E suite's alone, with the commented example left at `8642`. Separately: `docs/designs/e2e-testing-harness.md` still described port-forwarding for a mechanism marked "implemented"; and this branch created a canonicity cycle, with `platformagent-crd.md` pointing at a script that had just disclaimed owning the mechanism — now split so each fact has one home, and the gVisor explanation reduced from three copies to one with two links.

**Caught while fixing something else.** Correcting the fixture's return annotation to `Generator[str, None, None]` — the last trace of the removed guard's contract, since it never yields `None` now — surfaced a `Generator` imported from `typing` on top of the existing `collections.abc` import, shadowing it. Removed.

**Deliberately not fixed.** The conftest-local helpers have no CI coverage, for the reason given under Testing: the fix would put e2e-specific policy in a general-purpose module. The credential proxy's `send_error`-before-draining defect is real, explains the earlier runs' `ECONNRESET` rather than a clean 401, and belongs to a region four open PRs are rewriting — filed in #971.

**Not covered.** Nothing was exercised against a real cluster; see Live validation.

## Risk & Rollout

Confined to the E2E harness and one developer script. No operator, chart, image or runtime path is touched, so nothing about a deployed install changes. The blast radius is `make test-e2e` and anyone running `scripts/hermes-dashboard-tunnel.py`, and that script's flags, defaults and relay program are unchanged.

The new failure mode to watch for is the transport itself. `kubectl exec` needs `pods/exec` where the old path needed `pods/portforward`; the RC service account already has it, since several tests in this same suite exec into the pod, but a differently-scoped runner would fail at the relay rather than at the probe — and would say so, naming the pod and kubectl's own error. Reverting is a plain revert of the single commit; nothing is persisted and no state is migrated.

Merge-time: this and #969 share two files, so whichever goes second rebases past the first (see Context). Neither order is preferable and the regions do not overlap. The first RC run after merge is the real verdict — if the diagnosis is right the test passes, and if it is wrong the failure now names the hop instead of an anonymous reset.

---

Generated with the help of Claude.
