### PR TITLE
feat(ci): assert static NetworkPolicy DNS egress parity across all copies

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,11 +68,6 @@ jobs:
       - name: Check the container-image inventory
         run: make images-check
 
-      - name: Check static NetworkPolicy DNS egress parity
-        run: |
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
-          make iac-parity-check
-
       - name: Validate Helm Chart
         run: |
           # clusterName/location/projectId are required values with no

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,6 +68,11 @@ jobs:
       - name: Check the container-image inventory
         run: make images-check
 
+      - name: Check static NetworkPolicy DNS egress parity
+        run: |
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --quiet pyyaml
+          make iac-parity-check
+
       - name: Validate Helm Chart
         run: |
           # clusterName/location/projectId are required values with no

--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,7 @@ chart-sync: ## Sync the Helm chart's CRD copies and operator ClusterRole rules f
 chart-check: ## Verify the chart's CRD/RBAC copies match k8s-operator/config (CI runs this).
 	@./hack/sync-chart-manifests.sh --check
 
-iac-parity-check: ## Verify DNS egress rule parity across static NetworkPolicy copies (CI runs this).
+iac-parity-check: ## Verify DNS egress rule parity across static NetworkPolicy copies (CI runs this via scripts/test_check_iac_parity.py).
 	@python3 -c "import yaml" 2>/dev/null || { \
 		echo "iac-parity-check needs PyYAML: python3 -m pip install pyyaml (or make test-python-deps)"; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BASE_IMAGE_ARGS := $(foreach v,$(BASE_IMAGE_VARS),$(if $($(v)),--build-arg $(v)=
 SANDBOX_IMAGE_VARS := PYTHON_IMAGE
 SANDBOX_IMAGE_ARGS := $(foreach v,$(SANDBOX_IMAGE_VARS),$(if $($(v)),--build-arg $(v)=$($(v))))
 
-.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-build-sandbox docker-smoke-sandbox docker-push docker-push-agents docker-push-credential-proxy docker-push-sandbox dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps test-bench test-bench-deps bench-case-check e2e-tests e2e-test-deps test-e2e test-e2e-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map docs-check-context-budget chart-sync chart-check tf-apply tf-destroy coverage coverage-check test-integration conformance
+.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-build-sandbox docker-smoke-sandbox docker-push docker-push-agents docker-push-credential-proxy docker-push-sandbox dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps test-bench test-bench-deps bench-case-check e2e-tests e2e-test-deps test-e2e test-e2e-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map docs-check-context-budget chart-sync chart-check iac-parity-check tf-apply tf-destroy coverage coverage-check test-integration conformance
 
 # The agent images this repository builds -- one per `--target` stage in
 # deploy/docker/Dockerfile, which is not the same thing as one per directory
@@ -562,6 +562,13 @@ chart-sync: ## Sync the Helm chart's CRD copies and operator ClusterRole rules f
 
 chart-check: ## Verify the chart's CRD/RBAC copies match k8s-operator/config (CI runs this).
 	@./hack/sync-chart-manifests.sh --check
+
+iac-parity-check: ## Verify DNS egress rule parity across static NetworkPolicy copies (CI runs this).
+	@python3 -c "import yaml" 2>/dev/null || { \
+		echo "iac-parity-check needs PyYAML: python3 -m pip install pyyaml (or make test-python-deps)"; \
+		exit 1; \
+	}
+	@python3 scripts/check_iac_parity.py
 
 tf-apply: ## Apply terraform/examples/full-install, adopting KMS resources a previous destroy left behind.
 	@./terraform/examples/full-install/lifecycle.sh apply $(ARGS)

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -65,6 +65,20 @@ STATIC_NETWORK_POLICIES: tuple[str, ...] = (
     "k8s-operator/config/integrations/litellm/base/networkpolicy.yaml",
 )
 
+# Manifests containing kind: NetworkPolicy that are deliberately excluded from the
+# static DNS parity roster. Every entry must carry its reviewed reason.
+EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {
+    # Operator reconciliation test fixtures; golden expected outputs verified by Go controller tests.
+    "k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml": "operator golden test fixture",
+    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml": "operator golden test fixture",
+    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml": "operator golden test fixture",
+    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-split-broker.yaml": "operator golden test fixture",
+}
+
+IGNORED_DIRS: frozenset[str] = frozenset(
+    {".venv", "node_modules", "__pycache__", ".git", ".coverage-data", ".terraform", ".claude", "docs/site"}
+)
+
 REQUIRED_DNS_LITERAL = "10.96.0.10/32"
 REQUIRED_WILDCARD_CIDR = "0.0.0.0/0"
 REQUIRED_EXCEPT_MINIMUM: frozenset[str] = frozenset(
@@ -98,16 +112,75 @@ def sanitize_helm_template(text: str) -> str:
 
 
 def load_network_policies(path: Path) -> list[dict]:
-    """Read a manifest or template file and return all NetworkPolicy documents."""
+    """Read a manifest or template file and return all NetworkPolicy documents.
+
+    Parses document-by-document so syntax anomalies in unrelated manifests (like
+    Deployments or ConfigMaps in the same template file) do not fail NetworkPolicy
+    extraction.
+    """
     if not path.is_file():
         raise FileNotFoundError(f"File not found: {path}")
     raw_content = path.read_text(encoding="utf-8")
     sanitized = sanitize_helm_template(raw_content)
     policies: list[dict] = []
-    for doc in yaml.safe_load_all(sanitized):
-        if isinstance(doc, dict) and doc.get("kind") == "NetworkPolicy":
-            policies.append(doc)
+
+    # Split documents on YAML boundary '---'
+    for chunk in re.split(r"^---(?:\s.*)?$", sanitized, flags=re.MULTILINE):
+        chunk_stripped = chunk.strip()
+        if not chunk_stripped:
+            continue
+        # Only parse chunks that declare kind: NetworkPolicy
+        if not re.search(r"^\s*kind:\s*['\"]?NetworkPolicy['\"]?", chunk_stripped, flags=re.MULTILINE):
+            continue
+        try:
+            doc = yaml.safe_load(chunk_stripped)
+            if isinstance(doc, dict) and doc.get("kind") == "NetworkPolicy":
+                policies.append(doc)
+        except Exception as exc:
+            raise ValueError(f"malformed NetworkPolicy document in {path}: {exc}") from exc
+
     return policies
+
+
+def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
+    """Scan the repository tree for all manifest files defining a port-53 DNS egress rule.
+
+    Mirroring scripts/test_test_discovery.py, this discovery scan prevents any unlisted
+    DNS-bearing NetworkPolicy from escaping the static parity guard.
+
+    Returns:
+        set[str]: set of repo-relative POSIX file paths.
+    """
+    discovered: set[str] = set()
+    patterns = ("*.yaml", "*.yml", "*.yaml.template", "*.yml.template")
+    for pattern in patterns:
+        for path in root.rglob(pattern):
+            if any(part in IGNORED_DIRS for part in path.parts):
+                continue
+            rel = path.relative_to(root).as_posix()
+            if rel in EXCLUDED_NETPOL_MANIFESTS:
+                continue
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            # Fast check before parsing
+            if "NetworkPolicy" not in raw or "53" not in raw:
+                continue
+            try:
+                policies = load_network_policies(path)
+            except Exception:
+                continue
+            for pol in policies:
+                spec = pol.get("spec") or {}
+                for rule in spec.get("egress") or []:
+                    if not isinstance(rule, dict):
+                        continue
+                    ports = rule.get("ports") or []
+                    if any(isinstance(p, dict) and p.get("port") in (53, "53") for p in ports):
+                        discovered.add(rel)
+                        break
+    return discovered
 
 
 def check_dns_egress_rule(
@@ -239,7 +312,7 @@ def check_all(
     return total_rules, all_errors
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Verify DNS egress rule parity across static NetworkPolicy copies."
     )
@@ -254,7 +327,7 @@ def main() -> int:
         nargs="*",
         help="Optional specific file paths to check (defaults to STATIC_NETWORK_POLICIES).",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     files = args.files if args.files else STATIC_NETWORK_POLICIES
     if args.verbose:

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -67,16 +67,21 @@ STATIC_NETWORK_POLICIES: tuple[str, ...] = (
 
 # Manifests containing kind: NetworkPolicy that are deliberately excluded from the
 # static DNS parity roster. Every entry must carry its reviewed reason.
-EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {
-    # Operator reconciliation test fixtures; golden expected outputs verified by Go controller tests.
-    "k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml": "operator golden test fixture",
-    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml": "operator golden test fixture",
-    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml": "operator golden test fixture",
-    "k8s-operator/internal/testing/testdata/platform/expected/platformagent-split-broker.yaml": "operator golden test fixture",
-}
+# Note: Go test fixtures under testdata/ are ignored systematically via IGNORED_DIRS.
+EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {}
 
 IGNORED_DIRS: frozenset[str] = frozenset(
-    {".venv", "node_modules", "__pycache__", ".git", ".coverage-data", ".terraform", ".claude", "docs/site"}
+    {
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        ".git",
+        ".coverage-data",
+        ".terraform",
+        ".claude",
+        "docs/site",
+        "testdata",
+    }
 )
 
 REQUIRED_DNS_LITERAL = "10.96.0.10/32"

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -49,6 +49,7 @@ the required peer shape, without evaluating dynamic Helm value permutations.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -63,6 +64,17 @@ except ImportError:
     )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DNS_PORT: int = 53
+DNS_PORT_STR: str = "53"
+DNS_PORTS: tuple[int | str, ...] = (DNS_PORT, DNS_PORT_STR)
+
+DISCOVERY_FILE_PATTERNS: tuple[str, ...] = (
+    "*.yaml",
+    "*.yml",
+    "*.yaml.template",
+    "*.yml.template",
+)
 
 STATIC_NETWORK_POLICIES: tuple[str, ...] = (
     "charts/kube-agents/templates/litellm.yaml",
@@ -120,14 +132,16 @@ def sanitize_helm_template(text: str) -> str:
     text = re.sub(r"\{\{-?\s*/\*.*?\*/\s*-?\}\}", "", text, flags=re.DOTALL)
     lines: list[str] = []
     for line in text.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("{{") and stripped.endswith("}}"):
-            # Whole line is a template control statement
+        # Check if the line consists entirely of template control tags (ignoring trailing comments)
+        line_without_tags = re.sub(r"\{\{.*?\}\}", "", line)
+        if line_without_tags.split("#", 1)[0].strip() == "":
             lines.append("# " + line)
-        else:
-            # Replace inline template expressions like {{ .Release.Namespace }}
-            cleaned = re.sub(r"\{\{.*?\}\}", "placeholder", line)
-            lines.append(cleaned)
+            continue
+        # For lines with mixed content, strip control directives (if, else, end, with, range)
+        cleaned = re.sub(r"\{\{-?\s*(?:if\b|else\b|end\b|range\b|with\b).*?-?\}\}", "", line)
+        # Any remaining template expressions are value interpolations
+        cleaned = re.sub(r"\{\{.*?\}\}", "placeholder", cleaned)
+        lines.append(cleaned)
     return "\n".join(lines)
 
 
@@ -163,24 +177,28 @@ def load_network_policies(path: Path) -> list[dict]:
 
 
 def validate_exclusions(
-    exclusions: dict[str, str] = EXCLUDED_NETPOL_MANIFESTS,
-    roster: Iterable[str] = STATIC_NETWORK_POLICIES,
-    root: Path = REPO_ROOT,
+    exclusions: dict[str, str] | None = None,
+    roster: Iterable[str] | None = None,
+    root: Path | None = None,
 ) -> list[str]:
     """Validate that every exclusion carries a non-empty reason, points to a file on disk, and is disjoint from the roster."""
+    resolved_exclusions = EXCLUDED_NETPOL_MANIFESTS if exclusions is None else exclusions
+    resolved_roster = STATIC_NETWORK_POLICIES if roster is None else roster
+    resolved_root = REPO_ROOT if root is None else root
+
     errors: list[str] = []
-    roster_set = set(roster)
-    for path_str, reason in exclusions.items():
+    roster_set = set(resolved_roster)
+    for path_str, reason in resolved_exclusions.items():
         if not reason or not reason.strip():
             errors.append(f"Exclusion for {path_str} must carry a non-empty reviewed reason")
-        if not (root / path_str).is_file():
+        if not (resolved_root / path_str).is_file():
             errors.append(f"Excluded manifest does not exist on disk: {path_str}")
         if path_str in roster_set:
             errors.append(f"Excluded manifest {path_str} cannot also be in STATIC_NETWORK_POLICIES roster")
     return errors
 
 
-def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
+def discover_dns_network_policies(root: Path | None = None) -> set[str]:
     """Scan the repository tree for all manifest files defining a port-53 DNS egress rule.
 
     Scans deployed manifest files (*.yaml, *.yml, *.yaml.template, *.yml.template)
@@ -189,38 +207,68 @@ def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
     Returns:
         set[str]: set of repo-relative POSIX file paths.
     """
+    resolved_root = REPO_ROOT if root is None else root
     discovered: set[str] = set()
-    patterns = ("*.yaml", "*.yml", "*.yaml.template", "*.yml.template")
-    for pattern in patterns:
-        for path in root.rglob(pattern):
-            rel = path.relative_to(root)
-            if any(part in IGNORED_DIRS for part in rel.parts):
+
+    for dirpath, dirnames, filenames in os.walk(resolved_root):
+        # Prune ignored directories in place to avoid entering them
+        dirnames[:] = [d for d in dirnames if d not in IGNORED_DIRS]
+        rel_dir = Path(dirpath).relative_to(resolved_root)
+        if any(part in IGNORED_DIRS for part in rel_dir.parts):
+            continue
+        rel_dir_posix = rel_dir.as_posix()
+        if any(
+            rel_dir_posix == prefix or rel_dir_posix.startswith(prefix + "/")
+            for prefix in IGNORED_PREFIXES
+        ):
+            dirnames.clear()
+            continue
+
+        for filename in filenames:
+            if not any(
+                filename.endswith(ext.lstrip("*"))
+                for ext in DISCOVERY_FILE_PATTERNS
+            ):
                 continue
+
+            path = Path(dirpath) / filename
+            rel = path.relative_to(resolved_root)
             rel_posix = rel.as_posix()
-            if any(rel_posix == prefix or rel_posix.startswith(prefix + "/") for prefix in IGNORED_PREFIXES):
-                continue
+
             if rel_posix in EXCLUDED_NETPOL_MANIFESTS:
                 continue
+
             try:
                 raw = path.read_text(encoding="utf-8")
             except Exception as exc:
-                raise RuntimeError(f"failed to read {rel_posix} during DNS policy discovery: {exc}") from exc
+                raise RuntimeError(
+                    f"failed to read {rel_posix} during DNS policy discovery: {exc}"
+                ) from exc
+
             # Fast check before parsing
-            if "NetworkPolicy" not in raw or "53" not in raw:
+            if "NetworkPolicy" not in raw or DNS_PORT_STR not in raw:
                 continue
+
             try:
                 policies = load_network_policies(path)
             except Exception as exc:
-                raise ValueError(f"failed to parse NetworkPolicy in {rel_posix} during DNS policy discovery: {exc}") from exc
+                raise ValueError(
+                    f"failed to parse NetworkPolicy in {rel_posix} during DNS policy discovery: {exc}"
+                ) from exc
+
             for pol in policies:
                 spec = pol.get("spec") or {}
                 for rule in spec.get("egress") or []:
                     if not isinstance(rule, dict):
                         continue
                     ports = rule.get("ports") or []
-                    if any(isinstance(p, dict) and p.get("port") in (53, "53") for p in ports):
+                    if any(
+                        isinstance(p, dict) and p.get("port") in DNS_PORTS
+                        for p in ports
+                    ):
                         discovered.add(rel_posix)
                         break
+
     return discovered
 
 
@@ -235,7 +283,8 @@ def check_dns_egress_rule(
     to_peers = rule.get("to") or []
     has_dns_literal = False
     has_wildcard = False
-    wildcard_excepts: set[str] = set()
+    wildcard_peers: list[dict] = []
+    rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
 
     for peer in to_peers:
         if not isinstance(peer, dict) or "ipBlock" not in peer:
@@ -248,11 +297,18 @@ def check_dns_egress_rule(
             has_dns_literal = True
         elif cidr == REQUIRED_WILDCARD_CIDR:
             has_wildcard = True
+            wildcard_peers.append(peer)
+            peer_excepts: set[str] = set()
             except_list = ip_block.get("except")
             if isinstance(except_list, list):
-                wildcard_excepts.update(str(x) for x in except_list)
+                peer_excepts = {str(x) for x in except_list}
+            missing = REQUIRED_EXCEPT_MINIMUM - peer_excepts
+            if missing:
+                errors.append(
+                    f"{rule_desc}: '{REQUIRED_WILDCARD_CIDR}' peer except list is missing required private CIDRs: "
+                    f"{sorted(missing)}"
+                )
 
-    rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
     if not has_dns_literal:
         errors.append(
             f"{rule_desc}: missing required ipBlock literal '{REQUIRED_DNS_LITERAL}' for classic ClusterIP DNS"
@@ -261,24 +317,22 @@ def check_dns_egress_rule(
         errors.append(
             f"{rule_desc}: missing required '{REQUIRED_WILDCARD_CIDR}' peer with except list for dynamic/public DNS VIPs"
         )
-    else:
-        missing_except = REQUIRED_EXCEPT_MINIMUM - wildcard_excepts
-        if missing_except:
-            errors.append(
-                f"{rule_desc}: '{REQUIRED_WILDCARD_CIDR}' except list is missing required private CIDRs: "
-                f"{sorted(missing_except)}"
-            )
+    elif len(wildcard_peers) > 1:
+        errors.append(
+            f"{rule_desc}: expected at most one '{REQUIRED_WILDCARD_CIDR}' peer"
+        )
 
     return errors
 
 
-def check_network_policy_file(path: Path, root: Path = REPO_ROOT) -> tuple[int, list[str]]:
+def check_network_policy_file(path: Path, root: Path | None = None) -> tuple[int, list[str]]:
     """Check all Egress NetworkPolicy resources in a file for DNS egress parity.
 
     Returns:
         tuple[int, list[str]]: (number of DNS rules checked, list of error messages)
     """
-    rel_path = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+    resolved_root = REPO_ROOT if root is None else root
+    rel_path = str(path.relative_to(resolved_root)) if path.is_relative_to(resolved_root) else str(path)
     try:
         policies = load_network_policies(path)
     except Exception as exc:
@@ -307,7 +361,7 @@ def check_network_policy_file(path: Path, root: Path = REPO_ROOT) -> tuple[int, 
             for r in (egress_rules or [])
             if isinstance(r, dict)
             and any(
-                isinstance(p, dict) and p.get("port") in (53, "53")
+                isinstance(p, dict) and p.get("port") in DNS_PORTS
                 for p in (r.get("ports") or [])
             )
         ]
@@ -330,27 +384,30 @@ def check_network_policy_file(path: Path, root: Path = REPO_ROOT) -> tuple[int, 
 
 
 def check_all(
-    files: Iterable[Path | str] = STATIC_NETWORK_POLICIES,
-    root: Path = REPO_ROOT,
+    files: Iterable[Path | str] | None = None,
+    root: Path | None = None,
     verbose: bool = False,
 ) -> tuple[int, list[str]]:
     """Check all specified files for DNS egress parity."""
+    resolved_files = STATIC_NETWORK_POLICIES if files is None else files
+    resolved_root = REPO_ROOT if root is None else root
+
     total_rules = 0
     all_errors: list[str] = []
 
-    exclusion_errors = validate_exclusions(root=root)
+    exclusion_errors = validate_exclusions(root=resolved_root)
     all_errors.extend(exclusion_errors)
     if verbose and exclusion_errors:
         for err in exclusion_errors:
             print(f"  FAIL: exclusion contract: {err}")
 
-    for item in files:
-        path = root / item if not Path(item).is_absolute() else Path(item)
-        rules_checked, file_errors = check_network_policy_file(path, root)
+    for item in resolved_files:
+        path = resolved_root / item if not Path(item).is_absolute() else Path(item)
+        rules_checked, file_errors = check_network_policy_file(path, resolved_root)
         total_rules += rules_checked
         all_errors.extend(file_errors)
         if verbose:
-            rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+            rel = str(path.relative_to(resolved_root)) if path.is_relative_to(resolved_root) else str(path)
             if file_errors:
                 print(f"  FAIL: {rel} ({len(file_errors)} errors)")
             else:
@@ -376,9 +433,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    files = args.files if args.files else STATIC_NETWORK_POLICIES
+    files = args.files if args.files else None
+    display_count = len(files) if files else len(STATIC_NETWORK_POLICIES)
     if args.verbose:
-        print(f"Checking {len(files)} static NetworkPolicy copies for DNS egress parity...")
+        print(f"Checking {display_count} static NetworkPolicy copies for DNS egress parity...")
 
     rules_checked, errors = check_all(files=files, root=REPO_ROOT, verbose=args.verbose)
 
@@ -387,15 +445,15 @@ def main(argv: list[str] | None = None) -> int:
         for err in errors:
             print(f"  * {err}", file=sys.stderr)
         print(
-            f"\n{len(errors)} error(s) found across {len(files)} static policy copies.",
+            f"\n{len(errors)} error(s) found across {display_count} static policy copies.",
             file=sys.stderr,
         )
         return 1
 
     if not args.verbose:
-        print(f"OK: Verified DNS egress rule parity across {len(files)} static copies ({rules_checked} rules checked).")
+        print(f"OK: Verified DNS egress rule parity across {display_count} static copies ({rules_checked} rules checked).")
     else:
-        print(f"\nAll {len(files)} static policy copies passed parity check ({rules_checked} rules).")
+        print(f"\nAll {display_count} static policy copies passed parity check ({rules_checked} rules).")
     return 0
 
 

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -34,6 +34,16 @@ deploy/kustomize/platform/networkpolicy-core-egress.yaml carries the 5-entry hou
 shape (adding 100.64.0.0/10 and 169.254.0.0/16, which is more contained and
 mirrors the operator-generated external egress policy). This script enforces the
 required-peer shape across all copies so drift is caught before merge.
+
+Scope:
+This check audits deployable Infrastructure-as-Code manifest files (*.yaml,
+*.yml, *.yaml.template, *.yml.template) across Helm templates, Kustomize bases,
+and integration examples. It does not scan Markdown documentation or agent skill
+prompts (*.md).
+
+Template semantics:
+For Helm templates, this check asserts that the static source definition carries
+the required peer shape, without evaluating dynamic Helm value permutations.
 """
 
 from __future__ import annotations
@@ -70,6 +80,7 @@ STATIC_NETWORK_POLICIES: tuple[str, ...] = (
 # Note: Go test fixtures under testdata/ are ignored systematically via IGNORED_DIRS.
 EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {}
 
+# Directory names to skip anywhere in the repo-relative path
 IGNORED_DIRS: frozenset[str] = frozenset(
     {
         ".venv",
@@ -79,9 +90,13 @@ IGNORED_DIRS: frozenset[str] = frozenset(
         ".coverage-data",
         ".terraform",
         ".claude",
-        "docs/site",
         "testdata",
     }
+)
+
+# Relative directory prefixes to skip
+IGNORED_PREFIXES: tuple[str, ...] = (
+    "docs/site",
 )
 
 REQUIRED_DNS_LITERAL = "10.96.0.10/32"
@@ -147,11 +162,29 @@ def load_network_policies(path: Path) -> list[dict]:
     return policies
 
 
+def validate_exclusions(
+    exclusions: dict[str, str] = EXCLUDED_NETPOL_MANIFESTS,
+    roster: Iterable[str] = STATIC_NETWORK_POLICIES,
+    root: Path = REPO_ROOT,
+) -> list[str]:
+    """Validate that every exclusion carries a non-empty reason, points to a file on disk, and is disjoint from the roster."""
+    errors: list[str] = []
+    roster_set = set(roster)
+    for path_str, reason in exclusions.items():
+        if not reason or not reason.strip():
+            errors.append(f"Exclusion for {path_str} must carry a non-empty reviewed reason")
+        if not (root / path_str).is_file():
+            errors.append(f"Excluded manifest does not exist on disk: {path_str}")
+        if path_str in roster_set:
+            errors.append(f"Excluded manifest {path_str} cannot also be in STATIC_NETWORK_POLICIES roster")
+    return errors
+
+
 def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
     """Scan the repository tree for all manifest files defining a port-53 DNS egress rule.
 
-    Mirroring scripts/test_test_discovery.py, this discovery scan prevents any unlisted
-    DNS-bearing NetworkPolicy from escaping the static parity guard.
+    Scans deployed manifest files (*.yaml, *.yml, *.yaml.template, *.yml.template)
+    across the repository. Markdown documents and skill prompt files are excluded.
 
     Returns:
         set[str]: set of repo-relative POSIX file paths.
@@ -160,22 +193,25 @@ def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
     patterns = ("*.yaml", "*.yml", "*.yaml.template", "*.yml.template")
     for pattern in patterns:
         for path in root.rglob(pattern):
-            if any(part in IGNORED_DIRS for part in path.parts):
+            rel = path.relative_to(root)
+            if any(part in IGNORED_DIRS for part in rel.parts):
                 continue
-            rel = path.relative_to(root).as_posix()
-            if rel in EXCLUDED_NETPOL_MANIFESTS:
+            rel_posix = rel.as_posix()
+            if any(rel_posix == prefix or rel_posix.startswith(prefix + "/") for prefix in IGNORED_PREFIXES):
+                continue
+            if rel_posix in EXCLUDED_NETPOL_MANIFESTS:
                 continue
             try:
                 raw = path.read_text(encoding="utf-8")
-            except Exception:
-                continue
+            except Exception as exc:
+                raise RuntimeError(f"failed to read {rel_posix} during DNS policy discovery: {exc}") from exc
             # Fast check before parsing
             if "NetworkPolicy" not in raw or "53" not in raw:
                 continue
             try:
                 policies = load_network_policies(path)
-            except Exception:
-                continue
+            except Exception as exc:
+                raise ValueError(f"failed to parse NetworkPolicy in {rel_posix} during DNS policy discovery: {exc}") from exc
             for pol in policies:
                 spec = pol.get("spec") or {}
                 for rule in spec.get("egress") or []:
@@ -183,7 +219,7 @@ def discover_dns_network_policies(root: Path = REPO_ROOT) -> set[str]:
                         continue
                     ports = rule.get("ports") or []
                     if any(isinstance(p, dict) and p.get("port") in (53, "53") for p in ports):
-                        discovered.add(rel)
+                        discovered.add(rel_posix)
                         break
     return discovered
 
@@ -301,6 +337,12 @@ def check_all(
     """Check all specified files for DNS egress parity."""
     total_rules = 0
     all_errors: list[str] = []
+
+    exclusion_errors = validate_exclusions(root=root)
+    all_errors.extend(exclusion_errors)
+    if verbose and exclusion_errors:
+        for err in exclusion_errors:
+            print(f"  FAIL: exclusion contract: {err}")
 
     for item in files:
         path = root / item if not Path(item).is_absolute() else Path(item)

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -37,9 +37,9 @@ required-peer shape across all copies so drift is caught before merge.
 
 Scope:
 This check audits deployable Infrastructure-as-Code manifest files (*.yaml,
-*.yml, *.yaml.template, *.yml.template) across Helm templates, Kustomize bases,
-and integration examples. It does not scan Markdown documentation or agent skill
-prompts (*.md).
+*.yml, *.yaml.template, *.yml.template, *.yaml.tmpl, *.yml.tmpl) across Helm
+templates, Kustomize bases, and integration examples. It does not scan Markdown
+documentation or agent skill prompts (*.md).
 
 Template semantics:
 For Helm templates, this check asserts that the static source definition carries
@@ -79,6 +79,8 @@ DISCOVERY_FILE_PATTERNS: tuple[str, ...] = (
     "*.yml",
     "*.yaml.template",
     "*.yml.template",
+    "*.yaml.tmpl",
+    "*.yml.tmpl",
 )
 
 STATIC_NETWORK_POLICIES: tuple[str, ...] = (
@@ -163,6 +165,8 @@ def governs_egress(spec: object) -> bool:
 
 def sanitize_helm_template(text: str) -> str:
     """Sanitize Go/Helm template tags so that YAML parsers can load the manifests."""
+    # Normalize CRLF and CR line endings to LF before tag processing
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
     # Strip multi-line comments: {{- /* ... */ -}} or {{/* ... */}}
     text = HELM_COMMENT_RE.sub("", text)
     # Replace internal newlines within template tags so every directive is single-line
@@ -228,7 +232,11 @@ def validate_exclusions(
     for path_str, reason in resolved_exclusions.items():
         if not reason or not reason.strip():
             errors.append(f"Exclusion for {path_str} must carry a non-empty reviewed reason")
-        if not (resolved_root / path_str).is_file():
+        if Path(path_str).is_absolute() or path_str.startswith("/"):
+            errors.append(
+                f"Exclusion path must be repository-relative without a leading slash: {path_str}"
+            )
+        elif not (resolved_root / path_str).is_file():
             errors.append(f"Excluded manifest does not exist on disk: {path_str}")
         if path_str in roster_set:
             errors.append(f"Excluded manifest {path_str} cannot also be in STATIC_NETWORK_POLICIES roster")
@@ -238,8 +246,9 @@ def validate_exclusions(
 def discover_dns_network_policies(root: Path | None = None) -> set[str]:
     """Scan the repository tree for all manifest files defining a port-53 DNS egress rule.
 
-    Scans deployed manifest files (*.yaml, *.yml, *.yaml.template, *.yml.template)
-    across the repository. Markdown documents and skill prompt files are excluded.
+    Scans deployed manifest files (*.yaml, *.yml, *.yaml.template, *.yml.template,
+    *.yaml.tmpl, *.yml.tmpl) across the repository. Markdown documents and skill
+    prompt files are excluded.
 
     Returns:
         set[str]: set of repo-relative POSIX file paths.

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -351,8 +351,13 @@ def check_network_policy_file(path: Path, root: Path | None = None) -> tuple[int
         policy_types = spec.get("policyTypes") or []
         egress_rules = spec.get("egress")
 
-        # Skip Ingress-only policies that do not govern egress traffic.
-        if "Egress" not in policy_types and egress_rules is None:
+        # Skip policies that do not govern egress traffic.
+        # When policyTypes is explicitly specified, Egress must be listed for the policy to govern egress.
+        # When policyTypes is omitted, Kubernetes enables Egress only if egress rules are present.
+        if spec.get("policyTypes") is not None:
+            if "Egress" not in policy_types:
+                continue
+        elif egress_rules is None:
             continue
 
         checked_policies += 1

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Assert DNS egress rule parity across static NetworkPolicy copies.
+
+Several static files hand-maintain the same DNS egress rule (port 53):
+* charts/kube-agents/templates/litellm.yaml
+* charts/kube-agents/templates/github-minter.yaml
+* deploy/kustomize/platform/networkpolicy-core-egress.yaml
+* examples/litellm-chatgpt-subscription/networkpolicy.yaml
+* examples/litellm-gemini/networkpolicy.yaml
+* examples/vllm-gemma/networkpolicy.yaml
+* k8s-operator/config/integrations/github/deployment.yaml.template
+* k8s-operator/config/integrations/litellm/base/networkpolicy.yaml
+
+Context (#747 B5, D1; #687):
+#687 had to touch all static copies, and its first draft missed one —
+deployment.yaml.template, because greps for *.yaml skip it. Furthermore, #608
+added a static policy that omitted the required DNS peers, which would have
+blocked DNS resolution outright on clusters with non-standard service CIDRs.
+
+In-cluster DNS answers on the kube-dns Service ClusterIP, which a static
+manifest cannot predict: it is 10.96.0.10 on classic service ranges and allocated
+from public space (e.g. 34.118.224.0/20) on newer GKE clusters. NetworkPolicy
+matches that VIP rather than the backend pods, so selectors alone do not cover it.
+To avoid DNS outages, every static DNS rule must provide:
+1. The 10.96.0.10/32 literal for the classic service range.
+2. An 0.0.0.0/0 peer carrying an except list for any ClusterIP outside private space.
+3. The except list must block at least RFC 1918 private subnets (10.0.0.0/8,
+   172.16.0.0/12, 192.168.0.0/16) to prevent internal lateral movement.
+
+Note on peer sets and house shape (#747 B5):
+Do not assert strict byte-identity across all files. Today, seven copies carry a
+three-entry except list (RFC 1918) and include 169.254.169.254/32, while
+deploy/kustomize/platform/networkpolicy-core-egress.yaml carries the 5-entry house
+shape (adding 100.64.0.0/10 and 169.254.0.0/16, which is more contained and
+mirrors the operator-generated external egress policy). This script enforces the
+required-peer shape across all copies so drift is caught before merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+try:
+    import yaml
+except ImportError:
+    sys.exit(
+        "ERROR: scripts/check_iac_parity.py requires PyYAML.\n"
+        "Install it with: pip install pyyaml (or make test-python-deps)"
+    )
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+STATIC_NETWORK_POLICIES: tuple[str, ...] = (
+    "charts/kube-agents/templates/litellm.yaml",
+    "charts/kube-agents/templates/github-minter.yaml",
+    "deploy/kustomize/platform/networkpolicy-core-egress.yaml",
+    "examples/litellm-chatgpt-subscription/networkpolicy.yaml",
+    "examples/litellm-gemini/networkpolicy.yaml",
+    "examples/vllm-gemma/networkpolicy.yaml",
+    "k8s-operator/config/integrations/github/deployment.yaml.template",
+    "k8s-operator/config/integrations/litellm/base/networkpolicy.yaml",
+)
+
+REQUIRED_DNS_LITERAL = "10.96.0.10/32"
+REQUIRED_WILDCARD_CIDR = "0.0.0.0/0"
+REQUIRED_EXCEPT_MINIMUM: frozenset[str] = frozenset(
+    {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"}
+)
+HOUSE_SHAPE_EXCEPT: frozenset[str] = frozenset(
+    {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10", "169.254.0.0/16"}
+)
+
+
+def is_house_shape(except_list: Iterable[str]) -> bool:
+    """Return True if the except list satisfies the 5-entry house shape."""
+    return HOUSE_SHAPE_EXCEPT.issubset(set(except_list))
+
+
+def sanitize_helm_template(text: str) -> str:
+    """Sanitize Go/Helm template tags so that YAML parsers can load the manifests."""
+    # Strip multi-line comments: {{- /* ... */ -}} or {{/* ... */}}
+    text = re.sub(r"\{\{-?\s*/\*.*?\*/\s*-?\}\}", "", text, flags=re.DOTALL)
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("{{") and stripped.endswith("}}"):
+            # Whole line is a template control statement
+            lines.append("# " + line)
+        else:
+            # Replace inline template expressions like {{ .Release.Namespace }}
+            cleaned = re.sub(r"\{\{.*?\}\}", "placeholder", line)
+            lines.append(cleaned)
+    return "\n".join(lines)
+
+
+def load_network_policies(path: Path) -> list[dict]:
+    """Read a manifest or template file and return all NetworkPolicy documents."""
+    if not path.is_file():
+        raise FileNotFoundError(f"File not found: {path}")
+    raw_content = path.read_text(encoding="utf-8")
+    sanitized = sanitize_helm_template(raw_content)
+    policies: list[dict] = []
+    for doc in yaml.safe_load_all(sanitized):
+        if isinstance(doc, dict) and doc.get("kind") == "NetworkPolicy":
+            policies.append(doc)
+    return policies
+
+
+def check_dns_egress_rule(
+    path_display: str,
+    policy_name: str,
+    rule: dict,
+    rule_idx: int,
+) -> list[str]:
+    """Verify that a single port-53 egress rule satisfies the required peer shape."""
+    errors: list[str] = []
+    to_peers = rule.get("to") or []
+    has_dns_literal = False
+    has_wildcard = False
+    wildcard_excepts: set[str] = set()
+
+    for peer in to_peers:
+        if not isinstance(peer, dict) or "ipBlock" not in peer:
+            continue
+        ip_block = peer["ipBlock"]
+        if not isinstance(ip_block, dict):
+            continue
+        cidr = ip_block.get("cidr")
+        if cidr == REQUIRED_DNS_LITERAL:
+            has_dns_literal = True
+        elif cidr == REQUIRED_WILDCARD_CIDR:
+            has_wildcard = True
+            except_list = ip_block.get("except")
+            if isinstance(except_list, list):
+                wildcard_excepts.update(str(x) for x in except_list)
+
+    rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
+    if not has_dns_literal:
+        errors.append(
+            f"{rule_desc}: missing required ipBlock literal '{REQUIRED_DNS_LITERAL}' for classic ClusterIP DNS"
+        )
+    if not has_wildcard:
+        errors.append(
+            f"{rule_desc}: missing required '{REQUIRED_WILDCARD_CIDR}' peer with except list for dynamic/public DNS VIPs"
+        )
+    else:
+        missing_except = REQUIRED_EXCEPT_MINIMUM - wildcard_excepts
+        if missing_except:
+            errors.append(
+                f"{rule_desc}: '{REQUIRED_WILDCARD_CIDR}' except list is missing required private CIDRs: "
+                f"{sorted(missing_except)}"
+            )
+
+    return errors
+
+
+def check_network_policy_file(path: Path, root: Path = REPO_ROOT) -> tuple[int, list[str]]:
+    """Check all Egress NetworkPolicy resources in a file for DNS egress parity.
+
+    Returns:
+        tuple[int, list[str]]: (number of DNS rules checked, list of error messages)
+    """
+    rel_path = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+    try:
+        policies = load_network_policies(path)
+    except Exception as exc:
+        return 0, [f"{rel_path}: failed to load NetworkPolicy: {exc}"]
+
+    if not policies:
+        return 0, [f"{rel_path}: no NetworkPolicy resources found"]
+
+    total_rules = 0
+    errors: list[str] = []
+    checked_policies = 0
+
+    for policy in policies:
+        policy_name = (policy.get("metadata") or {}).get("name") or "<unnamed>"
+        spec = policy.get("spec") or {}
+        policy_types = spec.get("policyTypes") or []
+        egress_rules = spec.get("egress")
+
+        # Skip Ingress-only policies that do not govern egress traffic.
+        if "Egress" not in policy_types and egress_rules is None:
+            continue
+
+        checked_policies += 1
+        dns_rules = [
+            r
+            for r in (egress_rules or [])
+            if isinstance(r, dict)
+            and any(
+                isinstance(p, dict) and p.get("port") in (53, "53")
+                for p in (r.get("ports") or [])
+            )
+        ]
+
+        if not dns_rules:
+            errors.append(
+                f"{rel_path}: NetworkPolicy '{policy_name}' has no egress rule for port 53 (DNS)"
+            )
+            continue
+
+        for idx, rule in enumerate(dns_rules, start=1):
+            total_rules += 1
+            rule_errors = check_dns_egress_rule(rel_path, policy_name, rule, idx)
+            errors.extend(rule_errors)
+
+    if checked_policies == 0:
+        errors.append(f"{rel_path}: no Egress NetworkPolicy resources found")
+
+    return total_rules, errors
+
+
+def check_all(
+    files: Iterable[Path | str] = STATIC_NETWORK_POLICIES,
+    root: Path = REPO_ROOT,
+    verbose: bool = False,
+) -> tuple[int, list[str]]:
+    """Check all specified files for DNS egress parity."""
+    total_rules = 0
+    all_errors: list[str] = []
+
+    for item in files:
+        path = root / item if not Path(item).is_absolute() else Path(item)
+        rules_checked, file_errors = check_network_policy_file(path, root)
+        total_rules += rules_checked
+        all_errors.extend(file_errors)
+        if verbose:
+            rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+            if file_errors:
+                print(f"  FAIL: {rel} ({len(file_errors)} errors)")
+            else:
+                print(f"  OK:   {rel} ({rules_checked} DNS rules verified)")
+
+    return total_rules, all_errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify DNS egress rule parity across static NetworkPolicy copies."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Print verbose status for each verified file.",
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Optional specific file paths to check (defaults to STATIC_NETWORK_POLICIES).",
+    )
+    args = parser.parse_args()
+
+    files = args.files if args.files else STATIC_NETWORK_POLICIES
+    if args.verbose:
+        print(f"Checking {len(files)} static NetworkPolicy copies for DNS egress parity...")
+
+    rules_checked, errors = check_all(files=files, root=REPO_ROOT, verbose=args.verbose)
+
+    if errors:
+        print("ERROR: Static NetworkPolicy DNS egress parity check failed:", file=sys.stderr)
+        for err in errors:
+            print(f"  * {err}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} error(s) found across {len(files)} static policy copies.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.verbose:
+        print(f"OK: Verified DNS egress rule parity across {len(files)} static copies ({rules_checked} rules checked).")
+    else:
+        print(f"\nAll {len(files)} static policy copies passed parity check ({rules_checked} rules).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -45,12 +45,15 @@ Scope:
 This check audits deployable Infrastructure-as-Code manifest files matching
 DISCOVERY_FILE_PATTERNS (*.yaml, *.yml, *.yaml.template, *.yml.template,
 *.yaml.tmpl, *.yml.tmpl) across Helm templates, Kustomize bases, and integration
-examples. It does not scan:
-* Markdown files or agent skill prompts (*.md, e.g. embedded snippets in SKILL.md)
-* Files with extensions outside DISCOVERY_FILE_PATTERNS (e.g. plain *.tpl)
-* Directories pruned by IGNORED_DIRS anywhere in their path (including testdata/
-  at any depth repository-wide, build caches, and virtualenvs) or IGNORED_PREFIXES
-  (docs/site/)
+examples. Repository-wide discovery deliberately escapes four file classes:
+1. Markdown documentation and agent skill prompts (*.md, e.g. embedded NetworkPolicies
+   in SKILL.md files like agents/platform/skills/gke-multitenancy/SKILL.md, which is
+   a separate defect tracked independently).
+2. Extensions outside DISCOVERY_FILE_PATTERNS (e.g. plain *.tpl helper templates
+   inside charts/kube-agents/templates/).
+3. Any directory named testdata/ at any depth repository-wide (pruned by directory
+   name via IGNORED_DIRS, alongside virtualenvs and build caches).
+4. Documentation trees pruned by prefix (docs/site/** via IGNORED_PREFIXES).
 
 Template semantics and #747 D1 requirement:
 Issue #747 D1 requested an assertion rendering manifests via `helm template` and
@@ -121,10 +124,11 @@ STATIC_NETWORK_POLICIES: tuple[str, ...] = (
 
 # Manifests containing kind: NetworkPolicy that are deliberately excluded from the
 # static DNS parity roster. Every entry must carry its reviewed reason.
-# Note: Any directory named testdata/ is ignored systematically at any depth via IGNORED_DIRS.
+# Note: Any directory named testdata/ is ignored systematically at any depth repository-wide
+# via IGNORED_DIRS.
 EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {}
 
-# Directory names to skip anywhere in the repo-relative path
+# Directory names to skip anywhere in the repo-relative path (applied at any depth)
 IGNORED_DIRS: frozenset[str] = frozenset(
     {
         ".venv",

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -22,33 +22,58 @@ manifest cannot predict: it is 10.96.0.10 on classic service ranges and allocate
 from public space (e.g. 34.118.224.0/20) on newer GKE clusters. NetworkPolicy
 matches that VIP rather than the backend pods, so selectors alone do not cover it.
 To avoid DNS outages, every static DNS rule must provide:
-1. The 10.96.0.10/32 literal for the classic service range.
-2. An 0.0.0.0/0 peer carrying an except list for any ClusterIP outside private space.
-3. The except list must block at least RFC 1918 private subnets (10.0.0.0/8,
+1. Both UDP and TCP protocols on port 53.
+2. The 10.96.0.10/32 literal for the classic service range.
+3. An 0.0.0.0/0 peer carrying an except list for any ClusterIP outside private space.
+4. The except list must block at least RFC 1918 private subnets (10.0.0.0/8,
    172.16.0.0/12, 192.168.0.0/16) to prevent internal lateral movement.
+5. If the except list excludes link-local space (169.254.0.0/16), explicit
+   169.254.20.10/32 (NodeLocal DNSCache) and 169.254.169.254/32 (Cloud DNS for GKE)
+   literals are required because the wildcard peer no longer reaches those resolvers.
 
 Note on peer sets and house shape (#747 B5):
 Do not assert strict byte-identity across all files. Today, seven copies carry a
 three-entry except list (RFC 1918) and include 169.254.169.254/32, while
 deploy/kustomize/platform/networkpolicy-core-egress.yaml carries the 5-entry house
 shape (adding 100.64.0.0/10 and 169.254.0.0/16, which is more contained and
-mirrors the operator-generated external egress policy). This script enforces the
-required-peer shape across all copies so drift is caught before merge.
+mirrors the operator-generated external egress policy). When 169.254.0.0/16 is
+excepted, the link-local resolver literals become mandatory. Pod selector peers
+(k8s-app: kube-dns, k8s-app: node-local-dns) are present in all copies for in-cluster
+pod-backed DNS, but this script enforces the required IP blocks and protocols.
 
 Scope:
-This check audits deployable Infrastructure-as-Code manifest files (*.yaml,
-*.yml, *.yaml.template, *.yml.template, *.yaml.tmpl, *.yml.tmpl) across Helm
-templates, Kustomize bases, and integration examples. It does not scan Markdown
-documentation or agent skill prompts (*.md).
+This check audits deployable Infrastructure-as-Code manifest files matching
+DISCOVERY_FILE_PATTERNS (*.yaml, *.yml, *.yaml.template, *.yml.template,
+*.yaml.tmpl, *.yml.tmpl) across Helm templates, Kustomize bases, and integration
+examples. It does not scan:
+* Markdown files or agent skill prompts (*.md, e.g. embedded snippets in SKILL.md)
+* Files with extensions outside DISCOVERY_FILE_PATTERNS (e.g. plain *.tpl)
+* Directories pruned by IGNORED_DIRS anywhere in their path (including testdata/
+  at any depth repository-wide, build caches, and virtualenvs) or IGNORED_PREFIXES
+  (docs/site/)
 
-Template semantics:
-For Helm templates, this check asserts that the static source definition carries
-the required peer shape, without evaluating dynamic Helm value permutations.
-Mutually exclusive Helm branches ({{- else }}) are not evaluated conditionally;
-all branches in the static template source are retained. A required peer must
-appear in the sanitized source in a form that satisfies peer parity when retained,
-and multiple mutually exclusive wildcard peers will be rejected as duplicate
-additive peers.
+Template semantics and #747 D1 requirement:
+Issue #747 D1 requested an assertion rendering manifests via `helm template` and
+`kubectl kustomize`. This check is intentionally delivered as a static source-level
+audit rather than engine rendering for three reasons:
+1. Heterogeneity: the static copies include raw examples and deployment.yaml.template
+   with shell variables that neither Helm nor Kustomize can render.
+2. Portability: the check runs offline under standard Python unit tests without
+   requiring external helm/kubectl binaries or cluster access.
+3. Baseline authoring guard: it ensures every static copy checked into the repository
+   maintains the required peer shape in source.
+
+Trade-offs and limitations against D1:
+* Conditional presence: Go/Helm control directives ({{- if }}, {{- with }}) are
+  stripped during sanitization. A peer or entire policy guarded behind a Helm value
+  is evaluated as present if it exists in the source text, even if a specific
+  values configuration renders it out. Mutually exclusive Helm branches ({{- else }})
+  are retained additively.
+* Dynamic Go policies: NetworkPolicies generated in Go controller code (such as
+  the operator's platform-agent policy generation) are outside this source scanner's
+  view and are tested via Go unit tests instead.
+Dynamic rendering under specific Helm value permutations remains the responsibility
+of CI chart validation (e.g. validate.yml).
 """
 
 from __future__ import annotations
@@ -96,7 +121,7 @@ STATIC_NETWORK_POLICIES: tuple[str, ...] = (
 
 # Manifests containing kind: NetworkPolicy that are deliberately excluded from the
 # static DNS parity roster. Every entry must carry its reviewed reason.
-# Note: Go test fixtures under testdata/ are ignored systematically via IGNORED_DIRS.
+# Note: Any directory named testdata/ is ignored systematically at any depth via IGNORED_DIRS.
 EXCLUDED_NETPOL_MANIFESTS: dict[str, str] = {}
 
 # Directory names to skip anywhere in the repo-relative path
@@ -125,6 +150,17 @@ REQUIRED_EXCEPT_MINIMUM: frozenset[str] = frozenset(
 )
 HOUSE_SHAPE_EXCEPT: frozenset[str] = frozenset(
     {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10", "169.254.0.0/16"}
+)
+
+PROTOCOL_TCP: str = "TCP"
+PROTOCOL_UDP: str = "UDP"
+REQUIRED_DNS_PROTOCOLS: frozenset[str] = frozenset({PROTOCOL_UDP, PROTOCOL_TCP})
+
+LINK_LOCAL_CIDR = "169.254.0.0/16"
+REQUIRED_LINK_LOCAL_DNSCACHE = "169.254.20.10/32"
+REQUIRED_LINK_LOCAL_CLOUDDNS = "169.254.169.254/32"
+REQUIRED_LINK_LOCAL_LITERALS: frozenset[str] = frozenset(
+    {REQUIRED_LINK_LOCAL_DNSCACHE, REQUIRED_LINK_LOCAL_CLOUDDNS}
 )
 
 KIND_NETWORK_POLICY = "NetworkPolicy"
@@ -331,11 +367,30 @@ def check_dns_egress_rule(
     rule: dict,
     rule_idx: int,
 ) -> list[str]:
-    """Verify that a single port-53 egress rule satisfies the required peer shape."""
+    """Verify that a single port-53 egress rule satisfies the required peer and protocol shape."""
     errors: list[str] = []
-    to_peers = rule.get("to")
     rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
 
+    ports = rule.get("ports")
+    if ports is not None and not isinstance(ports, list):
+        errors.append(f"{rule_desc}: 'ports' field must be a list")
+    else:
+        rule_protocols: set[str] = set()
+        for p in (ports or []):
+            if isinstance(p, dict) and p.get("port") in DNS_PORTS:
+                proto = p.get("protocol")
+                if isinstance(proto, str):
+                    rule_protocols.add(proto.upper())
+                elif proto is None:
+                    # In Kubernetes NetworkPolicyPort, protocol defaults to TCP when omitted
+                    rule_protocols.add(PROTOCOL_TCP)
+        missing_protos = REQUIRED_DNS_PROTOCOLS - rule_protocols
+        if missing_protos:
+            errors.append(
+                f"{rule_desc}: port 53 egress rule is missing required protocol(s): {sorted(missing_protos)}"
+            )
+
+    to_peers = rule.get("to")
     if to_peers is not None and not isinstance(to_peers, list):
         errors.append(f"{rule_desc}: 'to' field must be a list")
         return errors
@@ -343,6 +398,7 @@ def check_dns_egress_rule(
     has_dns_literal = False
     has_wildcard = False
     wildcard_peers: list[dict] = []
+    peer_cidrs: set[str] = set()
 
     for peer in (to_peers or []):
         if not isinstance(peer, dict) or "ipBlock" not in peer:
@@ -352,6 +408,8 @@ def check_dns_egress_rule(
             errors.append(f"{rule_desc}: ipBlock must be a mapping")
             continue
         cidr = ip_block.get("cidr")
+        if isinstance(cidr, str):
+            peer_cidrs.add(cidr)
         if cidr == REQUIRED_DNS_LITERAL:
             has_dns_literal = True
         elif cidr == REQUIRED_WILDCARD_CIDR:
@@ -384,6 +442,23 @@ def check_dns_egress_rule(
         errors.append(
             f"{rule_desc}: expected at most one '{REQUIRED_WILDCARD_CIDR}' peer"
         )
+    else:
+        wildcard_ipblock = wildcard_peers[0].get("ipBlock")
+        if isinstance(wildcard_ipblock, dict):
+            except_val = wildcard_ipblock.get("except")
+            peer_excepts = (
+                {str(x) for x in except_val}
+                if isinstance(except_val, list)
+                else set()
+            )
+            if LINK_LOCAL_CIDR in peer_excepts:
+                missing_link_local = REQUIRED_LINK_LOCAL_LITERALS - peer_cidrs
+                if missing_link_local:
+                    errors.append(
+                        f"{rule_desc}: '{REQUIRED_WILDCARD_CIDR}' except list excludes '{LINK_LOCAL_CIDR}', "
+                        f"requiring explicit ipBlock literal(s) for NodeLocal DNSCache and Cloud DNS for GKE: "
+                        f"{sorted(missing_link_local)}"
+                    )
 
     return errors
 

--- a/scripts/check_iac_parity.py
+++ b/scripts/check_iac_parity.py
@@ -44,6 +44,11 @@ prompts (*.md).
 Template semantics:
 For Helm templates, this check asserts that the static source definition carries
 the required peer shape, without evaluating dynamic Helm value permutations.
+Mutually exclusive Helm branches ({{- else }}) are not evaluated conditionally;
+all branches in the static template source are retained. A required peer must
+appear in the sanitized source in a form that satisfies peer parity when retained,
+and multiple mutually exclusive wildcard peers will be rejected as duplicate
+additive peers.
 """
 
 from __future__ import annotations
@@ -120,27 +125,59 @@ HOUSE_SHAPE_EXCEPT: frozenset[str] = frozenset(
     {"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "100.64.0.0/10", "169.254.0.0/16"}
 )
 
+KIND_NETWORK_POLICY = "NetworkPolicy"
+TEMPLATE_PLACEHOLDER = "placeholder"
+
+HELM_COMMENT_RE = re.compile(r"\{\{-?\s*/\*.*?\*/\s*-?\}\}", flags=re.DOTALL)
+HELM_TAG_MULTILINE_RE = re.compile(r"\{\{.*?\}\}", flags=re.DOTALL)
+HELM_TAG_LINE_RE = re.compile(r"\{\{.*?\}\}")
+HELM_CONTROL_DIRECTIVE_RE = re.compile(
+    r"\{\{-?\s*(?:if\b|else\b|end\b|range\b|with\b).*?-?\}\}"
+)
+YAML_DOC_SEPARATOR_RE = re.compile(r"^---(?:\s.*)?$", flags=re.MULTILINE)
+NETWORK_POLICY_KIND_RE = re.compile(
+    r"^\s*kind:\s*['\"]?NetworkPolicy['\"]?", flags=re.MULTILINE
+)
+
 
 def is_house_shape(except_list: Iterable[str]) -> bool:
     """Return True if the except list satisfies the 5-entry house shape."""
     return HOUSE_SHAPE_EXCEPT.issubset(set(except_list))
 
 
+def governs_egress(spec: object) -> bool:
+    """Return True if a NetworkPolicy spec governs egress traffic.
+
+    When policyTypes is explicitly specified, Egress must be included.
+    When policyTypes is omitted, Kubernetes enables Egress only if egress rules are present.
+    """
+    if not isinstance(spec, dict):
+        return False
+    policy_types = spec.get("policyTypes")
+    if isinstance(policy_types, list):
+        return "Egress" in policy_types
+    if spec.get("policyTypes") is not None:
+        return False
+    return spec.get("egress") is not None
+
+
 def sanitize_helm_template(text: str) -> str:
     """Sanitize Go/Helm template tags so that YAML parsers can load the manifests."""
     # Strip multi-line comments: {{- /* ... */ -}} or {{/* ... */}}
-    text = re.sub(r"\{\{-?\s*/\*.*?\*/\s*-?\}\}", "", text, flags=re.DOTALL)
+    text = HELM_COMMENT_RE.sub("", text)
+    # Replace internal newlines within template tags so every directive is single-line
+    text = HELM_TAG_MULTILINE_RE.sub(lambda m: m.group(0).replace("\n", " "), text)
     lines: list[str] = []
     for line in text.splitlines():
         # Check if the line consists entirely of template control tags (ignoring trailing comments)
-        line_without_tags = re.sub(r"\{\{.*?\}\}", "", line)
+        line_without_tags = HELM_TAG_LINE_RE.sub("", line)
         if line_without_tags.split("#", 1)[0].strip() == "":
             lines.append("# " + line)
             continue
         # For lines with mixed content, strip control directives (if, else, end, with, range)
-        cleaned = re.sub(r"\{\{-?\s*(?:if\b|else\b|end\b|range\b|with\b).*?-?\}\}", "", line)
+        cleaned = HELM_CONTROL_DIRECTIVE_RE.sub("", line)
         # Any remaining template expressions are value interpolations
-        cleaned = re.sub(r"\{\{.*?\}\}", "placeholder", cleaned)
+        cleaned = HELM_TAG_LINE_RE.sub(TEMPLATE_PLACEHOLDER, cleaned)
         lines.append(cleaned)
     return "\n".join(lines)
 
@@ -159,16 +196,16 @@ def load_network_policies(path: Path) -> list[dict]:
     policies: list[dict] = []
 
     # Split documents on YAML boundary '---'
-    for chunk in re.split(r"^---(?:\s.*)?$", sanitized, flags=re.MULTILINE):
+    for chunk in YAML_DOC_SEPARATOR_RE.split(sanitized):
         chunk_stripped = chunk.strip()
         if not chunk_stripped:
             continue
         # Only parse chunks that declare kind: NetworkPolicy
-        if not re.search(r"^\s*kind:\s*['\"]?NetworkPolicy['\"]?", chunk_stripped, flags=re.MULTILINE):
+        if not NETWORK_POLICY_KIND_RE.search(chunk_stripped):
             continue
         try:
             doc = yaml.safe_load(chunk_stripped)
-            if isinstance(doc, dict) and doc.get("kind") == "NetworkPolicy":
+            if isinstance(doc, dict) and doc.get("kind") == KIND_NETWORK_POLICY:
                 policies.append(doc)
         except Exception as exc:
             raise ValueError(f"malformed NetworkPolicy document in {path}: {exc}") from exc
@@ -246,7 +283,7 @@ def discover_dns_network_policies(root: Path | None = None) -> set[str]:
                 ) from exc
 
             # Fast check before parsing
-            if "NetworkPolicy" not in raw or DNS_PORT_STR not in raw:
+            if KIND_NETWORK_POLICY not in raw or DNS_PORT_STR not in raw:
                 continue
 
             try:
@@ -257,11 +294,18 @@ def discover_dns_network_policies(root: Path | None = None) -> set[str]:
                 ) from exc
 
             for pol in policies:
-                spec = pol.get("spec") or {}
-                for rule in spec.get("egress") or []:
+                spec = pol.get("spec")
+                if not governs_egress(spec):
+                    continue
+                egress_rules = spec.get("egress") if isinstance(spec, dict) else []
+                if not isinstance(egress_rules, list):
+                    continue
+                for rule in egress_rules:
                     if not isinstance(rule, dict):
                         continue
-                    ports = rule.get("ports") or []
+                    ports = rule.get("ports")
+                    if not isinstance(ports, list):
+                        continue
                     if any(
                         isinstance(p, dict) and p.get("port") in DNS_PORTS
                         for p in ports
@@ -280,17 +324,23 @@ def check_dns_egress_rule(
 ) -> list[str]:
     """Verify that a single port-53 egress rule satisfies the required peer shape."""
     errors: list[str] = []
-    to_peers = rule.get("to") or []
+    to_peers = rule.get("to")
+    rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
+
+    if to_peers is not None and not isinstance(to_peers, list):
+        errors.append(f"{rule_desc}: 'to' field must be a list")
+        return errors
+
     has_dns_literal = False
     has_wildcard = False
     wildcard_peers: list[dict] = []
-    rule_desc = f"{path_display} (policy '{policy_name}', DNS rule #{rule_idx})"
 
-    for peer in to_peers:
+    for peer in (to_peers or []):
         if not isinstance(peer, dict) or "ipBlock" not in peer:
             continue
-        ip_block = peer["ipBlock"]
+        ip_block = peer.get("ipBlock")
         if not isinstance(ip_block, dict):
+            errors.append(f"{rule_desc}: ipBlock must be a mapping")
             continue
         cidr = ip_block.get("cidr")
         if cidr == REQUIRED_DNS_LITERAL:
@@ -298,10 +348,14 @@ def check_dns_egress_rule(
         elif cidr == REQUIRED_WILDCARD_CIDR:
             has_wildcard = True
             wildcard_peers.append(peer)
+            except_val = ip_block.get("except")
             peer_excepts: set[str] = set()
-            except_list = ip_block.get("except")
-            if isinstance(except_list, list):
-                peer_excepts = {str(x) for x in except_list}
+            if isinstance(except_val, list):
+                peer_excepts = {str(x) for x in except_val}
+            elif except_val is not None:
+                errors.append(
+                    f"{rule_desc}: '{REQUIRED_WILDCARD_CIDR}' peer except must be a list"
+                )
             missing = REQUIRED_EXCEPT_MINIMUM - peer_excepts
             if missing:
                 errors.append(
@@ -346,30 +400,48 @@ def check_network_policy_file(path: Path, root: Path | None = None) -> tuple[int
     checked_policies = 0
 
     for policy in policies:
-        policy_name = (policy.get("metadata") or {}).get("name") or "<unnamed>"
-        spec = policy.get("spec") or {}
-        policy_types = spec.get("policyTypes") or []
-        egress_rules = spec.get("egress")
+        metadata = policy.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            errors.append(f"{rel_path}: metadata must be a mapping")
+            policy_name = "<unnamed>"
+        elif isinstance(metadata, dict):
+            name_val = metadata.get("name")
+            policy_name = name_val if isinstance(name_val, str) else "<unnamed>"
+        else:
+            policy_name = "<unnamed>"
 
-        # Skip policies that do not govern egress traffic.
-        # When policyTypes is explicitly specified, Egress must be listed for the policy to govern egress.
-        # When policyTypes is omitted, Kubernetes enables Egress only if egress rules are present.
-        if spec.get("policyTypes") is not None:
-            if "Egress" not in policy_types:
-                continue
-        elif egress_rules is None:
+        spec = policy.get("spec")
+        if not isinstance(spec, dict):
+            errors.append(f"{rel_path}: NetworkPolicy '{policy_name}' spec must be a mapping")
+            continue
+
+        policy_types = spec.get("policyTypes")
+        if policy_types is not None and not isinstance(policy_types, list):
+            errors.append(f"{rel_path}: NetworkPolicy '{policy_name}' policyTypes must be a list")
+
+        egress_rules = spec.get("egress")
+        if egress_rules is not None and not isinstance(egress_rules, list):
+            errors.append(f"{rel_path}: NetworkPolicy '{policy_name}' egress must be a list")
+            continue
+
+        if not governs_egress(spec):
             continue
 
         checked_policies += 1
-        dns_rules = [
-            r
-            for r in (egress_rules or [])
-            if isinstance(r, dict)
-            and any(
+        dns_rules: list[dict] = []
+        for r in (egress_rules or []):
+            if not isinstance(r, dict):
+                errors.append(f"{rel_path}: NetworkPolicy '{policy_name}' egress rule must be a mapping")
+                continue
+            ports = r.get("ports")
+            if ports is not None and not isinstance(ports, list):
+                errors.append(f"{rel_path}: NetworkPolicy '{policy_name}' rule ports must be a list")
+                continue
+            if any(
                 isinstance(p, dict) and p.get("port") in DNS_PORTS
-                for p in (r.get("ports") or [])
-            )
-        ]
+                for p in (ports or [])
+            ):
+                dns_rules.append(r)
 
         if not dns_rules:
             errors.append(

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_iac_parity.py."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_iac_parity import (
+    HOUSE_SHAPE_EXCEPT,
+    REQUIRED_DNS_LITERAL,
+    REQUIRED_EXCEPT_MINIMUM,
+    REQUIRED_WILDCARD_CIDR,
+    STATIC_NETWORK_POLICIES,
+    check_all,
+    check_dns_egress_rule,
+    check_network_policy_file,
+    is_house_shape,
+    load_network_policies,
+    main,
+    sanitize_helm_template,
+)
+
+
+class CheckIacParityProductionTest(unittest.TestCase):
+    """Verify that all live production static copies satisfy the DNS peer shape."""
+
+    def test_all_production_copies_pass(self):
+        rules_checked, errors = check_all()
+        self.assertEqual(
+            errors,
+            [],
+            f"Expected all production static policies to pass parity check, but found errors: {errors}",
+        )
+        self.assertEqual(
+            rules_checked,
+            len(STATIC_NETWORK_POLICIES),
+            f"Expected {len(STATIC_NETWORK_POLICIES)} DNS rules checked, got {rules_checked}",
+        )
+
+    def test_roster_contains_all_known_copies(self):
+        expected_subset = {
+            "charts/kube-agents/templates/litellm.yaml",
+            "charts/kube-agents/templates/github-minter.yaml",
+            "deploy/kustomize/platform/networkpolicy-core-egress.yaml",
+            "examples/litellm-chatgpt-subscription/networkpolicy.yaml",
+            "examples/litellm-gemini/networkpolicy.yaml",
+            "examples/vllm-gemma/networkpolicy.yaml",
+            "k8s-operator/config/integrations/github/deployment.yaml.template",
+            "k8s-operator/config/integrations/litellm/base/networkpolicy.yaml",
+        }
+        self.assertTrue(expected_subset.issubset(set(STATIC_NETWORK_POLICIES)))
+
+
+class CheckIacParitySyntheticTest(unittest.TestCase):
+    """Verify that regressions in peer shape are caught as expected."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_manifest(self, filename: str, content: str) -> Path:
+        p = self.root / filename
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_missing_dns_literal_fails(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any(REQUIRED_DNS_LITERAL in err for err in errors))
+
+    def test_missing_wildcard_cidr_fails(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any(REQUIRED_WILDCARD_CIDR in err for err in errors))
+
+    def test_wildcard_missing_except_list_fails(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("missing required private CIDRs" in err for err in errors))
+
+    def test_incomplete_except_list_fails(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("10.0.0.0/8" in err for err in errors))
+
+    def test_house_shape_except_passes(self):
+        manifest = f"""apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+{chr(10).join(f"              - {cidr}" for cidr in sorted(HOUSE_SHAPE_EXCEPT))}
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+        self.assertTrue(is_house_shape(HOUSE_SHAPE_EXCEPT))
+
+    def test_string_port_representation_supported(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: "53"
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_multi_doc_ingress_only_policy_skipped(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only-db
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app-egress
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("multi.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_missing_dns_rule_fails(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("has no egress rule for port 53" in err for err in errors))
+
+    def test_non_existent_file_fails(self):
+        p = self.root / "does_not_exist.yaml"
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("failed to load NetworkPolicy" in err for err in errors))
+
+    def test_helm_template_sanitization(self):
+        raw = """{{- /* Multi-line comment
+that should be
+stripped */ -}}
+{{- if .Values.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+  namespace: {{ .Release.Namespace }}
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+{{- end }}"""
+        p = self._write_manifest("template.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from scripts.check_iac_parity import (
     EXCLUDED_NETPOL_MANIFESTS,
     HOUSE_SHAPE_EXCEPT,
+    REPO_ROOT,
     REQUIRED_DNS_LITERAL,
     REQUIRED_EXCEPT_MINIMUM,
     REQUIRED_WILDCARD_CIDR,
@@ -22,6 +24,7 @@ from scripts.check_iac_parity import (
     load_network_policies,
     main,
     sanitize_helm_template,
+    validate_exclusions,
 )
 
 
@@ -48,6 +51,13 @@ class CheckIacParityProductionTest(unittest.TestCase):
         containing a port-53 egress rule must either be in STATIC_NETWORK_POLICIES
         or explicitly listed in EXCLUDED_NETPOL_MANIFESTS with a reviewed reason.
         """
+        exclusion_errors = validate_exclusions(root=REPO_ROOT)
+        self.assertEqual(
+            exclusion_errors,
+            [],
+            f"EXCLUDED_NETPOL_MANIFESTS failed contract validation: {exclusion_errors}",
+        )
+
         discovered = discover_dns_network_policies()
         roster = set(STATIC_NETWORK_POLICIES)
 
@@ -64,6 +74,15 @@ class CheckIacParityProductionTest(unittest.TestCase):
             stale,
             set(),
             f"STATIC_NETWORK_POLICIES contains files that no longer contain DNS egress rules: {sorted(stale)}",
+        )
+
+    def test_excluded_manifests_contract(self):
+        """Verify that EXCLUDED_NETPOL_MANIFESTS entries have non-empty reasons, point to existing files, and are disjoint from STATIC_NETWORK_POLICIES."""
+        errors = validate_exclusions(root=REPO_ROOT)
+        self.assertEqual(
+            errors,
+            [],
+            f"EXCLUDED_NETPOL_MANIFESTS failed contract validation: {errors}",
         )
 
 
@@ -102,6 +121,128 @@ spec:
         self._write_manifest("examples/new-service/networkpolicy.yaml", manifest)
         discovered = discover_dns_network_policies(root=self.root)
         self.assertIn("examples/new-service/networkpolicy.yaml", discovered)
+
+    def test_ignored_dirs_in_ancestor_path_does_not_break_discovery(self):
+        """Verify that an ancestor path containing an ignored dirname (e.g. .claude/worktrees) does not suppress discovery."""
+        worktree_root = self.root / ".claude" / "worktree"
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        manifest_path = worktree_root / "manifest.yaml"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(manifest, encoding="utf-8")
+
+        # An ignored directory within the root should still be skipped
+        ignored_path = worktree_root / ".venv" / "manifest.yaml"
+        ignored_path.parent.mkdir(parents=True, exist_ok=True)
+        ignored_path.write_text(manifest, encoding="utf-8")
+
+        discovered = discover_dns_network_policies(root=worktree_root)
+        self.assertIn("manifest.yaml", discovered)
+        self.assertNotIn(".venv/manifest.yaml", discovered)
+
+    def test_ignored_prefixes_docs_site(self):
+        """Verify that manifests under docs/site are ignored by prefix."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: doc-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        self._write_manifest("docs/site/manifest.yaml", manifest)
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertNotIn("docs/site/manifest.yaml", discovered)
+
+    def test_discovery_raises_on_malformed_network_policy(self):
+        """Verify that malformed YAML containing NetworkPolicy and 53 raises rather than being silently swallowed."""
+        bad_yaml = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+spec: [unclosed json syntax with 53
+"""
+        self._write_manifest("invalid.yaml", bad_yaml)
+        with self.assertRaises(ValueError):
+            discover_dns_network_policies(root=self.root)
+
+    def test_validate_exclusions_contract(self):
+        """Verify that validate_exclusions flags empty reasons, missing files, and roster collisions."""
+        self._write_manifest("valid.yaml", "dummy")
+        # 1. Valid exclusion passes
+        errors = validate_exclusions(
+            exclusions={"valid.yaml": "reviewed test reason"},
+            roster=set(),
+            root=self.root,
+        )
+        self.assertEqual(errors, [])
+
+        # 2. Empty or whitespace reason fails
+        errors = validate_exclusions(
+            exclusions={"valid.yaml": "   "},
+            roster=set(),
+            root=self.root,
+        )
+        self.assertTrue(any("non-empty reviewed reason" in err for err in errors))
+
+        # 3. Missing file fails
+        errors = validate_exclusions(
+            exclusions={"nonexistent.yaml": "valid reason"},
+            roster=set(),
+            root=self.root,
+        )
+        self.assertTrue(any("does not exist on disk" in err for err in errors))
+
+        # 4. Roster collision fails
+        errors = validate_exclusions(
+            exclusions={"valid.yaml": "valid reason"},
+            roster={"valid.yaml"},
+            root=self.root,
+        )
+        self.assertTrue(any("cannot also be in STATIC_NETWORK_POLICIES" in err for err in errors))
+
+    def test_discovery_respects_excluded_netpol_manifests(self):
+        """Verify that discover_dns_network_policies ignores entries listed in EXCLUDED_NETPOL_MANIFESTS."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        self._write_manifest("excluded.yaml", manifest)
+        with unittest.mock.patch.dict(
+            "scripts.check_iac_parity.EXCLUDED_NETPOL_MANIFESTS",
+            {"excluded.yaml": "reviewed test reason"},
+        ):
+            discovered = discover_dns_network_policies(root=self.root)
+            self.assertNotIn("excluded.yaml", discovered)
+
+    def test_discovery_raises_on_unreadable_file(self):
+        """Verify that read errors during discovery raise RuntimeError."""
+        self._write_manifest("unreadable.yaml", "dummy")
+        with unittest.mock.patch.object(
+            Path, "read_text", side_effect=OSError("simulated permission error")
+        ):
+            with self.assertRaises(RuntimeError):
+                discover_dns_network_policies(root=self.root)
 
     def test_missing_dns_literal_fails(self):
         manifest = """apiVersion: networking.k8s.io/v1

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -619,6 +619,45 @@ spec:
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])
 
+    def test_ingress_only_with_empty_egress_skipped(self):
+        """Verify that Ingress-only policies with explicit egress: [] are skipped."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress: []
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valid-egress
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("ingress_empty_egress.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
     def test_main_success_default(self):
         self.assertEqual(main([]), 0)
 

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -3,10 +3,15 @@
 
 from __future__ import annotations
 
+import sys
 import tempfile
 import unittest
 import unittest.mock
 from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.check_iac_parity import (
     EXCLUDED_NETPOL_MANIFESTS,
@@ -38,10 +43,10 @@ class CheckIacParityProductionTest(unittest.TestCase):
             [],
             f"Expected all production static policies to pass parity check, but found errors: {errors}",
         )
-        self.assertEqual(
+        self.assertGreaterEqual(
             rules_checked,
             len(STATIC_NETWORK_POLICIES),
-            f"Expected {len(STATIC_NETWORK_POLICIES)} DNS rules checked, got {rules_checked}",
+            f"Expected at least {len(STATIC_NETWORK_POLICIES)} DNS rules checked, got {rules_checked}",
         )
 
     def test_discovery_matches_roster_exactly(self):
@@ -499,6 +504,117 @@ spec:
               - 192.168.0.0/16
 {{- end }}"""
         p = self._write_manifest("template.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_split_wildcard_peers_fails(self):
+        """Verify that splitting required private CIDRs across multiple 0.0.0.0/0 peers is rejected."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("split_wildcard.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("missing required private CIDRs" in err for err in errors))
+        self.assertTrue(any("expected at most one '0.0.0.0/0' peer" in err for err in errors))
+
+    def test_multiple_wildcard_peers_rejected(self):
+        """Verify that multiple 0.0.0.0/0 peers in a single rule are rejected."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("dup_wildcard.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("expected at most one '0.0.0.0/0' peer" in err for err in errors))
+
+    def test_helm_template_trailing_comment(self):
+        """Verify that template directives with trailing comments parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    {{- if .Values.enabled }} # conditionally included
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+    {{- end }} # end of condition
+"""
+        p = self._write_manifest("template_comment.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_inline_conditional(self):
+        """Verify that inline conditionals preserve the manifest payload."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        {{- if .Values.includeClassic }}- ipBlock: { cidr: 10.96.0.10/32 }{{- end }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("template_inline.yaml", raw)
         rules, errors = check_network_policy_file(p, self.root)
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 
 from scripts.check_iac_parity import (
+    EXCLUDED_NETPOL_MANIFESTS,
     HOUSE_SHAPE_EXCEPT,
     REQUIRED_DNS_LITERAL,
     REQUIRED_EXCEPT_MINIMUM,
@@ -16,6 +17,7 @@ from scripts.check_iac_parity import (
     check_all,
     check_dns_egress_rule,
     check_network_policy_file,
+    discover_dns_network_policies,
     is_house_shape,
     load_network_policies,
     main,
@@ -39,18 +41,30 @@ class CheckIacParityProductionTest(unittest.TestCase):
             f"Expected {len(STATIC_NETWORK_POLICIES)} DNS rules checked, got {rules_checked}",
         )
 
-    def test_roster_contains_all_known_copies(self):
-        expected_subset = {
-            "charts/kube-agents/templates/litellm.yaml",
-            "charts/kube-agents/templates/github-minter.yaml",
-            "deploy/kustomize/platform/networkpolicy-core-egress.yaml",
-            "examples/litellm-chatgpt-subscription/networkpolicy.yaml",
-            "examples/litellm-gemini/networkpolicy.yaml",
-            "examples/vllm-gemma/networkpolicy.yaml",
-            "k8s-operator/config/integrations/github/deployment.yaml.template",
-            "k8s-operator/config/integrations/litellm/base/networkpolicy.yaml",
-        }
-        self.assertTrue(expected_subset.issubset(set(STATIC_NETWORK_POLICIES)))
+    def test_discovery_matches_roster_exactly(self):
+        """Ensure no DNS NetworkPolicy in the repository escapes the static roster.
+
+        Mirroring scripts/test_test_discovery.py: any static manifest in the tree
+        containing a port-53 egress rule must either be in STATIC_NETWORK_POLICIES
+        or explicitly listed in EXCLUDED_NETPOL_MANIFESTS with a reviewed reason.
+        """
+        discovered = discover_dns_network_policies()
+        roster = set(STATIC_NETWORK_POLICIES)
+
+        untracked = discovered - roster
+        self.assertEqual(
+            untracked,
+            set(),
+            f"Found DNS-bearing NetworkPolicy files not tracked in STATIC_NETWORK_POLICIES: {sorted(untracked)}. "
+            "Either add them to STATIC_NETWORK_POLICIES or to EXCLUDED_NETPOL_MANIFESTS with an explicit reason.",
+        )
+
+        stale = roster - discovered
+        self.assertEqual(
+            stale,
+            set(),
+            f"STATIC_NETWORK_POLICIES contains files that no longer contain DNS egress rules: {sorted(stale)}",
+        )
 
 
 class CheckIacParitySyntheticTest(unittest.TestCase):
@@ -68,6 +82,26 @@ class CheckIacParitySyntheticTest(unittest.TestCase):
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
         return p
+
+    def test_discovery_catches_untracked_dns_policy(self):
+        """Verify that discover_dns_network_policies flags newly introduced manifests."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: new-service-egress
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        self._write_manifest("examples/new-service/networkpolicy.yaml", manifest)
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertIn("examples/new-service/networkpolicy.yaml", discovered)
 
     def test_missing_dns_literal_fails(self):
         manifest = """apiVersion: networking.k8s.io/v1
@@ -244,6 +278,36 @@ spec:
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])
 
+    def test_multi_doc_unrelated_syntax_error_ignored(self):
+        manifest = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: broken-unrelated
+spec: [unclosed json syntax
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valid-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("resilient.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
     def test_missing_dns_rule_fails(self):
         manifest = """apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -297,6 +361,28 @@ spec:
         rules, errors = check_network_policy_file(p, self.root)
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])
+
+    def test_main_success_default(self):
+        self.assertEqual(main([]), 0)
+
+    def test_main_verbose(self):
+        self.assertEqual(main(["-v"]), 0)
+
+    def test_main_failure(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+"""
+        p = self._write_manifest("failing.yaml", manifest)
+        self.assertEqual(main([str(p)]), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -165,7 +165,14 @@ spec:
         - ipBlock:
             cidr: 10.96.0.10/32
 """
-        extensions = [".yaml", ".yml", ".yaml.template", ".yml.template"]
+        extensions = [
+            ".yaml",
+            ".yml",
+            ".yaml.template",
+            ".yml.template",
+            ".yaml.tmpl",
+            ".yml.tmpl",
+        ]
         for ext in extensions:
             rel_name = f"sub/policy_{ext.replace('.', '_')}{ext}"
             self._write_manifest(rel_name, manifest)
@@ -265,6 +272,16 @@ spec: [unclosed json syntax with 53
             root=self.root,
         )
         self.assertTrue(any("cannot also be in STATIC_NETWORK_POLICIES" in err for err in errors))
+
+        # 5. Absolute path or path with leading slash fails
+        errors = validate_exclusions(
+            exclusions={"/valid.yaml": "valid reason"},
+            roster=set(),
+            root=self.root,
+        )
+        self.assertTrue(
+            any("must be repository-relative without a leading slash" in err for err in errors)
+        )
 
     def test_discovery_respects_excluded_netpol_manifests(self):
         """Verify that discover_dns_network_policies ignores entries listed in EXCLUDED_NETPOL_MANIFESTS."""
@@ -895,6 +912,14 @@ spec:
   {{- end }}
 """
         p = self._write_manifest("multiline_if_and.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_crlf_multiline_directive(self):
+        """Verify that multiline Go template directives with CRLF line endings parse cleanly."""
+        raw = "apiVersion: networking.k8s.io/v1\r\nkind: NetworkPolicy\r\nmetadata:\r\n  name: test-netpol\r\nspec:\r\n  {{- if and\r\n      .Values.enabled\r\n      .Values.networkPolicy.enabled }}\r\n  egress:\r\n    - ports:\r\n        - port: 53\r\n      to:\r\n        - ipBlock:\r\n            cidr: 10.96.0.10/32\r\n        - ipBlock:\r\n            cidr: 0.0.0.0/0\r\n            except:\r\n              - 10.0.0.0/8\r\n              - 172.16.0.0/12\r\n              - 192.168.0.0/16\r\n  {{- end }}\r\n"
+        p = self._write_manifest("crlf_multiline.yaml", raw)
         rules, errors = check_network_policy_file(p, self.root)
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -127,6 +127,32 @@ spec:
         discovered = discover_dns_network_policies(root=self.root)
         self.assertIn("examples/new-service/networkpolicy.yaml", discovered)
 
+    def test_discovery_supports_all_target_file_extensions(self):
+        """Verify that discover_dns_network_policies recognizes all target file extensions."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dns-policy
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        extensions = [".yaml", ".yml", ".yaml.template", ".yml.template"]
+        for ext in extensions:
+            rel_name = f"sub/policy_{ext.replace('.', '_')}{ext}"
+            self._write_manifest(rel_name, manifest)
+
+        discovered = discover_dns_network_policies(root=self.root)
+        for ext in extensions:
+            rel_name = f"sub/policy_{ext.replace('.', '_')}{ext}"
+            self.assertIn(rel_name, discovered, f"Expected {ext} file to be discovered")
+
     def test_ignored_dirs_in_ancestor_path_does_not_break_discovery(self):
         """Verify that an ancestor path containing an ignored dirname (e.g. .claude/worktrees) does not suppress discovery."""
         worktree_root = self.root / ".claude" / "worktree"
@@ -657,6 +683,65 @@ spec:
         rules, errors = check_network_policy_file(p, self.root)
         self.assertEqual(rules, 1)
         self.assertEqual(errors, [])
+
+    def test_ingress_only_with_non_empty_egress_skipped(self):
+        """Verify that Ingress-only policies with a non-empty egress list are skipped."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress:
+    - ports:
+        - port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: valid-egress
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("ingress_non_empty_egress.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_explicit_egress_policy_type_missing_dns_fails(self):
+        """Verify that explicit policyTypes: [Egress] with no port-53 rule fails."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 443
+"""
+        p = self._write_manifest("egress_no_dns.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("has no egress rule for port 53" in err for err in errors))
 
     def test_main_success_default(self):
         self.assertEqual(main([]), 0)

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -233,6 +233,46 @@ spec:
         discovered = discover_dns_network_policies(root=self.root)
         self.assertNotIn("docs/site/manifest.yaml", discovered)
 
+    def test_discovery_ignores_testdata_at_any_depth(self):
+        """Verify that any directory named testdata is ignored repository-wide at any depth."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: testdata-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        self._write_manifest("k8s-operator/internal/testing/testdata/netpol.yaml", manifest)
+        self._write_manifest("deep/nested/path/testdata/manifest.yaml", manifest)
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertNotIn("k8s-operator/internal/testing/testdata/netpol.yaml", discovered)
+        self.assertNotIn("deep/nested/path/testdata/manifest.yaml", discovered)
+
+    def test_discovery_ignores_unmatched_extensions(self):
+        """Verify that files with extensions outside DISCOVERY_FILE_PATTERNS (e.g. .tpl, .md) are ignored."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: helper-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+"""
+        self._write_manifest("charts/kube-agents/templates/_helpers.tpl", manifest)
+        self._write_manifest("agents/platform/skills/gke-multitenancy/SKILL.md", manifest)
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertNotIn("charts/kube-agents/templates/_helpers.tpl", discovered)
+        self.assertNotIn("agents/platform/skills/gke-multitenancy/SKILL.md", discovered)
+
     def test_discovery_raises_on_malformed_network_policy(self):
         """Verify that malformed YAML containing NetworkPolicy and 53 raises rather than being silently swallowed."""
         bad_yaml = """apiVersion: networking.k8s.io/v1

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import sys
 import tempfile
 import unittest
@@ -25,6 +27,7 @@ from scripts.check_iac_parity import (
     check_dns_egress_rule,
     check_network_policy_file,
     discover_dns_network_policies,
+    governs_egress,
     is_house_shape,
     load_network_policies,
     main,
@@ -47,6 +50,25 @@ class CheckIacParityProductionTest(unittest.TestCase):
             rules_checked,
             len(STATIC_NETWORK_POLICIES),
             f"Expected at least {len(STATIC_NETWORK_POLICIES)} DNS rules checked, got {rules_checked}",
+        )
+
+    def test_core_egress_satisfies_house_shape(self):
+        """Verify that deploy/kustomize/platform/networkpolicy-core-egress.yaml satisfies the 5-entry house shape (#747 B5)."""
+        manifest_path = REPO_ROOT / "deploy/kustomize/platform/networkpolicy-core-egress.yaml"
+        policies = load_network_policies(manifest_path)
+        self.assertTrue(len(policies) > 0)
+        found_house_shape = False
+        for pol in policies:
+            for rule in (pol.get("spec") or {}).get("egress") or []:
+                for peer in rule.get("to") or []:
+                    ip_block = peer.get("ipBlock") if isinstance(peer, dict) else None
+                    if isinstance(ip_block, dict) and ip_block.get("cidr") == REQUIRED_WILDCARD_CIDR:
+                        except_list = ip_block.get("except") or []
+                        if is_house_shape(except_list):
+                            found_house_shape = True
+        self.assertTrue(
+            found_house_shape,
+            "deploy/kustomize/platform/networkpolicy-core-egress.yaml must satisfy the 5-entry house shape",
         )
 
     def test_discovery_matches_roster_exactly(self):
@@ -505,6 +527,35 @@ spec:
         self.assertEqual(rules, 0)
         self.assertTrue(any("failed to load NetworkPolicy" in err for err in errors))
 
+    def test_no_network_policies_in_file_fails(self):
+        manifest = """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: non-policy
+spec:
+  replicas: 1
+"""
+        p = self._write_manifest("deployment_only.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertEqual(errors, ["deployment_only.yaml: no NetworkPolicy resources found"])
+
+    def test_ingress_only_policy_fails_egress_check(self):
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from: []
+"""
+        p = self._write_manifest("ingress_only.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertEqual(errors, ["ingress_only.yaml: no Egress NetworkPolicy resources found"])
+
     def test_helm_template_sanitization(self):
         raw = """{{- /* Multi-line comment
 that should be
@@ -743,11 +794,501 @@ spec:
         self.assertEqual(rules, 0)
         self.assertTrue(any("has no egress rule for port 53" in err for err in errors))
 
+    def test_governs_egress_contract(self):
+        """Verify governs_egress correctly identifies when a NetworkPolicy governs egress."""
+        # Explicit Ingress-only policies do not govern egress
+        self.assertFalse(governs_egress({"policyTypes": ["Ingress"]}))
+        self.assertFalse(governs_egress({"policyTypes": ["Ingress"], "egress": []}))
+        self.assertFalse(
+            governs_egress({"policyTypes": ["Ingress"], "egress": [{"ports": [{"port": 53}]}]})
+        )
+
+        # Explicit Egress policies govern egress
+        self.assertTrue(governs_egress({"policyTypes": ["Egress"]}))
+        self.assertTrue(governs_egress({"policyTypes": ["Egress"], "egress": []}))
+        self.assertTrue(governs_egress({"policyTypes": ["Ingress", "Egress"]}))
+
+        # When policyTypes is omitted, Kubernetes enables Egress only if egress is present
+        self.assertTrue(governs_egress({"egress": []}))
+        self.assertTrue(governs_egress({"egress": [{"ports": [{"port": 53}]}]}))
+        self.assertFalse(governs_egress({"ingress": []}))
+        self.assertFalse(governs_egress({}))
+
+        # Non-dict or malformed specs do not govern egress
+        self.assertFalse(governs_egress(None))
+        self.assertFalse(governs_egress("scalar"))
+        self.assertFalse(governs_egress(True))
+        self.assertFalse(governs_egress({"policyTypes": "not-a-list"}))
+
+    def test_discovery_skips_ingress_only_with_port_53_egress(self):
+        """Verify discover_dns_network_policies ignores policies whose policyTypes explicitly excludes Egress."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-only
+spec:
+  policyTypes:
+    - Ingress
+  ingress:
+    - from: []
+  egress:
+    - ports:
+        - port: 53
+"""
+        self._write_manifest("ingress_with_dns.yaml", manifest)
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertNotIn("ingress_with_dns.yaml", discovered)
+
+    def test_discovery_skips_malformed_egress_and_ports(self):
+        """Verify discovery safely ignores scalar egress, scalar rule items, and non-list ports."""
+        self._write_manifest("scalar_egress.yaml", """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: p1
+spec:
+  # mentions 53 in comment
+  egress: invalid_scalar
+""")
+        self._write_manifest("scalar_rule.yaml", """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: p2
+spec:
+  egress:
+    - not_a_dict_53
+""")
+        self._write_manifest("scalar_ports.yaml", """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: p3
+spec:
+  egress:
+    - ports: 53
+""")
+        discovered = discover_dns_network_policies(root=self.root)
+        self.assertNotIn("scalar_egress.yaml", discovered)
+        self.assertNotIn("scalar_rule.yaml", discovered)
+        self.assertNotIn("scalar_ports.yaml", discovered)
+
+    def test_helm_template_multiline_if_and(self):
+        """Verify that multiline {{- if and ... }} directives parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  {{- if and
+      .Values.enabled
+      .Values.networkPolicy.enabled }} # conditionally included
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  {{- end }}
+"""
+        p = self._write_manifest("multiline_if_and.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_multiline_with(self):
+        """Verify that multiline {{- with ... }} directives parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  {{- with
+      .Values.spec }}
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  {{- end }}
+"""
+        p = self._write_manifest("multiline_with.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_multiline_range(self):
+        """Verify that multiline {{- range ... }} directives parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  {{- range
+      .Values.configs }}
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+  {{- end }}
+"""
+        p = self._write_manifest("multiline_range.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_multiline_value_interpolation(self):
+        """Verify that multiline value interpolations parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-%s"
+      .Release.Name
+      .Values.component }}
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("multiline_interp.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_multiline_comment(self):
+        """Verify that multiline Go template comments parse cleanly."""
+        raw = """{{- /*
+Multi-line
+template comment
+*/ -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("multiline_comment.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_multiline_directive_with_inline_yaml(self):
+        """Verify that multiline directives with inline YAML content on the same line parse cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        {{- if or
+            .Values.includeClassic
+            .Values.legacy }}- ipBlock: { cidr: 10.96.0.10/32 }{{- end }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("multiline_inline_yaml.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_helm_template_if_else_branches_treated_as_additive(self):
+        """Verify that mutually exclusive if/else branches in static source are treated as additive peers per documented limitation."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        {{- if .Values.useHouseShape }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 100.64.0.0/10
+              - 169.254.0.0/16
+        {{- else }}
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+        {{- end }}
+"""
+        p = self._write_manifest("if_else_limitation.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("expected at most one '0.0.0.0/0' peer" in err for err in errors))
+
+    def test_malformed_spec_scalar_fails_cleanly(self):
+        """Verify that a scalar spec field (e.g. spec: true) reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec: true
+"""
+        p = self._write_manifest("scalar_spec.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("spec must be a mapping" in err for err in errors))
+
+    def test_malformed_metadata_scalar_fails_cleanly(self):
+        """Verify that a scalar metadata field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata: "text"
+spec:
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("scalar_metadata.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("metadata must be a mapping" in err for err in errors))
+
+    def test_malformed_policy_types_scalar_fails_cleanly(self):
+        """Verify that a scalar policyTypes field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes: 123
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("scalar_policy_types.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertTrue(any("policyTypes must be a list" in err for err in errors))
+
+    def test_malformed_egress_scalar_fails_cleanly(self):
+        """Verify that a scalar egress field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress: "text"
+"""
+        p = self._write_manifest("scalar_egress.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("egress must be a list" in err for err in errors))
+
+    def test_malformed_egress_rule_scalar_fails_cleanly(self):
+        """Verify that a non-mapping egress rule item reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - true
+"""
+        p = self._write_manifest("scalar_egress_rule.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("egress rule must be a mapping" in err for err in errors))
+
+    def test_malformed_ports_scalar_fails_cleanly(self):
+        """Verify that a scalar ports field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("scalar_ports.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertTrue(any("rule ports must be a list" in err for err in errors))
+
+    def test_malformed_ports_items_scalar_fails_cleanly(self):
+        """Verify that scalar ports items (e.g. ports: ["53"]) report missing DNS rule cleanly."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - "53"
+"""
+        p = self._write_manifest("scalar_port_items.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 0)
+        self.assertTrue(any("has no egress rule for port 53" in err for err in errors))
+
+    def test_malformed_to_peers_scalar_fails_cleanly(self):
+        """Verify that a scalar 'to' field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to: "all"
+"""
+        p = self._write_manifest("scalar_to.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("'to' field must be a list" in err for err in errors))
+
+    def test_malformed_ipblock_scalar_fails_cleanly(self):
+        """Verify that a scalar ipBlock field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock: true
+"""
+        p = self._write_manifest("scalar_ipblock.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("ipBlock must be a mapping" in err for err in errors))
+
+    def test_malformed_except_scalar_fails_cleanly(self):
+        """Verify that a scalar except field reports a clean error without traceback."""
+        raw = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: "10.0.0.0/8"
+"""
+        p = self._write_manifest("scalar_except.yaml", raw)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("'0.0.0.0/0' peer except must be a list" in err for err in errors))
+
     def test_main_success_default(self):
-        self.assertEqual(main([]), 0)
+        buf_out = io.StringIO()
+        buf_err = io.StringIO()
+        with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+            rc = main([])
+        self.assertEqual(rc, 0)
+        self.assertIn("OK: Verified DNS egress", buf_out.getvalue())
 
     def test_main_verbose(self):
-        self.assertEqual(main(["-v"]), 0)
+        buf_out = io.StringIO()
+        buf_err = io.StringIO()
+        with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+            rc = main(["-v"])
+        self.assertEqual(rc, 0)
+        self.assertIn("All 8 static policy copies passed", buf_out.getvalue())
 
     def test_main_failure(self):
         manifest = """apiVersion: networking.k8s.io/v1
@@ -763,7 +1304,50 @@ spec:
             cidr: 0.0.0.0/0
 """
         p = self._write_manifest("failing.yaml", manifest)
-        self.assertEqual(main([str(p)]), 1)
+        buf_out = io.StringIO()
+        buf_err = io.StringIO()
+        with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+            rc = main([str(p)])
+        self.assertEqual(rc, 1)
+        self.assertIn("ERROR: Static NetworkPolicy DNS egress parity check failed", buf_err.getvalue())
+
+    def test_check_all_verbose_file_failure(self):
+        p = self._write_manifest("verbose_bad.yaml", """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bad
+spec:
+  egress: []
+""")
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rules, errors = check_all([p], root=self.root, verbose=True)
+        self.assertTrue(errors)
+        self.assertIn("FAIL: verbose_bad.yaml", buf.getvalue())
+
+    @unittest.mock.patch.dict("scripts.check_iac_parity.EXCLUDED_NETPOL_MANIFESTS", {"nonexistent.yaml": "test"})
+    def test_check_all_verbose_exclusion_failure(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rules, errors = check_all([], root=self.root, verbose=True)
+        self.assertTrue(errors)
+        self.assertIn("FAIL: exclusion contract:", buf.getvalue())
+
+    def test_main_verbose_failure(self):
+        p = self._write_manifest("main_verbose_bad.yaml", """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bad
+spec:
+  egress: []
+""")
+        buf_out = io.StringIO()
+        buf_err = io.StringIO()
+        with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_err):
+            rc = main(["-v", str(p)])
+        self.assertEqual(rc, 1)
+        self.assertIn(f"FAIL: {p}", buf_out.getvalue())
+        self.assertIn("ERROR: Static NetworkPolicy DNS egress parity check failed", buf_err.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/test_check_iac_parity.py
+++ b/scripts/test_check_iac_parity.py
@@ -18,9 +18,14 @@ if str(_REPO_ROOT) not in sys.path:
 from scripts.check_iac_parity import (
     EXCLUDED_NETPOL_MANIFESTS,
     HOUSE_SHAPE_EXCEPT,
+    LINK_LOCAL_CIDR,
     REPO_ROOT,
     REQUIRED_DNS_LITERAL,
+    REQUIRED_DNS_PROTOCOLS,
     REQUIRED_EXCEPT_MINIMUM,
+    REQUIRED_LINK_LOCAL_CLOUDDNS,
+    REQUIRED_LINK_LOCAL_DNSCACHE,
+    REQUIRED_LINK_LOCAL_LITERALS,
     REQUIRED_WILDCARD_CIDR,
     STATIC_NETWORK_POLICIES,
     check_all,
@@ -415,6 +420,10 @@ spec:
           protocol: TCP
       to:
         - ipBlock:
+            cidr: 169.254.20.10/32
+        - ipBlock:
+            cidr: 169.254.169.254/32
+        - ipBlock:
             cidr: 10.96.0.10/32
         - ipBlock:
             cidr: 0.0.0.0/0
@@ -437,6 +446,156 @@ spec:
     - ports:
         - port: "53"
           protocol: UDP
+        - port: "53"
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertEqual(errors, [])
+
+    def test_missing_udp_protocol_fails(self):
+        """Verify that a port-53 egress rule missing protocol UDP fails."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("missing required protocol(s): ['UDP']" in err for err in errors))
+
+    def test_missing_tcp_protocol_fails(self):
+        """Verify that a port-53 egress rule missing protocol TCP fails."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+      to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(any("missing required protocol(s): ['TCP']" in err for err in errors))
+
+    def test_house_shape_missing_cloud_dns_literal_fails(self):
+        """Verify that house shape (excepting 169.254.0.0/16) missing Cloud DNS literal fails (#1169)."""
+        manifest = f"""apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {REQUIRED_LINK_LOCAL_DNSCACHE}
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+{chr(10).join(f"              - {cidr}" for cidr in sorted(HOUSE_SHAPE_EXCEPT))}
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(
+            any(
+                "requiring explicit ipBlock literal(s) for NodeLocal DNSCache and Cloud DNS for GKE" in err
+                and REQUIRED_LINK_LOCAL_CLOUDDNS in err
+                for err in errors
+            )
+        )
+
+    def test_house_shape_missing_node_local_dns_literal_fails(self):
+        """Verify that house shape (excepting 169.254.0.0/16) missing NodeLocal DNSCache literal fails."""
+        manifest = f"""apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: {REQUIRED_LINK_LOCAL_CLOUDDNS}
+        - ipBlock:
+            cidr: 10.96.0.10/32
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+{chr(10).join(f"              - {cidr}" for cidr in sorted(HOUSE_SHAPE_EXCEPT))}
+"""
+        p = self._write_manifest("netpol.yaml", manifest)
+        rules, errors = check_network_policy_file(p, self.root)
+        self.assertEqual(rules, 1)
+        self.assertTrue(
+            any(
+                "requiring explicit ipBlock literal(s) for NodeLocal DNSCache and Cloud DNS for GKE" in err
+                and REQUIRED_LINK_LOCAL_DNSCACHE in err
+                for err in errors
+            )
+        )
+
+    def test_rfc1918_without_link_local_literals_passes(self):
+        """Verify that policies with RFC1918-only except list do not require explicit link-local literals."""
+        manifest = """apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: test-netpol
+spec:
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -474,6 +633,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -504,6 +666,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -587,6 +752,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -673,6 +841,9 @@ spec:
     {{- if .Values.enabled }} # conditionally included
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -699,6 +870,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         {{- if .Values.includeClassic }}- ipBlock: { cidr: 10.96.0.10/32 }{{- end }}
         - ipBlock:
@@ -737,6 +911,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -778,6 +955,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -900,6 +1080,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -918,7 +1101,7 @@ spec:
 
     def test_helm_template_crlf_multiline_directive(self):
         """Verify that multiline Go template directives with CRLF line endings parse cleanly."""
-        raw = "apiVersion: networking.k8s.io/v1\r\nkind: NetworkPolicy\r\nmetadata:\r\n  name: test-netpol\r\nspec:\r\n  {{- if and\r\n      .Values.enabled\r\n      .Values.networkPolicy.enabled }}\r\n  egress:\r\n    - ports:\r\n        - port: 53\r\n      to:\r\n        - ipBlock:\r\n            cidr: 10.96.0.10/32\r\n        - ipBlock:\r\n            cidr: 0.0.0.0/0\r\n            except:\r\n              - 10.0.0.0/8\r\n              - 172.16.0.0/12\r\n              - 192.168.0.0/16\r\n  {{- end }}\r\n"
+        raw = "apiVersion: networking.k8s.io/v1\r\nkind: NetworkPolicy\r\nmetadata:\r\n  name: test-netpol\r\nspec:\r\n  {{- if and\r\n      .Values.enabled\r\n      .Values.networkPolicy.enabled }}\r\n  egress:\r\n    - ports:\r\n        - port: 53\r\n          protocol: UDP\r\n        - port: 53\r\n          protocol: TCP\r\n      to:\r\n        - ipBlock:\r\n            cidr: 10.96.0.10/32\r\n        - ipBlock:\r\n            cidr: 0.0.0.0/0\r\n            except:\r\n              - 10.0.0.0/8\r\n              - 172.16.0.0/12\r\n              - 192.168.0.0/16\r\n  {{- end }}\r\n"
         p = self._write_manifest("crlf_multiline.yaml", raw)
         rules, errors = check_network_policy_file(p, self.root)
         self.assertEqual(rules, 1)
@@ -936,6 +1119,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -964,6 +1150,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -992,6 +1181,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -1021,6 +1213,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         - ipBlock:
             cidr: 10.96.0.10/32
@@ -1046,6 +1241,9 @@ spec:
   egress:
     - ports:
         - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
       to:
         {{- if or
             .Values.includeClassic


### PR DESCRIPTION
## Summary

Adds an automated parity checker (`scripts/check_iac_parity.py`), unit test suite (`scripts/test_check_iac_parity.py`), and Makefile target (`iac-parity-check`) to assert that all static NetworkPolicy copies in the repository maintain the required DNS egress peer shape (`10.96.0.10/32` literal plus `0.0.0.0/0` with RFC 1918 exceptions). Also adds repository-wide discovery to ensure no newly added DNS-bearing NetworkPolicy can escape the static roster.

## Why This Change

Eight static manifests hand-maintain port 53 DNS egress rules. In #687, an update had to touch all copies and initially missed `deployment.yaml.template` because standard `*.yaml` searches skipped it. In #608, a static policy was added omitting required DNS peers, which causes silent DNS resolution failures on GKE clusters where `kube-dns` is assigned a non-standard or public Service CIDR VIP (e.g. `34.118.224.0/20`). Nothing previously checked that static copies stay aligned or that new copies do not drift.

## What Changed

- Implemented `scripts/check_iac_parity.py` to parse static NetworkPolicy manifests, sanitize Go/Helm template tags offline, and verify that every port 53 egress rule contains `10.96.0.10/32` and an `0.0.0.0/0` peer with at least RFC 1918 private subnets (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) in its `except` list. Accommodates the 5-entry house shape in `networkpolicy-core-egress.yaml`.
- Added `discover_dns_network_policies()` in `scripts/check_iac_parity.py` and `test_discovery_matches_roster_exactly` in `scripts/test_check_iac_parity.py` to walk the repository tree and assert that any manifest defining a port 53 egress rule is tracked in `STATIC_NETWORK_POLICIES` or explicitly listed with a reason in `EXCLUDED_NETPOL_MANIFESTS`.
- Added `make iac-parity-check` target in `Makefile` with a PyYAML preflight check for local developer convenience.
- Automated CI enforcement runs via `scripts/test_check_iac_parity.py` under `make test-python` (`.github/workflows/python-tests.yml`), leaving `.github/workflows/` untouched and avoiding runner environment package installation hazards.
- Added 66 unit tests in `scripts/test_check_iac_parity.py` covering live production manifests, discovery drift across all 6 extensions (`.yaml`, `.yml`, `.yaml.template`, `.yml.template`, `.yaml.tmpl`, `.yml.tmpl`), synthetic peer mutations, string port handling, multi-doc ingress skipping (omitted, empty, and non-empty egress), protocol TCP/UDP validation, independent wildcard exception validation, Helm template trailing comments/inline conditionals, link-local DNS literals, defensive scalar error handling without tracebacks, and CLI invocation modes.

## Context

Closes #747 (Item B5 and D1).
Addresses code review feedback from review pullrequestreview-5076622375.

## Testing

- Ran `python3 -m unittest scripts/test_check_iac_parity.py -v`: 66/66 tests pass in 0.591s.
- Ran `make iac-parity-check`: verified exit code 0 (`OK: Verified DNS egress rule parity across 8 static copies (8 rules checked).`).
- Ran `make docs-check`: all documentation checks, links, and context budgets pass with 0 errors.

### Live validation

Conducted live local mutation testing to verify that real-world drift is blocked:
1. **Classic DNS literal omission:**
   - Removed `10.96.0.10/32` from `deploy/kustomize/platform/networkpolicy-core-egress.yaml` -> `make iac-parity-check` failed immediately with exit code 1 and reported missing literal `10.96.0.10/32`. Restored file -> passed with exit code 0 (`OK`).
2. **RFC 1918 exception omission:**
   - Removed `10.0.0.0/8` from `k8s-operator/config/integrations/litellm/base/networkpolicy.yaml` -> `make iac-parity-check` failed immediately with exit code 1 and reported missing private CIDR `10.0.0.0/8`. Restored file -> passed with exit code 0 (`OK`).
3. **CI Execution:**
   - Executed under `python-tests.yml` via `make test-python` on every pull request, where `scripts/test_check_iac_parity.py` validates all live production static manifests and discovery completeness.

## Self-Review

Ran required pre-PR passes in isolated contexts and addressed subsequent review feedback:
- **`review-adversarial` pass (isolated subagent)**:
  - *Angle A (`IntOrString` port sensitivity)*: Identified that `ports[].port` specified as a string `"53"` would evaluate `!= 53`. **Disposition: Fixed.** Updated port matcher to accept `port in (53, "53")`.
  - *Angle C (Dead constant)*: Identified unused `HOUSE_SHAPE_EXCEPT` constant. **Disposition: Fixed.** Exported `is_house_shape()` helper and added test coverage.
  - *Angle A (Multi-doc Ingress policies)*: Flagged that an Ingress-only policy in a multi-document file would report missing port 53. **Disposition: Fixed.** Filtered out policies that do not define egress.
- **Review `pullrequestreview-5076622375` & follow-up passes**:
  - *MEDIUM (Hardcoded roster with no discovery-drift check)*: Flagged that a future unlisted manifest with port 53 would escape the guard. **Disposition: Fixed.** Implemented `discover_dns_network_policies()` and `test_discovery_matches_roster_exactly`.
  - *LOW (PEP-668 runner hazard in validate.yml)*: Flagged that `pip install` on Ubuntu 24.04 could fail without `--break-system-packages`. **Disposition: Fixed.** Reverted edits to `.github/workflows/validate.yml` completely. CI enforcement is handled purely through `python-tests.yml` via `scripts/test_check_iac_parity.py`.
  - *LOW (Whole-file parse coupling)*: Flagged that unparseable non-NetworkPolicy templates in multi-doc manifests could fail NetworkPolicy extraction. **Disposition: Fixed.** Refactored `load_network_policies()` to isolate and parse `kind: NetworkPolicy` chunks per-document.
  - *HIGH/MEDIUM (Wildcard exception pooling across multiple peers)*: Flagged that multiple `0.0.0.0/0` peers pooled exceptions, allowing split private CIDR exclusions to bypass validation. **Disposition: Fixed.** Validated every wildcard peer independently and rejected multiple `0.0.0.0/0` peers per rule.
  - *MEDIUM (Helm template trailing comments & inline controls)*: Flagged that trailing comments on control directives caused PyYAML parser errors. **Disposition: Fixed.** Stripped control tags before YAML parsing while preserving inline YAML payloads.
  - *MEDIUM (Ingress-only policy with explicit empty `egress: []`)*: Flagged that policies with `policyTypes: [Ingress]` and `egress: []` falsely failed DNS check. **Disposition: Fixed.** Differentiated explicit `policyTypes` from inferred types.
  - *LOW (Live validation exit code mismatch)*: Corrected live validation record to state exit code 1.
  - *LOW/TEST (Discovery extension table & Ingress coverage)*: Added table-driven discovery test covering `.yaml`, `.yml`, `.yaml.template`, `.yml.template`, `.yaml.tmpl`, and `.yml.tmpl`, plus tests for non-empty egress on ingress-only policies and explicit `policyTypes: [Egress]` missing DNS rules.
  - *LOW (Protocol validation & link-local literals)*: Added validation that port 53 egress rules specify both UDP and TCP protocols, and ensured RFC 1918-only policies are not rejected when omitting link-local literals.
  - *LOW (Defensive scalar parsing)*: Added graceful error reporting for malformed scalar fields in manifests without throwing unhandled exceptions.
  - *LOW (PR body test count drift)*: Refreshed PR body test count from 32 to 66 across all 6 discovery extensions to match the suite at HEAD.
- **`review-docs-drift` pass (isolated context)**:
  - Checked docs map `docs/README.md`, `AGENTS.md`, and `docs/site/`. Sibling presubmit targets (`images-check`, `chart-check`) are not listed in a global doc table (they are documented via self-describing `make help` `## description` comments). `make help` correctly formats `iac-parity-check`. No documentation was rendered stale. `make docs-check` passed with 0 errors. **Disposition: Confirmed clean, no docs changes required.**

## Risk & Rollout

- **Blast radius:** Zero runtime impact. Confined to CI presubmits and developer testing tooling.
- **Failure modes & fallbacks:** If a static manifest is edited and omits required DNS peers, or if a new unlisted DNS policy is added, `make test-python` / `scripts/test_check_iac_parity.py` fails in presubmit with the exact file, policy, and missing CIDR.
- **Upgrade impact:** None. No CRDs, manifests, or agent configurations are altered.
- **Reversion:** `git revert` this commit.

---
_Generated with the help of Antigravity._
