### PR TITLE
fix(ci): remove unencrypted secrets fallback in reusable deploy workflow

### DIFF
--- a/.github/workflows/reusable-deploy-integrations.yml
+++ b/.github/workflows/reusable-deploy-integrations.yml
@@ -126,9 +126,7 @@ jobs:
           CLUSTER_NAME: ${{ vars.GKE_CLUSTER_NAME }}
           MODEL_PROVIDER: ${{ vars.MODEL_PROVIDER }}
           MODEL_DEFAULT_NAME: ${{ vars.MODEL_DEFAULT_NAME }}
-          # Allow deployments on pre-existing CI evaluation / environment clusters
-          # created without Cloud KMS CMEK encryption until they are upgraded.
-          ALLOW_UNENCRYPTED_SECRETS: ${{ vars.ALLOW_UNENCRYPTED_SECRETS || 'true' }}
+          ALLOW_UNENCRYPTED_SECRETS: ${{ vars.ALLOW_UNENCRYPTED_SECRETS }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Removes the temporary fallback `|| 'true'` for `ALLOW_UNENCRYPTED_SECRETS` and cleans up obsolete comments in `reusable-deploy-integrations.yml`, aligning the integration redeploy pipeline with the now fully CMEK-encrypted environment stands.

## Why This Change

During the rollout of Customer-Managed Encryption Keys (CMEK) for GKE database encryption (Task 537147497 / PR #495), `ALLOW_UNENCRYPTED_SECRETS` was temporarily given a fallback of `'true'` in `reusable-deploy-integrations.yml` to allow redeploys against existing unencrypted environment clusters until they were upgraded. With all environments (Autopush, RC, Staging, and CI evaluation pools) migrated to Terraform and CMEK database encryption enabled (b/543839009), the temporary fallback allowing unencrypted deployments is no longer needed.

## What Changed

- In `.github/workflows/reusable-deploy-integrations.yml`: removed the `|| 'true'` fallback for `ALLOW_UNENCRYPTED_SECRETS`, passing the variable value directly as `${{ vars.ALLOW_UNENCRYPTED_SECRETS }}` without falling back to `true`.
- Removed the outdated temporary comment describing unencrypted pre-existing clusters awaiting upgrade.

## Context

- Resolves remaining scope for Taskflow iteration 6011656 / b/543839009.
- Follow-up to PR #495 and PR #653 (which set `ALLOW_UNENCRYPTED_SECRETS:-false` for CI eval clusters).

## Testing

- Automated workflow validation and tests:
  - `npx prettier --check .github/workflows/reusable-deploy-integrations.yml`
  - `python -m unittest tests/test_gateway_rollout_budgets.py scripts/test_integration_contracts.py`
  - `python -m unittest tests/test_e2e_github_repo_resolution.py`

### Live validation

Not live-tested against a running cluster: this change only modifies a GitHub Actions reusable workflow environment mapping (`reusable-deploy-integrations.yml`) by removing a fallback expression; no runtime controller, agent binary, or cluster infrastructure code is modified.

## Self-Review

- **Adversarial pass**: Verified that removing `|| 'true'` does not break environments where `vars.ALLOW_UNENCRYPTED_SECRETS` is unset; the environment variable will simply be empty/unset, matching the strict default enforcement across all encrypted environments.
- **Docs-drift pass**: Checked documentation in `INSTALL.md`, `docs/site/.../security-and-iam.md`, and `hack/ci-deploy.sh`; all documentation already describes CMEK as required by default, with `ALLOW_UNENCRYPTED_SECRETS=true` being an explicit manual override for test environments.

## Risk & Rollout

Low risk. Only touches `.github/workflows/reusable-deploy-integrations.yml`. Revertible by restoring the fallback if any stand requires unencrypted secrets.
