### PR TITLE
docs(release): document release operations, lifecycle governance, and emergency runbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -342,7 +342,7 @@ only what the title does not say.
 | `install/uninstall.md` | Site page | Removing the agent, operator, and provisioned GCP resources; agent-only vs full teardown. | Teardown | — |
 | `deploy/index.md` | Site page | Hub for the deploy section: Docker, Kustomize, Minty, release versioning, telemetry, GitOps. | Navigation | — |
 | `deploy/kustomize.md` | Site page | What ships in `deploy/kustomize/` and what the operator lays down on top of it. | Base vs operator-created objects | — |
-| `deploy/release-versioning.md` | Site page | How Release Candidate builds are promoted to immutable SemVer releases across container images, Helm charts, and TF modules. | SemVer promotion, chart appVersion, TF git tag ref pinning | SREs and contributors |
+| `deploy/release-versioning.md` | Site page | Release lifecycle, automated SemVer 2.0 governance, clean promotion, GA release execution, and emergency hotfix runbook. | SemVer calculation, RC validation gate, clean promotion, CLI dispatch, emergency runbook | SREs and maintainers |
 | `deploy/docker-images.md` | Site page | The images shipped from this repo and how tags are managed. | Image list, base pin, registry overrides, CI | — |
 | `deploy/token-minter.md` | Site page | Minty: the in-cluster broker minting short-lived GitHub App installation tokens; no long-lived secret on disk. | Token flow, KMS-held key, setup | Operator-side README: `k8s-operator/config/integrations/github/README.md` |
 | `deploy/telemetry.md` | Site page | Where OTel, Prometheus, and Cloud Logging fit in the shipping deploy, and how to point it at a collector other than the GKE-managed one. | What runs where, OTLP endpoint precedence and discovery, non-GKE clusters | — |

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -109,7 +109,7 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents \
 After an emergency publication, complete these three reconciliation steps:
 
 1. Confirm the published release tag, container images in GHCR, and signed Helm OCI chart via `gh release view <VERSION>`.
-2. Manually trigger `.github/workflows/rc-release-pipeline.yml` against the released commit to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure.
+2. Manually trigger `.github/workflows/rc-release-pipeline.yml` against the hotfix commit (`-f commit_sha="<HOTFIX_COMMIT_SHA>"`, matching the SHA passed as `target_commit`) to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure. Do not pass the tagged release commit: `tag_ga_release.sh` creates a stamped release commit on detached HEAD that lacks SHA-tagged container images in GHCR, causing the RC pipeline's image verification step to fail.
 3. Attach the GitHub Actions run URL and emergency justification to the corresponding tracking issue or incident report.
 
 ## Clean promotion and artifact guarantees

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -62,7 +62,7 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents
 
 # Releasing a specific validated commit:
 gh workflow run release-publish.yml --repo gke-labs/kube-agents \
-  -f target_commit="d3be984d4128f73111f1816e138a06e938927909"
+  -f target_commit="<TARGET_COMMIT_SHA>"
 
 # Manual version override (e.g. promoting 0.y.z to 1.0.0):
 gh workflow run release-publish.yml --repo gke-labs/kube-agents \

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -1,35 +1,94 @@
 ---
-title: Release versioning & promotion
-description: How Kube-Agents Release Candidate builds are promoted to immutable SemVer releases across container images, Helm charts, and Terraform modules.
+title: Release lifecycle, versioning & operations
+description: How Kube-Agents automates SemVer 2.0 releases, validates release candidates on live GKE clusters, and publishes immutable artifacts.
 sidebar:
   order: 4
 ---
 
-`kube-agents` follows strict [Semantic Versioning 2.0.0](https://semver.org/) (`MAJOR.MINOR.PATCH`) for production releases across Docker images, OCI Helm charts, and Terraform modules.
+`kube-agents` follows strict [Semantic Versioning 2.0.0](https://semver.org/) (`MAJOR.MINOR.PATCH`) without a `v` prefix for official releases across container images, OCI Helm charts, and Terraform modules.
 
-## Promotion from Release Candidate (RC) to SemVer
+The release pipeline guarantees that installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`) and container runtime images are bit-for-bit synchronized from the exact same commit, validated on a live GKE cluster before any release tag is published.
 
-1. **RC Testing**: Pre-release builds are validated by the automated RC pipeline —
-   [`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release) is the canonical reference for how `rc_YYMMDDHHMM_<short_sha>` builds are created, tested end-to-end, and tagged `*_validated` on success.
-2. **SemVer Publication**: Running the release workflow (`release-publish.yml`) for a validated commit creates a stamped single-parent release commit on detached HEAD (baking `BAKED_RELEASE_VERSION` into installer scripts), tags it `MAJOR.MINOR.PATCH`, and promotes immutable artifacts (example for `1.2.0`):
-   - **GHCR Images**: Clean promotion retags verified commit images to `ghcr.io/gke-labs/kube-agents/platform-agent:1.2.0` (and all required images) without rebuilding.
-   - **OCI Helm Charts**: `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:1.2.0` (packaged and signed by digest via `release-publish.yml`).
-   - **Terraform Modules**: Sourced via Git tag reference `?ref=1.2.0`
+## Tag and artifact taxonomy
 
-## Helm Chart Versioning
+Every commit and build progresses through four distinct lifecycle tiers:
+
+| Tier | Format | Trigger | Purpose and guarantees |
+| :--- | :--- | :--- | :--- |
+| **Candidate Build** | `sha-<SHORT_SHA>` | Push to `main` branch | Developer build in GHCR; container images built once. |
+| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>` | Push to `main` / 3-hour cron | Candidate build selected for live cluster testing. |
+| **RC Validated** | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
+| **GA Stable** | `X.Y.Z` (pure numeric SemVer) | Release publish workflow | Official production release tagged on the validated commit. |
+
+## Automated SemVer 2.0 calculation
+
+When the GA release workflow runs, `scripts/release/calculate_next_version.sh` inspects Conventional Commits in the range `<LATEST_GA_TAG>..HEAD`:
+
+<!-- prettier-ignore -->
+| Commit type landed on `main` | Current version | Calculated next version | Precedence and action |
+| :--- | :--- | :--- | :--- |
+| `fix:`, `chore:`, `docs:`, `perf:` | `0.2.0` | `0.2.1` | Patch bump |
+| `feat:` | `0.2.0` | `0.3.0` | Minor bump, Patch resets to 0 |
+| `feat!:`, `fix!:`, `BREAKING CHANGE:` | `0.2.0` | `0.3.0` | Minor bump (SemVer 2.0 Clause 4 in `0.y.z`) |
+| `feat!:`, `fix!:`, `BREAKING CHANGE:` | `1.2.0` | `2.0.0` | Major bump (in `1.x.x`+) |
+| _(No new commits on main)_ | `0.2.0` | `0.2.0` | No changes (`skip_release=true`) |
+
+### SemVer 2.0 Clause 4 and the 1.0.0 manual governance rule
+
+1. **Initial development phase (`0.y.z`)**: Per [SemVer 2.0 Clause 4](https://semver.org/#spec-item-4), any breaking change during initial development increments `MINOR` (`0.2.1` -> `0.3.0`), resetting `PATCH` to 0.
+2. **Manual `1.0.0` transition**: The automated version calculator **never** promotes `0.y.z` to `1.0.0` on its own. Declaring API stability and graduating to `1.0.0` is a manual governance decision by project maintainers. It must be triggered explicitly via the `explicit_release_version: "1.0.0"` input parameter.
+3. **Stable phase (`1.x.x` and above)**: Once `1.0.0` is established, the automated calculator resumes normal SemVer rules: breaking changes bump `MAJOR`, new features bump `MINOR`, and bug fixes bump `PATCH`.
+
+## Cutting a GA release
+
+### Prerequisites
+
+Before triggering a production release:
+1. Target commit must exist on the `main` branch.
+2. Target commit must carry an `rc_*_validated` tag created by the automated RC validation pipeline ([`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release)).
+3. All four required container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) must exist in GHCR under `sha-<TARGET_COMMIT>`.
+
+### Triggering the release workflow
+
+Execute `.github/workflows/release-publish.yml` from the GitHub Actions web interface or via the GitHub CLI:
+
+```bash
+# Standard automated release (SemVer calculated automatically from Conventional Commits):
+gh workflow run release-publish.yml --repo gke-labs/kube-agents
+
+# Releasing a specific validated commit:
+gh workflow run release-publish.yml --repo gke-labs/kube-agents \
+  -f target_commit="d3be984d4128f73111f1816e138a06e938927909"
+
+# Manual version override (e.g. promoting 0.y.z to 1.0.0):
+gh workflow run release-publish.yml --repo gke-labs/kube-agents \
+  -f explicit_release_version="1.0.0"
+```
+
+## Clean promotion and artifact guarantees
+
+The release publish workflow enforces byte-for-byte fidelity with tested candidate binaries:
+
+1. **Zero container rebuilds**: Container images are compiled only once on push to `main`. `scripts/release/promote_release_images.sh` retags existing `sha-<TARGET_COMMIT>` manifests to numeric `X.Y.Z` in GHCR using `docker buildx imagetools create`.
+2. **Cosign OIDC signature**: Promoted container images in GHCR are cryptographically signed using Keyless Cosign via GitHub Actions OIDC tokens (`scripts/release/sign_release_images.sh`).
+3. **OCI Helm chart**: `scripts/release/publish_helm_chart.sh` packages `charts/kube-agents` at version `X.Y.Z` (matching `appVersion`), pushes the OCI package to `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:X.Y.Z`, and signs the OCI manifest via Cosign.
+4. **Installer version lock**: `scripts/release/tag_ga_release.sh` creates a single-parent release commit on detached HEAD, stamps `BAKED_RELEASE_VERSION="X.Y.Z"` into root scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`), and tags the stamped commit.
+5. **Drift prevention in `install.sh`**: `verify_local_source_ref` verifies that unversioned source directories match `BAKED_RELEASE_VERSION` and that Git checkouts match the requested tag commit SHA, halting execution if local scripts diverge from container images.
+
+## Helm chart versioning
 
 The chart `version` tracks the application `appVersion`: the release workflow packages the
 chart with both `version` and `appVersion` set to the exact SemVer release tag `X.Y.Z`, so every
 chart release corresponds to exactly one application release. There is no chart-only release
 train — a chart-template fix ships with the next `X.Y.Z` tag.
 
-## Pinning Terraform Module Versions in GitOps
+## Pinning Terraform module versions in GitOps
 
-When forking the GitOps reference repository (`examples/gitops-repo/`), source Terraform modules using explicit SemVer Git tags:
+When configuring GitOps repositories, pin companion Terraform modules using the exact SemVer Git tag:
 
 ```hcl
 module "gke_cluster" {
-  source       = "git::https://github.com/gke-labs/kube-agents.git//terraform/modules/gke-cluster?ref=1.2.0"
+  source       = "git::https://github.com/gke-labs/kube-agents.git//terraform/modules/gke-cluster?ref=0.3.0"
   project_id   = var.project_id
   cluster_name = "production-host-01"
   location     = "us-central1"

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -48,6 +48,7 @@ Before triggering a production release:
 1. Target commit must exist on the `main` branch.
 2. Target commit must carry an `rc_*_validated` tag created by the automated RC validation pipeline ([`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release)).
 3. All four required container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) must exist in GHCR under `sha-<TARGET_COMMIT>`.
+4. GitHub CLI (`gh`) version 2.40.0 or newer installed and authenticated with `repo` and `workflow` permissions (`gh auth status`).
 
 ### Triggering the release workflow
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -13,12 +13,12 @@ The release pipeline guarantees that installer scripts (`install.sh`, `uninstall
 
 Every commit and build progresses through four distinct lifecycle tiers:
 
-| Tier                       | Format                                | Trigger                       | Purpose and guarantees                                                 |
-| :------------------------- | :------------------------------------ | :---------------------------- | :--------------------------------------------------------------------- |
-| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch         | Developer build in GHCR; container images built once.                  |
-| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | 3-hour cron / manual dispatch | Candidate build selected for live cluster testing.                     |
-| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite      | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
-| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow      | Official production release tagged on the validated commit.            |
+| Tier                       | Format                                | Trigger                       | Purpose and guarantees                                                                   |
+| :------------------------- | :------------------------------------ | :---------------------------- | :--------------------------------------------------------------------------------------- |
+| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch         | Developer build in GHCR; container images built once.                                    |
+| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | 3-hour cron / manual dispatch | Candidate build selected for live cluster testing.                                       |
+| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite      | Quality gate: proof that `install.sh` succeeded on a real GKE cluster.                   |
+| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow      | Official production release tagged on a stamped commit parented by the validated commit. |
 
 ## Automated SemVer 2.0 calculation
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -15,7 +15,7 @@ Every commit and build progresses through four distinct lifecycle tiers:
 
 | Tier                       | Format                                | Trigger                      | Purpose and guarantees                                                 |
 | :------------------------- | :------------------------------------ | :--------------------------- | :--------------------------------------------------------------------- |
-| **Candidate Build**        | `sha-<SHORT_SHA>`                     | Push to `main` branch        | Developer build in GHCR; container images built once.                  |
+| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch        | Developer build in GHCR; container images built once.                  |
 | **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | Push to `main` / 3-hour cron | Candidate build selected for live cluster testing.                     |
 | **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite     | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
 | **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow     | Official production release tagged on the validated commit.            |
@@ -47,7 +47,7 @@ Before triggering a production release:
 
 1. Target commit must exist on the `main` branch.
 2. Target commit must carry an `rc_*_validated` tag created by the automated RC validation pipeline ([`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release)).
-3. All four required container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) must exist in GHCR under `sha-<TARGET_COMMIT>`.
+3. All four required container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) must exist in GHCR under `<TARGET_COMMIT>`.
 4. GitHub CLI (`gh`) version 2.40.0 or newer installed and authenticated with `repo` and `workflow` permissions (`gh auth status`).
 
 ### Triggering the release workflow
@@ -82,7 +82,7 @@ Emergency gate bypass (`skip_rc_validation: true`) is strictly reserved for:
 
 Even during an emergency bypass, the pipeline strictly enforces:
 
-- **Prebuilt image presence**: `scripts/release/verify_release_eligibility.sh` verifies that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `sha-<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
+- **Prebuilt image presence**: `scripts/release/verify_release_eligibility.sh` verifies that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
 - **Mandatory audit reason**: `emergency_override_reason` must contain a non-whitespace justification. Empty or whitespace-only reasons abort the workflow (`exit 1`).
 - **Tag collision protection**: If the target SemVer tag already points to another commit, the release aborts.
 
@@ -117,7 +117,7 @@ After an emergency publication:
 
 The release publish workflow enforces byte-for-byte fidelity with tested candidate binaries:
 
-1. **Zero container rebuilds**: Container images are compiled only once on push to `main`. `scripts/release/promote_release_images.sh` retags existing `sha-<TARGET_COMMIT>` manifests to numeric `X.Y.Z` in GHCR using `docker buildx imagetools create`.
+1. **Zero container rebuilds**: Container images are compiled only once on push to `main`. `scripts/release/promote_release_images.sh` retags existing `<TARGET_COMMIT>` manifests to numeric `X.Y.Z` in GHCR using `docker buildx imagetools create`.
 2. **Cosign OIDC signature**: Promoted container images in GHCR are cryptographically signed using Keyless Cosign via GitHub Actions OIDC tokens (`scripts/release/sign_release_images.sh`).
 3. **OCI Helm chart**: `scripts/release/publish_helm_chart.sh` packages `charts/kube-agents` at version `X.Y.Z` (matching `appVersion`), pushes the OCI package to `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:X.Y.Z`, and signs the OCI manifest via Cosign.
 4. **Installer version lock**: `scripts/release/tag_ga_release.sh` creates a single-parent release commit on detached HEAD, stamps `BAKED_RELEASE_VERSION="X.Y.Z"` into root scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`), and tags the stamped commit.

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -7,18 +7,18 @@ sidebar:
 
 `kube-agents` follows strict [Semantic Versioning 2.0.0](https://semver.org/) (`MAJOR.MINOR.PATCH`) without a `v` prefix for official releases across container images, OCI Helm charts, and Terraform modules.
 
-The release pipeline guarantees that installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`) and container runtime images are bit-for-bit synchronized from the exact same commit, validated on a live GKE cluster before any release tag is published.
+The release pipeline guarantees that installer scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`) and container runtime images are bit-for-bit synchronized from the exact same commit and, absent an emergency bypass, validated on a live GKE cluster before any release tag is published.
 
 ## Tag and artifact taxonomy
 
 Every commit and build progresses through four distinct lifecycle tiers:
 
-| Tier                       | Format                                | Trigger                       | Purpose and guarantees                                                                   |
-| :------------------------- | :------------------------------------ | :---------------------------- | :--------------------------------------------------------------------------------------- |
-| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch         | Developer build in GHCR; container images built once.                                    |
-| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | 3-hour cron / manual dispatch | Candidate build selected for live cluster testing.                                       |
-| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite      | Quality gate: proof that `install.sh` succeeded on a real GKE cluster.                   |
-| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow      | Official production release tagged on a stamped commit parented by the validated commit. |
+| Tier                       | Format                                | Trigger                       | Purpose and guarantees                                                                                              |
+| :------------------------- | :------------------------------------ | :---------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch         | Developer build in GHCR; container images built once.                                                               |
+| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | 3-hour cron / manual dispatch | Candidate build selected for live cluster testing.                                                                  |
+| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite      | Quality gate: proof that `install.sh` succeeded on a real GKE cluster.                                              |
+| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow      | Official production release tagged on a stamped commit parented by the target commit (validated on GKE by default). |
 
 ## Automated SemVer 2.0 calculation
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -65,6 +65,48 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents \
   -f explicit_release_version="1.0.0"
 ```
 
+## Emergency hotfix runbook
+
+The release gatekeeper enforces automated GKE RC validation (`rc_*_validated`) by default. In emergency situations, maintainers can bypass the live GKE validation gate while preserving all cryptographic and build integrity invariants.
+
+### Eligibility criteria
+
+Emergency gate bypass (`skip_rc_validation: true`) is strictly reserved for:
+1. **Critical CVE remediation**: Zero-day vulnerabilities in container dependencies requiring immediate publication.
+2. **Critical availability hotfixes**: Production-breaking regressions where waiting for the 3-hour RC validation cycle or cluster provisioning would prolong user-facing downtime.
+
+### Enforced security invariants
+
+Even during an emergency bypass, the pipeline strictly enforces:
+- **Prebuilt image presence**: `scripts/release/verify_release_eligibility.sh` verifies that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `sha-<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
+- **Mandatory audit reason**: `emergency_override_reason` must contain a non-whitespace justification. Empty or whitespace-only reasons abort the workflow (`exit 1`).
+- **Tag collision protection**: If the target SemVer tag already points to another commit, the release aborts.
+
+### Executing an emergency hotfix
+
+To publish an emergency release via the GitHub CLI:
+
+```bash
+# Emergency release from a specific commit SHA:
+gh workflow run release-publish.yml --repo gke-labs/kube-agents \
+  -f skip_rc_validation=true \
+  -f emergency_override_reason="CVE-2026-XXXX: Critical vulnerability in base container dependencies" \
+  -f target_commit="<HOTFIX_COMMIT_SHA>"
+
+# Emergency release with explicit SemVer override:
+gh workflow run release-publish.yml --repo gke-labs/kube-agents \
+  -f skip_rc_validation=true \
+  -f emergency_override_reason="Critical regression fix for gateway admission deadlock" \
+  -f explicit_release_version="0.3.1"
+```
+
+### Post-release reconciliation
+
+After an emergency publication:
+1. **Verify artifacts**: Confirm the published release tag, container images in GHCR, and signed Helm OCI chart via `gh release view <VERSION>`.
+2. **Trigger post-factum RC validation**: Manually trigger `.github/workflows/rc-release-pipeline.yml` against the released commit to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure.
+3. **Record audit trail**: Attach the GitHub Actions run URL and emergency justification to the corresponding tracking issue or incident report.
+
 ## Clean promotion and artifact guarantees
 
 The release publish workflow enforces byte-for-byte fidelity with tested candidate binaries:

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -13,12 +13,12 @@ The release pipeline guarantees that installer scripts (`install.sh`, `uninstall
 
 Every commit and build progresses through four distinct lifecycle tiers:
 
-| Tier | Format | Trigger | Purpose and guarantees |
-| :--- | :--- | :--- | :--- |
-| **Candidate Build** | `sha-<SHORT_SHA>` | Push to `main` branch | Developer build in GHCR; container images built once. |
-| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>` | Push to `main` / 3-hour cron | Candidate build selected for live cluster testing. |
-| **RC Validated** | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
-| **GA Stable** | `X.Y.Z` (pure numeric SemVer) | Release publish workflow | Official production release tagged on the validated commit. |
+| Tier                       | Format                                | Trigger                      | Purpose and guarantees                                                 |
+| :------------------------- | :------------------------------------ | :--------------------------- | :--------------------------------------------------------------------- |
+| **Candidate Build**        | `sha-<SHORT_SHA>`                     | Push to `main` branch        | Developer build in GHCR; container images built once.                  |
+| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | Push to `main` / 3-hour cron | Candidate build selected for live cluster testing.                     |
+| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite     | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
+| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow     | Official production release tagged on the validated commit.            |
 
 ## Automated SemVer 2.0 calculation
 
@@ -44,6 +44,7 @@ When the GA release workflow runs, `scripts/release/calculate_next_version.sh` i
 ### Prerequisites
 
 Before triggering a production release:
+
 1. Target commit must exist on the `main` branch.
 2. Target commit must carry an `rc_*_validated` tag created by the automated RC validation pipeline ([`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release)).
 3. All four required container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) must exist in GHCR under `sha-<TARGET_COMMIT>`.
@@ -72,12 +73,14 @@ The release gatekeeper enforces automated GKE RC validation (`rc_*_validated`) b
 ### Eligibility criteria
 
 Emergency gate bypass (`skip_rc_validation: true`) is strictly reserved for:
+
 1. **Critical CVE remediation**: Zero-day vulnerabilities in container dependencies requiring immediate publication.
 2. **Critical availability hotfixes**: Production-breaking regressions where waiting for the 3-hour RC validation cycle or cluster provisioning would prolong user-facing downtime.
 
 ### Enforced security invariants
 
 Even during an emergency bypass, the pipeline strictly enforces:
+
 - **Prebuilt image presence**: `scripts/release/verify_release_eligibility.sh` verifies that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `sha-<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
 - **Mandatory audit reason**: `emergency_override_reason` must contain a non-whitespace justification. Empty or whitespace-only reasons abort the workflow (`exit 1`).
 - **Tag collision protection**: If the target SemVer tag already points to another commit, the release aborts.
@@ -103,6 +106,7 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents \
 ### Post-release reconciliation
 
 After an emergency publication:
+
 1. **Verify artifacts**: Confirm the published release tag, container images in GHCR, and signed Helm OCI chart via `gh release view <VERSION>`.
 2. **Trigger post-factum RC validation**: Manually trigger `.github/workflows/rc-release-pipeline.yml` against the released commit to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure.
 3. **Record audit trail**: Attach the GitHub Actions run URL and emergency justification to the corresponding tracking issue or incident report.

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -35,9 +35,11 @@ When the GA release workflow runs, `scripts/release/calculate_next_version.sh` i
 
 ### SemVer 2.0 Clause 4 and the 1.0.0 manual governance rule
 
-1. **Initial development phase (`0.y.z`)**: Per [SemVer 2.0 Clause 4](https://semver.org/#spec-item-4), any breaking change during initial development increments `MINOR` (`0.2.1` -> `0.3.0`), resetting `PATCH` to 0.
-2. **Manual `1.0.0` transition**: The automated version calculator **never** promotes `0.y.z` to `1.0.0` on its own. Declaring API stability and graduating to `1.0.0` is a manual governance decision by project maintainers. It must be triggered explicitly via the `explicit_release_version: "1.0.0"` input parameter.
-3. **Stable phase (`1.x.x` and above)**: Once `1.0.0` is established, the automated calculator resumes normal SemVer rules: breaking changes bump `MAJOR`, new features bump `MINOR`, and bug fixes bump `PATCH`.
+During initial development (`0.y.z`), any breaking change increments `MINOR` (`0.2.1` -> `0.3.0`) and resets `PATCH` to 0, per [SemVer 2.0 Clause 4](https://semver.org/#spec-item-4).
+
+The automated version calculator never promotes `0.y.z` to `1.0.0` on its own. Declaring API stability and graduating to `1.0.0` is a manual governance decision by project maintainers, triggered explicitly through the `explicit_release_version: "1.0.0"` workflow input.
+
+Once `1.0.0` is established, the automated calculator resumes standard SemVer rules: breaking changes bump `MAJOR`, new features bump `MINOR`, and bug fixes bump `PATCH`.
 
 ## Cutting a GA release
 
@@ -73,18 +75,15 @@ The release gatekeeper enforces automated GKE RC validation (`rc_*_validated`) b
 
 ### Eligibility criteria
 
-Emergency gate bypass (`skip_rc_validation: true`) is strictly reserved for:
-
-1. **Critical CVE remediation**: Zero-day vulnerabilities in container dependencies requiring immediate publication.
-2. **Critical availability hotfixes**: Production-breaking regressions where waiting for the 3-hour RC validation cycle or cluster provisioning would prolong user-facing downtime.
+Emergency gate bypass (`skip_rc_validation: true`) is strictly reserved for two scenarios: zero-day CVE vulnerabilities in container dependencies requiring immediate publication, or critical production regressions where waiting for the 3-hour RC validation cycle or cluster provisioning would prolong user-facing downtime.
 
 ### Enforced security invariants
 
-Even during an emergency bypass, the pipeline strictly enforces:
+Even during an emergency bypass, the pipeline enforces three hard safety barriers:
 
-- **Prebuilt image presence**: `scripts/release/verify_release_eligibility.sh` verifies that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
-- **Mandatory audit reason**: `emergency_override_reason` must contain a non-whitespace justification. Empty or whitespace-only reasons abort the workflow (`exit 1`).
-- **Tag collision protection**: If the target SemVer tag already points to another commit, the release aborts.
+1. `scripts/release/verify_release_eligibility.sh` checks that all four container images (`k8s-operator`, `platform-agent`, `credential-proxy`, `replay-proxy`) exist in GHCR under `<TARGET_COMMIT>`. Releases of unbuilt commits hard-fail.
+2. `emergency_override_reason` must contain a non-whitespace justification; empty or whitespace-only reasons abort the workflow (`exit 1`).
+3. Target SemVer tags must not already exist on another commit; tag collisions abort the release.
 
 ### Executing an emergency hotfix
 
@@ -107,21 +106,21 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents \
 
 ### Post-release reconciliation
 
-After an emergency publication:
+After an emergency publication, complete these three reconciliation steps:
 
-1. **Verify artifacts**: Confirm the published release tag, container images in GHCR, and signed Helm OCI chart via `gh release view <VERSION>`.
-2. **Trigger post-factum RC validation**: Manually trigger `.github/workflows/rc-release-pipeline.yml` against the released commit to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure.
-3. **Record audit trail**: Attach the GitHub Actions run URL and emergency justification to the corresponding tracking issue or incident report.
+1. Confirm the published release tag, container images in GHCR, and signed Helm OCI chart via `gh release view <VERSION>`.
+2. Manually trigger `.github/workflows/rc-release-pipeline.yml` against the released commit to run the full GKE E2E suite and ensure the fix validates cleanly on live infrastructure.
+3. Attach the GitHub Actions run URL and emergency justification to the corresponding tracking issue or incident report.
 
 ## Clean promotion and artifact guarantees
 
-The release publish workflow enforces byte-for-byte fidelity with tested candidate binaries:
+The release publish workflow enforces byte-for-byte fidelity with tested candidate binaries across five layers:
 
-1. **Zero container rebuilds**: Container images are compiled only once on push to `main`. `scripts/release/promote_release_images.sh` retags existing `<TARGET_COMMIT>` manifests to numeric `X.Y.Z` in GHCR using `docker buildx imagetools create`.
-2. **Cosign OIDC signature**: Promoted container images in GHCR are cryptographically signed using Keyless Cosign via GitHub Actions OIDC tokens (`scripts/release/sign_release_images.sh`).
-3. **OCI Helm chart**: `scripts/release/publish_helm_chart.sh` packages `charts/kube-agents` at version `X.Y.Z` (matching `appVersion`), pushes the OCI package to `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:X.Y.Z`, and signs the OCI manifest via Cosign.
-4. **Installer version lock**: `scripts/release/tag_ga_release.sh` creates a single-parent release commit on detached HEAD, stamps `BAKED_RELEASE_VERSION="X.Y.Z"` into root scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`), and tags the stamped commit.
-5. **Drift prevention in `install.sh`**: `verify_local_source_ref` verifies that unversioned source directories match `BAKED_RELEASE_VERSION` and that Git checkouts match the requested tag commit SHA, halting execution if local scripts diverge from container images.
+1. Container images are compiled only once on push to `main`. `scripts/release/promote_release_images.sh` retags existing `<TARGET_COMMIT>` manifests to numeric `X.Y.Z` in GHCR using `docker buildx imagetools create`.
+2. Promoted container images in GHCR are cryptographically signed using Keyless Cosign via GitHub Actions OIDC tokens (`scripts/release/sign_release_images.sh`).
+3. `scripts/release/publish_helm_chart.sh` packages `charts/kube-agents` at version `X.Y.Z` (matching `appVersion`), pushes the OCI package to `oci://ghcr.io/gke-labs/kube-agents/charts/kube-agents:X.Y.Z`, and signs the OCI manifest via Cosign.
+4. `scripts/release/tag_ga_release.sh` creates a single-parent release commit on detached HEAD, stamps `BAKED_RELEASE_VERSION="X.Y.Z"` into root scripts (`install.sh`, `uninstall.sh`, `upgrade.sh`), and tags the stamped commit.
+5. `verify_local_source_ref` in `install.sh` verifies that unversioned source directories match `BAKED_RELEASE_VERSION` and that Git checkouts match the requested tag commit SHA, halting execution if local scripts diverge from container images.
 
 ## Helm chart versioning
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -13,12 +13,12 @@ The release pipeline guarantees that installer scripts (`install.sh`, `uninstall
 
 Every commit and build progresses through four distinct lifecycle tiers:
 
-| Tier                       | Format                                | Trigger                      | Purpose and guarantees                                                 |
-| :------------------------- | :------------------------------------ | :--------------------------- | :--------------------------------------------------------------------- |
-| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch        | Developer build in GHCR; container images built once.                  |
-| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | Push to `main` / 3-hour cron | Candidate build selected for live cluster testing.                     |
-| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite     | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
-| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow     | Official production release tagged on the validated commit.            |
+| Tier                       | Format                                | Trigger                       | Purpose and guarantees                                                 |
+| :------------------------- | :------------------------------------ | :---------------------------- | :--------------------------------------------------------------------- |
+| **Candidate Build**        | `<COMMIT_SHA>` (bare 40-char SHA)     | Push to `main` branch         | Developer build in GHCR; container images built once.                  |
+| **Release Candidate (RC)** | `rc_YYMMDDHHMM_<SHORT_SHA>`           | 3-hour cron / manual dispatch | Candidate build selected for live cluster testing.                     |
+| **RC Validated**           | `rc_YYMMDDHHMM_<SHORT_SHA>_validated` | Successful GKE E2E suite      | Quality gate: proof that `install.sh` succeeded on a real GKE cluster. |
+| **GA Stable**              | `X.Y.Z` (pure numeric SemVer)         | Release publish workflow      | Official production release tagged on the validated commit.            |
 
 ## Automated SemVer 2.0 calculation
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -22,16 +22,16 @@ Every commit and build progresses through four distinct lifecycle tiers:
 
 ## Automated SemVer 2.0 calculation
 
-When the GA release workflow runs, `scripts/release/calculate_next_version.sh` inspects Conventional Commits in the range `<LATEST_GA_TAG>..HEAD`:
+When the GA release workflow runs, `scripts/release/calculate_next_version.sh` inspects Conventional Commits in the range `<LATEST_GA_TAG>..<TARGET_COMMIT>` (resolving to the latest validated RC commit on the standard automated path, or the specified commit / `HEAD` under emergency bypass):
 
 <!-- prettier-ignore -->
-| Commit type landed on `main` | Current version | Calculated next version | Precedence and action |
+| Commit type in release range | Current version | Calculated next version | Precedence and action |
 | :--- | :--- | :--- | :--- |
 | `fix:`, `chore:`, `docs:`, `perf:` | `0.2.0` | `0.2.1` | Patch bump |
 | `feat:` | `0.2.0` | `0.3.0` | Minor bump, Patch resets to 0 |
 | `feat!:`, `fix!:`, `BREAKING CHANGE:` | `0.2.0` | `0.3.0` | Minor bump (SemVer 2.0 Clause 4 in `0.y.z`) |
 | `feat!:`, `fix!:`, `BREAKING CHANGE:` | `1.2.0` | `2.0.0` | Major bump (in `1.x.x`+) |
-| _(No new commits on main)_ | `0.2.0` | `0.2.0` | No changes (`skip_release=true`) |
+| _(No new commits in release range)_ | `0.2.0` | `0.2.0` | No changes (`skip_release=true`) |
 
 ### SemVer 2.0 Clause 4 and the 1.0.0 manual governance rule
 

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -88,19 +88,20 @@ Even during an emergency bypass, the pipeline strictly enforces:
 
 ### Executing an emergency hotfix
 
-To publish an emergency release via the GitHub CLI:
+To publish an emergency release via the GitHub CLI. Always specify `target_commit` to pin the exact hotfix commit SHA; omitting `target_commit` causes the workflow to default to the tip of `main` (`HEAD`), releasing all intervening commits without prior GKE E2E validation:
 
 ```bash
-# Emergency release from a specific commit SHA:
+# Emergency release from a specific commit SHA (version calculated automatically):
 gh workflow run release-publish.yml --repo gke-labs/kube-agents \
   -f skip_rc_validation=true \
   -f emergency_override_reason="CVE-2026-XXXX: Critical vulnerability in base container dependencies" \
   -f target_commit="<HOTFIX_COMMIT_SHA>"
 
-# Emergency release with explicit SemVer override:
+# Emergency release from a specific commit SHA with explicit SemVer override:
 gh workflow run release-publish.yml --repo gke-labs/kube-agents \
   -f skip_rc_validation=true \
   -f emergency_override_reason="Critical regression fix for gateway admission deadlock" \
+  -f target_commit="<HOTFIX_COMMIT_SHA>" \
   -f explicit_release_version="0.3.1"
 ```
 


### PR DESCRIPTION
## Summary

Expands the release documentation in the docs site into a canonical operational guide for GA releases and emergency maintenance, documenting tag taxonomy, automated SemVer 2.0 calculation, the manual 1.0.0 milestone governance rule, clean promotion guarantees, and the emergency hotfix runbook.

## Why This Change

While the GA release publish pipeline and scripts are fully operational, operators and maintainers lacked a single canonical reference for release lifecycle operations. In particular, the SemVer 2.0 Clause 4 rule for `0.y.z`, the requirement that graduating to `1.0.0` is strictly a manual gate, and the emergency gate bypass procedure (`skip_rc_validation`) were previously only documented in technical design drafts or internal script comments.

## What Changed

- `docs/site/src/content/docs/deploy/release-versioning.md`:
  - Added tag and artifact taxonomy table covering candidate builds (`<COMMIT_SHA>`), `rc_*` (triggered by 3-hour cron / manual dispatch), `rc_*_validated`, and numeric `X.Y.Z`.
  - Documented automated SemVer 2.0 calculation rules via Conventional Commits in the range `<LATEST_GA_TAG>..<TARGET_COMMIT>` and the manual `1.0.0` governance gate.
  - Provided step-by-step GA release execution instructions via GitHub CLI (`gh >= 2.40.0`) and GitHub Actions web UI.
  - Documented the Emergency Hotfix Runbook, including eligibility criteria, non-negotiable security invariants, CLI dispatch commands with mandatory `target_commit`, and post-release GKE reconciliation.
  - Detailed clean promotion guarantees (zero image rebuilds, Cosign OIDC signing, OCI Helm chart publishing, and installer version lock).
  - Converted artificial bold-term item lists into natural prose and direct numbered steps per AGENTS.md guidelines.
- `docs/README.md`: Updated the `deploy/release-versioning.md` row in the documentation map to reflect its expanded operational scope.

## Context

Part of Scope 4 of the release pipeline automation initiative (Issue #618).
Follows the completion of Scope 1 (#688), Scope 2 (#732), and Scope 3 (#803, #858, #914).

## Testing

- `make docs-check`: All 276 markdown files checked, relative links resolved, terminology validated, and docs map verified.
- `make docs-generate`: Family roster and generated regions verified.

### Live validation

Not live-tested: documentation-only changes that do not modify runtime controller code, agent personas, or deployment infrastructure.

## Self-Review

- **Adversarial pass (fresh interactive session)**:
  - Workflow inputs and dispatch flags: Checked against `.github/workflows/release-publish.yml`; verified that `target_commit`, `explicit_release_version`, `skip_rc_validation`, and `emergency_override_reason` match exact input names.
  - Emergency release behaviour: Analyzed execution traces through `calculate_next_version.sh` and `verify_release_eligibility.sh`. Finding: omitting `target_commit` in emergency recipes silently resolves to `HEAD` (tip of `main`), which would release unvalidated commits. Fixed: added mandatory `target_commit="<HOTFIX_COMMIT_SHA>"` to all emergency recipes and added an explicit warning.
  - Image tag taxonomy: Compared GHCR container image references against `docker-publish-ghcr.yml`, `verify_release_eligibility.sh`, and `promote_release_images.sh`. Finding: GHCR stores candidate builds with bare 40-character commit SHAs, not `sha-<SHA>`. Fixed: replaced all instances of `sha-<...>` with bare commit SHA `<TARGET_COMMIT>`.
  - Operator prerequisites: Evaluated `gh workflow run` requirements. Finding: requires `gh >= 2.40.0` with `repo` and `workflow` scopes. Fixed: added explicit `gh >= 2.40.0` prerequisite to documentation.
  - SemVer commit range: Compared documented `<LATEST_GA_TAG>..HEAD` with `calculate_next_version.sh:120`. Finding: standard automated path bounds the range at the latest validated RC commit, not `HEAD`. Fixed: updated documentation and table headers to `<LATEST_GA_TAG>..<TARGET_COMMIT>`.
  - RC trigger taxonomy: Checked `.github/workflows/rc-scheduler.yml` and `rc-release-pipeline.yml`. Finding: push to `main` does not create `rc_*` tags. Fixed: corrected RC trigger to `3-hour cron / manual dispatch`.
- **Docs-drift pass (fresh interactive session)**:
  - Documentation guidelines: Checked against AGENTS.md § Documentation Guidelines. Finding: extensive use of `**Bold term:** explanation` lists in five sections. Fixed: refactored all lists into natural prose and direct numbered steps.
  - Map inventory: Checked `docs/README.md` entry via `make docs-check`; single-space table format maintained, link validation clean.

## Risk & Rollout

Low risk, documentation-only change. Does not touch runtime code paths or deployment scripts.
