### PR TITLE
chore(deps): bump alpine/k8s from 1.34.9 to 1.36.2

### DIFF
--- a/charts/kube-agents/README.md
+++ b/charts/kube-agents/README.md
@@ -449,7 +449,7 @@ other third-party images, so a mirrored install needs nothing extra; set
 entirely — any image with `kubectl` and `/bin/sh` works.
 
 > **Breaking:** `platformAgent.cleanupHook.image` was a single string
-> (`alpine/k8s:1.34.9`) and is now a `{repository, tag}` map, because the
+> (`alpine/k8s:<tag>`) and is now a `{repository, tag}` map, because the
 > registry rewrite needs the two halves separately. A values file that still
 > sets the string form fails the render rather than installing something wrong:
 >
@@ -466,14 +466,15 @@ entirely — any image with `kubectl` and `/bin/sh` works.
 > platformAgent:
 >   cleanupHook:
 >     image:
->       repository: docker.io/alpine/k8s # was: image: alpine/k8s:1.34.9
->       tag: "1.34.9"
+>       repository: docker.io/alpine/k8s # was: image: alpine/k8s:<tag>
+>       tag: "<tag>" # or drop both lines to take the chart default
 > ```
 >
-> The default reference also gained its registry — `alpine/k8s:1.34.9` is now
-> spelled `docker.io/alpine/k8s:1.34.9`. That resolves to the same image on a
+> The default reference also gained its registry — the implied `alpine/k8s` is
+> now spelled `docker.io/alpine/k8s`. That resolves to the same image on a
 > default install; it is written out because a prefix cannot be prepended to a
-> reference whose registry is implied.
+> reference whose registry is implied. The default tag itself is in
+> `values.yaml`, mirrored from `images.json`.
 
 With `platformAgent.cleanupHook.enabled=false`, the ordering is yours to keep:
 

--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -482,8 +482,10 @@ platformAgent:
     enabled: true
     # Needs kubectl AND a shell: the `|| true` that keeps a wait timeout from
     # failing the hook (and with it the whole uninstall) needs `sh -c`, which
-    # rules out the distroless registry.k8s.io/kubectl. Skew of a minor or two
-    # is fine for a delete.
+    # rules out the distroless registry.k8s.io/kubectl. One pin serves the whole
+    # kubeVersion range rather than tracking the server, because the hook only
+    # deletes a CRD-backed object and waits on it — never the built-in API
+    # surface kubectl's +/-1 skew policy governs.
     #
     # Third-party, so it follows global.thirdPartyImageRegistry: an uninstall
     # on an air-gapped cluster otherwise fails to pull the very hook that keeps
@@ -491,7 +493,7 @@ platformAgent:
     # images.json like every other third-party image.
     image:
       repository: docker.io/alpine/k8s
-      tag: "1.34.9"
+      tag: "1.36.2"
     # How long to wait for the finalizer to clear.
     timeout: 120s
     # Bounds the Job itself (image pull, scheduling) above that wait.

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -11,13 +11,20 @@ Every image an install pulls or a rebuild needs, and how their tags are managed.
 
 [`images.json`](https://github.com/gke-labs/kube-agents/blob/main/images.json) at the repository root is the source of truth for this list. It is what `make mirror-images` copies from, what the chart and the dev tooling resolve their third-party pins from, and what the table below is generated from — so there is one pin per image, not one per install path.
 
-That cuts both ways: **a version bump edits `images.json` and nothing else.** The manifest,
-Dockerfile, or chart value that used to carry a pin now names a variable, so editing the old
-location changes nothing. `make images-check` cross-checks the entries that still have a second
-copy — LiteLLM and fluent-bit against the chart values, the build-time bases against their
-Dockerfile `ARG` defaults — but for `github-token-minter-server`, both Hindsight images, and the
-four cert-manager entries this file is the only copy, and nothing else in the tree is left to
-disagree with it. Bump the pin here, then run `make images-check` and `make docs-generate`.
+A bump starts here but rarely ends here. Several images keep a second copy that this file is the
+source for — a chart value, a Dockerfile `ARG` default, a compiled constant in the operator — and
+`make images-check` is what holds them in step. It covers every image the chart renders, on both a
+default and a mirrored install; the build-time bases against their Dockerfile `ARG` defaults; the
+fluent-bit fallback baked into the operator binary; the example manifests; and the kustomize
+integrations, which it requires to name a variable this file owns rather than a literal.
+
+Two copies it does not reach, where a stale pin passes every check. An image behind a non-default
+chart toggle is never rendered, so Hindsight (`memory.provider`) and the GitHub token minter
+(`githubMinter.enabled`) keep unguarded pins in `charts/kube-agents/values.yaml`. And cert-manager's
+version is set again in `terraform/examples/full-install/variables.tf`, which no check reads.
+
+Bump the pin here, run `make images-check` and `make docs-generate`, then grep the tree for the old
+version before opening the pull request.
 
 <!-- BEGIN GENERATED: container-images -->
 <!-- Regenerate with: make docs-generate -- do not edit by hand. -->
@@ -42,7 +49,7 @@ Pinned here so `make mirror-images` and the install ask for the same version.
 | ----- | ------------------ | --- | -------- | --------- |
 | `litellm` | `ghcr.io/berriai/litellm` | `v1.96.2` | `LITELLM_IMAGE` | The LiteLLM gateway, from either the chart or the kustomize integration. |
 | `fluent-bit` | `docker.io/fluent/fluent-bit` | `5.1.0` | `FLUENT_BIT_IMAGE` | The logging sidecar the operator injects into every agent pod. |
-| `k8s` | `docker.io/alpine/k8s` | `1.34.9` | — | The chart's pre-delete cleanup hook Job. |
+| `k8s` | `docker.io/alpine/k8s` | `1.36.2` | — | The chart's pre-delete cleanup hook Job. |
 | `github-token-minter-server` | `us-docker.pkg.dev/abcxyz-artifacts/docker-images/github-token-minter-server` | `v2.7.1-amd64` | `GITHUB_MINTER_IMAGE` | The optional GitHub integration. |
 | `hindsight-api` | `ghcr.io/vectorize-io/hindsight-api` | `0.9.1@sha256:24a079bead8aa58e45d728bf535ea727bfe559d8784024b6b9f89d56646954ab` | `HINDSIGHT_API_IMAGE` | The chart, when the memory provider uses Hindsight (make deploy-hindsight for the kustomize dev path). |
 | `hindsight-postgresql` | `docker.io/ankane/pgvector` | `latest@sha256:956744bd14e9cbdf639c61c2a2a7c7c2c48a9c8cdd42f7de4ac034f4e96b90f8` | `HINDSIGHT_POSTGRES_IMAGE` | The chart, alongside the Hindsight API. |

--- a/images.json
+++ b/images.json
@@ -58,7 +58,7 @@
       "name": "k8s",
       "origin": "third-party",
       "repository": "docker.io/alpine/k8s",
-      "tag": "1.34.9",
+      "tag": "1.36.2",
       "pulledBy": "The chart's pre-delete cleanup hook Job.",
       "description": "alpine/k8s — kubectl plus a shell, for the hook that deletes the PlatformAgent CR before Helm removes the operator. The name is the trailing path segment because the chart renders this one: kube-agents.imageRepository rewrites onto <prefix>/<trailing name>, which has to be the destination mirror_images.sh writes (<prefix>/<name>)."
     },


### PR DESCRIPTION
## Summary

Moves the chart's pre-delete cleanup-hook image from `alpine/k8s:1.34.9` to `1.36.2`, two Kubernetes minors forward. The hook is `kubectl` plus a shell, run once during `helm uninstall` to delete the `PlatformAgent` CR before the operator that owns its finalizer goes away.

It also carries three documentation fixes the review passes surfaced, all about this image or the file that pins it. They are described in Self-Review rather than buried in the diff, because two of them are pre-existing defects rather than consequences of the bump.

## Why This Change

`1.34.9` is two minors behind, and the hook's job is to talk to a `1.35` API server — the live-test cluster runs `v1.35.6-gke.1641000`. kubectl supports ±1 minor from the server, so `1.34` against `1.35` was inside the policy but at its edge, and would have fallen outside it on the next cluster upgrade.

What makes that worth fixing rather than leaving is the hook's error handling. It ends in `|| true`, deliberately: a wait timeout must not fail the hook and take the whole uninstall down with it. But `|| true` cannot distinguish a timeout from a kubectl that refused to talk to the server at all. A skew failure would therefore be **silently swallowed**, the hook would report success, and the `PlatformAgent` finalizer the hook exists to clear would be stranded — leaving an uninstall that appears to work and hangs on namespace deletion.

## Version choice

`1.36.2`, not the newest tag. `1.37.0`, `1.36.4`, `1.35.8` and `1.34.11` were all published on the day this was prepared, and this repository applies a seven-day cooldown everywhere Dependabot reaches. `1.36.2` is the same minor, three months soaked, and it is the version actually exercised in the live test below.

Worth knowing for whoever bumps this next: **`1.36.3` does not exist** — the registry skips it, and `docker manifest inspect` returns a 404. A typo there passes every check in this repository and fails at `helm uninstall`, which is the worst possible place for it to fail. Check the tag resolves before you push.

## What Changed

- `images.json` — the `k8s` entry, source for the chart value.
- `charts/kube-agents/values.yaml` — `platformAgent.cleanupHook.image.tag`, plus a rewritten comment above it (see below).
- `charts/kube-agents/README.md` — the breaking-change migration note, de-versioned.
- `docs/site/src/content/docs/deploy/docker-images.md` — the regenerated table, plus a rewritten opening paragraph.

The three prose edits:

- **`values.yaml`** justified the single pin with *"Skew of a minor or two is fine for a delete."* That is false against the chart's declared `kubeVersion` floor of 1.29, and this bump widens the range it was wrong about. Replaced with the actual reason one pin serves the whole range: the hook only deletes a CRD-backed object and waits on it, never touching the built-in API surface kubectl's ±1 policy governs.
- **`charts/kube-agents/README.md`** stated `1.34.9` three times inside a migration note about the string→map change. That note is about the *shape* of the value, not its content, so the version was never load-bearing there — it was just a fourth copy of the pin that no check covers and that goes stale on every bump. De-versioned to `<tag>`, with a pointer to where the default actually lives.
- **`docker-images.md`** opened by claiming **"a version bump edits `images.json` and nothing else"**, and that the file is the only copy for several images. Both halves are false, and this batch of seven pull requests is the proof — every one of them edits a second copy. Rewritten to say what `make images-check` actually covers, and to name the two places it does not: an image behind a non-default chart toggle is never rendered, so Hindsight and the GitHub token minter keep unguarded pins in `values.yaml`; and cert-manager's version is set again in `terraform/examples/full-install/variables.tf`, which no check reads.

## Context

One of seven single-image bumps opened together, each independently revertable: alpine/k8s, Envoy, LiteLLM, fluent-bit, hindsight-api, the Go toolchain, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last.

The `docker-images.md` rewrite is repository-wide and the other six pull requests defer to it, so it is fixed once here rather than six times. No open issue or pull request touches these files.

## Testing

- `make images-check` — passes; check 3a/3b/3c (default render, mirrored render, mirrored reference shape) all cover this image.
- `make docs-check` — passes.
- `helm template` at default and with `global.thirdPartyImageRegistry` set — the hook renders `1.36.2` on both paths.
- `prettier --check` on the changed Markdown and YAML — clean.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace `kubeagents-system`, API server `v1.35.6-gke.1641000`. Live-test lease held throughout. Part of one batched run covering all six non-Hermes bumps.

**Proven — and tested through a deliberately different path from the one that ships, for a reason.**

The chart's hook ends in `|| true`, so **the hook's own exit code is worthless as evidence**: it reports success whether kubectl worked or refused. Running the real hook and seeing it pass would have proved nothing, which is exactly the failure mode this bump is about. So the same commands were run as a plain `Job` on `alpine/k8s:1.36.2` with the `|| true` removed, against the live cluster's real `PlatformAgent`:

- `kubectl version` — Client **v1.36.2**, Server **v1.35.6-gke.1641000**. Client one minor ahead of server, inside the ±1 policy, and the client actually negotiated with this server rather than being asserted to.
- `kubectl get platformagents -A` — listed the install's real CR, so the client can read a CRD-backed resource on this server. That is the API surface the hook touches.
- `kubectl delete --dry-run=server` against that CR — **exit 0**, unmasked. The delete path the hook exists for works, and the exit code is real because nothing swallowed it.

**Not covered, said plainly:**

- **No unmasked run of the hook itself.** The `|| true` is in the chart template; removing it to test would mean testing a template that is not the one shipping. The Job above runs the same commands on the same image against the same server, which is the closest an install can get without editing the chart.
- **No real `helm uninstall`.** This install has no Helm release — it predates the chart — and there was no second install to destroy. The end-to-end "finalizer clears and the namespace terminates" path is therefore untested on a cluster; `helm template` covers the rendering.
- The batched run means no observation separates this bump from the other five, though nothing in the six diffs overlaps.

No artifacts left behind: the throwaway Job was deleted, and the CR was only ever touched with `--dry-run=server`.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both. Both were **re-run** after the fixes below, in fresh contexts, without being shown the first round's findings. What follows is the merged current state.

- **Blocking (`review-docs-drift`) and CONFIRMED (`review-adversarial`) — fixed.** `charts/kube-agents/README.md` still said `1.34.9` after the bump. I had decided before the passes to leave it alone, on the grounds that it documents a value's shape rather than its content; two independent passes graded it a defect, so I was wrong and it is fixed. De-versioned rather than re-pinned, so it cannot go stale again.
- **MEDIUM (both passes) — fixed.** The `values.yaml` skew comment, described above. Flagged by both passes on the grounds that the bump widens exactly the range the comment is wrong about.
- **CONFIRMED (`review-adversarial`) / Blocking (`review-docs-drift`) — fixed here, on the adversarial pass's argument.** The `docker-images.md:14` paragraph. Five of the fourteen passes across this batch flagged it independently. The argument for fixing it in *this* pull request rather than filing it: this batch is what exposes the omission, and the alpine bump is the one that touches that file's surrounding prose anyway.
- **MEDIUM (`review-adversarial`) — the `|| true` masking.** Not fixed, and this is a deliberate decision to argue with. The `|| true` is load-bearing: without it a wait timeout fails the hook and takes down the uninstall, which is worse than a stranded finalizer. Distinguishing a timeout from a skew failure means restructuring the hook's error handling, which is a behaviour change to the uninstall path and wants its own change and its own review — not a rider on a pin bump. What this PR does about it instead is keep the pin close enough to the server that the masked case does not arise, and test through the mask rather than around it.
- **A regression I introduced while fixing the first finding, caught by the re-run.** My first pass at the README wrote `tag: "<tag>" # whichever tag the string form carried`, which tells a migrating user to freeze at their old version — 1.34.9 forever — which is the opposite of the point. The docs-drift re-run caught it. Now reads `# or drop both lines to take the chart default`.
- **Found by me, before the passes: the tag itself.** The branch originally targeted `1.36.4`, published two hours earlier. Changed to `1.36.2` for the cooldown reason in "Version choice" above. `1.36.3`'s non-existence was found the same way.
- **No findings on:** the mirrored-registry render path, the `<prefix>/<name>` reference shape, and the generated table — all three were looked at by the adversarial pass and are covered by `make images-check`.

## Risk & Rollout

Low in blast radius, narrow in timing: this image is pulled **once, during `helm uninstall`**, and never during normal operation. Nothing running in a cluster changes when this merges. An install that never uninstalls never pulls it.

The failure mode if `1.36.2` were wrong is the one described above — the hook silently reports success, the `PlatformAgent` finalizer is stranded, and namespace deletion hangs. That is unpleasant to debug, which is why the live test unmasked the exit code rather than trusting the hook's. Against a 1.35 server the client is inside the skew policy, and it was exercised against that exact server.

Two documentation edits change what the project claims rather than what it does. The `docker-images.md` rewrite now names two unguarded pins (Hindsight, the GitHub token minter, and cert-manager's Terraform copy) — that is a disclosure of existing behaviour, not a new gap. **Closing it is follow-up work**: extending `images-check` to render with `memory.provider=hindsight` and `githubMinter.enabled=true` would catch two of the three, and is not attempted here.

Revert is `images.json` plus `make docs-generate`; the prose edits are independently revertable and none of them is load-bearing for the render. Nothing has to happen at merge time.

Generated with the help of Claude Opus 5.
