### PR TITLE
chore(deps): bump Envoy from v1.39.0 to v1.39.1

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -49,7 +49,7 @@
 # The defaults are the upstream references, so an ordinary build is unchanged.
 ARG HERMES_AGENT_TAG
 ARG HERMES_AGENT_IMAGE=nousresearch/hermes-agent
-ARG ENVOY_VERSION=v1.39.0
+ARG ENVOY_VERSION=v1.39.1
 ARG ENVOY_IMAGE=envoyproxy/envoy
 ARG GOLANG_IMAGE=golang
 ARG GOLANG_VERSION=1.26-alpine

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -59,7 +59,7 @@ Needed only to rebuild the images above from source, not to run an install. Each
 | Image | Upstream reference | Pin | Override | Pulled by |
 | ----- | ------------------ | --- | -------- | --------- |
 | `hermes-agent` | `docker.io/nousresearch/hermes-agent` | `HERMES_AGENT_TAG` in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) | `HERMES_AGENT_IMAGE` | deploy/docker/Dockerfile (agent-base stage). |
-| `envoy` | `docker.io/envoyproxy/envoy` | `v1.39.0` | `ENVOY_IMAGE` | deploy/docker/Dockerfile (envoy-bin stage). |
+| `envoy` | `docker.io/envoyproxy/envoy` | `v1.39.1` | `ENVOY_IMAGE` | deploy/docker/Dockerfile (envoy-bin stage). |
 | `golang` | `docker.io/library/golang` | `1.26-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages. |
 | `python` | `docker.io/library/python` | `3.11-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile. |
 | `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile runtime stage. |

--- a/images.json
+++ b/images.json
@@ -145,7 +145,7 @@
       "name": "envoy",
       "origin": "build-time",
       "repository": "docker.io/envoyproxy/envoy",
-      "tag": "v1.39.0",
+      "tag": "v1.39.1",
       "buildArg": "ENVOY_IMAGE",
       "pulledBy": "deploy/docker/Dockerfile (envoy-bin stage).",
       "description": "Source of the envoy binary copied into the credential-proxy image."


### PR DESCRIPTION
## Summary

Moves the Envoy pin from `v1.39.0` to `v1.39.1`, the current patch on the 1.39 line. Envoy runs here as the credential-proxy sidecar in the platform-agent pod — it is not the cluster's ingress — so this is a patch-level bump inside a minor the install already runs, against a configuration surface the release does not change.

## Why This Change

`v1.39.1` (published 2026-08-27) is a security release fixing 13 CVEs. Most of them do not reach this deployment, and the honest reason to take it is hygiene rather than urgency — but the reasoning is worth writing down, because "13 CVEs" reads as an emergency and this is not one.

`deploy/shared/envoy-credential-proxy.yaml` is 44 lines: one listener on `127.0.0.1:8765` (pod-local, not a Service port), one virtual host with a single `match: { prefix: "/" }` route, the router filter and nothing else, a STATIC cluster to a unix socket, and the admin interface on a pipe. Against that config:

- **Structurally unreachable** — the two HTTP/3 defects (CVE-2026-73512, CVE-2026-48521) and the QUIC crash (CVE-2026-73549), because there is no HTTP/3 listener; both ext_authz defects (CVE-2026-50572, CVE-2026-73547), because there is no ext_authz filter; the RBAC path-matching bypass (CVE-2026-73553), because there is no RBAC filter; and the `safe_regex` charset change (CVE-2026-73552), because there is no regex matcher.
- **Reachable but low** — the path-parameter normalization fixes (CVE-2026-73511, CVE-2026-73551) land on a route that matches every path anyway, so there is nothing to bypass. The HTTP/1 pre-upgrade smuggling fix (CVE-2026-73548) applies to a connection pool whose only client is the agent container in the same pod. The admin stat-name HTML injection (CVE-2026-73546) is behind a unix socket with no HTTP exposure.
- **A behaviour change, not a hole** — CVE-2026-73550 starts counting dropped `Host` headers against header map limits. The chart sets none.

So the value is staying current on a patch line rather than closing a live exposure. Full list in the [upstream release notes](https://github.com/envoyproxy/envoy/releases/tag/v1.39.1).

## What Changed

- `images.json` — the `envoy` entry's pin, the source every other copy is generated or checked against.
- `deploy/docker/Dockerfile` — the build-time `ARG` default, which `make images-check` cross-checks against the inventory.
- `docs/site/src/content/docs/deploy/docker-images.md` — regenerated `<!-- BEGIN GENERATED -->` region, written by `make docs-generate`.

## Context

One of seven single-image bumps opened together, each independently revertable: Envoy, LiteLLM, fluent-bit, alpine/k8s, hindsight-api, the Go toolchain, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last, because it carries more than a version string. No open issue or pull request touches these files.

## Testing

- `make images-check` — passes; all five inventory checks green.
- `make docs-check` — passes.
- `prettier --check` on the changed Markdown — clean.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace `kubeagents-system`, operator `dns-endpoint-7dac349`. Live-test lease held throughout.

Exercised as part of **one batched run** covering all six non-Hermes bumps: the six branches were cherry-picked onto a scratch branch, the images built from it, and the install driven once. So the observations below are of a build that carried the other five bumps too — they isolate Envoy's version, not Envoy's version in isolation.

**Proven.** Envoy is not pulled as `envoyproxy/envoy` at runtime; `deploy/docker/Dockerfile` copies the binary out of it (`FROM ${ENVOY_IMAGE}:${ENVOY_VERSION} AS envoy-bin`) into this repo's own `credential-proxy` image. So the bump only takes effect through a rebuild, and that is what was tested.

Built and pushed `credential-proxy:imgbump-3f1748bf`, and checked the binary before deploying it:

```
$ docker run --rm --platform linux/amd64 --entrypoint /usr/local/bin/envoy \
    .../credential-proxy:imgbump-3f1748bf --version
/usr/local/bin/envoy  version: b579d07d3ad7ee11d32b105e91a5a39ad24718d7/1.39.1/Clean/RELEASE/BoringSSL
```

Deployed it and confirmed the running process, not the Deployment spec. Envoy runs as a native sidecar here — an initContainer with `restartPolicy=Always`, named `envoy-credential-proxy`:

```
$ kubectl exec -n kubeagents-system $POD -c envoy-credential-proxy -- /usr/local/bin/envoy --version
/usr/local/bin/envoy  version: b579d07d3ad7ee11d32b105e91a5a39ad24718d7/1.39.1/Clean/RELEASE/BoringSSL
```

Then confirmed it routes rather than merely starts. The backend behind the unix socket logged real traffic arriving through the new Envoy:

```
2026-08-31 21:34:59,488 INFO credential-proxy http "GET /healthz HTTP/1.1" 200 -
2026-08-31 21:35:05,538 INFO credential-proxy http "GET /v1/chat/events HTTP/1.1" 200 -
2026-08-31 21:35:14,481 INFO credential-proxy http "GET /healthz HTTP/1.1" 200 -
```

The operator agreed: `PlatformAgent` `.status` held `Ready=True`, reason `Reconciled`, message *"Agent sandbox and Envoy credential sidecar are fully reconciled"*, `deploymentStatus.readyReplicas: 1`, and all four containers `ready=true`.

Reverted to the baseline `credential-proxy:dns-endpoint-7dac349`; the rollout returned, the install is back on baseline, and the `imgbump-3f1748bf` tag has been deleted from the registry.

**Not covered, and why:**

- This install has no Helm release — it predates the chart — so nothing here exercises the chart substituting the pin from `images.json`. `make images-check` covers that statically, against both a default and a mirrored render.
- The batched run means no observation separates this bump from the other five. Nothing in the six diffs overlaps, but the evidence is joint.
- The behaviour-changing CVE fixes (`safe_regex` charset, `Host` header accounting) were reasoned about against the rendered config rather than exercised — there is no matcher or limit in that config to exercise them against.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran in the main loop first and its output went to both.

- **`review-adversarial`** — looked for a pin changed in one copy and missed in another, a tag that does not exist upstream, a configuration surface the new version renames, and a generated region left stale. **No CONFIRMED findings.** It went further than the diff: it built the proxy image at both versions and drove traffic through each, which is the risk class a base-image bump actually carries, and it checked every behaviour-changing CVE fix against this deployment — concluding the URL-normalization fixes do not alter the forwarded path here. It reported the release as carrying 14 CVEs; counting the identifiers in the upstream release body gives **13**, which is the figure used above.
- **`review-docs-drift`** — looked for prose the bump makes untrue, generated regions out of step with the inventory, and the version restated in narrative text as well as in the pin. **No Blocking findings.**
- **Advisory (`review-docs-drift`), LOW — fixed, in another pull request.** `docs/site/.../deploy/docker-images.md:14` claims "a version bump edits `images.json` and nothing else", which this diff falsifies: the Dockerfile `ARG` is a second copy. Five of the fourteen passes across this batch flagged it independently. The paragraph is rewritten in full in the **alpine/k8s** pull request; duplicating that rewrite here would conflict at merge. Merging either one fixes it.
- **Found by me, after the passes, and it changed this PR body rather than the diff.** My first draft of "Why This Change" described Envoy as terminating external chat ingress and called the CVEs remotely reachable. Reading `envoy-credential-proxy.yaml` to check a claim about `safe_regex` showed that is wrong — it is a localhost sidecar. Both passes had the diff, which does not include that file, so neither was positioned to catch it. Recording it because a reviewer should know the threat model in this body was corrected rather than got right first time.

## Risk & Rollout

Low. A patch bump inside a minor already running in production, on a sidecar reachable only from `127.0.0.1` inside its own pod. The blast radius is that pod: had 1.39.1 failed to load the rendered config, the container would crash-loop and the agent would lose its credential path — which the live test rules out against this install's actual config.

One behaviour change to name for downstream installs that have customised the proxy config beyond what ships: CVE-2026-73550 now counts dropped `Host` headers against header map size and count limits, so a request that previously slipped under a tight custom limit can now be rejected. The chart sets no such limits.

Revert is a one-line change to `images.json` plus `make docs-generate`. Nothing has to happen at merge time.

Generated with the help of Claude Opus 5.
