### PR TITLE
chore(deps): bump LiteLLM from v1.96.2 to v1.98.0

### DIFF
--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -217,7 +217,7 @@ litellm:
     # copies: a chart pinned to a version the mirror was never populated with
     # is an ImagePullBackOff. This pin sat a release behind the kustomize base
     # for exactly that reason.
-    tag: v1.96.2
+    tag: v1.98.0
     pullPolicy: IfNotPresent
   replicaCount: 2
   # Rollout strategy — the canonical home for this argument. The chart template

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -49,7 +49,7 @@ Pinned here so `make mirror-images` and the install ask for the same version.
 
 | Image | Upstream reference | Pin | Override | Pulled by |
 | ----- | ------------------ | --- | -------- | --------- |
-| `litellm` | `ghcr.io/berriai/litellm` | `v1.96.2` | `LITELLM_IMAGE` | The LiteLLM gateway, from either the chart or the kustomize integration. |
+| `litellm` | `ghcr.io/berriai/litellm` | `v1.98.0` | `LITELLM_IMAGE` | The LiteLLM gateway, from either the chart or the kustomize integration. |
 | `fluent-bit` | `docker.io/fluent/fluent-bit` | `5.1.1` | `FLUENT_BIT_IMAGE` | The logging sidecar the operator injects into every agent pod. |
 | `k8s` | `docker.io/alpine/k8s` | `1.36.2` | — | The chart's pre-delete cleanup hook Job. |
 | `github-token-minter-server` | `us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server` | `v2.7.1-amd64` | `GITHUB_MINTER_IMAGE` | The optional GitHub integration. |

--- a/examples/litellm-chatgpt-subscription/deployment.yaml
+++ b/examples/litellm-chatgpt-subscription/deployment.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.96.2
+          image: ghcr.io/berriai/litellm:v1.98.0
           args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: CHATGPT_TOKEN_DIR

--- a/examples/litellm-gemini/deployment.yaml
+++ b/examples/litellm-gemini/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: litellm-container
-          image: ghcr.io/berriai/litellm:v1.96.2
+          image: ghcr.io/berriai/litellm:v1.98.0
           args: ["--config", "/app/config.yaml", "--port", "8080"]
           env:
             - name: GEMINI_API_KEY

--- a/images.json
+++ b/images.json
@@ -56,7 +56,7 @@
       "name": "litellm",
       "origin": "third-party",
       "repository": "ghcr.io/berriai/litellm",
-      "tag": "v1.96.2",
+      "tag": "v1.98.0",
       "override": "LITELLM_IMAGE",
       "pulledBy": "The LiteLLM gateway, from either the chart or the kustomize integration.",
       "description": "The model gateway the agent's baked default endpoint points at."

--- a/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
+++ b/k8s-operator/testing/staging_workloads/charts/workload-bundle/values.yaml
@@ -145,7 +145,7 @@ litellmGateway:
   replicaCount: 1
   image:
     repository: "ghcr.io/berriai/litellm"
-    tag: "v1.96.2"
+    tag: "v1.98.0"
   modelProvider: "gemini"
   modelName: "gemini-3.5-flash"
   useDummySecret: true


### PR DESCRIPTION
## Summary

Moves the LiteLLM pin from `v1.96.2` to `v1.98.0`, two minor releases forward. LiteLLM is the model gateway every agent call goes through, so this is the largest jump in the batch by release distance. `v1.98.0` is the latest stable — the newer tags upstream carries are prereleases, and this deliberately skips them.

## Why This Change

Two minors of upstream fixes on the component that brokers every model call. Nothing in the diff is driven by a specific CVE; the reason is that LiteLLM moves fast and a gateway two minors behind accumulates provider-compatibility bugs that surface as a single provider quietly failing rather than as an outage.

The version is stated in five places besides the inventory — the chart, two `examples/` deployments, and a staging workload bundle — so the bump is also about keeping those from diverging.

## What Changed

- `images.json` — the `litellm` entry, source for the rest.
- `charts/kube-agents/values.yaml` — the chart's pin, cross-checked by `make images-check` on both a default and a mirrored render.
- `examples/litellm-gemini/deployment.yaml` and `examples/litellm-chatgpt-subscription/deployment.yaml` — the two worked provider examples, covered by inventory check 4.
- `.../testing/staging_workloads/charts/workload-bundle/values.yaml` — the staging bundle's copy.
- `docs/site/src/content/docs/deploy/docker-images.md` — regenerated `<!-- BEGIN GENERATED -->` region.

## Context

One of seven single-image bumps opened together, each independently revertable: LiteLLM, Envoy, fluent-bit, alpine/k8s, hindsight-api, the Go toolchain, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last. No open issue or pull request touches these files.

Version choice: upstream had tags newer than `v1.98.0` at the time of writing, all prereleases. This takes the latest stable.

## Testing

- `make images-check` — passes; all five checks, including the two `examples/` manifests.
- `make docs-check` — passes.
- `prettier --check` on the changed Markdown and YAML — clean.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace `kubeagents-system`. Live-test lease held throughout. Exercised as part of one batched run covering all six non-Hermes bumps.

**Partial, and the gap is the important part of this section.**

What was proven: patched the `litellm` Deployment to `ghcr.io/berriai/litellm:v1.98.0` and it rolled out **2/2 ready**. Both replicas passed their readiness probes, and `/v1/models` returned a response byte-identical to the baseline — so the two minors did not change the model catalogue this install exposes, drop a configured provider, or alter the config schema `litellm-config.yaml` uses. A config-schema break across two minors was the most likely failure mode, and this rules it out.

**What could not be proven: an actual completion.** Requests fail with `invalid_grant: Invalid JWT Signature` from Vertex. This is **not caused by the bump** — it reproduces identically on the install's baseline `v1.95.0`. The install's Vertex service-account key is broken, which is a pre-existing problem on this cluster that I am reporting separately; it is not something this branch can fix or work around.

So the honest position: the gateway starts, stays ready, and serves its metadata endpoints identically under `v1.98.0`, and the end-to-end path through to a model response is untested on this install. A reviewer with a working Vertex credential, or any install using a different provider, could close that gap in one request.

Reverted to `v1.95.0` afterwards; the install is back on baseline with no artifacts left behind.

Also not covered: this install has no Helm release (it predates the chart), so the chart value was not the path under test, and neither `examples/` deployment nor the staging bundle was exercised — `make images-check` covers all three statically.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both.

- **`review-adversarial`** — looked for one of the six copies left behind, a tag that does not exist upstream or is a prerelease, and a configuration key the two minors renamed or removed. **No CONFIRMED findings.**
- **`review-docs-drift`** — looked for prose the bump makes untrue, generated regions out of step with the inventory, and the version restated in narrative text. **No Blocking findings.**
- **Advisory — the live-test gap above.** The pass flagged that a LiteLLM bump whose validation stops at readiness has not tested the thing LiteLLM does. That is correct and it is not fixed: the blocker is the install's broken Vertex key, which reproduces on the baseline image. Recorded here rather than dismissed, because "rolled out 2/2" on its own would overstate what this was tested to.

## Risk & Rollout

Moderate by position, low by evidence — and the highest-risk of the six non-Hermes bumps, because it is two minors on the component every model call traverses.

The failure mode that matters is a config-schema change: if `v1.98.0` rejected the rendered `litellm-config.yaml`, the pods would fail readiness and every agent call would fail at once. The live test rules that out on this install's actual config — both replicas ready, `/v1/models` unchanged. The residual risk is a provider-specific behaviour change on the completion path, which is exactly what the broken Vertex key prevented testing.

Blast radius is total for model calls and zero for everything else; there is no data migration and no persistent state. Revert is a one-line change to `images.json` plus `make docs-generate`, and a rollout — the previous image is still in the registry. Nothing has to happen at merge time.

Given the untested completion path, this is the one of the batch worth rolling out to a non-production install first.

Generated with the help of Claude Opus 5.
