### PR TITLE
test(ci): assert the missing Cloud Build reader by member, not by domain

### DIFF
--- a/scripts/test_verify_ci_pool_project.py
+++ b/scripts/test_verify_ci_pool_project.py
@@ -1656,15 +1656,23 @@ class IamGrantsTest(unittest.TestCase):
 
     def test_missing_legacy_cloudbuild_reader_fails(self):
         # This is exactly the drift found on kube-agents-evals-2.
+        project_number = "123456"
         with mock.patch.object(checker, "run_cmd") as run:
             run.side_effect = [
                 _ok(self._wi_policy("kube-agents-evals-2")),
                 _ok(self._project_policy("kube-agents-evals-2")),
-                _ok(self._reader_policy(["serviceAccount:123456-compute@developer.gserviceaccount.com"])),
+                _ok(self._reader_policy([f"serviceAccount:{project_number}-compute@developer.gserviceaccount.com"])),
             ]
-            result = checker.check_iam_and_service_accounts("kube-agents-evals-2", "123456")
+            result = checker.check_iam_and_service_accounts("kube-agents-evals-2", project_number)
         self.assertFalse(result.passed)
-        self.assertTrue(any("cloudbuild.gserviceaccount.com" in d for d in result.details), result.details)
+        # The whole member the checker builds, not the domain it ends in. A
+        # detail naming any cloudbuild SA -- another project's, or a
+        # remediation hint quoting the domain -- satisfied the old spelling
+        # without the reported identity being this project's. Matching a bare
+        # host literal also reads to CodeQL as an incomplete URL check
+        # (py/incomplete-url-substring-sanitization).
+        cloudbuild_sa = f"serviceAccount:{project_number}@cloudbuild.gserviceaccount.com"
+        self.assertTrue(any(cloudbuild_sa in d for d in result.details), result.details)
 
     def test_missing_workload_identity_binding_fails(self):
         with mock.patch.object(checker, "run_cmd") as run:


### PR DESCRIPTION
## Summary

`test_missing_legacy_cloudbuild_reader_fails` asserted that the checker's failure details contained the string `cloudbuild.gserviceaccount.com`. That is the domain, not the identity: a detail naming a different project's Cloud Build SA, or a remediation hint that merely quotes the domain, satisfied it. The assertion now matches the member the checker actually builds, `serviceAccount:{project_number}@cloudbuild.gserviceaccount.com`, with the project number hoisted into a variable so the test and the mocked policy agree by construction.

## Why This Change

CodeQL alert 21 (`py/incomplete-url-substring-sanitization`, security-severity high) points at that assertion. The alert is a false positive as a security finding: nothing on this path sanitizes a URL. The production code compares exact IAM members — `verify_ci_pool_project.py:826` builds `cb_sa` and line 834 checks `cb_sa not in readers` — and the flagged expression is a test asserting the shape of a human-readable diagnostic. What the rule matched is a bare host literal on the left of `in`.

The assertion was nonetheless weaker than it should be, and fixing that removes the literal the rule keys on. If the next scan shows the alert survived anyway, it should be dismissed as a false positive rather than worked around further.

## What Changed

- `scripts/test_verify_ci_pool_project.py` — one assertion in `test_missing_legacy_cloudbuild_reader_fails` now pins the full member instead of the domain; `project_number` is a local so the mocked policy, the call, and the expected member cannot drift apart. A comment records both reasons.

## Context

- CodeQL alert https://github.com/gke-labs/kube-agents/security/code-scanning/21. Whether the alert closes is decided by the scan on this PR — the rule matches a string literal, and the operand is now a name bound to an f-string, but that is a prediction about CodeQL rather than something verifiable in the checkout.
- #1086 is the other open instance of the same rule (alert 20, `github_token_refresh.py`), and that one is a real defect rather than a false positive. No file overlap.
- #1078 also touches `scripts/test_verify_ci_pool_project.py`, as a pure insertion before `class IamGrantsTest`; this edit is inside that class, so the two should merge cleanly. Whoever rebases second should re-run the file's suite rather than assume it.
- The sibling assertion at line 958 (`"123456-compute@developer.gserviceaccount.com"`) is deliberately left alone: it already carries the project number, so it pins an identity and is not a bare host literal. Alert 21 is the only hit in this file.

## Testing

- `scripts/test_verify_ci_pool_project.py` — 181 pass, under pytest and under `python3 -m unittest discover` from `scripts/`, which is how `make test-python` reaches it.
- Red/green by mutation, in a `/tmp` copy so the tree stayed clean: weakening the checker's detail to `"Cloud Build SA missing roles/artifactregistry.reader on kube-agents-prow (see cloudbuild.gserviceaccount.com identities)"` leaves the old assertion **passing** and makes the new one **fail**. The preflight review repeated this independently with a different mutation (hardcoding the wrong project number in `cb_sa`) and got the same split.
- `make docs-check` — clean.

### Live validation

The diff is a unit-test assertion, so there is no cluster layer for it to touch. What can be checked live is the thing the assertion pins — that the detail string it now expects is the string the checker emits from real data — and that was checked against a real CI pool project rather than a fixture.

Ran `scripts/verify_ci_pool_project.py --project-id kube-agents-evals-2` (project number 311197446601, the project this test's scenario is named after). The check the test covers passes against the live policy:

```
[✓] Service Accounts & IAM Grants: Workload Identity, Prow runner and platform GSA project roles, and cross-project AR reader grants verified
```

Then drove `check_iam_and_service_accounts` over the same live `gcloud` output with one member filtered out of the response in memory — this project's `serviceAccount:311197446601@cloudbuild.gserviceaccount.com` reader binding on `kube-agents-prow` — which is the drift the test simulates:

```
== unmodified real policy ==
passed: True | Workload Identity, Prow runner and platform GSA project roles, and cross-project AR reader grants verified

== same real policy, this project's legacy Cloud Build reader removed ==
stripped from roles: ['roles/artifactregistry.reader']
passed: False
  detail: Cloud Build SA (serviceAccount:311197446601@cloudbuild.gserviceaccount.com) missing roles/artifactregistry.reader on kube-agents-prow

assertion under test ->  True
```

Not covered: no IAM binding was changed in GCP — the member was removed from the policy JSON in the calling process, so nothing was mutated and there is nothing to clean up. Two checks on that project report `MANUAL VERIFICATION REQUIRED` (App installation membership, and a KMS sign that needs `cloudKMS.cryptoKeyVersions.useToSign`); both predate this branch and are unrelated to the IAM check. CodeQL was not run locally — no CLI here and scanning is GitHub default setup with no in-tree config — so the alert's disposition is settled by the scan on this PR.

## Self-Review

`/pr-preflight` ran both required passes as subagents, neither holding this change's reasoning, against `refs/kube-agents-base/main...HEAD`.

- **Adversarial — no findings.** Angles run: B (a test-only diff is a candidate until the test is shown to have been wrong, which it settled by mutation rather than argument), C (the detail string traced back to its construction in the checker), E, I, and J (sibling pull requests #1086 and #1078, and the unflagged sibling assertion at line 958). It confirmed the new assertion is a strict superset of the old one — no coverage removed — and confirmed alert 21 points at exactly the deleted line.
- **Docs-drift — no Blocking findings, one Advisory.** It re-verified that `ci-pool-projects.md:78`, `provision_ci_pool_project.sh:227`, and the checker all spell the member the same way, that `docs/README.md`'s identifier-source row names the checker (untouched), and that the map needs no edit. The Advisory: the comment's CodeQL half is unverifiable from the checkout, since scanning is enabled through GitHub's default setup and no workflow or config commits it. **Not fixed** — four other files already reference CodeQL query names the same way, and the comment's primary rationale (the old spelling accepted a detail about the wrong identity) stands without it.

Neither pass could run CodeQL, which is the one claim this PR cannot settle before merge; the Context section says so rather than implying the alert is closed.

## Risk & Rollout

A single test assertion, narrowed. No production code, no interfaces, no CI configuration. The failure mode if the new expectation is somehow wrong is a red test on this PR, which it is not. Revert is the one commit.

Generated with the help of Claude Opus 5 (Claude Code).
