### PR TITLE
perf(eval): run the task matrix as a parallel fan-out of (task, repetition) units

### DIFF
--- a/docs/designs/eval-scorer.md
+++ b/docs/designs/eval-scorer.md
@@ -1070,6 +1070,15 @@ actually lives, with rung 6 as the collapse alarm underneath it.
   `150m` would still have been a guaranteed timeout, which is what made #2669 a prerequisite rather
   than a follow-up.
 
+  **The table above is serial arithmetic, and the loop is no longer serial.** `hack/ci-eval-pr.sh`
+  now runs the matrix as a bounded parallel fan-out of (task, repetition) units
+  (`EVAL_TASK_PARALLELISM`, default 4; tofu-stack units and repetitions of one task still serialize
+  among themselves). Wall clock is therefore fixed cost + roughly invocations ÷ realised
+  parallelism, where "realised" is capped by the leased project's model quota — measured on a
+  quota-constrained dev install: 16 units serial 3240s, parallelism 4 in 1022s with six units lost
+  to model 429s, parallelism 2 in 2512s with one. The serial figures in this section are the
+  fan-out's baseline; the first parallel Prow run replaces them.
+
   **One term in that is still a substitution rather than a measurement, and 1.26× is the honest
   figure.** #998 activated `rca-remediation-pr` precisely so its own smoke run would be the first
   measurement of it, so the table prices it at the fleet average. It is one of the two active tasks
@@ -1084,11 +1093,10 @@ actually lives, with rung 6 as the collapse alarm underneath it.
   `compliance-rbac-overgrant` at 2042s for three repetitions, 24% of the whole task budget on its
   own.
 
-  **It is not being raised a third time, and that is a decision rather than an oversight.** Work to
-  cut the eval's runtime is in flight separately; if it lands, the headroom returns without another
-  pull request against another repository, and a `300m` ceiling raised in the meantime would outlive
-  the reason for it. At a measured 1.26×–1.43× there is real room, so `300m` stays a follow-up
-  rather than a blocker.
+  **It is not being raised a third time, and that is a decision rather than an oversight.** The
+  fan-out above is the runtime cut that was awaited: if it realises even half its parallelism in a
+  pool project, the serial 1.26×–1.43× drops below 1× and the headroom returns without another pull
+  request against another repository. `300m` stays a follow-up rather than a blocker.
 
   The recurring failure is structural rather than arithmetical, and worth naming: **the budget lives
   in another repository**, so activating a case here spends headroom that only a separate pull

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -941,9 +941,13 @@ done
 # silently un-gate transcript-read checks.
 STATE_DIR="$(mktemp -d)"
 
-# mkdir is the mutex: atomic on every filesystem this runs on, and a crashed
-# holder is collected by `wait`, after which nothing contends. Two locks
-# serialize what genuinely cannot overlap while noop units fill the lanes:
+# mkdir is the mutex: atomic on every filesystem this runs on. A holder that
+# dies without releasing (an OOM-killed subshell releases nothing) would
+# otherwise strand every contender in a silent spin that `wait` can never
+# collect past, so acquisition carries a deadline: a unit that gives up fails
+# loudly and grades as MISSING, which is a diagnosis the gate already
+# reports. Two locks serialize what genuinely cannot overlap while noop
+# units fill the lanes:
 #   per task  -- repetitions of ONE task never overlap. Concurrent reps of a
 #                ledger-writing audit rewrite one shared ledger issue and
 #                grade each other's artifact; concurrent reps of the autoops
@@ -955,14 +959,36 @@ STATE_DIR="$(mktemp -d)"
 #                per-run isolation (own kubeconfig, gcloud config, tofu data
 #                dir) is off, and two concurrent tofu units would race the
 #                shared kubeconfig's current-context and their state locks.
-lock_acquire() { until mkdir "$1" 2>/dev/null; do sleep 3; done; }
+lock_acquire() { # <dir> [deadline-seconds]
+  local waited=0 limit="${2:-1800}"
+  until mkdir "$1" 2>/dev/null; do
+    sleep 3
+    waited=$((waited + 3))
+    if [ "${waited}" -ge "${limit}" ]; then
+      echo "ERROR: gave up on ${1} after ${limit}s; holder likely died without releasing" >&2
+      return 1
+    fi
+  done
+}
 lock_release() { rmdir "$1" 2>/dev/null || true; }
 
-run_one_unit() { # <task-path> <task-name> <rep> <reuse:true|empty> <has-stack:true|empty>
-  local task="$1" name="$2" rep="$3" reuse="$4" has_stack="$5"
+run_one_unit() { # <task-path> <task-name> <rep> <reuse:true|empty> <has-stack:true|empty> <seq>
+  local task="$1" name="$2" rep="$3" reuse="$4" has_stack="$5" seq="$6"
   local log="/tmp/eval_${name}_rep${rep}.log"
-  lock_acquire "${STATE_DIR}/lock-task-${name}"
-  [ -n "${has_stack}" ] && lock_acquire "${STATE_DIR}/lock-infra"
+  # A distinct local port per unit: the harness's port-forward is owned by
+  # the process that spawned it and its atexit teardown would drop a shared
+  # listener under every sibling mid-conversation. On its own port, each
+  # unit owns its own tunnel and keeps the harness's stale-tunnel recycling.
+  export AGENT_LOCAL_PORT=$((28642 + seq))
+  if ! lock_acquire "${STATE_DIR}/lock-task-${name}"; then
+    echo "<<< [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] ${name} rep ${rep} gave up on its task lock" >&2
+    return 0
+  fi
+  if [ -n "${has_stack}" ] && ! lock_acquire "${STATE_DIR}/lock-infra"; then
+    lock_release "${STATE_DIR}/lock-task-${name}"
+    echo "<<< [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] ${name} rep ${rep} gave up on the infra lock" >&2
+    return 0
+  fi
   if [ -n "${reuse}" ]; then
     export GKE_CLUSTER_NAME="${SEEDED_TASK_CLUSTER}" CLUSTER_NAME="${SEEDED_TASK_CLUSTER}"
     export TF_VAR_cluster_name="${SEEDED_TASK_CLUSTER}" GCP_LOCATION="${SEEDED_TASK_LOCATION}"
@@ -992,28 +1018,31 @@ run_one_unit() { # <task-path> <task-name> <rep> <reuse:true|empty> <has-stack:t
   echo "<<< [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] finished ${name} rep ${rep} in $(((end - start) / 1000))s"
 }
 
-# Cost-descending, then rep-ascending: repetitions of one task serialize on
-# the task lock, so adjacent same-task units would park a lane sleeping on
-# it -- rep-major interleaving keeps every lane doing work.
+# Rep-ascending FIRST, cost-descending within a rep: repetitions of one task
+# serialize on the task lock, so a same-task unit launched early just parks a
+# lane sleeping on it -- the pool run of 2026-08-31 (build 2094432646640701440)
+# spent two of four lanes that way for its first twelve minutes under the
+# cost-first ordering this replaces.
 UNIT_QUEUE="$(
   for REP in $(seq 1 "${EVAL_REPETITIONS}"); do
     i=0
     for TASK in "${TASKS[@]}"; do
-      printf '%s %s %s\n' "$(unit_cost_hint "${TASK_NAMES[i]}")" "${REP}" "$i"
+      printf '%s %s %s\n' "${REP}" "$(unit_cost_hint "${TASK_NAMES[i]}")" "$i"
       i=$((i + 1))
     done
-  done | sort -k1,1rn -k2,2n
+  done | sort -k1,1n -k2,2rn
 )"
 UNIT_TOTAL="$(printf '%s\n' "${UNIT_QUEUE}" | grep -c .)"
 
 profile_begin "task fan-out: ${UNIT_TOTAL} units, parallelism=${EVAL_TASK_PARALLELISM}"
-while read -r _COST REP IDX; do
+while read -r REP _COST IDX; do
   [ -n "${IDX:-}" ] || continue
   while [ "$(jobs -rp | wc -l | tr -d ' ')" -ge "${EVAL_TASK_PARALLELISM}" ]; do
     sleep 3
   done
   echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] launching ${TASK_NAMES[IDX]} rep ${REP}/${EVAL_REPETITIONS}"
-  run_one_unit "${TASKS[IDX]}" "${TASK_NAMES[IDX]}" "${REP}" "${TASK_REUSE[IDX]}" "${TASK_HAS_STACK[IDX]}" &
+  UNIT_SEQ=$((${UNIT_SEQ:-0} + 1))
+  run_one_unit "${TASKS[IDX]}" "${TASK_NAMES[IDX]}" "${REP}" "${TASK_REUSE[IDX]}" "${TASK_HAS_STACK[IDX]}" "${UNIT_SEQ}" &
   # Staggered, so N units do not open their first model call in the same
   # second -- burst 429s at the model quota are the fan-out's failure mode.
   sleep 5

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -217,6 +217,10 @@ profile_and_dump_on_exit() {
   dump_prow_artifacts_on_failure
 }
 trap profile_and_dump_on_exit EXIT
+# A Prow deadline delivers SIGTERM, which does not run the EXIT trap on its
+# own; converting it to an exit is what lets the artifact collection above
+# fire on a deadline kill.
+trap 'exit 143' TERM INT
 
 START_TIME=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running PR Smoke Test Evaluation for PR #${PR_ID} in Namespace: ${TARGET_NAMESPACE} ==="
@@ -517,12 +521,10 @@ TASKS=(
   # crashloop 142s + the two incumbents, against the deadline the
   # 2026-08-26 run blew with full audits.
   #
-  # The six probes sit ahead of the rest on purpose. The loop below is
-  # sequential (one task at a time, no BENCH_PARALLEL), so the Prow deadline
-  # truncates the TAIL of this list; none of the probes has ever executed, so
-  # their cost is unmeasured and their signal is what this change exists to
-  # produce. Ordering the unmeasured work first means a timeout loses a
-  # measured repeat, not the new signal.
+  # This list is the gate's REPORTING order. Execution order is the
+  # fan-out's cost-hinted queue below (longest units first), so a Prow
+  # deadline kills whatever is still in flight rather than truncating this
+  # list's tail.
   "./tasks/reliability-pdb-probe/task.yaml"
   "./tasks/capacity-pinned-pool-probe/task.yaml"
   "./tasks/security-overgrant-probe/task.yaml"
@@ -542,8 +544,8 @@ TASKS=(
   # rca-remediation-pr -- remediation domain. Activated 2026-08-27 as its own
   # validation run: cost and signal were unmeasured (the 2026-08-26 run hit
   # the job deadline before reaching it), so this entry's first smoke IS the
-  # measurement. Placed after the six probes (proven, ~20 min together) and
-  # before the canary so a surprise here cannot starve the probes of budget.
+  # measurement. Launch priority lives in unit_cost_hint below, not in this
+  # list's position.
   # The one active task that WRITES: it files a remediation PR against the
   # leased project's throwaway GitOps repo via submit-suggestion.
   "./tasks/rca-remediation-pr/task.yaml"
@@ -559,15 +561,10 @@ TASKS=(
   # role to a kubeconfig. It is the cheapest task in this array (142s on the
   # 2026-08-25 run) and it proves the chain the probes above stand on.
   "./tasks/cluster-agent-crashloop-debug/task.yaml"
-  # Three more cluster-debugging cases in the same family, added by #982 and
-  # placed here rather than at the head of the array. The probes above go
-  # first because they are unmeasured and the sequential loop truncates the
-  # TAIL; these three are measured -- 190s, 142s and 220s on build
-  # 2092719124550520832 -- so ordering them first would protect the known at
-  # the expense of the unknown, which is backwards. What they do need is to
-  # stay AHEAD of gpu-stress-test-diagnosis below, the first of the array's two
-  # `deployer: tofu` entries, which spends minutes provisioning a cluster
-  # before it scores anything. All three are `deployer: noop`.
+  # Three more cluster-debugging cases in the same family, added by #982:
+  # measured 190s, 142s and 220s on build 2092719124550520832, all
+  # `deployer: noop`. Position here is reporting order only; execution
+  # order is unit_cost_hint's queue.
   #
   # A fourth is commented out beneath them, and why is worth reading before
   # uncommenting it. All four are read-only: no pull request, no ledger, so
@@ -735,9 +732,11 @@ export DETERMINISTIC_CORRECTNESS_FLOOR="${DETERMINISTIC_CORRECTNESS_FLOOR:-1.0}"
 
 # Repetitions per task. Three is what the collapse rule needs: a case reds the
 # job alone only by failing ALL of them. Two-of-three would fire 1.45 times per
-# pull request by chance at suite scale; three-of-three fires 0.03 times. The
-# loop is serial (BENCH_PARALLEL=false), so this multiplies wall-clock by three
-# -- how it scales past a handful of tasks is issue #902's lane, not this one.
+# pull request by chance at suite scale; three-of-three fires 0.03 times.
+# Each repetition is one unit of the parallel fan-out below, so at
+# parallelism P this multiplies wall-clock by roughly 3/P, not 3; scale past
+# that is issue #902's lane. The serial measurements kept below predate the
+# fan-out and are its baseline.
 #
 # FOURTEEN tasks at three repetitions is FORTY-TWO devops-bench invocations,
 # where the presubmit's budget was sized for two. This number is no longer an
@@ -777,9 +776,13 @@ export DETERMINISTIC_CORRECTNESS_FLOOR="${DETERMINISTIC_CORRECTNESS_FLOOR:-1.0}"
 # separate pull request can replace, and this number was invalidated FOUR times
 # by a matrix that grew after it was computed (#956, then #982, then #998)
 # before a real run finally replaced the arithmetic. At the measured 3.6min
-# average, each further average-cost case costs ~11min of the remaining ~49-72min
-# of headroom, and a canary-cost case costs ~34min. Activating a case and raising
-# the budget are one change in two repositories, not a change and a follow-up.
+# average, each further average-cost case adds ~11min of INVOCATION time and a
+# canary-cost case ~34min -- divided by however much of EVAL_TASK_PARALLELISM
+# the fan-out below actually realises against the pool's model quota, which the
+# first parallel Prow run will measure. Until it has, budget serially: a case
+# that fits at parallelism 1 cannot be the thing that blows the deadline.
+# Activating a case and raising the budget are one change in two repositories,
+# not a change and a follow-up.
 #
 # The variance that was flagged as the thing to watch has resolved in the good
 # direction: consistency-authorized-networks-probe took 1039s on the one earlier
@@ -879,91 +882,168 @@ ARTIFACT_DIR="${ARTIFACTS:-/tmp/artifacts}"
 mkdir -p "${ARTIFACT_DIR}"
 CASE_RESULTS=()
 
+# ─── Parallel fan-out ─────────────────────────────────────────────────────────
+# The schedulable unit is one (task, repetition): every invocation is an
+# independent agent conversation, and the agent span is ~98% of its wall clock
+# (profiled 2026-08-28), so the matrix is embarrassingly parallel. The cap
+# bounds concurrent load on the one gateway, LiteLLM and the judge quota;
+# 1 reproduces serial behaviour through the same code path.
+EVAL_TASK_PARALLELISM="${EVAL_TASK_PARALLELISM:-4}"
+if ! [ "${EVAL_TASK_PARALLELISM}" -ge 1 ] 2>/dev/null; then
+  echo "ERROR: EVAL_TASK_PARALLELISM must be a positive integer, got '${EVAL_TASK_PARALLELISM}'." >&2
+  exit 1
+fi
+
+# Pre-warm the bench virtualenv once; N cold `uv run`s would sync it N times
+# concurrently.
+(cd "${BENCH_DIR}" && uv run python -c '' >/dev/null 2>&1) || true
+
+# Launch-order hints, longest first, from measured runs (2026-08-27/28).
+# A wrong hint costs packing efficiency, never correctness.
+unit_cost_hint() {
+  case "$1" in
+    gpu-stress-test-diagnosis | autoops-warning-event-triage) echo 900 ;;
+    compliance-rbac-overgrant | rca-remediation-pr) echo 700 ;;
+    consistency-authorized-networks-probe) echo 300 ;;
+    *) echo 200 ;;
+  esac
+}
+
+# Per-task env is decided ONCE, before the fan-out, and handed to each unit:
+# the serial loop exported it globally per iteration, which two concurrent
+# units would trample. Per TASK, not per repetition, so repetitions stay
+# comparable. Seeded-cluster reuse is opted into by the task's own stack --
+# only a stack declaring `variable "reuse_existing_cluster"` knows to plan
+# nothing when handed an existing cluster's name.
+TASK_NAMES=()
+TASK_REUSE=()
+TASK_HAS_STACK=()
 for TASK in "${TASKS[@]}"; do
   TASK_NAME="$(basename "$(dirname "${TASK}")")"
-  profile_begin "task ${TASK_NAME}: devops-bench run"
-  TASK_START=$SECONDS
-  echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Running Task: ${TASK_NAME} (${TASK}) x${EVAL_REPETITIONS} <<<"
-
-  # BENCH_NO_INFRA stays false for EVERY task, noop-deployer ones included.
-  # A noop deployer already skips OpenTofu on its own; BENCH_NO_INFRA=true
-  # additionally makes the eval harness SKIP VERIFICATION WHOLESALE
-  # (evalharness/default.py, verification_status "skipped_no_infra"), which
-  # silently un-gates any task whose checks read the transcript rather than a
-  # cluster -- the kanban probe's tool_called check would never evaluate.
-  #
-  # The deployer itself is no longer read here. bench-gate parses the task
-  # file with a real YAML parser (bench/kube_agents_bench/cases.py) and echoes
-  # what it found; the two greps this replaced could not tell a real
-  # `deployer:` from one inside a comment or a prompt block.
-  export BENCH_NO_INFRA="false"
-  echo "Executing with BENCH_NO_INFRA=${BENCH_NO_INFRA}"
-
-  # Seeded-cluster reuse is per task, opted into by the task's own stack:
-  # only a stack that declares `variable "reuse_existing_cluster"` knows to
-  # plan nothing when handed an existing cluster's name. Handing that name
-  # to any other tofu stack would make it try to CREATE the seeded cluster
-  # and 409 on every run in every fleet-carrying project -- so a task whose
-  # stack has not opted in gets the per-run name and location restored, and
-  # so do the {{GKE_CLUSTER_NAME}}/{{CLUSTER_NAME}} placeholders its prompt
-  # and checks resolve against.
-  #
-  # This is per TASK, not per repetition: every repetition of one task targets
-  # the same cluster, which is what makes the repetitions comparable.
+  TASK_NAMES+=("${TASK_NAME}")
   TASK_STACK="$(task_stack "${BENCH_DIR}/${TASK}")"
+  if [ -n "${TASK_STACK}" ]; then TASK_HAS_STACK+=("true"); else TASK_HAS_STACK+=(""); fi
   if [ -n "${SEEDED_TASK_CLUSTER}" ] && [ -n "${TASK_STACK}" ] \
     && grep -qs 'variable "reuse_existing_cluster"' "${BENCH_DIR}/tf/${TASK_STACK}"/*.tf; then
-    export GKE_CLUSTER_NAME="${SEEDED_TASK_CLUSTER}"
-    export CLUSTER_NAME="${SEEDED_TASK_CLUSTER}"
-    export TF_VAR_cluster_name="${SEEDED_TASK_CLUSTER}"
-    export GCP_LOCATION="${SEEDED_TASK_LOCATION}"
-    export TF_VAR_reuse_existing_cluster="true"
+    TASK_REUSE+=("true")
     echo "Task ${TASK_NAME}: reusing seeded cluster ${SEEDED_TASK_CLUSTER} (${SEEDED_TASK_LOCATION}); no per-run task cluster will be created"
   else
-    export GKE_CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
-    export CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
-    export TF_VAR_cluster_name="${EVAL_CLUSTER_NAME}"
-    export GCP_LOCATION="${EVAL_DEFAULT_LOCATION}"
+    TASK_REUSE+=("")
+  fi
+done
+
+# One unit, in a background subshell: its exports stay local, its output goes
+# only to its own log (kept as an artifact either way), and its run directory
+# is read back from that log's own `results:` line -- the directory-set diff
+# the serial loop used cannot tell concurrent siblings apart. BENCH_NO_INFRA
+# stays false for every unit, noop-deployer ones included: true would skip
+# verification wholesale (evalharness/default.py, "skipped_no_infra") and
+# silently un-gate transcript-read checks.
+STATE_DIR="$(mktemp -d)"
+
+# mkdir is the mutex: atomic on every filesystem this runs on, and a crashed
+# holder is collected by `wait`, after which nothing contends. Two locks
+# serialize what genuinely cannot overlap while noop units fill the lanes:
+#   per task  -- repetitions of ONE task never overlap. Concurrent reps of a
+#                ledger-writing audit rewrite one shared ledger issue and
+#                grade each other's artifact; concurrent reps of the autoops
+#                task plant simultaneous incidents with no card attribution;
+#                and same-task reps share a tofu stack directory and cluster
+#                name. Serial reps are also what keeps them comparable.
+#   infra     -- at most one stack-bearing (tofu) unit runs at a time,
+#                across tasks: BENCH_PARALLEL stays false, so devops-bench's
+#                per-run isolation (own kubeconfig, gcloud config, tofu data
+#                dir) is off, and two concurrent tofu units would race the
+#                shared kubeconfig's current-context and their state locks.
+lock_acquire() { until mkdir "$1" 2>/dev/null; do sleep 3; done; }
+lock_release() { rmdir "$1" 2>/dev/null || true; }
+
+run_one_unit() { # <task-path> <task-name> <rep> <reuse:true|empty> <has-stack:true|empty>
+  local task="$1" name="$2" rep="$3" reuse="$4" has_stack="$5"
+  local log="/tmp/eval_${name}_rep${rep}.log"
+  lock_acquire "${STATE_DIR}/lock-task-${name}"
+  [ -n "${has_stack}" ] && lock_acquire "${STATE_DIR}/lock-infra"
+  if [ -n "${reuse}" ]; then
+    export GKE_CLUSTER_NAME="${SEEDED_TASK_CLUSTER}" CLUSTER_NAME="${SEEDED_TASK_CLUSTER}"
+    export TF_VAR_cluster_name="${SEEDED_TASK_CLUSTER}" GCP_LOCATION="${SEEDED_TASK_LOCATION}"
+    export TF_VAR_reuse_existing_cluster="true"
+  else
+    export GKE_CLUSTER_NAME="${EVAL_CLUSTER_NAME}" CLUSTER_NAME="${EVAL_CLUSTER_NAME}"
+    export TF_VAR_cluster_name="${EVAL_CLUSTER_NAME}" GCP_LOCATION="${EVAL_DEFAULT_LOCATION}"
     unset TF_VAR_reuse_existing_cluster
   fi
+  export BENCH_NO_INFRA="false"
+  local start end dir
+  start="$(_now_ms)"
+  (cd "${BENCH_DIR}" && uv run devops-bench "${task}" --agent-type kubeagents 2>&1 | _ts_lines > "${log}") || true
+  end="$(_now_ms)"
+  [ -n "${has_stack}" ] && lock_release "${STATE_DIR}/lock-infra"
+  lock_release "${STATE_DIR}/lock-task-${name}"
+  # `|| true`: a run that never printed a `results:` line must still write
+  # its state files and reach the artifact copy -- it is exactly the crashed
+  # run someone will need the log for.
+  dir="$(grep -oE 'results: [^ ]*/results\.json' "${log}" | tail -1 | sed -e 's/^results: //' -e 's|/results\.json$||' || true)"
+  printf '%s\n' "${start}" > "${STATE_DIR}/${name}.rep${rep}.start"
+  printf '%s\n' "${end}" > "${STATE_DIR}/${name}.rep${rep}.end"
+  printf '%s\n' "${dir}" > "${STATE_DIR}/${name}.rep${rep}.dir"
+  # Copied here, not in the grading pass: a Prow deadline that kills the
+  # fan-out must still leave every completed unit's log in the artifacts.
+  cp "${log}" "${ARTIFACT_DIR}/eval_${name}_rep${rep}.log" 2>/dev/null || true
+  echo "<<< [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] finished ${name} rep ${rep} in $(((end - start) / 1000))s"
+}
+
+# Cost-descending, then rep-ascending: repetitions of one task serialize on
+# the task lock, so adjacent same-task units would park a lane sleeping on
+# it -- rep-major interleaving keeps every lane doing work.
+UNIT_QUEUE="$(
+  for REP in $(seq 1 "${EVAL_REPETITIONS}"); do
+    i=0
+    for TASK in "${TASKS[@]}"; do
+      printf '%s %s %s\n' "$(unit_cost_hint "${TASK_NAMES[i]}")" "${REP}" "$i"
+      i=$((i + 1))
+    done
+  done | sort -k1,1rn -k2,2n
+)"
+UNIT_TOTAL="$(printf '%s\n' "${UNIT_QUEUE}" | grep -c .)"
+
+profile_begin "task fan-out: ${UNIT_TOTAL} units, parallelism=${EVAL_TASK_PARALLELISM}"
+while read -r _COST REP IDX; do
+  [ -n "${IDX:-}" ] || continue
+  while [ "$(jobs -rp | wc -l | tr -d ' ')" -ge "${EVAL_TASK_PARALLELISM}" ]; do
+    sleep 3
+  done
+  echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] launching ${TASK_NAMES[IDX]} rep ${REP}/${EVAL_REPETITIONS}"
+  run_one_unit "${TASKS[IDX]}" "${TASK_NAMES[IDX]}" "${REP}" "${TASK_REUSE[IDX]}" "${TASK_HAS_STACK[IDX]}" &
+  # Staggered, so N units do not open their first model call in the same
+  # second -- burst 429s at the model quota are the fan-out's failure mode.
+  sleep 5
+done <<EOF_UNIT_QUEUE
+${UNIT_QUEUE}
+EOF_UNIT_QUEUE
+wait
+
+# ─── Per-case verdicts, in the order TASKS declares ───────────────────────────
+profile_begin "per-repetition breakdowns + case verdicts"
+i=0
+for TASK in "${TASKS[@]}"; do
+  TASK_NAME="${TASK_NAMES[i]}"
+  i=$((i + 1))
+  echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Grading Task: ${TASK_NAME} (${TASK}) x${EVAL_REPETITIONS} <<<"
 
   # One --result per repetition, positionally. A repetition that produced no
   # run directory contributes the literal MISSING, so the gate can tell "died
-  # before writing anything" from "wrote an unusable record" -- a different
-  # diagnosis with a different owner.
+  # before writing anything" from "wrote an unusable record". The harness log
+  # is kept for every repetition, green ones included: a green record is the
+  # raw material for the baseline store.
   RESULT_ARGS=()
   for REP in $(seq 1 "${EVAL_REPETITIONS}"); do
-    echo "--- [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] ${TASK_NAME} repetition ${REP}/${EVAL_REPETITIONS}"
-    # Snapshot existing result directories before running to prevent stale score leakage
-    PRE_RUNS="$(ls -d "${BENCH_DIR}/results/run_"* 2>/dev/null | sort || true)"
     EVAL_LOG="/tmp/eval_${TASK_NAME}_rep${REP}.log"
-
-    RUN_START_MS="$(_now_ms)"
-    (cd "${BENCH_DIR}" && uv run devops-bench "${TASK}" --agent-type kubeagents 2>&1 | _ts_lines | tee "${EVAL_LOG}") || true
-    RUN_END_MS="$(_now_ms)"
-
-    # Use set difference (comm -13) to isolate the brand new directory created strictly by THIS repetition.
-    # If devops-bench crashed before or during execution without completing results.json, NEW_RUN_DIR will be empty.
-    POST_RUNS="$(ls -d "${BENCH_DIR}/results/run_"* 2>/dev/null | sort || true)"
-    NEW_RUN_DIR="$(comm -13 <(echo "${PRE_RUNS}") <(echo "${POST_RUNS}") | head -n 1)"
-
-    # The harness log is kept for every repetition, green ones included: a
-    # green record is the raw material for the baseline store, and its log is
-    # how anyone reconstructs what produced it.
-    cp "${EVAL_LOG}" "${ARTIFACT_DIR}/eval_${TASK_NAME}_rep${REP}.log" 2>/dev/null || true
-
-    # Phase breakdown per repetition rather than per task: with repetitions the
-    # per-task number would average away the thing the table exists to show,
-    # which is where one run's time went. Informational, never fatal.
+    NEW_RUN_DIR="$(cat "${STATE_DIR}/${TASK_NAME}.rep${REP}.dir" 2>/dev/null || true)"
+    RUN_START_MS="$(cat "${STATE_DIR}/${TASK_NAME}.rep${REP}.start" 2>/dev/null || echo 0)"
+    RUN_END_MS="$(cat "${STATE_DIR}/${TASK_NAME}.rep${REP}.end" 2>/dev/null || echo 0)"
     REP_RESULT=""
     [ -n "${NEW_RUN_DIR}" ] && REP_RESULT="${NEW_RUN_DIR}/results.json"
     analyze_eval_phases "${EVAL_LOG}" "${RUN_START_MS}" "${RUN_END_MS}" "${TASK_NAME} rep ${REP}" "${REP_RESULT}"
-
-    # No inline RUN_CLASS here any more. INFRA / BROKEN / OK classification --
-    # including the noop carve-out, the documented empty-list record and #959's
-    # KUBE_AGENTS_INFRA_FAILURE transport marker -- moved into `bench-gate
-    # case`, which has to make the same call per repetition and must not
-    # disagree with a second copy of the rule living in shell.
     if [ -n "${NEW_RUN_DIR}" ]; then
       RESULT_ARGS+=(--result "${NEW_RUN_DIR}")
       cp "${NEW_RUN_DIR}/results.json" "results_${TASK_NAME}_rep${REP}.json" 2>/dev/null || true
@@ -973,18 +1053,14 @@ for TASK in "${TASKS[@]}"; do
   done
 
   # The verdict. bench-gate exits 0 for ANY verdict it could reach, including a
-  # blocking one -- under `set -e` a non-zero here would abort the loop and
-  # silently drop every remaining task. It exits 2 only when it could not grade
-  # at all (an unreadable task file, a broken VERSIONS.json), which is a
-  # different failure and must stop the job.
+  # blocking one; it exits 2 only when it could not grade at all, which must
+  # stop the job.
   CASE_JSON="${ARTIFACT_DIR}/case-${TASK_NAME}.json"
   (cd "${BENCH_DIR}" && uv run bench-gate case \
     --task "${TASK}" \
     "${RESULT_ARGS[@]}" \
     --json-out "${CASE_JSON}")
   CASE_RESULTS+=(--case-result "${CASE_JSON}")
-
-  echo "Task ${TASK_NAME} finished in $((SECONDS - TASK_START))s"
 done
 
 profile_begin "record + final gate"

--- a/scripts/test_ci_eval_fanout.py
+++ b/scripts/test_ci_eval_fanout.py
@@ -1,0 +1,156 @@
+"""The eval fan-out's scheduler is model-free shell, so it is testable here.
+
+`hack/ci-eval-pr.sh` launches one background unit per (task, repetition) and
+serializes the collisions with two mkdir mutexes. Three properties carry the
+correctness of that scheme and each is exercised against the REAL text lifted
+out of the script, in the same style as test_ci_eval_trap.py:
+
+  - the lock deadline: a holder that died without releasing must convert into
+    a loud per-unit failure, never a silent spin `wait` can outlast;
+  - lock mutual exclusion: two contenders never hold one lock at once;
+  - queue order: repetition-major, cost-descending within a repetition, so a
+    lane is never parked on the task lock of a unit launched seconds earlier
+    (the 2026-08-31 pool run paid two of four lanes for twelve minutes that
+    way).
+
+The run-directory recovery regex is pinned too: it is what replaced the
+directory-set diff that could not tell concurrent siblings apart.
+"""
+
+import pathlib
+import re
+import subprocess
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "hack" / "ci-eval-pr.sh"
+
+
+def lifted(name: str) -> str:
+    """A top-level shell function as written, lifted from the script."""
+    src = SCRIPT.read_text(encoding="utf-8")
+    match = re.search(rf"^{name}\(\) \{{.*?^\}}$|^{name}\(\) \{{[^\n]*\}}$", src, re.S | re.M)
+    if match is None:  # pragma: no cover - a rename should say so loudly
+        raise AssertionError(f"{name}() not found in {SCRIPT}")
+    return match.group(0)
+
+
+def run_bash(body: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", "set -uo pipefail\n" + body],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class LockTest(unittest.TestCase):
+    def test_a_dead_holders_lock_fails_the_contender_loudly(self):
+        # Pre-create the lock dir and never release it: the acquire must give
+        # up at its deadline with a diagnosis, not spin forever.
+        body = "\n".join(
+            [
+                lifted("lock_acquire"),
+                'd="$(mktemp -d)/lock"',
+                'mkdir "$d"',
+                'if lock_acquire "$d" 6; then echo ACQUIRED; else echo GAVE_UP; fi',
+            ]
+        )
+        result = run_bash(body)
+        self.assertIn("GAVE_UP", result.stdout)
+        self.assertIn("holder likely died", result.stderr)
+
+    def test_two_contenders_never_hold_the_lock_at_once(self):
+        body = "\n".join(
+            [
+                lifted("lock_acquire"),
+                lifted("lock_release"),
+                'd="$(mktemp -d)"',
+                "worker() {",
+                '  lock_acquire "$d/lock" 60 || return 1',
+                '  echo "ENTER $1" >> "$d/events"',
+                "  sleep 1",
+                '  echo "LEAVE $1" >> "$d/events"',
+                '  lock_release "$d/lock"',
+                "}",
+                "worker a & worker b &",
+                "wait",
+                'cat "$d/events"',
+            ]
+        )
+        result = run_bash(body)
+        events = result.stdout.split()
+        # Sequence must be ENTER x, LEAVE x, ENTER y, LEAVE y — never nested.
+        self.assertEqual(events[0], "ENTER")
+        self.assertEqual(events[2], "LEAVE")
+        self.assertEqual(events[1], events[3], "a holder was preempted mid-critical-section")
+        self.assertEqual(events[4], "ENTER")
+        self.assertNotEqual(events[1], events[5])
+
+
+class QueueOrderTest(unittest.TestCase):
+    def queue(self, reps: int) -> list[tuple[int, int, int]]:
+        src = SCRIPT.read_text(encoding="utf-8")
+        match = re.search(r'^UNIT_QUEUE="\$\(\n.*?^\)"$', src, re.S | re.M)
+        if match is None:  # pragma: no cover
+            raise AssertionError(f"UNIT_QUEUE block not found in {SCRIPT}")
+        body = "\n".join(
+            [
+                lifted("unit_cost_hint"),
+                f"EVAL_REPETITIONS={reps}",
+                # compliance carries a 700 hint, the probe 200: order within a
+                # repetition must be cost-descending.
+                'TASKS=("t/reliability-pdb-probe/task.yaml" "t/compliance-rbac-overgrant/task.yaml")',
+                'TASK_NAMES=(reliability-pdb-probe compliance-rbac-overgrant)',
+                match.group(0),
+                'printf "%s\\n" "${UNIT_QUEUE}"',
+            ]
+        )
+        result = run_bash(body)
+        rows = []
+        for line in result.stdout.splitlines():
+            if line.strip():
+                rep, cost, idx = line.split()
+                rows.append((int(rep), int(cost), int(idx)))
+        return rows
+
+    def test_rep_major_then_cost_descending(self):
+        rows = self.queue(reps=3)
+        self.assertEqual(len(rows), 6)
+        # All rep-1 units precede any rep-2 unit: a task's second repetition
+        # must not launch while its first plausibly still runs.
+        self.assertEqual([r for r, _, _ in rows], [1, 1, 2, 2, 3, 3])
+        # Within a repetition, the expensive unit launches first.
+        for pair in (rows[0:2], rows[2:4], rows[4:6]):
+            self.assertGreaterEqual(pair[0][1], pair[1][1])
+
+
+class RunDirRecoveryTest(unittest.TestCase):
+    def test_the_results_line_regex_recovers_the_run_directory(self):
+        src = SCRIPT.read_text(encoding="utf-8")
+        match = re.search(r'dir="\$\(grep[^\n]*\)"', src)
+        if match is None:  # pragma: no cover
+            raise AssertionError(f"run-directory recovery pipeline not found in {SCRIPT}")
+        body = "\n".join(
+            [
+                'log="$(mktemp)"',
+                # The [TS ...] prefix and the absolute path are what the real
+                # log carries; a crashed run carries neither.
+                "cat > \"$log\" <<'EOF'",
+                "[TS 1788137774.137] some other line",
+                "[TS 1788137775.001] ran 1 task(s), 0 failed; results: /abs/bench/results/run_20260831_010203_000001/results.json",
+                "EOF",
+                match.group(0),
+                'echo "DIR=${dir}"',
+                ': > "$log"',
+                match.group(0),
+                'echo "EMPTY=[${dir}]"',
+            ]
+        )
+        result = run_bash(body)
+        self.assertIn("DIR=/abs/bench/results/run_20260831_010203_000001", result.stdout)
+        self.assertIn("EMPTY=[]", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Runs the eval presubmit's task matrix as a bounded parallel fan-out of (task, repetition) units instead of a serial loop. Profiling (#947's tables) showed the agent conversation is ~98% of every invocation's wall clock and each invocation is independent — at fourteen tasks × three repetitions the serial loop was 140.4 of the job's 156.8 measured minutes. The unit of parallelism is one repetition; launch order is longest-first from measured cost hints; `EVAL_TASK_PARALLELISM` caps concurrency (default 4, `1` reproduces serial behaviour through the same code path). Grading is untouched: `bench-gate case` consumes the same positional per-repetition results in the same `TASKS` order, `bench-gate suite` the same case files.

Draft on purpose: the one number this change cannot measure from a dev checkout is the pool projects' model-quota headroom, and this PR's own presubmit run is that measurement — see Risk & Rollout.

This PR was generated with the help of Claude.

## Why This Change

The presubmit budget has been raised twice (85m → 150m → 240m) and the matrix keeps growing; the measured serial run is 1.26×–1.43× of the 240m ceiling at fourteen tasks × 3. The serial loop's time is almost entirely independent agent conversations, which is the textbook fan-out case.

Measured, same install, same matrix (16 tasks), same day:

| run | config | wall clock | notes |
| --- | --- | ---: | --- |
| A | serial (P=1), reps=1 | **3240s** (54.0m) | quota-clean baseline, new code path |
| B | P=4, reps=1 | **1022s** (17.0m, 3.17×) | 6/16 units lost to Vertex 429s on this dev project's quota |
| C | P=2, reps=1 | **2512s** (41.9m, 1.29×) | 1 unit 429'd |
| D | P=4, reps=2, all review fixes | **3706s** (61.8m vs ~6480s serial-equivalent, 1.75×) | **exit 0, green**; task/infra locks held; all artifacts present |
| Prow (pool, pre-fix head 21ed298) | P=4, reps=3, 48 units | **8963s eval** (149.4m), job 2h46m57s | **green**, zero 429s; units averaged 548s vs serial ~216s — root-caused to the shared-tunnel transport churn this PR's review round fixed (15/48 unit logs carry `unable to listen`/`RemoteDisconnected`; the worst unit spent 79% of its 1664s in two dead-transport stalls), plus 26% queue-packing loss — both fixed in 9fd8e2b, unverified on the pool until the next run |
| E | P=16, reps=1 | **1074s** (17.9m) | no faster than P=4; 7/16 units 429'd; surviving conversations slowed 5–6× (366–799s vs 85–140s serial) |

The ceiling is the model quota, not the mechanism: B's 3.17× includes cheap 429 fast-fails, D's honest 1.75× carries per-task repetition serialization and a throttled Vertex quota, and E shows the curve flat beyond it — P=16 matched P=4's wall clock while poisoning more units and slowing every surviving conversation 5–6×, so past the quota extra lanes only convert healthy units into throttled ones. On this project the knee is between 2 and 4. The pool measurement (build 2094432646640701440) is green with zero 429s, and its 2.5× per-unit slowdown root-caused NOT to the key but to this PR's own pre-fix transport bug: 15/48 unit logs carry port-bind/`RemoteDisconnected` markers, and the sampled worst unit spent 79% of its wall in dead-tunnel stalls — the review round's per-unit-port fix (9fd8e2b) removes exactly this, so more of the clean-room 3.17× should be recoverable on the pool than this run shows. The shared-key aggregate-budget concern from review stands as the design constraint (the dev project's quoted 429s prove the failure mode): pick the default from max_concurrency × P on the shared key, and record contention into the baseline evidence before the store turns on — the latter is a committed follow-up, not in this diff.

## What Changed

- **Fan-out:** a flat queue of (task, repetition) units, cost-hinted longest-first and rep-major interleaved (repetitions of one task serialize, so adjacent same-task units would park a lane), launched into `EVAL_TASK_PARALLELISM` slots with a 5s stagger to soften model-quota bursts.
- **Isolation the serial loop got for free, restructured rather than worked around:** per-task env (seeded-cluster reuse, cluster names) is precomputed and handed to each unit's subshell instead of exported globally; the new-run-directory discovery reads each unit's own log (`results:` line) instead of diffing the shared results directory, which cannot tell concurrent siblings apart.
- **Two mkdir-mutexes serialize what genuinely cannot overlap** while noop units fill the lanes: repetitions of one task (a ledger-writing audit's concurrent reps would rewrite one shared ledger issue and grade each other's artifact; the autoops task's concurrent incidents would have no card attribution; same-task reps share a tofu stack and cluster name), and stack-bearing (tofu) units across tasks (`BENCH_PARALLEL` stays false, so devops-bench's per-run isolation is off and concurrent tofu units would race the shared kubeconfig's context and their state locks).
- **Deadline behaviour:** each unit copies its log into `$ARTIFACTS` the moment it finishes, and a `TERM` trap converts Prow's deadline SIGTERM into an exit so the artifact-collection EXIT trap fires — the serial loop's property that a timeout preserves completed work, kept.
- **Output:** unit transcripts go to per-unit logs (shipped as artifacts, as before) instead of interleaving the job log; the job log carries launch/finish lines and the per-repetition phase breakdowns.
- Docs: `docs/designs/eval-scorer.md`'s presubmit-budget open item restated in fan-out arithmetic (its serial tables kept as the labelled baseline); the stale serial-ordering rationale in `TASKS` comments and the activation-cost guidance corrected.

## Context

- Follows the measurement chain: #947 (profiler), #949/#951 (infra costs removed), #948 (agent latency dominates — this PR is the schedule-level answer; per-conversation latency remains its lane). Issue #902 owns scale beyond this.
- Merge-conflict warnings, no competing work: #1043 (dashboard) and #1050/#981 (task activations) edit this file — #1050's placement prose is written against serial-truncation semantics this PR removes, and its new tasks will take the default cost hint; whichever merges second reconciles. #944 (plant hook) also touches the loop region.
- The serial measurements quoted in comments and design docs are kept, labelled as the fan-out's baseline.

## Testing

- `bash -n`; `make docs-check` clean; prettier clean on the changed design doc.
- Offline machinery tests: queue construction/ordering, semaphore cap (max-concurrent observed = cap), state-file round trip, and both mutexes (same-task and infra overlap checks against event logs) — all green on bash 3.2.
- The four live runs above; D (all fixes in) exercised: lock serialization live (zero same-task work overlap in 32 units), in-unit artifact copies (rep-2 logs present mid-run), the `results:`-line discovery (zero MISSING across A–D), and a green `bench-gate suite` end to end.

### Live validation

Install: `platform-agent-host` (GKE `us-central1`, project `haoxuw-gke-dev`), fresh Helm-managed deploy of current images, namespace `kubeagents-system`, mock seeded slot-c cluster for the gpu task's reuse path. Runs A–E as tabled above (~4h of eval runs total); run D is the run of record for the committed code, and run E (P=16) is the over-provisioning probe that located the quota knee — exit 0, 32/32 units completed, all `eval_*_rep*.log` and `results_*_rep*.json` artifacts present, both locks held throughout. **Not covered:** a run in a real pool project (fleet fixtures, real quota, Prow's SIGTERM path) — the draft's own presubmit is that run; and the rep-major queue interleave landed after run D began, so its packing benefit is asserted from the queue math, not yet measured live.

## Self-Review

`make docs-check` ran clean in the main loop; both passes ran in subagents handed only the diff range. Dispositions, merged:

- **[BLOCKER/CONFIRMED, adversarial] Concurrent tofu units share state, kubeconfig context, and cluster name (`BENCH_PARALLEL=false` isolation is off)** → fixed: the infra mutex serializes stack-bearing units across tasks; noop units (13 of 16) fill the lanes.
- **[HIGH/CONFIRMED, adversarial] Concurrent repetitions of a ledger-writing audit rewrite one shared ledger issue and can grade each other's artifact** → fixed: the per-task mutex serializes repetitions of one task; also restores rep comparability and fixes the autoops card-attribution case (MEDIUM/PLAUSIBLE sibling finding).
- **[HIGH/PLAUSIBLE, adversarial] The shared pre-opened tunnel defeats the harness's stale-tunnel recovery (it never recycles a forward it didn't spawn)** → fixed by removal: the 5s stagger already prevents the bind race the tunnel existed for, and per-harness ownership restores the recycle path. This also moots the two LOW findings on tunnel logging/silent failure.
- **[MEDIUM/CONFIRMED, adversarial] `set -e` kills a unit's state writes when its run printed no `results:` line** → fixed (`|| true` on the parse; exactly the crashed runs need their logs).
- **[MEDIUM/CONFIRMED, adversarial] All artifacts deferred behind `wait`, so a Prow deadline kill uploaded nothing** → fixed: in-unit log copies + `TERM` trap.
- **[MEDIUM/CONFIRMED, adversarial] Cost hints omitted the two plausibly-longest tasks and contradicted an in-file measurement** → fixed from the fleet measurements (gpu/autoops 900; the evidence-chain 1300 was my quota-skewed local sample against the fleet's measured 190s — removed).
- **[LOW/CONFIRMED ×2, adversarial + Blocking, docs-drift] Stale serial-ordering comments inside `TASKS` and the activation-cost guidance (~P× overstated)** → fixed; execution-order rationale now lives at `unit_cost_hint`.
- **[Blocking, docs-drift] `eval-scorer.md`'s budget story was serial arithmetic plus "work in flight" prose this PR falsifies on merge** → fixed: fan-out arithmetic added, serial tables labelled baseline, "in flight" replaced.
- **[LOW/CONFIRMED, adversarial + MEDIUM, bot review] No test reaches the scheduler shell — and my original disposition ("no test seam exists") was wrong: `scripts/test_ci_eval_trap.py` is that seam** → fixed in 9fd8e2b: `scripts/test_ci_eval_fanout.py` pins the lock deadline, mutual exclusion, queue order, and run-directory recovery against the real script text in the same lift-and-run style; already covered by the `scripts/test_*.py` glob in `PYTHON_TEST_DIRS`.
- **[HIGH, bot review] Shared port-forward torn down by its owner's exit under mid-conversation siblings** → fixed in 9fd8e2b: per-unit `AGENT_LOCAL_PORT`, one owned tunnel per unit.
- **[review, jayantid] Dead lock holder strands contenders in a silent spin past what `wait` can collect** → fixed in 9fd8e2b: acquisition deadline, loud give-up, held locks released, unit grades MISSING; the backwards comment corrected.
- **[review, jayantid] Baseline evidence and PR runs graded at different contention levels on one shared key** → default-choice guidance folded into Risk & Rollout; recording `EVAL_TASK_PARALLELISM` into the evidence schema is a committed follow-up before `EVAL_BASELINE_STORE` turns on (schema change to `BaselineRecord`/`VersionKey`, not smuggled in here).
- **[Advisory, docs-drift] `DRAFTS.md`'s "six audits do not fit" and `eval-scorer.md`'s nightly-cost split rest on serial arithmetic** → not changed: historical rationale for decisions already made; the recast may still stand on quota grounds, and re-litigating it belongs to the first pool-quota measurement, not this diff.
- **[Advisory, docs-drift] Pre-existing drift in `bench-case-format.md` (deployer-parsing claim, one-invocation claim)** → out of scope, predates this change; worth a docs sweep.
- Both passes' non-findings worth keeping: bare `wait` cannot kill the script under `set -e`; the heredoc-fed launch loop is safe from stdin-eating units; `--result` positionality, MISSING semantics, INFRA classification, and seeded-reuse selection are byte-equivalent to serial; run-directory collisions are prevented upstream by microsecond-suffixed run ids.

## Risk & Rollout

Presubmit-only shell. `EVAL_TASK_PARALLELISM=1` is the tested escape hatch and reproduces serial semantics through the same code path. The known risk is model-quota exhaustion at the default of 4: on a quota-constrained dev project that lost 6/16 units to 429s at P=4, one at P=2, and 7/16 at P=16 — with no wall-clock gain from 4 to 16, so over-provisioning lanes is all cost and no speed (each loss surfaced loudly as a graded transport failure, not a silent pass). The pool projects' quota is unmeasured from here — **this draft's own presubmit run is the measurement**, and the default should be settled from its log (429 count at P=4) before undrafting. Revert = one commit; no state outlives a run beyond the artifacts it always shipped.



