### PR TITLE
docs(bench): correct the single-cluster claim about k8s-event-watcher

### DIFF
--- a/bench/tasks/autoops-warning-event-triage/task.yaml
+++ b/bench/tasks/autoops-warning-event-triage/task.yaml
@@ -5,12 +5,16 @@
 #
 # The scenario brings its own incident. bench/tf/prebuilt/autoops-incident
 # plants one OOM-killed Deployment in one namespace on the cluster the Platform
-# Agent pod runs in -- the only cluster k8s-event-watcher sees -- and does not
-# return until the watcher has logged that it opened an incident for it. By the
-# time the prompt below runs, the card exists and is being worked. The stack
-# reads no seeded fleet and shares no planted defect with any other case:
-# cluster-agent-crashloop-debug owns the fleet's payments-api crashloop, and two
-# cases pointed at one pod share its dedup entry and its failures.
+# Agent pod runs in, and does not return until the watcher has logged that it
+# opened an incident for it. That cluster, and not a per-run one, because it is
+# the only cluster k8s-event-watcher is guaranteed to be watching while the
+# case runs -- the watcher does fan in over the Cluster Agent profile clusters
+# as well, but a per-run cluster is in neither set, for the timing reasons that
+# stack's header gives. By the time the prompt below runs, the card exists and
+# is being worked. The stack reads no seeded fleet and shares no planted defect
+# with any other case: cluster-agent-crashloop-debug owns the fleet's
+# payments-api crashloop, and two cases pointed at one pod share its dedup
+# entry and its failures.
 #
 # This is the one presubmit case that mutates, which is why it is
 # namespace-scoped rather than read-only: the namespace is created by the

--- a/bench/tf/fleet/README.md
+++ b/bench/tf/fleet/README.md
@@ -325,8 +325,10 @@ rows above to appear alongside the planted finding in their respective audits.
 
 The chat-routing and incident-triage scenarios need no defect planted in the
 fleet — incident triage plants its own, an OOM-killed workload applied to the
-host cluster by `bench/tf/prebuilt/autoops-incident`, because the only cluster
-`k8s-event-watcher` sees is the one it runs in; the
+host cluster by `bench/tf/prebuilt/autoops-incident`, because a per-run cluster
+joins `k8s-event-watcher`'s watch set too late to be watched inside the run
+(the watcher does fan in over the Cluster Agent profile clusters; that stack's
+header has the timing argument); the
 silence-on-a-clean-fleet case needs a clean view, which is an open fleet-design
 decision recorded with the scenario drafts. The silence case in particular must
 tolerate the declared background rows above.

--- a/bench/tf/prebuilt/autoops-incident/main.tf
+++ b/bench/tf/prebuilt/autoops-incident/main.tf
@@ -17,10 +17,26 @@
 # Every other prebuilt stack here builds a cluster and plants something on it.
 # This one builds nothing. The incident has to happen on the cluster the
 # Platform Agent pod is running on, because that is the only cluster
-# k8s-event-watcher sees: it is a peer process inside that pod's
-# envoy-credential-proxy container, started by deploy/shared/start-services.sh
-# with --in-cluster. An incident planted on a per-run task cluster is never
-# detected and the case waits out its timeout for a card nobody filed.
+# k8s-event-watcher is guaranteed to be watching while the case runs.
+#
+# It is not a single-cluster watcher. It runs as a peer process inside that
+# pod's envoy-credential-proxy container, started by
+# deploy/shared/start-services.sh with BOTH --in-cluster and --profiles-dir,
+# and those sources are additive: the host cluster, plus every Cluster Agent
+# profile on the PVC naming a cluster the direct entry does not already cover
+# (#497; see the README of k8s-operator/cmd/k8s-event-watcher, Section 4,
+# "Option C: Multi-Cluster Fan-In").
+#
+# What makes the host cluster the only usable target here is timing, twice
+# over. A per-run task cluster gets a Cluster Agent profile only from the
+# hourly cluster-agent-reconcile tick (agents/chat/defaults/cron/jobs.json),
+# and the watcher reads that directory once, at startup, so a profile written
+# mid-run is picked up only from the watcher process's next start -- a pod
+# restart, or a crash the start-services.sh supervisor loop restarts it from.
+# An incident on a per-run task cluster therefore goes undetected unless both
+# of those land inside the run, which is a race rather than a design, and one
+# the case loses on almost every run while waiting out its timeout for a card
+# nobody filed.
 #
 # So this stack takes the host cluster as an input, applies one Deployment into
 # one namespace on it, waits until the pipeline has demonstrably started, and
@@ -129,10 +145,12 @@ resource "null_resource" "incident" {
       # documents the same mechanism, which is why it pins the agent connection
       # with --context.
       #
-      # An incident planted on the wrong cluster is never seen: k8s-event-watcher
-      # runs in-cluster inside the Platform Agent pod and watches only the cluster
-      # it is in. The old form of this step asserted the context instead of
-      # setting it, which would have failed the apply on every presubmit run.
+      # An incident planted on the wrong cluster is never seen inside the run:
+      # the watcher fans in over the host cluster plus the Cluster Agent
+      # profiles present when it started, and a per-run task cluster is in
+      # neither set -- see the header of this file for why. The old form of
+      # this step asserted the context instead of setting it, which would have
+      # failed the apply on every presubmit run.
       #
       # A plain get-credentials is the right call and needs no DNS-endpoint
       # handling: it is exactly what hack/ci-eval-pr.sh does for this same
@@ -248,6 +266,13 @@ resource "null_resource" "incident" {
       # --since-time, not --since: the namespace name is static, so a wall-clock
       # window would also match the `fire` line from an earlier run against a
       # recycled Boskos lease and return before this run's incident exists.
+      #
+      # The fire line carries no cluster (k8s-event-watcher/main.go), and the
+      # watcher fans in over several, so in principle this matches a pod of
+      # that name on any watched cluster. Nothing reaches it today: only this
+      # stack plants ${local.ns}, the destroy removes it, and the task loop is
+      # sequential. A leftover namespace from a failed teardown on another
+      # watched cluster, or the concurrency of #637, would.
       elapsed=0
       until kubectl logs "deployment/${var.agent_deployment}" \
               -n "${var.agent_namespace}" -c "${var.agent_container}" \

--- a/bench/tf/prebuilt/autoops-incident/variables.tf
+++ b/bench/tf/prebuilt/autoops-incident/variables.tf
@@ -21,12 +21,13 @@
 # and NOT declared here raises ConfigError. So the task file and this one are a
 # matched pair.
 
-# The cluster the Platform Agent pod runs in, which is the ONLY cluster this
-# scenario can use. k8s-event-watcher is a peer process inside that pod's
-# envoy-credential-proxy container and reads events through --in-cluster, so an
-# incident planted anywhere else is never seen. hack/ci-eval-pr.sh passes these
-# two from HOST_CLUSTER_NAME/REGION -- deliberately not from the per-run task
-# cluster the other tofu stacks build, which has no agent on it.
+# The cluster the Platform Agent pod runs in, and the only cluster this
+# scenario can use -- not because k8s-event-watcher is confined to the cluster
+# it runs in (it fans in over the Cluster Agent profile clusters as well), but
+# because a per-run cluster joins that watch set too late to be watched inside
+# the run. main.tf's header carries the argument. hack/ci-eval-pr.sh passes
+# these two from HOST_CLUSTER_NAME/REGION -- deliberately not from the per-run
+# task cluster the other tofu stacks build, which has no agent on it.
 variable "host_cluster_name" {
   type        = string
   description = "Name of the cluster the Platform Agent runs in; the incident is planted here."

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -323,9 +323,12 @@ export TF_VAR_infra_provider="gcp"
 # Every other stack under bench/tf builds its own cluster or reuses the seeded
 # slot-c one; prebuilt/autoops-incident can use neither, because the incident
 # it plants has to be seen by k8s-event-watcher, which runs as a peer process
-# inside the Platform Agent pod and reads events --in-cluster. An incident on
-# any other cluster is never detected, and the case waits out its timeout for
-# a card nobody filed. A stack that does not declare these ignores them.
+# inside the Platform Agent pod. The watcher does fan in over the Cluster Agent
+# profile clusters as well as its own, but a per-run cluster reaches that watch
+# set too late to be watched inside the run -- see the header of
+# bench/tf/prebuilt/autoops-incident/main.tf. An incident there goes
+# undetected and the case waits out its timeout for a card nobody filed. A
+# stack that does not declare these ignores them.
 export TF_VAR_host_cluster_name="${HOST_CLUSTER_NAME}"
 export TF_VAR_host_cluster_location="${REGION}"
 export TF_VAR_agent_namespace="${TARGET_NAMESPACE}"


### PR DESCRIPTION
## Summary

Five committed comments in the AutoOps incident-triage scenario say that `k8s-event-watcher` watches only the cluster it runs in. It has fanned in over every managed cluster since #497, three weeks before those comments were written. The decision the comments defend is still correct — the host cluster is the right place to plant the incident — but the reason given for it is not, so this replaces it with the reason that actually holds. Comments and Markdown prose only; no executable line changes.

## Why This Change

`deploy/shared/start-services.sh:221-231` starts the watcher with **both** `--in-cluster` and `--profiles-dir`, and those sources are additive (`k8s-operator/cmd/k8s-event-watcher/main.go:148`, and the watcher README §4, "Option C: Multi-Cluster Fan-In"): `--in-cluster` contributes the host, `--profiles-dir` contributes one watched cluster per Cluster Agent profile on the PVC. That line has been in the deployed invocation since `99c2e7a` — "Feat/watcher in credential proxy (#497)", merged 2026-08-07. The comments asserting the opposite landed with #1045 on 2026-08-29.

Nothing is broken today, which is exactly what makes this worth fixing: the error is in a *reason*, and reasons propagate. The next person designing an AutoOps case reads "the watcher only sees its own cluster" and rules out a fleet-facing scenario that is in fact reachable. #1047 (`FailedScheduling`) and #612 are the kind of follow-up work that would read these comments first.

The reason that does hold is timing, twice over. A per-run task cluster gets a Cluster Agent profile only from the hourly `cluster-agent-reconcile` tick (`agents/chat/defaults/cron/jobs.json`, `11 * * * *`), and the watcher reads the profiles directory once at startup, so a profile written mid-run is picked up only from the watcher process's next start. An incident on a per-run cluster therefore goes undetected unless both land inside the run — a race, not a design, and one the case loses on almost every run. Same conclusion as before, on a premise a reader can check.

One nuance the old comments also obscured: the **seeded fleet** clusters share the eval project with the host, so once reconcile has run they *are* in the watch set. The reason to avoid planting there is the one #1045 also gave and which still stands — `cluster-agent-crashloop-debug` already owns the fleet's `payments-api` crashloop, and two cases pointed at one pod share its dedup entry and its failures.

## What Changed

- `bench/tf/prebuilt/autoops-incident/main.tf` — the file header carries the corrected model and the timing argument. It is now the single home for that argument; the other three files defer to it rather than restating it, so the next correction has one place to land.
- `bench/tf/prebuilt/autoops-incident/variables.tf`, `hack/ci-eval-pr.sh`, `bench/tf/fleet/README.md` — the three sibling restatements of the same claim, found by the pre-PR passes rather than by the original edit. `variables.tf` matters most: `main.tf`'s header explicitly pairs itself with that file, so leaving it would have pointed the reader straight at the wrong reason.
- `bench/tasks/autoops-warning-event-triage/task.yaml` — the same claim in passing, in the scenario preamble.
- Two comments in `main.tf` record limits the corrected model makes visible: the watch set can change on a watcher process restart, not only a pod restart; and the step-3 gate greps a `fire` line that carries no cluster, so it is cluster-blind in principle (nothing reaches it today — only this stack plants that namespace, the destroy removes it, and the task loop is sequential).

## Context

- Corrects comments introduced by #1045. Its PR body carries a sixth copy of the claim, which is a frozen artifact and not editable.
- No issue filed for the claim itself: the fix is smaller than the issue would be, and the reasoning lives here.
- **Follow-up found by the adversarial pass and not fixed here:** under fan-in, the seeded fleet's permanently crash-looping `payments-api` spends the same *fleet-wide* alert budget as this case (`ALERT_DAILY_LIMITS` in `agents/platform/scripts/session_kv_server.py:332-334`, fleet-wide on purpose per `:498`). With the Warning ceiling spent, the planted OOM kill logs `quota-suppressed` instead of `fire`, and step 3 times out printing a diagnosis that rules out the actual cause. Pre-existing on `main` and derived from source, not observed live. It is invisible while the repo believes the watcher is single-cluster, which is an argument for this correction rather than against it. Issue to follow.
- No competing work: no open PR touches `bench/tasks/autoops-warning-event-triage/` or `bench/tf/prebuilt/autoops-incident/`. #1066 touches `bench/tf/fleet/README.md` but not the paragraph changed here; #1050, #944, #981 and #1057 touch `hack/ci-eval-pr.sh` elsewhere. Small conflict risk, no overlap in intent.

## Testing

- `make docs-check` — green (generated regions current, 276 files link-checked, terminology, map coverage, context budget).
- `python3 scripts/validate_bench_cases.py` — 28 bench cases OK.
- `bash -n hack/ci-eval-pr.sh` — clean.
- `prettier` at the pinned version — `bench/tf/fleet/README.md` unchanged.
- Diff verified mechanically to be documentation-only: every added or removed line is a `#` comment or Markdown prose.

### Live validation

**Not live-tested**, because there is nothing to observe. The change alters no executable line — the filter above returns nothing but comments and prose — so no CR `.status`, Deployment env, or in-pod file or process differs before and after it. Applying it to a running install and reading those layers would prove only that comments do not reach them.

What the change asserts was instead verified against source, and independently by both pre-PR passes: `deploy/shared/start-services.sh:221-231` passes both flags unconditionally; the sources are additive at `main.go:148` and `:1007-1060`; `buildWatchSet` drops the profile duplicating the direct cluster (`main.go:1035-1050`), which is why the text says "every profile naming a cluster the direct entry does not already cover"; the profiles directory is on the PVC; the reconcile tick is `11 * * * *`; and the README citation resolves to §4 / "Option C: Multi-Cluster Fan-In".

Not covered: whether a given eval install actually holds Cluster Agent profiles at run time. That is a property of a live install, and confirming it needs the leased eval project — the mechanism is verified, its state on any particular install is not. No test artifacts created; nothing to clean up.

## Self-Review

Two passes, both run by subagents handed only the diff range — neither held the reasoning that produced the change. `/pr-preflight` spawned them concurrently after `make docs-check` passed as the mechanical gate. Merged list, most serious first:

1. **Three surviving copies of the corrected-away claim** (`variables.tf`, `hack/ci-eval-pr.sh`, `bench/tf/fleet/README.md`) — found independently by *both* passes, and the finding behind the finding: the original edit grepped for phrasings it had already seen. A correction that fixes two of five statements of one fact leaves the repository self-contradicting, which is worse for a reader than the uniform error was. **Fixed**, and restructured so one file owns the argument.
2. **Fleet-wide alert budget** (adversarial, PLAUSIBLE) — the composition described under Context. **Not fixed**: it is pre-existing, in code this PR does not touch, and needs a live install to confirm. "Pre-existing" is not a disposition on its own, so an issue follows; the reasoning is recorded above so it is not lost if the issue lags.
3. **"would need a pod restart"** (both passes, CONFIRMED) — narrower than source. `start-services.sh` supervises the binary, so any watcher *process* exit re-reads the directory, and the watcher README says so at `:154`. Adversarial went further than docs-drift here: this was a hole in my own paragraph's conclusion, since an hourly tick landing mid-run plus a crash-restart *would* put the per-run cluster in the watch set. **Fixed** by weakening the claim to what is true — a race the case loses on almost every run, rather than "never".
4. **The additive set over-counted by one** (both passes, CONFIRMED) — "one cluster per Cluster Agent profile" ignores that the host's own profile is folded onto the direct entry. **Fixed**.
5. **The step-3 `fire` grep is cluster-blind** (adversarial, PLAUSIBLE) — the log line carries no cluster (`main.go:766`), so under fan-in the gate could in principle match another cluster's pod. **Fixed as a comment only**; narrowing the gate is a behaviour change and this PR is prose. The comment names what would make it reachable: a failed teardown elsewhere, or #637 concurrency.

Angles that produced no finding, so that "no findings" means something: every identifier the new text introduces resolves; `#497` is the right attribution (the Go fan-in itself was #473, but the sentence is about how the deployed pod starts the watcher); both hunks in the heredoc are comments and the one interpolation added (`${local.ns}`) is a valid existing reference used on the neighbouring line; no behaviour change; the hedge "*guaranteed* to be watching" holds, including the one path where the host loses its direct entry; `eod_event_watcher_daily_report_sop.md` and the site docs already describe fan-in correctly, so there is no sixth copy; no `docs/README.md` row needed.

What the passes could not cover: no live install, which is why findings 2 and 5 stay PLAUSIBLE — neither could read the deployed watcher's log for `fire` / `quota-suppressed` lines or list which clusters carry profiles. No `tofu validate`, `go test` or `gofmt` in this environment; nothing in the diff changes HCL or Go semantics, but the HCL is unparsed by anything that ran. The adversarial pass's competing-work sweep used the unauthenticated GitHub API, so review threads on sibling PRs were invisible to it.

## Risk & Rollout

No runtime code paths touched and no rendered manifest changes — the entire diff is comments and Markdown. Revert is a single revert commit. Nothing has to happen at merge time.

---

Generated with the help of Claude Opus 5.
