### PR TITLE
fix(agent): match the git remote host exactly when resolving the GitHub repo

### DIFF
--- a/agents/platform/scripts/forge.py
+++ b/agents/platform/scripts/forge.py
@@ -65,6 +65,12 @@ The looser parser in `gitops_workspace.repo_from_settings` is deliberately not
 reused. It strips a `github.com/` prefix and otherwise takes the last two path
 segments, so `https://evil.com/github.com/attacker/repo` resolves to
 `attacker/repo`. That is out of scope here and noted rather than fixed.
+
+A third parser, `github_token_refresh.github_repo_from_remote`, reads the git
+remote rather than a configured value and rejects a non-GitHub host outright.
+Its host set carries `ssh.github.com` — GitHub's SSH-over-443 endpoint, which
+appears in a clone URL but not in a `SETTINGS.md` repository line — so a remote
+of that form resolves there and not here.
 """
 
 from __future__ import annotations

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -34,12 +34,22 @@ TOKEN_BROKER_URL = os.getenv(
 
 
 # Hosts this refresher will mint a token for. `ssh.github.com` is GitHub's
-# SSH-over-443 endpoint, a different hostname for the same repositories.
+# SSH-over-443 endpoint and `www.github.com` is the redirecting alias `git
+# clone` accepts, both naming the same repositories as `github.com`. An
+# enterprise host is deliberately absent: Minty issues tokens for github.com
+# installations only.
 GITHUB_HOSTS = frozenset({"github.com", "www.github.com", "ssh.github.com"})
 
 # scp-like remote syntax — `[user@]host:path` — which is not a URL and so has
 # to be split before the host can be compared.
 _SCP_REMOTE = re.compile(r"^(?:[^/@]+@)?(?P<host>[^/:]+):(?P<path>.+)$")
+
+# One `owner/name` slug, the shape `credential_proxy.is_valid_repository`
+# accepts on the sidecar path. Checked here because the other path — direct to
+# Minty, for the standalone deployments the module docstring names — has no
+# validator downstream, so a deep link's extra segments would be posted as a
+# repository name.
+_REPOSITORY_SEGMENT = re.compile(r"[A-Za-z0-9_.-]+")
 
 
 def github_repo_from_remote(url: str) -> str | None:
@@ -60,13 +70,40 @@ def github_repo_from_remote(url: str) -> str | None:
             return None
         host, path = match.group("host"), match.group("path")
 
-    if not host or host.lower() not in GITHUB_HOSTS:
+    if not host:
+        return None
+    if host.lower() not in GITHUB_HOSTS:
+        # The host, never the URL: a remote can carry `user:token@` in front of
+        # it. Without this an operator whose clone uses an SSH host alias sees
+        # only the caller's "Could not identify target repository 'None'".
+        log(f"Ignoring git remote: host '{host}' is not a GitHub host.")
         return None
 
     path = path.strip("/")
     if path.endswith(".git"):
         path = path[:-4]
-    return path or None
+    owner, slash, name = path.partition("/")
+    if (
+        not slash
+        or not _valid_repository_segment(owner)
+        or not _valid_repository_segment(name)
+    ):
+        log(f"Ignoring git remote: path '{path}' is not an owner/repo slug.")
+        return None
+    return f"{owner}/{name}"
+
+
+def _valid_repository_segment(segment: str) -> bool:
+    """One half of an `owner/name` slug, with the traversal shapes rejected.
+
+    The character class permits `.` and `-`, so it matches `..` and a leading
+    dash as happily as a real name; neither is a repository.
+    """
+    return (
+        _REPOSITORY_SEGMENT.fullmatch(segment) is not None
+        and segment not in (".", "..")
+        and not segment.startswith("-")
+    )
 
 
 def get_current_git_repo() -> str | None:

--- a/agents/platform/scripts/github_token_refresh.py
+++ b/agents/platform/scripts/github_token_refresh.py
@@ -11,11 +11,13 @@ import email.message
 import io
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlsplit
 
 from credential_proxy_client import authorization_headers
 
@@ -31,6 +33,42 @@ TOKEN_BROKER_URL = os.getenv(
 )
 
 
+# Hosts this refresher will mint a token for. `ssh.github.com` is GitHub's
+# SSH-over-443 endpoint, a different hostname for the same repositories.
+GITHUB_HOSTS = frozenset({"github.com", "www.github.com", "ssh.github.com"})
+
+# scp-like remote syntax — `[user@]host:path` — which is not a URL and so has
+# to be split before the host can be compared.
+_SCP_REMOTE = re.compile(r"^(?:[^/@]+@)?(?P<host>[^/:]+):(?P<path>.+)$")
+
+
+def github_repo_from_remote(url: str) -> str | None:
+    """Return `owner/repo` when `url` is a GitHub remote, else None.
+
+    The host is compared against `GITHUB_HOSTS` after parsing rather than
+    searched for in the raw string: `https://evil.example/github.com/o/r.git`
+    and `https://github.com.evil.example/o/r.git` both contain `github.com`,
+    and a substring check would hand a token request for someone else's
+    repository to Minty.
+    """
+    if "://" in url:
+        parts = urlsplit(url)
+        host, path = parts.hostname, parts.path
+    else:
+        match = _SCP_REMOTE.match(url)
+        if not match:
+            return None
+        host, path = match.group("host"), match.group("path")
+
+    if not host or host.lower() not in GITHUB_HOSTS:
+        return None
+
+    path = path.strip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    return path or None
+
+
 def get_current_git_repo() -> str | None:
     try:
         res = subprocess.run(
@@ -39,12 +77,7 @@ def get_current_git_repo() -> str | None:
             text=True,
             check=True,
         )
-        url = res.stdout.strip()
-        if "github.com" in url:
-            path = url.split("github.com")[-1].lstrip(":").lstrip("/")
-            if path.endswith(".git"):
-                path = path[:-4]
-            return path
+        return github_repo_from_remote(res.stdout.strip())
     except Exception:
         pass
     return None

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -30,6 +30,44 @@ class GitHubTokenRefreshTest(unittest.TestCase):
         self.assertEqual("gke-labs/kube-agents", get_current_git_repo())
 
     @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_ssh_over_443(self, run):
+        res = MagicMock()
+        res.stdout = "ssh://git@ssh.github.com:443/gke-labs/kube-agents.git\n"
+        run.return_value = res
+        self.assertEqual("gke-labs/kube-agents", get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_rejects_lookalike_hosts(self, run):
+        res = MagicMock()
+        run.return_value = res
+        for url in (
+            "https://evil.example/github.com/gke-labs/kube-agents.git",
+            "https://github.com.evil.example/gke-labs/kube-agents.git",
+            "https://notgithub.com/gke-labs/kube-agents.git",
+            "git@evil.example:github.com/gke-labs/kube-agents.git",
+            "https://github.com@evil.example/gke-labs/kube-agents.git",
+            "https://evil.example/x.git?github.com",
+            "https://evil.example/x.git#github.com",
+        ):
+            with self.subTest(url=url):
+                res.stdout = url + "\n"
+                self.assertIsNone(get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_non_github_remote_returns_none(self, run):
+        res = MagicMock()
+        res.stdout = "https://gitlab.com/gke-labs/kube-agents.git\n"
+        run.return_value = res
+        self.assertIsNone(get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_local_path_returns_none(self, run):
+        res = MagicMock()
+        res.stdout = "/srv/git/kube-agents.git\n"
+        run.return_value = res
+        self.assertIsNone(get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
     def test_get_current_git_repo_failure_returns_none(self, run):
         run.side_effect = Exception("git not found")
         self.assertIsNone(get_current_git_repo())

--- a/agents/platform/scripts/test_github_token_refresh.py
+++ b/agents/platform/scripts/test_github_token_refresh.py
@@ -54,6 +54,30 @@ class GitHubTokenRefreshTest(unittest.TestCase):
                 self.assertIsNone(get_current_git_repo())
 
     @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_www_alias(self, run):
+        res = MagicMock()
+        res.stdout = "https://www.github.com/gke-labs/kube-agents.git\n"
+        run.return_value = res
+        self.assertEqual("gke-labs/kube-agents", get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
+    def test_get_current_git_repo_rejects_non_slug_paths(self, run):
+        res = MagicMock()
+        run.return_value = res
+        for url in (
+            # A deep link, not a clone URL: nothing downstream on the direct
+            # Minty path would reject "kube-agents/tree/main" as a repository.
+            "https://github.com/gke-labs/kube-agents/tree/main",
+            "https://github.com/../../etc/passwd",
+            "https://github.com/%2e%2e/x.git",
+            "https://github.com/gke-labs",
+            "https://github.com/",
+        ):
+            with self.subTest(url=url):
+                res.stdout = url + "\n"
+                self.assertIsNone(get_current_git_repo())
+
+    @patch("github_token_refresh.subprocess.run")
     def test_get_current_git_repo_non_github_remote_returns_none(self, run):
         res = MagicMock()
         res.stdout = "https://gitlab.com/gke-labs/kube-agents.git\n"


### PR DESCRIPTION
## Summary

`get_current_git_repo` in the agent's GitHub token refresher decided a git remote was on GitHub by testing `"github.com" in url`, then took everything after that substring as `owner/repo`. Any remote carrying the string anywhere passed, and the slug it produced was whatever followed it — so a clone from `https://evil.example/github.com/attacker/loot.git` made the agent ask the credential sidecar for a token scoped to `attacker/loot`. This parses the remote instead: `urlsplit` for URL-shaped remotes, a regex for the scp-like `[user@]host:path` form, an exact host allowlist, and a check that the remaining path is one `owner/repo` slug.

## Why This Change

CodeQL alert 20 (`py/incomplete-url-substring-sanitization`, security-severity high) on `agents/platform/scripts/github_token_refresh.py:43`. Left alone, the refresher's local check — the one that is supposed to decide which repository a token request names — accepts a host it should not, and the request it composes reaches Minty with an attacker-chosen slug. Minty's CEL rules are what actually decide whether a token is issued, so this is a malformed request rather than a guaranteed cross-org token; the point is that the check meant to stop it did not.

The substring form was also wrong on a legitimate remote: `ssh://git@ssh.github.com:443/gke-labs/kube-agents.git` resolved to `443/gke-labs/kube-agents`.

## What Changed

- `agents/platform/scripts/github_token_refresh.py` — new `github_repo_from_remote`, which `get_current_git_repo` now delegates to. Hosts are compared against `GITHUB_HOSTS` (`github.com`, `www.github.com`, `ssh.github.com`) after parsing; the path must be a single `owner/repo` slug, matching the shape `credential_proxy.is_valid_repository` enforces on the sidecar path — the direct-to-Minty path used by standalone deployments has no validator downstream. A rejected remote logs the host (never the URL, which can carry `user:token@`).
- `agents/platform/scripts/forge.py` — one paragraph in the existing "On the repository parser" note, which is where this repository records which GitHub-remote parsers exist and how they differ.
- `agents/platform/scripts/test_github_token_refresh.py` — lookalike hosts, non-slug paths, SSH-over-443, the `www` alias.

## Context

- Closes CodeQL alert https://github.com/gke-labs/kube-agents/security/code-scanning/20.
- #1085 — filed from this branch's review: `gitops_workspace.repo_from_settings`, which `resolve_repo` consults *before* the git remote, has no host check at all, and `ValidateGitRepoURL` admits any non-empty host. This PR hardens the fallback parser only.
- **Conflicts with #504** (`feat(agent): add support for multiple github repos`), which rewrites this same function with no host check — it returns the last two path segments for any host, a superset of the behaviour removed here. Whoever rebases second decides the outcome; a resolution taking #504's side reverts this silently, and the new tests are the only thing that would catch it. #504 also carries a tightening this PR does not: `repository.count("/") != 1` on the caller's gate for the CLI-argument path.
- #913 touches this file (WIF identity token) but not this function; it will conflict textually in the import block only.

## Testing

- `agents/platform/scripts/test_github_token_refresh.py` — 25 pass. The two new host tests were verified red against the base implementation (`'gke-labs/kube-agents' is not None`, `'gke-labs/kube-agents' != '443/gke-labs/kube-agents'`).
- `test_forge.py` — 96 pass, including the cross-parser agreement corpus.
- `make docs-check` — clean.
- `make test-python` has three failures in `agents/platform/scripts/` that predate this branch and do not touch these files: a `test_session_kv_server` import error (missing third-party deps), `test_slack_relay_patch`, and `test_pr_triggers`.

### Live validation

gkedemos install: cluster `kube-agents-cluster` (`bhoekstra-gkedemos`, us-central1), namespace `kubeagents-system`, pod `platform-agent-gateway-568f95dcf6-wb8kn`, container `platform-agent`, image `platform-agent:dns-endpoint-7dac349`, Python 3.13.5. Live-test lease held for the run and released.

The change is a pure agent-side script, so there is no CR `.status` or Deployment env layer to observe — the layer it touches is the file in the pod and the request that file composes. Both versions of the script were run inside the pod against a real scratch clone, with real `git config --get remote.origin.url` going through the pod's own credential-proxy `git`:

```
remote                                                  base                            branch
https://github.com/gke-labs/kube-agents.git             'gke-labs/kube-agents'          'gke-labs/kube-agents'
git@github.com:gke-labs/kube-agents.git                 'gke-labs/kube-agents'          'gke-labs/kube-agents'
ssh://git@ssh.github.com:443/gke-labs/kube-agents.git   '443/gke-labs/kube-agents'      'gke-labs/kube-agents'
https://www.github.com/gke-labs/kube-agents.git         'gke-labs/kube-agents'          'gke-labs/kube-agents'
https://evil.example/github.com/attacker/loot.git       'attacker/loot'                 None
https://github.com.evil.example/attacker/loot.git       '.evil.example/attacker/loot'   None
git@evil.example:github.com/attacker/loot.git           'attacker/loot'                 None
https://github.com/gke-labs/kube-agents/tree/main       'gke-labs/kube-agents/tree/main' None
```

Then at the layer that matters — `refresh_git_credentials()` from the lookalike clone, with `urlopen` stubbed so the request is captured rather than sent, and the pod's real `CREDENTIAL_PROXY_URL=http://127.0.0.1:8765`:

```
remote=https://evil.example/github.com/attacker/loot.git
--- base ---
[SRE-AUTH] GitHub credentials refreshed in credential sidecar for attacker/loot.
POSTed [('http://127.0.0.1:8765/v1/github/refresh', {'repository': 'attacker/loot'})]
--- branch ---
[SRE-AUTH] Ignoring git remote: host 'evil.example' is not a GitHub host.
RuntimeError: Could not identify target repository 'None'. Must be in 'owner/repo' format. | requests sent: []
```

and the honest remote still gets through, so the rejection is the host check and not a blanket failure:

```
remote=git@github.com:gke-labs/kube-agents.git
[SRE-AUTH] GitHub credentials refreshed in credential sidecar for gke-labs/kube-agents.
POSTed [('http://127.0.0.1:8765/v1/github/refresh', {'repository': 'gke-labs/kube-agents'})]
```

Not covered: the deployed image predates the current `main` copy of this script, so the comparison is base-vs-branch run inside the pod's runtime rather than a redeploy — no image was built or rolled out. The token request was stubbed at `urlopen` rather than allowed to reach the sidecar and Minty, so nothing was minted; whether Minty would reject the malformed slug is unverified and out of tree. CodeQL was not run locally, so the alert closing is inferred from the fix shape (parsed host, exact allowlist) rather than observed.

Cleanup: the scratch clone under `/opt/data/workspace` and the `/tmp` copies were removed and their absence confirmed; the workspace is empty again, as it was before. Lease released.

## Self-Review

`/pr-preflight` ran both required passes as subagents, neither holding this change's reasoning, against `refs/kube-agents-base/main...HEAD`. Angles run: adversarial A (fallback and return-value audit), C (sibling contract symmetry, cross-file trace), D (operability of the failure mode), E (reuse), G (altitude), I (untested behaviour), J (interaction with open PRs); docs-drift checked every doc that names this script or the repo-inference behaviour, the map, and the identifier-source rows.

| Finding | Verdict | Disposition |
| --- | --- | --- |
| `gitops_workspace.repo_from_settings` — consulted *before* the git remote, and the only source on the audit-cron path — has no host check, and `ValidateGitRepoURL` admits any non-empty host. The hardening here covers the fallback source only. | MEDIUM, CONFIRMED | Not fixed here: a different input path, a different module, and it needs a separate decision about admission-time validation on the CR. Filed as #1085 with the executed evidence. |
| #504 rewrites this function without a host check, so merge order decides whether the fix survives. | MEDIUM, CONFIRMED | Not a code finding; recorded under Context so whoever rebases second sees it. |
| The returned path was not constrained to `owner/name`: `https://github.com/o/r/tree/main` and `../../etc/passwd` both resolved. The sidecar's `is_valid_repository` catches it; the direct-to-Minty path does not. | LOW, CONFIRMED | Fixed — slug check in the parser, with tests for the deep-link, traversal and percent-encoded shapes. |
| Rejection was silent; the caller's only message was `Could not identify target repository 'None'`, which names neither the remote nor the reason. Real remotes land there (SSH host aliases, trailing-dot FQDNs). | LOW, CONFIRMED | Fixed — logs the host on rejection, and the host only, since a remote can embed `user:token@`. |
| `www.github.com` was in the allowlist with no test and no stated reason, so a later narrowing would drop it silently. | LOW, CONFIRMED | Fixed — test added, comment states why each host is in the set. |
| `forge.py`'s parser-inventory note did not mention this parser, and the host sets diverge (`ssh.github.com` here, not there). | Advisory (docs-drift) | Fixed — paragraph added to that note. Host sets deliberately not aligned: `ssh.github.com` appears in a clone URL, not in a `SETTINGS.md` repository line. |
| No `docs/README.md` identifier-source row for the host set. | Advisory (docs-drift) | Not fixed: no published doc states the host set, so there is no prose to keep true. Worth adding if one ever does. |

Recorded as not-findings after being checked: `urlsplit` raising on a malformed IPv6 remote (the caller's `except Exception` covers it); userinfo confusion in both directions (`https://github.com@evil.example/…` rejected, `https://evil@github.com/o/r.git` accepted, matching git and curl's last-`@` rule); query- and fragment-borne lookalikes, which fall outside `.path`; no GitHub Enterprise regression, since `github.mycorp.com` never contained the substring either; no `insteadOf` regression.

What the passes could not cover: neither consulted a running installation (that is the Live validation section above, run separately); Minty is out of tree, so the downstream handling of a malformed slug is unverified; the adversarial pass ran only the touched suite, in a `/tmp` copy, to avoid mutating a checkout its sibling was reading.

## Risk & Rollout

Narrowing, not widening: every remote the parser now rejects is one that could not have yielded a valid GitHub App token anyway, and the three legitimate remote forms are covered by tests and were exercised in the pod. The behaviour change an operator could notice is a clone whose `origin` is not a GitHub host — previously it produced a garbage slug that failed at Minty, now it fails locally with a log line naming the host. Ships in the agent image on the next build; revert is the two commits, with no state to unwind.

Generated with the help of Claude Opus 5 (Claude Code).
