### PR TITLE
chore(deps): bump fluent-bit from 5.1.0 to 5.1.1

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -458,7 +458,7 @@ injects into every agent pod — so nothing else sets them:
 ```bash
 kubectl set env deployment/kubeagents-controller-manager -n kubeagents-system \
   PLATFORM_AGENT_IMAGE=registry.example.com/kube-agents/platform-agent:latest \
-  FLUENT_BIT_IMAGE=registry.example.com/kube-agents/fluent-bit:5.1.0
+  FLUENT_BIT_IMAGE=registry.example.com/kube-agents/fluent-bit:5.1.1
 ```
 
 The Helm chart does this for you when a registry prefix

--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -388,7 +388,7 @@ githubMinter:
 fluentBit:
   image:
     repository: docker.io/fluent/fluent-bit
-    tag: "5.1.0"
+    tag: "5.1.1"
 
 platformAgent:
   enabled: true

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -48,7 +48,7 @@ Pinned here so `make mirror-images` and the install ask for the same version.
 | Image | Upstream reference | Pin | Override | Pulled by |
 | ----- | ------------------ | --- | -------- | --------- |
 | `litellm` | `ghcr.io/berriai/litellm` | `v1.96.2` | `LITELLM_IMAGE` | The LiteLLM gateway, from either the chart or the kustomize integration. |
-| `fluent-bit` | `docker.io/fluent/fluent-bit` | `5.1.0` | `FLUENT_BIT_IMAGE` | The logging sidecar the operator injects into every agent pod. |
+| `fluent-bit` | `docker.io/fluent/fluent-bit` | `5.1.1` | `FLUENT_BIT_IMAGE` | The logging sidecar the operator injects into every agent pod. |
 | `k8s` | `docker.io/alpine/k8s` | `1.36.2` | — | The chart's pre-delete cleanup hook Job. |
 | `github-token-minter-server` | `us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server` | `v2.7.1-amd64` | `GITHUB_MINTER_IMAGE` | The optional GitHub integration. |
 | `hindsight-api` | `ghcr.io/vectorize-io/hindsight-api` | `0.9.2@sha256:7b14a1f4062252992d0176758753615e0a2071d9a269995be007be223ab01812` | `HINDSIGHT_API_IMAGE` | The chart, when the memory provider uses Hindsight (make deploy-hindsight for the kustomize dev path). |

--- a/images.json
+++ b/images.json
@@ -49,7 +49,7 @@
       "name": "fluent-bit",
       "origin": "third-party",
       "repository": "docker.io/fluent/fluent-bit",
-      "tag": "5.1.0",
+      "tag": "5.1.1",
       "override": "FLUENT_BIT_IMAGE",
       "pulledBy": "The logging sidecar the operator injects into every agent pod.",
       "description": "Ships agent container logs off the pod."

--- a/k8s-operator/config/manager/manager.yaml
+++ b/k8s-operator/config/manager/manager.yaml
@@ -57,7 +57,7 @@ spec:
             # - name: CREDENTIAL_PROXY_IMAGE
             #   value: "registry.example.com/kube-agents/credential-proxy:latest"
             # - name: FLUENT_BIT_IMAGE
-            #   value: "registry.example.com/mirror/fluent-bit:5.1.0"
+            #   value: "registry.example.com/mirror/fluent-bit:5.1.1"
             # IMAGE_PULL_SECRETS is the pull identity for those images, as
             # comma-separated names of Secrets that must already exist in each
             # agent's namespace. Needed only for a registry the nodes cannot

--- a/k8s-operator/internal/controller/manifest_helpers.go
+++ b/k8s-operator/internal/controller/manifest_helpers.go
@@ -50,7 +50,7 @@ func fallbackPlatformAgentImage() string {
 }
 
 const (
-	fallbackFluentBitImage = "fluent/fluent-bit:5.1.0"
+	fallbackFluentBitImage = "fluent/fluent-bit:5.1.1"
 
 	// Operator-level image overrides for installs that mirror images into a
 	// private registry. Set on the controller-manager Deployment; a CR's

--- a/k8s-operator/internal/controller/platformagent_manifests_test.go
+++ b/k8s-operator/internal/controller/platformagent_manifests_test.go
@@ -844,8 +844,8 @@ func TestBuildDeployment(t *testing.T) {
 	if fbContainer.Name != "fluent-bit" {
 		t.Errorf("expected container name fluent-bit, got %s", fbContainer.Name)
 	}
-	if fbContainer.Image != "fluent/fluent-bit:5.1.0" {
-		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.1.0, got %s", fbContainer.Image)
+	if fbContainer.Image != "fluent/fluent-bit:5.1.1" {
+		t.Errorf("expected fluent-bit image fluent/fluent-bit:5.1.1, got %s", fbContainer.Image)
 	}
 	if fbContainer.SecurityContext == nil || fbContainer.SecurityContext.ReadOnlyRootFilesystem == nil || !*fbContainer.SecurityContext.ReadOnlyRootFilesystem {
 		t.Errorf("expected SecurityContext.ReadOnlyRootFilesystem true on fluent-bit container")
@@ -1412,10 +1412,10 @@ func TestImageEnvOverrides(t *testing.T) {
 }
 
 func TestFluentBitImageEnvOverride(t *testing.T) {
-	if got := fluentBitImage(); got != "fluent/fluent-bit:5.1.0" {
+	if got := fluentBitImage(); got != "fluent/fluent-bit:5.1.1" {
 		t.Fatalf("unexpected default fluent-bit image: %s", got)
 	}
-	t.Setenv("FLUENT_BIT_IMAGE", "registry.corp/mirror/fluent-bit:5.1.0")
+	t.Setenv("FLUENT_BIT_IMAGE", "registry.corp/mirror/fluent-bit:5.1.1")
 
 	agent := &agentv1alpha1.PlatformAgent{
 		ObjectMeta: metav1.ObjectMeta{Name: "my-agent", Namespace: "my-ns"},
@@ -1425,7 +1425,7 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 	for _, c := range dep.Spec.Template.Spec.Containers {
 		if c.Name == "fluent-bit" {
 			found = true
-			if c.Image != "registry.corp/mirror/fluent-bit:5.1.0" {
+			if c.Image != "registry.corp/mirror/fluent-bit:5.1.1" {
 				t.Fatalf("expected FLUENT_BIT_IMAGE override on sidecar, got %s", c.Image)
 			}
 		}
@@ -1444,7 +1444,7 @@ func TestFluentBitImageEnvOverride(t *testing.T) {
 func TestNoPublicRegistryWhenMirrored(t *testing.T) {
 	const mirror = "registry.corp/mirror"
 	t.Setenv("PLATFORM_AGENT_IMAGE", mirror+"/platform-agent:v1.2.3")
-	t.Setenv("FLUENT_BIT_IMAGE", mirror+"/fluent-bit:5.1.0")
+	t.Setenv("FLUENT_BIT_IMAGE", mirror+"/fluent-bit:5.1.1")
 	// CREDENTIAL_PROXY_IMAGE deliberately left unset: the sidecar must derive
 	// its registry from PLATFORM_AGENT_IMAGE, not fall back to ghcr.io.
 

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-egress-allowlist.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-egress-allowlist.yaml
@@ -1039,7 +1039,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-scoped-sa.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-scoped-sa.yaml
@@ -746,7 +746,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-split-broker.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-split-broker.yaml
@@ -1039,7 +1039,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-tagged.yaml
@@ -745,7 +745,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-telemetry.yaml
@@ -702,7 +702,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent.yaml
@@ -745,7 +745,7 @@ spec:
         - args:
             - -c
             - /fluent-bit/etc/fluent-bit.conf
-          image: fluent/fluent-bit:5.1.0
+          image: fluent/fluent-bit:5.1.1
           name: fluent-bit
           resources:
             limits:

--- a/tests/test_deploy_image_confirmation.py
+++ b/tests/test_deploy_image_confirmation.py
@@ -216,7 +216,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
             sandbox-credential-cleanup={_GHCR}/platform-agent:{_TAG}
             envoy-credential-proxy={_GHCR}/credential-proxy:{_TAG}
             platform-agent={_GHCR}/platform-agent:{_TAG}
-            fluent-bit=docker.io/fluent/fluent-bit:5.1.0
+            fluent-bit=docker.io/fluent/fluent-bit:5.1.1
             """
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -226,7 +226,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
         result = self._run(
             f"""
             platform-agent={_GHCR}/platform-agent:{_TAG}
-            fluent-bit=docker.io/fluent/fluent-bit:5.1.0
+            fluent-bit=docker.io/fluent/fluent-bit:5.1.1
             """
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -240,7 +240,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
             sandbox-credential-cleanup={_MIRROR}/platform-agent:{_TAG}
             envoy-credential-proxy={_MIRROR}/credential-proxy:{_TAG}
             platform-agent={_MIRROR}/platform-agent:{_TAG}
-            fluent-bit={_MIRROR}/fluent-bit:5.1.0
+            fluent-bit={_MIRROR}/fluent-bit:5.1.1
             """
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
@@ -254,7 +254,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
             sandbox-credential-cleanup={_GHCR}/platform-agent:{_OLD}
             envoy-credential-proxy={_GHCR}/credential-proxy:{_OLD}
             platform-agent={_GHCR}/platform-agent:{_OLD}
-            fluent-bit=docker.io/fluent/fluent-bit:5.1.0
+            fluent-bit=docker.io/fluent/fluent-bit:5.1.1
             """,
             cr_image=f"{_GHCR}/platform-agent:{_OLD}",
         )
@@ -334,7 +334,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
             f"""
             platform-agent={_GHCR}/platform-agent:{_TAG}
             envoy-credential-proxy={_GHCR}/credential-proxy:{_OLD}
-            fluent-bit=docker.io/fluent/fluent-bit:5.1.0
+            fluent-bit=docker.io/fluent/fluent-bit:5.1.1
             """
         )
         self.assertEqual(result.returncode, 1)
@@ -348,7 +348,7 @@ class ConfirmAgentImageScriptTest(_StubKubectl, unittest.TestCase):
 
     def test_it_fails_when_no_release_image_is_present(self):
         # An unrecognisable read-back is not a pass.
-        result = self._run("fluent-bit=docker.io/fluent/fluent-bit:5.1.0")
+        result = self._run("fluent-bit=docker.io/fluent/fluent-bit:5.1.1")
         self.assertEqual(result.returncode, 1)
         self.assertIn("Found no first-party release image", result.stdout)
 


### PR DESCRIPTION
## Summary

Moves the fluent-bit pin from `5.1.0` to `5.1.1`. Unlike the other bumps in this batch, this one is not only a manifest edit: the operator also carries the fluent-bit reference as a **compiled-in constant** (`fallbackFluentBitImage`), so the pin lives in two places that reach a cluster by different routes.

- **A Helm install reads the chart value.** `operator-deployment.yaml` renders `FLUENT_BIT_IMAGE` onto the controller-manager unconditionally — not only under a mirror — and `fluentBitImage()` reads that env var before the constant. A `helm upgrade` carrying this `values.yaml` moves every agent pod's sidecar with no operator rebuild anywhere.
- **An install that sets no `FLUENT_BIT_IMAGE` reads the constant**, and that copy moves only through a rebuilt operator binary.

The diff updates both, plus the chart value, the commented example, the install guide, and the golden manifests that assert on the rendered sidecar.

## Why This Change

`5.1.1` is the current patch on the 5.1 line, which the install already runs. Staying on `5.1.0` is not a live exposure — the value is keeping the log-shipping sidecar on a supported patch, and keeping the places that state the version from drifting apart.

The reason this is worth reading the diff for is the constant. Leaving it behind while the chart value moves would produce two answers to "which fluent-bit does this install run", decided by how the install was deployed.

## What Changed

- `k8s-operator/internal/controller/manifest_helpers.go` — `fallbackFluentBitImage`, the default for an install with no `FLUENT_BIT_IMAGE` set. This is the edit that requires an operator rebuild to take effect.
- `charts/kube-agents/values.yaml` — `fluentBit.image.tag`, checked against `images.json` by `make images-check`. This is the one a Helm install actually reads.
- `images.json` — the inventory entry, source for everything above.
- `INSTALL.md`, `docs/site/src/content/docs/deploy/docker-images.md`, and `k8s-operator/config/manager/manager.yaml` — a worked `kubectl set env` example, a generated inventory row, and a commented-out env var, all of which state the version.
- `k8s-operator/internal/controller/platformagent_manifests_test.go` and six golden manifests under `.../testing/testdata/platform/expected/` — the assertions that pin the rendered sidecar image. The sixth, `platformagent-egress-allowlist.yaml`, arrived on `main` in #963 after this branch was cut; see Self-Review.
- `tests/test_deploy_image_confirmation.py` — six fixtures. See Self-Review: these were already stale before this change.

## Context

One of seven single-image bumps opened together, each independently revertable: fluent-bit, Envoy, LiteLLM, alpine/k8s, hindsight-api, the Go toolchain, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last. No open issue or pull request touches these files.

Adjacent open work worth flagging for merge order rather than correctness: #963 and #720 both touch `manifest_helpers.go`. Neither changes the constant, so the collision is textual.

## Testing

Everything below was re-run at the current head, `a9aae250`, which sits on `upstream/main` past #1119. The rebase resolved one conflict, in the generated table in `docs/site/src/content/docs/deploy/docker-images.md`, where the merged alpine/k8s bump moved the row next to fluent-bit's; both sides' values were kept. The intervening commits touch `manifest_helpers.go` and `platformagent_manifests.go` only through #504, which shifted the line numbers this description cites — updated below, and re-checked at this head — and left the code they point at as it was. What the rebase did change is the diff itself: it pulled in a sixth golden manifest this branch had to update. See Self-Review.

- `make images-check` — passes; check 2 (the compiled constant) is the one that matters here and it is green.
- `make docs-check` — passes.
- `go build ./...` in `k8s-operator/` — clean.
- `go test ./internal/controller/... ./internal/testing/...` — green, including all six golden manifests. `internal/testing` is the package the sixth one lives in, and it failed on this branch until the rebase past #1119; see Self-Review.
- `tests/test_deploy_image_confirmation.py` — 24 passed.
- `prettier --check` on the changed Markdown and YAML — clean.
- **Chart render, both shapes**, at `a9aae250` — the Helm route the Summary describes. Static, not a live upgrade:

```
$ helm template ka charts/kube-agents \
    --set platformAgent.harness.clusterName=ci-cluster \
    --set platformAgent.harness.location=us-central1 \
    --set platformAgent.harness.projectId=ci-project \
  | grep -A1 'name: FLUENT_BIT_IMAGE'
            - name: FLUENT_BIT_IMAGE
              value: "docker.io/fluent/fluent-bit:5.1.1"

$ ...same, plus --set global.imageRegistry=us-central1-docker.pkg.dev/example/mirror
            - name: FLUENT_BIT_IMAGE
              value: "us-central1-docker.pkg.dev/example/mirror/fluent-bit:5.1.1"
```

Both land on the `ka-controller-manager` Deployment, and neither is gated on a mirror being configured.

**Why `Run Controller Tests` was red on the two previous heads.** `main` was briefly broken, not by this branch: #963 added a sixth golden manifest, #504 landed afterwards and regenerated only the five that existed when it was written, so `platformagent-egress-allowlist.yaml` was missing #504's `gitops-state-volume` rendering. Clean `upstream/main` failed `go test ./internal/testing/...` for that reason with nothing checked out on top, and every green `Run Controller Tests` on a sibling bump at the time was a branch that had not rebased onto #504 yet. #1119 (bnaylor) regenerated exactly that file; this branch deferred to it rather than duplicating the fix, and is now rebased past it. The two edits landed in different hunks of the file and merged without conflict.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace `kubeagents-system`. Live-test lease held throughout. Exercised as part of **one batched run** covering all six non-Hermes bumps — the branches were cherry-picked onto a scratch branch and the images built from it, so the evidence isolates this bump's mechanism but not this branch in isolation.

**Proven, and the mechanism rather than a coincidence.** The install's baseline was fluent-bit **5.0.7** — two patches behind the old pin, not equal to it. That is what makes the observation mean something: had the baseline been 5.1.0, seeing 5.1.1 would not have told us which copy drove it.

Built and deployed an operator from the branch with **no `FLUENT_BIT_IMAGE` env var set anywhere** — neither on the controller-manager Deployment nor on the CR. The operator then re-rendered the agent Deployment's sidecar from `5.0.7` to `5.1.1` on its own, which can only have come from the recompiled constant.

Confirmed it was running and shipping, not merely scheduled:

```
$ kubectl get pod -n kubeagents-system -l app=platform-agent-gateway \
    -o jsonpath='{...containers[?(@.name=="fluent-bit")].image}'
fluent/fluent-bit:5.1.1
```

with the container `ready=true` and its logs actively parsing and forwarding records.

Then reverted: rolling the operator back to `dns-endpoint-7dac349` returned the sidecar to `5.0.7`, so the new value tracks the binary rather than having been written once and stuck. The install is back on baseline and no artifacts remain.

This run predates the rebase. It was not repeated at `a9aae250`: what it proves is that the recompiled constant drives the rendered sidecar, and the rebase changed neither the constant, `fluentBitImage()`, nor the code that renders the container — confirmed by re-running the full controller suite and the golden manifests at the new head rather than assumed.

**Not covered — the Helm route, which is the one most installs take.** This install has no Helm release (it predates the chart), so what ran was the constant path with `FLUENT_BIT_IMAGE` deliberately unset. No cluster was observed picking the tag up through `helm upgrade`. The chart route rests on the render above and on `make images-check`, both static.

**Not covered — a registry that does not yet hold the tag.** The live install could already resolve `5.1.1`, which is the case the pull-failure mode below does not apply to.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both.

- **`review-adversarial`** — looked for a copy of the pin left behind (the constant, the chart value, the golden files, the commented example), a version that does not exist upstream, and golden manifests updated to match the code rather than the code being right. **No CONFIRMED findings.**
- **`review-docs-drift`** — looked for prose the bump makes untrue, generated regions out of step with `images.json`, and the version restated in narrative text. **No Blocking findings.**
- **`kube-agents-bot`, two Medium findings — both verified against the source, both correct, both fixed.** Neither is a defect in the diff; both were false claims in this description, which AGENTS.md ranks above most code defects because they misdirect every later reader.
  - *"Only reaches a cluster through a rebuilt operator binary."* Wrong for any Helm install. `charts/kube-agents/templates/operator-deployment.yaml:60-61` renders `FLUENT_BIT_IMAGE` with no conditional, `operator.enabled` defaults to `true` (`values.yaml:74`), and `fluentBitImage()` prefers the env var (`manifest_helpers.go:260-265`), so the constant is never consulted there. **Fixed** — Summary and Risk & Rollout now carry both routes, with the chart render under Testing as the evidence the original claim lacked. The mirror corollary holds too and is now stated: `thirdPartyImageRegistry` falls back to `global.imageRegistry` (`_helpers.tpl:50-53`), so a mirrored install asks for `<mirror>/fluent-bit:5.1.1` on upgrade whether or not `make mirror-images` has been re-run.
  - *"Degraded observability, not a serving outage."* Also wrong, in the safe-sounding direction. **Fixed** — see Risk & Rollout, rewritten with the three source locations.
  - Why the pre-PR passes missed both: each subagent got the diff range and nothing else, which is the rule, and neither finding is visible in the diff — both are claims in prose that did not exist when the passes ran. Worth recording as a limit of the pre-PR passes on a description-heavy change, not as a fault in them.
- **Advisory — fixed here, and it is a pre-existing defect this change did not cause.** `tests/test_deploy_image_confirmation.py` carried six hard-coded `5.1.0` fixtures that the pass judged inert: they are input strings to a confirmation-prompt test, not assertions about the real pin, so they would not have failed. They are updated to `5.1.1` anyway. The reason to fix rather than file: they are string literals of exactly the version this PR moves, in a file about deploying images, and leaving six stale copies behind is how the next reader concludes the pin is `5.1.0`. 24/24 tests pass. This is scope creep of six identical one-word edits, and a reviewer who wants them out can say so.
- **Found by the rebase, not by any pass, and fixed: a sixth copy of the pin.** #963 landed on `main` after this branch was cut, adding `platformagent-egress-allowlist.yaml` — a golden manifest that asserts the rendered sidecar image. This branch updated five and left that one on `5.1.0`, which is precisely the "copy of the pin left behind" the adversarial pass went looking for; it found none because the sixth file did not exist in the tree it was handed. **Fixed**, and carried through the rebase past #1119. `grep -rn 'fluent-bit:5\.1\.0'` across the tree now returns nothing. The general lesson is not about this pin: a pass run against a branch's own tree cannot see a copy that `main` adds afterwards, so on a change that edits every instance of a literal, the grep is worth re-running at the rebased head rather than trusting the pre-rebase pass.
- **Advisory — reported, not fixed.** #963 and #720 also touch `manifest_helpers.go`. Textual collision only; neither touches the constant. #1119 has since merged and this branch is rebased past it; the two edits to the shared golden file are in different hunks and merged cleanly.
- **A judgement I made and am flagging so a reviewer can overrule it.** The fixture edit landed *after* both preflight passes had run. I did not re-run them for it, on the grounds that both had already read that file and graded those lines inert, and the edit changes six same-shaped string literals to the same new value. `review-preflight` §7 says to re-run whatever a fix invalidates; I judged this did not invalidate anything. If you disagree, that is a `/review` away.

## Risk & Rollout

Low as a version change, with two notes that are not obvious from the diff.

**Which copy of the pin an install reads decides when it moves.** A Helm install reads the chart value: `helm upgrade` with this `values.yaml` rewrites `FLUENT_BIT_IMAGE` on the controller-manager, restarts it, and the next reconcile re-renders every agent pod's sidecar — no operator rebuild, and agent pod restarts included. An install that sets no `FLUENT_BIT_IMAGE` reads the compiled constant, and for that one merging this change moves nothing until the operator is rebuilt and rolled out. Both are existing behaviour rather than anything this change introduces.

**Blast radius is the agent, not just its logs.** The rendered fluent-bit is an ordinary entry in `containers` — no probes, no `restartPolicy: Always` sidecar semantics (`platformagent_manifests.go:3406`). Had `5.1.1` failed to pull or failed to parse the rendered config, the container would not be running, the pod's `Ready` condition would go false, and the pod would leave the endpoints of the agent Service, which is a plain selector with `publishNotReadyAddresses` unset (`platformagent_manifests.go:3822-3835`). The default rollout shape compounds it: one replica with `Recreate` (`manifest_helpers.go:427-431`), so the old pod is deleted before the new one pulls and there is nothing behind it. The failure mode is a serving outage.

The live test rules that out against one install's actual fluent-bit config, with the tag already resolvable from its registry. It does not rule out a mirror that has not been given `5.1.1`; `make mirror-images` before the chart upgrade is the guard there, as it is for any image bump.

Revert is `images.json` plus `make docs-generate`, then rebuild the operator.

Generated with the help of Claude Opus 5.

