### PR TITLE
fix(docker): state the mode on the hermes_cli patch files

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -820,7 +820,7 @@ RUN /opt/hermes/.venv/bin/python3 /tmp/kanban-result/apply_kanban_report_format.
 # that rather than leaving it to a reader.
 # See the module docstring in deploy/docker/patches/kanban_scheduling.py and the
 # applier docstring in deploy/docker/patches/apply_kanban_scheduling.py.
-COPY deploy/docker/patches/kanban_scheduling.py /opt/hermes/hermes_cli/kanban_scheduling.py
+COPY --chmod=0644 deploy/docker/patches/kanban_scheduling.py /opt/hermes/hermes_cli/kanban_scheduling.py
 COPY deploy/docker/patches/apply_kanban_scheduling.py \
      deploy/docker/patches/verify_kanban_scheduling.py \
      deploy/docker/patches/patchlib.py \
@@ -886,7 +886,7 @@ RUN /opt/hermes/.venv/bin/python3 /tmp/kanban-scheduling/apply_kanban_scheduling
 # further down. It must not ship alone: raising the cap only moves when the bug
 # fires.
 # See the module docstring in deploy/docker/patches/kanban_guardrail_exit.py.
-COPY deploy/docker/patches/kanban_guardrail_exit.py /opt/hermes/hermes_cli/kanban_guardrail_exit.py
+COPY --chmod=0644 deploy/docker/patches/kanban_guardrail_exit.py /opt/hermes/hermes_cli/kanban_guardrail_exit.py
 COPY deploy/docker/patches/apply_kanban_guardrail_exit.py \
      deploy/docker/patches/verify_kanban_guardrail_exit.py \
      deploy/docker/patches/patchlib.py \
@@ -1013,7 +1013,18 @@ COPY deploy/docker/patches/kanban_wake_nudge.py \
      deploy/docker/patches/verify_kanban_event_routing.py \
      deploy/docker/patches/patchlib.py \
      /tmp/latency-patches/
-RUN cp /tmp/latency-patches/kanban_wake_nudge.py /opt/hermes/hermes_cli/kanban_wake_nudge.py && \
+# `install -m 0644`, not `cp`, for the first line. `cp` gives a newly created
+# destination the source's mode masked by the umask in force, and the source
+# here is whatever the build context held: git tracks one permission bit, so a
+# tree checked out under `umask 077` carries 0600 throughout and `cp`
+# propagates it rather than repairing it. The agent runs as uid 10000 and
+# cannot read the result. Same failure agentplugins/lib/plugin_image.sh:798
+# stages against for the plugin image, same cause.
+#
+# The other four land in /opt/hermes/tools and /opt/hermes/gateway, which the
+# `platform` stage normalizes; /opt/hermes/hermes_cli is the one patch
+# destination no loop walks, so it is stated here at the write site.
+RUN install -m 0644 /tmp/latency-patches/kanban_wake_nudge.py /opt/hermes/hermes_cli/kanban_wake_nudge.py && \
     cp /tmp/latency-patches/kanban_auto_subscribe.py /opt/hermes/tools/kanban_auto_subscribe.py && \
     cp /tmp/latency-patches/kanban_comment_status.py /opt/hermes/tools/kanban_comment_status.py && \
     cp /tmp/latency-patches/kanban_notify_delivery.py /opt/hermes/gateway/kanban_notify_delivery.py && \
@@ -1188,6 +1199,14 @@ FROM agent-base AS platform
 # across template edits; the staged repo plugins arrive root-owned via the
 # final RUN's cp -a. Skills stay in the final RUN with their provenance
 # manifest. Not in agent-base: credential-proxy carries neither.
+#
+# /opt/hermes/hermes_cli is deliberately not on the list. The only files in it
+# whose mode is ever in question are the three modules the patch layers write,
+# and those state their mode on the instruction that writes them, back in
+# agent-base -- where the mode is wrong, and in the one image this stage is not
+# a part of. Cost is not the reason either way: a find/chmod over a tree whose
+# modes are already correct exports a ~4kB layer, since BuildKit diffs the
+# result rather than the syscall.
 RUN set -eu; \
     for d in /opt/hermes/plugins /opt/hermes/gateway /opt/hermes/tools; do \
         find "$d" -type d -exec chmod 755 {} + ; \

--- a/deploy/docker/test_image_startup_contract.py
+++ b/deploy/docker/test_image_startup_contract.py
@@ -21,6 +21,7 @@ regex over the file the weaker substitute.
 import importlib.util
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -59,6 +60,48 @@ def stage_body(dockerfile_text: str, target: str) -> str:
 def platform_stage(dockerfile_text: str) -> str:
     """The Dockerfile text belonging to the `platform` target."""
     return stage_body(dockerfile_text, "platform")
+
+
+def joined_instructions(dockerfile_text: str) -> list:
+    """Every instruction in the text, line continuations joined into one line.
+
+    A shell command in a Dockerfile is wrapped across physical lines with
+    trailing backslashes, and the parts that matter to a caller here — an
+    interpreter and its `||` fallback, a `cp` and the `chmod` that repairs it —
+    sit on different ones. Comment lines are dropped, including inside a
+    continuation, which is how BuildKit reads them: the instruction continues
+    around the comment rather than ending at it.
+    """
+    instructions = []
+    current = []
+    for line in dockerfile_text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        current.append(line.rstrip().removesuffix("\\"))
+        if not line.rstrip().endswith("\\"):
+            instructions.append(" ".join(current))
+            current = []
+    if current:
+        instructions.append(" ".join(current))
+    return instructions
+
+
+# Dockerfile keywords are case-insensitive. Upper-casing them on the way out
+# means a lower-case `copy` cannot slip past a caller that matches on "COPY".
+DOCKERFILE_KEYWORDS = frozenset(
+    """ADD ARG CMD COPY ENTRYPOINT ENV EXPOSE FROM HEALTHCHECK LABEL MAINTAINER
+    ONBUILD RUN SHELL STOPSIGNAL USER VOLUME WORKDIR""".split()
+)
+
+
+def keyed_instructions(dockerfile_text: str) -> list:
+    """(keyword, argument) per instruction, keyword upper-cased."""
+    out = []
+    for instruction in joined_instructions(dockerfile_text):
+        parts = instruction.split(None, 1)
+        if len(parts) == 2 and parts[0].upper() in DOCKERFILE_KEYWORDS:
+            out.append((parts[0].upper(), parts[1]))
+    return out
 
 
 class EntrypointStartsInsideTheWorkspaceTest(unittest.TestCase):
@@ -287,22 +330,8 @@ class BytecodeIsBakedAtBuildTimeTest(unittest.TestCase):
         self.stage = platform_stage(DOCKERFILE.read_text())
 
     def compileall_command(self):
-        """The whole RUN instruction that precompiles, continuations joined.
-
-        A shell command in a Dockerfile is wrapped across physical lines with
-        trailing backslashes, and the parts that matter here — the interpreter
-        and the `||` fallback — sit on different ones.
-        """
-        instructions = []
-        current = []
-        for line in self.stage.splitlines():
-            if line.lstrip().startswith("#"):
-                continue
-            current.append(line.rstrip().removesuffix("\\"))
-            if not line.rstrip().endswith("\\"):
-                instructions.append(" ".join(current))
-                current = []
-        for instruction in instructions:
+        """The whole RUN instruction that precompiles, continuations joined."""
+        for instruction in joined_instructions(self.stage):
             if "compileall" in instruction:
                 return instruction
         self.fail("the platform stage does not precompile /opt/hermes")
@@ -454,16 +483,7 @@ class SkillProvenanceContractTest(unittest.TestCase):
 
     def generation_block(self):
         """The Dockerfile RUN that writes the manifests, continuations joined."""
-        instructions = []
-        current = []
-        for line in self.stage.splitlines():
-            if line.lstrip().startswith("#"):
-                continue
-            current.append(line.rstrip().removesuffix("\\"))
-            if not line.rstrip().endswith("\\"):
-                instructions.append(" ".join(current))
-                current = []
-        for instruction in instructions:
+        for instruction in joined_instructions(self.stage):
             if "sha256sum" in instruction:
                 return instruction
         self.fail("the platform stage does not generate a skill manifest")
@@ -662,6 +682,222 @@ class SkillProvenanceContractTest(unittest.TestCase):
         # which `cp -ru` can leave older than the image.
         self.assertIn("/opt/defaults/scripts/verify_skills_provenance.py", self.entrypoint)
         self.assertIn("agents/platform/scripts/ /opt/defaults/scripts/", self.stage)
+
+
+# The tree no normalization loop walks, so every write into it has to carry its
+# own mode. Held as a prefix rather than a set of filenames: the point is that a
+# fourth module dropped in beside the three is caught too.
+UNNORMALIZED_TREE = "/opt/hermes/hermes_cli"
+
+# The trees the `platform` stage's loop does normalize, which is what lets the
+# unmoded COPYs into them stand.
+NORMALIZED_TREES = ("/opt/hermes/plugins", "/opt/hermes/gateway", "/opt/hermes/tools")
+
+FILE_WRITING_COMMANDS = ("cp", "mv", "install")
+
+# `do`, `then` and friends lead a segment when a write sits inside a loop or a
+# conditional; stripping them reads the write as the write it is.
+SHELL_KEYWORDS = ("do", "done", "then", "else", "elif", "fi", "!")
+
+
+def grants_world_read(mode: str) -> bool:
+    """True when a `chmod` or `--chmod` mode argument grants read to `other`.
+
+    Both notations, because a false red here reads as "your correct Dockerfile
+    is wrong" and invites someone to change working code to satisfy a parser.
+    """
+    if re.fullmatch(r"[0-7]{3,4}", mode):
+        return bool(int(mode, 8) & 0o004)
+    # Symbolic. Only a clause naming `o` or `a` reaches `other`, and only `+`
+    # or `=` grants: `a+r`, `ugo+r` and `o=rX` do, `u+r` and `go-r` do not.
+    return any(
+        re.fullmatch(r"[ugoa]*[ao][ugoa]*[+=][rwxXst]*r[rwxXst]*", clause)
+        for clause in mode.split(",")
+    )
+
+
+def copy_destination_and_mode(argument: str):
+    """(destination, --chmod value or None) for a COPY, or (None, None).
+
+    Heredoc COPYs are skipped — the repository has none, and guessing at one
+    would be a false failure rather than a caught bug.
+    """
+    if "<<" in argument:
+        return None, None
+    try:
+        tokens = shlex.split(argument)
+    except ValueError:
+        return None, None
+    mode = None
+    while tokens and tokens[0].startswith("--"):
+        flag = tokens.pop(0)
+        if flag.startswith("--chmod="):
+            mode = flag.split("=", 1)[1]
+    if len(tokens) < 2:
+        return None, None
+    return tokens[-1], mode
+
+
+def install_mode(tokens):
+    """The mode an `install` command was given, in either notation, or None."""
+    for index, token in enumerate(tokens):
+        if token.startswith("--mode="):
+            return token.split("=", 1)[1]
+        if token.startswith("-m") and len(token) > 2:
+            return token[2:]
+        if token == "-m" and index + 1 < len(tokens):
+            return tokens[index + 1]
+    return None
+
+
+def run_commands(argument: str):
+    """The tokenized commands a shell would run for one RUN body."""
+    for segment in re.split(r"&&|\|\||[;|]", argument):
+        tokens = segment.split()
+        while tokens and tokens[0] in SHELL_KEYWORDS:
+            tokens.pop(0)
+        if tokens:
+            yield tokens
+
+
+def normalization_loops(stage_text: str):
+    """The tree lists of the stage's `for d in … ; do find … chmod` loops.
+
+    The lists themselves, not the enclosing RUN's text: a tree that a later
+    `cp -a` in the same RUN merely mentions is not a tree the loop normalizes,
+    and matching on the RUN as a whole cannot tell the two apart.
+    """
+    for keyword, argument in keyed_instructions(stage_text):
+        if keyword != "RUN" or "-type f -exec chmod" not in argument:
+            continue
+        for trees in re.findall(r"\bfor\s+\w+\s+in\s+(.*?);?\s*\bdo\b", argument):
+            yield trees.split()
+
+
+class HermesCliPatchesShipWorldReadableTest(unittest.TestCase):
+    """The patched modules have to be readable by the uid that imports them.
+
+    `agentplugins/lib/plugin_image.sh:798` states the mechanism and stages the
+    plugin image against it; the same thing reaches the agent image by a
+    different route. Git tracks one permission bit, so a tree checked out under
+    `umask 077` carries mode 0600 throughout, an unmoded `COPY` brings that into
+    the image, and `cp` — which masks the source's mode by the umask in force
+    rather than repairing it — carries it the rest of the way. The agent runs as
+    uid 10000, so the same Dockerfile yields a working image on one builder and,
+    on another, one that dies on its first import:
+
+        PermissionError: [Errno 13] Permission denied:
+          '/opt/hermes/hermes_cli/kanban_scheduling.py'
+
+    Precompiled bytecode does not paper over it. CPython derives a `.pyc`'s
+    mode from its source's, so an unreadable source has an unreadable cache.
+
+    Nothing else catches a regression here. CI builds under `umask 022`, where
+    an unmoded COPY lands at 0644 by luck and every gate stays green; the
+    failure reaches only whoever builds in a hardened environment, at agent
+    startup, as a stack trace with no visible connection to their umask.
+
+    Scope. These are pinned for `/opt/hermes/hermes_cli` because it is the one
+    patch destination no normalization loop walks, so a write into it is the one
+    that has to carry its own mode. The other destinations are swept by the
+    `platform` stage's loop, which is checked below — but only in the `platform`
+    image. `credential-proxy` builds from `agent-base` and never runs that loop,
+    so the unmoded COPYs into /opt/hermes/{tools,gateway} reach it as-is; that is
+    latent rather than live, since the sidecar runs only
+    /opt/defaults/scripts/credential_proxy.py and imports none of them.
+
+    These read the Dockerfile, so they pin what the build is told to do and not
+    what a layer ends up holding, and they see only `COPY` and the `cp`/`mv`/
+    `install` family. A module arriving by `ADD`, a redirect, `tar -x`, or a
+    Python applier using `shutil.copy` — which also preserves the source mode —
+    is outside them, as are the base image's own modes and the `/tmp/*` staging
+    directories the patch layers copy through.
+    """
+
+    def setUp(self):
+        self.text = DOCKERFILE.read_text()
+        self.instructions = keyed_instructions(self.text)
+        self.assertTrue(self.instructions, "the Dockerfile parsed to nothing")
+
+    def test_every_copy_into_hermes_cli_sets_a_world_readable_mode(self):
+        offenders = []
+        for keyword, argument in self.instructions:
+            if keyword != "COPY":
+                continue
+            destination, mode = copy_destination_and_mode(argument)
+            if destination is None or not destination.startswith(UNNORMALIZED_TREE):
+                continue
+            if mode is None:
+                offenders.append(f"{destination} (no --chmod)")
+            elif not grants_world_read(mode):
+                offenders.append(f"{destination} (--chmod={mode})")
+        self.assertEqual(
+            [],
+            offenders,
+            f"these COPY instructions write into {UNNORMALIZED_TREE}, which no "
+            "normalization loop walks, without a world-readable --chmod. On a builder "
+            "whose umask is stricter than 022 the file lands unreadable and the agent "
+            "dies at import as uid 10000. Add --chmod=0644.",
+        )
+
+    def test_every_run_that_writes_into_hermes_cli_sets_a_world_readable_mode(self):
+        offenders = []
+        for keyword, argument in self.instructions:
+            if keyword != "RUN":
+                continue
+            commands = list(run_commands(argument))
+            # A world-readable chmod anywhere in the same RUN is an equally good
+            # fix, so collect those before judging the writes. A chmod to some
+            # other mode is not a fix and does not count.
+            chmodded = set()
+            for tokens in commands:
+                if tokens[0] != "chmod":
+                    continue
+                # Flags first, so `chmod -R a+r <tree>` reads as the fix it is.
+                operands = [token for token in tokens[1:] if not token.startswith("-")]
+                if len(operands) > 1 and grants_world_read(operands[0]):
+                    chmodded.update(operands[1:])
+            for tokens in commands:
+                if tokens[0] not in FILE_WRITING_COMMANDS:
+                    continue
+                destination = tokens[-1]
+                if not destination.startswith(UNNORMALIZED_TREE):
+                    continue
+                if destination in chmodded:
+                    continue
+                mode = install_mode(tokens) if tokens[0] == "install" else None
+                if mode is not None and grants_world_read(mode):
+                    continue
+                offenders.append(" ".join(tokens))
+        self.assertEqual(
+            [],
+            offenders,
+            f"these commands write into {UNNORMALIZED_TREE} without setting a "
+            "world-readable mode. `cp` gives the destination the source's mode masked "
+            "by the umask, so a 0600 source stays 0600 and the uid 10000 the agent runs "
+            "as cannot read it. Use `install -m 0644` instead.",
+        )
+
+    def test_the_platform_stage_still_normalizes_the_other_patch_destinations(self):
+        # The two tests above are scoped to hermes_cli because everywhere else a
+        # patch lands is swept by the platform stage's loop. Dropping a tree from
+        # that loop would silently widen the bug rather than fail anything, so
+        # pin its membership here.
+        loops = list(normalization_loops(platform_stage(self.text)))
+        self.assertTrue(
+            loops,
+            "the platform stage no longer normalizes any tree with a `for d in … ; do "
+            "find … -type f -exec chmod` loop; the unmoded COPYs into /opt/hermes/tools "
+            "and /opt/hermes/gateway now depend on the builder's umask",
+        )
+        swept = {tree for trees in loops for tree in trees}
+        for tree in NORMALIZED_TREES:
+            self.assertIn(
+                tree,
+                swept,
+                f"{tree} is written by COPY instructions that set no mode, so it has to "
+                "stay in the platform stage's normalization loop",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three of the kanban patch modules land in `/opt/hermes/hermes_cli` without an explicit mode. `cp` gives a newly created destination the source's mode masked by the umask in force, and an unmoded `COPY` carries the build context's mode straight into the layer — so the mode those files end up with is the mode they had in whoever's working tree built the image. Git tracks only the executable bit, so a tree cloned under `umask 077` carries 0600 throughout, and the agent, which runs as uid 10000, cannot read its own modules. This sets the mode at the three write sites and adds three guards to the Dockerfile contract suite.

## Why This Change

Built under `umask 022` — which is what CI does — the files land 0644 by luck and everything is fine. Built under `umask 077`, the identical Dockerfile produces an image that dies on its first import:

```
PermissionError: [Errno 13] Permission denied:
  '/opt/hermes/hermes_cli/kanban_scheduling.py'
```

Precompiled bytecode doesn't paper over it: CPython derives a `.pyc`'s mode from its source's, so an unreadable source has an unreadable cache. Without this, the repo builds correctly only for people whose umask is permissive, and no gate anywhere reports the difference.

`agentplugins/lib/plugin_image.sh:798` already stages the plugin image against exactly this failure. The agent image reaches it by a different route.

## What Changed

- **`deploy/docker/Dockerfile`** — `--chmod=0644` on the two COPYs into `/opt/hermes/hermes_cli`, and `install -m 0644` in place of `cp` for the third. `hermes_cli` is the only patch destination no normalization loop walks; every other one is swept by the `platform` stage's loop. No instruction added or removed, so the chain stays at 114 of the 120 layer budget.
- **`deploy/docker/test_image_startup_contract.py`** — three guards, plus one shared `joined_instructions()` helper that replaces two hand-rolled copies of the continuation-joining loop already in that file.

Stated at the write site rather than by adding `hermes_cli` to the loop, because the mode is wrong in `agent-base` and the loop runs three stages later. **Layer cost is not the trade-off it appears to be and is not the reason:** measured against this base, a `find … -exec chmod` over a tree whose modes are already correct exports a ~4kB layer — identical to `RUN true` — because BuildKit diffs the result, not the syscall.

## Context

`hermes_cli` is the one patch destination outside the `platform` stage's `find … -exec chmod` normalization loop over `/opt/hermes/{plugins,gateway,tools}`, which is why it is the only tree where an unmoded write survives to runtime.

## Testing

`make docs-check` clean. All 50 tests in `deploy/docker/test_image_startup_contract.py` pass; the two new write-site guards are red against this PR's merge base and green at HEAD, and the loop-membership guard goes red when a tree is dropped from the loop. Also verified the guards reject `chmod 600` as a "fix", accept `chmod -R a+r` and `install --mode=`, and catch a lowercase `copy`.

### Live validation

Against a real install — GKE Standard, `us-central1`, namespace `kubeagents-system`, operator-managed `PlatformAgent` CR, agent running as uid 10000. Both images built **from a working tree with the three patch sources at 0600**, since building from a normal 0644 checkout produces a correct image with or without the fix and proves nothing.

Rolled by patching `.spec.deployment.tag`; the operator reconciled it through to the Deployment.

```
CR:          .spec.deployment.tag = hermescli-modes-1ab5b71a   .status.phase = Ready
Deployment:  platform-agent = …/platform-agent:hermescli-modes-1ab5b71a
Pod:         3/3 Running

$ kubectl exec … -c platform-agent -- sh -c 'id -u; ls -l …; python3 -c "import …"'
uid=10000 gid=10000
-rw-r--r-- root /opt/hermes/hermes_cli/kanban_guardrail_exit.py
-rw-r--r-- root /opt/hermes/hermes_cli/kanban_scheduling.py
-rw-r--r-- root /opt/hermes/hermes_cli/kanban_wake_nudge.py
-rw-r--r-- /opt/hermes/hermes_cli/__pycache__/kanban_scheduling.cpython-313.pyc
-rw-r--r-- /opt/hermes/hermes_cli/__pycache__/kanban_wake_nudge.cpython-313.pyc
import OK
```

**Negative control, on the same install.** The merge-base Dockerfile, same 0600 context, same base digest, run as a throwaway pod so the shared agent was never deliberately broken:

```
uid=10000
-rw------- /opt/hermes/hermes_cli/kanban_guardrail_exit.py
-rw------- /opt/hermes/hermes_cli/kanban_scheduling.py
-rw------- /opt/hermes/hermes_cli/kanban_wake_nudge.py
PermissionError: [Errno 13] Permission denied: '/opt/hermes/hermes_cli/kanban_scheduling.py'
```

Same at the image layer, two `--target agent-base` builds differing only in the Dockerfile: 0600 + `PermissionError` before, 0644 + `import OK` after.

**Not covered:** the agent's own logs show an unrelated pre-existing `HTTP Error 503` from `google_chat_relay_patch.py` polling a chat relay that isn't up on this install — present before and after, nothing to do with file modes. I did not exercise a full kanban work cycle, only module import and the patched-behaviour grep (`_kanban_record_wake(conn)` → 3).

**Cleanup:** install restored to its prior tag and `Ready` (confirmed), throwaway pod deleted, the deliberately broken negative-control image deleted from the registry.

## Self-Review

Adversarial and docs-drift, both run twice, each time in a subagent handed only the diff range. The second round changed the design, so only it is reported here.

- **The layer-cost argument in my first version was false.** I had claimed extending the normalization loop to `hermes_cli` would copy 21MB into that layer. Both passes challenged it; measuring says a no-op `chmod` over that tree exports 4.1kB, and over all of `/opt/hermes` 45.1kB. The size figures were wrong too (~12MB in the pinned base, not 21MB — the 21MB is post-`compileall`; `web_dist` is 25%, not "nearly all"). **Fixed by deleting the argument** and stating the measurement instead. The approach survives on a different rationale; the old one didn't survive checking.
- **My second justification was also wrong.** I'd argued `credential-proxy` needs the write-site fix because it never runs the loop. It runs only `credential_proxy.py`, which imports nothing from those trees. **Fixed**; the comment now gives only the reason that holds.
- **A hunk I'd added introduced a hazard this Dockerfile already documents.** I had put `--chmod=0644` on the staging `COPY` into `/tmp/latency-patches`; `--chmod` propagates to parent directories BuildKit creates, making that directory 0644 — the exact trap called out at `Dockerfile:1591`. Confirmed by building it. **Reverted.** The two direct COPYs are unaffected: their parent already exists and stays 755.
- **The loop-membership guard was vacuous.** It substring-matched the joined text of every `find … chmod` RUN, and `/opt/hermes/plugins` appears in two others — deleting it from the loop left the test green. **Fixed**: it now parses the `for d in …` list and is scoped to the `platform` stage. Verified the mutation fails.
- **The suite was a third copy of a Dockerfile parser, in the wrong directory.** Moved from `tests/` into `deploy/docker/test_image_startup_contract.py` — the Dockerfile-contract suite, which already carries `stage_body`/`platform_stage` and already asserts on build-time modes — and the two existing hand-rolled join loops now call the shared helper. The two passes disagreed here (one read `AGENTS.md` as pointing to `deploy/docker/`, the other read `docs/testing-map.md` as pointing to `tests/`); I went with the existing suite.
- **Mode-parsing was both too lax and too strict.** It credited a `chmod` to *any* mode, so `cp … && chmod 600 …` passed; and it rejected `ugo+r`, `chmod -R`, and `install --mode=`, which would go red on a correct Dockerfile. Both fixed and checked across 15 mode forms.
- **Not fixed, deliberately.** Seven other unmoded COPYs into `/opt/hermes/{tools,gateway}` in `agent-base` reach the `credential-proxy` image with no loop behind them. That is the same latent defect, but it isn't live — the sidecar imports none of those modules — and widening this PR to cover it would change an image whose behaviour is not otherwise in question. The test docstring names the gap rather than hiding it.
- **Reported, not fixed (pre-existing, unrelated):** `docs/testing-map.md` has no row for the `deploy/docker/test_*.py` home, and line 11 cites `Makefile:129-142` where the glob block now runs to 144.
- **Known limits of the guards:** they read the Dockerfile, not a built image, and see only `COPY` and `cp`/`mv`/`install`. A module arriving via `ADD`, `tar -x`, or an applier using `shutil.copy` (which also preserves the source mode) would not be caught. Stated in the docstring.

## Risk & Rollout

Low. Three tokens in one build stage; no runtime code path, no interface, no manifest, no IAM. The modes it sets are what the surrounding tree already has, and all 620 files in `/opt/hermes/hermes_cli` in the base image are already 0644, so nothing is loosened relative to a correct build — it only stops a hardened builder from producing a broken image. No layer added; 114 of 120. Revert is the commit.

Generated with the help of Claude Opus 5.
