### PR TITLE
fix(audit): make the ledger body file readable across the #955 uid split, and fail loudly instead of falling back to a private tmp dir

### DIFF
--- a/agents/platform/scripts/github_scan_gate.py
+++ b/agents/platform/scripts/github_scan_gate.py
@@ -411,18 +411,34 @@ def _post_body(provider, repo: str, pr, body: str) -> None:
     in its own filesystem; `/tmp` is a per-container emptyDir, so a
     `--body-file /tmp/…` path names a file the other container cannot open. The
     refusal then fails with "no such file" — observed live before this moved.
-    `audit_report._write_temp` documents the same trap. Falls back to the system
-    temp directory when the volume is absent, so tests still run off-cluster.
+    `audit_report._write_temp` documents the same trap, and a second one: since
+    #955 the sandbox (uid 10000) and the sidecar (uid 10001) are different
+    users, so the 0600 file `NamedTemporaryFile` creates must be `fchmod`ed
+    group-readable or the sidecar cannot open it even on the shared volume.
+
+    NO fallback to the system temp directory when the volume is absent: the
+    sidecar can never see this container's private tmp, so in-cluster that
+    fallback turned a fixable mount problem into a guaranteed failure that read
+    as a graceful degrade (#1030). Raise instead — the per-sweep try in `main`
+    turns it into a warning the room sees. Tests patch SCRATCH_DIR.
     """
-    directory: str | None = SCRATCH_DIR
     try:
         Path(SCRATCH_DIR).mkdir(parents=True, exist_ok=True)
-    except OSError:
-        directory = None
-    handle = tempfile.NamedTemporaryFile(
-        "w", encoding="utf-8", suffix=".md", delete=False, dir=directory
-    )
+        handle = tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=".md", delete=False, dir=SCRATCH_DIR
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            "publish path broken: cannot stage a body file in the shared "
+            f"scratch directory {SCRATCH_DIR} (uid {os.getuid()}): {exc}. "
+            "The credential sidecar resolves body-file paths in its own "
+            "filesystem, so a container-private temp file can never work — "
+            "fix the shared mount/permissions (see gke-labs/kube-agents#1030)."
+        ) from exc
     try:
+        # Group-readable across the #955 uid split; owner-only is unreadable
+        # to the sidecar that actually runs `gh`.
+        os.fchmod(handle.fileno(), 0o664)
         handle.write(body)
         handle.close()
         provider.post_comment(repo, pr, handle.name)

--- a/agents/platform/scripts/test_github_scan_gate.py
+++ b/agents/platform/scripts/test_github_scan_gate.py
@@ -569,12 +569,61 @@ class PostBodyTest(unittest.TestCase):
                 gate._post_body(recorder, "acme/toolkit", make_pr(), "x")
             self.assertFalse(Path(recorder.path).exists())
 
-    def test_an_absent_volume_falls_back_rather_than_crashing(self):
-        """Off-cluster there is no /opt/data, and the unit tests still run."""
+    def test_the_body_file_is_group_readable_across_the_uid_split(self):
+        """Since #955 the sidecar running `gh` is a different uid; the 0600
+        file `NamedTemporaryFile` creates is unreadable to it even on the
+        shared volume, so the group bits are load-bearing."""
+        import os as _os
+        import tempfile as _tempfile
+
+        modes = []
         recorder = self._Recorder()
-        with mock.patch.object(gate, "SCRATCH_DIR", "/proc/nonexistent/scratch"):
-            gate._post_body(recorder, "acme/toolkit", make_pr(), "x")
-        self.assertEqual(recorder.body, "x")
+        original = recorder.post_comment
+
+        def post_and_stat(repo, pr, body_file):
+            modes.append(_os.stat(body_file).st_mode)
+            original(repo, pr, body_file)
+
+        recorder.post_comment = post_and_stat
+        with _tempfile.TemporaryDirectory() as shared:
+            with mock.patch.object(gate, "SCRATCH_DIR", shared):
+                gate._post_body(recorder, "acme/toolkit", make_pr(), "the refusal")
+        self.assertEqual(
+            modes[0] & 0o060,
+            0o060,
+            f"body file is {oct(modes[0] & 0o777)}: the sidecar can only read "
+            "it through the group bits",
+        )
+
+    def test_an_unusable_volume_fails_loudly_with_no_private_tmp_file(self):
+        """The old silent fallback to the system temp dir guaranteed failure
+        in-cluster — the sidecar can never see this container's private tmp —
+        while looking like a graceful degrade (#1030). It must raise instead,
+        and leave nothing behind in the private temp dir."""
+        import tempfile as _tempfile
+
+        recorder = self._Recorder()
+        with _tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "readonly"
+            parent.mkdir()
+            parent.chmod(0o500)
+            private = Path(tmp) / "private-tmp"
+            private.mkdir()
+            try:
+                with mock.patch.object(
+                    gate, "SCRATCH_DIR", str(parent / "scratch")
+                ), mock.patch.object(_tempfile, "tempdir", str(private)):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        gate._post_body(recorder, "acme/toolkit", make_pr(), "x")
+            finally:
+                parent.chmod(0o700)
+            message = str(ctx.exception)
+            self.assertIn("publish path broken", message)
+            self.assertIn("#1030", message)
+            self.assertIsNone(
+                recorder.path, "nothing must be posted from a private file"
+            )
+            self.assertEqual(list(private.iterdir()), [])
 
 
 # ---------------------------------------------------------------------------
@@ -667,6 +716,19 @@ def make_comment(
 
 
 class PrCommentsSweepTest(unittest.TestCase):
+    def setUp(self):
+        # A refusal posts through `_post_body`, which stages the body on the
+        # shared volume and — since the silent private-tmp fallback died with
+        # #1030 — raises where /opt/data does not exist. Off-cluster that is
+        # here, so point it at a directory that does.
+        import tempfile as _tempfile
+
+        scratch = _tempfile.TemporaryDirectory()
+        self.addCleanup(scratch.cleanup)
+        patcher = mock.patch.object(gate, "SCRATCH_DIR", scratch.name)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def _sweep(self, provider, repo=REPO, env=None, repo_error=None, dry_run=False):
         target = mock.Mock(side_effect=repo_error) if repo_error else mock.Mock(return_value=repo)
         with mock.patch.object(forge, "target_repo", target), \

--- a/agents/platform/skills/fleet-audit/scripts/audit_report.py
+++ b/agents/platform/skills/fleet-audit/scripts/audit_report.py
@@ -4346,19 +4346,40 @@ def _write_temp(text: str, suffix: str = ".md") -> str:
     with "no such file". The shared PersistentVolumeClaim at /opt/data is the
     only filesystem both containers can see.
 
-    Falls back to the system temp directory when the PVC is absent, so the unit
-    tests and a local `--dry-run` still work off-cluster.
+    Being on the shared volume is necessary but not sufficient. Since #955 the
+    sandbox (uid 10000) and the credential sidecar (uid 10001) are different
+    users who share files only through the pod's fsGroup, and
+    `NamedTemporaryFile` creates 0600, owner-only — a file the sidecar's `gh`
+    cannot open even on the PVC. Hence the `fchmod` to group-readable below.
+
+    NO fallback to the container-private temp directory. There used to be one,
+    for the PVC-less off-cluster case, and in-cluster it converted a fixable
+    mount or permission problem into a guaranteed publish failure that *looked*
+    like a graceful degrade: the sidecar can never see this container's private
+    tmp, so every `gh` write died locally while the audit itself reported
+    nothing wrong (#1030). Off-cluster, point FLEET_AUDIT_SCRATCH_DIR at any
+    writable directory; the unit tests patch SCRATCH_DIR.
     """
-    directory: str | None = SCRATCH_DIR
     try:
         Path(SCRATCH_DIR).mkdir(parents=True, exist_ok=True)
-    except OSError:
-        directory = None
-    handle = tempfile.NamedTemporaryFile(
-        "w", suffix=suffix, delete=False, encoding="utf-8", dir=directory
-    )
-    with handle:
-        handle.write(text)
+        handle = tempfile.NamedTemporaryFile(
+            "w", suffix=suffix, delete=False, encoding="utf-8", dir=SCRATCH_DIR
+        )
+        with handle:
+            # Group-readable across the #955 uid split: the sidecar running the
+            # real `gh` is not the owner of this file.
+            os.fchmod(handle.fileno(), 0o664)
+            handle.write(text)
+    except OSError as exc:
+        raise RuntimeError(
+            "publish path broken: cannot stage a gh body file in the shared "
+            f"scratch directory {SCRATCH_DIR} (uid {os.getuid()}): {exc}. "
+            "The credential sidecar resolves --body-file paths in its own "
+            "filesystem, so a container-private temp file can never work — "
+            "fix the shared mount/permissions (see "
+            "gke-labs/kube-agents#1030), or set FLEET_AUDIT_SCRATCH_DIR when "
+            "running off-cluster."
+        ) from exc
     return handle.name
 
 

--- a/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
+++ b/agents/platform/skills/fleet-audit/scripts/test_audit_report.py
@@ -613,6 +613,61 @@ class HarnessTestCase(BaseTestCase):
 
 
 # --------------------------------------------------------------------------- #
+# The body-file handoff to the credential sidecar
+# --------------------------------------------------------------------------- #
+
+
+class WriteTempTest(BaseTestCase):
+    """The #955 uid split: the sandbox writes the body file, the sidecar's
+    `gh` — a different user — reads it. Group permissions are the only bridge,
+    and a fallback into this container's private tmp is a file the sidecar can
+    never see at all (#1030)."""
+
+    def test_the_body_file_is_group_readable_across_the_uid_split(self):
+        scratch = self.tmp_path / "scratch"
+        self.patch_attr("SCRATCH_DIR", str(scratch))
+        path = audit_report._write_temp("the report body")
+        self.addCleanup(audit_report._unlink, path)
+        self.assertTrue(
+            Path(path).is_relative_to(scratch),
+            f"{path} is not in the shared scratch directory {scratch}",
+        )
+        mode = os.stat(path).st_mode
+        self.assertEqual(
+            mode & 0o060,
+            0o060,
+            f"body file is {oct(mode & 0o777)}: the sidecar (a different uid "
+            "since #955) can only read it through the group bits",
+        )
+        self.assertEqual(Path(path).read_text(encoding="utf-8"), "the report body")
+
+    def test_an_unusable_scratch_dir_fails_loudly_with_no_private_tmp_file(self):
+        # The uid split simulated by permissions: a parent the test cannot
+        # write through stands in for a scratch mount the sandbox uid cannot
+        # create files in.
+        parent = self.tmp_path / "readonly"
+        parent.mkdir()
+        parent.chmod(0o500)
+        self.addCleanup(parent.chmod, 0o700)
+        self.patch_attr("SCRATCH_DIR", str(parent / "scratch"))
+        private = self.tmp_path / "private-tmp"
+        private.mkdir()
+        with patch.object(tempfile, "tempdir", str(private)):
+            with self.assertRaises(RuntimeError) as ctx:
+                audit_report._write_temp("body")
+        message = str(ctx.exception)
+        self.assertIn("publish path broken", message)
+        self.assertIn(str(parent / "scratch"), message)
+        self.assertIn("#1030", message)
+        self.assertEqual(
+            list(private.iterdir()),
+            [],
+            "a body file landed in the container-private temp dir, which the "
+            "sidecar can never read — the silent-fallback failure of #1030",
+        )
+
+
+# --------------------------------------------------------------------------- #
 # Rendering
 # --------------------------------------------------------------------------- #
 

--- a/deploy/shared/docker-entrypoint.sh
+++ b/deploy/shared/docker-entrypoint.sh
@@ -1417,6 +1417,19 @@ if [ -n "$BOOTSTRAP_LOCK_FD" ]; then
     exec 9>&-
 fi
 
+# 4.5 The scratch directory where scripts stage `gh --body-file` payloads for
+# the credential sidecar (audit_report._write_temp, github_scan_gate._post_body).
+# Created HERE, deterministically and under this script's umask-0002 discipline
+# (the header comment on the #955 UID split), rather than lazily by whichever
+# process reaches it first with whatever umask it happens to carry: the sandbox
+# (uid 10000) writes these files and the sidecar (uid 10001) reads them through
+# the shared fsGroup, which only works if the directory is group-accessible.
+# The chmod also repairs a long-lived PVC where a pre-#955 process already
+# created it too tight; guarded because an already-correct dir owned by the
+# peer uid may refuse the chmod, and that is fine.
+mkdir -p "$TARGET_DIR/scratch"
+chmod 0775 "$TARGET_DIR/scratch" 2>/dev/null || true
+
 # 5. Start background microservices (FastAPI proxy)
 #
 # Primary only: this binds a fixed port in the pod's shared network namespace,

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -115,6 +115,37 @@ class SharedStateGateTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertTrue(ran_setup, "the gateway container must build the shared tree")
 
+    def test_the_setup_creates_a_group_accessible_scratch_dir(self):
+        """Step 4.5: the `gh --body-file` handoff directory must exist,
+        group-accessible, before any script lazily creates it with whatever
+        umask that process happens to carry. The sandbox (uid 10000) stages
+        body files there and the credential sidecar (uid 10001) reads them
+        through the shared fsGroup — group bits are the whole bridge since the
+        #955 uid split; #1030 is what their absence looks like."""
+        with tempfile.TemporaryDirectory() as tmp:
+            home = pathlib.Path(tmp) / "data"
+            proc = subprocess.run(
+                ["sh", str(_ENTRYPOINT), "echo", "hermes", "gateway", "run"],
+                capture_output=True,
+                text=True,
+                env={
+                    "PATH": "/usr/bin:/bin",
+                    "PLATFORM_AGENT_HOME": str(home),
+                    "AGENT_SHARED_STATE_WAIT_SECS": "0",
+                },
+                timeout=60,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            scratch = home / "scratch"
+            self.assertTrue(scratch.is_dir(), "the setup must create scratch/")
+            mode = scratch.stat().st_mode
+            self.assertEqual(
+                mode & 0o070,
+                0o070,
+                f"scratch/ is {oct(mode & 0o777)}: the sidecar reaches it only "
+                "through the group bits",
+            )
+
     def test_dashboard_sidecar_skips_the_setup(self):
         proc, ran_setup = self._run(["hermes", "dashboard"])
         self.assertEqual(proc.returncode, 0, proc.stderr)


### PR DESCRIPTION
## Root cause

Since #955 split the sandbox (uid 10000) from the credential-proxy sidecar (uid 10001), the two containers share files only through group-permission discipline (`umask 0002` + the pod fsGroup). `audit_report.py`'s `_write_temp` — the function that stages every `gh --body-file` payload for the sidecar — violated it twice: `NamedTemporaryFile` creates the body file 0600, owner-only, so the sidecar's `gh` cannot read it even on the shared PVC; and on any `OSError` touching `/opt/data/scratch` it silently fell back to the container-private temp dir, which the sidecar can *never* see. The proxy logs show the resulting shape exactly: ~11 successful `gh` reads, then the one write dying locally in ~55 ms, nine cycles in a row, after which the worker improvises around its SOP (stale ledgers, bodies blanked to empty, a mid-run issue with body `"test"`, 2700s delegation timeouts). Full evidence chain: https://github.com/gke-labs/kube-agents/issues/1030#issuecomment-5456653330

## The fix, in three parts

1. **`audit_report._write_temp`**: `os.fchmod(fd, 0o664)` after create, so the group shared across the #955 uid split can read the file; and the silent private-tmp fallback is replaced by a `RuntimeError` — `publish path broken: cannot stage a gh body file in the shared scratch directory /opt/data/scratch (uid …)` — naming the directory, the uid, the errno, and #1030. `main`'s existing catch-all turns that into one actionable `FATAL:` log line the worker can report verbatim instead of improvising. Off-cluster use keeps working via the existing `FLEET_AUDIT_SCRATCH_DIR` override.
2. **`github_scan_gate._post_body`**: same two changes, adapted to that file's posture — the raise surfaces through the per-sweep `try` in `main` as a warning the room sees, without blinding the other sweeps.
3. **`deploy/shared/docker-entrypoint.sh`**: new step 4.5 creates `$TARGET_DIR/scratch` (i.e. `/opt/data/scratch`) deterministically at container start, under the entrypoint's `umask 0002` discipline, with a `chmod 0775` that also repairs a long-lived PVC where a pre-#955 process created it too tight — instead of leaving it to whichever process gets there first with whatever umask it happens to carry.

## Why the silent fallback must die

Off-cluster it was a convenience; in-cluster it is a guarantee of failure that *presents* as a graceful degrade. The sidecar resolves `--body-file` paths in its own filesystem, so a container-private temp file can never work — the fallback converts a fixable mount/permission problem into a certain publish failure while hiding the cause, which is precisely the #1030 failure mode (one report said it outright: directory permissions prevented `finish` from applying the update, and nothing in the logs said why).

## Tests

New: `WriteTempTest` in `test_audit_report.py` (group bits `stat & 0o060` asserted; unusable scratch dir raises `publish path broken … #1030` and leaves the private temp dir empty), the equivalent pair in `test_github_scan_gate.PostBodyTest`, and an entrypoint test asserting the owner's setup creates `scratch/` group-accessible. The old `test_an_absent_volume_falls_back_rather_than_crashing` asserted the buggy behaviour and is replaced by the loud-failure test; the sweep fixture now patches `SCRATCH_DIR` at a temp dir, since the fallback was what let those tests run off-cluster.

**Mutation check**: with the `os.fchmod` line deleted, `test_the_body_file_is_group_readable_across_the_uid_split` fails with `body file is 0o600: the sidecar (a different uid since #955) can only read it through the group bits`; restored, it passes.

Suites: `test_audit_report.py` 509 tests OK, `test_github_scan_gate.py` 83 tests OK, `tests/test_docker_entrypoint.py` 58 tests OK; `make validate` and `check_prompt_assets.py` pass. (`test_credential_proxy.py` / `test_install_script.py` failures under `make test-python` reproduce identically on a clean checkout of main on this host — unrelated.)

## Impact

Canary red on ~85% of smoke runs; blocks making the smoke job required.

Fixes #1030. Part of #897.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
