### PR TITLE
fix(install): support Autopilot cluster detection and fix KMS adoption import

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -947,7 +947,16 @@ ensure_existing_cluster_cmek() {
 # postcondition backstops installs driven through bare Terraform.
 ensure_existing_cluster_workload_identity() {
   local project_id="$1" cluster_name="$2" region="$3"
-  local pool
+  local pool is_autopilot
+
+  is_autopilot=$(trap - ERR; gcloud container clusters describe "$cluster_name" \
+    --location="$region" --project="$project_id" \
+    --format="value(autopilot.enabled)" 2>/dev/null) || is_autopilot="false"
+  if [ "$is_autopilot" = "True" ]; then
+    print_success "Existing cluster '$cluster_name' is GKE Autopilot (Workload Identity enabled natively)."
+    return 0
+  fi
+
   # `trap - ERR` inside the substitution: bash 3.2 (macOS's default, the
   # curl|bash audience) runs the inherited ERR trap in the subshell even
   # though the outer failure is handled, printing a spurious abort banner
@@ -975,10 +984,10 @@ ensure_existing_cluster_workload_identity() {
     gcloud container node-pools update "$legacy_pool" \
       --cluster="$cluster_name" --location="$region" --project="$project_id" \
       --workload-metadata=GKE_METADATA --quiet
-  done < <(gcloud container node-pools list --cluster="$cluster_name" \
+  done < <(trap - ERR; gcloud container node-pools list --cluster="$cluster_name" \
       --location="$region" --project="$project_id" \
       --format="csv[no-heading](name,config.workloadMetadataConfig.mode)" 2>/dev/null \
-    | awk -F',' '$2 != "GKE_METADATA" {print $1}')
+    | awk -F',' '$2 != "GKE_METADATA" {print $1}' || true)
 }
 
 # NetworkPolicy enforcement on a pre-existing cluster is the third such

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -151,8 +151,9 @@ with_override() {
 # again. If you are reading this in a committed diff, something went wrong.
 provider "helm" {
   kubernetes = {
-    host  = "https://127.0.0.1"
-    token = "placeholder"
+    host                   = "https://127.0.0.1"
+    token                  = "placeholder"
+    cluster_ca_certificate = ""
   }
 }
 EOF


### PR DESCRIPTION
fix(install): handle Autopilot Workload Identity and stub Helm CA cert during KMS import

## Summary

Updates `install.sh` and `lifecycle.sh` to resolve installation failures when targeting existing GKE Autopilot clusters and pre-existing KMS keyrings. `ensure_existing_cluster_workload_identity()` now detects GKE Autopilot clusters where Workload Identity is natively enabled and returns early, while `with_override()` in `lifecycle.sh` explicitly stubs `cluster_ca_certificate = ""` in the temporary Helm provider configuration to prevent `terraform import` from evaluating uncomputed cluster attributes during KMS adoption.

## Why This Change

- Installing onto an existing GKE Autopilot cluster triggered unnecessary node-pool migration logic intended only for GKE Standard clusters.
- During KMS adoption (`adopt_kms()`), `terraform import` failed on fresh cluster deployments because the Helm provider configuration in `providers.tf` evaluated `module.gke_cluster.cluster_ca_certificate` (which is uncomputed prior to cluster creation). The failed import caused subsequent `terraform apply` attempts to hit HTTP 409 Conflict errors when attempting to re-create existing KMS keyrings.

## What Changed

- **`install.sh`**:
  - Added a GKE Autopilot check to `ensure_existing_cluster_workload_identity()`, printing success and returning early when `autopilot.enabled` is `True`.
  - Added `trap - ERR` and `|| true` to the `gcloud container node-pools list` pipeline to prevent false-positive script aborts when listing node pools in macOS/bash 3.2 environments.
- **`terraform/examples/full-install/lifecycle.sh`**:
  - Added `cluster_ca_certificate = ""` to the temporary Helm provider block in `with_override()`, ensuring all cluster-dependent provider attributes are stubbed out during `terraform import`.

## Context

Fixes KMS adoption errors and Autopilot Workload Identity checks during installation.

## Testing

- Executed `diff -u` verification against source changes.
- Checked shell execution logic and syntax.

### Live validation

Tested script execution against existing GKE Autopilot cluster and confirmed `ensure_existing_cluster_workload_identity()` returns early without attempting node pool updates, and verified `terraform import` succeeds without evaluating uncomputed cluster endpoints.

## Self-Review

- **Adversarial pass (subagent context)**: Verified diff range across `install.sh` and `lifecycle.sh`. Confirmed changes are tightly scoped to Workload Identity probing and Helm provider override stubs.
- **Docs drift pass (subagent context)**: Confirmed installer flags and interface contracts remain unchanged.

## Risk & Rollout

Low risk; changes are isolated to installation/adoption helper scripts (`install.sh` and `lifecycle.sh`).
