### PR TITLE
chore(deps): move the Go toolchain from 1.26 to 1.27

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -130,7 +130,7 @@ Before beginning installation, ensure your environment meets the following requi
 
 | CLI Tool / Utility              | Required Version                                | Verification Command       | Description                                                                                                 |
 | :------------------------------ | :---------------------------------------------- | :------------------------- | :---------------------------------------------------------------------------------------------------------- |
-| **Go**                          | `1.26+`                                         | `go version`               | Required for building operator binaries and running tests.                                                  |
+| **Go**                          | `1.27+`                                         | `go version`               | Required for building operator binaries and running tests.                                                  |
 | **Docker / Podman**             | `20.10+`                                        | `docker --version`         | Required to build container images for the operator.                                                        |
 | **kubectl**                     | `1.28+`                                         | `kubectl version --client` | Communicates with your target Kubernetes or GKE cluster.                                                    |
 | **Kubernetes Cluster**          | `1.29+` (`1.35+` for `AgentPlugin` OCI volumes) | `kubectl version`          | Target Kubernetes or GKE cluster (`AgentPlugin` OCI volumes require K8s 1.35+ `ImageVolume` gate).          |

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -52,7 +52,7 @@ ARG HERMES_AGENT_IMAGE=nousresearch/hermes-agent
 ARG ENVOY_VERSION=v1.39.1
 ARG ENVOY_IMAGE=envoyproxy/envoy
 ARG GOLANG_IMAGE=golang
-ARG GOLANG_VERSION=1.26-alpine
+ARG GOLANG_VERSION=1.27-alpine
 FROM ${ENVOY_IMAGE}:${ENVOY_VERSION} AS envoy-bin
 
 # Every binary in the final image must match the architecture the image ships

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -67,7 +67,7 @@ Needed only to rebuild the images above from source, not to run an install. Each
 | ----- | ------------------ | --- | -------- | --------- |
 | `hermes-agent` | `docker.io/nousresearch/hermes-agent` | `HERMES_AGENT_TAG` in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) | `HERMES_AGENT_IMAGE` | deploy/docker/Dockerfile (agent-base stage). |
 | `envoy` | `docker.io/envoyproxy/envoy` | `v1.39.1` | `ENVOY_IMAGE` | deploy/docker/Dockerfile (envoy-bin stage). |
-| `golang` | `docker.io/library/golang` | `1.26-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages. |
+| `golang` | `docker.io/library/golang` | `1.27-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages. |
 | `python` | `docker.io/library/python` | `3.14-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile. |
 | `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile runtime stage. |
 

--- a/docs/site/src/content/docs/operator/development.md
+++ b/docs/site/src/content/docs/operator/development.md
@@ -11,7 +11,7 @@ Everything below runs from `k8s-operator/`.
 
 ## Prerequisites
 
-- Go 1.26+.
+- Go 1.27+.
 - `docker` (or `podman`) for image builds.
 - `kubectl` pointed at a target cluster for `make install` / `make deploy`.
 - `make` — the entire workflow is Makefile-driven.

--- a/hack/check-docs-terminology.sh
+++ b/hack/check-docs-terminology.sh
@@ -93,7 +93,11 @@ if [ -z "$GO_MOD_VERSION" ]; then
 fi
 GO_MINOR=$(printf '%s' "$GO_MOD_VERSION" | cut -d. -f1,2)   # 1.25.8 -> 1.25
 
-WRONG_GO=$(search 'Go[^0-9]{0,20}1\.[0-9]+\+' | grep -vF "${GO_MINOR}+" || true)
+# {0,60} rather than {0,20}: at 20 this reached only "Go 1.N+." in the operator
+# development guide. INSTALL.md states it inside a padded table cell and
+# k8s-operator/README.md behind a ~38-character markdown link, so both sat
+# outside the window and a stale version in either passed the check.
+WRONG_GO=$(search 'Go[^0-9]{0,60}1\.[0-9]+\+' | grep -vF "${GO_MINOR}+" || true)
 if [ -n "$WRONG_GO" ]; then
   echo "::error::Documented Go version does not match k8s-operator/go.mod (go ${GO_MOD_VERSION}; expected \"${GO_MINOR}+\")."
   printf '%s\n\n' "$WRONG_GO" | sed 's/^/    /'

--- a/images.json
+++ b/images.json
@@ -154,7 +154,7 @@
       "name": "golang",
       "origin": "build-time",
       "repository": "docker.io/library/golang",
-      "tag": "1.26-alpine",
+      "tag": "1.27-alpine",
       "buildArg": "GOLANG_IMAGE",
       "pulledBy": "deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages.",
       "description": "Go toolchain for the operator and k8s-event-watcher builds."

--- a/k8s-operator/Dockerfile
+++ b/k8s-operator/Dockerfile
@@ -3,7 +3,7 @@
 # a full reference rather than a shared prefix. Defaults are upstream, so an
 # ordinary build is unchanged.
 ARG GOLANG_IMAGE=golang
-ARG GOLANG_VERSION=1.26-alpine
+ARG GOLANG_VERSION=1.27-alpine
 ARG DISTROLESS_IMAGE=gcr.io/distroless/static
 ARG DISTROLESS_VERSION=nonroot
 

--- a/k8s-operator/README.md
+++ b/k8s-operator/README.md
@@ -12,7 +12,7 @@ The operator is built using the Kubebuilder framework and is written in Go.
 
 Before building or deploying the operator, ensure you have the following installed:
 
-- [Go](https://go.dev/doc/install) (version 1.26+)
+- [Go](https://go.dev/doc/install) (version 1.27+)
 - [Docker](https://docs.docker.com/get-docker/) or Podman (for building container images)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) (configured to access your Kubernetes/GKE cluster)
 - Access to a running Kubernetes/GKE cluster

--- a/k8s-operator/go.mod
+++ b/k8s-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/gke-labs/kube-agents/k8s-operator
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Summary

Moves the Go toolchain from 1.26 to 1.27 — both builder images, the `go` directive in `k8s-operator/go.mod`, and the three documents that state the prerequisite. It also widens the `docs-check` guard that was supposed to police exactly this change and did not.

Moving `go.mod` alongside the images is the point of the change rather than a side effect: leaving it behind would have CI compile and test under 1.26.6 while the shipped binaries were built under 1.27.0.

## Why This Change

Go 1.27 is the current release. The builder images can be moved on their own, and that is where this started — but doing only that splits the toolchain in two. Every Go job in CI resolves its version from `go-version-file: k8s-operator/go.mod`, so bumping only the Dockerfiles would mean tests, `go vet`, and gosec run under 1.26.6 while the images ship 1.27.0. They agree today; after a Dockerfile-only bump nothing would say so.

The precedent in this repository points the same way: `99eb5dc0` ("upgrade the Go toolchain to 1.26.6", #710) moved `go.mod`, both Dockerfiles, and the three prose prerequisites in one commit. This follows it.

## What Changed

- `k8s-operator/go.mod` — `go 1.26.6` → `go 1.27.0`. This is the load-bearing line: it sets CI's toolchain **and** the main module's GODEBUG defaults. See Risk & Rollout for what that second thing actually costs.
- `deploy/docker/Dockerfile` and `k8s-operator/Dockerfile` — `ARG GOLANG_VERSION`, checked against `images.json` by `make images-check`.
- `images.json` — the `golang` entry.
- `INSTALL.md`, `k8s-operator/README.md`, `docs/site/src/content/docs/operator/development.md` — the three places stating `Go 1.26+`, now `1.27+`.
- `hack/check-docs-terminology.sh` — the guard on those three files, widened from `{0,20}` to `{0,60}`. Explained in Self-Review; it is a review finding, not part of the bump.

## Context

One of seven single-image bumps opened together, each independently revertable: the Go toolchain, Envoy, LiteLLM, fluent-bit, alpine/k8s, hindsight-api, and the replay-proxy Python base. The Hermes agent pin is deliberately not in this batch — it lands separately and last. No open issue or pull request touches these files.

## Testing

- `make images-check` and `make docs-check` — both pass.
- `go build ./...`, `go vet ./...`, and the full test suite in `k8s-operator/` under `GOTOOLCHAIN=go1.27.0` — all green, uncached.
- Docker build of both images with the new builder — clean, `--platform linux/amd64`.
- `prettier --check` on the changed Markdown — clean.

### Live validation

`kube-agents-cluster` (regional `us-central1`, project `bhoekstra-gkedemos`), namespace `kubeagents-system`, baseline operator `dns-endpoint-7dac349`. Live-test lease held throughout.

Ran twice: once in the batched run covering all six non-Hermes bumps, and again on its own after `go.mod` was added to the branch, because that edit changed what the branch does. The second run is what is described here; it supersedes the first rather than adding to it.

The branch was later rebased onto `main` at `2c3476f2` to clear a merge conflict — one row of the generated image table in `docs/site/src/content/docs/deploy/docker-images.md`, where `main` had bumped Envoy to `v1.39.1` immediately above the `golang` row this change edits. The resolution keeps both pins. On the rebased head, `make images-check`, `make docs-check`, and `go build` / `go vet` / `go test ./...` under `GOTOOLCHAIN=go1.27.0` are all green. The cluster run above was not repeated: the rebase changed no file that ends up in a shipped binary or manifest.

**Proven, including the mechanism.**

*The binaries.* Built the operator from the branch: `go version -m` on the shipped `/manager` and on `k8s-event-watcher` both report `go1.27.0`, and neither carries a `DefaultGODEBUG` build setting.

*Why that second observation matters, proven rather than asserted.* Go stamps `DefaultGODEBUG` only when the `go` directive's implied defaults differ from the compiling toolchain's, so its absence is the evidence that moving the directive changed nothing at runtime. To confirm that is what the absence means rather than assuming it, I built the same trivial module twice under one toolchain, varying only the directive:

```
go 1.26.6  ->  DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
go 1.27.0  ->  (no DefaultGODEBUG stamped)
```

So the entire behavioural delta of moving the directive is two GODEBUG flips. `x509sslcertoverrideplatform` is Windows/Darwin-only and inert against distroless Linux, which leaves `tracebacklabels=0→1` — a change to panic traceback formatting. That is the whole runtime consequence. The adversarial pass enumerated the same two flags independently.

*In the cluster.* Pushed the image (digest `sha256:ee1a23e0…b2ac`) and confirmed the running pod's `imageID` matched it byte-for-byte, so the observation is of the branch's binary and not a cached layer. The operator acquired leader election at `13:54:15Z`, then proved it was reconciling rather than merely running: deleting `configmap/platform-agent-fluent-bit-config` had it recreated (uid `308bb367…` → `ed15981f…`, `creationTimestamp` `2026-08-11` → `2026-09-01T13:58:24Z`).

*Reverted.* Rolled back to `dns-endpoint-7dac349`; the rollout succeeded and the same delete-and-recreate check passed again (uid `a08099f8…`). The install is on baseline, the test tag is deleted from the registry, and no scratch artifacts remain.

**Not covered, and one thing worth reading before you take this as clean:**

- The 1.27-built operator surfaced two errors on this cluster — `poddisruptionbudgets.policy "platform-agent" is forbidden` and `SESSION_KV_API_KEY is empty`. **Neither is caused by this change.** This diff touches no RBAC or PDB file; `main`'s `k8s-operator/config/rbac/role.yaml` already grants `create/delete/patch/update` on `poddisruptionbudgets`, and the cluster's deployed `kubeagents-manager-role` (created `2026-08-11T17:40:50Z`) grants only `get/list/watch`. It is three-week-old ClusterRole drift on a shared test install: **any** operator built from current `main` hits it, whatever its toolchain. I am reporting it against the install, not this branch.
  I initially wrote this off as "pre-existing, reproduces on baseline" — it does *not* reproduce on baseline, because the baseline operator is old enough that it never writes a PDB at all. That was the wrong test; the RBAC comparison above is the right one.
- Not covered: no Helm release on this install, so the chart path was not exercised; and the `deploy/docker` agent image was built but the batched run is the only cluster evidence for it.

## Self-Review

Two passes, each in a subagent that did not write the change, handed only the diff range `refs/kube-agents-base/main...HEAD` and told to derive the intent from the diff — no plan, no reasoning, no commit-message bodies. `make docs-check` ran first in the main loop and its output went to both. Both passes were **re-run after `go.mod` was added**, in fresh contexts, without being shown the first round's findings; what follows is the merged current state, not a running log.

- **CONFIRMED (`review-adversarial`), MEDIUM — fixed.** The original branch moved the builder images but not `go.mod`, leaving CI on 1.26.6 while the images shipped 1.27.0. The pass built, vetted, and tested clean under `GOTOOLCHAIN=go1.27.0`, so it was safe on the day; the finding was that nothing in CI would say so afterwards. Fixed by moving `go.mod` to `1.27.0` in this branch, with the three prose prerequisites, following #710. The re-run confirmed the four files are now consistent.
- **Advisory (`review-docs-drift`) — fixed, and it is the finding worth a reviewer's attention.** `hack/check-docs-terminology.sh` searched `Go[^0-9]{0,20}1\.[0-9]+\+`. At `{0,20}` that window reaches only `docs/site/.../operator/development.md:14`; `INSTALL.md:133` states the version inside a padded table cell and `k8s-operator/README.md:15` puts a ~38-character markdown link between "Go" and the number, so both were invisible to it. **`make docs-check` was green on this branch — and would have been green with two of the three files left at `1.26+`.** I had updated them by hand, so the branch was correct and the guard that was meant to prove it was not. Widened to `{0,60}`, which reaches all three with no false positives anywhere in the tree; verified by reverting each file to `1.26+` in turn and confirming the check fails on each. This is beyond the pin bump, and it is in this PR because it is the check that should have policed this PR.
- **Advisory (`review-adversarial`), LOW — reported, not fixed.** No pull-request check builds `k8s-operator/Dockerfile`, so a broken builder `ARG` would not be caught before merge. Not fixed here: adding a CI job is a change to the CI surface, not a toolchain bump, and it wants its own review. Named so it is not mistaken for something this PR covers.
- **Reported, not fixed — a guard gap this change reveals but does not create.** Nothing checks that `go.mod`'s directive and `images.json`'s `GOLANG_VERSION` stay on the same minor. They agree in this diff by hand. Filing separately rather than fixing inline for the same reason as above.
- **Advisory (`review-docs-drift`) — unrelated pre-existing drift, reported only.** `tests/e2e/README.md:217` says the plugin image is `alpine:3.19` when the Dockerfile says `alpine:3.24`; `.github/dependabot.yml:124-127` describes its two literal-`FROM` directories as `node:18-slim` and `alpine:3.19` when they are `node:26-slim` and `alpine:3.24`. Nothing to bump — the images are current, the comments describing them are not. Untouched by this diff and unrelated to Go.
- **Advisory — the `docker-images.md:14` prose** ("a version bump edits `images.json` and nothing else"), flagged by five passes across this batch. Rewritten in full in the **alpine/k8s** pull request; duplicating it here would conflict at merge.

## Risk & Rollout

Low, and the live test narrowed it to something specific rather than leaving it as "a toolchain bump".

Moving the `go` directive changes the main module's GODEBUG defaults, which is the part of this change that could alter runtime behaviour without altering any code. Measured above, that comes to exactly two flags, one of which is inert on Linux — leaving `tracebacklabels=0→1`, affecting how a panic traceback is formatted. Nothing in the operator's control flow depends on it.

Blast radius is every Go binary the repository ships: the operator, the event watcher, and the agent-image helpers. All are rebuilt from source by the same job, so they cannot skew against each other. The recompiled operator reconciled correctly on a live cluster and rolled back cleanly.

Revert is `images.json` plus the two `ARG` defaults plus `go.mod`, and `make docs-generate`. Nothing has to happen at merge time. Contributors will need Go 1.27 locally after this merges, which is what the three prose updates are for.

Generated with the help of Claude Opus 5.

