### PR TITLE
docs(designs): fold stage 1 findings into the A2A specs and reconcile divergent copies

### DIFF
--- a/docs/designs/spec-a2a-payloads.md
+++ b/docs/designs/spec-a2a-payloads.md
@@ -133,7 +133,7 @@ lacked.
 | Field                  | Rules                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `protocol`             | Required. Major.minor; bump major on breaking change. Consumers MUST reject unknown majors and MUST ignore unknown envelope fields within a major.                                                                                                                                                                                                                                                                                                                            |
-| `envelopeId`           | Required, unique per envelope. The dedup key: JetStream redelivery means consumers will see repeats, and this is how the library delivers each envelope to the application at most once.                                                                                                                                                                                                                                                                                      |
+| `envelopeId`           | Required, unique per envelope. The dedup key: JetStream redelivery means consumers will see repeats, and this is how the library delivers each envelope to the application at most once. The dedup window is bounded - an LRU or time window sized to the redelivery horizon (`MaxAckPending` × ack wait, plus margin), never an unbounded set that grows for the life of the process.                                                                                        |
 | `correlationId`        | Required. Minted once by the gateway at the user interaction that starts a task. Copied verbatim on every hop; never re-minted by an intermediary. A task spawned in service of another task inherits its parent's value, and a follow-up or steer to a running task carries the task's original value - the steer is attributed by its own envelope and `authority` block, not by a new correlation. This is the identifier that spans question, hops, and resulting change. |
 | `traceparent`          | Optional. W3C trace context, for OTel tooling. `correlationId` is authoritative; `traceparent` is a convenience and may be re-parented per span.                                                                                                                                                                                                                                                                                                                              |
 | `taskId` / `contextId` | Required for kinds `message`, `status-update`, `artifact-update`, `cancel`. Optional for `topic-update` (present when a topic write happened in the course of a task - see Topics). Absent for `agent-card`, `agent-closed`.                                                                                                                                                                                                                                                  |
@@ -144,6 +144,13 @@ lacked.
 | `authority`            | **Reserved**, advisory. Populated by the chatops gateway only. See below.                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `kind`                 | Required. Enum below; selects the payload type.                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `payload`              | The A2A object, per kind.                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+
+One rule spanning three fields: `correlationId`, `taskId`, and `contextId` are minted as
+opaque random tokens and MUST NOT embed backend identifiers, thread titles, emails, or
+any user content. They are the identifier class that escapes the pseudonymization rule
+(they ride every subject and every envelope in the clear), and they stay clean by
+construction, not by redaction - a `corr-{threadTitle}` would quietly put labelled
+content on the bus.
 
 ### Reserved fields: `identity` and `authority`
 
@@ -199,12 +206,12 @@ starting it.
 
 ### Subjects
 
-| Subject                                   | Carries                                                                                                                                                                                                                              |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `a2a.tasks.{addressee}.{taskId}.in`       | `message` (submission and follow-up input) and `cancel`, requester to executor                                                                                                                                                       |
-| `a2a.tasks.{addressee}.{taskId}.events`   | `status-update` and `artifact-update`, executor to anyone                                                                                                                                                                            |
-| `a2a.agents.{profile}`                    | `agent-card` when a profile is created, `agent-closed` tombstone on delete - published by the profile's owner (the operator once profiles are CRs), not by workers. Chat sessions are not discoverable services and publish no card. |
-| `agents.hb.{agentType}.{owner}.{session}` | Core-NATS heartbeat every 15 s, Synadia-compatible shape, outside the stream. `owner` is the owning scope/account name - a single fixed value until the multi-scope split is exercised.                                              |
+| Subject                                   | Carries                                                                                                                                                                                                                                                              |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `a2a.tasks.{addressee}.{taskId}.in`       | `message` (submission and follow-up input) and `cancel`, requester to executor. Two reader roles by design: the dispatcher consumes new-task submissions; the executor's own ephemeral consumer takes everything after the submission (follow-ups, steers, cancels). |
+| `a2a.tasks.{addressee}.{taskId}.events`   | `status-update` and `artifact-update`, executor to anyone                                                                                                                                                                                                            |
+| `a2a.agents.{profile}`                    | `agent-card` when a profile is created, `agent-closed` tombstone on delete - published by the profile's owner (the operator once profiles are CRs), not by workers. Chat sessions are not discoverable services and publish no card.                                 |
+| `agents.hb.{agentType}.{owner}.{session}` | Core-NATS heartbeat every 15 s, Synadia-compatible shape, outside the stream. `owner` is the owning scope/account name - a single fixed value until the multi-scope split is exercised.                                                                              |
 
 **The addressee token (added in 0.4) is the authorization seam.** `{addressee}` is the
 executor's name - a profile, or a chat session. With it in the subject, connection-time
@@ -212,8 +219,13 @@ grants become exact: who may delegate to which profiles, who may emit events as 
 executor, each a per-user subject-prefix grant. Without it (0.3 and earlier), every
 grant collapsed to `a2a.tasks.>` and the deployment spec's connect-time property was
 unimplementable on the task plane. The envelope's `to` MUST agree with the subject's
-addressee token; a mismatch is a protocol error. Per-task (rather than per-executor)
-scoping stays the parked tightening with the authority work.
+addressee token; a mismatch is a protocol error. `{addressee}` and `{taskId}` MUST be
+dot-free tokens - lowercase alphanumerics and hyphens, DNS-1123-shaped - because dots
+are NATS token separators, and a dotted value silently changes the subject's token
+count out from under every wildcard filter. (Topic tokens already carry this rule; it
+is the same rule.) Session names (`<profile>-<animal>`) and sanitized profile names
+comply by construction; the library enforces it anyway. Per-task (rather than
+per-executor) scoping stays the parked tightening with the authority work.
 
 (0.1's `.request` becomes `.in` because it now carries follow-up input and cancel, not just
 the one submission.)
@@ -237,15 +249,32 @@ calls and become properties of the stream:
 - The first event on a task is a `status-update` with state `submitted`, published by the
   executor on accepting the message. (The Synadia `ack` chunk collapses into this.)
 - Exactly one event carries `final: true`, and it is a terminal `status-update`.
-- Nothing follows the final event. An event after `final` is a protocol error the library
-  must surface, not ignore.
+- Nothing follows the final event. An event after `final` is a protocol error the
+  library must surface, not ignore - and surface means a structured warning and a
+  metric, with the late event dropped. It MUST NOT terminate the consumer: a zombie
+  worker flushing its buffer after the supervisor's terminal event must not be able to
+  crash a gateway or dispatcher.
 - `input-required` flow: executor publishes `status-update` with state `input-required`
   carrying an A2A message that asks for the input. The requester publishes a follow-up
   `kind: message` with the same `taskId` to `…in`. Executor resumes and publishes
   `working`.
-- Steering (added 8/24): a follow-up `message` on `…in` while the task is `working` is
-  legal. It is steering input - delivered to the executor, incorporated at its next turn
-  boundary, no state transition implied. The hard interrupt is `cancel`, not a steer.
+- Steering (added 8/24; refusal posture recorded 8/31): a follow-up `message` on `…in`
+  while the task is `working` is legal. It is steering input - delivered to the
+  executor, incorporated at its next turn boundary, no state transition implied. The
+  hard interrupt is `cancel`, not a steer. An executor that cannot absorb input
+  mid-turn (today's standing front door) refuses instead: a non-final `status-update`
+  carrying the task's CURRENT state, visible on the stream - never a silent drop, and
+  never a state change caused by the follow-up alone. Assertion 21's stdin delivery
+  applies to absorbing executors; a refusal satisfies its never-silently-dropped half.
+- Turn accounting is the steering contract (amended 8/31, from the worker adapter). A
+  harness driven over stream-json emits one `result` per user turn, so once steers
+  exist, "the harness produced a result" no longer means "the task is done." The
+  executor's adapter counts turns - the opening prompt is one, each absorbed steer adds
+  one, each harness `result` settles one - and the result that settles the count is the
+  task's deliverable. Racing steers are drained before that decision; a steer that
+  arrives after the deliverable is chosen is warn-and-drop, the same rule as an event
+  after `final`. Without this rule, the first result after a steer would terminate the
+  task with the pre-steer answer and the correction would be silently lost.
 - There is deliberately no protocol-level inactivity timeout. Liveness is judged from
   heartbeats and consumer health, which the deployment spec owns. A task whose executor
   died without a terminal event gets terminal `failed` written by its supervisor - the
@@ -257,12 +286,12 @@ calls and become properties of the stream:
 Added 8/24, ratified with the subagent framework. `artifact-update` payloads name their
 artifact, and four names are reserved so renderers and audit tooling can rely on them:
 
-| Name       | Content                                                               |
-| ---------- | --------------------------------------------------------------------- |
-| `result`   | The deliverable, chunked per A2A chunking rules                       |
-| `thinking` | Reasoning deltas. Debug views only                                    |
-| `activity` | Tool-call trace, one entry per invocation. Always in the audit replay |
-| `progress` | Agent-authored milestones, renderable to chat at zero model cost      |
+| Name       | Content                                                                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `result`   | The deliverable, chunked per A2A chunking rules                                                                                                                 |
+| `thinking` | Reasoning deltas. Debug views only                                                                                                                              |
+| `activity` | Tool-call trace, one entry per invocation. Always in the audit replay                                                                                           |
+| `progress` | Agent-authored milestones, renderable to chat at zero model cost. Stage 1 derives these from model narration; the subagent framework spec records the deviation |
 
 Artifact names are data, so the set can grow without touching the envelope; only these
 four carry reserved semantics.
@@ -326,17 +355,18 @@ Long-term audit archival is the deployment spec's exporter.
 
 ## Conformance assertions
 
-The stage 1 client library ships with a suite that asserts all of the following. Resilience
-assertions (server restart, reconnect behavior) live in the NATS deployment spec's
-requirements. The last two are repeated here because the suite is one suite.
+The stage 1 client library ships with a suite that asserts all of the following.
+Resilience assertions (server restart, reconnect behavior) live in the NATS deployment
+spec's requirements; 19 and 20 are repeated here because the suite is one suite. Where
+an assertion needs more than the library to prove (21), it names its home.
 
 Envelope:
 
 1. An envelope with an unknown protocol major is rejected. Same-major envelopes with
    unknown fields are accepted and the unknown fields ignored.
 2. The library never emits an envelope missing `protocol`, `envelopeId`, `correlationId`,
-   `ts`, `from`, or `kind`, nor one missing `taskId`/`contextId` for the kinds that require
-   them.
+   `ts`, `from`, or `kind`, nor one missing `taskId`/`contextId` for the kinds that
+   require them, nor one whose `taskId` or addressee fails the dot-free token rule.
 3. The library never populates `identity`. It populates `authority` only on the gateway's
    ingress path; every other producer emits it null. Inbound values are passed through
    byte-identical and are not consulted for any decision.
@@ -357,8 +387,8 @@ Payloads:
 Lifecycle:
 
 9. The first event on every task is a `status-update` with state `submitted`.
-10. Exactly one event has `final: true`, its state is terminal, and any event after it is
-    surfaced as a protocol error.
+10. Exactly one event has `final: true`, its state is terminal, and any event after it
+    is surfaced as a protocol error - warn-and-drop, with the consumer loop surviving.
 11. A `tasks/get` materialized by replay yields the same terminal state and artifact set a
     live subscriber saw.
 12. A follow-up message with the same `taskId` resumes an `input-required` task, and the
@@ -390,6 +420,15 @@ Resilience (shared with the deployment spec's requirements):
 19. The client survives a NATS server restart and resumes delivery without a process
     restart.
 20. After a reconnect, the consumer resumes with no gap, and assertion 5 still holds.
+
+Steering delivery (added 8/25, with the dual-reader rule):
+
+21. A steering message published to a running task reaches the executor's harness stdin
+    exactly once, including under JetStream redelivery. No dispatcher path consumes a
+    steer without delivering it - a steer to a live task is delivered to the executor,
+    never dropped. The executable test lands with the worker adapter, asserting against
+    a stub harness that echoes its stdin - proving "reached the harness stdin" needs the
+    adapter, not the library alone.
 
 ## Open Questions
 

--- a/docs/designs/spec-a2a-payloads.md
+++ b/docs/designs/spec-a2a-payloads.md
@@ -285,7 +285,11 @@ calls and become properties of the stream:
   heartbeats and consumer health, which the deployment spec owns. A task whose executor
   died without a terminal event gets terminal `failed` written by its supervisor - the
   gateway for chat sessions it spawned, the dispatcher's janitor for profile-addressed
-  tasks. Ratified 8/24.
+  tasks. Ratified 8/24. One refinement (8/31): `failed` is the state for an executor
+  that died mid-work, but where the supervisor is finishing a cancel the requester
+  already published - the executor is being torn down deliberately, on that cancel -
+  the terminal is `canceled`. The supervisor writes what happened, and assertion 13's
+  enumeration holds for every path a cancel can take.
 
 ### Reserved artifact names
 

--- a/docs/designs/spec-a2a-payloads.md
+++ b/docs/designs/spec-a2a-payloads.md
@@ -271,10 +271,16 @@ calls and become properties of the stream:
   exist, "the harness produced a result" no longer means "the task is done." The
   executor's adapter counts turns - the opening prompt is one, each absorbed steer adds
   one, each harness `result` settles one - and the result that settles the count is the
-  task's deliverable. Racing steers are drained before that decision; a steer that
-  arrives after the deliverable is chosen is warn-and-drop, the same rule as an event
-  after `final`. Without this rule, the first result after a steer would terminate the
-  task with the pre-steer answer and the correction would be silently lost.
+  task's deliverable. Racing steers are drained before that decision. A steer that
+  still arrives after the deliverable is chosen is answered with the refusal shape
+  above - a non-final `status-update` carrying the task's current state, published
+  before the terminal event - so the requester learns the correction missed on the
+  stream, not from silence; nothing stream-visible marks this window otherwise, since
+  the choice of deliverable is adapter-internal. The stage 1 adapter logs and counts
+  the drop without publishing the refusal yet - a recorded deviation, closed with the
+  rest of the adapter work. Without this rule, the first result after a steer would
+  terminate the task with the pre-steer answer and the correction would be silently
+  lost.
 - There is deliberately no protocol-level inactivity timeout. Liveness is judged from
   heartbeats and consumer health, which the deployment spec owns. A task whose executor
   died without a terminal event gets terminal `failed` written by its supervisor - the

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -235,12 +235,17 @@ the supervisor rule below is what keeps that from being a silent stop.
 
 **One rule for every pod the gateway deletes itself** (stated once here because three
 paths reach it - reap, Delegate, and any future one): if the pod is running a
-DETACHED task, the gateway publishes that task's terminal `failed` before deleting,
-as the supervisor of the sessions it spawns. Deleting first strands the task
+DETACHED task, the gateway publishes that task's terminal event before deleting, as
+the supervisor of the sessions it spawns. The state is `canceled`, not `failed`:
+every task this rule reaches is detached, and detached means a `stop` already
+published a cancel, so the gateway is finishing the cancel the requester asked for
+rather than reporting an error. That keeps assertion 13's enumeration intact
+(`canceled`, or `completed` if the race was lost) and keeps replay able to tell a
+stopped task from one that broke. Deleting first strands the task
 non-terminal for the whole retention window - the adapter's deadline dies with the
 process, and a deleted pod never reaches the terminal phase Sweep watches for - which
-would break the payload spec's every-task-has-a-supervisor rule and assertion 13,
-since a detached task got that way from a `stop` that published a cancel. Do not
+would break both that assertion and the payload spec's every-task-has-a-supervisor
+rule. Do not
 reason from the config defaults here: the adapter's deadline runs from task start and
 the idle TTL from the last user message, so which fires first is a property of two
 independently tunable numbers, not a guarantee.

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -185,9 +185,9 @@ Two rules keep the conversation's route coherent:
   bus credential with nothing able to reclaim it. The active-task guard above bounds
   which pods this can reach: a delegation is only recognized when no task serializes
   the conversation, so the pod is either idle or running a DETACHED task - and
-  detached is not closed, so the deletion rule in Session lifecycle applies and the
-  terminal `failed` is published first. With that done, the delete is what reap or
-  sweep would have done anyway.
+  detached is not closed, so the deletion rule in Session lifecycle applies and that
+  task's terminal is published first. The state is that rule's to name, not this
+  section's. With that done, the delete is what reap or sweep would have done anyway.
 
 ## Session lifecycle
 
@@ -227,7 +227,13 @@ and a pod that dies wedged reaches a terminal phase where Sweep takes over. The
 spawner owes the pod-level `activeDeadlineSeconds` mirroring that deadline - the
 adapter's contract is written assuming it - so a wedged adapter also lands in Sweep's
 domain instead of holding its bus credential indefinitely; until that field ships, a
-wedged adapter is the one unowned end, named here rather than papered over. The
+wedged adapter is the one unowned end, named here rather than papered over. It costs
+two things, not one: the held bus credential, and the content posture below - with no
+terminal event the active-task record is never deleted, `session-state` has no age
+limit, and the `ask` copy outlives the stream copy its justification rests on. The
+same missing field closes both, and until it does the gateway owes the record an
+independent bound (a bucket TTL, or clearing an active task whose pod no longer
+exists) rather than a justification that assumes a terminal that may not come. The
 terminal event this chain guarantees is also what deletes the active-task record (and
 the `ask` copy riding it). A detached task is the exception on both counts: it does
 not exempt the session, so reap may delete a pod whose harness is still working, and
@@ -329,9 +335,14 @@ content; the payload spec's opaque-token rule is the same rule seen from the oth
 side. Within that posture, the gateway may hold a bounded copy of the active task's ask
 in the session KV - truncated, one revision, deleted with the active-task record at the
 terminal event - for status rendering. The copy adds no new audience (the gateway is
-the bucket's only reader and writer) and has a shorter horizon than the stream copy it
+the bucket's only reader and writer, by grant - see the deployment spec's note on the
+one residual write route) and has a shorter horizon than the stream copy it
 duplicates. What would breach the posture is content anywhere with a wider audience or
-a longer life than the stream already grants it.
+a longer life than the stream already grants it - which makes the horizon a condition
+on the copy, not a property of it. The horizon holds only where a terminal event is
+guaranteed, so the one case Session lifecycle names as unowned (a wedged adapter,
+until the pod-level deadline ships) is a case where this justification does not hold
+and the record needs the independent bound named there.
 
 - `requester.principal` is the pseudonymized identity in _our_ trust domain; the gateway
   resolves it to the RBAC string at the boundary that needs one. `subject` is the

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -177,10 +177,17 @@ Two rules keep the conversation's route coherent:
 - **The previous incarnation dies at delegation, deliberately.** A lingering pod from
   an earlier incarnation is deleted, not merely untracked: reap walks session records
   and sweep sees only terminal pod phases, so an untracked Running pod would hold its
-  bus credential with nothing able to reclaim it. The active-task guard above is what
-  makes this safe - a delegation is only recognized with no live task in flight, so
-  the previous task is already closed (healed or detached) and the delete is what
-  reap or sweep would have done anyway.
+  bus credential with nothing able to reclaim it. The active-task guard above bounds
+  which pods this can reach: a delegation is only recognized when no task serializes
+  the conversation, so the pod is either idle or running a DETACHED task. Detached is
+  not closed, and that case is where the gateway's supervisor duty applies - a
+  detached task's pod deleted here would leave a task non-terminal on the stream for
+  the rest of the retention window, with the adapter's deadline dying alongside the
+  process and Sweep never seeing a terminal pod phase. So the gateway publishes the
+  terminal `failed` for a detached task before deleting its pod, as the supervisor of
+  the sessions it spawned (payload spec: every task has a supervisor; assertion 13: a
+  cancel always ends in a terminal event, never a silent stop). With that published,
+  the delete is what reap or sweep would have done anyway.
 
 ## Session lifecycle
 
@@ -277,14 +284,22 @@ metadata (`docs/designs/audit-logging-user-attribution.md`). The bus holds label
 content at rest for the whole retention window, so it gets the same treatment as the
 session KV. The plaintext join lives in the gateway's local ingress log, and the
 gateway resolves plaintext at the boundaries that need it - `openDirect` now, the
-lowest-common-denominator grant computation when the authority work lands. The salt
-must be one value per install, shared by every replica - or hashes diverge between
-turns of the same conversation and `openDirect` routing and audit joins silently
-corrupt. A dedicated salt Secret is the target shape; stage 1 derives the salt from
-the shared bus credential when none is configured, which keeps replicas agreeing but
-couples the pseudonyms to a password rotation - rotate the NATS password and every
-pseudonym on the stream stops joining to its history. Named here so the rotation
-hazard is a known cost, not a surprise.
+lowest-common-denominator grant computation when the authority work lands.
+
+**The salt is `SESSION_KV_SALT`, the one the install already provisions** (settled
+8/31). It is generated once into `platform-agent-secrets`, deliberately never
+rewritten on upgrade - rotating it re-anonymises every user and breaks correlation
+with their own history - and it is what the shipped attribution path already hashes
+with. Using it is what makes the "same posture" claim above true rather than
+approximate: one human hashes to one value in session metadata and in
+`authority.requester.principal`, so the cross-surface audit join resolves. A second
+salt would not merely be redundant, it would silently yield nothing on exactly the
+join this rule exists to preserve. The requirement that follows: one value per
+install, read by every gateway replica from that Secret. Deriving a salt from
+another credential - the stage 1 gateway derives from the bus password when none is
+configured - is a deviation on two counts, the broken join and a de-anonymization
+key handed to whoever holds that credential over an identifier space (chat emails, a
+room roster) small enough to enumerate.
 
 **The rule covers identifiers, not content (stated explicitly 8/31; it was always the
 design, never written down).** Task content cannot be pseudonymized without destroying

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -145,10 +145,15 @@ edits), the status card, the steer acknowledgement, and failure notices (a submi
 or steer that never reached the bus). All are deterministic templates over facts the
 gateway itself owns - its own publishes, its own registry, stream replay - which is
 what keeps them inside the no-model rule. They also say only what the gateway knows:
-the steer acknowledgement reports that the steer is on the stream and that, if the
-task is still running when it lands, the executor picks it up at its next turn
-boundary - not that it was absorbed, which the gateway cannot know. The payload
-spec's race-window refusal is what closes that loop on the stream.
+the steer acknowledgement reports that the steer is on the stream, and what it says
+next is conditioned on the route the same way the width bias above is, because the
+gateway knows the route and the two executors do different things: on a
+session-routed conversation, that the worker picks it up at its next turn boundary
+if the task is still running; on a fixed-routed one, that the standing executor does
+not take mid-task input and the reply will say so. Neither claims the steer was
+absorbed, which the gateway cannot know. The payload spec's refusal posture - both
+the fixed-route refusal and the race-window one - is what closes the loop on the
+stream.
 
 ## The Delegate flow (added 8/31)
 

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -19,8 +19,11 @@ Companion docs: the payload spec owns the envelope and the task lifecycle, and r
 the `identity` and `authority` fields this doc names. The execution shape is settled -
 pod per session, gateway coded to the headless CLI contract - and this design assumes
 it. The NATS deployment spec owns accounts and connection-time authz.
-The declarative subagent framework (its own doc) owns what happens when a session
-delegates work; this doc stops at the session boundary.
+The declarative subagent framework (its own doc) owns profile-addressed delegation -
+the dispatcher, Jobs, `AgentProfile`s. This doc stops at the session boundary, with one
+amendment (8/31): the Delegate flow below hands a single task to a fresh
+gateway-spawned session worker, which stays inside the session model - the worker is an
+incarnation of the conversation's own session, not a profile executor.
 
 ## The gateway holds no model
 
@@ -44,7 +47,12 @@ pod at a time.** Concretely:
   group space (eg `discord:1234/5678`, `gchat:spaces/AAA/threads/BBB`). A channel or
   space is not a session; a conversation in it is.
 - `contextId` is minted at first contact with a conversation and never changes. It is
-  the durable name of the conversation on the bus.
+  the durable name of the conversation on the bus. Minting MUST be create-only (a KV
+  `Create`, compare-and-swap semantics), so that two replicas or a rehydrate racing
+  first contact cannot fork a conversation - the loser reads and adopts the winner's
+  value. The stage 1 gateway runs a single replica and serializes per conversation
+  in-process, which narrows the race without closing it (a plain `Put` persists the
+  record today); the `Create` is owed before a second replica is.
 - The pod is an incarnation, not the identity. Reaping and respawning changes the pod
   and the bus session name; `contextId` persists across every incarnation.
 - In a group thread, everyone in the room shares the one session. Attribution is per
@@ -57,8 +65,13 @@ mix unrelated conversations into one context and make the room the unit of histo
 which nobody wants from a busy channel.
 
 Session state lives in a NATS KV bucket, keyed by session key: `contextId`, current pod
-name, bus session name, last-activity timestamp, roster. Runtime state is not git and
-not pod annotations; KV is the house answer. A gateway restart rediscovers its sessions
+name, bus session name, last-activity timestamp, roster, the task history with each
+task's own addressee (session addressees rotate per incarnation, so a straggler's
+replay must use the addressee its subjects carried, not the record's current one), and
+the active task's serialization record - `taskId`, `correlationId`, the echoed `ask`
+(truncated) and its `submittedAt`, which feed the status card below; the `ask` copy is
+user content, governed by the content rule in the identity section. Runtime state is
+not git and not pod annotations; KV is the house answer. A gateway restart rediscovers its sessions
 from KV plus pod labels, so a gateway crash strands nothing - the pods keep running and
 the transcript is on the stream.
 
@@ -91,17 +104,92 @@ each steer carries its own `authority` block, so group-room attribution stays cl
 cancel affordance ("stop") maps to `kind: cancel` and stays the hard interrupt; wiring it
 to a chat gesture is adapter polish, later.
 
+**The deterministic interceptors (amended 8/31).** The gateway holds no model, so its
+affordances are literal: a small set of normalized phrases and prefixes, deterministic
+by construction. Three interceptors run on each turn, ahead of the routing above:
+
+- **Status ask.** While a task is active, a message matching the status set ("status",
+  "what is it doing", …) is answered by stream replay - a status card carrying the
+  task's state, the echoed ask, an elapsed clock since submission, the transition
+  history, and the latest `progress` line, labeled as replay so nobody reads it as a
+  live claim about the executor. It never reaches the executor.
+- **Stop.** "stop" / "cancel" / "abort", exact after normalization - the text form of
+  the cancel affordance above; a backend-native gesture stays adapter polish, later.
+- **Delegate.** A prefix, not a phrase; its own section below.
+
+Two routes exist, and the terms recur below: a conversation is **fixed-routed** when
+its tasks address the standing executor configured at deploy time (the platform front
+door), and **session-routed** when they address the conversation's own spawned worker.
+The two differ on steers: a session worker absorbs them at its next turn boundary,
+while the standing front door refuses them with an honest status reply - the refusal
+posture the payload spec's steering rule records.
+
+The status matcher's width bias inverts per executor, and the inversion is the
+contract, not a tuning detail. Beyond the exact phrase set there is a wide
+interrogative rule (status-shaped words in an interrogative frame), and it applies only
+where the executor refuses steers - the fixed-route front door - because there a stolen
+false positive costs nothing. Where the executor absorbs steers, a session worker, only
+the exact phrases match: a stolen steer there is a dropped correction, and a
+status-shaped steer is a question the worker can answer itself. Anything no interceptor
+claims during a `working` task is a steer, per the 8/24 decision above.
+
+**Gateway-authored posts (amended 8/31).** Step 4's relay - events in, chat out - is
+not the whole output story: the gateway authors a small set of posts of its own. The
+placeholder that opens a task ("submitted…", which becomes the rolling line the relay
+edits), the status card, the steer acknowledgement, and failure notices (a submission
+or steer that never reached the bus). All are deterministic templates over facts the
+gateway itself owns - its own publishes, its own registry, stream replay - which is
+what keeps them inside the no-model rule. They also say only what the gateway knows:
+the steer acknowledgement reports that the steer is on the stream and the executor
+picks it up at its next turn boundary, not that it was absorbed, which the gateway
+cannot know.
+
+## The Delegate flow (added 8/31)
+
+A turn starting with the word "delegate" plus a separator routes that one task to a
+freshly spawned session worker. The prefix is stripped; the rest of the original text,
+casing and punctuation intact, is the task. The gateway mints a fresh bus session name,
+publishes the task with the new session as its addressee, and spawns the worker through
+the same machinery that serves session-routed conversations - a delegate is an
+incarnation, not a new kind of executor, and everything above about incarnations
+(minted bus session name per spawn, `contextId` persisting) applies. A bare "delegate"
+with nothing after it is not a delegation, and while the spawner is dark the prefix is
+not an affordance at all: the text passes through as an ordinary turn.
+
+Two rules keep the conversation's route coherent:
+
+- **One task.** The delegation covers exactly the prefixed task. On a fixed-route
+  conversation, the next plain ask re-homes to the configured default addressee - never
+  to a dead delegate session. On a session-routed conversation, the delegate
+  incarnation becomes the next standing incarnation, which is inside the session
+  route's contract: incarnations rotate anyway.
+- **The previous incarnation dies at delegation, deliberately.** A lingering pod from
+  an earlier incarnation is deleted, not merely untracked: reap walks session records
+  and sweep sees only terminal pod phases, so an untracked Running pod would hold its
+  bus credential with nothing able to reclaim it. Its task is already closed (healed or
+  detached) by the time the delegate routes, so the delete is what reap or sweep would
+  have done anyway.
+
 ## Session lifecycle
 
 The session manager is the demo's chatops code generalized from one-shot workers to
 long-lived sessions. Four operations:
 
 **Spawn.** First message in a conversation creates the pod: the demo's reference worker
-shape (no ambient k8s credentials, scratch on emptyDir, 250m/512Mi requests), running the
-headless harness behind a thin shim that bridges bus envelopes to the CLI's stream-json
-stdin/stdout. Model auth is Workload Identity against the Vertex backend - no per-pod API keys. Cold
-start is 5-10s; the adapter posts
-a placeholder to the conversation while the pod comes up, which the demo already does.
+shape (no ambient k8s credentials, scratch on emptyDir, 250m/512Mi requests; egress
+fenced (8/31) to DNS, the bus, and LiteLLM - the deployment spec owns the policy),
+running the headless harness behind a thin shim that bridges bus envelopes to the CLI's
+stream-json stdin/stdout. Model auth, as shipped (amended 8/31): the worker talks to
+the install's own LiteLLM, in-namespace, with no per-pod credential at all - the
+spawned pod carries no ServiceAccount and no Workload Identity. Its bus credential is
+the static worker user, injected as env, until the deployment spec's auth callout
+arms; arming it is what gives a session pod a KSA and a projected token, per the
+subagent framework's worker posture. Direct Vertex via WI
+stays the target, and arming it is a policy change as well as an IAM one: the session
+egress fence encodes the shipped path (no 443, no metadata route), which is where a
+piecemeal flip fails loudly instead of silently widening. Cold start is 5-10s; the
+adapter posts a placeholder to the conversation while the pod comes up, which the demo
+already does.
 
 **Stream.** The shim consumes envelopes addressed to its session, feeds them to the
 harness, and maps the stream-json output to `status-update` and `artifact-update` events.
@@ -165,8 +253,28 @@ the bus - the same posture the shipped attribution path applies before writing s
 metadata (`docs/designs/audit-logging-user-attribution.md`). The bus holds labelled
 content at rest for the whole retention window, so it gets the same treatment as the
 session KV. The plaintext join lives in the gateway's local ingress log, and the
-gateway resolves plaintext at the boundaries that need it - `openDirect` now, RBAC
-intersection when the authority work lands.
+gateway resolves plaintext at the boundaries that need it - `openDirect` now, the
+lowest-common-denominator grant computation when the authority work lands. The salt
+must be one value per install, shared by every replica - or hashes diverge between
+turns of the same conversation and `openDirect` routing and audit joins silently
+corrupt. A dedicated salt Secret is the target shape; stage 1 derives the salt from
+the shared bus credential when none is configured, which keeps replicas agreeing but
+couples the pseudonyms to a password rotation - rotate the NATS password and every
+pseudonym on the stream stops joining to its history. Named here so the rotation
+hazard is a known cost, not a surprise.
+
+**The rule covers identifiers, not content (stated explicitly 8/31; it was always the
+design, never written down).** Task content cannot be pseudonymized without destroying
+it - the executor has to read the ask - so the submission message rides the TASKS
+stream in the clear for the whole retention window, which is exactly why the deployment
+spec calls W a tenancy decision. What the rule forbids is identifiers that carry
+content; the payload spec's opaque-token rule is the same rule seen from the other
+side. Within that posture, the gateway may hold a bounded copy of the active task's ask
+in the session KV - truncated, one revision, deleted with the active-task record at the
+terminal event - for status rendering. The copy adds no new audience (the gateway is
+the bucket's only reader and writer) and has a shorter horizon than the stream copy it
+duplicates. What would breach the posture is content anywhere with a wider audience or
+a longer life than the stream already grants it.
 
 - `requester.principal` is the pseudonymized identity in _our_ trust domain; the gateway
   resolves it to the RBAC string at the boundary that needs one. `subject` is the
@@ -221,9 +329,9 @@ later. What the gateway builds now is the substrate those need:
 One property worth stating because it falls out of the session model: a group session's
 context is labeled for the room. Everyone in the thread shares the pod, so anything the
 harness reads into context is readable by the whole roster - which is exactly as leaky as
-the chat window itself, no more. When per-user authority lands, the intersection for a
-group session computes against the audience, not just the requester. That is the LCD
-question, parked with its tool.
+the chat window itself, no more. When per-user authority lands, the
+lowest-common-denominator grants for a group session compute against the audience, not
+just the requester. That is the LCD question, parked with its tool.
 
 ## The test backend
 

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -141,9 +141,10 @@ edits), the status card, the steer acknowledgement, and failure notices (a submi
 or steer that never reached the bus). All are deterministic templates over facts the
 gateway itself owns - its own publishes, its own registry, stream replay - which is
 what keeps them inside the no-model rule. They also say only what the gateway knows:
-the steer acknowledgement reports that the steer is on the stream and the executor
-picks it up at its next turn boundary, not that it was absorbed, which the gateway
-cannot know.
+the steer acknowledgement reports that the steer is on the stream and that, if the
+task is still running when it lands, the executor picks it up at its next turn
+boundary - not that it was absorbed, which the gateway cannot know. The payload
+spec's race-window refusal is what closes that loop on the stream.
 
 ## The Delegate flow (added 8/31)
 
@@ -206,7 +207,11 @@ that translation lives in the shim, next to the process it translates for.
 **Reap.** Idle TTL since the last user message (30 minutes, config-backed). Reaping is
 deleting the pod. Nothing is saved first, because
 the stream already has everything - that's the whole point of the transcript of record.
-The KV entry stays, holding the `contextId`.
+The KV entry stays, holding the `contextId`. Reap never deletes a pod out from under a
+live task: an active, non-detached task exempts the session from the idle TTL however
+long it runs - the executor's own task deadline and Sweep own that pod's end, and the
+terminal event they guarantee is also what deletes the active-task record (and the
+`ask` copy riding it).
 
 **Rehydrate.** The next message on a reaped conversation spawns a fresh pod. The
 gateway replays the context's tasks from JetStream, folds them into a transcript primer,

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -179,15 +179,10 @@ Two rules keep the conversation's route coherent:
   and sweep sees only terminal pod phases, so an untracked Running pod would hold its
   bus credential with nothing able to reclaim it. The active-task guard above bounds
   which pods this can reach: a delegation is only recognized when no task serializes
-  the conversation, so the pod is either idle or running a DETACHED task. Detached is
-  not closed, and that case is where the gateway's supervisor duty applies - a
-  detached task's pod deleted here would leave a task non-terminal on the stream for
-  the rest of the retention window, with the adapter's deadline dying alongside the
-  process and Sweep never seeing a terminal pod phase. So the gateway publishes the
-  terminal `failed` for a detached task before deleting its pod, as the supervisor of
-  the sessions it spawned (payload spec: every task has a supervisor; assertion 13: a
-  cancel always ends in a terminal event, never a silent stop). With that published,
-  the delete is what reap or sweep would have done anyway.
+  the conversation, so the pod is either idle or running a DETACHED task - and
+  detached is not closed, so the deletion rule in Session lifecycle applies and the
+  terminal `failed` is published first. With that done, the delete is what reap or
+  sweep would have done anyway.
 
 ## Session lifecycle
 
@@ -229,7 +224,21 @@ adapter's contract is written assuming it - so a wedged adapter also lands in Sw
 domain instead of holding its bus credential indefinitely; until that field ships, a
 wedged adapter is the one unowned end, named here rather than papered over. The
 terminal event this chain guarantees is also what deletes the active-task record (and
-the `ask` copy riding it).
+the `ask` copy riding it). A detached task is the exception on both counts: it does
+not exempt the session, so reap may delete a pod whose harness is still working, and
+the supervisor rule below is what keeps that from being a silent stop.
+
+**One rule for every pod the gateway deletes itself** (stated once here because three
+paths reach it - reap, Delegate, and any future one): if the pod is running a
+DETACHED task, the gateway publishes that task's terminal `failed` before deleting,
+as the supervisor of the sessions it spawns. Deleting first strands the task
+non-terminal for the whole retention window - the adapter's deadline dies with the
+process, and a deleted pod never reaches the terminal phase Sweep watches for - which
+would break the payload spec's every-task-has-a-supervisor rule and assertion 13,
+since a detached task got that way from a `stop` that published a cancel. Do not
+reason from the config defaults here: the adapter's deadline runs from task start and
+the idle TTL from the last user message, so which fires first is a property of two
+independently tunable numbers, not a guarantee.
 
 **Rehydrate.** The next message on a reaped conversation spawns a fresh pod. The
 gateway replays the context's tasks from JetStream, folds them into a transcript primer,

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -115,7 +115,8 @@ by construction. Three interceptors run on each turn, ahead of the routing above
   live claim about the executor. It never reaches the executor.
 - **Stop.** "stop" / "cancel" / "abort", exact after normalization - the text form of
   the cancel affordance above; a backend-native gesture stays adapter polish, later.
-- **Delegate.** A prefix, not a phrase; its own section below.
+- **Delegate.** A prefix, not a phrase, and recognized only when no live task
+  serializes the conversation; its own section below.
 
 Two routes exist, and the terms recur below: a conversation is **fixed-routed** when
 its tasks address the standing executor configured at deploy time (the platform front
@@ -152,9 +153,14 @@ casing and punctuation intact, is the task. The gateway mints a fresh bus sessio
 publishes the task with the new session as its addressee, and spawns the worker through
 the same machinery that serves session-routed conversations - a delegate is an
 incarnation, not a new kind of executor, and everything above about incarnations
-(minted bus session name per spawn, `contextId` persisting) applies. A bare "delegate"
-with nothing after it is not a delegation, and while the spawner is dark the prefix is
-not an affordance at all: the text passes through as an ordinary turn.
+(minted bus session name per spawn, `contextId` persisting) applies. The guard,
+stated because the delete rule below depends on it: a delegation is recognized only
+when no live task serializes the conversation. While a task is `working`,
+"delegate: …" is a steer like any other text - the routing above claims status asks
+and stops first and steers everything else, and the delegate prefix is consulted
+only when the turn would start a task. A bare "delegate" with nothing after it is
+not a delegation, and while the spawner is dark the prefix is not an affordance at
+all: the text passes through as an ordinary turn.
 
 Two rules keep the conversation's route coherent:
 
@@ -166,9 +172,10 @@ Two rules keep the conversation's route coherent:
 - **The previous incarnation dies at delegation, deliberately.** A lingering pod from
   an earlier incarnation is deleted, not merely untracked: reap walks session records
   and sweep sees only terminal pod phases, so an untracked Running pod would hold its
-  bus credential with nothing able to reclaim it. Its task is already closed (healed or
-  detached) by the time the delegate routes, so the delete is what reap or sweep would
-  have done anyway.
+  bus credential with nothing able to reclaim it. The active-task guard above is what
+  makes this safe - a delegation is only recognized with no live task in flight, so
+  the previous task is already closed (healed or detached) and the delete is what
+  reap or sweep would have done anyway.
 
 ## Session lifecycle
 

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -115,6 +115,10 @@ by construction. Three interceptors run on each turn, ahead of the routing above
   live claim about the executor. It never reaches the executor.
 - **Stop.** "stop" / "cancel" / "abort", exact after normalization - the text form of
   the cancel affordance above; a backend-native gesture stays adapter polish, later.
+  A stopped task whose terminal event has not yet arrived DETACHES: it stops
+  serializing the conversation - new turns start new tasks - while its events, if
+  they ever arrive, still relay. "Detached" and "non-detached" below mean exactly
+  this state and its absence.
 - **Delegate.** A prefix, not a phrase, and recognized only when no live task
   serializes the conversation; its own section below.
 
@@ -208,10 +212,17 @@ that translation lives in the shim, next to the process it translates for.
 deleting the pod. Nothing is saved first, because
 the stream already has everything - that's the whole point of the transcript of record.
 The KV entry stays, holding the `contextId`. Reap never deletes a pod out from under a
-live task: an active, non-detached task exempts the session from the idle TTL however
-long it runs - the executor's own task deadline and Sweep own that pod's end, and the
-terminal event they guarantee is also what deletes the active-task record (and the
-`ask` copy riding it).
+live task: an active task that has not detached (see Stop above) exempts the session
+from the idle TTL. The exemption is safe because the pod's end has owners. The session
+worker's adapter enforces a task deadline (30 minutes default, config-backed): at the
+deadline it kills the harness process group and publishes the terminal event itself,
+and a pod that dies wedged reaches a terminal phase where Sweep takes over. The
+spawner owes the pod-level `activeDeadlineSeconds` mirroring that deadline - the
+adapter's contract is written assuming it - so a wedged adapter also lands in Sweep's
+domain instead of holding its bus credential indefinitely; until that field ships, a
+wedged adapter is the one unowned end, named here rather than papered over. The
+terminal event this chain guarantees is also what deletes the active-task record (and
+the `ask` copy riding it).
 
 **Rehydrate.** The next message on a reaped conversation spawns a fresh pod. The
 gateway replays the context's tasks from JetStream, folds them into a transcript primer,

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -239,8 +239,8 @@ the `ask` copy riding it). A detached task is the exception on both counts: it d
 not exempt the session, so reap may delete a pod whose harness is still working, and
 the supervisor rule below is what keeps that from being a silent stop.
 
-**One rule for every pod the gateway deletes itself** (stated once here because three
-paths reach it - reap, Delegate, and any future one): if the pod is running a
+**One rule for every pod the gateway deletes itself** (stated once here because four
+paths reach it - reap, Sweep, Delegate, and any future one): if the pod is running a
 DETACHED task, the gateway publishes that task's terminal event before deleting, as
 the supervisor of the sessions it spawns. The state is `canceled`, not `failed`:
 every task this rule reaches is detached, and detached means a `stop` already
@@ -267,9 +267,15 @@ that suddenly remembers June. If review disagrees, the fix is a compacted transc
 topic, not longer task retention.
 
 **Sweep**, as in the demo: a pod in a terminal phase whose task never emitted a final
-event gets a terminal `failed` published by the gateway, then deleted. This is the
+event gets a terminal event published by the gateway, then deleted. This is the
 gateway's half of the payload spec's orphaned-task answer - it is the supervisor for
-sessions it spawned; the dispatcher's janitor is the other half (settled 8/24).
+sessions it spawned; the dispatcher's janitor is the other half (settled 8/24). The
+state follows the same rule as every other supervisor publish below: `failed` for a
+task whose executor died mid-work, `canceled` where the task had already detached and
+the gateway is finishing a cancel the requester published. Sweep reaches detached
+tasks routinely - a worker that exits or wedges after a `stop` leaves exactly this
+shape - so an unconditional `failed` here would report broken for every task a user
+stopped, which is the distinction the rule exists to keep.
 
 ## Requester identity on the bus
 

--- a/docs/designs/spec-mode-switch.md
+++ b/docs/designs/spec-mode-switch.md
@@ -61,7 +61,12 @@ third mode, an older operator binary reads it. Silently rendering `today` at tha
 the cluster runs something other than what the spec asks, with nothing in
 `kubectl describe` to say so. Instead the reconciler goes Degraded through the existing
 `updateStatusDegraded` path with a named reason, `ModeNotRecognized`, keeps rendering
-today's stack, and requeues. (Same pattern as `RuntimeClassNotFound`.)
+today's stack, preserves whatever A2A surface already exists - it tears nothing down,
+and the agent's bus env and egress rule survive the skew too - and requeues. (Same
+Degraded pattern as `RuntimeClassNotFound`.) The preservation matters most on the
+`next` side: "fail closed to today" must not mean "clean up next," or a one-version
+operator rollback against a live `next` install kills the bus while dutifully
+reporting Degraded. Found live during stage 1 bring-up (8/26).
 
 ## What the operator renders
 
@@ -69,9 +74,26 @@ today's stack, and requeues. (Same pattern as `RuntimeClassNotFound`.)
 - `next`: everything above, plus the NATS component and the gateway skeleton. Next is
   additive - today's path keeps running until stage 4 starts retiring pieces.
 
-The operator also writes the mode into the managed settings it already renders
-(`reconcileSettingsConfigMap`), as a single key: `KUBEAGENTS_MODE`. That is the only way
-the mode reaches the agent runtime.
+One thing `next` does not ship: long-term audit. The stream is a 72h ring buffer and
+the audit exporter is stage 2 scope, so `next` has no archive - the NATS spec's audit
+section describes the design, not what this toggle turns on. Dev posture; don't run
+traffic that matters on it and expect audit to exist.
+
+The operator also writes the mode into the managed settings it already renders, as a
+single key: `KUBEAGENTS_MODE`. (Amended 8/26: the draft said
+`reconcileSettingsConfigMap`, but the surface with env semantics and agent-write
+protection is the managed `.env` - `renderManagedEnv`, applied last, refused by
+`save_env_value` - so the key rides that and the config-hash rollout annotation. The
+agent cannot fake its own mode, which the draft's route would not have given.) That is
+the only way the mode reaches the agent runtime.
+
+A mode change is a rollout, not a hot reload. Kubernetes does not restart running pods
+when a ConfigMap changes, so the operator stamps the rendered config's hash onto the
+agent pod template (the `kubeagents.x-k8s.io/config-hash` annotation, which already
+covers the ConfigMap carrying the managed `.env`) - flipping the mode rolls the Deployment,
+and no agent keeps running in a mode the spec no longer asks for. Without the stamp,
+`mode: next` would produce a silent split-brain: NATS up, the running fleet still on
+today's path until something happens to kill its pods.
 
 ## Agent-side rule
 

--- a/docs/designs/spec-mode-switch.md
+++ b/docs/designs/spec-mode-switch.md
@@ -64,7 +64,13 @@ third mode, an older operator binary reads it. Silently rendering `today` at tha
 the cluster runs something other than what the spec asks, with nothing in
 `kubectl describe` to say so. Instead the reconciler goes Degraded through the existing
 `updateStatusDegraded` path with a named reason, `ModeNotRecognized`, keeps rendering
-today's stack, and requeues (same Degraded pattern as `RuntimeClassNotFound`) - and the
+today's stack, and requeues. It reaches Degraded by a different route from
+`RuntimeClassNotFound`, and the difference is the point: that check returns early, so
+nothing downstream of it renders, while the mode check is evaluated at the top and its
+error CARRIED - every render step still runs, including the workload, and Degraded is
+reported at the end instead of Ready. A skew that returned early would neither pin the
+managed `.env` nor move the config hash, leaving the running fleet on `next` behavior
+with only a status message to say otherwise. And the
 two layers the mode touches are split deliberately on skew. The mode DELIVERED to the
 agent fails closed: the managed `.env` pins `today`, the config hash moves, and the
 fleet rolls to today's behavior - the skill is withdrawn, which is what fail-closed

--- a/docs/designs/spec-mode-switch.md
+++ b/docs/designs/spec-mode-switch.md
@@ -48,7 +48,10 @@ func renderMode(agent *agentv1alpha1.PlatformAgent, component string) Mode
 ```
 
 The reconciler calls `resolveMode` once at the top and handles the error (below);
-everything downstream uses `renderMode`. Without the pair, fail-closed and
+everything downstream uses `renderMode`, with one deliberate carve-out defined with
+the skew behavior below: the agent's A2A surface takes its skew answer from the
+reconciler's error handling, not from `renderMode` - fail-closed rendering at those
+call sites would tear down a live bus. Without the pair, fail-closed and
 Degraded-on-skew are mutually exclusive - a single helper that maps unrecognized to
 `ModeToday` leaves the reconciler no way to notice the skew without reading `Spec.Mode`
 itself. Fail-closed here means the dark stack stays dark. The `component` argument is
@@ -65,14 +68,18 @@ today's stack, and requeues (same Degraded pattern as `RuntimeClassNotFound`) - 
 two layers the mode touches are split deliberately on skew. The mode DELIVERED to the
 agent fails closed: the managed `.env` pins `today`, the config hash moves, and the
 fleet rolls to today's behavior - the skill is withdrawn, which is what fail-closed
-means. The RENDERED surface is preserved: the A2A objects and the agent's bus surface
-are not torn down - the bus credentials are container env and the egress rule its own
-object, neither a managed-`.env` key, so pinning the mode removes neither. The
-preservation matters most on the `next` side: "fail closed to today" must not mean
-"clean up next," or a one-version operator rollback against a live `next` install
-kills the bus while dutifully reporting Degraded - established connections and sidecar
-dials survive precisely because the env and the egress rule do. Found live during
-stage 1 bring-up (8/26).
+means. The RENDERED surface is preserved, and not by accident of the helper contract:
+`renderMode`'s fail-closed answer would stop emitting the bus env and the egress
+rule, and this operator deletes policies it stops rendering - so the reconciler, the
+one place that sees the skew through `resolveMode`'s error, arms the preservation
+carve-out named in the helper section, and the A2A objects and the agent's bus
+surface (container-env credentials, the 4222 egress rule) render through the skew
+rather than drop. The preservation matters most on the `next` side: "fail closed to
+today" must not mean "clean up next," or a one-version operator rollback against a
+live `next` install kills the bus while dutifully reporting Degraded. The behavior
+rollout does replace the agent pods; what preservation guarantees is that the
+replacements keep the credential and the route, so the bridge reconnects instead of
+hanging at the dial. Found live during stage 1 bring-up (8/26).
 
 ## What the operator renders
 

--- a/docs/designs/spec-mode-switch.md
+++ b/docs/designs/spec-mode-switch.md
@@ -61,12 +61,18 @@ third mode, an older operator binary reads it. Silently rendering `today` at tha
 the cluster runs something other than what the spec asks, with nothing in
 `kubectl describe` to say so. Instead the reconciler goes Degraded through the existing
 `updateStatusDegraded` path with a named reason, `ModeNotRecognized`, keeps rendering
-today's stack, preserves whatever A2A surface already exists - it tears nothing down,
-and the agent's bus env and egress rule survive the skew too - and requeues. (Same
-Degraded pattern as `RuntimeClassNotFound`.) The preservation matters most on the
-`next` side: "fail closed to today" must not mean "clean up next," or a one-version
-operator rollback against a live `next` install kills the bus while dutifully
-reporting Degraded. Found live during stage 1 bring-up (8/26).
+today's stack, and requeues (same Degraded pattern as `RuntimeClassNotFound`) - and the
+two layers the mode touches are split deliberately on skew. The mode DELIVERED to the
+agent fails closed: the managed `.env` pins `today`, the config hash moves, and the
+fleet rolls to today's behavior - the skill is withdrawn, which is what fail-closed
+means. The RENDERED surface is preserved: the A2A objects and the agent's bus surface
+are not torn down - the bus credentials are container env and the egress rule its own
+object, neither a managed-`.env` key, so pinning the mode removes neither. The
+preservation matters most on the `next` side: "fail closed to today" must not mean
+"clean up next," or a one-version operator rollback against a live `next` install
+kills the bus while dutifully reporting Degraded - established connections and sidecar
+dials survive precisely because the env and the egress rule do. Found live during
+stage 1 bring-up (8/26).
 
 ## What the operator renders
 

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -293,8 +293,16 @@ deployment's job is to keep the substrate intact and reachable:
   told W is the only thing that can delete evidence. Lag is a first-class alert on
   whichever horizon is nearer: backlog age approaching W, or stream bytes approaching
   `max_bytes`.
-- The audit path is read-only by construction: the exporter's user may subscribe and may
-  not publish, enforced at connect like everything else.
+- The audit path is read-only by construction, and "read-only" means what the
+  JetStream tax above establishes it can mean: the exporter's user publishes nothing
+  onto the A2A subjects, and holds no grant that can destroy evidence - no purge, no
+  stream or message delete, no consumer delete beyond its own. It does hold the
+  client grants reading requires, because reading a stream is not a subscribe-only
+  act: the reserved durable `audit` consumer is created through `$JS.API`, and its
+  acks are publishes to `$JS.ACK`. A user rendered from a literal no-publish reading
+  cannot create its consumer, and would redeliver forever if it somehow had one -
+  its own lag alerts firing on a user structurally unable to make progress. Enforced
+  at connect like everything else.
 - The attribution salt the gateway hashes identifiers with is `SESSION_KV_SALT`, the
   per-install salt the chart already provisions into `platform-agent-secrets` for the
   shipped attribution path - not a new secret this deployment mints. Replicas must

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -212,8 +212,11 @@ Layout:
   kubectl and through nothing else in-cluster. The enumeration is today's client
   list, and it must grow with the components this spec designs: the audit exporter,
   the janitor, and the metrics scrape (the alert set above is scraped series) each
-  add a peer when they arm - the topic-grant corollary that two edits travel
-  together, applied to the fence. A second policy in the same amendment
+  add a peer when they arm, and the NATS pods themselves join the enumeration on
+  their route port the moment the deployment leaves the single-node dev shape - a
+  3-node cluster's servers dial each other, and a fence without the route peer
+  prevents the cluster from ever forming. The topic-grant corollary that two edits
+  travel together, applied to the fence. A second policy in the same amendment
   fences the session pods' egress (DNS, 4222 by label, LiteLLM - a spawned worker has
   no other legitimate destination, carrying no ServiceAccount and no Workload
   Identity; its bus credential is the static worker user until the callout arms). The origin

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -79,7 +79,11 @@ Three KV buckets ride the same JetStream deployment:
 - `runtime-state` - which agents are alive, what is in flight. Runtime state does not
   belong in git, and this is where it goes instead.
 - `session-state` - the gateway's session registry (session key, `contextId`, current
-  pod, roster). The gateway's user is the only writer.
+  pod, roster, and the active task's bounded ask echo - user content, deliberately; the
+  gateway design owns the content-vs-identifier rule). The gateway's user is the only
+  writer, and since the 8/31 narrowing the only reader too: no other user holds
+  `$KV.session-state.>` on either side, and the web user's consumer-create route into
+  the bucket is closed by its per-stream enumeration.
 - A bucket reserved for capability entries per the capability envelope design
   (`docs/architecture/09-capability-envelope.md`), which landed on KV-backed
   capabilities. Reserved so the account layout allows for it; it arms with the
@@ -106,6 +110,11 @@ API server - zero key handling, works on any conformant cluster - with local JWT
 verification against the API server's `openid/v1/jwks` endpoint as the offline
 alternative.
 
+Stage 1 status (recorded 8/31): the rendered config still authenticates its users
+statically - rendered credentials, deny-by-default grants in `nats.conf`. The callout
+is the design of record, and the residues named in this section as "closed by the
+callout" are open until it arms.
+
 Layout:
 
 - **`$SYS`** - human operators and monitoring only. No agent ever authenticates into it.
@@ -119,10 +128,92 @@ Layout:
   shared topics it is granted. The addressee token in the task subjects (payload spec
   0.4) is what makes these grants expressible - executor-granularity at connect time,
   with per-task scoping the parked tightening under the authority work.
+- **The JetStream tax.** Deny-by-default reaches JetStream's own plumbing, and three
+  grants are part of being a JetStream client at all: the `$JS.API.>` surface a role's
+  streams and buckets need; `$JS.ACK.<its streams>.>` for explicit acks - an ack is a
+  publish, and missing this grant means every consumer redelivers forever while TCP
+  health stays green, the NR-5 incident class created at connect time; and `$JS.FC.>`
+  for flow control. The inbox rule cuts both ways, too: a client whose subscribe grant
+  is `_INBOX.<user>.>` MUST configure its inbox prefix to match - the client library's
+  default random inbox is refused by the user's own grant and every API call times out.
+  Both halves were found live (8/26): the provision Job could never succeed and no
+  consumer could ever ack until these landed. The ack grant should be scoped per
+  stream, for the reason the web section below teaches: an ack subject names a stream
+  and a consumer, never the caller, so an unscoped `$JS.ACK.>` lets any holder `+TERM`
+  another principal's in-flight delivery. The stage 1 render still grants the unscoped
+  form to the trusted system users; narrowing it is recorded debt, not a settled shape.
+- **Topic publish grants are exact, never namespace wildcards.** Publish grants match
+  the provisioned topic list subject-for-subject. A wildcard over a topic namespace
+  turns provisioned-only into silent loss - a publish to an unprovisioned topic sails
+  into core NATS and vanishes; an exact grant makes it a connect-time refusal. The
+  corollary is operational: adding a topic is two edits that must travel together, the
+  stream's subject list and the writer's grant. The rationale is publish-side only: a
+  read-side wildcard (`a2a.topics.>` in a subscribe list) loses nothing and stays fine.
 - **Per-user inbox prefixes.** Push delivery uses inbox subjects, so each user gets its own
   prefix (`_INBOX.<user>.>`) and permission to subscribe only to that. Without this, any
   agent can subscribe to any inbox and the whole property above leaks through the reply
   path.
+- **The web read surface (amended 8/31; rewritten the same day after review).** One
+  `web` user for the read-only web UI, and the only bus credential that is published to
+  a browser by design. Subscribe on `a2a.>` and its own inbox; publish only the JetStream
+  read API - account-level `INFO`, and `STREAM.INFO`, `CONSUMER.CREATE`, `CONSUMER.INFO`,
+  `CONSUMER.MSG.NEXT` **enumerated per stream** over the four message streams - plus its
+  own inbox. It rides a websocket listener on 9222 rendered plain (`no_tls: true`) with
+  an `allowed_origins` allow-list.
+
+  **"Read-only" is not expressible as a subject list, and the first version of this user
+  proved it.** Subject permissions cannot see a request BODY, and JetStream puts the
+  reach there - a consumer's target stream, its durability and its delivery subject are
+  all fields. Reproduced live against the rendered config before the narrowing:
+  `$JS.API.CONSUMER.CREATE.>` let `web` build a push consumer on
+  `KV_session-state` delivering into its own inbox and read the session registry out of a
+  bucket it has no `$KV` grant for (subscribe permissions are not consulted at consumer
+  creation; the deliver subject is); `$JS.ACK.>` let it publish `+TERM` onto the
+  gateway's in-flight delivery, because an ack subject names a stream and a consumer and
+  never the caller. Both are closed by the enumeration. The lesson generalises past this
+  user: **for JetStream, a grant list is a capability surface, not a read/write
+  distinction** - enumerate the streams, and never hand a browser-facing user
+  `$JS.API.>`.
+
+  Residues, all closed by the auth callout and none of them "can read what it shouldn't":
+  durability is a body field, so withholding the legacy `DURABLE.CREATE` subject does not
+  prevent a durable - `max_consumers` per stream bounds the cost instead; within the four
+  granted streams consumer names are the caller's choice, so `web` can pull a delivery
+  off another reader's consumer or retune it through create-as-update; and a consumer's
+  deliver subject can aim replay of stored messages at another stream's subject, which is
+  a persisted write, reaching `a2a.agents.>` (the identity plane) as easily as
+  annotations. Per-name scoping is **not** available as a mitigation: NATS wildcards match
+  whole tokens, so a `web-*` grant matches a consumer literally named `web-*` and nothing
+  else - measured, not assumed. The real closes are the callout or a separate account
+  with an export/import.
+
+  **The probe subject.** `a2a.topics.shared.probe` is provisioned into `TOPICS-STATE`
+  with **no writer in any user's publish list** - the single deliberate exception to the
+  rule above that a topic's subject list and its writer's grant travel together. It
+  exists so an authorization probe has a real provisioned subject to be refused on: a
+  refusal against an unprovisioned subject proves only that the subject is missing, while
+  a refusal here proves the grant. Aiming such a probe at a topic the fleet reads means
+  that the one time the grant is wrong, the probe writes junk into standing state; a
+  writerless subject makes that failure land nowhere.
+
+  Posture, stated accurately: plain ws puts the credential on the pod network in
+  cleartext, and the Service is ClusterIP, so nothing outside the cluster reaches it.
+  Amended 8/31: the pod network is fenced too. The operator renders an ingress
+  NetworkPolicy on the NATS pod granting **4222 to exactly the enumerated bus clients**
+  (the agent pod - whose sidecars, the Hermes bridge included, share its labels - the
+  A2A gateway, session pods by the spawner's labels, the provision Job, and the
+  hand-applied seed Job), and **no pod-network peer for 8222 or 9222**. The demo's
+  `kubectl port-forward` and the kubelet's readiness probe both enter from the node,
+  which NetworkPolicy does not govern, so the ws surface stays reachable through
+  kubectl and through nothing else in-cluster. A second policy in the same amendment
+  fences the session pods' egress (DNS, 4222 by label, LiteLLM - a spawned worker has
+  no other legitimate destination, carrying no ServiceAccount and no Workload
+  Identity; its bus credential is the static worker user until the callout arms). The origin
+  allow-list (`allowed_origins`, not `same_origin`, which can never match a UI on a
+  different port) remains the browser-side control: WebSockets are exempt from CORS,
+  so for as long as a port-forward runs, any page the operator's browser visits could
+  otherwise drive this surface.
+
 - **Bucket access is subject access.** KV and the Object Store ride internal subjects -
   `$KV.{bucket}.>`, `$O.{bucket}.C.>` / `$O.{bucket}.M.>`, plus the `$JS.API` surface for
   their streams - and the deny-by-default map grants them explicitly per role: the

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -214,9 +214,12 @@ Layout:
   `kubectl port-forward` and the kubelet's readiness probe both enter from the node,
   which NetworkPolicy does not govern, so the ws surface stays reachable through
   kubectl and through nothing else in-cluster. The enumeration is today's client
-  list, and it must grow with the components this spec designs: the audit exporter,
-  the janitor, and the metrics scrape (the alert set above is scraped series) each
-  add a peer when they arm, and the NATS pods themselves join the enumeration on
+  list, and it must grow with the components this spec designs: the auth callout
+  service first of all - it is itself a bus client (a system-account subscriber on
+  the connection path), so arming it against the fence as-enumerated refuses the one
+  peer every new connection depends on and takes the fabric dark to new work - then
+  the audit exporter, the janitor, and the metrics scrape (the alert set above is
+  scraped series) each add a peer when they arm, and the NATS pods themselves join the enumeration on
   their route port the moment the deployment leaves the single-node dev shape - a
   3-node cluster's servers dial each other, and a fence without the route peer
   prevents the cluster from ever forming. The topic-grant corollary that two edits

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -170,7 +170,11 @@ Layout:
   bucket it has no `$KV` grant for (subscribe permissions are not consulted at consumer
   creation; the deliver subject is); `$JS.ACK.>` let it publish `+TERM` onto the
   gateway's in-flight delivery, because an ack subject names a stream and a consumer and
-  never the caller. Both are closed by the enumeration. The lesson generalises past this
+  never the caller. The consumer-create escape is closed by the enumeration; the ack
+  escape is closed by deleting the grant outright - web consumers are ack-none by
+  design, so no ack grant is owed, and the JetStream-tax bullet's redelivery failure
+  (which needs an ack-expecting consumer) does not arise. There is deliberately no
+  `$JS.FC.>` for web either, for the same reason. The lesson generalises past this
   user: **for JetStream, a grant list is a capability surface, not a read/write
   distinction** - enumerate the streams, and never hand a browser-facing user
   `$JS.API.>`.
@@ -205,7 +209,11 @@ Layout:
   hand-applied seed Job), and **no pod-network peer for 8222 or 9222**. The demo's
   `kubectl port-forward` and the kubelet's readiness probe both enter from the node,
   which NetworkPolicy does not govern, so the ws surface stays reachable through
-  kubectl and through nothing else in-cluster. A second policy in the same amendment
+  kubectl and through nothing else in-cluster. The enumeration is today's client
+  list, and it must grow with the components this spec designs: the audit exporter,
+  the janitor, and the metrics scrape (the alert set above is scraped series) each
+  add a peer when they arm - the topic-grant corollary that two edits travel
+  together, applied to the fence. A second policy in the same amendment
   fences the session pods' egress (DNS, 4222 by label, LiteLLM - a spawned worker has
   no other legitimate destination, carrying no ServiceAccount and no Workload
   Identity; its bus credential is the static worker user until the callout arms). The origin
@@ -269,9 +277,12 @@ deployment's job is to keep the substrate intact and reachable:
   `max_bytes`.
 - The audit path is read-only by construction: the exporter's user may subscribe and may
   not publish, enforced at connect like everything else.
-- The attribution salt the gateway hashes identifiers with is one shared Secret per
-  install, provisioned with this deployment - replicas must agree or the pseudonyms on
-  the stream stop joining.
+- The attribution salt the gateway hashes identifiers with must be one value per
+  install - replicas must agree or the pseudonyms on the stream stop joining. A
+  dedicated salt Secret provisioned with this deployment is the target shape; stage 1
+  derives the salt from the shared bus credential when none is configured. The gateway
+  design owns that rule and its rotation hazard; this deployment owes the Secret when
+  it lands.
 - W stays a tenancy decision as well as a cost one - the bus holds labelled content at rest
   for the whole window.
 

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -171,17 +171,21 @@ Layout:
   creation; the deliver subject is); `$JS.ACK.>` let it publish `+TERM` onto the
   gateway's in-flight delivery, because an ack subject names a stream and a consumer and
   never the caller. The consumer-create escape is closed by the enumeration; the ack
-  escape is closed by deleting the grant outright - web consumers are ack-none by
-  design, so no ack grant is owed, and the JetStream-tax bullet's redelivery failure
-  (which needs an ack-expecting consumer) does not arise. There is deliberately no
-  `$JS.FC.>` for web either, for the same reason. The lesson generalises past this
+  escape by deleting the grant outright - web consumers are ack-none by design, so a
+  well-behaved client needs no ack grant (and no `$JS.FC.>`: ack-none push takes no
+  flow control), while granting either would reopen what the deletion closed. Ack
+  policy is a body field, so ack-none is a design intent the grant list cannot
+  enforce - the residue is recorded below with its siblings. The lesson generalises past this
   user: **for JetStream, a grant list is a capability surface, not a read/write
   distinction** - enumerate the streams, and never hand a browser-facing user
   `$JS.API.>`.
 
   Residues, all closed by the auth callout and none of them "can read what it shouldn't":
   durability is a body field, so withholding the legacy `DURABLE.CREATE` subject does not
-  prevent a durable - `max_consumers` per stream bounds the cost instead; within the four
+  prevent a durable - `max_consumers` per stream bounds the cost instead; ack policy is
+  the same class of body field, so a hostile holder can create an explicit-ack consumer
+  it holds no grant to ack - endless redeliveries, churn against the server, and an
+  amplifier for the deliver-subject write below; within the four
   granted streams consumer names are the caller's choice, so `web` can pull a delivery
   off another reader's consumer or retune it through create-as-update; and a consumer's
   deliver subject can aim replay of stored messages at another stream's subject, which is

--- a/docs/designs/spec-nats-deployment.md
+++ b/docs/designs/spec-nats-deployment.md
@@ -81,9 +81,17 @@ Three KV buckets ride the same JetStream deployment:
 - `session-state` - the gateway's session registry (session key, `contextId`, current
   pod, roster, and the active task's bounded ask echo - user content, deliberately; the
   gateway design owns the content-vs-identifier rule). The gateway's user is the only
-  writer, and since the 8/31 narrowing the only reader too: no other user holds
-  `$KV.session-state.>` on either side, and the web user's consumer-create route into
-  the bucket is closed by its per-stream enumeration.
+  writer by grant, and since the 8/31 narrowing the only reader too: no other user
+  holds `$KV.session-state.>` on either side, and the web user's consumer-create route
+  INTO the bucket - a push consumer bound to `KV_session-state` - is closed by the
+  per-stream enumeration. One write route survives and is the deliver-subject residue
+  recorded with the web user below, not an exception to it: a consumer created on a
+  granted stream may aim its deliver subject at `$KV.session-state.>`, and the server's
+  own replay publishes land as bucket revisions. What the gateway reads back is
+  corruptible that way - current pod name, bus session name, roster - so "only writer"
+  is a statement about grants, not a property the subject list enforces. The residue's
+  closes are the residue paragraph's: the callout, or a separate account with an
+  export/import.
 - A bucket reserved for capability entries per the capability envelope design
   (`docs/architecture/09-capability-envelope.md`), which landed on KV-backed
   capabilities. Reserved so the account layout allows for it; it arms with the
@@ -287,12 +295,12 @@ deployment's job is to keep the substrate intact and reachable:
   `max_bytes`.
 - The audit path is read-only by construction: the exporter's user may subscribe and may
   not publish, enforced at connect like everything else.
-- The attribution salt the gateway hashes identifiers with must be one value per
-  install - replicas must agree or the pseudonyms on the stream stop joining. A
-  dedicated salt Secret provisioned with this deployment is the target shape; stage 1
-  derives the salt from the shared bus credential when none is configured. The gateway
-  design owns that rule and its rotation hazard; this deployment owes the Secret when
-  it lands.
+- The attribution salt the gateway hashes identifiers with is `SESSION_KV_SALT`, the
+  per-install salt the chart already provisions into `platform-agent-secrets` for the
+  shipped attribution path - not a new secret this deployment mints. Replicas must
+  read that one value or the pseudonyms on the stream stop joining, to each other and
+  to session metadata. The gateway design owns the rule and why a second salt is worse
+  than no salt.
 - W stays a tenancy decision as well as a cost one - the bus holds labelled content at rest
   for the whole window.
 

--- a/docs/designs/spec-subagent-profiles.md
+++ b/docs/designs/spec-subagent-profiles.md
@@ -292,6 +292,16 @@ draws today (`platformagent_manifests.go:1348-1371`).
 Artifact names are data, so the set can grow without touching the envelope or the payload
 spec. These four are reserved so that renderers and the audit tooling can rely on them.
 
+Deviation, recorded 8/31: the worker adapter as first built (ahead of its stage 3
+slot, for the gateway's session workers) produces `progress` from the model's own
+narration, not from an explicit tool. It maps the harness's assistant text blocks to
+`progress` chunks (thinking deltas to `thinking`, tool calls to `activity`), so the
+milestones are whatever the model chose to say out loud, at the model's cadence. The
+rendering path is unaffected - the gateway's rolling line consumes them the same way -
+but "agent-authored milestones" overstates what rides the artifact today. What closes
+it: the adapter exposing the progress tool (the demo used an in-process MCP server for
+this) and mapping only its calls to `progress` - the rest of the stage 3 adapter work.
+
 **Input flows the other way on the same subjects.** A worker that needs a human lands on
 `input-required` with a message saying what it needs - the `needs_input` escalation, now a
 first-class task state. The requester (or the gateway, relaying a human) publishes a


### PR DESCRIPTION
## Summary

Amends the five A2A design specs in `docs/designs/` with what the stage 1 implementation round established as design truth, and reconciles the three divergent spec copies (upstream, the drafting supersets, and one feature branch's local edits) so upstream is the superset again. New normative content: the Delegate flow and the gateway's deterministic interceptors, the per-executor steering contract (absorb vs refuse, and the status matcher's width bias inverting with it), turn accounting as the steering contract, the content-vs-identifier pseudonymization rule, the web read surface and why "read-only" is not expressible as a subject list, the writerless probe subject, the network fences around the NATS pod and session pods, and the mode switch's preservation-on-skew semantics.

## Why This Change

The specs became design-of-record upstream in #930, but three things drifted immediately. First, the merged copy of `spec-a2a-payloads.md` predates the restoration of review-ratified text (assertion 21, the dual-reader rule, dot-free tokens, warn-and-drop after final, the bounded dedup window, the opaque-identifier rule) — the wire library implements that text, so upstream currently understates the contract the code passes. Second, ratified amendments from the implementation round (the managed-`.env` mode delivery, skew preservation, the rollout annotation, the web user's grant narrowing) lived only on working branches and drafting copies. Third, the implementation round surfaced design decisions no spec carried at all — most consequentially the two steering postures and the JetStream capability-surface lesson. Without this PR, the next contributor reads a spec that is wrong in places the code is right.

## What Changed

- `spec-a2a-payloads.md` — restores the six regressed review-round hunks; adds the refusal posture to the steering rule; adds turn accounting (one `result` per user turn; the executor's adapter counts) as a lifecycle rule; notes the stage 1 `progress` deviation in the artifact table.
- `spec-chatops-gateway.md` — the Delegate flow (one-task contract, re-home rule, previous-incarnation delete); the deterministic interceptors and the width-bias inversion, with fixed-route/session-routed defined; gateway-authored posts reconciled with the relay-only model; the content-vs-identifier rule and the session KV's bounded `ask` copy; model auth as shipped (LiteLLM, no per-pod credential) with the static-bus-credential bridge to the callout design; contextId minting stated as a create-only requirement with the stage 1 gap named; `SESSION_KV_SALT` named as the attribution salt; and one supervisor rule covering every pod the gateway deletes itself.
- `spec-mode-switch.md` — `ModeNotRecognized` preserves rather than re-renders-today-only (tears nothing down on skew); the managed-`.env` delivery amendment; mode flip as a rollout via `kubeagents.x-k8s.io/config-hash`; `next` ships no long-term audit.
- `spec-nats-deployment.md` — the JetStream tax (ack/flow-control/inbox-prefix grants) with the ack-scoping rule and the unscoped stage 1 render named as debt; exact topic publish grants; the web read surface, its two reproduced escapes, the residues and their closes; the writerless probe subject as the one exception to "subject list and writer's grant travel together"; the NATS-pod ingress and session-pod egress fences; stage 1's static-auth status against the callout design.
- `spec-subagent-profiles.md` — the `progress`-as-narration deviation and what closes it.

## Context

- The specs merged upstream in #930; #720's re-cut is the code path and this PR deliberately carries no code.
- No open PR touches `docs/designs/spec-*.md` (checked the open PR list on this repository today).
- Reconciliation direction per file, since three copies existed: **payloads** resolved toward the ratified drafting superset (the upstream copy had regressed via a stale-copy commit); **mode-switch** resolved toward the 8/26 ratified amendments, then corrected against operator source during this PR's review (annotation name, preservation wording); **nats** resolved toward the feature branch that amended it on 8/31, then corrected against the rendered config during review (publish-only exactness, the web user's account-level `INFO` grant, ack scoping stated as debt rather than fact); **gateway** resolved toward the drafting superset with two claims corrected against the code (contextId minting is a plain `Put` today, so the spec states the create-only requirement and the gap; the salt claim resolved toward neither copy but toward the install — `SESSION_KV_SALT` already exists and is what both surfaces must hash with); **profiles** had no divergence.
- Five defects this PR's review found live on the gateway branch rather than here, and are flagged there rather than fixed: a spawner comment still claiming Workload-Identity model auth that this spec supersedes, plus four behavioural items the spec is now ahead of — the salt read, publishing a detached task's terminal before deleting its pod, the pod-level `activeDeadlineSeconds` the worker adapter's own contract assumes but the spawner never sets, and the contextId `Create`.

## Testing

- `make docs-check` green (generated regions, links, terminology, map coverage, context budget).
- `prettier --write` (3.9.6, the CI-pinned version) run over the five files; no residue.

### Live validation

Not live-tested: docs-only. The empirical claims the amendments carry (the web user's two reproduced escapes, the netpol probe results, the skew behavior) were established and validated live during the stage 1 implementation round on its dev install; this PR records them and its review re-verified each claim against the implementing source rather than re-running the cluster experiments.

## Self-Review

Both required passes ran in fresh contexts before opening (subagents handed the diff range and the review skill, not the drafting session's reasoning): `review-adversarial` (10 angles; 9 findings, all CONFIRMED against the implementing source) and `review-docs-drift` (5 Blocking, 6 Advisory). `kube-agents-bot` then reviewed ten times — the opening pass plus nine strict `/review` passes, each mostly re-reading the previous round's fixes — for 25 further findings, 3 High. One was refuted with evidence rather than fixed (below); the rest are corrected. Every finding is dispositioned in its thread against the commit that answered it; below is the current state of the branch, merged by topic rather than by round.

**Claims the passes falsified against source, all now corrected in the spec.** Four were defects in text ratified by earlier review rounds rather than in this drafting — the drafting copies asserted mechanisms nobody had checked:

- **The salt.** The install already provisions a per-install HMAC salt — `SESSION_KV_SALT`, generated once into `platform-agent-secrets` by the chart, never rewritten on upgrade, consumed by the shipped redactor — while the gateway derives its own from the bus password, so the spec's "same posture as the shipped attribution path" was false and the cross-surface audit join silently yields nothing. Settled by the author: that Secret is the salt, named in both specs; the derivation is recorded as a stage 1 deviation with its second cost (a de-anonymization key held by whoever holds the bus credential, over an enumerable identifier space), and the gateway branch owes the change.
- **contextId minting** claimed compare-and-swap; the code is a plain `Put` behind an in-process lock. Now stated as a create-only requirement with the stage 1 gap named.
- **Per-stream ack scoping** was stated as fact; the render grants unscoped `$JS.ACK.>`. The rule stays, the wider grant is named as debt. Relatedly, "ack-none by design" for the web user rested on a body field the grant list cannot enforce (the section's own lesson, applied to my earlier fix): the hostile explicit-ack consumer now sits with the residues.
- **`session-state`'s "only writer"** is refuted by this same file's deliver-subject residue — the enumeration closes the read route into the bucket, not where a permitted consumer aims delivery. Now a grant-level claim with the surviving write route recorded.
- Smaller: the rollout annotation was misnamed (`checksum/config` → `kubeagents.x-k8s.io/config-hash`), a cited regression test did not exist at this head, "topic grants are exact" overclaimed the read side, and the web enumeration omitted account-level `$JS.API.INFO`.

**Gaps the passes found in the amendments themselves, all closed:**

- **Every pod the gateway deletes itself** now carries one supervisor rule, covering all four paths (reap, Sweep, Delegate, future): if it runs a detached task, publish its terminal first — `canceled`, since detached means a `stop` already published a cancel and the gateway is finishing it rather than reporting an error (the payload spec's general supervisor rule carries the matching refinement, so `failed` stays the state for an executor that died mid-work and assertion 13's enumeration holds on every cancel path). Found twice — first on the Delegate path, then on reap, which deletes detached tasks' pods on the idle TTL and publishes nothing. Stated once, in Session lifecycle, with both callers deferring to it; the ordering of the adapter deadline against the idle TTL is explicitly not something to reason from, since they are independently tunable.
- **The `ask` copy's retention horizon is a condition, not a property.** It holds only where a terminal event is guaranteed, so the one case named as unowned (a wedged adapter, until the pod-level deadline ships) is a case where the justification does not hold; both the content rule and the lifecycle section now say so, and the gateway owes the record an independent bound meanwhile.
- **The turn-accounting race window** was a silent drop contradicting the refusal posture added in the same diff. Resolved by author decision: the losing steer gets the visible refusal before the terminal, with the stage 1 adapter's log-and-count recorded as a deviation and the gateway's acknowledgement made conditional.
- **The NATS ingress fence** enumerated today's clients with no growth rule; it now names the auth callout service first (a bus client on the connection path — arming it against a closed enumeration takes the fabric dark to new work), then the route port for any 3-node R3 deployment, the audit exporter, the janitor, and the metrics scrape.
- **Skew preservation** had no mechanism under the spec's own helper contract: `renderMode` fails closed and this operator deletes what it stops rendering. The helper section now names the reconciler-armed carve-out as the one exception, and the survival claim is corrected to what preservation actually guarantees across the behavior rollout.
- **What "read-only" means for the audit exporter.** The observability section's "may subscribe and may not publish" predates this diff and survived unexamined until the JetStream tax made it mean something specific and wrong — a user rendered from the literal reading cannot create its own durable consumer. It now says what it means: nothing onto the A2A subjects and no grant that can destroy evidence, while holding the client grants reading requires.
- **The steer acknowledgement** promised pick-up the fixed-route executor is defined two paragraphs earlier to refuse; now conditioned on the route the way the width bias is.
- **Definitions and contradictions:** fixed-route vs session-routed, `detached`, and the session worker's deadline chain were all load-bearing and undefined; the deviation note contradicted the standing "the adapter is stage 3 code" sentence; session-pod bus auth contradicted the callout section; workstream labels no repo reader can resolve were replaced with dates.

**Refuted with evidence, not fixed:** the review argued the `web` user cannot both hold `CONSUMER.MSG.NEXT` and lack an ack grant, on the premise that JetStream requires explicit ack for pull consumers. Probed against the repo's pinned nats-server: `PULL + AckNone` is accepted, and an ordered consumer negotiates `ackPolicy=AckNone` with an empty deliver subject — a pull consumer, which is exactly what the UI creates. So the grant list and its justification agree, and the hostile-client version of the hazard is already recorded in the residues.

**Reported, not fixed here:** the gateway branch's spawner still carries a stale Workload-Identity comment this spec supersedes, and the same branch owes four behavioural items this review surfaced (the salt read, terminal-before-delete, the pod-level `activeDeadlineSeconds` the adapter's contract assumes but the spawner never sets, and the contextId `Create`). Those are code on another branch; this diff is the correct side of each and they are flagged there. Pre-existing and untouched: the durable-push vs ephemeral-consumer tension in the deployment spec, and a drifted line reference in the profiles spec.

Checked clean by the passes, for the record: assertion numbering and enforcement points, the dedup bound, the interceptor sets and Delegate semantics, the session KV fields and `ask` lifecycle, the writerless probe, both NetworkPolicies, `allowed_origins`, the gateway-authored post inventory, cross-spec deferrals, and the documentation map (no rows owed, no churn).


Generated with the help of Claude Code.

## Risk & Rollout

Docs-only; no runtime code path is touched and no generated region changes. The risk is spec-level: this PR makes upstream the canonical superset, so any in-flight branch carrying its own spec edits should rebase its prose onto these files rather than re-editing branch-local copies. Revert is a clean `git revert` of one commit.
