### PR TITLE
feat(mcp): name kube-agents on remote MCP calls

### DIFF
--- a/.github/workflows/docker-publish-gcp.yml
+++ b/.github/workflows/docker-publish-gcp.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           gcloud builds submit \
             --config=deploy/docker/cloudbuild.yaml \
-            --substitutions="_IMAGE_URI=$GCP_REGISTRY/platform-agent:$GITHUB_SHA,_IMAGE_URI_LATEST=$GCP_REGISTRY/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=$HERMES_AGENT_TAG,_BUILDCACHE_URI=$GCP_REGISTRY/platform-agent:buildcache" \
+            --substitutions="_IMAGE_URI=$GCP_REGISTRY/platform-agent:$GITHUB_SHA,_IMAGE_URI_LATEST=$GCP_REGISTRY/platform-agent:latest,_TARGET=platform,_HERMES_AGENT_TAG=$HERMES_AGENT_TAG,_BUILDCACHE_URI=$GCP_REGISTRY/platform-agent:buildcache,_KUBE_AGENTS_VERSION=$GITHUB_SHA" \
             .
           DIGEST=$(gcloud artifacts docker images describe "$GCP_REGISTRY/platform-agent:$GITHUB_SHA" --format="value(image_summary.digest)")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-publish-ghcr.yml
+++ b/.github/workflows/docker-publish-ghcr.yml
@@ -57,8 +57,12 @@ jobs:
           tags: |
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:latest
             ghcr.io/${{ env.IMAGE_REPOSITORY }}/platform-agent:${{ github.sha }}
+          # KUBE_AGENTS_VERSION is the commit SHA the image is tagged with: it
+          # becomes the version in the User-Agent the agent's remote MCP calls
+          # carry, so a request in a Google API log names the exact image.
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
+            KUBE_AGENTS_VERSION=${{ github.sha }}
 
       - name: Build and Push Replay Proxy (GHCR)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/agents/cluster/config.yaml
+++ b/agents/cluster/config.yaml
@@ -36,10 +36,17 @@ mcp_servers:
   # Cluster-agent kanban workers are fresh processes per card and were paying
   # both proxy spawns at boot whether or not the card touched an MCP tool. See
   # the fuller note in agents/platform/config.yaml.
+  #
+  # `--header User-Agent: …` names this product and the build it came from, so
+  # the API team serving the endpoint can attribute the traffic;
+  # deploy/shared/defaults/config.yaml carries the full rationale. The string is
+  # the same one the Platform Agent sends, character for character.
   developer_knowledge:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://developerknowledge.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30
@@ -48,6 +55,8 @@ mcp_servers:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://container.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30

--- a/agents/platform/config.yaml
+++ b/agents/platform/config.yaml
@@ -94,10 +94,25 @@ mcp_servers:
   # The whole entry is redundant with the shared defaults — the build-time merge
   # unions the two — but repeating it here keeps this file from reading as if
   # gke were the one server without these settings.
+  #
+  # `--header User-Agent: …` names this product and the build it came from, so
+  # the API team serving the endpoint can attribute the traffic;
+  # deploy/shared/defaults/config.yaml carries the full rationale, including
+  # where the version comes from. That merge unions the two arg lists, so this
+  # copy has to stay character-identical to the one there. Drift does not
+  # produce two headers, which is the intuitive guess and the wrong one: the
+  # union dedups, so the repeated `--header` token collapses and the divergent
+  # VALUE survives alone, as a bare positional after the URL. mcp-remote reads
+  # that second positional as its optional callback port, parses it to NaN and
+  # ignores it — leaving one header, silently the shared-defaults one, whatever
+  # this file says. tests/test_remote_mcp_user_agent.py checks the merged argv
+  # for exactly that shape.
   gke:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://container.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -53,6 +53,12 @@ ARG ENVOY_VERSION=v1.39.1
 ARG ENVOY_IMAGE=envoyproxy/envoy
 ARG GOLANG_IMAGE=golang
 ARG GOLANG_VERSION=1.27-alpine
+# Declared here as well as in the `platform` stage that consumes it, so the
+# credential-proxy build -- which shares deploy/docker/cloudbuild.yaml and is
+# therefore handed the same --build-arg -- does not warn about an argument no
+# stage declares. The value and what it is for are documented where the ENV is
+# set, at the end of the `platform` stage.
+ARG KUBE_AGENTS_VERSION=dev
 FROM ${ENVOY_IMAGE}:${ENVOY_VERSION} AS envoy-bin
 
 # Every binary in the final image must match the architecture the image ships
@@ -1541,6 +1547,24 @@ RUN set -eu; \
     chown -R root:root /opt/hermes/skills /opt/platform-template /opt/cluster-template /opt/chat-template /opt/defaults/scripts
 
 USER 10000:10000
+
+# The build this image came from, for the `User-Agent` that remote MCP calls
+# carry. Hermes resolves `${KUBE_AGENTS_VERSION}` in an `mcp_servers` entry's
+# `args` from the agent process environment, so the value has to be on the
+# container rather than only in the config -- see the `--header` argument on the
+# mcp-remote entries in deploy/shared/defaults/config.yaml.
+#
+# Last instruction in the stage, not beside the ARGs at the top: the value
+# changes on every commit, and an ENV that early would invalidate the whole
+# `platform` chain's cache on every build. ENV writes no filesystem diff, so it
+# costs nothing against the layer budget.
+#
+# `dev` is the default (declared with the other build args above) because an
+# unset build arg must still produce a well-formed header. The publish workflows
+# pass the commit SHA the image is tagged with, so a User-Agent on the wire
+# names the exact image.
+ARG KUBE_AGENTS_VERSION
+ENV KUBE_AGENTS_VERSION=${KUBE_AGENTS_VERSION}
 
 # --- CREDENTIAL PROXY TOOLING ---
 # Everything the sidecar needs that is not agent source: the credential-aware

--- a/deploy/docker/cloudbuild-ci.yaml
+++ b/deploy/docker/cloudbuild-ci.yaml
@@ -80,6 +80,11 @@ steps:
 
         # Deployment targets are always amd64 GKE nodes; the multi-arch bases
         # otherwise resolve to the build host (#560).
+        #
+        # KUBE_AGENTS_VERSION is the User-Agent this image's remote MCP calls
+        # send. hack/ci-deploy.sh passes the pull-request tag, so an evaluation
+        # cluster's traffic reads as `kube-agents/pr-1234-abc1234` in the
+        # serving team's logs rather than being counted as a release.
         docker build \
           --platform linux/amd64 \
           -t "$_PLATFORM_URI" \
@@ -87,6 +92,7 @@ steps:
           -f deploy/docker/Dockerfile \
           --target platform \
           --build-arg HERMES_AGENT_TAG="$_HERMES_AGENT_TAG" \
+          --build-arg KUBE_AGENTS_VERSION="$_KUBE_AGENTS_VERSION" \
           .
 
   # No waitFor: this runs straight after platform on the same worker, which is
@@ -161,4 +167,5 @@ substitutions:
   _BUILDCACHE_IMAGE: ""
   _PROXY_BUILDCACHE_IMAGE: ""
   _HERMES_AGENT_TAG: ""
+  _KUBE_AGENTS_VERSION: "dev"
   _REQUIRE_CACHE: "false"

--- a/deploy/docker/cloudbuild.yaml
+++ b/deploy/docker/cloudbuild.yaml
@@ -27,6 +27,12 @@ steps:
       - "BUILDKIT_INLINE_CACHE=1"
       - "--build-arg"
       - "HERMES_AGENT_TAG=$_HERMES_AGENT_TAG"
+      # Baked into the image as an env var and sent as the User-Agent on every
+      # remote MCP call. Callers pass the tag they are publishing under; the
+      # default below keeps a build that omits it well-formed rather than
+      # empty.
+      - "--build-arg"
+      - "KUBE_AGENTS_VERSION=$_KUBE_AGENTS_VERSION"
       - "."
   # Publish a mode=max build cache beside the image: inline cache above covers
   # only the final image's layers, so presubmits re-ran every intermediate
@@ -55,6 +61,7 @@ steps:
           -f deploy/docker/Dockerfile \
           --target "$_TARGET" \
           --build-arg HERMES_AGENT_TAG="$_HERMES_AGENT_TAG" \
+          --build-arg KUBE_AGENTS_VERSION="$_KUBE_AGENTS_VERSION" \
           --cache-from "type=registry,ref=$_BUILDCACHE_URI" \
           --cache-from "type=registry,ref=$_IMAGE_URI_LATEST" \
           --cache-to "type=registry,ref=$_BUILDCACHE_URI,mode=max" \
@@ -74,3 +81,4 @@ substitutions:
   _TARGET: ""
   _HERMES_AGENT_TAG: ""
   _BUILDCACHE_URI: ""
+  _KUBE_AGENTS_VERSION: "dev"

--- a/deploy/shared/defaults/config.yaml
+++ b/deploy/shared/defaults/config.yaml
@@ -61,10 +61,45 @@ mcp_servers:
   # every worker's boot — paid even when no MCP tool was ever called. See the
   # fuller note in agents/platform/config.yaml; a cold cache falls back to an
   # eager connect and warms itself.
+  #
+  # `--header User-Agent: …` is what makes this traffic identifiable to the API
+  # teams that serve these endpoints. Without it every request goes out as
+  # undici's default `node`, indistinguishable from any other Node process on
+  # the internet, and the Developer Knowledge team asked for a name they can
+  # attribute in their logs and customer dashboards. This is the canonical
+  # explanation; agents/platform/config.yaml and agents/cluster/config.yaml
+  # carry the same flag and point back here.
+  #
+  #   - mcp-remote hands the header map to the SDK as `requestInit.headers`,
+  #     and undici sends a caller-set User-Agent rather than overwriting it, so
+  #     the value survives to the wire on the initialize POST and on every tool
+  #     call after it. The SDK's own OAuth metadata probes at connect
+  #     (/.well-known/…) are built without requestInit and still go out as
+  #     `node`; they are discovery, not MCP calls.
+  #   - `${KUBE_AGENTS_VERSION}` is resolved by Hermes, not by mcp-remote:
+  #     hermes `tools/mcp_tool.py` interpolates `${VAR}` in `args` from the agent
+  #     process environment, while the child itself gets only an allowlisted
+  #     baseline plus whatever an `env:` block names, which this variable is
+  #     not in. The value is baked into the image (deploy/docker/Dockerfile,
+  #     end of the `platform` stage) and is the commit the image was built
+  #     from, or `dev` for a build that passed no version.
+  #   - This copy and the one in agents/platform/config.yaml have to stay
+  #     character-identical, because deploy/docker/merge_configs.py unions the
+  #     two arg lists at image build. Drift does not produce two headers: the
+  #     union dedups, so the repeated `--header` token collapses and the
+  #     divergent value survives alone as a bare positional after the URL,
+  #     which mcp-remote reads as its optional callback port and discards as
+  #     NaN. The overlay's spelling is the one silently lost.
+  #   - One string, byte-identical at every call site. It names the product and
+  #     the build and nothing else; the customer project is already on the wire
+  #     as X-Goog-User-Project. Keep it that way — the API teams key dashboards
+  #     on this value, and a variation added in one file splits that key.
   developer_knowledge:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://developerknowledge.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30
@@ -73,6 +108,8 @@ mcp_servers:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://container.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30

--- a/docs/site/src/content/docs/reference/config.md
+++ b/docs/site/src/content/docs/reference/config.md
@@ -40,6 +40,8 @@ mcp_servers:
     command: "node"
     args:
       - "/opt/mcp-remote/dist/proxy.js"
+      - "--header"
+      - "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"
       - "https://container.googleapis.com/mcp"
     lazy: true
     connect_timeout: 30
@@ -102,6 +104,8 @@ Every server is `lazy: true`, so none of them is started at boot. Hermes registe
 
 - **`platform_control`** — In-pod Python MCP server (`agents/platform/scripts/platform_mcp_server.py`). Handles session state and agent-internal ops (chat ingress lives with the Planning Agent). The `env:` block is an allowlist rather than a pass-through: Hermes gives a stdio MCP server a safe baseline (`PATH`, `HOME`, `TMPDIR`, `XDG_*`) plus exactly the keys named there and drops every other pod variable, so anything a tool needs has to be listed. Currently the Kubernetes DNS variables, Hermes home, the Chat Pub/Sub config, the project ids, the Google Chat and Slack home channels, the API server key, and the Session KV bearer token and database path. A home channel is what `send_notification` falls back to when a notification has no thread to reply into — every alert-driven investigation — and it needs `spec.integration.googleChat.homeChannel` set to carry a value; the bearer token is what lets it read `chat_id` and `thread_id` back in the first place, so an absent one costs the thread and the incident report both. See the comments on those keys in the source file.
 - **`gke`** — Remote GKE MCP server proxied via `mcp-remote`. All Kubernetes/GKE reads and writes route through this endpoint.
+
+The two servers reached through `mcp-remote` — `gke` here, and `developer_knowledge` from the shared defaults — each pass `--header User-Agent: kube-agents/${KUBE_AGENTS_VERSION}`. Without it the request reaches Google as undici's default `node` and the API team serving the endpoint cannot separate kube-agents traffic from anything else running on Node. Hermes resolves `${KUBE_AGENTS_VERSION}` in `args` from the agent process environment, where the image build put it — the commit the image was built from, or `dev` for a build that passed no version. The string is the same everywhere it appears, including in the Cluster Agent template; it names the product and the build, and nothing else. The shared defaults and the platform overlay in particular have to stay character-identical, since the build-time merge unions the two arg lists: the repeated `--header` token dedups away and a divergent value is left as a stray positional after the URL, so the overlay's spelling is silently the one that goes missing.
 
 The two servers are timed out differently on purpose. `platform_control` gets `connect_timeout: 120` for cold-start latency — under `lazy` that bounds the first tool call rather than startup — and `timeout: 300` for long reasoning chains; it is a local subprocess, so a slow call is a slow call. `gke` gets `connect_timeout: 30` / `timeout: 60` because it is a remote endpoint reached through `mcp-remote`, where a failed call can consume the whole deadline without ever returning; the rationale is recorded in full alongside the block in [`agents/platform/config.yaml`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/config.yaml). Healthy calls to it measure under a second.
 

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -252,7 +252,7 @@ export CACHE_IMAGE="${CACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agent
 export BUILDCACHE_IMAGE="${BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:buildcache}"
 export PROXY_BUILDCACHE_IMAGE="${PROXY_BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/credential-proxy:buildcache}"
 gcloud builds submit --config="deploy/docker/cloudbuild-ci.yaml" \
-  --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_CACHE_IMAGE=${CACHE_IMAGE},_BUILDCACHE_IMAGE=${BUILDCACHE_IMAGE},_PROXY_BUILDCACHE_IMAGE=${PROXY_BUILDCACHE_IMAGE},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_REQUIRE_CACHE=${REQUIRE_CACHE:-false}" \
+  --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_CACHE_IMAGE=${CACHE_IMAGE},_BUILDCACHE_IMAGE=${BUILDCACHE_IMAGE},_PROXY_BUILDCACHE_IMAGE=${PROXY_BUILDCACHE_IMAGE},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_KUBE_AGENTS_VERSION=${TAG},_REQUIRE_CACHE=${REQUIRE_CACHE:-false}" \
   --project="${PROJECT_ID}" "${BUILD_WORKER_ARGS[@]}" --quiet .
 echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 

--- a/k8s-operator/scripts/dev/dev_rebuild_agent.sh
+++ b/k8s-operator/scripts/dev/dev_rebuild_agent.sh
@@ -153,7 +153,10 @@ execute_image_build() {
     docker pull "$IMAGE_URI_LATEST" 2>/dev/null || true
     # --platform linux/amd64: these images deploy to amd64 GKE nodes, and the
     # multi-arch bases otherwise resolve to this machine's architecture (#560).
-    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --cache-from "$IMAGE_URI_LATEST" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg HERMES_AGENT_TAG="$HERMES_AGENT_TAG" --target "$AGENT_TARGET" -t "$IMAGE_URI" -t "$IMAGE_URI_LATEST" -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" || return 1
+    # KUBE_AGENTS_VERSION is the dev tag: it is what the agent's remote MCP
+    # calls report as their User-Agent, so traffic from a hand-built image is
+    # distinguishable from a published one.
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 --cache-from "$IMAGE_URI_LATEST" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg HERMES_AGENT_TAG="$HERMES_AGENT_TAG" --build-arg KUBE_AGENTS_VERSION="$DEV_TAG" --target "$AGENT_TARGET" -t "$IMAGE_URI" -t "$IMAGE_URI_LATEST" -f "${REPO_ROOT}/deploy/docker/Dockerfile" "${REPO_ROOT}" || return 1
     print_info "Pushing images to Artifact Registry ($IMAGE_BASE)..."
     docker push "$IMAGE_URI" || return 1
     docker push "$IMAGE_URI_LATEST" || return 1
@@ -167,7 +170,7 @@ execute_image_build() {
       cd "${REPO_ROOT}"
       gcloud builds submit \
           --config="deploy/docker/cloudbuild.yaml" \
-          --substitutions="_IMAGE_URI=${IMAGE_URI},_IMAGE_URI_LATEST=${IMAGE_URI_LATEST},_TARGET=${AGENT_TARGET},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG}" \
+          --substitutions="_IMAGE_URI=${IMAGE_URI},_IMAGE_URI_LATEST=${IMAGE_URI_LATEST},_TARGET=${AGENT_TARGET},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_KUBE_AGENTS_VERSION=${DEV_TAG}" \
           --project="${PROJECT_ID}" \
           ${BUILD_POOL_ARGS[@]+"${BUILD_POOL_ARGS[@]}"} \
           .

--- a/tests/test_remote_mcp_user_agent.py
+++ b/tests/test_remote_mcp_user_agent.py
@@ -1,0 +1,214 @@
+"""Every remote MCP server this repository declares names itself on the wire.
+
+    python3 -m unittest discover -s tests -p 'test_*.py'
+
+Calls to `developerknowledge.googleapis.com/mcp` and `container.googleapis.com/mcp`
+used to go out with undici's default `node` User-Agent, so the API teams serving
+those endpoints could not tell kube-agents traffic from any other Node process.
+Each `mcp_servers` entry that launches the mcp-remote proxy now passes a
+`--header User-Agent: …` naming the product and the build it came from.
+
+Three ways that silently stops being true, one check each:
+
+* A new remote server is added and nobody remembers the flag. Every entry whose
+  argv is the proxy is checked, not a list of the two that exist today.
+* The version placeholder outlives the environment variable it reads. Hermes
+  leaves an unresolved `${VAR}` in place verbatim, so a renamed or dropped
+  `ENV KUBE_AGENTS_VERSION` in the Dockerfile turns the header into the literal
+  string rather than failing anything.
+* The two files that are merged at image build drift apart.
+  `deploy/docker/merge_configs.py` unions two arg lists, and the union
+  deduplicates, so one spelling in the shared defaults and a different one in
+  the platform overlay do NOT produce two headers — the repeated `--header`
+  token collapses and the overlay's value is left as a stray positional that
+  mcp-remote silently discards. So the merge is run here rather than reasoned
+  about, and what is asserted is the shape of the merged argv.
+
+`agents/platform/scripts/test_mcp_env_contract.py` makes the same
+assert-against-the-merged-config argument for the platform profile's toolsets
+and environment. This file is separate because its subject is every remote
+server in every config, the Cluster Agent template included, and because the
+two live under different test roots (see AGENTS.md, "Where Tests Go").
+"""
+
+import pathlib
+import sys
+import unittest
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+SHARED_DEFAULTS = REPO_ROOT / "deploy" / "shared" / "defaults" / "config.yaml"
+# Named separately because the merge test needs this one specifically: it is the
+# overlay half of what the image build merges into the platform profile.
+PLATFORM_CONFIG = REPO_ROOT / "agents" / "platform" / "config.yaml"
+DOCKERFILE = REPO_ROOT / "deploy" / "docker" / "Dockerfile"
+# Every Cloud Build config that builds the `platform` target: the publish one the
+# release workflows and the dev loop submit, and the CI one hack/ci-deploy.sh
+# submits for a pull request's evaluation cluster. A config that stops passing
+# the version publishes images whose traffic reports the `dev` default, which is
+# what a laptop build reports too.
+CLOUDBUILDS = (
+    REPO_ROOT / "deploy" / "docker" / "cloudbuild.yaml",
+    REPO_ROOT / "deploy" / "docker" / "cloudbuild-ci.yaml",
+)
+
+PROXY_ARG = "/opt/mcp-remote/dist/proxy.js"
+VERSION_VAR = "KUBE_AGENTS_VERSION"
+
+# Discovered, not listed: a config.yaml added for a new agent profile is checked
+# the day it lands. agents/chat/config.yaml declares no remote server today and
+# is scanned anyway, which costs nothing and is the point — the flag is easy to
+# forget precisely when someone is copying an existing entry into a new profile.
+CONFIGS = (SHARED_DEFAULTS,) + tuple(sorted((REPO_ROOT / "agents").glob("*/config.yaml")))
+
+# One string at every call site, version placeholder included. Asserted whole
+# rather than by pattern: the point of the header is that the API teams can key
+# a dashboard on it, and a per-file variation is what quietly splits that key.
+USER_AGENT = "User-Agent: kube-agents/${%s}" % VERSION_VAR
+
+
+def remote_servers(config_path):
+    """Yield (alias, args) for every entry that launches the mcp-remote proxy."""
+    document = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    for alias, spec in (document.get("mcp_servers") or {}).items():
+        args = (spec or {}).get("args") or []
+        if PROXY_ARG in args:
+            yield alias, args
+
+
+def header_values(args):
+    """The value of every `--header` flag in *args*, in order."""
+    return [args[i + 1] for i, arg in enumerate(args[:-1]) if arg == "--header"]
+
+
+def positional_args(args):
+    """What mcp-remote is left holding after it splices out the flag pairs.
+
+    args[0] is the script path node runs; mcp-remote never sees it. Of what
+    remains it takes the first positional as the server URL and the second, if
+    there is one, as an optional callback port. So a stray extra positional is
+    not a loud error — it is parsed to NaN and dropped.
+    """
+    positional = []
+    index = 1
+    while index < len(args):
+        if args[index] == "--header":
+            index += 2
+            continue
+        positional.append(args[index])
+        index += 1
+    return positional
+
+
+class RemoteMcpUserAgentTest(unittest.TestCase):
+    def test_every_remote_server_sends_a_user_agent(self):
+        checked = 0
+        for config_path in CONFIGS:
+            for alias, args in remote_servers(config_path):
+                where = f"{alias} in {config_path.relative_to(REPO_ROOT)}"
+                headers = header_values(args)
+                self.assertEqual(
+                    len(headers),
+                    1,
+                    f"{where} passes {len(headers)} --header flags, expected exactly "
+                    "one carrying the User-Agent",
+                )
+                self.assertEqual(
+                    headers[0],
+                    USER_AGENT,
+                    f"{where} sends {headers[0]!r} rather than {USER_AGENT!r}, the "
+                    "one string the API teams key their dashboards on",
+                )
+                checked += 1
+        self.assertGreaterEqual(
+            checked,
+            5,
+            "found fewer remote MCP servers than this repository declares — the "
+            "scan above is matching nothing and would pass an empty tree",
+        )
+
+    def test_the_argv_still_reaches_mcp_remote_as_a_flag_pair(self):
+        """`--header` and its value are adjacent, and the URL is still there.
+
+        mcp-remote splices out `--header <value>` pairs and then reads the URL as
+        the first remaining positional. A value that lost its flag, or a flag
+        that lost its value, leaves the URL in the wrong place and the proxy
+        exits on a usage error at first tool call.
+        """
+        for config_path in CONFIGS:
+            for alias, args in remote_servers(config_path):
+                where = f"{alias} in {config_path.relative_to(REPO_ROOT)}"
+                self.assertNotEqual(
+                    args[-1],
+                    "--header",
+                    f"{where} ends on a --header with no value",
+                )
+                self.assert_argv_shape(args, where)
+
+    def assert_argv_shape(self, args, where):
+        positional = positional_args(args)
+        self.assertEqual(
+            len(positional),
+            1,
+            f"{where} leaves {positional!r} for mcp-remote to read, expected only "
+            "the server URL",
+        )
+        self.assertTrue(
+            positional[0].startswith("https://"),
+            f"{where} would send mcp-remote to {positional[0]!r}",
+        )
+
+    def test_the_build_time_merge_yields_one_header_per_server(self):
+        """The union of the two platform-side files is still one command line.
+
+        Checked on the merged argv's SHAPE, not on its header count. The union
+        is `list(dict.fromkeys(a + b))` — deduplicating — so two spellings do
+        not yield two headers: the repeated `--header` token collapses and the
+        divergent value is left stranded as a second positional, which
+        mcp-remote reads as its optional callback port and discards. Counting
+        headers here would pass on exactly the drift this test exists to catch.
+        """
+        sys.path.insert(0, str(REPO_ROOT / "deploy" / "docker"))
+        try:
+            from merge_configs import merge
+        finally:
+            sys.path.pop(0)
+
+        base = yaml.safe_load(SHARED_DEFAULTS.read_text(encoding="utf-8"))
+        overlay = yaml.safe_load(PLATFORM_CONFIG.read_text(encoding="utf-8"))
+        merged = merge(base, overlay)
+
+        for alias, spec in merged["mcp_servers"].items():
+            args = (spec or {}).get("args") or []
+            if PROXY_ARG not in args:
+                continue
+            where = f"{alias}, merged from the shared defaults and the platform overlay"
+            self.assert_argv_shape(args, where)
+            self.assertEqual(
+                header_values(args),
+                [USER_AGENT],
+                f"{where}, sends {header_values(args)!r}; the two files have to "
+                "spell the flag identically because merge_configs unions arg lists",
+            )
+
+    def test_the_image_defines_the_version_the_header_interpolates(self):
+        dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+        self.assertRegex(
+            dockerfile,
+            rf"(?m)^ENV {VERSION_VAR}=",
+            f"the configs interpolate ${{{VERSION_VAR}}} from the agent process "
+            "environment; without the ENV the header ships the literal placeholder",
+        )
+        for cloudbuild in CLOUDBUILDS:
+            self.assertRegex(
+                cloudbuild.read_text(encoding="utf-8"),
+                rf'{VERSION_VAR}="?\$_{VERSION_VAR}',
+                f"{cloudbuild.relative_to(REPO_ROOT)} no longer passes the version "
+                "through to the build, so every image it publishes would report the "
+                "`dev` default",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Every call kube-agents makes to a Google remote MCP endpoint — `developerknowledge.googleapis.com/mcp` and `container.googleapis.com/mcp` — went out with undici's default `node` User-Agent, so the teams serving those endpoints could not tell our traffic from any other Node process on the internet. Each `mcp_servers` entry that launches the `mcp-remote` proxy now passes `--header "User-Agent: kube-agents/${KUBE_AGENTS_VERSION}"`, and the image build bakes the version in as an environment variable that Hermes interpolates when it spawns the proxy. One string, byte-identical at all five call sites; a published image reports the commit SHA it is tagged with, a CI evaluation image reports its `pr-<n>-<sha>` tag, and a build that passes no version reports `dev`.

## Why This Change

Suggested by the Developer Knowledge team, to track MCP usage per agent type: they asked for a name they can attribute in their serving logs and customer dashboards. Without it there is nothing on the wire that says kube-agents — no way to size the traffic, spot a regression we caused, or separate a release from a pull request's evaluation cluster.

## What Changed

- `deploy/shared/defaults/config.yaml`, `agents/platform/config.yaml`, `agents/cluster/config.yaml` — the `--header` argument on all five `mcp-remote` entries. The shared defaults carry the canonical rationale; the other two point back at it. The platform copy has to stay character-identical to the shared-defaults copy, because `deploy/docker/merge_configs.py` unions arg lists *with dedup*: two spellings do not yield two headers, they collapse the repeated `--header` token and leave the overlay's value stranded as a stray positional that mcp-remote silently discards.
- `deploy/docker/Dockerfile` — `ENV KUBE_AGENTS_VERSION` as the last instruction of the `platform` stage, from a build arg defaulting to `dev`. Last, not beside the other ARGs, because the value changes every commit and an early `ENV` would invalidate the whole `platform` chain's build cache. `ENV` writes no filesystem diff, so it costs nothing against the 120-layer budget (the image measures 113 either way).
- `deploy/docker/cloudbuild.yaml`, `deploy/docker/cloudbuild-ci.yaml`, `.github/workflows/docker-publish-gcp.yml`, `.github/workflows/docker-publish-ghcr.yml`, `hack/ci-deploy.sh`, `k8s-operator/scripts/dev/dev_rebuild_agent.sh` — every path that builds the `platform` image passes the tag it is publishing under.
- `tests/test_remote_mcp_user_agent.py` — the contract, so this does not rot silently.
- `docs/site/src/content/docs/reference/config.md` — the annotated `gke` block and a paragraph on where the version comes from.

### One thing deliberately not done

**Cluster Agent profiles already scaffolded on a PVC keep their old config.** `overlay_template` copies the cluster template only when the profile is absent, and the entrypoint's force-sync covers the platform profile and `skills/`, not `profiles/cluster-*/config.yaml` — deliberately, since that file carries the `cluster_identity` block the reconciler matches on. So existing cluster agents send the header from the next time their profile is scaffolded, and newly onboarded clusters send it immediately.

## Context

Closes #990.

The `--header` flag is the fork's (`bradhoekstra/mcp-remote`, pinned in the Dockerfile); mcp-remote hands the header map to the MCP SDK as `requestInit.headers`, and undici sends a caller-set User-Agent rather than overwriting it. The SDK's own OAuth metadata probes at connect (`/.well-known/…`) are built without `requestInit` and still go out as `node`; they are discovery, not MCP calls.

## Testing

- `tests/test_remote_mcp_user_agent.py` (new, 4 tests): every proxy entry in every discovered agent config sends exactly one well-formed header; the argv still parses as `--header <value>` plus exactly one URL, which is what mcp-remote's own arg splicing requires; the real `merge_configs.merge` over the shared defaults and the platform overlay still comes out that shape; the Dockerfile still defines the variable the header interpolates and both Cloud Build configs still pass it. Mutation-checked twice — varying the header's value in one config fails the first test, and drifting the overlay's spelling from the shared defaults fails the merge test (it did not, before the Self-Review below).
- `make test-python` — green.
- `make docs-check` — green.
- `prettier@3.9.6 --check` on every changed Markdown and YAML file — clean.
- `scripts/check_image_layers.py` against the built image — 113 layers, under the 120 budget.
- Docker build of both affected targets (`platform`, `credential-proxy`) on linux/amd64.

### Live validation

Install: `kube-agents-pr866` (GKE, `us-central1`, project `agentic-harness-demo`), namespace `kubeagents-system`. Lease taken with `scripts/live_test_lease.py` for the duration and released at the end.

Images built on a cloudtop and pushed to that project's Artifact Registry as `platform-agent:ka990-uatest` and `credential-proxy:ka990-uatest` (the operator derives the sidecar tag from the agent image, so both had to exist), built with `--build-arg KUBE_AGENTS_VERSION=ka990-live-20260827` — a value that is neither the `dev` default nor any commit SHA, so nothing observed below can be a coincidence.

**Before**, on the published image the install was running:

```
$ kubectl exec … -c platform-agent -- sh -c 'printenv KUBE_AGENTS_VERSION || echo UNSET'
UNSET
$ kubectl exec … -c platform-agent -- grep -A4 '^  gke:' /opt/data/profiles/platform/config.yaml
  gke:
    args:
    - /opt/mcp-remote/dist/proxy.js
    - https://container.googleapis.com/mcp
```

**After** patching the CR's `spec.deployment.tag` to `ka990-uatest` and a clean rollout:

```
$ kubectl exec … -c platform-agent -- printenv KUBE_AGENTS_VERSION
ka990-live-20260827

$ kubectl exec … -c platform-agent -- grep -A6 '^  gke:' /opt/data/profiles/platform/config.yaml
  gke:
    args:
    - /opt/mcp-remote/dist/proxy.js
    - --header
    - 'User-Agent: kube-agents/${KUBE_AGENTS_VERSION}'
    - https://container.googleapis.com/mcp
```

The spawned child process, read out of `/proc/<pid>/cmdline` in the pod while a real MCP call ran — this is the interpolation actually happening, not the template:

```
/opt/hermes/.venv/bin/python3 /opt/hermes/tools/mcp_stdio_watchdog.py --ppid 1613 --
  /usr/local/bin/node /opt/mcp-remote/dist/proxy.js
  --header 'User-Agent: kube-agents/ka990-live-20260827'
  https://developerknowledge.googleapis.com/mcp
```

Both endpoints answered a real connection with the flag in place, so the extra argv pair breaks neither mcp-remote's arg parsing nor the endpoints' auth:

```
  Testing 'developer_knowledge'...
  ✓ Connected (1852ms)
  ✓ Tools discovered: 3
  Testing 'gke'...
  ✓ Connected
  ✓ Tools discovered: 23   (list_clusters, get_k8s_resource, apply_k8s_manifest, …)
```

Also checked in the image itself, since the ENV is the part a cluster cannot show twice: `docker run --entrypoint printenv … KUBE_AGENTS_VERSION` returns the build arg, and a build that passes no `--build-arg` returns `dev`. The build-time merge of the shared defaults and the platform overlay produces exactly one `--header` in the shipped image's platform template.

**Restored.** The CR was patched back to the tag it was on, the rollout completed, and the pod reads `UNSET` with a header-less `gke` block again — which is the revert half of the mechanism check. Both `ka990-uatest` tags were deleted from Artifact Registry, the lease was released, and the local scratch images were removed.

**Not covered.** No dedicated `ka-990` cluster: `terraform/examples/full-install` hardcodes `kubeagents-platform-gsa` / `kubeagents-litellm-gsa`, so a second install in this project 409s on IAM (the wall #919/#923 closed rather than generalise), and this borrowed an existing per-PR install instead. The wire itself was not captured — Google does not echo the request's User-Agent back and there is no TLS interception point in the pod; the child's argv plus the fork's header handling is as close as this gets. A Cluster Agent profile was not re-scaffolded, so the cluster template's copy of the header is verified in the image and by test, not on a running cluster agent.

## Self-Review

Two passes, each in a fresh subagent that had the diff and nothing else — no commit message body, no notes from the session that wrote the change.

The adversarial pass worked ten angles and returned eight findings plus seven explicitly refuted hypotheses; the docs-drift pass returned five, none blocking. Merged, most serious first:

**The guard against the hazard this change's own comments name was inert.** `merge_configs.merge` unions arg lists with `list(dict.fromkeys(a + b))` — it *deduplicates*. So if the shared-defaults and platform copies drift, you do not get two headers: the repeated `--header` token collapses and the divergent value survives alone, as a bare positional after the URL, which mcp-remote parses as its optional callback port (`parseInt(…)` → `NaN`) and silently discards. The overlay's spelling is the one quietly lost. My merge test counted headers, so it was green on exactly the drift it existed to catch — reproduced by hand, then fixed: it now asserts the *shape* of the merged argv (one positional, the URL), and mutating one file's spelling fails it. Three comments and the docs paragraph stated the doubled-header consequence and have been corrected to the real one; that wrong mental model is what produced the bad assertion in the first place.

**The header does not reach profiles that already exist. Two paths, neither fixed here, both real:**

- Cluster Agent profiles. `overlay_template` copies the template once at scaffold time and `cluster_agent_reconcile` skips clusters it already knows, while the entrypoint's cluster loop force-syncs `SOUL.md`/`AGENTS.md`/`CAPABILITIES.md`/skills and deliberately not `config.yaml`, because that file is identity-stamped with `cluster_identity`. An agent managing twelve onboarded clusters ships the header in its image and keeps calling as `node` for all twelve; the thirteenth, newly onboarded, gets it.
- The platform profile under `experimental.platformFrontDoor: true`. That flag drops `config.yaml` from the force-sync list in favour of `backfill_config_from_template`, whose `fill()` adds absent keys and recurses only where both sides are mappings — by design, since "where the live file holds a scalar or a list the agent has spoken." `mcp_servers.gke.args` is an existing list, so the new pair is not added. Non-front-door installs and fresh volumes are unaffected, which is why the live test above shows the header arriving.

Not fixed because the fix is not this change's to make: back-filling into an existing list means overruling agent-edited config, and the entrypoint refuses that on purpose in a comment written for this exact case. The delivery gap is real and I would rather it be visible in the tracker than papered over here — happy to file it, or to widen this PR if a reviewer would rather it land together.

**Already-fixed, and found by both passes:** `deploy/docker/cloudbuild-ci.yaml` built the `platform` target without the new build arg, so every image `hack/ci-deploy.sh` publishes for a PR evaluation cluster would have reported the `dev` default — indistinguishable from a laptop build, and the one distinction the change advertises. The CI config now takes `_KUBE_AGENTS_VERSION`, `hack/ci-deploy.sh` passes the `pr-<n>-<sha>` tag, and the test covers both Cloud Build configs rather than one.

**Merge-order collision — predicted, and it happened.** The pass flagged that #997 rewrote the same lines in `docker-publish-gcp.yml`, both Cloud Build configs, `hack/ci-deploy.sh` and the tail of the Dockerfile's `platform` stage, and that a textual conflict would be the good outcome. #997 merged first (`706e141e`) and this branch is now rebased onto it, with three conflicts resolved by hand: the two `--substitutions` lines (`docker-publish-gcp.yml`, `hack/ci-deploy.sh`) take both sides' keys, and `cloudbuild.yaml`'s substitution block keeps `_BUILDCACHE_URI` alongside `_KUBE_AGENTS_VERSION`.

One real fix came out of it, and it is the thing the pass said to watch for: #997's new `buildx … --cache-to mode=max` step rebuilds the same `--target` and passed no `KUBE_AGENTS_VERSION`, so the exported cache's graph would diverge from the image just built beside it. It now passes the same build arg. Re-audited every `--target platform` build in the merged tree — `cloudbuild.yaml` (both the image build and the cache publish), `cloudbuild-ci.yaml`, `docker-publish-gcp.yml`, `docker-publish-ghcr.yml`, `hack/ci-deploy.sh`, `dev_rebuild_agent.sh` — all carry it. `docker-build.yml` deliberately does not: it is `push: false`, built only so the layer-budget step has an image to inspect, so `dev` is the right answer there. The Dockerfile's `ARG`/`ENV` survived #997's restructure in the right place, still the last instructions of the `platform` stage after `USER 10000:10000`. (#965's new profile declares no `mcp_servers`, so it needs nothing from this change.)

**Smaller, fixed:** the docs paragraph said "Both remote servers" on a page that names only `platform_control` and `gke`, so "both" resolved to a local stdio server that gets no header — the servers are now named. A comment cited `tools/mcp_tool.py` unqualified, which is not a path in this repository — qualified as `hermes tools/mcp_tool.py`, matching the same file's usage 44 lines above.

**Smaller, not fixed, with reasons:** the new test re-derives a `merged_config()` helper and a `sys.path` idiom that `agents/platform/scripts/test_mcp_env_contract.py` and `deploy/docker/test_merge_configs.py` already have; the two live under different test roots and this file's subject is every config rather than the platform profile, so instead of a cross-root import its docstring now points at the existing contract test and its argument. `docs/README.md`'s identifier-sources table has no row for an image-baked ENV — the existing "MCP servers of an agent profile → that profile's `config.yaml`" row lands a reader on the `--header` argument, and a row for one `ENV` line is map churn. The Cluster Agent half is documented only on a page titled for the platform config — four other pages describe the cluster template's MCP servers and none is now false; repeating the header across all of them is what the link-don't-summarise rule exists to prevent.

**One gap neither pass raised, found while acting on them:** the test scanned a hardcoded list of three config files, so a *fourth* agent profile adding a remote server would never have been checked — the exact "someone copies an existing entry into a new profile" case. It now globs `agents/*/config.yaml`, which picks up `agents/chat/config.yaml` (no remote servers today) for free.

**Refuted, worth recording** so a reviewer does not re-derive them: the fork folds headers into the `~/.mcp-auth` cache hash, but `proxy.ts` overrides the token provider with ADC so that cache is never load-bearing here; `mcp_security.py` and the OSV preflight both no-op for a local `command: node`; `_interpolate_env_vars` reaches a plain process env var through `_GLOBAL_ENV_EXACT` even under multiplexing, so there is no fail-closed path that blanks the header; mcp-remote's header regex accepts `User-Agent` and splices flag pairs before reading the URL; `ENV` costs no layer and its placement after `USER 10000:10000` invalidates nothing above it; the global-`ARG`-plus-bare-redeclaration is the correct BuildKit idiom and the `dev` default keeps un-plumbed builds working.

Both passes flagged the same limit of a static review: neither mcp-remote's `--header` splicing nor Hermes' `${VAR}` interpolation is in this tree (the fork is cloned at build time, `mcp_tool.py` is in the base image), so claims about them cannot be settled from the diff, and the adversarial pass had no Docker daemon or cluster. That is what the live validation above is for — the interpolated argv was read out of `/proc` in a running pod and both endpoints answered. Findings 1 and 2 above are traced through source, not observed on a live PVC.

## Risk & Rollout

Small blast radius: two extra argv entries on each stdio child process, plus one environment variable. Nothing reads the variable except the config interpolation, and an unresolved placeholder is inert — Hermes leaves `${VAR}` literal rather than failing, so the worst case of a missing ENV is an ugly User-Agent, not a broken MCP call. The endpoints accept the header, as the live test shows. Revert is the diff: no state written, no migration, no operator or CRD change. Existing Cluster Agent profiles pick the header up when their profile is next scaffolded, as described above.

---

🤖 This pull request was prepared with the help of Claude Code.
