### PR TITLE
fix(terraform): lifecycle.sh survives an empty KMS target list on bash 3.2

### DIFF
--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -222,8 +222,13 @@ adopt_kms() {
     )
   fi
 
+  # Skipping both halves — cluster KMS (create_cluster or database encryption
+  # off) and the minter — leaves targets empty, and macOS's bash 3.2 treats an
+  # empty array expansion as unbound under `set -u`. The ${arr[@]+...} form
+  # expands to nothing instead, so the loop runs zero times and the tail below
+  # still clears any stale provider override and logs what happened.
   local adopted=0 address kind id
-  for target in "${targets[@]}"; do
+  for target in ${targets[@]+"${targets[@]}"}; do
     IFS=$'\t' read -r address kind id <<<"$target"
 
     if in_state "$address"; then


### PR DESCRIPTION
## Summary

`adopt_kms` builds its adoption-target array conditionally: the cluster half is skipped when `create_cluster` or `enable_database_encryption` is off, the minter half when `enable_github_minter` is off. With both halves skipped the array is empty, and macOS's `/bin/bash` (3.2.57, the newest Apple ships) treats the empty `"${targets[@]}"` expansion as unbound under `set -u` — so every `./lifecycle.sh apply` or `adopt-kms` on a no-KMS configuration died before terraform ran. The fix guards the expansion itself with the standard 3.2-safe form, `${targets[@]+"${targets[@]}"}`: the loop runs zero times and the function tail still executes, so `drop_override` still clears any stale provider override and the completion log still says what happened.

## Why This Change

macOS is a supported operator platform — `docs/site/src/content/docs/install/prerequisites.md` says the installer scripts run under "the `/bin/bash` macOS ships", and this crash was the case where that claim was false. It is also getting easier to hit: #1014 made `create_cluster = false` alone skip the cluster half, so the installer's own liveness-probe path (existing cluster, minter off) now produces exactly the empty array.

## What Changed

- One hunk in `terraform/examples/full-install/lifecycle.sh`: the loop header expansion, plus a comment saying why the form matters and that the tail still runs.
- Deliberately not an early `return`: that shape would skip `drop_override` (leaving a stale `providers_lifecycle_override.tf` to fail the next apply with an unrelated-looking helm error) and exit silently — the silent-exit symptom this script's own `tfvar` comment treats as a defect.

## Context

- Open PR #1068 inserts a third `targets+=` block (stockout Pub/Sub) in this same region of `adopt_kms`, and its copy of the loop keeps the unguarded expansion — so #1068 as written still carries this crash, reachable with its toggle off too. Whichever lands second reconciles; the loop-header guard form has no ordering constraint against a new `targets+=` block (an early-return guard would have had one).
- Found 2026-08-26 standing up a real install from macOS with `enable_database_encryption = false`; that install has applied through this script since.

## Testing

- `make docs-check` green; no Markdown/YAML changed, so prettier is not in scope; shellcheck does not cover this file in CI (see Self-Review).

### Live validation

Run against the composition in this branch's checkout under `/bin/bash` 3.2.57 (arm64-apple-darwin25), with a tfvars carrying `enable_database_encryption = false`, `enable_github_minter = false`, and a local `terraform init`:

```
=== upstream/main's script (d82c26d) ===
lifecycle_old.sh: line 192: targets[@]: unbound variable
exit: 1
=== this branch, empty path, stale providers_lifecycle_override.tf planted ===
==> KMS adoption complete: 0 imported
exit: 0
(stale override removed by the tail)
=== this branch, non-empty path (enable_github_minter = true) ===
==> KMS adoption complete: 0 imported
exit: 0
```

The non-empty run iterates the loop for real (each `gcloud kms … describe` fails against the scratch project and hits the `|| continue`), proving the guarded expansion still yields one element per target with the tab-separated fields intact — also verified at construct level on 3.2.57 with tab, space, and glob payloads, and with the exact `local -a` + `targets+=` sequence the function uses. Test artifacts (tfvars, planted override, `.terraform`) were removed afterwards.

Not covered: an end-to-end `adopt-kms` that actually imports a real KMS keyring (no adoptable resource in a scratch state); nothing changes on bash ≥ 4, where the empty expansion was already legal — behavior there is byte-for-byte identical.

## Self-Review

Passes: `review-adversarial` (two rounds — initial, and a re-run after the first round's finding changed the guard's shape) and `review-docs-drift` (one round), each in a fresh subagent context handed the diff range and the skill, not the authoring conversation. Merged dispositions:

- **The first version's early `return 0` skipped `drop_override` and the completion log (adversarial round 1):** fixed — reshaped to the expansion guard; the empty path now proven to run the tail (transcript above, planted stale override removed).
- **PR #1068 carries a divergent unfixed copy of this loop (adversarial, CONFIRMED):** not fixable from this PR; named in Context so the merge-order reconciliation keeps the guard.
- **No automated regression coverage (adversarial, CONFIRMED):** not fixed. The crash only reproduces on bash < 4.4; CI's Linux runners can't exhibit it, and a test asserting the source text would pin vocabulary, not behavior. The red/green was performed manually on real 3.2.57. An installer-matrix macOS leg exercising `adopt-kms` would be the honest fix and is out of this PR's scope.
- **Usage banner breaks when the script is invoked by relative path from elsewhere (adversarial re-run, pre-existing, outside the changed function):** reported only.
- **Docs-drift: no findings** — checked the adopt-kms recovery recipes (`full-install/README.md`, `INSTALL.md`, `uninstall.md`, `scripts/release/README.md`) and the prerequisites claim against the change; the fix makes the macOS claim true rather than requiring any doc edit.

Generated with the help of Claude Code.

## Risk & Rollout

Five lines in one shell function; no behavior change on bash ≥ 4 and no change to what gets adopted — only the empty-list case stops crashing. Revert is a one-commit revert. Nothing has to happen at merge time; if #1068 merges first, the conflict resolution here is "keep the guarded loop header".