### PR TITLE
fix(ci): retry the agent connectivity check across fresh tunnels; capture envoy and kube-system evidence on failure

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -306,37 +306,70 @@ STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Verifying Platform Agent API Connectivity ==="
 API_KEY="$(kubectl get secret platform-agent-secrets -n "${NAMESPACE}" -o jsonpath='{.data.API_SERVER_KEY}' | base64 --decode)"
 
-kubectl port-forward svc/platform-agent -n "${NAMESPACE}" 8642:8642 >/tmp/pf-8642.log 2>&1 &
-PF_PID=$!
+# On cold autoscaling pools the API-server tunnel behind `kubectl port-forward`
+# drops mid-request ("error: lost connection to pod" with the gateway pod
+# healthy throughout), and a dead port-forward never comes back on its own —
+# so every attempt gets a fresh tunnel, and only the response decides health.
+PF_PID=""
 cleanup_pf_and_dump() {
   kill "${PF_PID:-}" 2>/dev/null || true
   dump_prow_artifacts_on_failure
 }
 trap cleanup_pf_and_dump EXIT
 
-echo "Waiting for platform-agent port-forward on port 8642..."
-for i in {1..30}; do
-  if nc -z localhost 8642 2>/dev/null; then
+CONNECTIVITY_ATTEMPTS=5
+CONNECTIVITY_OK="false"
+: >/tmp/pf-8642.log
+for ((attempt = 1; attempt <= CONNECTIVITY_ATTEMPTS; attempt++)); do
+  # Kill any previous tunnel and start a fresh one; the log is appended so a
+  # failure dump shows every attempt, not just the last.
+  if [ -n "${PF_PID}" ]; then
+    kill "${PF_PID}" 2>/dev/null || true
+    wait "${PF_PID}" 2>/dev/null || true
+  fi
+  echo "--- port-forward attempt ${attempt}/${CONNECTIVITY_ATTEMPTS} ---" >>/tmp/pf-8642.log
+  kubectl port-forward svc/platform-agent -n "${NAMESPACE}" 8642:8642 >>/tmp/pf-8642.log 2>&1 &
+  PF_PID=$!
+
+  echo "Waiting for platform-agent port-forward on port 8642 (attempt ${attempt}/${CONNECTIVITY_ATTEMPTS})..."
+  for i in {1..30}; do
+    if nc -z localhost 8642 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+
+  HEALTH_RESP="$(curl -s --max-time 120 -X POST http://localhost:8642/v1/responses \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d '{"model": "model-default", "input": "ping"}' || true)"
+
+  if [[ "$HEALTH_RESP" == *"output"* || "$HEALTH_RESP" == *"assistant"* || "$HEALTH_RESP" == *"pong"* ]]; then
+    CONNECTIVITY_OK="true"
     break
   fi
-  sleep 1
+  if [ -z "${HEALTH_RESP}" ]; then
+    FAIL_REASON="empty response after port-forward drop"
+  else
+    FAIL_REASON="unexpected response: ${HEALTH_RESP}"
+  fi
+  if [ "${attempt}" -lt "${CONNECTIVITY_ATTEMPTS}" ]; then
+    echo "connectivity attempt ${attempt}/${CONNECTIVITY_ATTEMPTS} failed: ${FAIL_REASON}; respawning tunnel"
+  else
+    echo "connectivity attempt ${attempt}/${CONNECTIVITY_ATTEMPTS} failed: ${FAIL_REASON}"
+  fi
 done
 
-HEALTH_RESP="$(curl -s -X POST http://localhost:8642/v1/responses \
-  -H "Authorization: Bearer ${API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d '{"model": "model-default", "input": "ping"}' || true)"
-  
-kill $PF_PID 2>/dev/null || true
+kill "${PF_PID:-}" 2>/dev/null || true
 trap dump_prow_artifacts_on_failure EXIT
 
-if [[ "$HEALTH_RESP" == *"output"* || "$HEALTH_RESP" == *"assistant"* || "$HEALTH_RESP" == *"pong"* ]]; then
+if [ "${CONNECTIVITY_OK}" = "true" ]; then
   echo "✓ Agent API Server responded successfully in $((SECONDS - STEP_START))s!"
 else
-  echo "ERROR: Platform Agent API server connectivity check failed!"
+  echo "ERROR: Platform Agent API server connectivity check failed after ${CONNECTIVITY_ATTEMPTS} attempts!"
   echo "Response received: ${HEALTH_RESP}"
-  echo "=== Debug: Port Forward Log ==="
-  cat /tmp/pf-8642.log 2>/dev/null || true
+  echo "=== Debug: Port Forward Log (tail) ==="
+  tail -n 40 /tmp/pf-8642.log 2>/dev/null || true
   echo "=== Debug: Kubernetes Workloads in Namespace ${NAMESPACE} ==="
   kubectl get pods,svc -n "${NAMESPACE}" || true
   exit 1

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -114,7 +114,12 @@ dump_prow_artifacts_on_failure() {
     kubectl logs deployment/platform-agent-gateway -n "${ns}" --tail=2000 > "${artifact_dir}/platform-agent-gateway.log" 2>&1 || true
     kubectl logs deployment/platform-agent-gateway -n "${ns}" --previous --tail=1000 > "${artifact_dir}/platform-agent-gateway-previous-crash.log" 2>&1 || true
     kubectl logs deployment/kube-agents-controller-manager -n "${ns}" --tail=1000 > "${artifact_dir}/controller-manager.log" 2>&1 || true
-    
+    # The gateway capture above reads the pod's default container (platform-agent);
+    # a dropped port-forward stream is only visible from the envoy sidecar's side.
+    kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
+    # Konnectivity/tunnel churn shows up as kube-system events, not in "${ns}".
+    kubectl get events -n kube-system --sort-by=.lastTimestamp 2>&1 | tail -100 > "${artifact_dir}/kube-system-events.txt" 2>&1 || true
+
     # 3. Detailed Pod Descriptions & K8s Events (explains image pull errors, scheduling blocks, OOMKilled, probe failures)
     kubectl describe pods -n "${ns}" > "${artifact_dir}/k8s-pod-descriptions.txt" 2>&1 || true
     kubectl get pods,svc,events -n "${ns}" -o wide > "${artifact_dir}/k8s-cluster-status.txt" 2>&1 || true

--- a/scripts/test_ci_connectivity_retry.py
+++ b/scripts/test_ci_connectivity_retry.py
@@ -1,0 +1,219 @@
+"""The deploy job's connectivity check must survive a dropped port-forward.
+
+`hack/ci-deploy.sh` verifies the Platform Agent by curling one real inference
+through a `kubectl port-forward` tunnel. On cold autoscaling pools that tunnel
+drops mid-request ("error: lost connection to pod") while the gateway pod is
+healthy, and a dead port-forward never comes back on its own — so the check
+retries with a FRESH tunnel per attempt, bounds the curl with --max-time, and
+only hard-fails after every attempt has spoken.
+
+Like scripts/test_ci_eval_trap.py, this lifts the real section out of the real
+file and runs it under bash with stubbed kubectl/curl/nc, so it fails if the
+retry loop is removed, if the tunnel stops being respawned per attempt, or if
+the curl loses its deadline.
+"""
+
+import os
+import pathlib
+import re
+import stat
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEPLOY_SCRIPT = REPO_ROOT / "hack" / "ci-deploy.sh"
+ENV_SCRIPT = REPO_ROOT / "hack" / "ci-env.sh"
+
+SECTION_START = "# ─── 7. Agent API Connectivity Verification"
+SECTION_END = "TOTAL_DURATION="
+
+KUBECTL_STUB = """#!/usr/bin/env bash
+echo "$@" >> "${STUB_LOG}/kubectl.args"
+case "$1" in
+  port-forward)
+    echo "Forwarding from 127.0.0.1:8642 -> 8642"
+    exec sleep 60
+    ;;
+  get)
+    # `get secret ... -o jsonpath=...` -> base64("test-key")
+    echo "dGVzdC1rZXk="
+    ;;
+esac
+exit "${KUBECTL_EXIT:-0}"
+"""
+
+CURL_STUB = """#!/usr/bin/env bash
+echo "$@" >> "${STUB_LOG}/curl.args"
+n=$(cat "${STUB_LOG}/curl.count" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "${STUB_LOG}/curl.count"
+if [ "$n" -ge "${CURL_SUCCEED_ON:-1}" ]; then
+  echo '{"output": [{"role": "assistant", "content": "pong"}]}'
+fi
+exit 0
+"""
+
+NC_STUB = """#!/usr/bin/env bash
+exit 0
+"""
+
+
+def connectivity_section() -> str:
+    """The connectivity-check section as written, lifted from the script."""
+    src = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        rf"^{re.escape(SECTION_START)}.*?(?=^{re.escape(SECTION_END)})",
+        src,
+        re.S | re.M,
+    )
+    if match is None:  # pragma: no cover - a rename should say so loudly
+        raise AssertionError(f"connectivity section not found in {DEPLOY_SCRIPT}")
+    return match.group(0)
+
+
+def dump_function() -> str:
+    """dump_prow_artifacts_on_failure() as written, lifted from ci-env.sh."""
+    src = ENV_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        r"^dump_prow_artifacts_on_failure\(\) \{\n.*?^\}$", src, re.S | re.M
+    )
+    if match is None:  # pragma: no cover
+        raise AssertionError(f"dump_prow_artifacts_on_failure() not found in {ENV_SCRIPT}")
+    return match.group(0)
+
+
+def write_stub(directory: pathlib.Path, name: str, body: str) -> None:
+    path = directory / name
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def run_check(succeed_on: int) -> tuple[subprocess.CompletedProcess, pathlib.Path]:
+    """Run the lifted section with the curl stub succeeding on attempt N."""
+    tmp = pathlib.Path(tempfile.mkdtemp(prefix="conncheck-"))
+    stubs = tmp / "bin"
+    stubs.mkdir()
+    write_stub(stubs, "kubectl", KUBECTL_STUB)
+    write_stub(stubs, "curl", CURL_STUB)
+    write_stub(stubs, "nc", NC_STUB)
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            "NAMESPACE=test-ns",
+            "STEP_START=0",
+            "dump_prow_artifacts_on_failure() { :; }",
+            connectivity_section(),
+            'echo "SECTION COMPLETED"',
+        ]
+    )
+    env = dict(
+        os.environ,
+        PATH=f"{stubs}:{os.environ['PATH']}",
+        STUB_LOG=str(tmp),
+        CURL_SUCCEED_ON=str(succeed_on),
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, env=env
+    )
+    return result, tmp
+
+
+class ConnectivityRetryTest(unittest.TestCase):
+    def test_a_dropped_first_attempt_is_retried_on_a_fresh_tunnel(self):
+        """One empty response (the 08-31 signature) must not fail the deploy."""
+        result, tmp = run_check(succeed_on=2)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("SECTION COMPLETED", result.stdout)
+        self.assertIn("✓ Agent API Server responded successfully", result.stdout)
+        # Exactly one failed attempt, logged as such, then a respawn.
+        self.assertEqual(result.stdout.count("respawning tunnel"), 1)
+        self.assertIn(
+            "connectivity attempt 1/5 failed: empty response after port-forward drop;"
+            " respawning tunnel",
+            result.stdout,
+        )
+        # The respawn is real: one port-forward per attempt, so two total.
+        kubectl_args = (tmp / "kubectl.args").read_text(encoding="utf-8")
+        self.assertEqual(
+            len([l for l in kubectl_args.splitlines() if l.startswith("port-forward")]),
+            2,
+        )
+
+    def test_exhausted_attempts_hard_fail_with_the_tunnel_log_echoed(self):
+        result, tmp = run_check(succeed_on=999)
+        self.assertEqual(result.returncode, 1)
+        self.assertNotIn("SECTION COMPLETED", result.stdout)
+        for attempt in range(1, 6):
+            self.assertIn(f"connectivity attempt {attempt}/5 failed", result.stdout)
+        self.assertIn(
+            "ERROR: Platform Agent API server connectivity check failed after 5 attempts!",
+            result.stdout,
+        )
+        # The port-forward log tail is echoed for diagnosis, one entry per attempt.
+        self.assertIn("=== Debug: Port Forward Log (tail) ===", result.stdout)
+        self.assertIn("--- port-forward attempt 5/5 ---", result.stdout)
+        # Five fresh tunnels were attempted.
+        kubectl_args = (tmp / "kubectl.args").read_text(encoding="utf-8")
+        self.assertEqual(
+            len([l for l in kubectl_args.splitlines() if l.startswith("port-forward")]),
+            5,
+        )
+
+    def test_the_inference_curl_carries_a_deadline(self):
+        """Without --max-time a half-dead tunnel hangs the job, not fails it."""
+        _, tmp = run_check(succeed_on=1)
+        curl_args = (tmp / "curl.args").read_text(encoding="utf-8")
+        self.assertIn("--max-time", curl_args)
+
+
+class FailureDumpArtifactsTest(unittest.TestCase):
+    """The evidence the 08-31 investigation lacked must be in the failure dump."""
+
+    def run_dump(self, kubectl_exit: int) -> tuple[subprocess.CompletedProcess, pathlib.Path]:
+        tmp = pathlib.Path(tempfile.mkdtemp(prefix="conndump-"))
+        stubs = tmp / "bin"
+        stubs.mkdir()
+        write_stub(stubs, "kubectl", KUBECTL_STUB)
+        write_stub(stubs, "gcloud", "#!/usr/bin/env bash\nexit ${KUBECTL_EXIT:-0}\n")
+        script = "\n".join(
+            [
+                "set -euo pipefail",
+                "collect_bench_results() { :; }",
+                dump_function(),
+                "false || dump_prow_artifacts_on_failure",
+                'echo "SURVIVED"',
+            ]
+        )
+        env = dict(
+            os.environ,
+            PATH=f"{stubs}:{os.environ['PATH']}",
+            STUB_LOG=str(tmp),
+            KUBECTL_EXIT=str(kubectl_exit),
+            ARTIFACTS=str(tmp / "artifacts"),
+            PROJECT_ID="test-project",
+            TARGET_NAMESPACE="test-ns",
+        )
+        result = subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True, check=False, env=env
+        )
+        return result, tmp
+
+    def test_the_envoy_sidecar_and_kube_system_events_are_captured(self):
+        result, tmp = self.run_dump(kubectl_exit=0)
+        self.assertIn("SURVIVED", result.stdout)
+        kubectl_args = (tmp / "kubectl.args").read_text(encoding="utf-8")
+        self.assertIn("-c envoy-credential-proxy", kubectl_args)
+        self.assertRegex(
+            kubectl_args, r"get events -n kube-system --sort-by=\.lastTimestamp"
+        )
+
+    def test_the_new_captures_cannot_fail_the_dump(self):
+        """Every command in the dumper is || true guarded; so are the new two."""
+        result, _ = self.run_dump(kubectl_exit=1)
+        self.assertIn("SURVIVED", result.stdout)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The smoke harness's Platform Agent connectivity check (`hack/ci-deploy.sh`, section 7) starts `kubectl port-forward svc/platform-agent 8642:8642` in the background, waits with `nc -z`, then issues **one** `curl -s -X POST /v1/responses` — a real model inference — with no `--max-time`, no retry, and no port-forward restart. Any empty or non-matching response is a hard `exit 1`.

On 2026-08-31, 4 of 7 runs died exactly there, with an identical port-forward log each time: one `Handling connection for 8642` followed by `error: lost connection to pod` — while the gateway pod was 4/4 Running, 0 restarts, probes passing. The four deaths landed on four different pool projects and the same `base_sha` as interleaved passes (builds `2094332662654177280`, `2094347266671251456`, and two PR-1058 builds). Healthy checks complete in 37–42s; the deaths came 26s–5m30s in, on cold autoscaling pools where the API-server tunnel is least stable. This is a flake in the check, not a product regression: a single tunnel drop mid-inference is indistinguishable from a broken agent, and a dead `kubectl port-forward` never recovers on its own.

## Fix

- Wrap the check in a bounded retry (5 attempts). **Each attempt gets a fresh tunnel**: kill any existing port-forward, spawn a new one (pid tracked, `nc -z` wait bounded as before), then curl with `--max-time 120`. One-line log per failed attempt (`connectivity attempt 2/5 failed: empty response after port-forward drop; respawning tunnel`); hard-fail only after all attempts, with the port-forward log tail echoed (the log is now appended across attempts with per-attempt headers, so the failure dump shows every tunnel's fate).
- The success predicate, endpoint, and payload are unchanged — what "healthy" means is identical. The check still exits with the tunnel torn down and the plain `dump_prow_artifacts_on_failure` trap restored; nothing downstream reuses this tunnel (the bench harness manages its own per-task forwards in `bench/kube_agents_bench/harness.py`).

This converts all four 08-31 deaths to passes: the same clusters served the identical request successfully minutes later, so a second attempt on a fresh tunnel would have succeeded in each case — while a genuinely broken agent still fails all 5 attempts, now with better evidence.

## Failure-dump additions (`dump_prow_artifacts_on_failure`, `hack/ci-env.sh`)

Two captures the 08-31 investigation was missing, each `|| true`-guarded in the function's existing style:

- `kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy` — the existing gateway capture reads the pod's default container (platform-agent); a dropped stream is visible from the envoy sidecar's side, which is exactly the evidence we didn't have.
- `kubectl get events -n kube-system --sort-by=.lastTimestamp | tail -100` — konnectivity/tunnel churn shows up there, not in the agent namespace.

## Tests

`scripts/test_ci_connectivity_retry.py` (same lift-the-real-shell convention as `scripts/test_ci_eval_trap.py`, stubbed `kubectl`/`curl`/`nc`): first-attempt drop → retry on a fresh tunnel and exit 0 with exactly one respawn logged; all attempts exhausted → exit 1 with every attempt logged and the tunnel log tail echoed; the curl carries `--max-time`; the two new artifact captures run in the dumper and cannot fail it. `bash -n` clean on both scripts; shellcheck delta vs main is empty (only the pre-existing SC2034 at a shifted line); `scripts/test_task_registration.py` and `scripts/test_ci_eval_trap.py` still green.

Part of #897; evidence relates to #988's startup family and the 08-31 wave investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
