### PR TITLE
chore(deps): bump hindsight-api from 0.9.1 to 0.9.2

### DIFF
--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -292,7 +292,7 @@ hindsight:
     # tag, because that is what mirror-images pushes.
     image:
       repository: ghcr.io/vectorize-io/hindsight-api
-      tag: "0.9.1@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab"
+      tag: "0.9.2@sha256:7b14a1f4062252992d0176758753615e0a2071d9a269995be007be223ab01812"
       pullPolicy: IfNotPresent
     # Recall is CPU-bound on the in-process cross-encoder reranker; see the
     # template before raising these — more CPU has been measured to buy

--- a/docs/designs/memory.md
+++ b/docs/designs/memory.md
@@ -449,7 +449,7 @@ It adds exactly two workloads to `kubeagents-system`.
 
 **1. `hindsight-api` — a `Deployment`, one replica** (`api.yaml`).
 
-- Image `ghcr.io/vectorize-io/hindsight-api:0.9.1`, pinned by digest. The pin
+- Image `ghcr.io/vectorize-io/hindsight-api:0.9.2`, pinned by digest. The pin
   lives in `images.json` at the repository root and the manifest takes it as a
   variable, so a mirrored install can point it at an approved registry.
 - Serves HTTP on **8888** behind a ClusterIP `Service` of the same name;

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -44,7 +44,7 @@ Pinned here so `make mirror-images` and the install ask for the same version.
 | `fluent-bit` | `docker.io/fluent/fluent-bit` | `5.1.0` | `FLUENT_BIT_IMAGE` | The logging sidecar the operator injects into every agent pod. |
 | `k8s` | `docker.io/alpine/k8s` | `1.34.9` | — | The chart's pre-delete cleanup hook Job. |
 | `github-token-minter-server` | `us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server` | `v2.7.1-amd64` | `GITHUB_MINTER_IMAGE` | The optional GitHub integration. |
-| `hindsight-api` | `ghcr.io/vectorize-io/hindsight-api` | `0.9.1@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab` | `HINDSIGHT_API_IMAGE` | The chart, when the memory provider uses Hindsight (make deploy-hindsight for the kustomize dev path). |
+| `hindsight-api` | `ghcr.io/vectorize-io/hindsight-api` | `0.9.2@sha256:7b14a1f4062252992d0176758753615e0a2071d9a269995be007be223ab01812` | `HINDSIGHT_API_IMAGE` | The chart, when the memory provider uses Hindsight (make deploy-hindsight for the kustomize dev path). |
 | `hindsight-postgresql` | `docker.io/ankane/pgvector` | `latest@sha256:956744bd14e9cbdf639c61c2a2a7c7c2c48a9c8cdd42f7de4ac034f4e96b90f8` | `HINDSIGHT_POSTGRES_IMAGE` | The chart, alongside the Hindsight API. |
 | `cert-manager-controller` | `quay.io/jetstack/cert-manager-controller` | `v1.21.1` | — | cert-manager, installed by the full-install composition unless enable_cert_manager is false. |
 | `cert-manager-cainjector` | `quay.io/jetstack/cert-manager-cainjector` | `v1.21.1` | — | cert-manager, installed by the full-install composition unless enable_cert_manager is false. |

--- a/images.json
+++ b/images.json
@@ -75,7 +75,7 @@
       "name": "hindsight-api",
       "origin": "third-party",
       "repository": "ghcr.io/vectorize-io/hindsight-api",
-      "tag": "0.9.1@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab",
+      "tag": "0.9.2@sha256:7b14a1f4062252992d0176758753615e0a2071d9a269995be007be223ab01812",
       "override": "HINDSIGHT_API_IMAGE",
       "pulledBy": "The chart, when the memory provider uses Hindsight (make deploy-hindsight for the kustomize dev path).",
       "description": "Serves the agents' long-term memory. Pinned by digest as well as tag; a mirrored install pulls the copy by tag, because that is what 'make mirror-images' pushes."


### PR DESCRIPTION
## Summary

Moves `hindsight-api` from `0.9.1` to `0.9.2`, tag and digest together. Hindsight serves the agents' long-term memory, and it is **off by default** — the chart only renders it when `memory.provider` is set to Hindsight, which no default install does.

This is the one bump in the batch where the review passes came back with findings I could not settle. They are PLAUSIBLE rather than CONFIRMED, they need a measurement this install cannot produce, and they are described in full below rather than compressed into "no blocking findings".

## Why This Change

A patch release on the memory service, keeping it current. Nothing here is driven by a CVE.

## What Changed

- `images.json` — the `hindsight-api` entry, tag and `@sha256:` digest.
- `charts/kube-agents/values.yaml` — `hindsight.api.image.tag`, carrying the same tag+digest.
- `docs/designs/memory.md` — the design document names the version in its workload description.
- `docs/site/src/content/docs/deploy/docker-images.md` — regenerated `<!-- BEGIN GENERATED -->` region.

Four lines, one value. The digest moves with the tag because this image is pinned by both.

## Context

One of seven single-image bumps opened together, each independently revertable: hindsight-api, Envoy, LiteLLM, fluent-bit, alpine/k8s, the Go toolchain, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last. No open issue or pull request touches these files.

Related: because Hindsight sits behind a non-default chart toggle, its `values.yaml` pin is **not covered by `make images-check`** — check 3a inspects only the default render, which never includes it. That gap is documented in the **alpine/k8s** pull request, which rewrites the `docker-images.md` paragraph that used to claim otherwise. It means the two copies in this diff were kept in step by hand and by review, not by a check.

## Testing

- `make images-check` — passes, with the caveat immediately above: it does not actually verify this image's chart value.
- `make docs-check` — passes.
- `helm template` with `memory.provider` set to Hindsight — renders `0.9.2` with the matching digest.
- `prettier --check` on the changed Markdown and YAML — clean.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`). Live-test lease held throughout. Part of one batched run covering all six non-Hermes bumps.

**Proven that it runs and is the right image.** Hindsight is disabled on this install, so there was nothing to upgrade in place. Stood it up in a throwaway namespace from the pinned digest, against pgvector:

- `/health` returned **200** with `database: connected` — so it started, ran its startup work, and reached its database.
- `openapi.json` self-reports `"version":"0.9.2"` — the running service, not the tag, says which version it is.
- The pod's `imageID` digest matched the `@sha256:` in `images.json` byte-for-byte, so the digest in the diff is the digest that ran.

Torn down afterwards; the namespace is gone and the default install was never switched to Hindsight.

**Not covered, and this is the part that matters.** The bank was **empty**. Both findings below turn on behaviour against a *populated* bank — recall latency and first-start duration — and an empty bank produces neither number. The live test therefore proves the image is correct and starts; it proves nothing about either finding. See Risk & Rollout.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both.

- **`review-adversarial`** — looked for a tag and digest that disagree, a copy of the pin left behind, the digest not resolving upstream, and behaviour changes between 0.9.1 and 0.9.2 that the unchanged configuration surface hides. **No CONFIRMED findings, two MEDIUM PLAUSIBLE**, both below.
- **`review-docs-drift`** — looked for prose the bump makes untrue, generated regions out of step with `images.json`, and the version restated in narrative text. **No Blocking findings.**

**PLAUSIBLE #1 — `DEFAULT_ANN_ITERATIVE_SCAN` flips to `True` in 0.9.2.** This deepens exactly the tag-scoped recalls this install performs. The concern is the interaction with the CPU limit: `docs/designs/memory.md` documents recall as CPU-bound on an in-process cross-encoder reranker and says more CPU has been measured not to help, and the chart caps the pod at 4 CPUs. A deeper scan against a fixed cap means slower recalls. If that is real, the "What a recall costs" numbers in `memory.md` describe a version we would no longer be running.

**PLAUSIBLE #2 — five new Alembic revisions run inside the FastAPI lifespan.** They execute *before* `/health` answers, inside a 300 s `startupProbe` budget whose comments in the chart justify it as model-load time alone — the budget was not sized with migrations in it. Against a large bank, first start after upgrade could exceed it, and the pod would be killed and restarted mid-migration.

**Disposition for both: shipping, disclosed rather than fixed.** Neither is "out of scope". Both resolve to a measurement — recall latency and first-start duration against a populated bank — and this install's bank is empty, so I cannot take it. What I could do instead: verified that upstream ships **`HINDSIGHT_API_ANN_ITERATIVE_SCAN=false`** as a documented kill switch for the first, and confirmed the second is bounded by an existing, tunable probe budget rather than being unbounded. Both are in Risk & Rollout so an operator with a populated bank knows what to watch. A reviewer who thinks a patch bump should not ship on that basis is making a reasonable call and I will hold it.

- **Advisory — the unguarded chart pin.** Recorded in Context. Not fixed here: extending `images-check` to render non-default toggles is a change to the check, not to this pin, and it wants its own review. Named in the **alpine/k8s** pull request's prose rewrite so it stops being invisible.
- **Advisory — the `docker-images.md:14` prose**, flagged across this batch. Rewritten in full in the **alpine/k8s** pull request; duplicating it here would conflict at merge.

## Risk & Rollout

Low for almost every install, and specifically bounded for the ones it touches.

**Most installs are unaffected.** Hindsight is off unless `memory.provider` selects it. A default install renders none of this and pulls nothing.

**For an install that does run Hindsight, two things to watch on the first rollout after this merges**, both from the PLAUSIBLE findings above and neither observed:

1. **Recall latency.** `0.9.2` turns on iterative ANN scanning by default, which deepens tag-scoped recalls against a 4-CPU cap. If recalls get slower, set `HINDSIGHT_API_ANN_ITERATIVE_SCAN=false` on the API Deployment to restore the 0.9.1 behaviour without rolling back the image.
2. **First start.** Five Alembic migrations run inside the lifespan, before `/health` answers, against a 300 s `startupProbe` budget sized for model loading alone. On a large bank, watch the first pod come up; if it is killed by the probe, raise the startup budget rather than letting it restart mid-migration.

Both were tested against an empty bank, which is why they are listed as things to watch rather than things ruled out.

Rolling back is an image change, and the migrations are the thing to think about before doing it: five schema revisions will have applied, and Hindsight does not roll them back on a downgrade. Reverting the pin on a bank that has already migrated is not a tested path. Revert on an install that has **not** yet rolled this out is a one-line change to `images.json` plus the chart value and `make docs-generate`.

Nothing has to happen at merge time.

Generated with the help of Claude Opus 5.
