### PR TITLE
docs(agents): add .agents/rules/ and the no-magic-constants rule

### DIFF
--- a/.agents/rules/core_engineering.md
+++ b/.agents/rules/core_engineering.md
@@ -1,0 +1,49 @@
+# Core engineering rules
+
+Rules for code written in this repository. [`AGENTS.md`](../../AGENTS.md) names this file and is
+where a new rule's one-line statement goes; the form each rule takes per language lives here.
+
+These rules bind the lines you write, not the files those lines land in. Editing one function of a
+file full of literals obliges you to name the ones your edit introduces or touches and nothing
+else; hoisting the rest is a separate change with its own argument, and landing it alongside a
+bugfix breaks "Keep changes scoped to the request" in [`AGENTS.md`](../../AGENTS.md). A file you
+are not otherwise touching is not in scope because you read it.
+
+## No magic constants
+
+Every hardcoded value gets a name, and the name is declared at the top of the file — after the
+imports, before the first function. This covers numbers, strings, durations, timeouts, retry
+counts, size limits, file paths, URLs, and resource names.
+
+A literal buried mid-function cannot be found by search, needs a comment at every use site to be
+understood, and drifts out of step with the other copies of itself. Naming it at the top makes the
+value reviewable on its own: a reader who wants to know what this file assumes about the world
+reads the top of it rather than all of it.
+
+`scripts/check_context_budget.py` is the pattern to copy — `BUDGET`, `FILES`, and `IMPORT_RE` sit
+above the first function, each with the reasoning for its value beside it.
+
+### Where "the top of the file" is
+
+- **Go** — a `const (...)` block immediately after the import block, or `var (...)` for values a
+  constant cannot hold. Unexported unless another package needs them.
+- **Python** — module-level `UPPER_SNAKE_CASE` after the imports.
+- **Bash** — `readonly NAME=...` after the shebang and the `set` line.
+
+Terraform, YAML, and Helm values are out of scope: `locals` and `values.yaml` already are the
+top-of-file declaration, and there is no second place for a literal to hide.
+
+### Exceptions
+
+- `0`, `1`, `-1`, `""`, and empty collections.
+- A literal that is the subject of the line it appears on — an array index, a version comparison,
+  an exit code on the line that documents it.
+- Test files, where the literal is the expected value. Naming it moves the assertion away from
+  what it asserts.
+
+### Enforcement
+
+No linter checks this. The repository runs `go fmt`, `go vet`, pytest, shellcheck (the three
+installer scripts only), and prettier; none of them has a magic-number rule enabled, and no
+`golangci-lint` or `ruff` config exists. This is a review expectation, and the pre-PR adversarial
+pass is where it gets caught.

--- a/.agents/rules/github_actions.md
+++ b/.agents/rules/github_actions.md
@@ -1,0 +1,26 @@
+# GitHub Actions rules
+
+[`AGENTS.md`](../../AGENTS.md) states both rules below under Pull Request Hygiene. This file holds
+the format each one takes and the cases exempt from it.
+
+## Pin GitHub Actions to a full commit SHA
+
+Every third-party `uses:` in `.github/workflows/` must reference a 40-character commit SHA with the
+human-readable version in a trailing comment (`uses: actions/checkout@3d3c42e… # v7.0.1`). Mutable
+tags (`@v4`, `@main`) are not permitted — a retagged release would silently change what CI runs.
+Local reusable workflows (`uses: ./.github/workflows/…`) are exempt. Dependabot updates the SHA and
+the comment together.
+
+## Guard automatically-triggered credentialed workflows against forks
+
+A workflow that needs this repository's secrets and starts on its own — `push`, a tag, `schedule`,
+or `workflow_run` — carries `if: github.repository == 'gke-labs/kube-agents'` on every job. A fork
+inherits those triggers but none of the secrets, so an unguarded job fails there on every sync and
+mails the fork owner. Put the guard on each job rather than trusting the skip to cascade through
+`needs`; an `always()` added later removes the implicit `success()` and the job runs anyway.
+
+Two classes need no guard: a workflow reachable only through `workflow_call` is gated by its caller
+(`reusable-deploy-*.yml`), and a `workflow_dispatch`-only one runs only when someone deliberately
+starts it (`rc-create-tag.yml`, `deploy-environment.yml`, `rc-tag-validated.yml`,
+`e2e-gchat-test.yml`). `docs-deploy.yml` is push-triggered and deliberately unguarded, so a fork
+can publish its own Pages site.

--- a/.agents/rules/pre_pr_review.md
+++ b/.agents/rules/pre_pr_review.md
@@ -21,8 +21,8 @@ The rule, and the requirement to fill in the template's **Self-Review** section,
   holds the plumbing and the rules for what to do with what comes back. Read the skill directly if
   your harness has no slash commands. Invoking the command is also the request to delegate that an
   agent is otherwise told to wait for — coding agents are instructed not to spawn subagents on
-  their own initiative, so an agent that reads only the rule in `AGENTS.md` finds its one route
-  closed and takes the silent fallback.
+  their own initiative, which is why `AGENTS.md` names the command in the rule itself rather than
+  leaving the only route to it on this page, which an agent reaches only after deciding to look.
 - **If your harness will not spawn one without a human's approval, go and get the approval.** A
   setting that requires sign-off before starting a subagent blocks this step; it does not waive
   it. Ask when you hit it, not after the review, and say what you are blocked on. Quietly running

--- a/.agents/rules/pre_pr_review.md
+++ b/.agents/rules/pre_pr_review.md
@@ -1,0 +1,72 @@
+# Pre-PR review mechanics
+
+[`AGENTS.md`](../../AGENTS.md) owns both rules below — that adversarial self-review and live
+validation are required before opening a pull request, and that each is recorded in the pull
+request body. This file holds the mechanics of carrying them out. Change the rule in `AGENTS.md`;
+change how it is done here.
+
+## Adversarial self-review
+
+The rule, and the requirement to fill in the template's **Self-Review** section, are in
+`AGENTS.md` under Pull Request Hygiene.
+
+- **Run the pass in a context that did not write the change** — a subagent, or a new session,
+  handed the diff range and nothing else. Not your plan, not your reasoning, not the summary you
+  were about to write. Reviewing a diff in the conversation that produced it is the one
+  configuration that reliably does not work: the same context that talked you into the code
+  talks you into approving it, and the blind spot sits exactly where you were already wrong.
+- **`/pr-preflight` is how you get one**, and it covers the docs-drift pass — the second required
+  pre-PR pass, stated in `AGENTS.md` beside this one — at the same time. It wraps
+  [`.agents/skills/review-preflight/SKILL.md`](../skills/review-preflight/SKILL.md), which
+  holds the plumbing and the rules for what to do with what comes back. Read the skill directly if
+  your harness has no slash commands. Invoking the command is also the request to delegate that an
+  agent is otherwise told to wait for — coding agents are instructed not to spawn subagents on
+  their own initiative, so an agent that reads only the rule in `AGENTS.md` finds its one route
+  closed and takes the silent fallback.
+- **If your harness will not spawn one without a human's approval, go and get the approval.** A
+  setting that requires sign-off before starting a subagent blocks this step; it does not waive
+  it. Ask when you hit it, not after the review, and say what you are blocked on. Quietly running
+  the pass in the session that wrote the code instead buys a review from the context that already
+  believes the change is correct, and reporting that as a self-review without the caveat tells
+  the reviewer something untrue about how the change was checked.
+- **Every finding gets a disposition: fixed, or deliberately not with a reason that argues about
+  this change.** "Out of scope", "pre-existing", and "will fix later" are not reasons on their
+  own; the separate issue you filed is. Fix what a pass confirms and report what it only
+  suspects — a finding it could not pin down is an open question for the section, not a licence
+  to rewrite working code. And "no findings" is an answer only alongside what you looked for: a
+  pass that names none of its angles is indistinguishable from no pass.
+  [`.agents/skills/review-preflight/SKILL.md`](../skills/review-preflight/SKILL.md) §6
+  elaborates, including how to merge two passes that grade differently.
+- **Do not claim more than you did.** A self-review the diff contradicts is worse than none: it
+  spends the reviewer's trust before they reach the code. Name the kind of context each pass ran
+  in — subagent, fresh session, or the one that wrote the change — so the claim above it is
+  something a reviewer can weigh rather than take on trust.
+
+## Live validation
+
+The rule, and the requirement to fill in the template's **Testing → Live validation** section, are
+in `AGENTS.md` under Pull Request Hygiene.
+
+- **Name the install and what you observed.** Cluster, image tag, operator version; what you
+  did; and the result at each layer the change claims to touch — the CR `.status`, the
+  Deployment env, the file or process inside the pod.
+- **Prove the mechanism, not a coincidence.** If the new value happens to equal the old
+  default, the observation proves nothing. Set something distinctly different, then revert and
+  confirm it goes back.
+- **Say what you could not cover, and why**, rather than implying full coverage. Clean up test
+  artifacts, restore prior state, and note anything left behind.
+- **Screenshots of graphical surfaces go through `scripts/pr_evidence_screenshot.sh`**, which
+  publishes the image where a PR body can render it and prints Markdown stamped with the
+  commit and capture time. Command output stays as fenced text transcripts — a screenshot of a
+  terminal is evidence degraded, not evidence.
+- **If the install is shared with other agents, take the lease.**
+  `scripts/live_test_lease.py` holds it as a ConfigMap in the install's own namespace. Copy
+  `.claude/settings.json.example` to `.claude/settings.json` once per checkout and its
+  `PreToolUse` hook claims the lease for you on the first mutating command and denies the
+  command while somebody else holds it — so two agents cannot overwrite each other's live
+  validation. Without the copy nothing is enforced, and you run `acquire` and `release` by hand.
+  [`docs/designs/live-test-lease.md`](../../docs/designs/live-test-lease.md) covers what counts as
+  a mutation, how an install is discovered, and why the wiring is not committed.
+- **If the change cannot reach a running installation** — docs-only, a CI workflow, a code path
+  that needs infrastructure you do not have — write "Not live-tested" and say why. An empty
+  section is not an answer.

--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -155,8 +155,10 @@ prefer generalizing the underlying mechanism.
 
 **Angle H — conventions and docs.** Read the `AGENTS.md` / `CLAUDE.md` files that govern the
 changed code: the repo root, plus any in a directory that is an ancestor of a changed file (a
-directory's file only applies at or below it). Flag a violation only when you can quote the exact
-rule and the exact line that breaks it — no style preferences, no "spirit of the doc" inferences.
+directory's file only applies at or below it). Read `.agents/rules/` alongside them — the root
+`AGENTS.md` states each rule in a line and that file holds the form it takes and the cases exempt
+from it, so the one-liner alone will have you flagging exempt code. Flag a violation only when you
+can quote the exact rule and the exact line that breaks it — no style preferences, no "spirit of the doc" inferences.
 Name the file and quote the rule so the report can cite it. This is also where docs drift belongs:
 one canonical home per fact, generated `<!-- BEGIN GENERATED -->` regions regenerated rather than
 hand-edited, identifiers verified against source rather than against other docs. `review-docs-drift`

--- a/.agents/skills/review-adversarial/SKILL.md
+++ b/.agents/skills/review-adversarial/SKILL.md
@@ -158,12 +158,13 @@ changed code: the repo root, plus any in a directory that is an ancestor of a ch
 directory's file only applies at or below it). Read `.agents/rules/` alongside them — the root
 `AGENTS.md` states each rule in a line and that file holds the form it takes and the cases exempt
 from it, so the one-liner alone will have you flagging exempt code. Flag a violation only when you
-can quote the exact rule and the exact line that breaks it — no style preferences, no "spirit of the doc" inferences.
-Name the file and quote the rule so the report can cite it. This is also where docs drift belongs:
-one canonical home per fact, generated `<!-- BEGIN GENERATED -->` regions regenerated rather than
-hand-edited, identifiers verified against source rather than against other docs. `review-docs-drift`
-is the exhaustive form of that check and the author is required to have run it before opening —
-which is a reason to read what they reported, not a reason to skip this angle.
+can quote the exact rule and the exact line that breaks it — no style preferences, no "spirit of
+the doc" inferences. Name the file and quote the rule so the report can cite it. This is also
+where docs drift belongs: one canonical home per fact, generated `<!-- BEGIN GENERATED -->` regions
+regenerated rather than hand-edited, identifiers verified against source rather than against other
+docs. `review-docs-drift` is the exhaustive form of that check and the author is required to have
+run it before opening — which is a reason to read what they reported, not a reason to skip this
+angle.
 
 **Angle I — scope and test coverage.** Hold the diff against the intent sentence from step 3. Flag
 changes that do not serve it: an unrelated refactor riding along, a dependency bump nobody asked

--- a/.agents/skills/review-preflight/SKILL.md
+++ b/.agents/skills/review-preflight/SKILL.md
@@ -124,7 +124,8 @@ instead. In order of preference:
   Neither of those trailing instructions is padding — step 5 explains what each one carries.
 
 If none of those is available to you, **you are blocked, and the pull request waits**. Say what you
-are blocked on. `AGENTS.md` is explicit that an approval you could not get blocks this step rather
+are blocked on. [`.agents/rules/pre_pr_review.md`](../../rules/pre_pr_review.md) is explicit that
+an approval you could not get blocks this step rather
 than waiving it, so the authoring context is not the fallback — running the pass there and
 disclosing it is what you do when a human, told the above, tells you to proceed anyway. Then
 **Self-Review** says which context ran the pass, in those words.
@@ -181,7 +182,8 @@ request opens, Advisory gets the same disposition treatment as PLAUSIBLE. Do not
 finding as CONFIRMED to make one column of it; the pass did not do the verification that word
 claims.
 
-Every survivor gets a disposition either way, to the bar `AGENTS.md` sets: fixed, or deliberately
+Every survivor gets a disposition either way, to the bar
+[`.agents/rules/pre_pr_review.md`](../../rules/pre_pr_review.md) sets: fixed, or deliberately
 not, with a reason that argues about this change.
 
 Report what a pass only suspects rather than acting on it. A finding it could not pin down is an

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,7 +62,8 @@ docs/designs/live-test-lease.md.
 Re-testing after new commits folds into this section rather than stacking a round
 beneath it: keep what still holds, and re-run or flag what the new commits invalidated.
 
-Full contract: AGENTS.md, "Pull Request Hygiene".
+Full contract: AGENTS.md, "Pull Request Hygiene", plus .agents/rules/pre_pr_review.md
+for the mechanics.
 -->
 
 -
@@ -95,7 +96,8 @@ Re-running the pass folds into this section rather than stacking a round beneath
 it: keep what still holds, re-state what the new commits changed, and drop the
 superseded round rather than a finding's disposition.
 
-Full contract: AGENTS.md, "Pull Request Hygiene".
+Full contract: AGENTS.md, "Pull Request Hygiene", plus .agents/rules/pre_pr_review.md
+for the mechanics.
 -->
 
 -

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,8 +239,8 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
   comment** (`uses: actions/checkout@3d3c42e… # v7.0.1`), and **guard automatically-triggered
   credentialed workflows against forks** with `if: github.repository == 'gke-labs/kube-agents'` on
   every job. A mutable tag lets a retagged release change what CI runs; an unguarded job fails on
-  every fork sync and mails the fork owner. Nothing in CI checks either one, and both have
-  exemptions — local reusable workflows need no pin, a `workflow_call`- or
+  every fork sync and mails the fork owner. No check in this repository blocks either one, and
+  both have exemptions — local reusable workflows need no pin, a `workflow_call`- or
   `workflow_dispatch`-only workflow needs no guard, and `docs-deploy.yml` is unguarded on purpose
   so a fork can publish its own Pages site. Open
   [`.agents/rules/github_actions.md`](.agents/rules/github_actions.md) whenever you touch a
@@ -258,16 +258,20 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
   answers "what happened", and the supporting detail follows it.
 - **Adversarial self-review before opening a PR, and record it in the PR body.** Run the
   `review-adversarial` skill (`.agents/skills/review-adversarial/SKILL.md`) against your branch
-  diff, fix what it confirms, and fill in the template's **Self-Review** section with what you
-  looked for, what it found, and the disposition of each finding. This is a required pre-PR step
-  for AI agents working in this repository: you are the change's first hostile reader, and a
-  reviewer who has to find what you could have found spends their attention on the wrong things.
+  diff **in a context that did not write the change** — a subagent or a fresh session handed the
+  diff range and nothing else, which `/pr-preflight` spawns for you. Invoking it is also the
+  request to delegate that an agent is otherwise told to wait for, so an agent that skips it
+  reviews the diff in the context that argued for it. Fix what the pass confirms, and fill in the
+  template's **Self-Review** section with what you looked for, what it found, and the disposition
+  of each finding. This is a required pre-PR step for AI agents working in this repository: you
+  are the change's first hostile reader, and a reviewer who has to find what you could have found
+  spends their attention on the wrong things.
   The section carries every pre-PR pass, not this one alone — the docs-drift pass below runs on
   every change too — merged into one list, so a reviewer reads what was looked for in one place
   rather than inferring which passes ran from which findings appeared.
   This bullet and [`.agents/rules/pre_pr_review.md`](.agents/rules/pre_pr_review.md) are together
-  the canonical statement — the requirement here, the mechanics there (`/pr-preflight` as the route
-  to a clean context, what to do when your harness will not spawn one, and the disposition every
+  the canonical statement — the requirement here, the mechanics there (why the clean context has
+  to be a real one, what to do when your harness will not spawn one, and the disposition every
   finding owes). The site's [contributing guide](docs/site/src/content/docs/contributing.md) and
   the comment in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise
   the pair — change this bullet or `pre_pr_review.md`, whichever owns what you are changing, then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
   - `platform/`: Configuration for the Platform Agent, scaffolded at pod startup into the `platform` profile.
   - `cluster/`: The Cluster Agent profile _template_ (persona, scoped config, and runtime-debugging skills). The Platform Agent scaffolds this into per-cluster Hermes profiles at runtime; it is not deployed directly.
 - `.agents/skills/`: Repository-level skills, not shipped in the agent images — review skills (adversarial change review, security audits, docs-drift, skill quality) run against pull requests and clusters, with `review-preflight` running the pre-PR set of them in a context that did not write the change, plus the `install-kube-agents`/`uninstall-kube-agents`/`upgrade-kube-agents` lifecycle skills that drive the repository's installer scripts.
+- `.agents/rules/`: Repository-level rules an agent follows, one file per family and none shipped in the agent images — `core_engineering.md` for the code itself, `github_actions.md` for workflow authoring, `pre_pr_review.md` for the mechanics of the two pre-PR passes. This file states each rule and links there for the form it takes; the split keeps `AGENTS.md` inside the context budget `scripts/check_context_budget.py` enforces.
 - `charts/`: Canonical Helm charts (`kube-agents`) for deploying the Kube-Agents operator and profiles.
 - `terraform/`: Companion reusable Terraform modules (`gke-cluster`, `kube-agents-iam`, `chat-pubsub`, `github-minter`, `gke-backup-plan`, `drift-pubsub`) for infrastructure provisioning, plus `examples/full-install/`, the single-apply composition that installs the Helm chart on top. `drift-pubsub` is not yet part of that composition.
 - `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
@@ -152,6 +153,22 @@ the assignee is the claim; do not apply `status:` labels to issues in this repos
 - Place a skill according to its persona: fleet/provisioning/GitOps-write skills belong to the Platform Agent; read-only, single-cluster runtime-debugging skills belong to the Cluster Agent.
 - When adding new skills, ensure they follow the existing structure and are clearly documented to be understood by AI agents.
 
+## Engineering Rules
+
+Rules an agent follows live in [`.agents/rules/`](.agents/rules/), one file per family — the code
+itself here, [workflow authoring](.agents/rules/github_actions.md) and
+[the pre-PR passes](.agents/rules/pre_pr_review.md) under Pull Request Hygiene below. Read the file
+that covers what you are writing before you write it.
+
+- **No magic constants.** Every hardcoded value — number, string, duration, path, limit — gets a
+  name declared at the top of the file, after the imports and before the first function. It binds
+  the lines you write, not the file they land in: literals already in a file you are editing stay
+  put unless you are touching them. Go, Python, and Bash; not Terraform, YAML, or Helm. Exempt:
+  `0`, `1`, `-1`, `""`, a literal that is the subject of its line, and test files, where the
+  literal is the expected value.
+  [`.agents/rules/core_engineering.md`](.agents/rules/core_engineering.md) gives the form per
+  language and why no linter enforces it yet.
+
 ## Documentation Guidelines
 
 Every fact has one home. Duplicating documentation across files is how it goes stale, so before
@@ -168,6 +185,7 @@ adding a paragraph, check whether the topic already has an owner:
 | The commands behind this file's pull-request rules       | `docs/pull-request-workflow.md`              |
 | What the agent is and is not permitted to do             | the site's `reference/security-and-iam.md`   |
 | How to develop a specific directory                      | that directory's `README.md` (keep it short) |
+| Rules an agent follows, by family (code, CI, pre-PR)     | `.agents/rules/`                             |
 
 Rules:
 
@@ -202,7 +220,8 @@ Rules:
   is the upstream source for this and for the conciseness rule above.
 
 Run `make docs-check` before pushing. It verifies generated regions are current, relative links
-resolve, identifiers match their source, every Markdown document has an entry in the documentation
+resolve, identifiers match their source, every Markdown document outside the root dot-directories
+has an entry in the documentation
 map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context budget
 (`scripts/check_context_budget.py`) — the same five checks CI runs.
 
@@ -216,23 +235,16 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
   - **Breaking Changes:** Mark with `!` before the colon (e.g. `feat!:`, `fix(operator)!:`) or a `BREAKING CHANGE:` footer.
   - **Release Preparation:** Standardized PR titles ensure consistent commit history and establish the Conventional Commit metadata required for the automated SemVer release pipeline. AI agents must ensure the proposed PR title prefix accurately reflects the changes in the branch diff and confirm classification with the author before opening a PR.
 - Push PR branches to a fork, not to the upstream repository.
-- **Pin GitHub Actions to a full commit SHA.** Every third-party `uses:` in
-  `.github/workflows/` must reference a 40-character commit SHA with the human-readable
-  version in a trailing comment (`uses: actions/checkout@3d3c42e… # v7.0.1`). Mutable tags
-  (`@v4`, `@main`) are not permitted — a retagged release would silently change what CI runs.
-  Local reusable workflows (`uses: ./.github/workflows/…`) are exempt. Dependabot updates the
-  SHA and the comment together.
-- **Guard automatically-triggered credentialed workflows against forks.** A workflow that needs
-  this repository's secrets and starts on its own — `push`, a tag, `schedule`, or `workflow_run`
-  — carries `if: github.repository == 'gke-labs/kube-agents'` on every job. A fork inherits those
-  triggers but none of the secrets, so an unguarded job fails there on every sync and mails the
-  fork owner. Put the guard on each job rather than trusting the skip to cascade through `needs`;
-  an `always()` added later removes the implicit `success()` and the job runs anyway. Two classes
-  need no guard: a workflow reachable only through `workflow_call` is gated by its caller
-  (`reusable-deploy-*.yml`), and a `workflow_dispatch`-only one runs only when someone deliberately
-  starts it (`rc-create-tag.yml`, `deploy-environment.yml`, `rc-tag-validated.yml`,
-  `e2e-gchat-test.yml`). `docs-deploy.yml` is push-triggered and deliberately unguarded, so a fork
-  can publish its own Pages site.
+- **Pin every third-party GitHub Action to a full commit SHA with the version in a trailing
+  comment** (`uses: actions/checkout@3d3c42e… # v7.0.1`), and **guard automatically-triggered
+  credentialed workflows against forks** with `if: github.repository == 'gke-labs/kube-agents'` on
+  every job. A mutable tag lets a retagged release change what CI runs; an unguarded job fails on
+  every fork sync and mails the fork owner. Nothing in CI checks either one, and both have
+  exemptions — local reusable workflows need no pin, a `workflow_call`- or
+  `workflow_dispatch`-only workflow needs no guard, and `docs-deploy.yml` is unguarded on purpose
+  so a fork can publish its own Pages site. Open
+  [`.agents/rules/github_actions.md`](.agents/rules/github_actions.md) whenever you touch a
+  `uses:` line or a workflow trigger.
 - Use `.github/PULL_REQUEST_TEMPLATE.md` for PR body structure and level of
   detail. Do not use `--fill` with `gh pr create` as it bypasses the template.
 - **AI Agent Attribution & Commit Authorship:**
@@ -253,41 +265,13 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
   The section carries every pre-PR pass, not this one alone — the docs-drift pass below runs on
   every change too — merged into one list, so a reviewer reads what was looked for in one place
   rather than inferring which passes ran from which findings appeared.
-  This bullet is the canonical statement of the requirement; the site's
-  [contributing guide](docs/site/src/content/docs/contributing.md) and the comment in
-  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise it — change
-  this list first, then reconcile them to it.
-  - **Run the pass in a context that did not write the change** — a subagent, or a new session,
-    handed the diff range and nothing else. Not your plan, not your reasoning, not the summary you
-    were about to write. Reviewing a diff in the conversation that produced it is the one
-    configuration that reliably does not work: the same context that talked you into the code
-    talks you into approving it, and the blind spot sits exactly where you were already wrong.
-  - **`/pr-preflight` is how you get one**, and it covers the docs-drift pass below at the same
-    time. It wraps
-    [`.agents/skills/review-preflight/SKILL.md`](.agents/skills/review-preflight/SKILL.md), which
-    holds the plumbing and the rules for what to do with what comes back. Read the skill directly if
-    your harness has no slash commands. Invoking the command is also the request to delegate that an
-    agent is otherwise told to wait for — coding agents are instructed not to spawn subagents on
-    their own initiative, so an agent that reads only the rule above finds its one route closed and
-    takes the silent fallback.
-  - **If your harness will not spawn one without a human's approval, go and get the approval.** A
-    setting that requires sign-off before starting a subagent blocks this step; it does not waive
-    it. Ask when you hit it, not after the review, and say what you are blocked on. Quietly running
-    the pass in the session that wrote the code instead buys a review from the context that already
-    believes the change is correct, and reporting that as a self-review without the caveat tells
-    the reviewer something untrue about how the change was checked.
-  - **Every finding gets a disposition: fixed, or deliberately not with a reason that argues about
-    this change.** "Out of scope", "pre-existing", and "will fix later" are not reasons on their
-    own; the separate issue you filed is. Fix what a pass confirms and report what it only
-    suspects — a finding it could not pin down is an open question for the section, not a licence
-    to rewrite working code. And "no findings" is an answer only alongside what you looked for: a
-    pass that names none of its angles is indistinguishable from no pass.
-    [`.agents/skills/review-preflight/SKILL.md`](.agents/skills/review-preflight/SKILL.md) §6
-    elaborates, including how to merge two passes that grade differently.
-  - **Do not claim more than you did.** A self-review the diff contradicts is worse than none: it
-    spends the reviewer's trust before they reach the code. Name the kind of context each pass ran
-    in — subagent, fresh session, or the one that wrote the change — so the claim above it is
-    something a reviewer can weigh rather than take on trust.
+  This bullet and [`.agents/rules/pre_pr_review.md`](.agents/rules/pre_pr_review.md) are together
+  the canonical statement — the requirement here, the mechanics there (`/pr-preflight` as the route
+  to a clean context, what to do when your harness will not spawn one, and the disposition every
+  finding owes). The site's [contributing guide](docs/site/src/content/docs/contributing.md) and
+  the comment in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise
+  the pair — change this bullet or `pre_pr_review.md`, whichever owns what you are changing, then
+  reconcile the summaries to it.
 - **Docs-drift review before opening a PR:** run the `review-docs-drift` skill
   (`.agents/skills/review-docs-drift/SKILL.md`) against your branch diff and address its
   Blocking findings. This is a required pre-PR step for AI agents working in this repository;
@@ -300,33 +284,15 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
   exercised against a real, running kube-agents installation — see [INSTALL.md](INSTALL.md) if
   you do not have one. Green unit tests and a clean `make docs-check` are necessary, not
   sufficient: they cannot tell you whether the operator reconciled the change or the agent pod
-  picked it up. This bullet is the canonical statement of the requirement; the site's
+  picked it up. This bullet and
+  [`.agents/rules/pre_pr_review.md`](.agents/rules/pre_pr_review.md) are together the canonical
+  statement — the requirement here, the mechanics there (what to name and observe, how to prove
+  the mechanism rather than a coincidence, the screenshot and shared-install lease rules, and what
+  to write when the change cannot reach an installation at all). The site's
   [contributing guide](docs/site/src/content/docs/contributing.md) and the comment in
-  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise it — change
-  this list first, then reconcile them to it.
-  - **Name the install and what you observed.** Cluster, image tag, operator version; what you
-    did; and the result at each layer the change claims to touch — the CR `.status`, the
-    Deployment env, the file or process inside the pod.
-  - **Prove the mechanism, not a coincidence.** If the new value happens to equal the old
-    default, the observation proves nothing. Set something distinctly different, then revert and
-    confirm it goes back.
-  - **Say what you could not cover, and why**, rather than implying full coverage. Clean up test
-    artifacts, restore prior state, and note anything left behind.
-  - **Screenshots of graphical surfaces go through `scripts/pr_evidence_screenshot.sh`**, which
-    publishes the image where a PR body can render it and prints Markdown stamped with the
-    commit and capture time. Command output stays as fenced text transcripts — a screenshot of a
-    terminal is evidence degraded, not evidence.
-  - **If the install is shared with other agents, take the lease.**
-    `scripts/live_test_lease.py` holds it as a ConfigMap in the install's own namespace. Copy
-    `.claude/settings.json.example` to `.claude/settings.json` once per checkout and its
-    `PreToolUse` hook claims the lease for you on the first mutating command and denies the
-    command while somebody else holds it — so two agents cannot overwrite each other's live
-    validation. Without the copy nothing is enforced, and you run `acquire` and `release` by hand.
-    [`docs/designs/live-test-lease.md`](docs/designs/live-test-lease.md) covers what counts as a
-    mutation, how an install is discovered, and why the wiring is not committed.
-  - **If the change cannot reach a running installation** — docs-only, a CI workflow, a code path
-    that needs infrastructure you do not have — write "Not live-tested" and say why. An empty
-    section is not an answer.
+  [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) summarise the pair —
+  change this bullet or `pre_pr_review.md`, whichever owns what you are changing, then reconcile
+  the summaries to it.
 - **Keep these sections current, not chronological.** **Self-Review** and **Live validation** tell
   a reviewer at a glance what has been reviewed and exercised against the branch as it stands. A
   second pass — after review findings, after a rebase — folds into what is there rather than being

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,11 @@ editing any doc.
 ## 1. Directory overview
 
 Dot-directories at the repository root (`.agents/`, `.github/`, `.claude/`)
-hold tooling — review skills, PR templates, agent config — not documentation;
-they are out of the map's scope and `docs-check-map` exempts them.
+hold tooling — review skills, agent rules, PR templates, agent config — not
+documentation; they are out of the map's scope and `docs-check-map` exempts
+them. `.agents/rules/` is the one the canonical-home table in `AGENTS.md`
+points at, so a rule's home is found through that table rather than through
+this map.
 
 This file states **no document counts**, anywhere — not a repository total, not
 a per-directory total, not a per-family total. A count is a number every
@@ -228,7 +231,7 @@ pull request:
 | --- | --- | --- | --- | --- |
 | `README.md` | Project overview | Front door for "The Kubernetes Agentic Harness": Planning Agent + Platform Agent managing GKE via GitOps PRs and ChatOps, with quick-start pointers and an architecture diagram. | Value proposition, components, governance/isolation summary, links to the docs site | Evaluators and adopters; also usable by an agent to start setup |
 | `INSTALL.md` | Install guide | Self-contained, executable installation guide: automated GCP/GKE provisioning, manual Kubernetes deployment, local dev, declarative Terraform+Helm install (pointer to its canonical guide), teardown, troubleshooting. Commands only; explanation lives on the site. | Prerequisites, provisioning stages, integrations, teardown | Written to be runnable end-to-end by a human or an AI agent |
-| `AGENTS.md` | Contributor rules | Workspace instructions: repo layout, branching from a freshly fetched `main`, the pre-task scan of open pull requests and issues, skills guidelines, the canonical-home documentation rules, generated-regions rule, PR hygiene, the live-validation requirement, and the automated pull-request review contract. States the rules; the commands that carry them out live in `docs/pull-request-workflow.md`. | Doc ownership table, `make docs-check`, fresh base, duplicate-work scan, Conventional Commits, fork PRs, bot review | AI coding agents and human contributors; owns the doc RULES; loaded into every session, so `make docs-check-context-budget` caps its size |
+| `AGENTS.md` | Contributor rules | Workspace instructions: repo layout, branching from a freshly fetched `main`, the pre-task scan of open pull requests and issues, skills guidelines, the engineering rules, the canonical-home documentation rules, generated-regions rule, PR hygiene, the live-validation requirement, and the automated pull-request review contract. States the rules; the commands that carry them out live in `docs/pull-request-workflow.md` and the mechanics that are prose in `.agents/rules/`. | Doc ownership table, engineering rules, `make docs-check`, fresh base, duplicate-work scan, Conventional Commits, fork PRs, bot review | AI coding agents and human contributors; owns the doc RULES; loaded into every session, so `make docs-check-context-budget` caps its size |
 | `CLAUDE.md` | Contributor rules | Imports `AGENTS.md` and points to it for commit authorship and PR attribution guidance. | Points to `AGENTS.md` rules | Claude Code sessions |
 | `admin_console/README.md` | Component README | Local setup and operating boundaries for the Kube Agents Console. | Connection, LLM gateway setup, chat, observability, integrations, validation | Console users and contributors |
 | `admin_console/CONNECTION_SECURITY.md` | Security reference | Security contract for the local console's persisted connection lease. | Stored metadata, filesystem controls, identity binding, revalidation, trust boundary | Console users and security reviewers |

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -17,8 +17,16 @@ reach an agent before it decides to wait, so `AGENTS.md` states it and only the 
 it is here. `AGENTS.md` is loaded into every session and this page is not, so anything that has to
 fire before an agent thinks to open a link belongs on that side of the line, not this one.
 
+The split is by form, not by topic: this page owns the mechanics that are commands, and
+[`.agents/rules/`](../.agents/rules/) owns the ones that are prose. `AGENTS.md` had no budget left
+to hold prose mechanics itself, so the pre-PR passes' went to
+[`.agents/rules/pre_pr_review.md`](../.agents/rules/pre_pr_review.md) and the workflow-authoring
+rules' to [`.agents/rules/github_actions.md`](../.agents/rules/github_actions.md). A mechanic with
+no command in it goes there rather than here, whichever rule it serves.
+
 Related: [`.agents/skills/review-preflight/SKILL.md`](../.agents/skills/review-preflight/SKILL.md)
-owns the pre-PR review plumbing, and
+owns the pre-PR review plumbing,
+[`.agents/rules/`](../.agents/rules/) owns the rules an agent follows by family, and
 [`.claude/commands/pr-review-batch.md`](../.claude/commands/pr-review-batch.md) owns the mechanics of
 reviewing somebody else's pull request.
 

--- a/docs/site/src/content/docs/contributing.md
+++ b/docs/site/src/content/docs/contributing.md
@@ -86,7 +86,7 @@ where a new one belongs, `docs/testing-map.md` maps the nine test homes to their
 
 The checks above tell you the code compiles, the docs resolve, and the unit tests agree with themselves. None of them tell you whether the operator reconciled your change or the agent pod picked it up — this project's failure mode is a green build that configures nothing. So every pull request fills in the template's **Testing → Live validation** section with how the change was exercised against a real, running kube-agents installation. If you don't have one, [INSTALL.md](https://github.com/gke-labs/kube-agents/blob/main/INSTALL.md) stands one up.
 
-[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement in full and is canonical; what follows summarises it, so trust it over this page if the two ever differ.
+[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement and [`.agents/rules/pre_pr_review.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/rules/pre_pr_review.md) holds its mechanics; together they are canonical. What follows summarises the pair, so trust them over this page if they ever differ.
 
 What that section should say:
 
@@ -115,7 +115,7 @@ there; `status` reports all of them either way. [`docs/designs/live-test-lease.m
 
 Nobody reads a change as cheaply as the person who wrote it, and right now the first hostile reader of most pull requests here is a reviewer who has never seen the code. So every pull request is reviewed by its author first, and the template's **Self-Review** section carries what those passes found — merged into one list, since more than one pass is required.
 
-[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement in full and is canonical; what follows summarises it, so trust it over this page if the two ever differ.
+[`AGENTS.md`](https://github.com/gke-labs/kube-agents/blob/main/AGENTS.md) states this requirement and [`.agents/rules/pre_pr_review.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/rules/pre_pr_review.md) holds its mechanics; together they are canonical. What follows summarises the pair, so trust them over this page if they ever differ.
 
 The method is the repository's own review skill, [`.agents/skills/review-adversarial/SKILL.md`](https://github.com/gke-labs/kube-agents/blob/main/.agents/skills/review-adversarial/SKILL.md) — run it against your branch diff with whatever agent you use. It works ten angles over the change, then re-derives each candidate from the source as a hostile second reader and throws out what it cannot defend.
 

--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -20,7 +20,8 @@ So the budget is checked rather than watched. The remedy when this fails is
 almost never to delete a rule -- it is to move the *mechanics* out to a
 document the agent opens when it is carrying the rule out, the way
 ``docs/pull-request-workflow.md`` holds the commands whose rules live in
-``AGENTS.md``. Raising ``BUDGET`` is the other option, and it is a real one, but
+``AGENTS.md`` and ``.agents/rules/`` holds the mechanics that are prose rather
+than commands. Raising ``BUDGET`` is the other option, and it is a real one, but
 it should be a decision someone argues for in a pull request rather than the
 path of least resistance.
 
@@ -143,9 +144,10 @@ def main() -> int:
             "\n"
             "These files are loaded into every session in every checkout, so this is a\n"
             "cost paid by every task in the repository. Prefer moving mechanics out over\n"
-            "deleting a rule: the commands for a procedure belong in a document the agent\n"
-            "opens while carrying it out (docs/pull-request-workflow.md is the worked\n"
-            "example), while the rule, its trigger, and its reason stay in AGENTS.md.\n"
+            "deleting a rule: mechanics belong in a document the agent opens while\n"
+            "carrying the rule out -- docs/pull-request-workflow.md for the ones that are\n"
+            "commands, .agents/rules/ for the ones that are prose -- while the rule, its\n"
+            "trigger, and its reason stay in AGENTS.md.\n"
             "Raising BUDGET in scripts/check_context_budget.py is a legitimate answer too,\n"
             "but argue for it in the pull request."
         )


### PR DESCRIPTION
## Summary

This change opens `.agents/rules/` as the home for the rules an agent follows when writing code here, and seeds it with one: no magic constants — every hardcoded value gets a name declared at the top of the file. Getting that rule into `AGENTS.md` meant paying for it first. The always-loaded instruction files were at 37,953 chars against the 38,000-char budget `scripts/check_context_budget.py` enforces in CI, so any addition failed the build. The same change therefore moves prose mechanics out of `AGENTS.md` into `.agents/rules/` — the two GitHub Actions rules and the mechanics of the two pre-PR review passes — and lands at 35.3k, 2.7k under budget with the new rule included. Nothing was deleted; every sentence removed from `AGENTS.md` is in one of the three new files, and the verification is described under Testing.

## Why This Change

There is no home in this repository for how to write code in it. No `.golangci.yml`, no ruff or pylint config, no `[tool.*]` section in `bench/pyproject.toml`, no `.editorconfig`; the canonical-home table in `AGENTS.md` has no row for it; and `docs/site/src/content/docs/contributing.md` delegates "repository conventions" back to `AGENTS.md`, which does not cover them. So a convention has nowhere to be written down, and each one gets re-argued in review or not at all.

The refactor is not incidental to that. `scripts/check_context_budget.py`'s own docstring says the remedy when the budget fails is to move the mechanics out to a document the agent opens when it is carrying the rule out, rather than to delete a rule or raise `BUDGET`. That is what this does, and it is what makes room for the rule.

## What Changed

- **`.agents/rules/core_engineering.md`** — the new rule. What "the top of the file" means in Go, Python, and Bash; Terraform, YAML, and Helm named as out of scope; the exceptions (`0`/`1`/`-1`/`""`, a literal that is the subject of its line, test files) listed so the rule is applicable rather than arguable; and a plain statement that no linter checks it and the pre-PR adversarial pass is where it gets caught. It binds the lines you write, not the files those lines land in.
- **`.agents/rules/github_actions.md`** and **`.agents/rules/pre_pr_review.md`** — the mechanics moved out of `AGENTS.md`, verbatim apart from relative-link re-pathing and five clarifying clauses (two bullet leads became headings; two `above`/`below` references lost their referent on the move and were rewritten to name what they point at; and `pre_pr_review.md`'s `/pr-preflight` bullet, whose closing premise that `AGENTS.md` leaves the route closed stopped being true once the delegation clause went back into `AGENTS.md` — see Self-Review).
- **`AGENTS.md`** — a `.agents/rules/` layout bullet, a new `## Engineering Rules` section stating the rule in one bullet, a canonical-home table row, and the five bullets whose mechanics moved condensed to the rule plus a link. Two things deliberately stay in the always-loaded file rather than moving: the canonical claims (each affected bullet says it and the rules file are together canonical, the requirement here and the mechanics there), and the requirement to run the adversarial pass in a context that did not write the change, which has to fire before an agent thinks to open a link.
- **`scripts/check_context_budget.py`** — docstring and failure message now name both destinations for moved mechanics, `docs/pull-request-workflow.md` for the ones that are commands and `.agents/rules/` for the ones that are prose. `BUDGET` is unchanged at 38,000.
- **`.agents/skills/review-adversarial/SKILL.md`** — Angle H now reads `.agents/rules/` alongside `AGENTS.md`/`CLAUDE.md`. Without this the pass sees a rule's one-line statement but not its exceptions, and flags exempt code.
- **`docs/pull-request-workflow.md`**, **`docs/README.md`**, **`docs/site/src/content/docs/contributing.md`**, **`.agents/skills/review-preflight/SKILL.md`**, **`.github/PULL_REQUEST_TEMPLATE.md`** — reconciled to the new ownership. `docs/pull-request-workflow.md` declares that it owns the pre-PR mechanics, so this change amends the split it states: by form, commands here and prose in `.agents/rules/`.

## Context

Duplicate-work scan: nothing open proposes a rules directory or code-style guidance, and nothing to claim. Overlap is merge-conflict risk only — #965, #876, and #720 edit `AGENTS.md`; #876 also edits `docs/pull-request-workflow.md`; #720 and #792 edit `contributing.md`; a dozen open PRs add rows to `docs/README.md`. The branch is rebased onto current `main` and merges clean; the one conflict that rebase produced is recorded in Self-Review, because it is evidence about this change rather than routine merge noise.

**One overlap a reviewer should decide on rather than let merge quietly.** #965 raises `BUDGET` from 38,000 to 38,500, with a committed comment justifying the raise by the headroom on `main` at the time — "37,760 by then — 240 chars of headroom for the whole repository". This branch reclaims 2.7k. The two `check_context_budget.py` edits sit in different hunks and would merge cleanly, leaving `main` with a raised budget defended by a figure that no longer holds; #965 is separately `CONFLICTING` against `main` right now, so it has to rebase regardless, which is the moment to drop or re-argue the raise.

## Testing

- `make docs-check` — clean at the head. All five sub-targets: generated regions current, relative links resolve in 281 files, terminology passes, the map covers all 248 tracked docs with no re-aligned rows, and the context budget reports 35.3k against 38,000.
- `prettier@3.9.6 --check` (the version `.github/workflows/prettier.yml` pins) on every changed Markdown file — clean.
- **Content-loss check**, because a refactor that silently drops a sentence is the failure mode here. Every sentence in the pre-change `AGENTS.md` was normalised for whitespace and link paths and searched for in the union of the post-change `AGENTS.md` and the three new files. Re-run at the head: of 232 sentences, 223 are found verbatim and the 9 unmatched are all accounted for — the canonical-home table (a row was added, so it re-padded), the `make docs-check` sentence (now says which files the map exempts), the two GitHub Actions bullet leads that became `##` headings with their bodies intact, and the five deliberate rewrites named under What Changed. Nothing is missing. Two of the three passes under Self-Review ran this independently and agreed.
- No Go, Python behaviour, Dockerfile, or chart changes, so `go build`, the agent-runner Docker build, the image-layer budget, and pytest have nothing to run against. `scripts/check_context_budget.py`'s edits are to its docstring and one print string; the file parses and runs.

### Live validation

Not live-tested. `.agents/` is repository tooling that is never baked into an agent image — verified by grep that nothing in `deploy/`, `deploy/docker/Dockerfile`, `.dockerignore`, the `Makefile`, or `scripts/generate_docs.py` references it — so no running installation can observe this change at any layer. There is no CR `.status`, Deployment env, or in-pod file for it to reach. Two of the three passes below confirmed this independently, the third by re-running the same greps at the head. No test artifacts, no install touched, no lease taken.

## Self-Review

Three passes are reflected here. The two required ones — adversarial and docs-drift — each ran in **its own subagent handed the diff range and nothing else**, no plan, no reasoning, no commit bodies, and both were re-run in fresh subagents after the first round's fixes and a rebase onto current `main`. A third pass then read the branch from a **separate worktree and session that had written none of it**, and found four things the first two missed, one of them only when the branch was rebased. Its fixes are in `88c618bb` and `2db2ec4c`, and they were written in that same session — so the fixes themselves have not been through an independent pass, and are the part of this branch with the least review on it. The list below is the current state, not a round-by-round history.

**What the adversarial pass looked for:** all ten angles, with these carrying the weight — the change's claimed intent against what the diff does (a refactor that also introduces a binding standard), conventions and docs (Angle H), operational blast radius on the CI rules being condensed, and Angle J, the interaction with open pull requests. **What docs-drift looked for:** the deletion audit, identifiers in the moved text re-derived from source rather than from the old prose, cross-references left behind in other documents, map staleness, hard-coded counts, and generated regions. **What the third pass looked for:** what the always-loaded file stopped saying, every factual claim in the three new files re-derived from source, the content-loss audit re-run independently, and whether the branch still merges.

Findings and dispositions:

- **The clean-context requirement fell out of the always-loaded file.** Moving the adversarial-self-review mechanics to `pre_pr_review.md` took with them "run the pass in a context that did not write the change" and the reason agents need telling it — that they are instructed not to spawn subagents unprompted, so invoking `/pr-preflight` is that ask. What was left behind said only "run the skill against your branch diff", which an agent satisfies by running it inline in the session that wrote the code. `docs/pull-request-workflow.md` states the criterion this breaks, and this diff adds a paragraph directly beneath it: anything that has to fire before an agent thinks to open a link belongs on the always-loaded side. Third pass, MEDIUM. **Fixed** in `338f7cb1` — both clauses are back in the bullet, the pointer below it now names the reasoning `pre_pr_review.md` holds rather than repeating `/pr-preflight`, and that file's closing sentence, whose premise the fix invalidated, is rewritten. Costs 0.3k of the reclaimed headroom.
- **The moved copy went stale within days, which is the standing cost of this change.** Rebasing onto `main` conflicted in exactly one place: #1058 renamed `rc-deploy-environment.yml` to `deploy-environment.yml` and corrected the exemption list in `AGENTS.md` — inside the block this branch deletes and re-homes in `.agents/rules/github_actions.md`. Resolving the textual conflict the obvious way, by keeping the branch's condensed bullet, would have reverted that correction, because the corrected name only ever existed in the deleted block. Third pass, MEDIUM. **Fixed** — the rename is carried into `github_actions.md` in the first commit, so no commit in this branch stands alone reverting #1058, and `rc-deploy-environment.yml` now appears nowhere in the tree. **The general case is not fixed and cannot be by this change:** prose that leaves `AGENTS.md` can fall out of step with what it describes, and nothing catches it — `make docs-check` validates links, terminology, and the map, none of which reach a workflow filename quoted inside `.agents/`, which the map exempts by design. That is the trade this pull request asks for, and it surfaced on the branch's first encounter with a moving `main` rather than in the abstract. A reviewer who thinks the trade is wrong should say so here.
- **"Nothing in CI checks either one" is an absolute this change introduced and cannot support.** An org-managed `pull_request_target` workflow — `github_actions_scan.yml`, which is not in this repository — runs zizmor 1.25.2 over the workflow files and posts four checks. It is report-only (`ZIZMOR_ENFORCE: false`) and its config lives in a private bucket, so what it enforces is not observable from here; the flat claim is not defensible either way. Third pass, LOW. **Fixed** — narrowed to "no check in this repository blocks either one", which is verifiable. This also closes the SHA-pin enforcement question the previous round left open, below.
- **Angle H's edit left one line at ~110 chars** in a file wrapped at 100. `proseWrap` is `preserve`, so prettier passes and CI never sees it, but it reads as a ragged diff. Third pass, LOW. **Fixed** — paragraph rewrapped.
- **`docs/pull-request-workflow.md` said the pre-PR passes were "the one exception"** to its command-mechanics ownership, which `github_actions.md` in the same diff contradicts. Adversarial, MEDIUM, CONFIRMED. **Fixed** — the split is now stated by form rather than by topic, and names both files.
- **The rule's scope was unbounded in the always-loaded file.** "Every hardcoded value gets a name declared at the top of the file" reads, in a file carrying eighty literals, as an obligation to hoist all of them during a one-function edit — which collides with "Keep changes scoped to the request". Adversarial, MEDIUM, CONFIRMED. **Fixed** — both `AGENTS.md` and `core_engineering.md` now say the rule binds the lines you write, not the file they land in, and `core_engineering.md` names the scope rule it would otherwise break.
- **The condensed pin bullet dropped the trailing-comment requirement and the pin rule's exemption**, and routed only guard decisions to the rules file, so an agent pinning an action was never sent to the file holding the format. Adversarial, LOW, CONFIRMED. **Fixed** — the format is back in the always-loaded bullet, both exemptions are named, and the routing now fires on any `uses:` line or trigger change.
- **`docs/README.md`'s `AGENTS.md` inventory row was stale** — no Engineering Rules section, and "the commands that carry them out live in `docs/pull-request-workflow.md`" became half the picture. Adversarial LOW CONFIRMED and docs-drift Advisory, same defect. **Fixed** in that row's cells only; no re-alignment, and `docs-check-map` confirms it.
- **`check_context_budget.py`'s failure message still named only `docs/pull-request-workflow.md`** after the docstring was updated — one file, two answers. Docs-drift Advisory. **Fixed.**
- **The adversarial pass could not reach the rule it is named as enforcing.** Angle H reads `AGENTS.md`/`CLAUDE.md`, never `.agents/rules/`, so it would see the one-line rule without its exceptions and flag array indices and test fixtures. Docs-drift Advisory. **Fixed** two ways: the exceptions are named inline in the `AGENTS.md` bullet, and Angle H now reads `.agents/rules/` alongside the instruction files.
- **"Change whichever of the two owns what you are changing"** had two other documents named in the clause before it. Adversarial, LOW, CONFIRMED. **Fixed** at both occurrences by naming the two.
- **An earlier round found the same dangling-referent problem** in `pre_pr_review.md`, where a moved bullet said "the docs-drift pass below" in a file that mentions docs-drift nowhere else. **Fixed** before that round closed; the re-run found nothing further there.
- **The new rule rides along in a reorganisation and arguably deserves its own PR.** Adversarial, MEDIUM, CONFIRMED as a scope finding — a reviewer reading a diff framed as a refactor may approve a standard they did not evaluate. **Deliberately not split**, and the reason is about this change: the rule cannot land alone, because the budget rejects it, and the refactor has no motivation alone. Split, the two halves are a change that fails CI and a change with no argument. Mitigated instead by naming the standard in the title, first in What Changed, and here.
- **Two canonical-home rows can both be read as owning pre-PR mechanics**, and the commands-vs-prose distinction is only stated in `docs/pull-request-workflow.md`. Docs-drift Advisory, marked optional. **Deliberately not fixed**: the existing row already says "commands" and the new one says "rules an agent follows, by family", and the first cell has six characters of slack before the table re-aligns — which `AGENTS.md` forbids and `docs-check-map` fails on.
- **The moved bullets keep the `**Bold lead:** explanation` form** the Documentation Guidelines discourage outside `SKILL.md`. Docs-drift, raised for the record. **Deliberately not changed** — they are verbatim moves, and rewriting them would hide what moved behind what was reworded, in the one change where that distinction is the thing a reviewer needs to check.
- **`.agents/rules/` filenames are snake_case where `.agents/skills/` is kebab-case.** Third pass raised this and then **withdrew it**: 28 tracked Markdown files use snake_case, including the whole `agents/platform/docs/*_sop.md` family, so the new files match existing practice. Recorded because it was raised, not because it stands. No rename.

**What the passes could not cover:** no live validation is possible (see above); the adversarial pass evaluated the new rule's scope and placement rather than whether it is a good rule; Angle J read the first hundred open pull requests, so anything older is unexamined; and the third pass's fixes have had no independent read, as noted above. The previous round left open whether checkov or another scanner independently enforces SHA pinning — partly answered now: `.checkov.yaml` carries path-skips only, and the org-level zizmor scan is report-only with a config not visible from this repository, which is why the claim was narrowed rather than restated.

**No automated review has run on this change.** `kube-agents-bot` returned "Review did not complete" in nine seconds on both the automatic pass at open and a `/review` retrigger at the head. It is not specific to this pull request — #1039, #1040, #1043, #1044, and #1046 all show the same, so the bot is down repository-wide and no human has been auto-assigned to any of them, since `auto_request_review.yml` waits for a check that cannot go green. This change has had three author-side passes and no independent one.

## Risk & Rollout

Documentation and repository tooling only; no runtime code path, no chart, no manifest, nothing shipped in an agent image. The one behavioural change is to a review skill (Angle H reads one more directory) and to a check script's output strings. Reverting is a single revert with no migration — the only cost is that `AGENTS.md` goes back over budget, so anything merged in the meantime that spent the reclaimed headroom would need to come back out with it. Nothing has to happen at merge time except the `BUDGET` question under Context. The standing cost after merge is the one Self-Review records second: three new files of prose describe things that live elsewhere in the tree — workflow filenames, script paths, skill sections — and no check ties them to their sources. `.agents/skills/` has carried the same exposure since it was created; this adds three files to it.

Generated with the help of Claude Opus 5 (Claude Code).
