### PR TITLE
fix(bench): classify terminal agent-endpoint 429s as infra, not as the agent's answer

### DIFF
--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -646,9 +646,14 @@ class _TransportError(RuntimeError):
 # Gateway statuses a proxy in front of the agent emits when the upstream is
 # gone or saturated -- the pod restarted, the tunnel died -- and which clear
 # once it is back. 429 is the endpoint's own admission control ("Too many
-# concurrent runs"): the request never reached an agent, and the condition
-# clears when a slot frees, which is the same run class as a saturated
-# gateway. Every other status is an answer about the request itself and
+# concurrent runs"): the rejected request itself never reached an agent --
+# true of an opening turn and of a status poll alike, where the delegating
+# turn already ran but this poll was refused at the door -- and the condition
+# clears when a slot frees, the same run class as a saturated gateway. On
+# exhaustion both turn paths deliberately end in _infra_failure rather than
+# grading a partial record: see _DelegationTransportExhausted for why settling
+# the cards into a record that is about to be replaced wholesale is not a
+# rescue. Every other status is an answer about the request itself and
 # repeating the request cannot change it, 500 included: a handler that raised
 # will raise again.
 _RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})

--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -832,10 +832,11 @@ class KubeAgentsHarness(AgentHarness):
                 result, session_id = _post_turn(url, body, headers, timeout)
                 break
             except _TransportError as exc:
-                # A 4xx, a 500, or a body that is not JSON says the endpoint
-                # answered; that is the agent's own failure and still belongs
-                # in front of the judge. Only a gateway status or a dropped
-                # connection is worth a second attempt.
+                # A 500, a 4xx other than 429, or a body that is not JSON
+                # says a handler answered; that is the agent's own failure and
+                # still belongs in front of the judge. Only a gateway status,
+                # an admission-control 429, or a dropped connection is worth a
+                # second attempt: see _RETRYABLE_STATUSES.
                 if not exc.retryable:
                     return AgentResult.errored(str(exc))
                 transport_failures += 1
@@ -926,8 +927,10 @@ class KubeAgentsHarness(AgentHarness):
             turn ran or the header was absent.
 
         Raises:
-            _DelegationTransportExhausted: Every retry died without an HTTP
-                answer; the run is infrastructure, not a gradable result.
+            _DelegationTransportExhausted: Every retry died without reaching
+                an agent -- no HTTP answer at all, or a 429 refused at the
+                admission door; the run is infrastructure, not a gradable
+                result.
         """
         # The delegating turn may already have shown a card done, in which case
         # there is nothing to wait on and no reason to sleep a poll interval.
@@ -989,11 +992,15 @@ class KubeAgentsHarness(AgentHarness):
                 if transport_failures < _MAX_TRANSPORT_FAILURES:
                     # Back off one poll interval and ask again: the loop top
                     # re-checks the deadline, so retries cannot outlive it.
-                    # A retryable failure means the endpoint never answered,
-                    # and the tunnel is the prime suspect (build
+                    # A retryable failure usually means the endpoint never
+                    # answered, and the tunnel is the prime suspect (build
                     # 2092638061140643840: three 502s over a live listener
                     # whose upstream pod had been replaced), so it is torn
-                    # down and respawned first, exactly like the opening turn.
+                    # down and respawned first, exactly like the opening
+                    # turn. The exception is 429, the one retryable status
+                    # the endpoint itself sends: the tunnel it arrived
+                    # through is healthy, and the respawn's few seconds are
+                    # merely pacing before the slot is asked for again.
                     if exc.retryable:
                         try:
                             _reset_port_forward(local_port)
@@ -1018,10 +1025,11 @@ class KubeAgentsHarness(AgentHarness):
                         f"status turns failed in transport {transport_failures} times "
                         "running; still waiting on: " + ", ".join(outstanding)
                     ) from exc
-                # The endpoint answered every time (a 4xx, a 500, non-JSON):
-                # that is the agent's own failure, so it stays in front of the
-                # judge as before -- recorded, not just logged, which is what
-                # stops devops-bench promoting the partial record.
+                # A handler answered every time (a non-429 4xx, a 500,
+                # non-JSON): that is the agent's own failure, so it stays in
+                # front of the judge as before -- recorded, not just logged,
+                # which is what stops devops-bench promoting the partial
+                # record.
                 result.errors.append(
                     f"status turns failed in transport {transport_failures} times running; "
                     "still waiting on: " + ", ".join(outstanding)

--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -645,10 +645,13 @@ class _TransportError(RuntimeError):
 
 # Gateway statuses a proxy in front of the agent emits when the upstream is
 # gone or saturated -- the pod restarted, the tunnel died -- and which clear
-# once it is back. Every other status is an answer about the request itself and
+# once it is back. 429 is the endpoint's own admission control ("Too many
+# concurrent runs"): the request never reached an agent, and the condition
+# clears when a slot frees, which is the same run class as a saturated
+# gateway. Every other status is an answer about the request itself and
 # repeating the request cannot change it, 500 included: a handler that raised
 # will raise again.
-_RETRYABLE_STATUSES = frozenset({502, 503, 504})
+_RETRYABLE_STATUSES = frozenset({429, 502, 503, 504})
 
 
 def _connection_dropped(exc: BaseException) -> bool:

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -1972,6 +1972,63 @@ def test_a_status_turn_gateway_storm_is_infrastructure_not_an_answer(
     assert _TASK_ID in purges[0]
 
 
+def test_a_status_turn_429_storm_is_infrastructure_not_an_answer(
+    stub_agent: _StubAgentServer,
+    instant_polls: None,
+    recorded_pf_resets: list[int],
+    no_cluster_exec: list[str],
+) -> None:
+    """Admission control refusing every status poll gives up as a run class too.
+
+    This is the retryable set's second call site: unlike the opening turn, the
+    delegating agent has already run and filed cards here, so the temptation
+    is to settle whatever finished into the record before giving up. That
+    record is replaced wholesale by ``_infra_failure`` (see
+    ``_DelegationTransportExhausted``), so anything settled into it would be
+    discarded unread -- and grading the partial record instead is exactly
+    build 2093030474753511424's failure, a 0.0 for a worker that had filed the
+    real answer. INFRA hands the whole repetition back to be rerun; the purge
+    is what keeps that rerun from reading this attempt's leavings.
+    """
+    stub_agent.turns = [_create_turn(), _show_turn("done")]
+    stub_agent.fail_on = frozenset(range(2, 2 + harness._MAX_TRANSPORT_FAILURES))
+    stub_agent.fail_on_status = 429
+
+    result = KubeAgentsHarness().run("Find the root cause.")
+
+    assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
+    assert _TASK_ID in result.errors[0]
+    assert "failed in transport" in result.errors[0]
+    assert result.output == ""
+    assert result.trajectory == []
+    assert len(stub_agent.requests) == 1 + harness._MAX_TRANSPORT_FAILURES
+    port = stub_agent.server_address[1]
+    assert recorded_pf_resets == [port] * (harness._MAX_TRANSPORT_FAILURES - 1)
+    purges = [s for s in no_cluster_exec if "rm -rf" in s]
+    assert len(purges) == 1
+    assert _TASK_ID in purges[0]
+
+
+def test_a_status_turn_429_clears_to_the_delegated_answer(
+    stub_agent: _StubAgentServer, instant_polls: None, recorded_pf_resets: list[int]
+) -> None:
+    """One refused poll while the slots are full costs a retry, not the result.
+
+    The likeliest occupants of the slots a mid-wait 429 reports full are this
+    very conversation's workers. When one frees, the next poll reads the board
+    and the delegated answer survives into the graded output.
+    """
+    stub_agent.turns = [_create_turn(), _show_turn("done", body=_RCA_RESULT)]
+    stub_agent.fail_on = frozenset({2})
+    stub_agent.fail_on_status = 429
+
+    result = KubeAgentsHarness().run("Find the root cause.")
+
+    assert not result.has_errors()
+    assert result.output.endswith(_RCA_RESULT)
+
+
 def test_a_status_turn_502_recovers_through_a_fresh_tunnel(
     stub_agent: _StubAgentServer, instant_polls: None, recorded_pf_resets: list[int]
 ) -> None:
@@ -2046,7 +2103,8 @@ def test_status_turns_the_endpoint_answered_still_grade_the_partial_record(
 ) -> None:
     """A 500 storm is the endpoint answering, so it keeps the old behaviour.
 
-    The INFRA class is only for retries that never got an HTTP answer. An
+    The INFRA class is only for retries that never reached an agent -- no
+    HTTP answer at all, or a 429 refused at the admission door. An
     endpoint that keeps answering badly is the agent's own failure: the wait
     still ends, the error is recorded (which stops devops-bench promoting the
     receipt as a validated deliverable), the first turn's work survives, and

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -1228,6 +1228,44 @@ def test_an_agent_side_error_is_still_graded(stub_agent: _StubAgentServer) -> No
     assert len(stub_agent.requests) == 1
 
 
+def test_a_saturated_endpoint_is_infra_not_an_answer(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int]
+) -> None:
+    """A 429 on every attempt gives up as a run class, not as the agent's text.
+
+    "Too many concurrent runs" is the endpoint's admission control: no agent
+    executed, and the condition clears when a slot frees. Before 429 joined
+    ``_RETRYABLE_STATUSES`` the error body was recorded as the agent's output
+    and graded NOT_A_REAL_RUN, failing seven tasks at once on build
+    2094714569262895104.
+    """
+    stub_agent.fail_with = 429
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
+    assert "HTTP 429" in result.errors[0]
+    assert result.output == ""
+    assert result.trajectory == []
+    assert len(stub_agent.requests) == harness._MAX_TRANSPORT_FAILURES
+    assert len(recorded_pf_resets) == harness._MAX_TRANSPORT_FAILURES - 1
+
+
+def test_a_transient_429_is_retried_to_the_answer(
+    stub_agent: _StubAgentServer, recorded_pf_resets: list[int]
+) -> None:
+    """One rejected admission, then a slot frees: the retry gets the answer."""
+    stub_agent.fail_on = frozenset({1})
+    stub_agent.fail_on_status = 429
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == _FINAL_TEXT
+    assert len(stub_agent.requests) == 2
+
+
 def test_a_well_formed_answer_that_reports_a_failure_is_untouched(
     stub_agent: _StubAgentServer,
 ) -> None:


### PR DESCRIPTION
## Summary

When the agent endpoint's admission control rejects a run with HTTP 429 ("Too many concurrent runs (max 10)"), the harness recorded the error body as the agent's output. The grader then — correctly — refused it as NOT_A_REAL_RUN (empty trajectory, no tokens), and the task failed. This PR moves 429 into `_RETRYABLE_STATUSES`, so a transient rejection retries to a real answer and a persistent one exhausts the transport ceiling into `_infra_failure`, the run class built for turns that never reached an agent.

## Why This Change

Build 2094714569262895104 (PR #1089) went red with 7 task failures that were all the same ~4-minute endpoint-saturation event hitting repetition 3. The same run proved the intended classification works where it is wired: two other repetitions hit the same saturation through the retry-exhaustion path, were tagged `KUBE_AGENTS_INFRA_FAILURE`, and their cases passed 2/2. The fast-fail 429 path was the one hole. With the presubmit about to become merge-blocking, this class of false red would block unrelated PRs whenever the endpoint saturates.

## What Changed

- `bench/kube_agents_bench/harness.py`: 429 added to `_RETRYABLE_STATUSES`, with the comment explaining why it is the same run class as a saturated gateway (and why 500 stays non-retryable). The comment also states explicitly that this reaches both call sites — the opening turn and the delegation wait's status polls — and why exhaustion on either ends in `_infra_failure` rather than settling cards into a record that gets replaced wholesale.
- `bench/tests/test_harness.py`: four tests — opening turn: a persistent 429 exhausts the ceiling and lands INFRA with empty output/trajectory, a one-shot 429 retries to the answer; delegation wait: a 429 storm across the status-poll ceiling ends INFRA with the card state purged, a single mid-wait 429 retries to the delegated answer.

## Context

- False-red classification of PR #1089's smoke run (the classification writeup names this as a new class, sibling of the #986/#998 transport-502 class, not a regression of it).
- #1097 tracks the server-side question: what held 6+ of the 10 endpoint slots during that window while harness parallelism was 4. This PR only fixes the harness's classification of the symptom.
- Part of the gating package with #1096 (BOOTSTRAP_ADMITTED roster) and the oss-test-infra `optional: false` flip (kubernetes/test-infra style repo, PR 2677).

## Testing

- `python -m pytest bench/tests/` — 605 passed (includes the four new tests).

### Live validation

Not live-tested: the change is in the eval harness's HTTP transport, which only runs inside the smoke job. The stub-server tests exercise the exhaustion and recovery paths, on both the opening turn and the status polls, at the same seam the live 429s hit; the natural live validation is the next smoke run that meets endpoint saturation, which will now report the repetition as INFRA (excluded) instead of FAILED. No test artifacts to clean up.

## Self-Review

Adversarial pass run in a context that did not write the change (a fresh session handed the diff and the review thread), plus the kube-agents-bot strict pass; docs-drift pass over the touched comments and docstrings. Findings, merged:

- `_RETRYABLE_STATUSES` has a second consumer: `_await_delegated_work`'s status polls go through the same `_post_turn`, so the one-line change also reroutes a poll-path 429 storm from append-and-settle to `_purge_card_state` + `_DelegationTransportExhausted` → `_infra_failure`. Found by the bot, confirmed against harness.py lines 1003–1015. Disposition: behavior kept deliberately, coverage fixed — the append-and-settle alternative is the documented failure this exhaustion path was built to prevent (build 2093030474753511424: worker filed the real remediation PR, receipt graded 0.0), and settling into a record `_execute` replaces wholesale would be discarded unread anyway. Two tests added pinning both poll-path outcomes (f011902).
- Docs-drift: the new comment's "the request never reached an agent" was ambiguous on poll turns (the delegating agent did run; the refused poll did not reach one) — sharpened. The 500-storm test's docstring claimed INFRA is only for retries that "never got an HTTP answer", no longer true with 429 in the set — aligned.
- Docs-drift, second round (bot strict pass on f011902): the first pass was over-scoped in the claim and under-scoped in fact — it covered the comments the diff touched, but four rationale comments elsewhere in `harness.py` still reasoned from the pre-429 set (the opening turn's retry decision, the poll path's reset justification, the non-retryable arm, and the `Raises:` entry for `_DelegationTransportExhausted`). All four aligned in b2d57e9; no code behavior changed.
- Considered and deliberately not done: backoff between 429 retries. Retries are already paced by the port-forward respawn on the retryable arm and by the poll interval mid-wait; the ceiling is not meant to outwait a multi-minute saturation window — exhaustion landing INFRA (repetition excluded and rerun) is the designed outcome.
- Pre-existing, not widened here: `_purge_card_state` on the exhaustion path runs while in-cluster workers may still be writing. Identical on the 502 path (a dead tunnel does not stop in-cluster workers); the purge-before-rerun contract is the 502 storm test's, unchanged.
- Out of scope: why the slots were saturated at all — #1097.

## Risk & Rollout

Blast radius is the bench harness's HTTP transport only; no operator or runtime code paths. The new failure mode: an endpoint that 429s persistently now reports the repetition as INFRA (excluded, rerun) instead of a red task failure — the same visibility 502/503/504 already have in the run report, and the correct attribution. Revert is removing 429 from the one frozenset and dropping the four tests. Nothing has to happen at merge time; companions #1096 and oss-test-infra#2677 merge after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
