### PR TITLE
fix(test): regenerate the egress golden for #504's gitops-state rendering

### DIFF
--- a/k8s-operator/internal/testing/testdata/platform/expected/platformagent-egress-allowlist.yaml
+++ b/k8s-operator/internal/testing/testdata/platform/expected/platformagent-egress-allowlist.yaml
@@ -423,7 +423,6 @@ apiVersion: v1
 data:
   SETTINGS.md: |
     # GKE Scope Configuration
-    - **Git Repo:** None
 kind: ConfigMap
 metadata:
   labels:
@@ -432,6 +431,24 @@ metadata:
     app.kubernetes.io/name: platform-agent
     app.kubernetes.io/part-of: kube-agents
   name: platformagent-settings
+  namespace: kubeagents-system
+  ownerReferences:
+    - apiVersion: kubeagents.x-k8s.io/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: PlatformAgent
+      name: platformagent
+      uid: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: kubeagents-system-platformagent
+    app.kubernetes.io/managed-by: platformagent-controller
+    app.kubernetes.io/name: platform-agent
+    app.kubernetes.io/part-of: kube-agents
+  name: platformagent-gitops-state
   namespace: kubeagents-system
   ownerReferences:
     - apiVersion: kubeagents.x-k8s.io/v1alpha1
@@ -576,6 +593,10 @@ spec:
               value: /var/run/secrets/kubeagents/serviceaccount/token
             - name: TOKEN_BROKER_URL
               value: http://github-token-minter.kubeagents-system.svc.cluster.local:8080/token
+            - name: GITOPS_STATE_CONFIGMAP
+              value: platformagent-gitops-state
+            - name: GITOPS_STATE_PATH
+              value: /etc/gitops/managed_repos
             - name: API_SERVER_KEY
               value: cluster-internal-trusted
             - name: CREDENTIAL_PROXY_SCOPED_SA_POOL
@@ -674,6 +695,9 @@ spec:
               readOnly: true
             - mountPath: /opt/data
               name: platform-agent-data-vol
+            - mountPath: /etc/gitops
+              name: gitops-state-volume
+              readOnly: true
       securityContext:
         fsGroup: 10000
         runAsGroup: 10000
@@ -729,6 +753,10 @@ spec:
         - name: platform-agent-data-vol
           persistentVolumeClaim:
             claimName: platformagent-data
+        - configMap:
+            defaultMode: 420
+            name: platformagent-gitops-state
+          name: gitops-state-volume
 status: {}
 ---
 apiVersion: v1
@@ -817,6 +845,10 @@ spec:
               value: cluster-internal-trusted
             - name: SESSION_KV_DB_PATH
               value: /var/lib/kube-agents/session/session_kv.db
+            - name: GITOPS_STATE_CONFIGMAP
+              value: platformagent-gitops-state
+            - name: GITOPS_STATE_PATH
+              value: /etc/gitops/managed_repos
             - name: SESSION_KV_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -940,6 +972,9 @@ spec:
             - mountPath: /var/lib/kube-agents/session
               name: system-metadata
               subPath: session
+            - mountPath: /etc/gitops
+              name: gitops-state-volume
+              readOnly: true
             - mountPath: /tmp
               name: tmp-scratch
             - mountPath: /var/run/secrets/kubeagents/credential-proxy
@@ -1157,6 +1192,10 @@ spec:
             defaultMode: 420
             name: platformagent-settings
           name: settings-volume
+        - configMap:
+            defaultMode: 420
+            name: platformagent-gitops-state
+          name: gitops-state-volume
         - emptyDir:
             sizeLimit: 2Gi
           name: tmp-scratch


### PR DESCRIPTION
## Summary

Regenerates `platformagent-egress-allowlist.yaml`, the golden fixture #963 added, to carry the rendering change #504 made. `TestAgentsGolden/PlatformAgentEgressAllowlist` has been red on `main` since `a6904de`, which is issue #1115 — this is the one-file fix.

## Why This Change

#963 and #504 merged within minutes of each other in the same merge window. #504 changed what the operator renders for every agent — a new `<name>-gitops-state` ConfigMap, the `SETTINGS.md` wording, env on both Deployments — and regenerated the five fixtures that existed on its branch. #963's sixth fixture was merging concurrently, so neither branch could see the other's change, and the combined tree fails a test both sides passed alone.

## What Changed

One file. Regenerated with `go test ./internal/testing/ -run TestAgentsGolden -update`; the style churn `-update` makes to the five sibling fixtures was reverted as unrelated, and the fixture was run through the pinned prettier (CI checks changed fixtures).

## Context

Fixes #1115, the auto-filed broken-main issue. Cause is the #963/#504 cross-merge interaction; neither PR was wrong on its own tree.

Three open PRs carry stale copies of goldens and will need a regeneration on rebase: #720 rewrites this same fixture without the gitops-state objects (re-merging its copy would recreate exactly this breakage — moot if #720 is closed as split-and-landed, which is in progress), and #913 / #1039 each regenerate four of the six fixtures from before the gitops renderer change.

## Testing

- `go test ./internal/testing/ ./internal/controller/` green at this head.
- The delta was verified semantically, not eyeballed: parsed old and new fixture, and the movement is exactly one added ConfigMap (`platformagent-gitops-state`) plus the same `platformagent-settings`/Deployment deltas #504's own regeneration gave the sibling fixtures — `platformagent-split-broker.yaml` (the closest sibling: it also renders the broker Deployment) carries the identical shape.

### Live validation

Not live-tested: a golden-fixture regeneration changes no shipped behaviour — the fixture records what `buildPodTemplateSpec` and its callers already render, and the golden test is itself the mechanism under test.

## Self-Review

Machine-regenerated content, so the review surface is the delta: checked that it is semantically exactly #504's rendering change (object-level diff old→new: one added ConfigMap, settings and Deployment deltas, nothing else) and that no sibling fixture moved.

Both required passes ran in fresh subagent contexts handed the diff range and nothing else (the PR was opened before they returned — broken main blocks every open PR's Operator Tests — and this section was folded once they landed, per the keep-current rule). What they found:

- **Adversarial, one finding (MEDIUM, CONFIRMED): #720's diverged copy of this fixture** — see Context; recorded there, and mooted by closing #720. Its other angles came back clean, with the red-then-green run done independently in a throwaway worktree: base fixture red on exactly the `Git Repo: None`/gitops-state delta, this fixture green. It also verified every identifier the fixture introduces against the renderer source at the expected values, and that the fixture is faithful `-update` output modulo the repo's standard prettier formatting (a `git diff -w` of a full regen is empty).
- **Docs-drift: no Blocking findings — a testdata regeneration touches no documented prose, as the outcome of checking rather than by assumption.** It verified the one doc that cites this fixture by name (`credential-isolation.md`'s `gke-managed-otel` placement claim) still holds after regeneration. Four Advisory items are pre-existing base drift this diff neither caused nor can fix — `ci-pool-projects.md` and `pr-comment-conversation.md` still describe the retired `Git Repo:` SETTINGS.md line, a dated DRAFTS.md entry, and the now-unreferenced `SETTINGS_REPO_RE` in `gitops_workspace.py` — reported here for a separate follow-up rather than folded into a one-file broken-main fix.

## Risk & Rollout

None to a running system: the change is one test fixture, shipped in no image and rendered into no cluster. The blast radius is CI itself — merging turns `main`'s Operator Tests green again, and every open pull request stops inheriting the failure. Rollback is reverting the commit, which just re-breaks the golden. The one follow-on risk is the stale fixture copies in open PRs (#720, #913, #1039), named under Context; each needs a regeneration on rebase, and #720's — the only one carrying this exact fixture — is mooted by closing it as split-and-landed.

Generated with the help of Claude.
