### PR TITLE
chore(deps): bump the replay proxy base from python 3.11-slim to 3.14-slim

### DIFF
--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -68,7 +68,7 @@ Needed only to rebuild the images above from source, not to run an install. Each
 | `hermes-agent` | `docker.io/nousresearch/hermes-agent` | `HERMES_AGENT_TAG` in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) | `HERMES_AGENT_IMAGE` | deploy/docker/Dockerfile (agent-base stage). |
 | `envoy` | `docker.io/envoyproxy/envoy` | `v1.39.1` | `ENVOY_IMAGE` | deploy/docker/Dockerfile (envoy-bin stage). |
 | `golang` | `docker.io/library/golang` | `1.26-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages. |
-| `python` | `docker.io/library/python` | `3.11-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile. |
+| `python` | `docker.io/library/python` | `3.14-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile. |
 | `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile runtime stage. |
 
 <!-- prettier-ignore-end -->

--- a/examples/inference-replay/replay-proxy/Dockerfile
+++ b/examples/inference-replay/replay-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build args so this can be rebuilt from a mirrored base; see
 # deploy/docker/Dockerfile for the reasoning. Defaults are upstream.
 ARG PYTHON_IMAGE=python
-ARG PYTHON_VERSION=3.11-slim
+ARG PYTHON_VERSION=3.14-slim
 FROM ${PYTHON_IMAGE}:${PYTHON_VERSION}
 WORKDIR /app
 RUN pip install fastapi uvicorn httpx

--- a/images.json
+++ b/images.json
@@ -163,7 +163,7 @@
       "name": "python",
       "origin": "build-time",
       "repository": "docker.io/library/python",
-      "tag": "3.11-slim",
+      "tag": "3.14-slim",
       "buildArg": "PYTHON_IMAGE",
       "pulledBy": "examples/inference-replay/replay-proxy/Dockerfile.",
       "description": "Runtime base for the replay proxy."


### PR DESCRIPTION
## Summary

Moves the replay-proxy's base image from `python:3.11-slim` to `python:3.14-slim`. Three lines: the `ARG PYTHON_VERSION` default, the `images.json` entry, and the generated table row that quotes it.

## Why This Change

3.11 is the oldest Python in the tree by a wide margin, and it is heading for end of security support. The replay proxy is a five-line Dockerfile over `fastapi`, `uvicorn`, and `httpx` — all three have supported 3.14 wheels — so there is no reason to hold it back, and holding it back is how an example quietly becomes the thing nobody can rebuild.

Three minors at once rather than one is deliberate: there is no intermediate state worth landing separately for a container that installs three packages and runs one script.

## What Changed

- `examples/inference-replay/replay-proxy/Dockerfile` — `ARG PYTHON_VERSION`, the build-time default.
- `images.json` — the `python` entry, which the `ARG` default is checked against by `make images-check`.
- `docs/site/src/content/docs/deploy/docker-images.md` — regenerated `<!-- BEGIN GENERATED -->` region.

Three lines, one value.

## Context

One of seven single-image bumps opened together, each independently revertable: the Python base, Envoy, LiteLLM, fluent-bit, alpine/k8s, hindsight-api, and the Go toolchain. The Hermes agent pin is deliberately not in this batch — it lands separately and last.

**One open pull request to coordinate with.** #913 adds a second `ARG PYTHON_VERSION=3.11-slim` elsewhere in the tree. It does not conflict textually with this diff, but whichever merges second leaves the repository with two Python bases at different versions, and `make images-check` will not catch it — the inventory has one `python` entry and check 1 verifies the `ARG` defaults it knows about. Worth a note on whichever lands second.

## Testing

- `make images-check` — passes; check 1 (build-time `ARG` defaults against the inventory) is the relevant one.
- `make docs-check` — passes.
- `prettier --check` on the changed Markdown — clean.

`pull-kube-agents-smoke-test` is red, and not because of this change. All 17 eval cases failed identically with `NOT_A_REAL_RUN` — "the trajectory is empty: the agent made no tool calls … no token accounting on the record (tokens.total is null)" — and the eval cluster was refusing connections by teardown. #1107, an unrelated bump on the same base SHA, has the same signature. Nothing in a replay-proxy base image reaches that job's install path.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), scratch namespace `replay-py314`, branch at `b4169c0a`. Live-test lease held throughout and released after.

**In-cluster, through the integration's own deploy path.** An earlier revision of this section said no live path existed for this image. That was wrong, and the correction is the point of this round: `make -C k8s-operator deploy-inference-replay` renders `k8s-operator/config/integrations/inference-replay/base/`, whose Deployment is `image: ${REPLAY_IMAGE}`. The path was taken.

- Built `examples/inference-replay/replay-proxy` from this branch, `--platform linux/amd64`, pushed to GAR, and deployed with `REPLAY_IMAGE` at that tag. The pod's `imageID` resolved to `sha256:e6c829aa…a5bc` — byte-for-byte the digest pushed, so everything below was observed on the branch's image and not a cached layer.
- Rolled out 1/1 and stayed Ready: the `readinessProbe` on `/admin/mode` passing, and the Service's endpoint list populated with the pod IP.
- Interpreter inside the running pod: `Python 3.14.7 (main, Sep  1 2026, 00:05:20) [GCC 14.2.0]` — distinctly not the 3.11 it replaces. `fastapi 0.141.1` and `httpx 0.28.1` imported from the same pod.
- **The behaviour the example exists to demonstrate, in-cluster.** Patched the `inference-replay-config` ConfigMap to `mode=on`; the proxy's watcher picked the change up off the mounted file (`mode changed: off -> on`) about 90s later, which is the kubelet's ConfigMap sync rather than the watcher. Then a record-then-replay cycle:

  ```
  before: {"mode":"on","cache_size":0,"valid_modes":["off","on"]}
  leg-1  cache MISS -> forwarded upstream, recorded
       133.0 ms  id=stub-upstream-call-1  content='upstream call #1'
  after leg-1: {"mode":"on","cache_size":1,"valid_modes":["off","on"]}
  leg-2  cache HIT  -> replayed from cache
         2.8 ms  id=stub-upstream-call-1  content='upstream call #1'
  after leg-2: {"mode":"on","cache_size":1,"valid_modes":["off","on"]}

  same response replayed, upstream not called twice: True
  ```

  The proxy's own log agrees — `Cache miss for hash: a49c1442…` / `Saved cache to /data/replay_cache.json` / `Cache hit for hash: a49c1442…. Replaying response.` — and the recorded entry is on the PVC, not just in memory.

**Why the upstream was a stub, and what was tried first.** The proxy was first pointed at the install's real LiteLLM Service. It answered HTTP 500: `litellm.InternalServerError: Vertex_aiException … ('invalid_grant: Invalid JWT Signature.')`. That is the gateway's own Vertex service-account credential no longer authenticating — **unrelated to this change**, reached over a Service this diff does not touch, and it fails that way for any client. The proxy handled it correctly (miss → forward → relay the 500 → record nothing, since only a 200 is recorded), which is an observation in its own right, but a 500 cannot produce a cache hit. A fixed-response upstream in the scratch namespace supplied the 200 the record leg needs. Reported against the install, not this branch.

**Why a scratch namespace rather than `kubeagents-system`.** The integration ships a `service.yaml` named `litellm` selecting `app: standalone-replay`. The install already has a Service of that name selecting `app: litellm` — the real gateway every agent model call goes through. Applying the integration into the default namespace would have repointed that name at the replay proxy and cut the agent off. `NAMESPACE=replay-py314` avoids it. Worth knowing before anyone follows the example's README against a live install.

**Local, retained from the earlier round.** Built and ran the image at both `3.11-slim` and `3.14-slim` and compared them, rather than only confirming the new one builds: `pip install fastapi uvicorn httpx` resolves all three to wheels rather than falling back to a source build, which a `-slim` base with no compiler could not complete. The 3.11 baseline behaved identically, which is what makes the 3.14 result a comparison. Independently reproduced by the adversarial pass, which built and ran the container without being told what I had observed.

**Cleaned up.** The scratch namespace is deleted, the test tag and its untagged manifests are gone from the registry, and the install is as it was — `kubeagents-system` still has its three Deployments and its `litellm` Service still selects `app: litellm`.

**Not covered.** The GHCR/GAR publish steps and `cosign sign` run only on `main`, so they were not exercised, and no 3.14 image has been through release-candidate verification.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both.

- **`review-adversarial`** — looked for a copy of the pin left behind, a tag that does not exist upstream, and dependencies without 3.14 support. **No CONFIRMED findings.** It built and ran the container at both versions independently to check the last of those.
- **`review-docs-drift`** — looked for prose the bump makes untrue, generated regions out of step with `images.json`, and the version restated in narrative text. **No Blocking findings.**
- **Advisory — reported, not fixed: #913's second `ARG`.** Recorded in Context above. Not fixed here because that `ARG` does not exist on this branch's base — there is nothing in this diff's tree to edit. It is a merge-order note for whichever pull request lands second, not a defect in either.
- **Three findings from `kube-agents-bot`, all confirmed against the tree and all fixed — in this body, since none of them was about the diff.** "Nothing has to happen at merge time" was wrong, and Risk & Rollout now says what merging actually starts. The blast radius was understated: the image is built, pushed and `cosign sign`ed on every push to `main` and gates release-candidate verification. And "no live path exists" was wrong — the path exists, and Live validation above is that path taken. Both pre-PR passes read the diff and found nothing wrong with it; all three errors were in the prose *about* the diff, where neither pass was looking. Naming that because it is the gap, not because the passes were skipped.

## Risk & Rollout

Low for anything running today, and not nothing at merge.

**At merge.** `images.json` is a trigger path of `.github/workflows/autopush-redeploy-integrations.yml`, and the `dorny/paths-filter` in `reusable-deploy-integrations.yml` lists that file under **both** the `litellm` and `github` groups — written for the pins that share the file, and unable to tell a `python` base-image bump from one of those. Squash-merging this therefore runs `provision-secrets`, `deploy-litellm` and `deploy-github` unattended against the `autopush` environment: three `helm upgrade`s on the shared release. This diff changes no chart-rendered value, so they should be no-ops — but the workflow's own header comment warns that an upgrade cancelled mid-flight strands the release in `pending-upgrade` until someone rolls it back by hand. Watch that run rather than assuming it is inert. The coarse filter is pre-existing and not fixed here: teaching it to distinguish entries inside `images.json` is a change to the deploy surface and wants its own review.

**On `main`.** `docker-publish-ghcr.yml` builds this context on every push, pushes `replay-proxy:latest` and `replay-proxy:<sha>`, and `cosign sign`s the digest; `docker-publish-gcp.yml` mirrors it into GAR. `scripts/release/common.sh` lists `replay-proxy` in `REQUIRED_RELEASE_IMAGES`, so a build failure would remove the image for that commit and fail release-candidate verification, not just an example.

**On a cluster.** Nothing in `charts/` or `terraform/` references the image, but `k8s-operator/config/integrations/inference-replay/base/deployment.yaml` does, with `imagePullPolicy: Always`. Anywhere `make deploy-inference-replay` has been run against a floating tag, the new base arrives on the next pod restart with no deploy step. That is the path exercised above, and it served a record/replay cycle on 3.14.

Three minors at once is the largest interpreter jump in the batch, so the risk that exists at all is a dependency without 3.14 wheels — checked directly, all three resolve.

**Revert** is the `ARG` default, the `images.json` entry, and `make docs-generate`. That restores the source; it does not un-publish the `:latest` and `:<sha>` tags a merge will already have pushed, so `:latest` returns only when the revert commit's own build overwrites it.

Generated with the help of Claude Opus 5.
