### PR TITLE
fix(bench): classify unestablishable agent tunnels as infra, not as the agent's answer

### DIFF
--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -80,12 +80,13 @@ _log = logging.getLogger("kube_agents_bench.harness")
 SERVICE_API_PORT = 8642
 
 # Prefix on ``AgentResult.errors[0]`` that marks a run whose transport died on
-# every attempt: the opening turn never reached the agent, or the delegation
-# wait lost the endpoint on every status-turn retry with cards still
-# outstanding. ``hack/ci-eval-pr.sh`` matches this string in results.json
-# and classifies the task ``RUN_CLASS=INFRA``, so it lands in
-# ``INFRA_FAILED_TASKS`` instead of failing the pull request. The literal is the
-# contract between the two files: change it in both or in neither.
+# every attempt: the agent tunnel never established, the opening turn never
+# reached the agent, or the delegation wait lost the endpoint on every
+# status-turn retry with cards still outstanding. ``scoring.py`` matches this
+# string on a record's error and classifies the repetition as infrastructure
+# rather than grading it. The literal is duplicated there (importing the
+# harness would drag ``devops_bench`` into the scorer), and ``test_scoring.py``
+# asserts the two strings agree: change it in both files or in neither.
 INFRA_FAILURE_MARKER = "KUBE_AGENTS_INFRA_FAILURE"
 
 # Where hermes keeps per-card state in the agent's data volume. A card's
@@ -713,7 +714,7 @@ def _infra_failure(detail: str) -> AgentResult:
     graded as the agent's answer to ``gpu-stress-test-diagnosis``
     ("The Actual Output consists entirely of an HTTP 502 Bad Gateway",
     OutcomeValidity 0.0). A transport failure has to set a run class, not an
-    output: the marker on ``errors[0]`` is what ``hack/ci-eval-pr.sh`` reads.
+    output: the marker on ``errors[0]`` is what ``scoring.py`` reads.
     """
     return AgentResult(
         output="",
@@ -789,10 +790,38 @@ class KubeAgentsHarness(AgentHarness):
         if not api_path.startswith("/"):
             return AgentResult.errored(f"AGENT_API_PATH must start with '/': {api_path!r}")
 
-        try:
-            _ensure_port_forward(local_port)
-        except RuntimeError as exc:
-            return AgentResult.errored(str(exc))
+        # A tunnel that cannot be established is the same outage as one that
+        # dies mid-run -- the gateway pod replaced, its node draining, its
+        # cluster unreachable -- so it gets the same bounded retry the two
+        # turn loops use and the same run class on exhaustion. Returning the
+        # RuntimeError text as an errored result put "kubectl port-forward
+        # exited with 1" in front of the judge as the agent's answer: 11 of
+        # the 17 no-agent-ran repetitions in #1116's 46-PR sweep are this
+        # shape, and three builds lost every repetition of a case to it,
+        # which repetition voting cannot absorb. INFRA instead drops the
+        # repetition from the denominator, the class terminal 429s join
+        # via #1095's _RETRYABLE_STATUSES entry.
+        transport_failures = 0
+        while True:
+            try:
+                _ensure_port_forward(local_port)
+                break
+            except RuntimeError as exc:
+                transport_failures += 1
+                _log.warning(
+                    "port-forward failed to establish (%d/%d): %s",
+                    transport_failures,
+                    _MAX_TRANSPORT_FAILURES,
+                    exc,
+                )
+                if transport_failures >= _MAX_TRANSPORT_FAILURES:
+                    # Not AgentResult.errored: see _infra_failure. No agent
+                    # ever saw the request, so this is the run class, not an
+                    # answer.
+                    return _infra_failure(
+                        f"the agent tunnel failed to establish {transport_failures} "
+                        f"times running; last failure: {exc}"
+                    )
 
         # 127.0.0.1 rather than localhost, matching _port_open's probe host: a
         # v4/v6 mismatch would make the probe and the request disagree.

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -1085,21 +1085,81 @@ def test_non_object_json_becomes_errored_result(stub_agent: _StubAgentServer) ->
     assert "non-object JSON" in result.errors[0]
 
 
-def test_unreachable_endpoint_becomes_errored_result(
+def test_unreachable_endpoint_is_infra_not_an_answer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # A closed port with kubectl missing from PATH: the port-forward attempt
-    # fails fast and surfaces as a known error, not an exception.
+    # fails fast on every retry and gives up as a run class, not an answer.
     monkeypatch.setenv("AGENT_LOCAL_PORT", "1")  # privileged port, never open
     monkeypatch.setenv("PATH", "/nonexistent")
 
     result = KubeAgentsHarness().run("prompt")
 
     assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
     # The spawn failure must travel the harness's own known-error path, not
     # the base class's unexpected-exception safety net: the error names the
     # port-forward rather than a bare FileNotFoundError traceback.
     assert "port-forward" in result.errors[0]
+    assert result.output == ""
+    assert result.trajectory == []
+
+
+def test_a_dead_gateway_on_the_opening_tunnel_is_infra_not_an_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A tunnel that never comes up gives up as a run class, not the answer.
+
+    Before the establishment retry, the RuntimeError text was returned as an
+    errored result, so "kubectl port-forward exited with 1" was graded as the
+    agent's output -- rung 3 NOT_A_REAL_RUN, or rung 2 CHECK_DID_NOT_RUN when
+    the safeguard kubectl calls died of the same outage first. 11 of the 17
+    no-agent-ran repetitions in #1116's 46-PR sweep carry this shape, and on
+    builds 2094792115153276928 and 2094793470475505664 it took all three
+    repetitions at once, which repetition voting cannot absorb.
+    """
+    attempts: list[int] = []
+
+    def _dead(port: int) -> None:
+        attempts.append(port)
+        raise RuntimeError(
+            "kubectl port-forward exited with 1: Error from server: rpc error: "
+            "code = Unknown desc = Unknown Error."
+        )
+
+    monkeypatch.setattr(harness, "_ensure_port_forward", _dead)
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert result.has_errors()
+    assert result.errors[0].startswith(harness.INFRA_FAILURE_MARKER)
+    assert "rpc error" in result.errors[0]
+    assert result.output == ""
+    assert result.trajectory == []
+    assert len(attempts) == harness._MAX_TRANSPORT_FAILURES
+
+
+def test_a_tunnel_that_establishes_on_retry_reaches_the_answer(
+    stub_agent: _StubAgentServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One dead spawn -- the gateway pod mid-replacement -- then the answer."""
+    attempts: list[int] = []
+
+    def _flaky(port: int) -> None:
+        attempts.append(port)
+        if len(attempts) == 1:
+            raise RuntimeError(
+                "unable to forward port because pod is not running. "
+                "Current status=Pending"
+            )
+
+    monkeypatch.setattr(harness, "_ensure_port_forward", _flaky)
+
+    result = KubeAgentsHarness().run("Provision operator agent in cluster mercury-09.")
+
+    assert not result.has_errors()
+    assert result.output == _FINAL_TEXT
+    assert attempts == [stub_agent.server_address[1]] * 2
 
 
 def test_an_unpinned_port_forward_failure_names_the_cluster_it_used(


### PR DESCRIPTION
## Summary

When the opening `kubectl port-forward` to the agent gateway cannot be established, the bench harness returned the error text as the agent's answer, and the judge graded it — rung 3 `NOT_A_REAL_RUN`, which is admission-blind and reds the whole presubmit job. This PR gives tunnel establishment the same bounded retry the two turn loops already have, and on exhaustion classifies the repetition as `KUBE_AGENTS_INFRA_FAILURE`, the run class the scorer already drops from the denominator instead of grading.

After this PR:

- Each repetition gets up to 3 attempts to establish the tunnel to the agent gateway (previously one, whose failure text was graded as the agent's answer). One success and the repetition runs normally.
- A repetition whose 3 attempts all fail is marked `KUBE_AGENTS_INFRA_FAILURE`, and the existing scorer excludes it from the pass-rate denominator instead of grading it — neither a pass nor a fail.

## Why This Change

#1116's 46-PR sweep of `cluster-agent-healthy-workload-no-finding` found 17 repetitions that never ran an agent; 11 of them are this port-forward shape, and on builds `2094792115153276928` and `2094793470475505664` it took all three repetitions of the case at once. Repetition voting cannot absorb a failure that kills every repetition, so each of those builds redded its PR over an environment outage. The infra classifier that handles this correctly already exists (`_infra_failure` / `scoring.py`'s marker check) — the port-forward path just never reached it.

## What Changed

- `bench/kube_agents_bench/harness.py`: the opening `_ensure_port_forward` call is retried up to `_MAX_TRANSPORT_FAILURES` (3) times, mirroring the opening-turn and status-turn transport loops; on exhaustion it returns `_infra_failure(...)` instead of `AgentResult.errored(...)`. The `_cluster_hint` context still travels inside the recorded failure text.
- The `INFRA_FAILURE_MARKER` comment now names the establishment path and the marker's actual consumer (`scoring.py`; the old comment credited `hack/ci-eval-pr.sh`, which no longer reads it).
- `bench/tests/test_harness.py`: the spawn-failure test now asserts the infra class; two new tests pin exhaustion (3 attempts, marker, empty output/trajectory) and recovery (one dead spawn, then the answer).

## Context

- Part of #1116 — the port-forward residue after its 429-shaped evidence moved to #1097/#1095. The rung-2 shape where the *safeguard* `kubectl` calls die of the same outage is not addressed here.
- Sibling: #1095, which routes terminal 429s into the same class via `_RETRYABLE_STATUSES`. No code overlap; a comment in this diff references it.

## Testing

- `python -m pytest bench/tests/` — 604 passed.
- The adversarial review pass verified the three new/updated tests fail against `upstream/main`'s harness and pass against this branch.

### Live validation

The exhaustion path was exercised with the real mechanism, not the test stubs: the harness from this branch, run with `AGENT_CLUSTER_CONTEXT` pointed at a context that does not exist, so the real `kubectl port-forward` spawn fails the way it does when the gateway's cluster is unreachable. Three real attempts logged against the ceiling, then the record carried the run class and nothing for the judge:

```
port-forward failed to establish (1/3): kubectl port-forward exited with 1: error: context "nonexistent-validation-context" does not exist
port-forward failed to establish (2/3): kubectl port-forward exited with 1: error: context "nonexistent-validation-context" does not exist
port-forward failed to establish (3/3): kubectl port-forward exited with 1: error: context "nonexistent-validation-context" does not exist
errors[0]: KUBE_AGENTS_INFRA_FAILURE: the agent tunnel failed to establish 3 times running; last failure: kubectl port-forward exited with 1: error: context "nonexistent-validation-context" does not exist
output: ''
trajectory: []
```

This shape's live form is the absence of a reachable installation, so no install lease was needed and there are no artifacts to clean up. Not covered, same boundary as #1095: the recovery path against a gateway pod genuinely mid-replacement (pinned by the stub test at the same seam), and the scorer-side exclusion on a full smoke run — `scoring.py`'s marker check is unchanged and covered by `test_scoring.py`, and the natural end-to-end proof is the next smoke run that meets a gateway outage, which will report the repetition as `infra` (excluded) instead of a red case.

## Self-Review

Both passes ran in clean contexts (subagents handed the diff range and the claim, not the reasoning).

- Adversarial pass: checked for retry-loop defects (infinite loop, off-by-one, `transport_failures` reuse — the later loops re-initialize it), dependents of the old errored behavior (`hack/ci-eval-pr.sh`, `scoring.py`, CUJ scripts — none parse the old text), information loss (`_cluster_hint` survives via the exception message), and test strength (all three tests verified red on `upstream/main`). Findings: (1) a comment claimed 429s were already in `_RETRYABLE_STATUSES` while #1095 is unmerged — fixed, the comment now points at #1095; (2) the retry has no pacing, so a fast-exiting spawn burns all three attempts in ~1–3s and rarely recovers a transient — deliberate: both existing transport loops are also unpaced, and this PR's goal is reclassification, not recovery; (3) worst-case added latency is 2×15s on the spawned-but-never-opens shape, bounded and paid only on an already-dead environment — accepted.
- Docs-drift pass: no repo prose documents the old behavior and nothing references the renamed test. Findings: the `INFRA_FAILURE_MARKER` comment's two-path enumeration and its stale `hack/ci-eval-pr.sh` consumer claim — both fixed here, since this diff adds a third path and points readers at that comment. `docs/designs/eval-scorer.md`'s "no record came back at all" wording is imprecise about marker-classified records, but it describes the pre-existing marker mechanism, which this PR does not change — left for a docs follow-up rather than widening this diff.

## Risk & Rollout

Blast radius is the bench harness's failure path only; no agent, chart, or operator code. The new failure mode is a permanently misconfigured environment (wrong context, missing kubectl) now reporting as infra instead of as a graded error — that record is dropped from the denominator, so a systematically broken runner shows up as repeated infra classifications rather than red cases, which the scorer already surfaces per repetition. Revert is a clean single-commit revert.

Generated with the help of Claude (Fable 5).
