### PR TITLE
fix(ci): sweep cluster-scoped chart resources in teardown, regardless of Helm state

### DIFF
--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -7,7 +7,11 @@
 #
 # One `helm uninstall` (the release owns every Kubernetes object ci-deploy.sh
 # created) plus an explicit CRD delete, since the chart leaves CRDs behind by
-# Helm's own design.
+# Helm's own design, plus an unconditional label sweep of every cluster-scoped
+# kind the chart or the operator can create — because a run killed mid-install
+# leaves cluster-scoped objects with no Helm release record for `helm
+# uninstall` to act on, and Helm then refuses to adopt them on the project's
+# next lease (#1006).
 # ==============================================================================
 
 set -uo pipefail
@@ -61,6 +65,45 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 2: Deleting CRDs ==="
 # not accumulate them.
 kubectl delete -f charts/kube-agents/crds/ --ignore-not-found || true
 echo "✓ CRD deletion finished in $((SECONDS - STEP_START))s"
+
+STEP_START=$SECONDS
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kube-agents resources ==="
+# Belt-and-braces sweep, independent of Helm release state (#1006). A run
+# killed mid-install or mid-teardown can leave cluster-scoped objects behind
+# with no release record for Step 1's `helm uninstall` to act on — and Helm
+# then refuses to adopt them on the project's next lease ("invalid ownership
+# metadata"), failing every subsequent PR that Boskos hands this project.
+# Namespace deletion never catches these: they are cluster-scoped by
+# construction.
+#
+# The kinds below are the full audit of what the chart renders
+# (agent-rbac-admission-policy.yaml, operator-rbac.yaml, operator-webhooks.yaml)
+# and what the operator applies at reconcile time (reconcileRBAC and the
+# credential-broker TokenReview pair in platformagent_controller.go). All of
+# them carry app.kubernetes.io/part-of=kube-agents — the label contract in
+# docs/site/src/content/docs/reference/resource-labels.md — except the CRDs,
+# which Step 2 already deletes by file because Helm's crds/ convention installs
+# them unlabelled.
+#
+# One kind per call, each `|| true`: an API group missing from this cluster
+# (ValidatingAdmissionPolicy needs 1.30+) or one flaky delete must not stop
+# the sweep of the kinds that do exist, and nothing here may change the
+# teardown's exit code. This block must stay reachable on every path through
+# the script — steps before it end in `|| true` and there is no `set -e`; the
+# only early exits are the two must-not-delete-the-wrong-cluster guards above.
+SWEEP_SELECTOR="app.kubernetes.io/part-of=kube-agents"
+SWEEP_KINDS=(
+  validatingadmissionpolicies.admissionregistration.k8s.io
+  validatingadmissionpolicybindings.admissionregistration.k8s.io
+  mutatingwebhookconfigurations.admissionregistration.k8s.io
+  validatingwebhookconfigurations.admissionregistration.k8s.io
+  clusterroles.rbac.authorization.k8s.io
+  clusterrolebindings.rbac.authorization.k8s.io
+)
+for SWEEP_KIND in "${SWEEP_KINDS[@]}"; do
+  kubectl delete "${SWEEP_KIND}" -l "${SWEEP_SELECTOR}" --ignore-not-found || true
+done
+echo "✓ Cluster-scoped sweep finished in $((SECONDS - STEP_START))s"
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/tests/test_ci_teardown_sweep.py
+++ b/tests/test_ci_teardown_sweep.py
@@ -1,0 +1,169 @@
+"""The teardown's cluster-scoped sweep runs on every path, whatever Helm says.
+
+#961 gave the chart its first cluster-scoped resources (two
+ValidatingAdmissionPolicies and their bindings), and #1006 is what happened
+next: a run killed mid-flight left the policy behind with no Helm release
+record, `helm uninstall` had nothing to act on, and every later lease of the
+project died at deploy on "cannot be imported into the current release" until
+a human deleted the object. Namespace deletion cannot catch a cluster-scoped
+object by construction, so `hack/ci-teardown.sh` carries an unconditional
+label sweep — and these tests pin the three properties that make it a fix
+rather than a decoration:
+
+* it deletes every audited cluster-scoped kind by the part-of label, with
+  --ignore-not-found;
+* it still runs when the steps before it (helm uninstall, the CRD delete)
+  have failed, because the aborted-run case is the whole point;
+* a failing kubectl neither stops the sweep at the first kind nor changes
+  the teardown's exit code.
+
+The steps are lifted from the script's own text and executed under bash with
+stubbed kubectl/helm, so the assertions are against the code that ships
+rather than a copy (the same approach as tests/test_ci_gitops_repo.py and
+scripts/test_ci_eval_trap.py). The lift starts after the get-credentials and
+context guards: those two are must-not-delete-the-wrong-cluster exits, the
+one path on which the sweep is *supposed* to be unreachable.
+"""
+
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_TEARDOWN = _REPO_ROOT / "hack" / "ci-teardown.sh"
+
+# Everything from here to end-of-file is the teardown proper — the steps that
+# run once the auth and context guards have passed. Asserted present below, so
+# a rename fails here loudly instead of silently shrinking what is tested.
+_STEPS_START = "START_TIME=$SECONDS"
+
+# The audit of #1006: every cluster-scoped kind the chart renders
+# (agent-rbac-admission-policy.yaml, operator-rbac.yaml, operator-webhooks.yaml)
+# or the operator applies at reconcile time (reconcileRBAC, the
+# credential-broker TokenReview pair). Repeated here on purpose rather than
+# parsed out of the script: a test that derives the expected list from the
+# list under test asserts nothing. The chart's CRDs are absent because they
+# install unlabelled and the teardown deletes them by file.
+_SWEPT_KINDS = (
+    "validatingadmissionpolicies.admissionregistration.k8s.io",
+    "validatingadmissionpolicybindings.admissionregistration.k8s.io",
+    "mutatingwebhookconfigurations.admissionregistration.k8s.io",
+    "validatingwebhookconfigurations.admissionregistration.k8s.io",
+    "clusterroles.rbac.authorization.k8s.io",
+    "clusterrolebindings.rbac.authorization.k8s.io",
+)
+
+_SELECTOR = "app.kubernetes.io/part-of=kube-agents"
+
+
+def _teardown_steps():
+    text = _CI_TEARDOWN.read_text(encoding="utf-8")
+    start = text.find(_STEPS_START)
+    assert start != -1, f"{_STEPS_START!r} not found in hack/ci-teardown.sh"
+    return text[start:]
+
+
+class CiTeardownSweepTest(unittest.TestCase):
+    maxDiff = None
+
+    def _run_steps(self, kubectl_exit=0, helm_exit=0):
+        """Run the teardown steps with recording stubs.
+
+        Returns (returncode, kubectl argv lines, stderr). Each stub appends
+        its argv to a log and exits with the requested code, so a test can
+        make any step "fail" and watch what still runs after it.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            log = tmp_path / "kubectl.log"
+            log.touch()
+            for tool, code in (("kubectl", kubectl_exit), ("helm", helm_exit)):
+                stub = bin_dir / tool
+                stub.write_text(
+                    "#!/usr/bin/env bash\n"
+                    + (f'echo "{tool} $*" >> "{log}"\n')
+                    + f"exit {code}\n",
+                    encoding="utf-8",
+                )
+                stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+            # set -uo pipefail mirrors the script's own header; NAMESPACE is
+            # the one variable the lifted steps read that the head sets.
+            proc = subprocess.run(
+                ["bash", "-c", "set -uo pipefail\n" + _teardown_steps()],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+                env=get_isolated_test_env(
+                    bin_dir=bin_dir, overrides={"NAMESPACE": "kubeagents-system"}
+                ),
+            )
+            calls = log.read_text(encoding="utf-8").splitlines()
+        return proc.returncode, calls, proc.stderr
+
+    def _sweep_calls(self, calls):
+        return [c for c in calls if c.startswith("kubectl delete") and "-l" in c.split()]
+
+    # --- (a) the sweep issues the right deletes ----------------------------
+
+    def test_every_audited_kind_is_swept_by_label(self):
+        rc, calls, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        sweeps = self._sweep_calls(calls)
+        for kind in _SWEPT_KINDS:
+            with self.subTest(kind=kind):
+                matching = [c for c in sweeps if kind in c.split()]
+                self.assertEqual(
+                    len(matching), 1, f"expected exactly one sweep of {kind}: {sweeps}"
+                )
+                argv = matching[0].split()
+                self.assertIn(_SELECTOR, argv)
+                self.assertIn("--ignore-not-found", argv)
+
+    def test_the_sweep_selects_by_label_never_by_bare_kind(self):
+        """A delete of a whole cluster-scoped kind with no selector would take
+        GKE's own objects with it; every sweep line must carry -l."""
+        rc, calls, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        for kind in _SWEPT_KINDS:
+            for call in [c for c in calls if kind in c.split()]:
+                argv = call.split()
+                self.assertIn("-l", argv, f"unselectored delete of {kind}: {call}")
+                self.assertIn(_SELECTOR, argv)
+
+    # --- (b) reachability after earlier failures ---------------------------
+
+    def test_sweep_still_runs_when_helm_uninstall_fails(self):
+        """The aborted-run case: no release record, `helm uninstall` red."""
+        rc, calls, err = self._run_steps(helm_exit=1)
+        self.assertEqual(rc, 0, err)
+        sweeps = self._sweep_calls(calls)
+        for kind in _SWEPT_KINDS:
+            with self.subTest(kind=kind):
+                self.assertTrue(any(kind in c.split() for c in sweeps), sweeps)
+
+    # --- (c) kubectl failure changes nothing --------------------------------
+
+    def test_kubectl_failure_neither_stops_the_sweep_nor_reds_the_teardown(self):
+        rc, calls, err = self._run_steps(kubectl_exit=1, helm_exit=1)
+        self.assertEqual(rc, 0, err)
+        sweeps = self._sweep_calls(calls)
+        # Every kind is still attempted: one kind's failure must not eat the
+        # deletes of the kinds after it.
+        for kind in _SWEPT_KINDS:
+            with self.subTest(kind=kind):
+                self.assertTrue(any(kind in c.split() for c in sweeps), sweeps)
+
+    # --- the file itself -----------------------------------------------------
+
+    def test_ci_teardown_parses(self):
+        subprocess.run(["bash", "-n", str(_CI_TEARDOWN)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Incident

A run killed mid-flight on `kube-agents-evals` left the `kube-agents-agent-readonly` ValidatingAdmissionPolicy (added by #961 — the chart's first cluster-scoped resources) orphaned with no Helm release record. `helm uninstall` had nothing to act on, namespace deletion cannot touch a cluster-scoped object by construction, and Helm refuses to adopt a resource it does not own — so every subsequent lease of that project died at deploy with `exists and cannot be imported into the current release: invalid ownership metadata`, redding PRs at random until a human deleted the object by hand. Full write-up in #1006. This PR makes `hack/ci-teardown.sh` sweep every cluster-scoped kind the chart or the operator can create, by label, unconditionally — independent of Helm release state.

## Audit: every cluster-scoped resource this project creates today

Verified two ways: `helm template` at kube-version 1.31 with every optional component enabled, and a read of the operator's apply paths (`applyManaged` stamps the common labels on everything the controller writes).

| Kind | Object(s) | Created by | Identifying label | Swept how |
| --- | --- | --- | --- | --- |
| ValidatingAdmissionPolicy | `kube-agents-agent-readonly`, `kube-agents-agent-binding-scope` | chart `agent-rbac-admission-policy.yaml` (default on k8s >= 1.30) | `app.kubernetes.io/part-of: kube-agents` (already in the template) | new Step 3 label sweep |
| ValidatingAdmissionPolicyBinding | same two names | same | same | Step 3 |
| ClusterRole | `<release>-<ns>-operator-role` | chart `operator-rbac.yaml` | `kube-agents.labels` (includes `part-of`) | Step 3 |
| ClusterRoleBinding | `<release>-<ns>-operator-rolebinding` | chart `operator-rbac.yaml` | same | Step 3 |
| ClusterRole | `kubeagents:minimal:<ns>:<name>`, `kubeagents:tokenreview:<ns>:<name>` | operator (`reconcileRBAC`, credential-broker split) via `applyManaged` → `commonLabels` | `part-of=kube-agents` stamped at apply | Step 3 |
| ClusterRoleBinding | `kubeagents:minimal:<ns>:<name>`, `kubeagents:tokenreview:<ns>:<name>` | operator, via `applyManaged` | same | Step 3 |
| MutatingWebhookConfiguration / ValidatingWebhookConfiguration | `<release>-<ns>-{mutating,validating}-webhook-configuration` | chart `operator-webhooks.yaml` — `operator.webhooks.enabled=false` by default and not enabled by `ci-deploy.sh` | `kube-agents.labels` | Step 3 (defensive: the chart *can* create them, so teardown knows about them) |
| CustomResourceDefinition | `platformagents.kubeagents.x-k8s.io`, `agentplugins.kubeagents.x-k8s.io` | chart `crds/` (Helm installs these unowned **and unlabelled** — no `part-of`) | none | existing Step 2 delete-by-file, unchanged |

Notes from the audit:

- The issue names one VAP; there are **two** policies and two bindings (`kube-agents-agent-binding-scope` is the second pair). A name-based delete would have missed half of them; the label sweep gets both.
- The VAP/VAPB templates already carry `app.kubernetes.io/part-of: kube-agents` (set deliberately — the template's own comment says `part-of` is the label every documented cleanup query selects on), so no template change was needed. The label contract is documented in `docs/site/src/content/docs/reference/resource-labels.md`, which already calls cluster-scoped RBAC "the objects most easily orphaned".
- On the pre-#961 question in the issue: the chart-owned operator ClusterRole/Binding were only ever removed by `helm uninstall`, and the operator-created ones only by the CR finalizer path inside it — so yes, an aborted run could always orphan those. We have been lucky; they never poisoned a deploy because their names are release-/CR-derived and Helm re-adopts nothing it isn't asked to own... until the fixed-name VAPs arrived. The sweep now covers all of them either way.

## The sweep

One kind per `kubectl delete`, fully-qualified group names, `--ignore-not-found`, each `|| true` — so an API group missing from the cluster (VAP needs 1.30+) or one flaky delete cannot stop the sweep of the remaining kinds, and nothing in it can change the teardown's exit code. The script runs `set -uo pipefail` with no `-e`, and every step before the sweep ends in `|| true`, so the sweep is reachable on every path through the script; the only earlier exits are the two wrong-cluster guards (failed `get-credentials`, kubectl-context mismatch), which are exactly the paths on which deleting things would be wrong.

## Which abort shapes this covers

`hack/ci-teardown.sh` has no caller in this repo — the presubmit wires it up in `oss-test-infra`, which is out of reach of this PR. Precisely:

- **Covered:** every run whose teardown step starts and passes the wrong-cluster guards — including runs where the deploy or eval step failed, where the Helm release record is missing or corrupt (the #1006 shape), and where `helm uninstall` itself fails.
- **Not covered:** aborts that prevent the teardown step from starting at all — Prow abort on a new push (SIGTERM), pod eviction, a job timeout that kills the pod. Whether teardown runs on those is decided by the job wiring in `oss-test-infra`, not here.
- **Backstop for the uncovered shapes:** the Boskos janitor is *not* it — `docs/site/src/content/docs/deploy/ci-pool-projects.md` §8 records that the janitor is deliberately disabled for `kube-agents-evals-project` to preserve the long-lived `platform-agent-host` cluster, and no janitor/cleaner config lives in this repo. The practical backstop is the sweep's own unconditionality: because it runs on every teardown regardless of what this run installed, a project poisoned by a hard abort now self-heals at its **next** lease's teardown — one red run at worst, instead of red-forever-until-a-human-intervenes. Two follow-ups worth considering, not done here: mirror the sweep as a pre-flight in `ci-deploy.sh` to remove even that one red run, and carry the same sweep into the janitor path if it is ever enabled for this pool.

## Tests

New `tests/test_ci_teardown_sweep.py` (auto-discovered via `PYTHON_TEST_DIRS`), following the repo's lift-and-run convention (`tests/test_ci_gitops_repo.py`, `scripts/test_ci_eval_trap.py`): the teardown steps are lifted from the script's own text and executed under `set -uo pipefail` with recording kubectl/helm stubs. It pins: (a) every audited kind is deleted exactly once, by the `part-of` selector, with `--ignore-not-found` — and never as a bare unselectored kind, which on a live cluster would take GKE's own objects with it; (b) the sweep still runs when `helm uninstall` fails; (c) kubectl failing everywhere neither stops the sweep at the first kind nor changes the teardown's exit code.

```
$ python3 -m unittest tests.test_ci_teardown_sweep -v
...
----------------------------------------------------------------------
Ran 5 tests in 2.349s

OK

$ python3 scripts/test_task_registration.py
..........................................................
----------------------------------------------------------------------
Ran 58 tests in 1.094s

OK

$ python3 -m unittest tests.test_ci_gitops_repo        # Ran 15 tests ... OK
$ python3 scripts/test_ci_eval_trap.py                 # Ran 5 tests ... OK
$ python3 -m unittest tests.test_admission_policy_shipped  # Ran 17 tests ... OK

$ bash -n hack/ci-teardown.sh && echo BASH_N_OK
BASH_N_OK
```

`shellcheck -x hack/ci-teardown.sh` delta vs main: **empty** — the same two pre-existing findings (SC2164 on the header `cd`, SC1091 info on the sourced env file) on both sides, line numbers shifted only.

Fixes #1006. Part of #897. Prerequisite for making pull-kube-agents-smoke-test a required check (#1020).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
