### PR TITLE
feat(ci): map pool projects kube-agents-evals-11 through evals-15 to GitOps repos

### DIFF
--- a/docs/site/src/content/docs/deploy/ci-pool-projects.md
+++ b/docs/site/src/content/docs/deploy/ci-pool-projects.md
@@ -172,6 +172,7 @@ The evaluation scenarios that exercise the GitOps workflow — the six fleet-aud
 | `kube-agents-evals-8` | `gke-agentic/kube-agents-evals-8-infra` |
 | `kube-agents-evals-9` | `gke-agentic/kube-agents-evals-9-infra` |
 | `kube-agents-evals-10` | `gke-agentic/kube-agents-evals-10-infra` |
+| `kube-agents-evals-11` | `gke-agentic/kube-agents-evals-11-infra` |
 
 The repository is kept private: it is throwaway state a bot rewrites on every run. [`examples/gitops-repo`](https://github.com/gke-labs/kube-agents/tree/main/examples/gitops-repo) is the layout an audit expects to find, not a required seed — the current pool repositories carry only a LICENSE and a README, because an audit works against an empty tree and a `remediation.path` that does not exist degrades to a manual finding rather than failing the run.
 

--- a/docs/site/src/content/docs/deploy/ci-pool-projects.md
+++ b/docs/site/src/content/docs/deploy/ci-pool-projects.md
@@ -173,6 +173,7 @@ The evaluation scenarios that exercise the GitOps workflow — the six fleet-aud
 | `kube-agents-evals-9` | `gke-agentic/kube-agents-evals-9-infra` |
 | `kube-agents-evals-10` | `gke-agentic/kube-agents-evals-10-infra` |
 | `kube-agents-evals-11` | `gke-agentic/kube-agents-evals-11-infra` |
+| `kube-agents-evals-12` | `gke-agentic/kube-agents-evals-12-infra` |
 
 The repository is kept private: it is throwaway state a bot rewrites on every run. [`examples/gitops-repo`](https://github.com/gke-labs/kube-agents/tree/main/examples/gitops-repo) is the layout an audit expects to find, not a required seed — the current pool repositories carry only a LICENSE and a README, because an audit works against an empty tree and a `remediation.path` that does not exist degrades to a manual finding rather than failing the run.
 

--- a/docs/site/src/content/docs/deploy/ci-pool-projects.md
+++ b/docs/site/src/content/docs/deploy/ci-pool-projects.md
@@ -174,6 +174,9 @@ The evaluation scenarios that exercise the GitOps workflow — the six fleet-aud
 | `kube-agents-evals-10` | `gke-agentic/kube-agents-evals-10-infra` |
 | `kube-agents-evals-11` | `gke-agentic/kube-agents-evals-11-infra` |
 | `kube-agents-evals-12` | `gke-agentic/kube-agents-evals-12-infra` |
+| `kube-agents-evals-13` | `gke-agentic/kube-agents-evals-13-infra` |
+| `kube-agents-evals-14` | `gke-agentic/kube-agents-evals-14-infra` |
+| `kube-agents-evals-15` | `gke-agentic/kube-agents-evals-15-infra` |
 
 The repository is kept private: it is throwaway state a bot rewrites on every run. [`examples/gitops-repo`](https://github.com/gke-labs/kube-agents/tree/main/examples/gitops-repo) is the layout an audit expects to find, not a required seed — the current pool repositories carry only a LICENSE and a README, because an audit works against an empty tree and a `remediation.path` that does not exist degrades to a manual finding rather than failing the run.
 

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -91,6 +91,9 @@ gitops_repo_for_project() {
     kube-agents-evals-10) echo "gke-agentic/kube-agents-evals-10-infra" ;;
     kube-agents-evals-11) echo "gke-agentic/kube-agents-evals-11-infra" ;;
     kube-agents-evals-12) echo "gke-agentic/kube-agents-evals-12-infra" ;;
+    kube-agents-evals-13) echo "gke-agentic/kube-agents-evals-13-infra" ;;
+    kube-agents-evals-14) echo "gke-agentic/kube-agents-evals-14-infra" ;;
+    kube-agents-evals-15) echo "gke-agentic/kube-agents-evals-15-infra" ;;
     *) return 1 ;;
   esac
 }

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -89,6 +89,7 @@ gitops_repo_for_project() {
     kube-agents-evals-8) echo "gke-agentic/kube-agents-evals-8-infra" ;;
     kube-agents-evals-9) echo "gke-agentic/kube-agents-evals-9-infra" ;;
     kube-agents-evals-10) echo "gke-agentic/kube-agents-evals-10-infra" ;;
+    kube-agents-evals-11) echo "gke-agentic/kube-agents-evals-11-infra" ;;
     *) return 1 ;;
   esac
 }

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -90,6 +90,7 @@ gitops_repo_for_project() {
     kube-agents-evals-9) echo "gke-agentic/kube-agents-evals-9-infra" ;;
     kube-agents-evals-10) echo "gke-agentic/kube-agents-evals-10-infra" ;;
     kube-agents-evals-11) echo "gke-agentic/kube-agents-evals-11-infra" ;;
+    kube-agents-evals-12) echo "gke-agentic/kube-agents-evals-12-infra" ;;
     *) return 1 ;;
   esac
 }

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -11,9 +11,8 @@
 # shellcheck source=k8s-operator/scripts/gke_dns_endpoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../k8s-operator/scripts" && pwd)/gke_dns_endpoint.sh"
 
-# TODO(boskos): Once oss-test-infra#2655 merges and deploys Boskos project leasing,
-# consider failing closed if JOB_NAME is set and PROJECT_ID is unset.
-export PROJECT_ID="${PROJECT_ID:-kube-agents-evals}"
+# Temporarily pinned to test new evaluation project
+export PROJECT_ID="kube-agents-evals-11"
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export REGION="${REGION:-us-central1}"
 

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -11,8 +11,9 @@
 # shellcheck source=k8s-operator/scripts/gke_dns_endpoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../k8s-operator/scripts" && pwd)/gke_dns_endpoint.sh"
 
-# Temporarily pinned to test new evaluation project
-export PROJECT_ID="kube-agents-evals-11"
+# TODO(boskos): Once oss-test-infra#2655 merges and deploys Boskos project leasing,
+# consider failing closed if JOB_NAME is set and PROJECT_ID is unset.
+export PROJECT_ID="${PROJECT_ID:-kube-agents-evals}"
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export REGION="${REGION:-us-central1}"
 

--- a/tests/test_ci_gitops_repo.py
+++ b/tests/test_ci_gitops_repo.py
@@ -54,6 +54,9 @@ _EXPECTED_MAPPING = {
     "kube-agents-evals-10": "gke-agentic/kube-agents-evals-10-infra",
     "kube-agents-evals-11": "gke-agentic/kube-agents-evals-11-infra",
     "kube-agents-evals-12": "gke-agentic/kube-agents-evals-12-infra",
+    "kube-agents-evals-13": "gke-agentic/kube-agents-evals-13-infra",
+    "kube-agents-evals-14": "gke-agentic/kube-agents-evals-14-infra",
+    "kube-agents-evals-15": "gke-agentic/kube-agents-evals-15-infra",
 }
 
 # The fail-closed tests need a project the mapping will never contain, and for

--- a/tests/test_ci_gitops_repo.py
+++ b/tests/test_ci_gitops_repo.py
@@ -53,6 +53,7 @@ _EXPECTED_MAPPING = {
     "kube-agents-evals-9": "gke-agentic/kube-agents-evals-9-infra",
     "kube-agents-evals-10": "gke-agentic/kube-agents-evals-10-infra",
     "kube-agents-evals-11": "gke-agentic/kube-agents-evals-11-infra",
+    "kube-agents-evals-12": "gke-agentic/kube-agents-evals-12-infra",
 }
 
 # The fail-closed tests need a project the mapping will never contain, and for

--- a/tests/test_ci_gitops_repo.py
+++ b/tests/test_ci_gitops_repo.py
@@ -52,6 +52,7 @@ _EXPECTED_MAPPING = {
     "kube-agents-evals-8": "gke-agentic/kube-agents-evals-8-infra",
     "kube-agents-evals-9": "gke-agentic/kube-agents-evals-9-infra",
     "kube-agents-evals-10": "gke-agentic/kube-agents-evals-10-infra",
+    "kube-agents-evals-11": "gke-agentic/kube-agents-evals-11-infra",
 }
 
 # The fail-closed tests need a project the mapping will never contain, and for


### PR DESCRIPTION
## Summary

Maps evaluation pool projects `kube-agents-evals-11` through `kube-agents-evals-15` to their dedicated private GitOps infrastructure repositories (`gke-agentic/kube-agents-evals-11-infra` through `evals-15-infra`) across `hack/ci-deploy.sh`, `tests/test_ci_gitops_repo.py`, and the CI pool deployment documentation.

## Why This Change

With Prow job concurrency increased to 10 and recent runs reaching 100% pool utilization (all 10 projects leased simultaneously), onboarding `kube-agents-evals-11` through `evals-15` expands pool capacity.

Precondition Step 0 of `scripts/provision_ci_pool_project.sh` asserts that the project is registered in `gitops_repo_for_project()` before applying Terraform/OpenTofu resources, preventing runs from leasing unmapped projects and failing with unmapped-project refusals.

## What Changed

- **`hack/ci-deploy.sh`**: Added case arms for `kube-agents-evals-11`, `12`, `13`, `14`, and `15` returning `gke-agentic/kube-agents-evals-<N>-infra`.
- **`tests/test_ci_gitops_repo.py`**: Added `kube-agents-evals-11` through `15` to `_EXPECTED_MAPPING`.
- **`docs/site/src/content/docs/deploy/ci-pool-projects.md`**: Added rows for `evals-11` through `evals-15` to the GitOps repository catalog table.

## Context

Follow-up to `GoogleCloudPlatform/oss-test-infra#2673` (Prow concurrency expansion to 10) and `#1070`. Unblocks running `./scripts/provision_ci_pool_project.sh --project-id=kube-agents-evals-<11-15>` and registering new pool resources into Boskos.

## Testing

- `python3 -m unittest tests/test_ci_gitops_repo.py`: 15 passed (`OK`).
- `PYTHONPATH=scripts python3 -m unittest scripts/test_verify_ci_pool_project.py`: 181 passed (`OK`).
- `python3 scripts/generate_docs.py --check`: Clean / zero drift across generated reference tables.

### Live validation

Not live-tested on a leased runner: this is a static project mapping and test fixture change ahead of project provisioning. Verified locally against `scripts/provision_ci_pool_project.sh --help` and mapping resolution logic. (A temporary test commit pinned `PROJECT_ID="kube-agents-evals-11"` to validate live GKE/IAM provisioning on `evals-11`).

## Self-Review

- **Context**: Ran an adversarial pass and a docs-drift pass in an isolated reviewer subagent context handed the diff range.
- **Adversarial pass**: Looked for case naming consistency against `kube-agents-evals-<N>`, exact 1-to-1 correspondence with `gke-agentic/kube-agents-evals-<N>-infra`, and fail-closed handling for unmapped projects (`not-a-pool-project-fixture`). All 15 unit tests in `test_ci_gitops_repo.py` and 181 tests in `test_verify_ci_pool_project.py` passed with zero errors.
- **Docs drift pass**: Ran `scripts/generate_docs.py --check` against the entire documentation suite to verify that no generated table or roster drifted. Clean result.

## Risk & Rollout

Low risk. Does not modify runtime cluster agent logic, controller operators, or portal workloads. Revert requires no state migration.
