### PR TITLE
fix(platform): fan cron reports out to every enabled chat platform

### DIFF
--- a/agents/platform/cron/README.md
+++ b/agents/platform/cron/README.md
@@ -82,6 +82,11 @@ prompt contract: **the job's prompt says nothing about it**, because the
 scheduler applies `[SILENT]` and builds the failure summary before delivery is
 reached.
 
+The relay itself posts to every chat platform the install has enabled, so on a
+dual-platform install a job left on `"all"` is now heard twice on _each_ of them
+rather than twice in one place. Every entry here names `"chat"`, so this reaches
+only a runtime-created job or a hand-edited roster.
+
 The mode is a bundled platform plugin, not a patch: `chat` is a delivery-only
 platform ([`deploy/docker/plugins/chat/`](../../../deploy/docker/plugins/chat/))
 that Hermes registers like any other. So it is one target among several — a job

--- a/agents/platform/governance/eod_event_watcher_daily_report_sop.md
+++ b/agents/platform/governance/eod_event_watcher_daily_report_sop.md
@@ -38,7 +38,11 @@ relay is always attempted. The home channel is needed one hop later, where the S
 posts what the Chat Agent composed: `_send_to_chat` runs `hermes send --to <platform>` with no
 chat id, and that bare form is the one `hermes send` documents as "platform (home channel)". Where
 there is none the send fails and the roster entry records
-`last_delivery_error: "composed but not delivered to google_chat"`. The value is set either by the
+`last_delivery_error: "composed but not delivered to google_chat"`. On an install with more than
+one chat platform enabled the send fans out to all of them, so one platform missing a home channel
+costs the recap only that audience: the entry then records
+`last_delivery_error: "chat relay partial: the report did not reach slack."` and the run is still a
+delivery. The value is set either by the
 CR — `spec.integration.googleChat.homeChannel`, which the operator renders into the pod as
 `GOOGLE_CHAT_HOME_CHANNEL` — or by running `/sethome` in the channel you want it in. Every entry
 on the roster shipping `deliver: "chat"` takes this route; nothing about it is specific to

--- a/agents/platform/governance/eod_event_watcher_daily_report_sop.md
+++ b/agents/platform/governance/eod_event_watcher_daily_report_sop.md
@@ -37,12 +37,23 @@ sets `CHAT_HOME_CHANNEL` on every cron child unconditionally, so the target alwa
 relay is always attempted. The home channel is needed one hop later, where the Session KV server
 posts what the Chat Agent composed: `_send_to_chat` runs `hermes send --to <platform>` with no
 chat id, and that bare form is the one `hermes send` documents as "platform (home channel)". Where
-there is none the send fails and the roster entry records
-`last_delivery_error: "composed but not delivered to google_chat"`. On an install with more than
-one chat platform enabled the send fans out to all of them, so one platform missing a home channel
-costs the recap only that audience: the entry then records
-`last_delivery_error: "chat relay partial: the report did not reach slack."` and the run is still a
-delivery. The value is set either by the
+there is none the send fails and the roster entry records a `last_delivery_error` that nests three
+layers of wrapping — the relay's own words inside the route's 502 detail inside the plugin's report
+of it, so grep for a fragment rather than the whole string:
+
+```
+chat relay answered HTTP 502: chat relay failed: composed but not delivered to google_chat
+```
+
+On an install with more than one chat platform enabled the send fans out to all of them, so one
+platform missing a home channel costs the recap only that audience. The run is then a delivery, and
+the entry records:
+
+```
+chat relay partial: the report did not reach slack. Delivered — do not re-run to resend.
+```
+
+The home channel is set either by the
 CR — `spec.integration.googleChat.homeChannel`, which the operator renders into the pod as
 `GOOGLE_CHAT_HOME_CHANNEL` — or by running `/sethome` in the channel you want it in. Every entry
 on the roster shipping `deliver: "chat"` takes this route; nothing about it is specific to

--- a/agents/platform/scripts/agent_common_server.py
+++ b/agents/platform/scripts/agent_common_server.py
@@ -46,10 +46,13 @@ DOTENV_PATH = os.environ.get("PLATFORM_AGENT_DOTENV_PATH", "/opt/data/.env")
 #     /opt/hermes, outside CREDENTIAL_PROXY_WORKSPACE_ROOT=/opt/data (see
 #     _within_workspace in credential_proxy.py, and docker-entrypoint.sh step
 #     5.5, which already records the cwd).
-# Both readers of the variable (platform_mcp_server.get_active_platform and
-# session_kv_server's active-platform helper) consult CONFIG_PATH first and only
-# fall back to the env var. Pinned by TestNoSubprocessAtImport in
-# test_agent_common_server.py.
+# Neither reader of the variable depends on this having populated it, because
+# each consults a config file before the environment:
+# platform_mcp_server.get_enabled_platforms reads CONFIG_PATH first, and
+# session_kv_server.enabled_chat_platforms reads the managed scope
+# (/etc/hermes/config.yaml) first and CONFIG_PATH second, falling through to the
+# environment per platform only where neither file says. Pinned by
+# TestNoSubprocessAtImport in test_agent_common_server.py.
 
 def _run_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     """Build a subprocess env with HOME redirected to /tmp for GKE container compatibility.

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -843,6 +843,13 @@ def report_to_chat(report: str, job_id: str, title: str = "") -> str:
         caveats.append(
             f"it did not reach {undelivered}, so that audience has not seen it"
         )
+    if str(payload.get("truncated") or "").strip():
+        labels.append("truncated")
+        caveats.append(
+            "it was over the chat character limit, so only the beginning of it "
+            "was posted and the rest is only in the saved output — write a "
+            "shorter report next time rather than resending this one"
+        )
     if caveats:
         return (
             f"SUCCESS ({', '.join(labels)}): the report was posted to chat "

--- a/agents/platform/scripts/platform_mcp_server.py
+++ b/agents/platform/scripts/platform_mcp_server.py
@@ -822,18 +822,36 @@ def report_to_chat(report: str, job_id: str, title: str = "") -> str:
     except Exception as exc:
         return f"ERROR: Failed to hand the report to the chat relay: {exc}"
 
-    # The route answers 200 for both a composed delivery and a degraded one, and
-    # says which in `relay`. Reading it here is the difference between the agent
-    # knowing its report went out raw and it believing the Chat Agent framed it.
+    # The route answers 200 for a composed delivery, a degraded one, and a
+    # fan-out that reached some platforms and not others, and says which in
+    # `relay` and `undelivered`. Reading both here is the difference between the
+    # agent knowing what actually happened to its report and it believing the
+    # Chat Agent framed it for everyone. The relay adapter — the other caller of
+    # this route — reads the same two fields; a sibling that reads only one
+    # reports a half-delivered report as a clean one.
+    session = payload.get("session_id", "?")
+    labels, caveats = [], []
     if payload.get("relay") == "degraded":
+        labels.append("degraded")
+        caveats.append(
+            "the Chat Agent turn failed, so the user sees your raw text marked "
+            "[unrelayed] rather than a composed message"
+        )
+    undelivered = str(payload.get("undelivered") or "").strip()
+    if undelivered:
+        labels.append("partial")
+        caveats.append(
+            f"it did not reach {undelivered}, so that audience has not seen it"
+        )
+    if caveats:
         return (
-            f"SUCCESS (degraded): the report was posted to chat (session "
-            f"{payload.get('session_id', '?')}) but the Chat Agent turn failed, so the user "
-            "sees your raw text marked [unrelayed] rather than a composed message. It is "
-            "delivered — do not send it again — and there is nothing for you to retry."
+            f"SUCCESS ({', '.join(labels)}): the report was posted to chat "
+            f"(session {session}), but "
+            + "; and ".join(caveats)
+            + ". It is delivered — do not send it again — and there is nothing for you to retry."
         )
     return (
-        f"SUCCESS: Report accepted for delivery to chat (session {payload.get('session_id', '?')}). "
+        f"SUCCESS: Report accepted for delivery to chat (session {session}). "
         "The Chat Agent posts it; do not also call send_notification for this report."
     )
 

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -737,6 +737,51 @@ def _platforms_enabled_in(path: str) -> Dict[str, bool]:
     return out
 
 
+def _platform_setting_in(path: str, platform: str, key: str) -> str:
+    """`platforms.<platform>.<key>` from one config file, or `""` if unset.
+
+    The string sibling of :func:`_platforms_enabled_in`, and hostile to the same
+    shapes for the same reason: this file is hand-editable and agent-writable.
+    """
+    try:
+        import yaml
+        with open(path, "r") as handle:
+            cfg = yaml.safe_load(handle) or {}
+        platforms = _mapping(_mapping(cfg).get("platforms"))
+    except FileNotFoundError:
+        return ""
+    except Exception as exc:
+        logger.error(f"Failed to parse {path} for {platform}.{key}: {exc}")
+        return ""
+    return str(_mapping(platforms.get(platform)).get(key) or "").strip()
+
+
+def _slack_home_channel() -> str:
+    """Slack's home channel, from the environment or from either config file.
+
+    The operator renders `SLACK_HOME_CHANNEL` only when the CR sets
+    `slack.homeChannel`, and that is not the only way an install gets one:
+    `/sethome` writes `platforms.slack.home_channel` into the writable
+    `config.yaml`, which is precisely why that file is not mounted read-only.
+    Reading the environment alone left such an install's Slack leg with an empty
+    `chat_id` — which :func:`_lookup_platform_threads` drops — so the leg opened
+    a fresh top-level message on every report and got no incident row, while the
+    send itself succeeded and nothing looked wrong.
+
+    Environment first, so an install whose CR sets the channel resolves exactly
+    as it did before; the files are consulted only when it is absent, which is
+    the case that was broken.
+    """
+    env = os.environ.get("SLACK_HOME_CHANNEL", "").strip()
+    if env:
+        return env
+    for path in (MANAGED_CONFIG_PATH, CONFIG_PATH):
+        value = _platform_setting_in(path, "slack", "home_channel")
+        if value:
+            return value
+    return ""
+
+
 def enabled_chat_platforms() -> list[str]:
     """Every chat platform this install posts to, in CHAT_PLATFORMS order.
 
@@ -800,12 +845,12 @@ def enabled_chat_platforms() -> list[str]:
     return resolved or [DEFAULT_CHAT_PLATFORM]
 
 
-def get_active_platform() -> str:
+def get_active_platform(platforms: Optional[list[str]] = None) -> str:
     """The one platform a single-destination caller posts to.
 
-    `_post_initial_alert` needs exactly one: it registers the thread it gets
-    back as the session's routing, the triage card's completion is addressed to
-    that thread, and a thread belongs to one platform — `hermes send` refuses a
+    The alert path needs exactly one: it registers the thread it gets back as
+    the session's routing, the triage card's completion is addressed to that
+    thread, and a thread belongs to one platform — `hermes send` refuses a
     Google Chat thread addressed as Slack rather than degrading it to the home
     channel. Two alerts in two threads would leave the report addressable to
     only one of them, so this path picks rather than fans out.
@@ -814,8 +859,13 @@ def get_active_platform() -> str:
     an install with more than one platform enabled says so in the log, once per
     call, naming the destination that lost. The relay in
     :func:`relay_cron_report` has no such constraint and does fan out.
+
+    `platforms` lets the caller pass a resolution it has already made, so
+    `trigger_agent_troubleshooter` — which needs the whole list for its
+    fall-through — gets the pick and the warning off the same answer rather
+    than resolving twice and risking two different ones. Omitted, it resolves.
     """
-    platforms = enabled_chat_platforms()
+    platforms = platforms or enabled_chat_platforms()
     if len(platforms) > 1:
         logger.warning(
             f"{len(platforms)} chat platforms are enabled; this send takes one "
@@ -825,8 +875,23 @@ def get_active_platform() -> str:
     return platforms[0]
 
 
+#: Returned by :func:`_post_initial_alert` when `hermes send` reported success
+#: but no message id could be read out of its `--json` stdout. Distinct from
+#: `None`, which means the send itself failed. The caller must not try the next
+#: platform on this one: the alert IS in the first platform's channel, and
+#: falling through would post it a second time somewhere else. Deliberately not
+#: a plausible thread id, so a caller that ignores it addresses nothing.
+ALERT_SENT_WITHOUT_THREAD = "\x00alert-sent-without-thread"
+
+
 def _post_initial_alert(active_platform: str, alert_msg: str) -> str | None:
-    """Send initial warning alert via hermes CLI and return the thread/message ID."""
+    """Send initial warning alert via hermes CLI and return the thread/message ID.
+
+    Three outcomes, not two: a thread id, `None` when the send failed, and
+    :data:`ALERT_SENT_WITHOUT_THREAD` when it succeeded and the id could not be
+    parsed. The route's own docstring names that third case as one that has
+    happened here, and it is the one where a retry does damage rather than good.
+    """
     try:
         res = subprocess.run(
             ["hermes", "send", "--json", "--to", active_platform, alert_msg],
@@ -844,6 +909,12 @@ def _post_initial_alert(active_platform: str, alert_msg: str) -> str | None:
                 thread_key = msg_part.split(".")[0]
                 return f"{space_part}/threads/{thread_key}"
             return msg_id
+        # Sent, but unaddressable. Say which, so the caller does not re-send.
+        logger.error(
+            f"Alert posted to '{active_platform}' but its response carried no message id; "
+            "the alert is delivered and the session cannot be threaded to it"
+        )
+        return ALERT_SENT_WITHOUT_THREAD
     except subprocess.CalledProcessError as exc:
         logger.error(f"Failed to post warning alert. Stdout: {exc.stdout}. Stderr: {exc.stderr}. Exc: {exc}")
     except Exception as exc:
@@ -948,7 +1019,7 @@ def _register_session_routing(session_id: str, platform: str, thread_id: str) ->
                     meta["thread_id"] = thread_id
                     meta["platform"] = platform
                     if platform == "slack":
-                        meta["chat_id"] = os.environ.get("SLACK_HOME_CHANNEL", "")
+                        meta["chat_id"] = _slack_home_channel()
                     else:
                         meta["chat_id"] = thread_id.split("/threads/")[0]
 
@@ -1212,10 +1283,25 @@ def trigger_agent_troubleshooter(
     #    send that fails while a working Slack sits second in the list. The
     #    relay learned to fan out for this reason; without this loop the alert
     #    path would have learned nothing.
+    #    The pick goes through `get_active_platform` rather than `platforms[0]`
+    #    so that a dual-platform install says in the log which destination the
+    #    alert took and which one will not see it. That warning is the other
+    #    half of #1094 — picking silently — and it has to fire on the pick
+    #    itself: the fall-through below logs only once a leg has already
+    #    refused, so on an install whose first leg accepts, nothing would say
+    #    the second was skipped.
     platforms = enabled_chat_platforms()
-    active_platform, thread_id = platforms[0], None
-    for candidate in platforms:
+    active_platform = get_active_platform(platforms)
+    thread_id = None
+    for candidate in [active_platform] + [p for p in platforms if p != active_platform]:
         thread_id = _post_initial_alert(candidate, alert_msg)
+        if thread_id == ALERT_SENT_WITHOUT_THREAD:
+            # Delivered, and unthreadable. Stop: the reader has the alert, and
+            # trying the next platform would post it to a second channel to
+            # chase a thread id. Fall into the `else` below, which records the
+            # delivery as unconfirmed rather than lost — the honest reading.
+            active_platform, thread_id = candidate, None
+            break
         if thread_id:
             active_platform = candidate
             break
@@ -1788,8 +1874,23 @@ def relay_cron_report(
         # the line most likely to be dropped. See :func:`_truncate_report`.
         message = truncation_notice + message
 
-    routed_platform = _lookup_session_routing(session_id)[0]
+    routed_platform, routed_chat_id, routed_thread_id = _lookup_session_routing(session_id)
     known_threads = _lookup_platform_threads(session_id)
+    if (
+        routed_platform
+        and routed_platform not in known_threads
+        and routed_chat_id
+        and routed_thread_id
+    ):
+        # A session routed by the code this replaces has the top-level triple
+        # and no `platform_threads` map. Roll-forward has the same shape as the
+        # rollback the risk note describes, and it is the direction that
+        # actually happens: without this seed the first report after the
+        # rollout finds no per-leg entry, sends with `('', '')`, and orphans a
+        # top-level message instead of replying into the thread the session
+        # already has. One message per job that already reported earlier the
+        # same UTC day, since session ids are per day.
+        known_threads[routed_platform] = (routed_chat_id, routed_thread_id)
 
     # One send per enabled platform, each into its OWN thread. A thread id is
     # platform-local, so every leg reads its own entry and none can pick up
@@ -1822,11 +1923,23 @@ def relay_cron_report(
     for platform in [p for p in platforms if p in threads and p != owner] + [owner]:
         _register_session_routing(session_id, platform, threads[platform])
 
-    # One incident row per landed leg, so a reply in ANY of the channels the
-    # report reached replays it. Storing only the owner's is what left a reply
-    # in the other channel answered by an agent that had never seen the report.
-    for chat_id, thread_id in _lookup_platform_threads(session_id).values():
-        _store_incident_report(chat_id, thread_id, message)
+    # One incident row per leg that landed ON THIS RUN, so a reply in any of
+    # the channels the report actually reached replays it. Storing only the
+    # owner's is what left a reply in the other channel answered by an agent
+    # that had never seen the report.
+    #
+    # The filter is not decoration. `platform_threads` is additive and never
+    # pruned, and the session id is per job per UTC day, so the read-back also
+    # holds legs that landed earlier today and failed just now — and a platform
+    # an operator disabled mid-day, which is no longer in `platforms` at all.
+    # `_store_incident_report` is INSERT OR REPLACE on `(chat_id, thread_id)`,
+    # so writing those rows would overwrite each channel's stored context with a
+    # report it never received and drop the one still on its screen.
+    registered = _lookup_platform_threads(session_id)
+    for platform in threads:
+        entry = registered.get(platform)
+        if entry:
+            _store_incident_report(entry[0], entry[1], message)
 
     logger.info(
         f"Relayed {profile}/{job_id} report to {', '.join(threads)} "
@@ -1893,12 +2006,15 @@ def submit_cron_report(request_data: Dict[str, Any]) -> Dict[str, str]:
     # whose front door has been down all week is visible without reading logs.
     # `undelivered` is the same idea one platform down: a fan-out that reached
     # one audience and missed another is a delivery, and still something the run
-    # record has to carry.
+    # record has to carry. `truncated` is the third: the human sees the
+    # `[truncated]` line in the channel, and without this the agent that wrote
+    # the report — the one that could have split it — is told only "accepted".
     return {
         "status": "delivered",
         "session_id": session_id,
         "relay": "degraded" if degraded else "ok",
         "undelivered": ",".join(undelivered),
+        "truncated": "true" if truncation_notice else "",
     }
 def _watcher_features(header_value: str) -> set:
     """The response behaviours the calling watcher said it understands.

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -751,7 +751,8 @@ def enabled_chat_platforms() -> list[str]:
        `platforms.<p>.enabled` keys as explicit booleans on every reconcile, so
        the CR's answer is on disk in the container and there is nothing to
        infer. Reading it is what #1094 means by "stop guessing the platform".
-    2. CONFIG_PATH, the profile's own writable `config.yaml`. Authoritative on
+    2. CONFIG_PATH — `/opt/data/config.yaml`, the front door's own writable
+       file rather than a named profile's. Authoritative on
        an install that has no operator — a `docker run` off the image, a profile
        configured by hand — and normally silent on a managed pod: Hermes
        overlays the managed scope per leaf inside its own config loader rather
@@ -769,8 +770,16 @@ def enabled_chat_platforms() -> list[str]:
     .get_enabled_platforms` is still keyed on the absent SLACK_BOT_TOKEN (#735
     is open against it), and open PR #996 adds `chat_platforms
     .enabled_chat_platforms` for the Cluster Agent reconcile summary (#989).
-    The ordering and the precedence here are deliberately #996's, so that
-    whichever lands second is a re-point rather than a behaviour change.
+
+    Converging on #996's module is a re-point for the ORDER and the per-platform
+    resolution, which are deliberately the same, and NOT for the sources: #996
+    reads `CONFIG_PATH` then the environment, and the managed scope above is a
+    third source it does not have, at higher precedence than either. Dropping it
+    is not a refactor — on a pod whose CR sets `slack.enabled: false` while a
+    stale `SLACK_RELAY_URL` lingers in the container environment, this resolves
+    `["google_chat"]` and #996's resolves `["google_chat", "slack"]`, re-enabling
+    a leg an operator turned off. Whichever lands second has to carry
+    `_platforms_enabled_in(MANAGED_CONFIG_PATH)` across with it.
     """
     from_managed = _platforms_enabled_in(MANAGED_CONFIG_PATH)
     from_profile = _platforms_enabled_in(CONFIG_PATH)
@@ -809,8 +818,9 @@ def get_active_platform() -> str:
     platforms = enabled_chat_platforms()
     if len(platforms) > 1:
         logger.warning(
-            f"{len(platforms)} chat platforms are enabled ({', '.join(platforms)}); "
-            f"this send takes one destination and uses '{platforms[0]}'"
+            f"{len(platforms)} chat platforms are enabled; this send takes one "
+            f"destination, so it uses '{platforms[0]}' and "
+            f"{', '.join(platforms[1:])} will not receive it"
         )
     return platforms[0]
 
@@ -916,6 +926,15 @@ def _register_session_routing(session_id: str, platform: str, thread_id: str) ->
     the patch treats as non-chat and declines to substitute — so a session that
     never reached this function keeps today's behaviour instead of being
     re-addressed to a guess.
+
+    The same call also records the thread under `platform_threads`, keyed by
+    platform. Those three fields hold ONE address because the card has one
+    destination, but a fanned-out cron report has a thread per platform, and
+    keeping only the winner's is what made a leg that failed once stay unthreaded
+    for the rest of the day: the next report found the row naming another
+    platform, posted a fresh top-level message, and did it again on every run.
+    `platform_threads` is additive and never overwritten by another platform, so
+    each leg keeps its own thread whatever the top-level fields say.
     """
     try:
         with closing(sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0)) as conn:
@@ -932,7 +951,16 @@ def _register_session_routing(session_id: str, platform: str, thread_id: str) ->
                         meta["chat_id"] = os.environ.get("SLACK_HOME_CHANNEL", "")
                     else:
                         meta["chat_id"] = thread_id.split("/threads/")[0]
-                    
+
+                    threads = meta.get("platform_threads")
+                    if not isinstance(threads, dict):
+                        threads = {}
+                    threads[platform] = {
+                        "chat_id": meta["chat_id"],
+                        "thread_id": thread_id,
+                    }
+                    meta["platform_threads"] = threads
+
                     # Update SQLite metadata table
                     conn.execute(
                         "UPDATE session_metadata SET metadata = ? WHERE session_id = ?",
@@ -1169,11 +1197,34 @@ def trigger_agent_troubleshooter(
     event_row_id: Optional[int] = None,
 ) -> None:
     """Post warning alert to Chat, configure thread mapping, and trigger the agent loop in background."""
-    active_platform = get_active_platform()
+    # 1. Post initial warning notification to Google Chat or Slack.
+    #
+    #    One destination, but the first one is not the only one tried. This path
+    #    cannot fan out the way `relay_cron_report` does — it registers the
+    #    thread it gets back as the session's routing, the triage card's
+    #    completion is addressed there, and a thread belongs to one platform —
+    #    so it takes the first platform that actually accepts the alert.
+    #
+    #    Falling through matters because picking is otherwise just a choice of
+    #    which install loses. #1094 was a dual-platform install whose Slack leg
+    #    had no home channel, and reordering alone would mirror it: an install
+    #    whose *Google Chat* leg is the broken one would lose every alert to a
+    #    send that fails while a working Slack sits second in the list. The
+    #    relay learned to fan out for this reason; without this loop the alert
+    #    path would have learned nothing.
+    platforms = enabled_chat_platforms()
+    active_platform, thread_id = platforms[0], None
+    for candidate in platforms:
+        thread_id = _post_initial_alert(candidate, alert_msg)
+        if thread_id:
+            active_platform = candidate
+            break
+        if len(platforms) > 1:
+            logger.warning(
+                f"Alert for session {session_id} was not accepted by '{candidate}'"
+                + (f"; trying the next enabled platform" if candidate != platforms[-1] else "")
+            )
 
-    # 1. Post initial warning notification to Google Chat or Slack
-    thread_id = _post_initial_alert(active_platform, alert_msg)
-    
     # 2. Register thread-to-session mappings for two-way chat routing. This has
     #    to happen before the turn in step 5: the card that turn files reads
     #    this row to address its completion back to the alert's thread (see
@@ -1196,11 +1247,12 @@ def trigger_agent_troubleshooter(
         # mode is false reassurance.
         mark_delivery_failed(
             event_row_id,
-            f"no message id from '{active_platform}'; see the session server log",
+            f"no message id from {' or '.join(repr(p) for p in platforms)}; "
+            "see the session server log",
         )
         logger.error(
-            f"Alert for session {session_id} was not delivered to '{active_platform}'; "
-            "the daily recap will report it as undelivered"
+            f"Alert for session {session_id} was not delivered to any enabled platform "
+            f"({', '.join(platforms)}); the daily recap will report it as undelivered"
         )
 
     # 3. Configure HTTP authentication headers for Hermes REST gateway
@@ -1309,21 +1361,30 @@ def _sanitize_label(value: str) -> str:
     return neutralised
 
 
-def _truncate_report(report: str, profile: str, job_id: str) -> str:
-    """Cut an oversized report down to the cap rather than dropping it.
+def _truncate_report(report: str, profile: str, job_id: str) -> tuple[str, str]:
+    """Cut an oversized report to the cap. Returns `(report, notice)`.
+
+    `notice` is `""` for a report that fits, and otherwise the line that says so
+    — which the caller **prepends to the composed message after the relay turn**
+    rather than appending here. That placement is the point. Appended to the
+    report, the notice is model input: it reaches the Chat Agent as the last
+    lines of a document that `_build_relay_instructions` tells it to reproduce
+    while adding "nothing at the bottom", so the one sentence a reader needs in
+    order to know the report is incomplete is the sentence the instructions
+    invite it to drop. Prepending it to the finished message is how
+    :func:`_unrelayed_notice` makes the same kind of admission unconditional,
+    and this follows it.
 
     An over-cap report used to be answered with HTTP 413, which the scheduler
     recorded in `last_delivery_error` and nothing else did anything about — so
-    the finding was lost. That is not a hypothetical: the fleet-wide audits on
-    the autopush roster produce 60k characters against a 12000 cap, and
-    `stockout-prevention` and `compliance-audit` were dropped whole on 30 and 31
-    August 2026 (#1094).
+    the finding was lost. #1094 records three such runs on the autopush roster
+    over 30 and 31 August 2026, across `stockout-prevention` and
+    `compliance-audit`, whose fleet-wide output runs to roughly five times this
+    cap.
 
     A cut report is worse than a whole one and much better than none. The head
-    is what survives, because every governance SOP on the roster leads with its
-    summary and puts the evidence appendix last, so the first 12000 characters
-    are the part a reader needs. The notice names the directory the scheduler
-    saved the full text to, so nothing is only in the truncated copy.
+    survives, and the notice names the directory the scheduler saved the full
+    text to, so nothing is only in the truncated copy.
 
     Not a link: the file lives on the agent's PVC under
     `$HERMES_HOME/cron/output/<job_id>/<timestamp>.md` and the run's own
@@ -1331,20 +1392,19 @@ def _truncate_report(report: str, profile: str, job_id: str) -> str:
     layer can honestly be.
     """
     if len(report) <= CRON_REPORT_MAX_CHARS:
-        return report
+        return report, ""
 
     notice = (
-        f"\n\n---\n[truncated] This report was {len(report)} characters, over the "
-        f"{CRON_REPORT_MAX_CHARS}-character chat limit. The text above is the "
-        f"beginning of it; the whole report was saved by the scheduler under "
-        f"`cron/output/{job_id}/` in the {profile} profile's home."
+        f"[truncated] This report was {len(report)} characters, over the "
+        f"{CRON_REPORT_MAX_CHARS}-character chat limit, so what follows is the "
+        f"beginning of it. The whole report was saved by the scheduler under "
+        f"`cron/output/{job_id}/` in the {profile} profile's home.\n\n"
     )
-    kept = max(0, CRON_REPORT_MAX_CHARS - len(notice))
     logger.warning(
         f"Relay for {profile}/{job_id}: report is {len(report)} chars, truncating to "
-        f"{kept} for the {CRON_REPORT_MAX_CHARS}-char chat limit"
+        f"{CRON_REPORT_MAX_CHARS} for the chat limit"
     )
-    return report[:kept].rstrip() + notice
+    return report[:CRON_REPORT_MAX_CHARS].rstrip(), notice
 
 
 def _cron_report_session_id(profile: str, job_id: str, day: str) -> str:
@@ -1372,13 +1432,24 @@ def _cron_report_session_id(profile: str, job_id: str, day: str) -> str:
 def _lookup_session_routing(session_id: str) -> tuple[str, str, str]:
     """Read back (platform, chat_id, thread_id), or ("", "", "") if unrouted.
 
-    `platform` matters to the fan-out in :func:`relay_cron_report`: a thread
-    belongs to exactly one platform, and replaying a Google Chat thread id on
-    the Slack leg addresses a thread that does not exist. Only the leg this
-    names may reuse the stored thread. `_ensure_session_row` seeds the field
-    with the `cron-report` sentinel, which matches no platform, so a session
-    nothing has routed yet reads as unrouted here rather than as Google Chat.
+    This is the session's ONE address — what the event-triage card is addressed
+    to. `_ensure_session_row` seeds `platform` with the `cron-report` sentinel,
+    which matches no platform, so a session nothing has routed yet reads as
+    unrouted here rather than as Google Chat.
+
+    For the per-leg threads a fanned-out report needs, see
+    :func:`_lookup_platform_threads`.
     """
+    meta = _session_metadata(session_id)
+    return (
+        str(meta.get("platform") or ""),
+        str(meta.get("chat_id") or ""),
+        str(meta.get("thread_id") or ""),
+    )
+
+
+def _session_metadata(session_id: str) -> Dict[str, Any]:
+    """The parsed metadata blob for a session, or `{}` if there is none."""
     try:
         with closing(sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0)) as conn:
             row = conn.execute(
@@ -1386,16 +1457,34 @@ def _lookup_session_routing(session_id: str) -> tuple[str, str, str]:
                 (session_id,),
             ).fetchone()
         if not row:
-            return "", "", ""
+            return {}
         meta = json.loads(row[0])
-        return (
-            str(meta.get("platform") or ""),
-            str(meta.get("chat_id") or ""),
-            str(meta.get("thread_id") or ""),
-        )
+        return meta if isinstance(meta, dict) else {}
     except Exception as exc:
         logger.error(f"Failed to read session routing for {session_id}: {exc}")
-        return "", "", ""
+        return {}
+
+
+def _lookup_platform_threads(session_id: str) -> Dict[str, tuple[str, str]]:
+    """Each platform's own `(chat_id, thread_id)` for this session.
+
+    A thread id is platform-local — `hermes send` refuses a Google Chat thread
+    addressed as Slack rather than degrading it to the home channel — so a
+    fanned-out report cannot share one address across its legs. Every leg reads
+    its own entry here and none of them can pick up another's.
+    """
+    threads = _session_metadata(session_id).get("platform_threads")
+    if not isinstance(threads, dict):
+        return {}
+    out: Dict[str, tuple[str, str]] = {}
+    for platform, entry in threads.items():
+        if not isinstance(entry, dict):
+            continue
+        chat_id = str(entry.get("chat_id") or "")
+        thread_id = str(entry.get("thread_id") or "")
+        if chat_id and thread_id:
+            out[str(platform)] = (chat_id, thread_id)
+    return out
 
 
 def _ensure_session_row(session_id: str, profile: str, job_id: str, title: str = "") -> None:
@@ -1627,7 +1716,12 @@ def _unrelayed_notice(profile: str, job_id: str) -> str:
 
 
 def relay_cron_report(
-    session_id: str, profile: str, job_id: str, title: str, report: str
+    session_id: str,
+    profile: str,
+    job_id: str,
+    title: str,
+    report: str,
+    truncation_notice: str = "",
 ) -> tuple[str | None, bool, list[str]]:
     """Hand a specialist's finished report to the Chat Agent, then post its reply.
 
@@ -1687,24 +1781,23 @@ def relay_cron_report(
         logger.warning(f"Relay for {profile}/{job_id}: posting the raw report, unrelayed")
         message = _unrelayed_notice(profile, job_id) + report
 
-    routed_platform, chat_id, thread_id = _lookup_session_routing(session_id)
+    if truncation_notice:
+        # After the turn, never before it. Appended to the report it would be
+        # model input, and the instructions tell the Chat Agent to add "nothing
+        # at the bottom" — so the one line saying the report is incomplete is
+        # the line most likely to be dropped. See :func:`_truncate_report`.
+        message = truncation_notice + message
 
-    # One send per enabled platform. Only the leg the session is already routed
-    # to may reuse the stored thread — a thread id is platform-local, and
-    # `hermes send` refuses a Google Chat thread addressed as Slack rather than
-    # degrading it to the home channel. Every other leg posts to its own home
-    # channel, so the second platform gets a top-level message per report
-    # instead of a thread of its own; per-platform threading needs a routing row
-    # that can hold more than one, which this does not attempt.
+    routed_platform = _lookup_session_routing(session_id)[0]
+    known_threads = _lookup_platform_threads(session_id)
+
+    # One send per enabled platform, each into its OWN thread. A thread id is
+    # platform-local, so every leg reads its own entry and none can pick up
+    # another's; a leg with no entry yet posts to its home channel and gets one.
     threads: Dict[str, str] = {}
     for platform in platforms:
-        threaded = platform == routed_platform
-        new_thread_id = _send_to_chat(
-            platform,
-            message,
-            chat_id if threaded else "",
-            thread_id if threaded else "",
-        )
+        leg_chat_id, leg_thread_id = known_threads.get(platform, ("", ""))
+        new_thread_id = _send_to_chat(platform, message, leg_chat_id, leg_thread_id)
         if new_thread_id:
             threads[platform] = new_thread_id
         else:
@@ -1716,21 +1809,28 @@ def relay_cron_report(
     if not threads:
         return f"composed but not delivered to {', '.join(platforms)}", degraded, undelivered
 
-    # The routed leg keeps the thread the user replies into; if it is the leg
-    # that failed, the first one that did land takes it over, so a follow-up
-    # question reaches a session that has the report rather than one addressed
-    # at a platform the report never arrived on.
+    # Register every leg that landed, so each keeps its own thread for the rest
+    # of the day. Order matters: the owner goes last, because the top-level
+    # `platform`/`chat_id`/`thread_id` fields hold one address and the last
+    # write wins. The owner is the routed platform when it landed, else the
+    # first that did — so a follow-up question reaches a session that has the
+    # report rather than one addressed at a platform it never arrived on, and a
+    # leg that fails once does not lose its thread for the rest of the day.
     owner = routed_platform if routed_platform in threads else next(
         p for p in platforms if p in threads
     )
-    if owner != routed_platform or threads[owner] != thread_id:
-        _register_session_routing(session_id, owner, threads[owner])
-        _, chat_id, thread_id = _lookup_session_routing(session_id)
+    for platform in [p for p in platforms if p in threads and p != owner] + [owner]:
+        _register_session_routing(session_id, platform, threads[platform])
 
-    _store_incident_report(chat_id, thread_id, message)
+    # One incident row per landed leg, so a reply in ANY of the channels the
+    # report reached replays it. Storing only the owner's is what left a reply
+    # in the other channel answered by an agent that had never seen the report.
+    for chat_id, thread_id in _lookup_platform_threads(session_id).values():
+        _store_incident_report(chat_id, thread_id, message)
+
     logger.info(
         f"Relayed {profile}/{job_id} report to {', '.join(threads)} "
-        f"({owner} thread {thread_id})"
+        f"(replies routed to {owner})"
     )
     if undelivered:
         logger.error(
@@ -1774,14 +1874,14 @@ def submit_cron_report(request_data: Dict[str, Any]) -> Dict[str, str]:
         raise HTTPException(status_code=400, detail="job_id field is required")
     if not report:
         raise HTTPException(status_code=400, detail="report field is required")
-    report = _truncate_report(report, profile, job_id)
+    report, truncation_notice = _truncate_report(report, profile, job_id)
 
     day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     session_id = _cron_report_session_id(profile, job_id, day)
 
     try:
         error, degraded, undelivered = relay_cron_report(
-            session_id, profile, job_id, title, report
+            session_id, profile, job_id, title, report, truncation_notice
         )
     except Exception as exc:  # never leak a stack trace into last_delivery_error
         logger.exception(f"Relay for {profile}/{job_id} raised")

--- a/agents/platform/scripts/session_kv_server.py
+++ b/agents/platform/scripts/session_kv_server.py
@@ -98,6 +98,16 @@ MANAGED_DOTENV_PATH = os.path.join(
     os.environ.get("HERMES_MANAGED_DIR", "").strip() or "/etc/hermes", ".env"
 )
 
+# The other half of the managed scope, and the only file on this pod that states
+# which chat platforms the CR turned on. `renderConfigYAML` always emits
+# `platforms.google_chat.enabled` and `platforms.slack.enabled` as explicit
+# booleans (no omitempty on either field), so unlike CONFIG_PATH this answers
+# the question rather than falling silent — see `enabled_chat_platforms`.
+# Resolved from HERMES_MANAGED_DIR the same way, and for the same reason.
+MANAGED_CONFIG_PATH = os.path.join(
+    os.environ.get("HERMES_MANAGED_DIR", "").strip() or "/etc/hermes", "config.yaml"
+)
+
 
 def _dotenv_value(path: str, name: str) -> str:
     """Return `name`'s value from a dotenv file, or "" if it does not carry one.
@@ -648,62 +658,161 @@ def get_severity_details(event_type: str, reason: str) -> tuple[str, str]:
 
 
 
-def get_active_platform() -> str:
+# The chat platforms this harness ships an egress path for, in the order a
+# message is posted to them and in the order a single-destination caller picks
+# one. Google Chat leads, and the ordering is the whole of #1094.
+#
+# #855 put Slack first, on the reasoning that a dual-platform install "resolves
+# the same way whichever branch answers". It does — and the answer it resolves
+# to is the wrong one. Autopush had both integrations on, Slack with no home
+# channel and a gateway that could not connect, so every scheduled governance
+# report from 2026-08-25 to 2026-09-01 was composed by the Chat Agent, posted
+# nowhere, and lost. Google Chat first means a dual-platform install *gains* a
+# platform rather than having its messages moved to one; the same order, for the
+# same reason, is what open PR #996 gives the Cluster Agent reconcile summary.
+#
+# This does not undo #855. That defect was a Slack-*only* install calling itself
+# google_chat, and resolution below is per platform: with Google Chat off,
+# nothing puts it in the list whatever the order says.
+CHAT_PLATFORMS = ("google_chat", "slack")
+
+# Per-platform environment signals, consulted only when no config file settles
+# the question. The relay URL leads each list because the operator sets it on
+# this container exactly when the matching `spec.integration.<p>.enabled` is
+# true (platformagent_manifests.go, the GoogleChat/Slack blocks in
+# buildPodTemplateSpec and renderManagedEnv), so it answers the question rather
+# than approximating it.
+#
+# SLACK_BOT_TOKEN is kept, and is inert on a deployed pod: a token is a
+# credential, so it lives in the credential-proxy container and never reaches
+# this one — the specific defect #855 fixed. It stays because a bare
+# `docker run` off the image has no operator to render a relay URL, and there an
+# exported token is the only statement that Slack is configured.
+_CHAT_ENV_SIGNALS: Dict[str, tuple[str, ...]] = {
+    "google_chat": ("GOOGLE_CHAT_RELAY_URL", "GOOGLE_CHAT_PROJECT_ID", "GOOGLE_CHAT_HOME_CHANNEL"),
+    "slack": ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN", "SLACK_HOME_CHANNEL"),
+}
+
+# Where a message goes when nothing resolves at all. Preserves what every caller
+# here did before any of this existed, so an install this cannot read is no
+# worse off than it was and no send is addressed to the empty string.
+DEFAULT_CHAT_PLATFORM = "google_chat"
+
+
+def _mapping(value: object) -> dict:
+    """`value` if it is a mapping, else an empty one.
+
+    Every traversal of a parsed config goes through this. `config.yaml` is a
+    file the running agent writes to and a human may hand-edit, so
+    `platforms: slack` is valid YAML that parses to a string and reaches `.get`
+    as one. A wrong shape must cost the platform resolution, not the caller.
+    """
+    return value if isinstance(value, dict) else {}
+
+
+def _platforms_enabled_in(path: str) -> Dict[str, bool]:
+    """`platforms.<name>.enabled` from one config file, for the keys that set it.
+
+    Absent keys are absent from the result rather than False: "this file does
+    not say" and "this file says no" are different answers, and only the second
+    may override a lower-precedence source. A bare `enabled:` with no value
+    parses to None, which is the first answer, so it is dropped too.
+    """
     try:
         import yaml
-        with open(CONFIG_PATH, "r") as f:
-            cfg = yaml.safe_load(f) or {}
-        platforms = cfg.get("platforms", {})
-        if platforms.get("slack", {}).get("enabled"):
-            return "slack"
-        if platforms.get("google_chat", {}).get("enabled"):
-            return "google_chat"
+        with open(path, "r") as handle:
+            cfg = yaml.safe_load(handle) or {}
+        platforms = _mapping(_mapping(cfg).get("platforms"))
+    except FileNotFoundError:
+        return {}
     except Exception as exc:
-        logger.error(f"Failed to parse config.yaml for active platform: {exc}")
-    # This is the selector on an operator-managed pod, not a corner case.
-    # CONFIG_PATH is $PLATFORM_AGENT_HOME/config.yaml — the agent's own
-    # writable file, seeded from agents/chat/config.yaml. The operator's
-    # `platforms.<p>.enabled` does not go there: renderConfigYAML writes it to
-    # the managed scope mounted read-only at /etc/hermes, which Hermes overlays
-    # per leaf key inside its own config loader rather than merging to disk
-    # (docker-entrypoint.sh, "The pins do NOT come through this file"; the
-    # template block at agents/chat/config.yaml:257 says the same from the
-    # other side). The open() above therefore reads a `platforms` subtree with
-    # no `enabled` key at all, both branches fall through, and control arrives
-    # here on every alert.
-    #
-    # So SLACK_RELAY_URL is not a better fallback signal, it is the answer.
-    # SLACK_BOT_TOKEN never reaches this container — it is a credential, so it
-    # lives in the credential-proxy container, which is what
-    # TestBuildDeploymentSlackIntegration in platformagent_manifests_test.go
-    # pins (TestBuildDeployment holds the general "no Secret-backed env in the
-    # sandbox" rule, but its fixture configures Google Chat only and never
-    # renders a Slack variable to check). Asking for the token here was asking
-    # a question whose answer in a deployed pod is always "no", so every
-    # Slack-only install called itself google_chat and lost the alert to a
-    # `hermes send` against a platform that is not configured. SLACK_RELAY_URL
-    # is set on this container exactly when spec.integration.slack.enabled is.
-    #
-    # Slack-before-Google-Chat matches the try block above, so an install with
-    # both integrations enabled resolves the same way whichever branch answers.
-    # That is a routing change for a dual-platform install, which until now
-    # always landed on google_chat here; see Risk & Rollout on the PR.
-    #
-    # The token is still accepted rather than replaced: it is the signal that
-    # works for a bare `docker run` off the image, where no operator has
-    # rendered anything and an exported token is all there is.
-    # platform_mcp_server.py:690 leans on the same absent SLACK_BOT_TOKEN, but
-    # it is not as badly off: it also accepts SLACK_HOME_CHANNEL, which the
-    # operator does render on this container when spec.integration.slack
-    # .homeChannel is set and which is allowlisted into that child
-    # (agents/platform/config.yaml). So it misroutes only on a Slack install
-    # with no home channel anywhere — an install whose sends have no
-    # destination in any case. It is deliberately left alone here — open PR
-    # #735 fixes that copy, and it needs the MCP env allowlist widened to pass
-    # SLACK_RELAY_URL through, which is that PR's to do.
-    if os.environ.get("SLACK_RELAY_URL") or os.environ.get("SLACK_BOT_TOKEN"):
-        return "slack"
-    return "google_chat"
+        logger.error(f"Failed to parse {path} for the active chat platform: {exc}")
+        return {}
+
+    out: Dict[str, bool] = {}
+    for name in CHAT_PLATFORMS:
+        block = _mapping(platforms.get(name))
+        if block.get("enabled") is not None:
+            out[name] = bool(block["enabled"])
+    return out
+
+
+def enabled_chat_platforms() -> list[str]:
+    """Every chat platform this install posts to, in CHAT_PLATFORMS order.
+
+    Three sources, most specific first, resolved **per platform** rather than
+    per source — so a file that names one platform cannot silence another that
+    only a lower-precedence source knows about. That short circuit is the shape
+    of the bug this replaces: one `if` matched, the function returned, and the
+    other platform was never considered.
+
+    1. The managed scope, `/etc/hermes/config.yaml`. On an operator-managed pod
+       this settles it outright: `renderConfigYAML` writes both
+       `platforms.<p>.enabled` keys as explicit booleans on every reconcile, so
+       the CR's answer is on disk in the container and there is nothing to
+       infer. Reading it is what #1094 means by "stop guessing the platform".
+    2. CONFIG_PATH, the profile's own writable `config.yaml`. Authoritative on
+       an install that has no operator — a `docker run` off the image, a profile
+       configured by hand — and normally silent on a managed pod: Hermes
+       overlays the managed scope per leaf inside its own config loader rather
+       than merging it onto this file (docker-entrypoint.sh, "The pins do NOT
+       come through this file"), so the `platforms` subtree here carries no
+       `enabled` key at all. #855 established that; it is read second rather
+       than dropped because it is the truth on the installs that do write it.
+    3. The environment signals above, for an install neither file describes.
+
+    Never returns an empty list — an install that resolves to nothing gets
+    DEFAULT_CHAT_PLATFORM.
+
+    This is the third copy of this question in the tree, and the copies should
+    converge rather than a fourth being added: `platform_mcp_server
+    .get_enabled_platforms` is still keyed on the absent SLACK_BOT_TOKEN (#735
+    is open against it), and open PR #996 adds `chat_platforms
+    .enabled_chat_platforms` for the Cluster Agent reconcile summary (#989).
+    The ordering and the precedence here are deliberately #996's, so that
+    whichever lands second is a re-point rather than a behaviour change.
+    """
+    from_managed = _platforms_enabled_in(MANAGED_CONFIG_PATH)
+    from_profile = _platforms_enabled_in(CONFIG_PATH)
+
+    resolved = []
+    for name in CHAT_PLATFORMS:
+        if name in from_managed:
+            enabled = from_managed[name]
+        elif name in from_profile:
+            enabled = from_profile[name]
+        else:
+            enabled = any(
+                os.environ.get(var, "").strip()
+                for var in _CHAT_ENV_SIGNALS.get(name, ())
+            )
+        if enabled:
+            resolved.append(name)
+    return resolved or [DEFAULT_CHAT_PLATFORM]
+
+
+def get_active_platform() -> str:
+    """The one platform a single-destination caller posts to.
+
+    `_post_initial_alert` needs exactly one: it registers the thread it gets
+    back as the session's routing, the triage card's completion is addressed to
+    that thread, and a thread belongs to one platform — `hermes send` refuses a
+    Google Chat thread addressed as Slack rather than degrading it to the home
+    channel. Two alerts in two threads would leave the report addressable to
+    only one of them, so this path picks rather than fans out.
+
+    Picking is not the same as picking silently, which is #1094's other half:
+    an install with more than one platform enabled says so in the log, once per
+    call, naming the destination that lost. The relay in
+    :func:`relay_cron_report` has no such constraint and does fan out.
+    """
+    platforms = enabled_chat_platforms()
+    if len(platforms) > 1:
+        logger.warning(
+            f"{len(platforms)} chat platforms are enabled ({', '.join(platforms)}); "
+            f"this send takes one destination and uses '{platforms[0]}'"
+        )
+    return platforms[0]
 
 
 def _post_initial_alert(active_platform: str, alert_msg: str) -> str | None:
@@ -1141,6 +1250,8 @@ _CRON_REPORT_SESSION_RE = re.compile(r"[^a-zA-Z0-9_-]+")
 # A report is a chat message, not a document. The cap is generous enough for a
 # full audit summary and small enough that a job which accidentally cats a log
 # cannot push a megabyte through the model and into the channel.
+#
+# It is a truncation point and not a rejection: see :func:`_truncate_report`.
 CRON_REPORT_MAX_CHARS = int(os.getenv("CRON_REPORT_MAX_CHARS", "12000") or "12000")
 
 # `job_id` and `title` are labels, and a label is one short line. The bound is
@@ -1198,6 +1309,44 @@ def _sanitize_label(value: str) -> str:
     return neutralised
 
 
+def _truncate_report(report: str, profile: str, job_id: str) -> str:
+    """Cut an oversized report down to the cap rather than dropping it.
+
+    An over-cap report used to be answered with HTTP 413, which the scheduler
+    recorded in `last_delivery_error` and nothing else did anything about — so
+    the finding was lost. That is not a hypothetical: the fleet-wide audits on
+    the autopush roster produce 60k characters against a 12000 cap, and
+    `stockout-prevention` and `compliance-audit` were dropped whole on 30 and 31
+    August 2026 (#1094).
+
+    A cut report is worse than a whole one and much better than none. The head
+    is what survives, because every governance SOP on the roster leads with its
+    summary and puts the evidence appendix last, so the first 12000 characters
+    are the part a reader needs. The notice names the directory the scheduler
+    saved the full text to, so nothing is only in the truncated copy.
+
+    Not a link: the file lives on the agent's PVC under
+    `$HERMES_HOME/cron/output/<job_id>/<timestamp>.md` and the run's own
+    timestamp is not on this request, so the directory is as precise as this
+    layer can honestly be.
+    """
+    if len(report) <= CRON_REPORT_MAX_CHARS:
+        return report
+
+    notice = (
+        f"\n\n---\n[truncated] This report was {len(report)} characters, over the "
+        f"{CRON_REPORT_MAX_CHARS}-character chat limit. The text above is the "
+        f"beginning of it; the whole report was saved by the scheduler under "
+        f"`cron/output/{job_id}/` in the {profile} profile's home."
+    )
+    kept = max(0, CRON_REPORT_MAX_CHARS - len(notice))
+    logger.warning(
+        f"Relay for {profile}/{job_id}: report is {len(report)} chars, truncating to "
+        f"{kept} for the {CRON_REPORT_MAX_CHARS}-char chat limit"
+    )
+    return report[:kept].rstrip() + notice
+
+
 def _cron_report_session_id(profile: str, job_id: str, day: str) -> str:
     """Deterministic session id for one job's reports on one UTC day.
 
@@ -1220,8 +1369,16 @@ def _cron_report_session_id(profile: str, job_id: str, day: str) -> str:
     return f"cron-{slug[:80]}-{day.replace('-', '')}"
 
 
-def _lookup_session_routing(session_id: str) -> tuple[str, str]:
-    """Read back (chat_id, thread_id) for a session, or ("", "") if unrouted."""
+def _lookup_session_routing(session_id: str) -> tuple[str, str, str]:
+    """Read back (platform, chat_id, thread_id), or ("", "", "") if unrouted.
+
+    `platform` matters to the fan-out in :func:`relay_cron_report`: a thread
+    belongs to exactly one platform, and replaying a Google Chat thread id on
+    the Slack leg addresses a thread that does not exist. Only the leg this
+    names may reuse the stored thread. `_ensure_session_row` seeds the field
+    with the `cron-report` sentinel, which matches no platform, so a session
+    nothing has routed yet reads as unrouted here rather than as Google Chat.
+    """
     try:
         with closing(sqlite3.connect(SESSION_KV_DB_PATH, timeout=5.0)) as conn:
             row = conn.execute(
@@ -1229,12 +1386,16 @@ def _lookup_session_routing(session_id: str) -> tuple[str, str]:
                 (session_id,),
             ).fetchone()
         if not row:
-            return "", ""
+            return "", "", ""
         meta = json.loads(row[0])
-        return str(meta.get("chat_id") or ""), str(meta.get("thread_id") or "")
+        return (
+            str(meta.get("platform") or ""),
+            str(meta.get("chat_id") or ""),
+            str(meta.get("thread_id") or ""),
+        )
     except Exception as exc:
         logger.error(f"Failed to read session routing for {session_id}: {exc}")
-        return "", ""
+        return "", "", ""
 
 
 def _ensure_session_row(session_id: str, profile: str, job_id: str, title: str = "") -> None:
@@ -1467,13 +1628,23 @@ def _unrelayed_notice(profile: str, job_id: str) -> str:
 
 def relay_cron_report(
     session_id: str, profile: str, job_id: str, title: str, report: str
-) -> tuple[str | None, bool]:
+) -> tuple[str | None, bool, list[str]]:
     """Hand a specialist's finished report to the Chat Agent, then post its reply.
 
-    Returns `(error, degraded)`. `error` is None when the report reached chat,
-    else a short description of what went wrong; the caller turns that into a
-    non-2xx and the string ends up in the job's `last_delivery_error` — see
-    :func:`submit_cron_report`.
+    Returns `(error, degraded, undelivered)`. `error` is None when the report
+    reached at least one chat platform, else a short description of what went
+    wrong; the caller turns that into a non-2xx and the string ends up in the
+    job's `last_delivery_error` — see :func:`submit_cron_report`.
+
+    `undelivered` names the enabled platforms this report did not reach while
+    another one did. The send fans out — every platform
+    :func:`enabled_chat_platforms` resolves gets the report, because a
+    dual-platform install has two audiences and delivering to one of them is
+    how #1094 lost seven days of governance output to a Slack leg that had no
+    home channel and no connection. A partial failure is a 200: the report is
+    in a channel and a re-run would post it twice to the platform that already
+    has it. It is not silent either — the caller puts this list in the response
+    body, from where the relay adapter writes it to `last_delivery_error`.
 
     `degraded` is the half that a boolean-or-nothing return used to swallow. The
     Chat Agent's turn can fail while the send still succeeds, and posting the raw
@@ -1494,7 +1665,7 @@ def relay_cron_report(
     report is posted unrelayed — a scheduled finding that reached a real problem
     should not be lost because the front door was busy.
     """
-    active_platform = get_active_platform()
+    platforms = enabled_chat_platforms()
     api_url = os.environ.get("PLATFORM_API_URL", "http://127.0.0.1:8642")
     headers = {"Content-Type": "application/json"}
     token = _gateway_api_token()
@@ -1516,19 +1687,57 @@ def relay_cron_report(
         logger.warning(f"Relay for {profile}/{job_id}: posting the raw report, unrelayed")
         message = _unrelayed_notice(profile, job_id) + report
 
-    chat_id, thread_id = _lookup_session_routing(session_id)
-    new_thread_id = _send_to_chat(active_platform, message, chat_id, thread_id)
-    if not new_thread_id:
-        logger.error(f"Relay for {profile}/{job_id}: report composed but not delivered")
-        return f"composed but not delivered to {active_platform}", degraded
+    routed_platform, chat_id, thread_id = _lookup_session_routing(session_id)
 
-    if new_thread_id != thread_id:
-        _register_session_routing(session_id, active_platform, new_thread_id)
-        chat_id, thread_id = _lookup_session_routing(session_id)
+    # One send per enabled platform. Only the leg the session is already routed
+    # to may reuse the stored thread — a thread id is platform-local, and
+    # `hermes send` refuses a Google Chat thread addressed as Slack rather than
+    # degrading it to the home channel. Every other leg posts to its own home
+    # channel, so the second platform gets a top-level message per report
+    # instead of a thread of its own; per-platform threading needs a routing row
+    # that can hold more than one, which this does not attempt.
+    threads: Dict[str, str] = {}
+    for platform in platforms:
+        threaded = platform == routed_platform
+        new_thread_id = _send_to_chat(
+            platform,
+            message,
+            chat_id if threaded else "",
+            thread_id if threaded else "",
+        )
+        if new_thread_id:
+            threads[platform] = new_thread_id
+        else:
+            logger.error(
+                f"Relay for {profile}/{job_id}: report composed but not delivered to {platform}"
+            )
+
+    undelivered = [p for p in platforms if p not in threads]
+    if not threads:
+        return f"composed but not delivered to {', '.join(platforms)}", degraded, undelivered
+
+    # The routed leg keeps the thread the user replies into; if it is the leg
+    # that failed, the first one that did land takes it over, so a follow-up
+    # question reaches a session that has the report rather than one addressed
+    # at a platform the report never arrived on.
+    owner = routed_platform if routed_platform in threads else next(
+        p for p in platforms if p in threads
+    )
+    if owner != routed_platform or threads[owner] != thread_id:
+        _register_session_routing(session_id, owner, threads[owner])
+        _, chat_id, thread_id = _lookup_session_routing(session_id)
 
     _store_incident_report(chat_id, thread_id, message)
-    logger.info(f"Relayed {profile}/{job_id} report to {active_platform} thread {thread_id}")
-    return None, degraded
+    logger.info(
+        f"Relayed {profile}/{job_id} report to {', '.join(threads)} "
+        f"({owner} thread {thread_id})"
+    )
+    if undelivered:
+        logger.error(
+            f"Relay for {profile}/{job_id}: delivered to {', '.join(threads)} but not to "
+            f"{', '.join(undelivered)}"
+        )
+    return None, degraded, undelivered
 
 
 @app.post("/v1/cron-reports", dependencies=[Depends(verify_api_key)])
@@ -1565,17 +1774,15 @@ def submit_cron_report(request_data: Dict[str, Any]) -> Dict[str, str]:
         raise HTTPException(status_code=400, detail="job_id field is required")
     if not report:
         raise HTTPException(status_code=400, detail="report field is required")
-    if len(report) > CRON_REPORT_MAX_CHARS:
-        raise HTTPException(
-            status_code=413,
-            detail=f"report is {len(report)} chars, over the {CRON_REPORT_MAX_CHARS} limit",
-        )
+    report = _truncate_report(report, profile, job_id)
 
     day = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     session_id = _cron_report_session_id(profile, job_id, day)
 
     try:
-        error, degraded = relay_cron_report(session_id, profile, job_id, title, report)
+        error, degraded, undelivered = relay_cron_report(
+            session_id, profile, job_id, title, report
+        )
     except Exception as exc:  # never leak a stack trace into last_delivery_error
         logger.exception(f"Relay for {profile}/{job_id} raised")
         raise HTTPException(status_code=502, detail=f"chat relay failed: {type(exc).__name__}") from exc
@@ -1584,10 +1791,14 @@ def submit_cron_report(request_data: Dict[str, Any]) -> Dict[str, str]:
     # 200, because the report is in the channel and the run did its job. `relay`
     # is what tells the scheduler which of the two deliveries it got, so a job
     # whose front door has been down all week is visible without reading logs.
+    # `undelivered` is the same idea one platform down: a fan-out that reached
+    # one audience and missed another is a delivery, and still something the run
+    # record has to carry.
     return {
         "status": "delivered",
         "session_id": session_id,
         "relay": "degraded" if degraded else "ok",
+        "undelivered": ",".join(undelivered),
     }
 def _watcher_features(header_value: str) -> set:
     """The response behaviours the calling watcher said it understands.

--- a/agents/platform/scripts/test_platform_mcp_server.py
+++ b/agents/platform/scripts/test_platform_mcp_server.py
@@ -846,6 +846,38 @@ class TestReportToChat(unittest.TestCase):
         result = report_to_chat("finding", job_id="j1")
         self.assertIn("SUCCESS", result)
         self.assertNotIn("degraded", result)
+        self.assertNotIn("partial", result)
+
+    @patch.dict(os.environ, {"HERMES_HOME": "/opt/data/profiles/platform", "SESSION_KV_API_KEY": "k"})
+    @patch("urllib.request.urlopen")
+    def test_a_partial_fan_out_is_not_reported_as_a_clean_success(self, mock_urlopen):
+        """The route fans out, so `relay: ok` no longer means everyone saw it.
+
+        This is the sibling of the relay adapter's own `undelivered` handling;
+        a caller that reads only `relay` tells the agent a half-delivered report
+        went out cleanly.
+        """
+        mock_urlopen.return_value = self._urlopen(
+            b'{"status": "delivered", "relay": "ok", "undelivered": "slack", "session_id": "s1"}'
+        )
+        result = report_to_chat("finding", job_id="j1")
+        self.assertIn("partial", result)
+        self.assertIn("slack", result)
+        self.assertNotIn("ERROR", result)
+        self.assertIn("do not send it again", result.lower())
+
+    @patch.dict(os.environ, {"HERMES_HOME": "/opt/data/profiles/platform", "SESSION_KV_API_KEY": "k"})
+    @patch("urllib.request.urlopen")
+    def test_degraded_and_partial_are_both_reported(self, mock_urlopen):
+        """A run can hit both, and an early return would drop one of them."""
+        mock_urlopen.return_value = self._urlopen(
+            b'{"status": "delivered", "relay": "degraded", "undelivered": "slack",'
+            b' "session_id": "s1"}'
+        )
+        result = report_to_chat("finding", job_id="j1")
+        self.assertIn("degraded", result)
+        self.assertIn("partial", result)
+        self.assertIn("unrelayed", result)
 
 
 class TestSanitizationAndMutationRemoval(unittest.TestCase):

--- a/agents/platform/scripts/test_platform_mcp_server.py
+++ b/agents/platform/scripts/test_platform_mcp_server.py
@@ -868,6 +868,34 @@ class TestReportToChat(unittest.TestCase):
 
     @patch.dict(os.environ, {"HERMES_HOME": "/opt/data/profiles/platform", "SESSION_KV_API_KEY": "k"})
     @patch("urllib.request.urlopen")
+    def test_a_truncated_report_says_so_to_the_agent_that_wrote_it(self, mock_urlopen):
+        """The `[truncated]` line goes to the human reading the channel.
+
+        The agent that composed the report is the only party that could have
+        split it, and without this it is told the report was accepted and
+        nothing else.
+        """
+        mock_urlopen.return_value = self._urlopen(
+            b'{"status": "delivered", "relay": "ok", "truncated": "true", "session_id": "s1"}'
+        )
+        result = report_to_chat("finding", job_id="j1")
+        self.assertIn("truncated", result)
+        self.assertNotIn("ERROR", result)
+        self.assertIn("do not send it again", result.lower())
+
+    @patch.dict(os.environ, {"HERMES_HOME": "/opt/data/profiles/platform", "SESSION_KV_API_KEY": "k"})
+    @patch("urllib.request.urlopen")
+    def test_an_untruncated_report_is_not_labelled_truncated(self, mock_urlopen):
+        """The route sends `truncated: ""` for a report that fit, and an empty
+        string must not read as a flag."""
+        mock_urlopen.return_value = self._urlopen(
+            b'{"status": "delivered", "relay": "ok", "truncated": "", "session_id": "s1"}'
+        )
+        result = report_to_chat("finding", job_id="j1")
+        self.assertNotIn("truncated", result)
+
+    @patch.dict(os.environ, {"HERMES_HOME": "/opt/data/profiles/platform", "SESSION_KV_API_KEY": "k"})
+    @patch("urllib.request.urlopen")
     def test_degraded_and_partial_are_both_reported(self, mock_urlopen):
         """A run can hit both, and an early return would drop one of them."""
         mock_urlopen.return_value = self._urlopen(

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -1070,19 +1070,18 @@ class TestSessionRoutingRecordsThePlatform(unittest.TestCase):
 
 
 class TestActivePlatformFallback(unittest.TestCase):
-    """`get_active_platform` when config.yaml does not name a platform.
+    """`get_active_platform` when no config file names a platform.
 
-    Which is every operator-managed pod: `platforms.<p>.enabled` is rendered
-    into the managed scope at /etc/hermes and overlaid inside Hermes' config
-    loader, never written to the CONFIG_PATH file this function opens. So the
-    environment branch is the live selector, and getting it wrong sends every
-    alert to a platform the install does not have. The config branch is still
-    covered below because it answers for a `docker run` off the image and for
-    any install whose writable config was edited to name one -- and because
-    the ordering between the two is what keeps this a fallback.
+    The three sources are the managed scope (/etc/hermes/config.yaml, which the
+    operator writes and which settles it outright on a deployed pod), the
+    profile's own writable CONFIG_PATH, and the environment. This class covers
+    the last two; `TestEnabledChatPlatforms` below covers the managed scope and
+    the per-platform resolution across all three.
     """
 
-    _KEYS = ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN")
+    _KEYS = ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN", "SLACK_HOME_CHANNEL",
+             "GOOGLE_CHAT_RELAY_URL", "GOOGLE_CHAT_PROJECT_ID",
+             "GOOGLE_CHAT_HOME_CHANNEL")
 
     def setUp(self):
         # patch.dict restores the whole mapping, and addCleanup runs even if a
@@ -1093,6 +1092,12 @@ class TestActivePlatformFallback(unittest.TestCase):
         self.addCleanup(env.stop)
         for key in self._KEYS:
             os.environ.pop(key, None)
+        # No managed scope, which is what a `docker run` off the image has and
+        # what makes the two lower-precedence sources observable here.
+        managed = patch.object(
+            session_kv_server, "MANAGED_CONFIG_PATH", "/nonexistent/managed.yaml")
+        managed.start()
+        self.addCleanup(managed.stop)
         # A path that cannot parse, so tests that do not override it land in
         # the environment branch the way a deployed pod does.
         self._config = tempfile.NamedTemporaryFile(
@@ -1162,6 +1167,142 @@ class TestActivePlatformFallback(unittest.TestCase):
         os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
         self._with_config("platforms:\n  google_chat:\n    enabled: true\n")
         self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
+
+
+class TestEnabledChatPlatforms(unittest.TestCase):
+    """`enabled_chat_platforms` — every platform, not the first `if` that matched.
+
+    The invariant: a platform the install has enabled is never dropped, the
+    resolution never returns nothing, and the sources are consulted per platform
+    so one naming Slack cannot hide a Google Chat another knows about. That
+    short circuit is #1094 — `get_active_platform` returned on its first match,
+    so a dual-platform install resolved to Slack alone and seven days of
+    governance reports went to a leg with no home channel.
+    """
+
+    _KEYS = ("SLACK_RELAY_URL", "SLACK_BOT_TOKEN", "SLACK_HOME_CHANNEL",
+             "GOOGLE_CHAT_RELAY_URL", "GOOGLE_CHAT_PROJECT_ID",
+             "GOOGLE_CHAT_HOME_CHANNEL")
+
+    def setUp(self):
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
+        for key in self._KEYS:
+            os.environ.pop(key, None)
+        self._point("MANAGED_CONFIG_PATH", None)
+        self._point("CONFIG_PATH", None)
+
+    def _point(self, attribute, text):
+        """Point `attribute` at a config holding `text`, or at a missing file."""
+        if text is None:
+            named = "/nonexistent/kube-agents-test-absent.yaml"
+        else:
+            with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".yaml", delete=False) as handle:
+                handle.write(text)
+                named = handle.name
+            self.addCleanup(os.unlink, named)
+        patcher = patch.object(session_kv_server, attribute, named)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_the_managed_scope_settles_a_dual_platform_install(self):
+        # What the operator actually writes: renderConfigYAML emits both keys as
+        # explicit booleans on every reconcile, so there is nothing to infer.
+        self._point(
+            "MANAGED_CONFIG_PATH",
+            "platforms:\n  google_chat:\n    enabled: true\n  slack:\n    enabled: true\n",
+        )
+        self.assertEqual(
+            session_kv_server.enabled_chat_platforms(), ["google_chat", "slack"])
+
+    def test_the_managed_scope_outranks_the_environment(self):
+        # The autopush shape inverted: Slack is off in the CR but the pod still
+        # holds a stale SLACK_RELAY_URL. The file the operator wrote wins.
+        self._point(
+            "MANAGED_CONFIG_PATH",
+            "platforms:\n  google_chat:\n    enabled: true\n  slack:\n    enabled: false\n",
+        )
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["google_chat"])
+
+    def test_the_managed_scope_outranks_the_profile_config(self):
+        self._point("MANAGED_CONFIG_PATH", "platforms:\n  slack:\n    enabled: false\n")
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    enabled: true\n")
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["google_chat"])
+
+    def test_a_slack_only_install_does_not_regress_to_google_chat(self):
+        # #855's defect, and the reason CHAT_PLATFORMS ordering does not bring it
+        # back: Google Chat leads the list but nothing puts it in the result.
+        self._point(
+            "MANAGED_CONFIG_PATH",
+            "platforms:\n  google_chat:\n    enabled: false\n  slack:\n    enabled: true\n",
+        )
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["slack"])
+        self.assertEqual(session_kv_server.get_active_platform(), "slack")
+
+    def test_a_file_naming_one_platform_does_not_silence_the_other(self):
+        # Per platform, not per source. The config mentions only Slack; Google
+        # Chat is still resolved, from the environment.
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    enabled: true\n")
+        os.environ["GOOGLE_CHAT_RELAY_URL"] = "http://127.0.0.1:8765"
+        self.assertEqual(
+            session_kv_server.enabled_chat_platforms(), ["google_chat", "slack"])
+
+    def test_a_platforms_block_with_no_enabled_key_is_not_an_answer(self):
+        # The operator-managed shape of the *profile* copy: the subtree is there,
+        # `enabled` is not, because Hermes overlays that leaf in its own loader.
+        # It must fall through to the environment rather than read as False.
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    home_channel: C0123ABCD\n")
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["slack"])
+
+    def test_a_valueless_enabled_is_not_an_explicit_no(self):
+        # `enabled:` with nothing after it parses to None — "this file does not
+        # say", not "this file says no".
+        self._point("MANAGED_CONFIG_PATH", "platforms:\n  slack:\n    enabled:\n")
+        os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["slack"])
+
+    def test_an_empty_environment_value_is_not_a_signal(self):
+        os.environ["SLACK_RELAY_URL"] = "   "
+        self.assertEqual(session_kv_server.enabled_chat_platforms(), ["google_chat"])
+
+    def test_valid_yaml_of_the_wrong_shape_does_not_raise(self):
+        # `platforms: slack` is valid YAML, so safe_load returns cleanly and the
+        # wrong type reaches the traversal. config.yaml is hand-editable.
+        for text in ("platforms: [google_chat, slack]\n", "platforms: slack\n",
+                     "platforms: 3\n", "platforms:\n  slack: enabled\n",
+                     "- just\n- a list\n"):
+            with self.subTest(config=text):
+                with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".yaml", delete=False) as handle:
+                    handle.write(text)
+                    named = handle.name
+                self.addCleanup(os.unlink, named)
+                with patch.object(session_kv_server, "MANAGED_CONFIG_PATH", named):
+                    os.environ["SLACK_RELAY_URL"] = "http://127.0.0.1:8765"
+                    self.assertEqual(
+                        session_kv_server.enabled_chat_platforms(), ["slack"])
+
+    def test_nothing_configured_resolves_to_the_default_rather_than_nothing(self):
+        # A send addressed to the empty string is worse than one addressed to the
+        # platform every caller used before any of this existed.
+        self.assertEqual(
+            session_kv_server.enabled_chat_platforms(),
+            [session_kv_server.DEFAULT_CHAT_PLATFORM],
+        )
+
+    def test_a_single_destination_caller_says_which_platform_lost(self):
+        # #1094's other half: picking is fine, picking silently is not.
+        self._point(
+            "MANAGED_CONFIG_PATH",
+            "platforms:\n  google_chat:\n    enabled: true\n  slack:\n    enabled: true\n",
+        )
+        with self.assertLogs(session_kv_server.logger, level="WARNING") as logs:
+            self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
+        self.assertIn("slack", "".join(logs.output))
 
 
 class TestAlertDailyQuota(unittest.TestCase):
@@ -1896,7 +2037,7 @@ class TestCronReportRelay(unittest.TestCase):
 
     def test_relay_runs_a_chat_agent_turn_and_posts_what_it_composed(self):
         """The report goes through the Chat Agent; its wording is what reaches chat."""
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="Chat Agent framing") as turn, \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
@@ -1922,7 +2063,7 @@ class TestCronReportRelay(unittest.TestCase):
         """
         import sqlite3
 
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed report"), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"):
@@ -1934,7 +2075,7 @@ class TestCronReportRelay(unittest.TestCase):
         self.assertEqual(row[1], "composed report")
 
     def test_second_report_same_day_replies_into_the_first_thread(self):
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
@@ -1947,7 +2088,7 @@ class TestCronReportRelay(unittest.TestCase):
 
     def test_a_failed_relay_turn_still_delivers_the_report(self):
         """A finding must not be lost because the front door was unavailable."""
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value=None), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
@@ -1961,7 +2102,7 @@ class TestCronReportRelay(unittest.TestCase):
         Seven consecutive relay failures on this job class went unnoticed because
         the raw report looks like a report.
         """
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value=None), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
@@ -1976,7 +2117,7 @@ class TestCronReportRelay(unittest.TestCase):
 
     def test_a_failed_relay_turn_is_reported_as_degraded_not_as_success(self):
         """`relay` is what a scheduler can see without reading logs."""
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value=None), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"):
@@ -1988,7 +2129,7 @@ class TestCronReportRelay(unittest.TestCase):
         self.assertEqual(degraded.json()["status"], "delivered")
         self.assertEqual(degraded.json()["relay"], "degraded")
 
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"):
@@ -2006,7 +2147,7 @@ class TestCronReportRelay(unittest.TestCase):
         the channel. Under the `deliver: "all"` these jobs came off, that same
         failure surfaced in the cron child.
         """
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value=None):
@@ -2018,7 +2159,7 @@ class TestCronReportRelay(unittest.TestCase):
 
     def test_an_exception_mid_relay_is_answered_as_a_failure(self):
         """Not a 500 with a stack trace: the string is stored per job run."""
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", side_effect=RuntimeError("boom")):
             response = self.client.post("/v1/cron-reports", json={"job_id": "j6", "report": "finding"})
@@ -2032,7 +2173,7 @@ class TestCronReportRelay(unittest.TestCase):
         that does not exist."""
         import sqlite3
 
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value=None):
@@ -2063,7 +2204,7 @@ class TestCronReportRelay(unittest.TestCase):
         self.assertIn("`kubectl get po` [INST]", defanged)
 
     def test_the_turn_receives_the_defanged_report(self):
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"), \
              patch.object(session_kv_server.urllib.request, "urlopen") as urlopen:
@@ -2088,7 +2229,7 @@ class TestCronReportRelay(unittest.TestCase):
         with sqlite3.connect(temp_db_path) as conn:
             with conn:
                 conn.execute("DELETE FROM alert_quota")
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"):
@@ -2099,13 +2240,126 @@ class TestCronReportRelay(unittest.TestCase):
             spent = conn.execute("SELECT COUNT(*) FROM alert_quota").fetchone()[0]
         self.assertEqual(spent, 0)
 
-    def test_missing_fields_and_oversized_reports_are_rejected(self):
+    def test_missing_fields_are_rejected(self):
         self.assertEqual(self.client.post("/v1/cron-reports", json={"report": "x"}).status_code, 400)
         self.assertEqual(self.client.post("/v1/cron-reports", json={"job_id": "j"}).status_code, 400)
-        over = "x" * (session_kv_server.CRON_REPORT_MAX_CHARS + 1)
-        self.assertEqual(
-            self.client.post("/v1/cron-reports", json={"job_id": "j", "report": over}).status_code, 413
-        )
+
+    def test_an_oversized_report_is_truncated_rather_than_dropped(self):
+        """#1094: a 413 here threw the finding away and told nobody who could act.
+
+        The fleet-wide audits produce 60k characters against a 12000 cap, and
+        `stockout-prevention` and `compliance-audit` were lost whole on 30 and
+        31 August 2026. A cut report is worse than a whole one and much better
+        than none.
+        """
+        over = "H" * (session_kv_server.CRON_REPORT_MAX_CHARS + 50_000)
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", side_effect=lambda *a, **k: a[2]), \
+             patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
+            response = self.client.post(
+                "/v1/cron-reports", json={"job_id": "compliance-audit", "report": over}
+            )
+
+        self.assertEqual(response.status_code, 200)
+        posted = send.call_args.args[1]
+        self.assertLessEqual(len(posted), session_kv_server.CRON_REPORT_MAX_CHARS)
+        # The head survives, so the summary every governance SOP leads with does.
+        self.assertTrue(posted.startswith("HHH"), posted[:20])
+        # And the reader is told where the whole thing is, rather than being left
+        # to believe the cut copy is all there was.
+        self.assertIn("[truncated]", posted)
+        self.assertIn("cron/output/compliance-audit/", posted)
+
+    def test_a_report_at_the_limit_is_left_alone(self):
+        """Off-by-one at the boundary would mark every full-size report cut."""
+        exact = "x" * session_kv_server.CRON_REPORT_MAX_CHARS
+        self.assertEqual(session_kv_server._truncate_report(exact, "platform", "j"), exact)
+
+    def test_the_fan_out_reaches_every_enabled_platform(self):
+        """#1094: a dual-platform install has two audiences, not a favourite.
+
+        Slack-first selection sent seven days of governance reports to a Slack
+        leg with no home channel while Google Chat, which had one, got nothing.
+        """
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", return_value="T1") as send:
+            response = self.client.post("/v1/cron-reports", json={"job_id": "jf", "report": "r"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([c.args[0] for c in send.call_args_list], ["google_chat", "slack"])
+        self.assertEqual(response.json()["undelivered"], "")
+
+    def test_a_dead_leg_does_not_cost_the_live_one_its_report(self):
+        """Autopush exactly: Slack enabled, unreachable, and Google Chat working."""
+        def only_google_chat(platform, *_args, **_kwargs):
+            return "spaces/AAA/threads/T1" if platform == "google_chat" else None
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", side_effect=only_google_chat):
+            response = self.client.post("/v1/cron-reports", json={"job_id": "jg", "report": "r"})
+
+        # 200: the report is in a channel, and a re-run would double-post there.
+        self.assertEqual(response.status_code, 200)
+        # But the audience that heard nothing is named, which is the whole of the
+        # issue — the failure was recorded nowhere a reader would find it.
+        self.assertEqual(response.json()["undelivered"], "slack")
+
+    def test_every_leg_failing_is_still_a_failure(self):
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", return_value=None):
+            response = self.client.post("/v1/cron-reports", json={"job_id": "jh", "report": "r"})
+
+        self.assertEqual(response.status_code, 502)
+        detail = response.json()["detail"]
+        self.assertIn("google_chat", detail)
+        self.assertIn("slack", detail)
+
+    def test_only_the_routed_leg_replays_the_stored_thread(self):
+        """A thread id is platform-local; replaying it on the other leg addresses
+        a thread that does not exist."""
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat",
+                          return_value="spaces/AAA/threads/T1") as send:
+            self.client.post("/v1/cron-reports", json={"job_id": "ji", "report": "first"})
+            send.reset_mock()
+            self.client.post("/v1/cron-reports", json={"job_id": "ji", "report": "second"})
+
+        by_platform = {c.args[0]: c.args[2:] for c in send.call_args_list}
+        self.assertEqual(by_platform["google_chat"], ("spaces/AAA", "spaces/AAA/threads/T1"))
+        self.assertEqual(by_platform["slack"], ("", ""))
+
+    def test_the_routing_falls_to_a_leg_that_actually_landed(self):
+        """If the routed platform is the one that failed, the follow-up thread has
+        to move — otherwise a reply reaches a session addressed at a channel the
+        report never arrived in."""
+        import sqlite3
+
+        def only_slack(platform, *_args, **_kwargs):
+            return "1712345678.000100" if platform == "slack" else None
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", side_effect=only_slack):
+            self.client.post("/v1/cron-reports", json={"job_id": "jj", "report": "r"})
+
+        with sqlite3.connect(temp_db_path) as conn:
+            (blob,) = conn.execute("SELECT metadata FROM session_metadata").fetchone()
+        self.assertEqual(json.loads(blob)["platform"], "slack")
 
     def test_route_requires_the_api_key(self):
         from fastapi.testclient import TestClient
@@ -2124,7 +2378,7 @@ class TestCronReportRelay(unittest.TestCase):
         """`title` is stored for one reader: /v1/incidents/recent."""
         import sqlite3
 
-        with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
              patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1"):
@@ -2213,7 +2467,7 @@ class TestCronReportLabelSanitisation(unittest.TestCase):
 
             client = TestClient(session_kv_server.app, headers=AUTH_HEADERS)
             build = session_kv_server._build_relay_instructions
-            with patch.object(session_kv_server, "get_active_platform", return_value="google_chat"), \
+            with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
                  patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
                  patch.object(session_kv_server, "_build_relay_instructions", side_effect=build) as built, \
                  patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -1365,6 +1365,94 @@ class TestAlertPlatformFallback(unittest.TestCase):
         self.assertIn("google_chat", detail)
         self.assertIn("slack", detail)
 
+    def test_the_pick_says_which_platform_will_not_get_the_alert(self):
+        """#1094's other half: picking is fine, picking SILENTLY is the defect.
+
+        The warning has to come off the pick, not out of the fall-through. The
+        fall-through logs only after a leg has refused, so on the common
+        dual-platform install -- where the first leg accepts -- it never runs,
+        and taking `platforms[0]` directly would emit nothing at all.
+        """
+        with self.assertLogs(session_kv_server.logger, level="WARNING") as logs:
+            self._run(lambda _platform, _msg: "spaces/AAA/threads/T1")
+        picked = [line for line in logs.output if "will not receive it" in line]
+        self.assertEqual(len(picked), 1, "exactly one warning, on the pick")
+        self.assertIn("google_chat", picked[0])
+        self.assertIn("slack", picked[0])
+
+    def test_a_send_with_no_message_id_is_not_posted_to_a_second_platform(self):
+        """`hermes send` can succeed and return stdout with no parseable id.
+
+        The alert is in that channel already, so falling through to the next
+        platform to chase a thread id posts it twice. Delivered-but-unthreaded
+        is recorded as unconfirmed instead.
+        """
+        alert = self._run(
+            lambda platform, _msg: session_kv_server.ALERT_SENT_WITHOUT_THREAD
+            if platform == "google_chat" else "1712345678.000100")
+        self.assertEqual(
+            [c.args[0] for c in alert.call_args_list], ["google_chat"],
+            "an alert that landed must not be posted again to chase a thread id")
+        session_kv_server._register_session_routing.assert_not_called()
+        session_kv_server.mark_delivery_failed.assert_called_once()
+
+
+class TestSlackHomeChannelResolution(unittest.TestCase):
+    """`_slack_home_channel` -- the environment, then either config file.
+
+    The operator renders SLACK_HOME_CHANNEL only when the CR sets
+    `slack.homeChannel`, but `/sethome` writes `platforms.slack.home_channel`
+    into the writable config.yaml instead -- which is why that file is not
+    mounted read-only. Reading the environment alone gave such an install an
+    empty `chat_id`, which `_lookup_platform_threads` drops, so the Slack leg
+    opened a fresh top-level message on every report and got no incident row
+    while the send itself succeeded.
+    """
+
+    def setUp(self):
+        env = patch.dict(os.environ)
+        env.start()
+        self.addCleanup(env.stop)
+        os.environ.pop("SLACK_HOME_CHANNEL", None)
+        self._point("MANAGED_CONFIG_PATH", None)
+        self._point("CONFIG_PATH", None)
+
+    def _point(self, attribute, text):
+        if text is None:
+            named = "/nonexistent/kube-agents-test-absent.yaml"
+        else:
+            with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".yaml", delete=False) as handle:
+                handle.write(text)
+                named = handle.name
+            self.addCleanup(os.unlink, named)
+        patcher = patch.object(session_kv_server, attribute, named)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_the_environment_wins_when_the_operator_rendered_one(self):
+        os.environ["SLACK_HOME_CHANNEL"] = "C0ENV"
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    home_channel: C0FILE\n")
+        self.assertEqual(session_kv_server._slack_home_channel(), "C0ENV")
+
+    def test_a_sethome_channel_is_found_when_the_environment_is_silent(self):
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    home_channel: C0FILE\n")
+        self.assertEqual(session_kv_server._slack_home_channel(), "C0FILE")
+
+    def test_the_managed_scope_is_read_before_the_profile_copy(self):
+        self._point("MANAGED_CONFIG_PATH", "platforms:\n  slack:\n    home_channel: C0MANAGED\n")
+        self._point("CONFIG_PATH", "platforms:\n  slack:\n    home_channel: C0FILE\n")
+        self.assertEqual(session_kv_server._slack_home_channel(), "C0MANAGED")
+
+    def test_nothing_anywhere_is_the_empty_string(self):
+        # #1094's autopush shape. Still no home channel -- the point is that it
+        # degrades to "" rather than raising.
+        self.assertEqual(session_kv_server._slack_home_channel(), "")
+
+    def test_a_hostile_config_shape_costs_the_lookup_and_not_the_caller(self):
+        self._point("CONFIG_PATH", "platforms: slack\n")
+        self.assertEqual(session_kv_server._slack_home_channel(), "")
+
 
 class TestAlertDailyQuota(unittest.TestCase):
     """The per-severity daily ceiling enforced in /sessions/{id}/inject."""
@@ -2493,6 +2581,105 @@ class TestCronReportRelay(unittest.TestCase):
             third["google_chat"], ("spaces/AAA", "spaces/AAA/threads/T1"),
             "the recovered leg must reply into the thread it opened, not orphan a new one",
         )
+
+    def test_a_leg_that_missed_this_report_does_not_get_its_incident_row(self):
+        """Keeping the thread is not the same as being sent the report.
+
+        `platform_threads` is additive and the session id is per UTC day, so
+        after a leg fails once the map still holds its thread -- deliberately,
+        so the next report can reply into it. Writing this report's incident
+        row against that thread would overwrite the channel's stored context
+        with a report it never received, and `_store_incident_report` is
+        INSERT OR REPLACE on (chat_id, thread_id), so the report still on
+        screen there is the one destroyed. A reply under it would then have
+        `incident_context` prepend text that was never posted in that channel.
+        """
+        import sqlite3
+
+        state = {"google_chat_up": True}
+
+        def flaky(platform, *_args, **_kwargs):
+            if platform == "google_chat":
+                return "spaces/AAA/threads/T1" if state["google_chat_up"] else None
+            return "1712345678.000100"
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn",
+                          side_effect=lambda *a, **k: f"COMPOSED:{a[2]}"), \
+             patch.object(session_kv_server, "_send_to_chat", side_effect=flaky):
+            self.client.post("/v1/cron-reports", json={"job_id": "jm", "report": "ONE"})
+            state["google_chat_up"] = False
+            self.client.post("/v1/cron-reports", json={"job_id": "jm", "report": "TWO"})
+
+        with sqlite3.connect(temp_db_path) as conn:
+            stored = dict(conn.execute("SELECT thread_id, report FROM incidents"))
+
+        self.assertIn("TWO", stored["1712345678.000100"],
+                      "the leg that landed must carry the report it received")
+        self.assertIn(
+            "ONE", stored["spaces/AAA/threads/T1"],
+            "the leg that missed report two must keep report one -- the one its "
+            "channel can actually see -- not be overwritten with report two",
+        )
+
+    def test_a_session_routed_before_the_upgrade_keeps_its_thread(self):
+        """Roll-forward, which is the direction that actually happens.
+
+        A row written by the code this replaces has the top-level
+        platform/chat_id/thread_id triple and no `platform_threads` map. Without
+        seeding the owning leg from the triple the first report after the
+        rollout sends with ('', '') and orphans a top-level message instead of
+        replying into the thread the session already has.
+        """
+        import sqlite3
+        from datetime import datetime, timezone
+
+        session_id = session_kv_server._cron_report_session_id(
+            "platform", "jn", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+        pre_upgrade = {
+            "platform": "google_chat",
+            "chat_id": "spaces/AAA",
+            "thread_id": "spaces/AAA/threads/T1",
+        }
+        with sqlite3.connect(temp_db_path) as conn:
+            with conn:
+                conn.execute(
+                    "INSERT INTO session_metadata (session_id, metadata) VALUES (?, ?)",
+                    (session_id, json.dumps(pre_upgrade)),
+                )
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat",
+                          return_value="spaces/AAA/threads/T1") as send:
+            self.client.post("/v1/cron-reports", json={"job_id": "jn", "report": "r"})
+
+        self.assertEqual(
+            send.call_args.args[2:], ("spaces/AAA", "spaces/AAA/threads/T1"),
+            "the first report after the rollout must reply into the existing thread",
+        )
+
+    def test_the_receipt_says_when_the_report_was_truncated(self):
+        """The human sees the [truncated] line in the channel; the agent that
+        wrote the report -- the only party that could split it -- saw nothing."""
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat",
+                          return_value="spaces/AAA/threads/T1"):
+            over = self.client.post(
+                "/v1/cron-reports",
+                json={"job_id": "jo", "report": "x" * (session_kv_server.CRON_REPORT_MAX_CHARS + 1)},
+            )
+            fits = self.client.post("/v1/cron-reports", json={"job_id": "jp", "report": "short"})
+
+        self.assertEqual(over.json()["truncated"], "true")
+        self.assertEqual(fits.json()["truncated"], "")
 
     def test_a_reply_in_either_channel_finds_the_report(self):
         """`incident_context` resolves by (chat_id, thread_id), so a fan-out that

--- a/agents/platform/scripts/test_session_kv_server.py
+++ b/agents/platform/scripts/test_session_kv_server.py
@@ -864,9 +864,14 @@ class TestSessionKvServerAuth(unittest.TestCase):
         # happens after.
         self._trigger = patch.object(session_kv_server, "trigger_agent_troubleshooter")
         self._trigger.start()
-        # (error, degraded) — an unconfigured MagicMock would not unpack.
+        # (error, degraded, undelivered) — an unconfigured MagicMock would not
+        # unpack, and neither would a stale 2-tuple: the route would raise
+        # ValueError, get caught by the 502 handler, and this suite would still
+        # pass because it only asserts the status is not 401/403/503. So the
+        # arity here is what keeps the authenticated case exercising a healthy
+        # relay rather than the exception path.
         self._relay = patch.object(
-            session_kv_server, "relay_cron_report", return_value=(None, False)
+            session_kv_server, "relay_cron_report", return_value=(None, False, [])
         )
         self._relay.start()
 
@@ -1295,14 +1300,70 @@ class TestEnabledChatPlatforms(unittest.TestCase):
         )
 
     def test_a_single_destination_caller_says_which_platform_lost(self):
-        # #1094's other half: picking is fine, picking silently is not.
+        # #1094's other half: picking is fine, picking silently is not. The log
+        # has to name the platform that will NOT receive it -- naming only the
+        # winner leaves a reader to infer the loss from a list.
         self._point(
             "MANAGED_CONFIG_PATH",
             "platforms:\n  google_chat:\n    enabled: true\n  slack:\n    enabled: true\n",
         )
         with self.assertLogs(session_kv_server.logger, level="WARNING") as logs:
             self.assertEqual(session_kv_server.get_active_platform(), "google_chat")
-        self.assertIn("slack", "".join(logs.output))
+        line = "".join(logs.output)
+        self.assertIn("slack", line)
+        self.assertIn("will not receive it", line)
+
+
+class TestAlertPlatformFallback(unittest.TestCase):
+    """The alert path takes the first platform that ACCEPTS the alert.
+
+    It cannot fan out — it registers the thread it gets back as the session's
+    routing and the triage card's completion is addressed there — so it picks
+    one. Picking without a fallback would only move which install loses: #1094
+    was a dual-platform install whose Slack leg was dead, and an order that
+    leads with Google Chat mirrors it exactly for an install whose Google Chat
+    leg is the broken one.
+    """
+
+    def setUp(self):
+        patcher = patch.object(
+            session_kv_server, "enabled_chat_platforms",
+            return_value=["google_chat", "slack"])
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        for name in ("_register_session_routing", "_create_gateway_session",
+                     "_start_agent_turn", "mark_delivery_failed"):
+            p = patch.object(session_kv_server, name)
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _run(self, post):
+        with patch.object(session_kv_server, "_post_initial_alert", side_effect=post) as alert:
+            session_kv_server.trigger_agent_troubleshooter("s1", "alert", {}, 7)
+        return alert
+
+    def test_a_dead_first_leg_does_not_cost_the_alert(self):
+        alert = self._run(
+            lambda platform, _msg: None if platform == "google_chat" else "1712345678.000100")
+        self.assertEqual([c.args[0] for c in alert.call_args_list], ["google_chat", "slack"])
+        session_kv_server._register_session_routing.assert_called_once_with(
+            "s1", "slack", "1712345678.000100")
+        session_kv_server.mark_delivery_failed.assert_not_called()
+
+    def test_the_first_leg_wins_when_it_works(self):
+        alert = self._run(lambda _platform, _msg: "spaces/AAA/threads/T1")
+        self.assertEqual([c.args[0] for c in alert.call_args_list], ["google_chat"],
+                         "a working first leg must not also post to the second")
+        session_kv_server._register_session_routing.assert_called_once_with(
+            "s1", "google_chat", "spaces/AAA/threads/T1")
+
+    def test_every_leg_failing_is_still_recorded_as_undelivered(self):
+        self._run(lambda _platform, _msg: None)
+        session_kv_server._register_session_routing.assert_not_called()
+        session_kv_server.mark_delivery_failed.assert_called_once()
+        detail = session_kv_server.mark_delivery_failed.call_args.args[1]
+        self.assertIn("google_chat", detail)
+        self.assertIn("slack", detail)
 
 
 class TestAlertDailyQuota(unittest.TestCase):
@@ -2011,6 +2072,14 @@ class TestCronReportRelay(unittest.TestCase):
 
         os.environ["SESSION_KV_API_KEY"] = API_KEY
         self.client = TestClient(session_kv_server.app, headers=AUTH_HEADERS)
+        # Slack's chat_id comes from SLACK_HOME_CHANNEL (`_register_session_routing`),
+        # and without one `_send_to_chat` cannot thread a Slack reply at all --
+        # which is #1094's autopush install, not a properly configured one. The
+        # fan-out tests below are about a dual-platform install that works, so
+        # they get the home channel autopush is missing.
+        env = patch.dict(os.environ, {"SLACK_HOME_CHANNEL": "C0123456789"})
+        env.start()
+        self.addCleanup(env.stop)
         # The temp database is shared across this file; a stale routing row for
         # a derived session id would make the second test see the first's thread.
         with sqlite3.connect(temp_db_path) as conn:
@@ -2263,18 +2332,66 @@ class TestCronReportRelay(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         posted = send.call_args.args[1]
-        self.assertLessEqual(len(posted), session_kv_server.CRON_REPORT_MAX_CHARS)
-        # The head survives, so the summary every governance SOP leads with does.
-        self.assertTrue(posted.startswith("HHH"), posted[:20])
-        # And the reader is told where the whole thing is, rather than being left
-        # to believe the cut copy is all there was.
+        # The cap bounds the REPORT -- what reaches the model -- not the posted
+        # message, which also carries the notice this server wrote.
+        self.assertIn("HHH", posted)
+        self.assertLessEqual(
+            len(posted.split("[truncated]")[-1].split("\n\n", 1)[-1]),
+            session_kv_server.CRON_REPORT_MAX_CHARS,
+        )
+        # The reader is told where the whole thing is, rather than being left to
+        # believe the cut copy is all there was.
         self.assertIn("[truncated]", posted)
         self.assertIn("cron/output/compliance-audit/", posted)
 
     def test_a_report_at_the_limit_is_left_alone(self):
         """Off-by-one at the boundary would mark every full-size report cut."""
         exact = "x" * session_kv_server.CRON_REPORT_MAX_CHARS
-        self.assertEqual(session_kv_server._truncate_report(exact, "platform", "j"), exact)
+        self.assertEqual(
+            session_kv_server._truncate_report(exact, "platform", "j"), (exact, ""))
+
+    def test_the_truncation_notice_survives_a_chat_agent_that_drops_it(self):
+        """The notice is prepended after the turn, not fed to the model.
+
+        `_build_relay_instructions` tells the Chat Agent to add "nothing at the
+        bottom", so a notice appended to the report is the line it is most
+        likely to drop -- and it is the one line telling the reader the report
+        is incomplete. This stubs a turn that returns only its own prose, the
+        way a compliant Chat Agent would.
+        """
+        over = "H" * (session_kv_server.CRON_REPORT_MAX_CHARS + 50_000)
+        with patch.object(session_kv_server, "enabled_chat_platforms", return_value=["google_chat"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="A composed summary."), \
+             patch.object(session_kv_server, "_send_to_chat", return_value="spaces/AAA/threads/T1") as send:
+            self.client.post(
+                "/v1/cron-reports", json={"job_id": "compliance-audit", "report": over}
+            )
+
+        posted = send.call_args.args[1]
+        self.assertTrue(posted.startswith("[truncated]"), posted[:40])
+        self.assertIn("cron/output/compliance-audit/", posted)
+        self.assertIn("A composed summary.", posted)
+
+    def test_the_model_never_sees_more_than_the_cap(self):
+        """The cap exists to bound what reaches the model, so truncation must
+        cut the report itself and not merely mark it."""
+        over = "H" * (session_kv_server.CRON_REPORT_MAX_CHARS + 50_000)
+        report, notice = session_kv_server._truncate_report(over, "platform", "compliance-audit")
+        self.assertLessEqual(len(report), session_kv_server.CRON_REPORT_MAX_CHARS)
+        self.assertTrue(notice)
+
+    def test_a_cap_smaller_than_the_notice_still_bounds_the_report(self):
+        """The notice is not part of the report, so it cannot push it over.
+
+        When the notice was appended, `max(0, cap - len(notice))` returned a
+        string ~2.5x a small cap -- the bound silently exceeded by the thing
+        enforcing it.
+        """
+        with patch.object(session_kv_server, "CRON_REPORT_MAX_CHARS", 100):
+            report, notice = session_kv_server._truncate_report("y" * 500, "platform", "j")
+        self.assertEqual(len(report), 100)
+        self.assertTrue(notice)
 
     def test_the_fan_out_reaches_every_enabled_platform(self):
         """#1094: a dual-platform install has two audiences, not a favourite.
@@ -2324,22 +2441,79 @@ class TestCronReportRelay(unittest.TestCase):
         self.assertIn("google_chat", detail)
         self.assertIn("slack", detail)
 
-    def test_only_the_routed_leg_replays_the_stored_thread(self):
+    def test_each_leg_replays_its_own_thread_and_never_another_s(self):
         """A thread id is platform-local; replaying it on the other leg addresses
         a thread that does not exist."""
+        def per_platform(platform, *_args, **_kwargs):
+            return "spaces/AAA/threads/T1" if platform == "google_chat" else "1712345678.000100"
+
         with patch.object(session_kv_server, "enabled_chat_platforms",
                           return_value=["google_chat", "slack"]), \
              patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
              patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
-             patch.object(session_kv_server, "_send_to_chat",
-                          return_value="spaces/AAA/threads/T1") as send:
+             patch.object(session_kv_server, "_send_to_chat", side_effect=per_platform) as send:
             self.client.post("/v1/cron-reports", json={"job_id": "ji", "report": "first"})
             send.reset_mock()
             self.client.post("/v1/cron-reports", json={"job_id": "ji", "report": "second"})
 
         by_platform = {c.args[0]: c.args[2:] for c in send.call_args_list}
         self.assertEqual(by_platform["google_chat"], ("spaces/AAA", "spaces/AAA/threads/T1"))
-        self.assertEqual(by_platform["slack"], ("", ""))
+        # Slack replays Slack's own thread, not Google Chat's, and not nothing.
+        self.assertEqual(by_platform["slack"][1], "1712345678.000100")
+
+    def test_a_leg_that_fails_once_keeps_its_thread_for_the_next_report(self):
+        """A transient failure used to unthread a leg for the rest of the day.
+
+        Ownership moved to the leg that landed, and because only the owner
+        replayed a thread, the recovered platform started a fresh top-level
+        message on every subsequent report -- orphans nobody could reply into
+        with context.
+        """
+        state = {"google_chat_up": True}
+
+        def flaky(platform, *_args, **_kwargs):
+            if platform == "google_chat":
+                return "spaces/AAA/threads/T1" if state["google_chat_up"] else None
+            return "1712345678.000100"
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", side_effect=flaky) as send:
+            self.client.post("/v1/cron-reports", json={"job_id": "jk", "report": "one"})
+            state["google_chat_up"] = False           # transient outage
+            self.client.post("/v1/cron-reports", json={"job_id": "jk", "report": "two"})
+            state["google_chat_up"] = True            # recovered
+            send.reset_mock()
+            self.client.post("/v1/cron-reports", json={"job_id": "jk", "report": "three"})
+
+        third = {c.args[0]: c.args[2:] for c in send.call_args_list}
+        self.assertEqual(
+            third["google_chat"], ("spaces/AAA", "spaces/AAA/threads/T1"),
+            "the recovered leg must reply into the thread it opened, not orphan a new one",
+        )
+
+    def test_a_reply_in_either_channel_finds_the_report(self):
+        """`incident_context` resolves by (chat_id, thread_id), so a fan-out that
+        stores only the owner's address leaves the other channel's readers
+        talking to an agent that never saw the report."""
+        import sqlite3
+
+        def per_platform(platform, *_args, **_kwargs):
+            return "spaces/AAA/threads/T1" if platform == "google_chat" else "1712345678.000100"
+
+        with patch.object(session_kv_server, "enabled_chat_platforms",
+                          return_value=["google_chat", "slack"]), \
+             patch.object(session_kv_server, "_create_gateway_session", return_value=True), \
+             patch.object(session_kv_server, "_run_relay_turn", return_value="composed"), \
+             patch.object(session_kv_server, "_send_to_chat", side_effect=per_platform):
+            self.client.post("/v1/cron-reports", json={"job_id": "jl", "report": "r"})
+
+        with sqlite3.connect(temp_db_path) as conn:
+            threads = {row[0] for row in conn.execute("SELECT thread_id FROM incidents")}
+        self.assertIn("spaces/AAA/threads/T1", threads)
+        self.assertIn("1712345678.000100", threads)
 
     def test_the_routing_falls_to_a_leg_that_actually_landed(self):
         """If the routed platform is the one that failed, the follow-up thread has

--- a/deploy/docker/plugins/chat/adapter.py
+++ b/deploy/docker/plugins/chat/adapter.py
@@ -231,8 +231,9 @@ async def standalone_send(
     for.
 
     ``chat_id``, ``thread_id``, ``media_files`` and ``force_document`` are
-    accepted for signature parity and ignored: the relay route has exactly one
-    destination, and the Chat Agent decides where its own message goes.
+    accepted for signature parity and ignored: this sender names no destination
+    at all. The route resolves them itself — one per enabled chat platform — and
+    the Chat Agent decides what its own message says.
 
     The error strings become ``last_delivery_error``, so they name the condition
     and never the key.
@@ -375,8 +376,8 @@ def register(ctx) -> None:
         standalone_sender_fn=standalone_send,
         # No chunking. The Chat Agent is composing a message from this text, not
         # posting it; the length bound that matters is CRON_REPORT_MAX_CHARS on
-        # the relay route, which rejects rather than silently splitting a report
-        # into pieces that each start a separate turn.
+        # the relay route, which truncates to a single marked report rather than
+        # splitting it into pieces that each start a separate turn.
         max_message_length=0,
         emoji="🗣️",
         # Never offer /update from a channel that has no inbound side.

--- a/deploy/docker/plugins/chat/adapter.py
+++ b/deploy/docker/plugins/chat/adapter.py
@@ -161,22 +161,28 @@ def _http_error_detail(exc: urllib.error.HTTPError) -> str:
     return f": {detail.strip()[:200]}"
 
 
-def _relay_verdict(response) -> str:
-    """The route's ``relay`` field off a 2xx body, or ``""`` if it did not say.
+def _relay_receipt(response) -> dict:
+    """The route's 2xx body, or ``{}`` if it could not be read.
+
+    Two fields are read off it, and both say something a bare 200 does not:
+    ``relay`` (``degraded`` when the Chat Agent turn failed and the raw text was
+    posted instead) and ``undelivered`` (the enabled chat platforms this report
+    did not reach while another one did).
 
     Best effort, like :func:`_http_error_detail`: the body is read once and a
     delivery that worked is never turned into an exception by failing to parse
-    the receipt for it. ``""`` therefore means "no verdict", not "composed" —
-    the caller treats only an explicit ``degraded`` as degraded.
+    the receipt for it. ``{}`` therefore means "the route did not say", not
+    "nothing to report" — the caller acts only on explicit values.
     """
     try:
-        return str((json.loads(response.read().decode("utf-8", "replace")) or {}).get("relay") or "")
+        body = json.loads(response.read().decode("utf-8", "replace"))
     except Exception:
-        return ""
+        return {}
+    return body if isinstance(body, dict) else {}
 
 
-def _post(url: str, payload: dict, api_key: str) -> Tuple[Optional[str], str]:
-    """POST *payload* as JSON. ``(None, verdict)`` on success, else ``(why, "")``.
+def _post(url: str, payload: dict, api_key: str) -> Tuple[Optional[str], dict]:
+    """POST *payload* as JSON. ``(None, receipt)`` on success, else ``(why, {})``.
 
     Blocking, and called through :func:`asyncio.to_thread`. ``urllib`` rather
     than ``httpx`` keeps this module stdlib-only, so its tests run wherever the
@@ -198,15 +204,15 @@ def _post(url: str, payload: dict, api_key: str) -> Tuple[Optional[str], str]:
         with urllib.request.urlopen(request, timeout=RELAY_TIMEOUT_SECONDS) as response:
             status = getattr(response, "status", None) or response.getcode()
             if status >= 300:
-                return f"chat relay answered HTTP {status}", ""
-            return None, _relay_verdict(response)
+                return f"chat relay answered HTTP {status}", {}
+            return None, _relay_receipt(response)
     except urllib.error.HTTPError as exc:
         # The route names the failing leg in `detail` ("composed but not
         # delivered to google_chat"), which is the difference between a
         # last_delivery_error someone can act on and a bare status code.
-        return f"chat relay answered HTTP {exc.code}{_http_error_detail(exc)}", ""
+        return f"chat relay answered HTTP {exc.code}{_http_error_detail(exc)}", {}
     except Exception as exc:  # URLError, socket timeout, malformed URL
-        return f"chat relay unreachable: {type(exc).__name__}: {exc}", ""
+        return f"chat relay unreachable: {type(exc).__name__}: {exc}", {}
 
 
 async def standalone_send(
@@ -279,29 +285,41 @@ async def standalone_send(
         "title": title,
         "report": report,
     }
-    error, verdict = await asyncio.to_thread(_post, relay_url(), payload, api_key)
+    error, receipt = await asyncio.to_thread(_post, relay_url(), payload, api_key)
     if error:
         return {"error": error}
 
-    if verdict == "degraded":
-        # The route answered 200 and the report is in the channel, so this is
-        # not a lost delivery — but the Chat Agent turn failed and what landed
-        # is the raw text under an `[unrelayed]` marker. `error` is the only
-        # field of this dict the scheduler reads, and `last_delivery_error` is
-        # the only place a run record can carry the fact, so the verdict goes
-        # there rather than into a log line nobody greps. The string says
-        # plainly that the report did arrive, because `cronjob list` showing a
-        # delivery error is otherwise read as "nothing was sent" and invites a
-        # re-run that would post the same finding twice.
-        #
-        # Not doing this is what the relay was built to stop, one layer out: a
-        # front door that has been down all week would otherwise produce run
-        # records byte-identical to healthy ones.
-        message = (
+    # Two ways a 200 is still worth recording, and a run can hit both at once,
+    # so they accumulate rather than returning early. In each case the report IS
+    # in a channel: `error` is the only field of this dict the scheduler reads
+    # and `last_delivery_error` is the only place a run record can carry the
+    # fact, so the verdict goes there rather than into a log line nobody greps —
+    # and each string says plainly that the report arrived, because `cronjob
+    # list` showing a delivery error is otherwise read as "nothing was sent" and
+    # invites a re-run that would post the same finding twice.
+    #
+    # Not doing this is what the relay was built to stop, one layer out: a front
+    # door that has been down all week would otherwise produce run records
+    # byte-identical to healthy ones.
+    notes = []
+
+    if receipt.get("relay") == "degraded":
+        # The Chat Agent turn failed and what landed is the raw text under an
+        # `[unrelayed]` marker.
+        notes.append(
             "chat relay degraded: the report was posted but the Chat Agent turn "
             "failed, so the channel has the raw text marked [unrelayed] rather "
-            "than a composed message. Delivered — do not re-run to resend."
+            "than a composed message."
         )
+
+    # A fan-out that reached one platform and missed another — the audience that
+    # heard nothing is exactly the silence #1094 is about.
+    undelivered = str(receipt.get("undelivered") or "").strip()
+    if undelivered:
+        notes.append(f"chat relay partial: the report did not reach {undelivered}.")
+
+    if notes:
+        message = " ".join(notes) + " Delivered — do not re-run to resend."
         logger.warning("chat relay: %s (job_id=%s)", message, job_id or "?")
         return {"error": message}
 

--- a/deploy/docker/plugins/chat/test_chat_relay.py
+++ b/deploy/docker/plugins/chat/test_chat_relay.py
@@ -395,15 +395,68 @@ class TestStandaloneSend(unittest.TestCase):
                 result = asyncio.run(mod.standalone_send(None, "c", "r"))
         self.assertIn("502", result["error"])
 
-    def test_post_returns_an_error_and_a_verdict(self):
+    def test_post_returns_an_error_and_a_receipt(self):
         """Every path out of `_post` is a 2-tuple; the callers unpack it."""
         with RecordingRelay(body=b'{"relay":"degraded"}') as relay:
             with patch.dict(os.environ, {}, clear=True):
-                self.assertEqual(mod._post(relay.url, {}, "k"), (None, "degraded"))
+                self.assertEqual(
+                    mod._post(relay.url, {}, "k"), (None, {"relay": "degraded"})
+                )
         with patch.dict(os.environ, {}, clear=True):
-            error, verdict = mod._post("not-a-url", {}, "k")
+            error, receipt = mod._post("not-a-url", {}, "k")
         self.assertIsNotNone(error)
-        self.assertEqual(verdict, "")
+        self.assertEqual(receipt, {})
+
+    def test_a_body_that_is_not_an_object_is_not_a_receipt(self):
+        """`_relay_receipt` indexes what it returns, so a list must not reach it."""
+        with RecordingRelay(body=b'["relay","degraded"]') as relay:
+            with patch.dict(
+                os.environ,
+                {"SESSION_KV_API_KEY": "k", "CRON_REPORT_RELAY_URL": relay.url},
+            ):
+                result = asyncio.run(mod.standalone_send(None, "c", "r"))
+        self.assertTrue(result.get("success"), result)
+
+    def test_a_partial_fan_out_is_recorded_but_not_a_failed_delivery(self):
+        """#1094: the report reached one platform and missed another.
+
+        `last_delivery_error` has to say so — that is the whole complaint — but
+        the run is still a delivery, so the string must not read as "nothing was
+        sent" and invite a re-run that double-posts to the platform that has it.
+        """
+        body = b'{"status":"delivered","relay":"ok","undelivered":"slack"}'
+        with RecordingRelay(body=body) as relay:
+            with patch.dict(
+                os.environ,
+                {"SESSION_KV_API_KEY": "k", "CRON_REPORT_RELAY_URL": relay.url},
+            ):
+                result = asyncio.run(mod.standalone_send(None, "c", "r"))
+        self.assertIn("slack", result["error"])
+        self.assertIn("do not re-run", result["error"].lower())
+
+    def test_a_clean_fan_out_reports_no_error(self):
+        """An empty `undelivered` is the normal case and must not read as a miss."""
+        body = b'{"status":"delivered","relay":"ok","undelivered":""}'
+        with RecordingRelay(body=body) as relay:
+            with patch.dict(
+                os.environ,
+                {"SESSION_KV_API_KEY": "k", "CRON_REPORT_RELAY_URL": relay.url},
+            ):
+                result = asyncio.run(mod.standalone_send(None, "c", "r"))
+        self.assertTrue(result.get("success"), result)
+        self.assertNotIn("error", result)
+
+    def test_degraded_and_partial_are_both_reported(self):
+        """A run can hit both, and an early return would drop one of them."""
+        body = b'{"status":"delivered","relay":"degraded","undelivered":"slack"}'
+        with RecordingRelay(body=body) as relay:
+            with patch.dict(
+                os.environ,
+                {"SESSION_KV_API_KEY": "k", "CRON_REPORT_RELAY_URL": relay.url},
+            ):
+                result = asyncio.run(mod.standalone_send(None, "c", "r"))
+        self.assertIn("unrelayed", result["error"])
+        self.assertIn("slack", result["error"])
 
     def test_the_timeout_outlasts_a_chat_agent_turn(self):
         """Time out before the route answers and a delivered report is recorded

--- a/docs/designs/cron-report-relay.md
+++ b/docs/designs/cron-report-relay.md
@@ -414,19 +414,38 @@ on every run. The top-level `platform`/`chat_id`/`thread_id` triple still holds
 one address, because the event-triage card has one destination; it goes to the
 leg the session was already routed to, or to the first that landed.
 
-An incident row is stored for every leg that landed, so a reply in any channel
-the report reached replays it. Storing only one left a reply in the other channel
-answered by an agent that had never seen the report.
+An incident row is stored for every leg that landed **on that run**, so a reply
+in any channel the report reached replays it. Storing only one left a reply in
+the other channel answered by an agent that had never seen the report. The
+qualifier is load-bearing in the other direction: `platform_threads` is additive
+and never pruned, and the session id is per job per UTC day, so the map also
+holds legs that landed earlier today and failed just now. Writing a row for one
+of those would overwrite that channel's stored context with a report it never
+received, and the store is `INSERT OR REPLACE` on `(chat_id, thread_id)`, so the
+report still on its screen would be the one lost.
 
-`get_active_platform` is the single-destination sibling, for
-`_post_initial_alert`: an incident alert registers the thread it gets back as the
-session's routing and the triage card's completion is addressed there, so two
-threads on two platforms would leave the report addressable to only one. It
-returns the first enabled platform and logs a warning naming the platforms that
-will not receive the message — and the alert path then tries each enabled
-platform in turn until one accepts, so a broken first leg costs a retry rather
-than the alert. Ordering alone would have mirrored #1094 onto whichever installs
-have the _other_ platform broken.
+`get_active_platform` is the single-destination sibling, called by the alert
+path — `trigger_agent_troubleshooter`, which drives `_post_initial_alert`. An
+incident alert registers the thread it gets back as the session's routing and
+the triage card's completion is addressed there, so two threads on two platforms
+would leave the report addressable to only one. It returns the first enabled
+platform and logs a warning naming the platforms that will not receive the
+message — and the alert path then tries each enabled platform in turn until one
+accepts, so a broken first leg costs a retry rather than the alert. Ordering
+alone would have mirrored #1094 onto whichever installs have the _other_
+platform broken.
+
+The warning fires on the pick rather than inside the fall-through, and that is
+why the pick goes through this function instead of taking `platforms[0]`
+directly. The fall-through logs only after a leg has already refused, so on the
+common dual-platform install — where the first leg accepts — nothing would say
+the second was skipped, and #1094's other half would be documented as fixed
+while emitting nothing.
+
+One send that reports success can still fail to yield a thread id, and the alert
+path treats that as delivered rather than retrying it: the alert is already in
+that channel, so trying the next platform would post it a second time to chase
+an id. The run is recorded as an unconfirmed delivery instead.
 
 ## What a job has to do: nothing
 

--- a/docs/designs/cron-report-relay.md
+++ b/docs/designs/cron-report-relay.md
@@ -362,11 +362,18 @@ the channel.
 
 The cap truncates rather than rejects. It answered HTTP 413 until #1094, and the
 finding then existed only in the job's saved output with a line in
-`last_delivery_error` that nothing read — which cost three fleet-wide audit
-reports at 60k characters apiece over 30 and 31 August 2026. The head survives,
-because every governance SOP leads with its summary and puts the evidence
-appendix last, and the cut copy ends with a `[truncated]` line naming
-`cron/output/<job_id>/`, where the whole report is.
+`last_delivery_error` that nothing read; #1094 records three runs lost that way
+over 30 and 31 August 2026, across `stockout-prevention` and `compliance-audit`,
+whose fleet-wide output runs to several times this cap. The head survives, and
+the message opens with a `[truncated]` line naming `cron/output/<job_id>/`,
+where the whole report is.
+
+That line is prepended to the **composed message, after the relay turn** — not
+appended to the report before it. Appended, it is model input, and the relay
+instructions tell the Chat Agent to reproduce the report while adding "nothing
+at the bottom": the one sentence telling a reader the report is incomplete would
+be the sentence the instructions invite it to drop. Prepending it afterwards is
+how `[unrelayed]` already makes the same kind of admission unconditional.
 
 ## Which platforms a report is posted to
 
@@ -375,30 +382,51 @@ Every chat platform the install has enabled, resolved by
 and consulted **per platform** so that one naming Slack cannot hide a Google Chat
 another knows about: the operator's managed scope
 (`/etc/hermes/config.yaml`, which carries `platforms.<p>.enabled` as explicit
-booleans and therefore settles it outright on a deployed pod), the profile's own
-writable `config.yaml`, then per-platform environment signals for an install
-neither file describes.
+booleans and therefore settles it outright on a deployed pod), then `CONFIG_PATH`
+— `/opt/data/config.yaml`, the front door's own writable file rather than a named
+profile's — then per-platform environment signals for an install neither file
+describes.
 
 A dual-platform install gets the report on both. Picking one is what #1094 was:
 the resolver returned on its first match, Slack led the order, and an install
-with Slack enabled but no home channel and no connection lost every scheduled
-governance report for seven days while Google Chat — which had a home channel —
-received nothing. A partial fan-out is still a 200, because the report is in a
-channel and a re-run would double-post there; the platforms it missed come back
-in the response body's `undelivered`, which the relay adapter turns into
-`last_delivery_error`.
+with Slack enabled but no home channel lost every scheduled governance report for
+seven days while Google Chat — which had a home channel — received nothing. A
+partial fan-out is still a 200, because the report is in a channel and a re-run
+would double-post there; the platforms it missed come back in the response body's
+`undelivered`, which the relay adapter turns into `last_delivery_error`.
 
-Only one leg is threaded. A thread id is platform-local, so the session's routing
-row names one platform and only that leg replays the stored thread; the others
-post to their own home channel each time. If the routed leg is the one that
-failed, the routing moves to a leg that landed, so a reply reaches a session that
-holds the report.
+**This widens who sees a report, and that is a deliberate change rather than a
+side effect.** A governance report carries `evidence.excerpt` — literal
+`kubectl -o yaml` from workloads other teams deploy — and on an install that
+enabled two platforms for two different audiences it now reaches both, with no
+per-job or per-platform opt-out and no CR edit required to take effect. The
+alternative is the status quo, where the same install silently reaches one
+audience and the operator cannot tell which; a report going somewhere unintended
+is visible and correctable, and a report going nowhere was not. An install that
+wants one destination should enable one platform.
+
+Each leg keeps its own thread. A thread id is platform-local, so the session row
+carries `platform_threads` — one `(chat_id, thread_id)` per platform — and every
+leg replays only its own. Keeping a single address instead is how a leg that
+failed once stayed unthreaded for the rest of the day: the next report found the
+row naming another platform, posted a fresh top-level message, and did it again
+on every run. The top-level `platform`/`chat_id`/`thread_id` triple still holds
+one address, because the event-triage card has one destination; it goes to the
+leg the session was already routed to, or to the first that landed.
+
+An incident row is stored for every leg that landed, so a reply in any channel
+the report reached replays it. Storing only one left a reply in the other channel
+answered by an agent that had never seen the report.
 
 `get_active_platform` is the single-destination sibling, for
 `_post_initial_alert`: an incident alert registers the thread it gets back as the
 session's routing and the triage card's completion is addressed there, so two
-threads on two platforms would leave the report addressable to only one. It picks
-the first enabled platform and logs a warning naming the destination that lost.
+threads on two platforms would leave the report addressable to only one. It
+returns the first enabled platform and logs a warning naming the platforms that
+will not receive the message — and the alert path then tries each enabled
+platform in turn until one accepts, so a broken first leg costs a retry rather
+than the alert. Ordering alone would have mirrored #1094 onto whichever installs
+have the _other_ platform broken.
 
 ## What a job has to do: nothing
 

--- a/docs/designs/cron-report-relay.md
+++ b/docs/designs/cron-report-relay.md
@@ -360,6 +360,46 @@ caps report length instead (`CRON_REPORT_MAX_CHARS`, default 12000), which bound
 the accident that route actually has: a job that cats a log into the model and
 the channel.
 
+The cap truncates rather than rejects. It answered HTTP 413 until #1094, and the
+finding then existed only in the job's saved output with a line in
+`last_delivery_error` that nothing read — which cost three fleet-wide audit
+reports at 60k characters apiece over 30 and 31 August 2026. The head survives,
+because every governance SOP leads with its summary and puts the evidence
+appendix last, and the cut copy ends with a `[truncated]` line naming
+`cron/output/<job_id>/`, where the whole report is.
+
+## Which platforms a report is posted to
+
+Every chat platform the install has enabled, resolved by
+`session_kv_server.enabled_chat_platforms`. Three sources, most specific first,
+and consulted **per platform** so that one naming Slack cannot hide a Google Chat
+another knows about: the operator's managed scope
+(`/etc/hermes/config.yaml`, which carries `platforms.<p>.enabled` as explicit
+booleans and therefore settles it outright on a deployed pod), the profile's own
+writable `config.yaml`, then per-platform environment signals for an install
+neither file describes.
+
+A dual-platform install gets the report on both. Picking one is what #1094 was:
+the resolver returned on its first match, Slack led the order, and an install
+with Slack enabled but no home channel and no connection lost every scheduled
+governance report for seven days while Google Chat — which had a home channel —
+received nothing. A partial fan-out is still a 200, because the report is in a
+channel and a re-run would double-post there; the platforms it missed come back
+in the response body's `undelivered`, which the relay adapter turns into
+`last_delivery_error`.
+
+Only one leg is threaded. A thread id is platform-local, so the session's routing
+row names one platform and only that leg replays the stored thread; the others
+post to their own home channel each time. If the routed leg is the one that
+failed, the routing moves to a leg that landed, so a reply reaches a session that
+holds the report.
+
+`get_active_platform` is the single-destination sibling, for
+`_post_initial_alert`: an incident alert registers the thread it gets back as the
+session's routing and the triage card's completion is addressed there, so two
+threads on two platforms would leave the report addressable to only one. It picks
+the first enabled platform and logs a warning naming the destination that lost.
+
 ## What a job has to do: nothing
 
 A job relays because of one field. `deliver: "chat"` and no prompt boilerplate —
@@ -451,7 +491,10 @@ every one of them is visible to a job author:
   saying so only in a log is how the seven consecutive failures above went
   unnoticed. So the degradation is stated twice: the posted message is prefixed
   `[unrelayed]`, naming the profile and job, and the response body carries
-  `"relay": "degraded"` next to `"status": "delivered"`.
+  `"relay": "degraded"` next to `"status": "delivered"`. A fan-out leg that
+  failed while another landed is reported the same way and for the same reason,
+  through `undelivered` — see [Which platforms a report is posted
+  to](#which-platforms-a-report-is-posted-to).
   That is the whole reason the route blocks rather than accepting into a
   background task: answering `accepted` first would make each of those failures
   invisible, leaving the run written down as delivered with nothing in the

--- a/docs/site/src/content/docs/concepts/chatops.md
+++ b/docs/site/src/content/docs/concepts/chatops.md
@@ -81,6 +81,8 @@ The harness doesn't only reply to messages. A cluster event posted to the in-pod
 - **Google Chat**: to the space that owns the interaction, or the space set via `GOOGLE_CHAT_HOME_CHANNEL`.
 - **Slack**: to `SLACK_HOME_CHANNEL`.
 
+An alert goes to **one** of them, not both: it opens a thread that the triage turn then replies into, and a thread belongs to a single platform. With both integrations enabled the alert goes to Google Chat, falling through to Slack if that send is not accepted. A scheduled report has no such constraint and is posted to every enabled platform — [the relay design](https://github.com/gke-labs/kube-agents/blob/main/docs/designs/cron-report-relay.md) is canonical for both rules.
+
 A governance watchdog's findings are not on this path. An audit publishes to its ledger issue and to the remediation pull requests that link back to it, so the report to read is the issue rather than a channel message — see [Proactive autonomy](/kube-agents/overview/proactive-autonomy/) and [Autonomous watchdogs](/kube-agents/concepts/autonomous-watchdogs/) for the schedules.
 
 ## First-run onboarding

--- a/tests/integration/_seams.py
+++ b/tests/integration/_seams.py
@@ -88,13 +88,19 @@ class KVServer:
                 "PYTHONPATH": str(SCRIPTS_DIR),
             }
         )
-        # An absent config file gets `get_active_platform` past the yaml branch
-        # but not to a fixed answer: it then reads SLACK_BOT_TOKEN from the
-        # environment and returns "slack" if it finds one
-        # (`session_kv_server.py:431`). Dropping the chat credentials is what
-        # makes the fallback deterministic, and it also means a server started
-        # here holds no token to post with.
-        for leaked in ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "GOOGLE_CHAT_WEBHOOK"):
+        # An absent config file gets `enabled_chat_platforms` past both yaml
+        # branches but not to a fixed answer: it then resolves each platform
+        # from the environment, and a maintainer's own shell is exactly where
+        # those variables live. Dropping every signal it reads is what makes the
+        # fallback deterministic, and dropping the credentials among them also
+        # means a server started here holds no token to post with. Keep this
+        # list in step with `session_kv_server._CHAT_ENV_SIGNALS`; a signal it
+        # gains and this loses reintroduces the hazard silently.
+        for leaked in (
+            "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_RELAY_URL", "SLACK_HOME_CHANNEL",
+            "GOOGLE_CHAT_WEBHOOK", "GOOGLE_CHAT_RELAY_URL", "GOOGLE_CHAT_PROJECT_ID",
+            "GOOGLE_CHAT_HOME_CHANNEL",
+        ):
             run_env.pop(leaked, None)
         # And a `hermes` that cannot reach a workspace, shadowing any real one
         # on the runner's PATH. `_post_initial_alert` shells out to a bare

--- a/tests/integration/_seams.py
+++ b/tests/integration/_seams.py
@@ -85,17 +85,26 @@ class KVServer:
                 "SESSION_KV_API_KEY": API_KEY,
                 "PLATFORM_AGENT_CONFIG_PATH": str(tmp_path / "absent-config.yaml"),
                 "PLATFORM_AGENT_DOTENV_PATH": str(tmp_path / "absent.env"),
+                # The managed scope, and the reason it is pinned at an empty
+                # directory rather than left alone: it is the HIGHEST-precedence
+                # source `enabled_chat_platforms` reads, resolved from this
+                # variable with a default of /etc/hermes. A maintainer running
+                # the seams on a workstation that has an /etc/hermes/config.yaml
+                # -- or that exports this variable -- would otherwise have the
+                # server answer from their own install, ahead of everything
+                # below. Absent files here, so both yaml branches fall through
+                # and the scrubbed environment is what decides.
+                "HERMES_MANAGED_DIR": str(tmp_path / "absent-managed-scope"),
                 "PYTHONPATH": str(SCRIPTS_DIR),
             }
         )
-        # An absent config file gets `enabled_chat_platforms` past both yaml
-        # branches but not to a fixed answer: it then resolves each platform
-        # from the environment, and a maintainer's own shell is exactly where
-        # those variables live. Dropping every signal it reads is what makes the
-        # fallback deterministic, and dropping the credentials among them also
-        # means a server started here holds no token to post with. Keep this
-        # list in step with `session_kv_server._CHAT_ENV_SIGNALS`; a signal it
-        # gains and this loses reintroduces the hazard silently.
+        # With both config files absent, `enabled_chat_platforms` resolves each
+        # platform from the environment, and a maintainer's own shell is exactly
+        # where those variables live. Dropping every signal it reads is what
+        # makes the fallback deterministic, and dropping the credentials among
+        # them also means a server started here holds no token to post with.
+        # Keep this list in step with `session_kv_server._CHAT_ENV_SIGNALS`; a
+        # signal it gains and this loses reintroduces the hazard silently.
         for leaked in (
             "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_RELAY_URL", "SLACK_HOME_CHANNEL",
             "GOOGLE_CHAT_WEBHOOK", "GOOGLE_CHAT_RELAY_URL", "GOOGLE_CHAT_PROJECT_ID",

--- a/tests/integration/test_seam_alert_path.py
+++ b/tests/integration/test_seam_alert_path.py
@@ -191,7 +191,7 @@ class AlertPathTest(unittest.TestCase):
                 "PLATFORM_API_URL": self.gateway.url,
                 "PATH": f"{os.environ.get('PATH', '')}{os.pathsep}{workstation_bin}",
                 # The other half of the hazard: with a token in the
-                # environment, `get_active_platform` returns "slack" and the
+                # environment, `enabled_chat_platforms` resolves Slack and the
                 # send targets whatever the machine is really configured for.
                 "SLACK_BOT_TOKEN": "xoxb-the-runners-real-token",
             },


### PR DESCRIPTION
## Summary

Scheduled governance reports on a dual-platform install were composed by the Chat Agent and then thrown away. `get_active_platform()` returned on its first match with Slack leading the order, so an install with both integrations enabled resolved to Slack alone — and where that leg has no home channel, "Slack alone" is nowhere. This makes the resolution per platform across three sources rather than per source across two, fans the cron relay out to every platform the install actually enabled, and truncates an over-cap report instead of answering HTTP 413 and losing it.

## Why This Change

On the autopush install this has been silently dropping every scheduled report since 2026-08-25 — seven days of `compliance-audit`, `ai-security-audit`, `obtainability-audit`, `gcp-networking-fabric-audit`, `stockout-prevention` and `eod-event-watcher-daily-report`. The scheduler is healthy and every one of those jobs ran to completion on time; the failure is entirely in delivery, it was recorded on every occurrence in `last_delivery_error`, and nothing reads that field, so the only user-visible signal was that the daily reports stopped arriving.

Three things had to be true at once, and all three are verified against the running pod:

1. **The config branch never answers.** `CONFIG_PATH` (`/opt/data/config.yaml`) carries a `platforms` subtree with both keys and no `enabled` on either, because the operator writes `enabled` into the managed scope and Hermes overlays it per leaf inside its own loader. So the env heuristic was not a fallback — it was the whole decision.
2. **`SLACK_RELAY_URL` is set**, because the operator renders it whenever `spec.integration.slack.enabled` is true. The condition matched and the selector returned `slack`.
3. **That leg cannot originate a message.** The CR sets no `slack.homeChannel`, so no `SLACK_HOME_CHANNEL` is rendered and neither `config.yaml` carries `platforms.slack.home_channel`.

Point 3 is narrower than #1094 states, and the correction matters: the issue attributes it to `Reconnect slack error: slack connect timed out after 30s`, but Slack on that install is **healthy** — it authenticates as `@kageautopush`, Socket Mode is connected, and it answers messages. It simply has no home channel, so it can *reply* (the inbound carries its own chat id) and cannot *originate*. Cron reports originate. The missing home channel is the entire cause, and #1094's proposed mitigation of disabling Slack would have been the wrong call.

## What Changed

- **`enabled_chat_platforms()` resolves each platform independently**, across the operator's managed scope (`/etc/hermes/config.yaml`, which carries both `platforms.<p>.enabled` keys as explicit booleans and so settles it outright on a deployed pod), then `CONFIG_PATH`, then per-platform env signals. A file naming one platform can no longer hide another that only a lower-precedence source knows about — that short circuit is the bug.
- **The cron relay fans out.** Every enabled platform gets the report. A partial fan-out is a 200 with the missed platforms in the response body's `undelivered`, which the relay adapter turns into `last_delivery_error` — recorded without inviting a re-run that double-posts to the platform that already has it.
- **Each leg keeps its own thread**, via `platform_threads` on the session row, and an incident row is stored for every leg that landed **on that run** so a reply in any of those channels replays the report. The qualifier is load-bearing: `platform_threads` is additive and the session id is per UTC day, so the map also holds a leg that landed earlier today and failed just now, and the store is `INSERT OR REPLACE` on `(chat_id, thread_id)`. A session routed before this change has no map at all, so the owning leg is seeded from the top-level triple rather than orphaning a message on the first report after the rollout.
- **`get_active_platform()` stays**, and the alert path calls it: `trigger_agent_troubleshooter` takes its pick through it and then drives `_post_initial_alert`, which registers the thread it gets back as the session's routing and so needs exactly one destination. It names the platforms that will not receive the message, and the alert path then tries each enabled platform until one accepts. The warning fires on the pick rather than inside the fall-through, because the fall-through logs only after a leg has already refused — so on the common install, where the first leg accepts, it would emit nothing. A send that succeeds without a parseable message id counts as delivered and stops the fall-through, rather than posting the alert a second time to chase a thread id.
- **Over-cap reports truncate.** The head survives and the message opens with a `[truncated]` line naming `cron/output/<job_id>/`. The notice is prepended after the relay turn, not appended before it — appended it is model input, and the relay instructions tell the Chat Agent to add "nothing at the bottom".
- **`platform_mcp_server.report_to_chat`**, the route's other caller, reads `undelivered` and `truncated` too — the human sees the `[truncated]` line in the channel, and the agent that wrote the report is the only party that could have split it.
- **Slack's home channel resolves from either config file** when `SLACK_HOME_CHANNEL` is absent. The operator renders that variable only from the CR, but `/sethome` writes `platforms.slack.home_channel` into the writable `config.yaml`; reading the environment alone gave such an install an empty `chat_id`, which `_lookup_platform_threads` drops, so its Slack leg opened a fresh top-level message on every report and got no incident row while the send itself succeeded.

## Context

Closes #1094. Items 1–4 of that issue are addressed here except item 4 (a watchdog on `last_delivery_error`), which I split out as #1102 — a watchdog reporting through the leg it monitors is silent exactly when it is needed, so the open question is the alert channel rather than the detection, and that deserves its own design. Item 5 (truncation) is included despite being offered as separable, because without it autopush still loses the 60k fleet-wide audits after the routing fix.

Item 1 (disabling Slack on autopush) is deliberately **not** done — see the correction above. The right fix there is to set `slack_home_channel`, which `terraform/examples/full-install` already exposes and which defaults to `""`.

Adjacent work, and the reason the ordering here is what it is:

- **#989 / PR #996** — the mirror-image defect, the Cluster Agent reconcile summary hardcoded to Google Chat. #996 adds `chat_platforms.enabled_chat_platforms`, and this change deliberately matches its Google-Chat-first order and per-platform resolution so that converging is a re-point rather than a behaviour change. It is **not** a pure re-point: the managed scope is a third source #996 does not have, at higher precedence than either of its two, and whichever lands second has to carry it across. Dropping it would re-enable a leg an operator disabled. The docstring says so at the call site.
- **#735** — the third copy of this selector, in `platform_mcp_server.get_enabled_platforms`, still keyed on the absent `SLACK_BOT_TOKEN`. Left alone; that PR owns it.

## Testing

- `make test-python` — green in every directory. The only failures are 4 pre-existing `signal: killed` Go-subprocess kills in `tests/integration/test_seam_injector_kv.py`, which I confirmed reproduce identically on a clean tree with this branch stashed.
- `make docs-check` — clean.
- `make prettier-check` — clean for every file this branch touches; the 19 remaining warnings are pre-existing files under `.agents/skills/`.
- New coverage: per-platform resolution and precedence across all three sources; fan-out to both platforms; a dead leg not costing the live one its report; every leg failing still being a 502; each leg replaying only its own thread; a leg that fails once keeping its thread for the next report; an incident row per landed leg; the alert-path fallback in all three shapes; truncation of the report but not the posted message, and a cap smaller than the notice. From the review round below: a leg that missed this report keeping the report its channel can actually see; the pick naming the platform that will not get the alert on the all-legs-healthy path; a delivered-but-unthreadable send not being posted twice; a pre-upgrade session row keeping its thread; the truncation flag on the receipt in both directions; and Slack home-channel resolution across the environment and both config files.

### Live validation

Against the **autopush** install — `gke_kube-agents-autopush_us-central1_platform-agent-host`, `kubeagents-system`, pod `platform-agent-gateway-66569f4898-rnpcr`. **Read-only throughout: `get`, `describe`, `logs`, and `exec` of `cat`/`python3` that only reads files. No lease taken, nothing mutated, no artifacts left behind.**

Confirmed the defect and the premises the fix rests on:

```
$ kubectl get platformagent platform-agent -n kubeagents-system -o jsonpath='{.spec.integration}'
googleChat: {enabled: true, homeChannel: spaces/AAQASr5Afnc, ...}
slack:      {enabled: true, botTokenSecretRef: ..., appTokenSecretRef: ...}   # no homeChannel

$ kubectl exec ... -- cat /etc/hermes/config.yaml
platforms:
  google_chat: {enabled: true, ...}
  slack:       {enabled: true, ...}          # both explicit booleans, as renderConfigYAML emits

# the profile-home copy, which is what the shipped selector reads:
profile-home platforms keys: ['google_chat', 'slack']
   google_chat enabled= <absent>
   slack       enabled= <absent>             # so the config branch never answers
```

Replayed both selectors in-pod against the real files and the real environment:

```
managed scope says: {'google_chat': True, 'slack': True}
profile home says : {}
SLACK_RELAY_URL set: True
SLACK_HOME_CHANNEL : '<unset>'
GOOGLE_CHAT_HOME_CHANNEL: 'spaces/AAQASr5Afnc'

OLD get_active_platform()    -> slack                       # the dead leg
NEW enabled_chat_platforms() -> ['google_chat', 'slack']    # Google Chat routed, Slack attempted
```

The failure is ongoing, not historical:

```
2026-09-01 06:23:15 ERROR Job 'compliance-audit':    chat relay answered HTTP 502: composed but not delivered to slack
2026-09-01 06:53:34 ERROR Job 'obtainability-audit': ... same
2026-09-01 08:53:45 ERROR Job 'ai-security-audit':   ... same
```

And the correction to the issue's third claim — Slack is connected, not dead:

```
2026-09-01 13:52:51 INFO [Slack] Authenticated as @kageautopush in workspace kubeagents (team: T0BRDBS2LBW)
2026-09-01 13:52:51 INFO [Slack] Socket Mode connected (1 workspace(s))
2026-09-01 13:58:54 INFO inbound message: platform=slack chat=C0BRDBT5GMS msg='ping'
2026-09-01 13:59:01 INFO response ready: platform=slack chat=C0BRDBT5GMS time=7.2s
```

**Still current at `2b26af56`.** The live observations above are of the *input* side — the operator-written state on the pod and what the resolver makes of it — and the review round changed neither the resolver nor anything it reads, so those observations still describe the head. What the round did add (the incident-row filter, the alert-path warning and sentinel, the Slack home-channel fallback, the pre-upgrade seed, the truncation flag) is delivery-side and rests on unit coverage, for the same reason the fan-out already did: exercising it needs a built image rolled onto a shared install I have not taken the lease for.

**What I could not cover.** The fan-out itself is not exercised end to end on a live install: that needs a built agent image rolled onto autopush, which is a mutation of a shared environment I did not take the lease for. What is verified live is the input side — that the resolver reads real operator-written state and returns a different, correct answer on the exact install that is losing reports. The delivery side rests on unit coverage. Two further things a live roll would settle: whether the Chat Agent preserves the prepended `[truncated]` line in practice, and the first real fan-out to a Slack leg once a home channel exists.

## Self-Review

Both required passes ran, each **in its own subagent** handed only the repository, the diff range, the skill path, and the mechanical-gate output — no plan, no commit messages, no intent sentence, and instructed to derive intent from the diff and to edit nothing. Neither pass ran in the context that wrote the change. Findings are merged and deduplicated below (two pairs overlapped); severity is each pass's own.

**A second round ran against `f764687`** after the pull request was opened: `kube-agents-bot`, plus a full `review-adversarial` pass and an issue-conformance audit, each again in its own subagent that had not written the change. All three converged on the same two MEDIUM defects — the incident-row filter and the dead `get_active_platform` — which is what raises them above judgment calls: three readers with different prompts found the same two lines. Their dispositions are the six rows immediately below, and everything they land on is fixed in `2b26af56`. The first-round table that follows is unchanged and still holds; nothing in this round invalidated it.

| # | Severity / source | Finding | Disposition |
|---|---|---|---|
| R1 | MEDIUM · bot + adversarial + audit | The incident row was written for **every** thread the session ever had, not the legs that landed on this run. `platform_threads` is additive and the session id is per UTC day, so a leg that landed earlier today and failed just now had its stored context overwritten with a report its channel never received — and since `_store_incident_report` is `INSERT OR REPLACE` on `(chat_id, thread_id)`, the report still on that channel's screen was the one destroyed. A reply under it would have `incident_context` prepend text never posted there. | **Fixed.** The loop filters to `threads`. New test asserts on the report *text* per channel, not on thread reuse — the existing test asserted only the latter, which is exactly how this got through. Design doc corrected to say "on that run" and why. |
| R2 | MEDIUM · bot + adversarial + audit | `get_active_platform()` had **no production caller**: the alert path took `platforms[0]` directly. Its `logger.warning` — the "picking is not silent" half of #1094 — was therefore emitted nowhere, while this body, the function's own docstring, and the design doc all said it was. The unit test passed by calling dead code. | **Fixed**, by wiring it back in rather than deleting it: `trigger_agent_troubleshooter` takes its pick through `get_active_platform(platforms)`, with the resolved list passed in so the pick and the warning come off one resolution. The placement is the substance — the fall-through logs only *after* a leg refuses, so on the common install where the first leg accepts, nothing was said at all. New test asserts exactly one warning naming both platforms on the all-healthy path. Both false claims corrected here and in the design doc. |
| R3 | MEDIUM · adversarial | Slack's `chat_id` was read only from `SLACK_HOME_CHANNEL`. The operator renders that solely from the CR, but `/sethome` writes `platforms.slack.home_channel` into the writable `config.yaml` — which is precisely why that file is not mounted read-only. On such an install `_lookup_platform_threads` dropped the entry, so the Slack leg opened a fresh top-level message on every report and got no incident row, while the send itself succeeded and nothing looked wrong. The branch's own tests papered over it by setting the variable in `setUp`. | **Fixed.** New `_slack_home_channel()` reads the environment, then the managed scope, then `CONFIG_PATH`. Environment first, so an install whose CR sets the channel resolves exactly as before and only the broken case changes. Five tests, including a hostile config shape. |
| R4 | LOW · adversarial | A session routed **before** this change has the top-level triple and no `platform_threads`, so the first report after the rollout sent with `('', '')` and orphaned a top-level message. The Risk section noted the fall-through for rollback only; roll-forward has the same shape and is the direction that actually happens. | **Fixed** — the owning leg is seeded from the triple. One message per job that already reported earlier the same UTC day, so small, but it lands on every install at rollout. |
| R5 | LOW · adversarial | `_post_initial_alert` returned `None` both when the send failed and when it succeeded with no parseable `message_id` — a case the route's own docstring names as having happened here. The new fall-through then posted the alert to a *second* platform to chase a thread id. | **Fixed** via an explicit `ALERT_SENT_WITHOUT_THREAD` sentinel; the loop stops and records the delivery as unconfirmed rather than lost. Existing mocks return `None` or a real id, so they are unaffected. |
| R6 | LOW · adversarial | Truncation was invisible to the agent that submitted the report — the receipt carried `relay` and `undelivered` but nothing about the cut, so a specialist that sent 60k characters was told only "accepted". The same silence `undelivered` was added to close, one field along. | **Fixed** — `truncated` on the receipt, read by `report_to_chat` with its own label. |

**Not taken from this round.** The audit noted that truncation is a raw slice and can cut mid-code-fence, leaving unbalanced Markdown in the channel. Left alone deliberately: a fence-aware cut is a different change with its own judgment calls about what to do with a fence that opens 200 characters from the cap, and the notice already tells the reader the text is incomplete and where the whole of it is. Worth a follow-up issue if a reviewer disagrees.

**Adversarial pass** — angles run and reported: dual-platform and single-platform install shapes, the alert path vs. the relay path, sibling callers of the changed route, test-arity and test-coverage regressions, cross-PR overlap (#996, #735), security and blast radius of the audience change, config-shape hostility, and boundary arithmetic on the cap.

| # | Severity / verdict | Finding | Disposition |
|---|---|---|---|
| 1 | HIGH · CONFIRMED | The alert path swapped which install loses instead of removing the loss — Google-Chat-first with no fallback mirrors #1094 onto an install whose Google Chat leg is broken. | **Fixed.** `trigger_agent_troubleshooter` tries each enabled platform until one accepts; three tests. This was the pass's most valuable finding — reordering alone would have shipped the same bug to different installs. |
| 2 | MEDIUM · CONFIRMED | `report_to_chat` read `relay` but not `undelivered`, reporting a half-delivered report as clean. | **Fixed**, with independent labels so degraded and partial each say so. |
| 3 | MEDIUM · CONFIRMED | The auth suite's relay stub stayed a 2-tuple, so the authenticated case exercised the 502 handler and passed anyway. | **Fixed**, and the comment now says why the arity is load-bearing. |
| 4 | MEDIUM · CONFIRMED | The docstring claimed precedence parity with #996; the managed scope is a third source #996 lacks. | **Fixed** — the docstring now names the divergence and what a re-point must carry. |
| 5 | MEDIUM · PLAUSIBLE | The `[truncated]` notice was model input while the instructions say add "nothing at the bottom", so the Chat Agent could drop it. | **Fixed** — prepended to the composed message after the turn, like `[unrelayed]`; the test stubs a compliant turn that returns only its own prose. The pass could not settle it without a live turn, and neither can I; the restructure removes the dependence on the model's cooperation rather than betting on it. |
| 6 | MEDIUM · CONFIRMED | Fan-out widens who sees `evidence.excerpt` content, with no opt-out. | **Not fixed, deliberately.** Documented as a deliberate call in the design doc. The alternative is the status quo, where the same install reaches one audience and the operator cannot tell which; a report arriving somewhere unintended is visible and correctable, a report arriving nowhere was not. An install wanting one destination should enable one platform. Flagged here because it is a judgment a reviewer should overturn if they disagree. |
| 7 | LOW · CONFIRMED | `adapter.py` docstring: "the relay route has exactly one destination". | **Fixed.** |
| 8 | LOW · CONFIRMED | `agent_common_server` comment on reader precedence. | **Fixed** (duplicate of docs-drift Blocking #2). |
| 9 | LOW · PLAUSIBLE | `_seams.py` scrubs the env signals but not `HERMES_MANAGED_DIR`, the highest-precedence input. | **Fixed** (duplicate of docs-drift #10) — the fixture pins it at an absent directory. A real determinism bug I introduced, not just prose. |
| 10 | LOW · CONFIRMED | `max(0, cap - len(notice))` returned a string longer than the cap for a small cap. | **Fixed** by finding 5's restructure; test at `cap=100`. |
| 11 | LOW · CONFIRMED | A leg failing once stayed unthreaded for the rest of the day, orphaning a message per report. | **Fixed** — `platform_threads` per platform, plus an incident row per landed leg so a reply in either channel replays the report. |
| 12 | LOW · PLAUSIBLE | `deliver: "all"` now double-posts per platform. | **Fixed** in both docs. |

**Docs-drift pass** — checked the design doc, the cron README, the eod SOP, `session_management.md`, `credential-isolation-design.md`, the site's chatops and watchdogs pages, `docs/README.md`, and every doc claim about the route's status codes and response shape, verifying each against source rather than against other docs.

| # | Triage | Finding | Disposition |
|---|---|---|---|
| 1 | Blocking | `register()` comment said the cap "rejects rather than silently splitting". | **Fixed.** |
| 2 | Blocking | `agent_common_server`: "Both readers … consult CONFIG_PATH first". Also names `platform_mcp_server.get_active_platform`, which does not exist. | **Fixed**, including the wrong symbol name. |
| 3 | Advisory | Doc said the warning names "the destination that lost"; the log named the winner. | **Fixed in the code**, since the doc described the better behaviour. |
| 4 | Advisory | "three reports at 60k characters" — unsourced and inconsistent with the docstring beside it. | **Fixed** — attributed to #1094 and made consistent (three runs across two jobs). |
| 5, 6 | Advisory | Both `last_delivery_error` values quoted in the eod SOP are truncated; the real values nest three layers of wrapping, so an operator grepping them finds nothing. | **Fixed** — both quoted as the full strings, in fenced blocks. #6 was pre-existing but sat in a paragraph this branch re-authored. |
| 7 | Advisory | `chatops.md` does not say a dual-platform install's unprompted alerts moved back to Google Chat. | **Fixed** — one paragraph stating the alert/report split, deferring to the design doc as canonical. |
| 8 | Advisory | `autonomous-watchdogs.md` does not mention the fan-out. | **Not fixed, deliberately.** The bullet already links the design doc, which owns the fact; stating it in both is what the Documentation Guidelines' "link rather than summarise" rule exists to prevent. |
| 9 | Advisory | `docs/README.md` identifier-source table has no row for chat-platform enablement. | **Not fixed, deliberately.** §5 asks for a map row when a *document* is added; none was. The identifier table's existing rows cover cross-file constants (service account names, the Go version) rather than one module's resolution order, which the design doc now states in one place. Happy to add a row if a reviewer reads §2 the other way. |
| 10 | Advisory | `_seams.py` determinism claim. | **Fixed** — see adversarial #9. |
| 11 | Advisory | "the profile's own writable `config.yaml`" is ambiguous about which profile. | **Fixed** — named as `/opt/data/config.yaml`, the front door's file. |

**What the passes could not cover, in their own words.** The adversarial pass exercised no live installation, so findings 1, 5 and 6 are reasoned from the manifests; it did not run `tests/integration/` or the Go tests, and did not read the full diffs of #735, #861 or #697, which also touch `session_kv_server.py` — merge-order conflicts with those are unassessed. The docs-drift pass could not verify the live incident claims (the seven-day window, the 60k figures) as nothing in the tree sources them; I have since confirmed those against the running pod, and corrected the issue's Slack-connectivity claim in the process. It also could not verify the "every SOP leads with its summary" premise behind the head-survives rationale, having found that the chat report shape is composed by the agent rather than fixed by the SOP — so treat that rationale as a reasonable default rather than a guarantee.

## Risk & Rollout

The blast radius is chat delivery on installs with more than one platform enabled; a single-platform install resolves to the same platform it did before and is unaffected. Two behaviour changes a reviewer should weigh: a dual-platform install now receives every scheduled report on **both** platforms rather than one (finding 6 above), and its unprompted incident alerts move from Slack back to Google Chat, with a fallback to Slack if that send is not accepted.

New failure mode: on an install with a platform enabled but unreachable, every run now records a `chat relay partial:` line in `last_delivery_error` where it previously recorded a hard 502. That is louder, and it is the correct signal — it goes quiet as soon as the platform is either given a home channel or disabled. On autopush specifically it will fire until `slack_home_channel` is set.

Revert is a plain revert of both commits; no migration, no state change. `platform_threads` is additive to a JSON blob and older rows without it fall through to the unthreaded path, so a rollback leaves nothing to clean up.

---

Generated with the help of Claude Opus 5.

