### PR TITLE
feat(dashboard): redesign the eval dashboard to the two-band agent/gate layout

### DIFF
--- a/scripts/eval_dashboard/SCHEMA.md
+++ b/scripts/eval_dashboard/SCHEMA.md
@@ -124,9 +124,9 @@ collector version in this tree emits them yet; the renderer already reads
 both.
 
 - `runs[].pr_merged` — `true` | `false` | `null`: whether the run's PR has
-  merged. The renderer's "agent" band charts only runs with `pr_merged:
-  true` (the final such run per PR); absent or `null` keeps a run out of
-  that cohort without any other effect.
+  merged. The renderer's "agent" band charts only runs where it is `true`
+  (the final such run per PR); absent or `null` keeps a run out of that
+  cohort without any other effect.
 - `runs[].tasks[].reps` — the task's individual repetitions, in order:
   `[{"n": 1, "result": "pass"|"fail"|"infra", "reason": "<string>"|null}]`.
   `reason` is free-form log text (renderers must escape it). `infra` reps

--- a/scripts/eval_dashboard/SCHEMA.md
+++ b/scripts/eval_dashboard/SCHEMA.md
@@ -117,6 +117,23 @@ Additive, optional, and safe to omit — consumers must default them.
   page labels itself `STALE`. No collector version emits it yet; the
   renderer defaults to `7200` when it is absent.
 
+### Optional run and task fields
+
+Additive, optional, and safe to omit — consumers must default them. No
+collector version in this tree emits them yet; the renderer already reads
+both.
+
+- `runs[].pr_merged` — `true` | `false` | `null`: whether the run's PR has
+  merged. The renderer's "agent" band charts only runs with `pr_merged:
+  true` (the final such run per PR); absent or `null` keeps a run out of
+  that cohort without any other effect.
+- `runs[].tasks[].reps` — the task's individual repetitions, in order:
+  `[{"n": 1, "result": "pass"|"fail"|"infra", "reason": "<string>"|null}]`.
+  `reason` is free-form log text (renderers must escape it). `infra` reps
+  are excluded from every pass-fraction denominator, exactly like `infra`
+  task results. When `reps` is absent the task's single `result` stands in
+  for one rep.
+
 ### `coverage` — from `docs/designs/domains.yaml`
 
 - `domains_total` — number of entries under `domains:`.

--- a/scripts/eval_dashboard/__init__.py
+++ b/scripts/eval_dashboard/__init__.py
@@ -4,7 +4,9 @@ The collector (`collect.py`) writes one data.json; its schema is a contract
 shared with the renderer and the publisher -- see SCHEMA.md in this directory
 before changing any field. `render.py` turns one data.json (schema_version 1)
 into `out/index.html` plus a copy of the data file; `publish.py` ships an
-out-dir to its serving location. Everything on the page is computed from
-data.json alone -- the one optional extra input is `case-notes.yaml`, which
-carries human one-line annotations and issue links per case.
+out-dir to its serving location. Everything measurable on the page is
+computed from data.json alone -- the two optional extra inputs are
+`case-notes.yaml` (human one-line annotations, issue links and badges per
+case) and `events.yaml` (dated event markers plus the human-classified
+catch and false-red counts); render.py's docstring owns the details.
 """

--- a/scripts/eval_dashboard/case-notes.yaml
+++ b/scripts/eval_dashboard/case-notes.yaml
@@ -12,13 +12,21 @@
 #     <case-name>:
 #       note: one-line human context, shown under the case name
 #       issues: ["#123", "#456"]   # rendered as links to this repo's issues
+#       badge: held-out            # matrix row pill: "held-out" or "new"
 
 notes:
   agent-kanban-smoke:
     note: redesigned 08-27
+  autoops-warning-event-triage:
+    badge: held-out
   capacity-pinned-pool-probe:
     issues: ["#1010"]
+    badge: held-out
+  cluster-agent-healthy-workload-no-finding:
+    badge: held-out
   compliance-rbac-overgrant:
     issues: ["#998", "#985"]
   gpu-stress-test-diagnosis:
     note: reuse regression under investigation
+  security-overgrant-remediation-proposal:
+    badge: new

--- a/scripts/eval_dashboard/events.yaml
+++ b/scripts/eval_dashboard/events.yaml
@@ -1,0 +1,34 @@
+# Optional human annotations for the eval dashboard that no log line can
+# carry: dated event markers, and the few human-judgment counts the tiles
+# show. Everything measurable comes from data.json; this file is only for
+# what a human classified or decided. render.py tolerates an absent or
+# empty file (markers disappear, the annotated tiles render an em-dash), so
+# deleting a stale line can never break a render.
+#
+# File shape (all keys optional):
+#
+#   events:                       # vertical markers on the day trend and the matrix
+#     - date: "2026-08-29"        # UTC day, YYYY-MM-DD
+#       label: "#1053 publish fix"
+#   catches:                      # band 1 "Product bugs caught" tile
+#     product_bugs: 4             # real product bugs the suite caught
+#     prs_blocked: 2              # PRs the gate stopped from merging
+#     ledger: "#1054"             # where the receipts live
+#   false_reds_7d: 1              # band 2 tile: human-classified false reds
+
+events:
+  - date: "2026-08-27"
+    label: "kanban redesign"
+  - date: "2026-08-29"
+    label: "#1053 publish fix"
+  - date: "2026-08-31"
+    label: "#1063 + 360m timeout"
+  - date: "2026-09-01"
+    label: "#1095 429→infra + #1096 roster"
+
+catches:
+  product_bugs: 4
+  prs_blocked: 2
+  ledger: "#1054"
+
+false_reds_7d: 1

--- a/scripts/eval_dashboard/render.py
+++ b/scripts/eval_dashboard/render.py
@@ -8,27 +8,48 @@ Usage::
 writes ``out/index.html`` (from ``template/index.html.tmpl``) and copies the
 data file alongside it, so the published directory is self-contained.
 
-Two rules shape everything here:
+The page tells one story in two bands:
+
+* **THE AGENT** -- is the agent getting better or worse, measured on the
+  merged-PR cohort (the final ``pr_merged`` run of each PR): weekly pass
+  rate, human-annotated catches, domain coverage, and a by-day pass-fraction
+  trend with named event markers.
+* **THE GATE** -- is the gate trustworthy: false-red and infra-rep tiles, a
+  case x run outcome matrix over the last runs, and a Pareto of normalized
+  failure signatures.
+
+Three rules shape everything here:
 
 * **Computed-only.** Every figure on the page is derived from data.json --
-  no hand-typed numbers can go stale in a template. The one optional extra
-  input is ``case-notes.yaml`` (``--notes``): human one-line annotations and
-  issue links per case. An absent notes file, or a case with no entry, is
-  simply a row without a note -- never an error.
-* **INFRA is not failure.** A task whose result is ``infra`` renders with its
-  own pill and history-dot color and is excluded from pass-fraction math,
-  matching the suite's policy that infrastructure failures never count
-  against a PR.
+  no hand-typed numbers can go stale in a template. The two optional extra
+  inputs are ``case-notes.yaml`` (``--notes``: one-line annotations, issue
+  links and badges per case) and ``events.yaml`` (``--events``: dated event
+  markers plus the few human-judgment counts no log line carries). An absent
+  file degrades to "no annotation" -- never an error.
+* **INFRA is not failure.** A rep (or task) whose result is ``infra`` is
+  excluded from every pass-fraction denominator, matching the suite's policy
+  that infrastructure failures never count against a PR.
+* **Run-level events are charged to the run, not the cases.** A run where at
+  least ``RUN_EVENT_FAIL_FRACTION`` of its graded tasks failed (a broken PR,
+  an endpoint outage) renders normally in the matrix but its failures are
+  excluded from per-case aggregates such as the failure-signature Pareto.
+  The exclusion is deliberately scoped to per-case aggregates: band 1's
+  cohort is the final run of each *merged* PR, and a merged PR's own
+  failures are that cohort's signal, not noise to exclude.
 
 The reader contract is schema_version 1 of the collector's data.json.
 Optional fields may be absent and unknown additive fields are ignored, so
-this renderer and the collector can ship independently.
+this renderer and the collector can ship independently. In particular
+``tasks[].reps`` and ``runs[].pr_merged`` are optional additive fields
+(SCHEMA.md, "Optional run and task fields") that no collector version emits
+yet; without them every task falls back to its single ``result`` and the
+merged-PR cohort is simply empty.
 
-The rendered page is also live: render.py bakes the data and notes into the
-template, whose script re-renders in place from a fresh ``data.json`` fetch
-every 60 seconds and keeps a freshness badge honest (see the template's
-"Live read side" comment). The Python fragment builders here and the JS
-mirrors there are intentionally parallel -- change them together.
+The rendered page is also live: render.py bakes the data, notes and events
+into the template, whose script re-renders in place from a fresh
+``data.json`` fetch every 60 seconds and keeps a freshness badge honest (see
+the template's "Live read side" comment). The Python fragment builders here
+and the JS mirrors there are intentionally parallel -- change them together.
 
 Only stdlib + PyYAML (already in requirements-test.txt) -- no build step.
 """
@@ -43,7 +64,6 @@ import math
 import pathlib
 import re
 import shutil
-import statistics
 import sys
 
 import yaml
@@ -51,11 +71,10 @@ import yaml
 HERE = pathlib.Path(__file__).resolve().parent
 TEMPLATE = HERE / "template" / "index.html.tmpl"
 DEFAULT_NOTES = HERE / "case-notes.yaml"
+DEFAULT_EVENTS = HERE / "events.yaml"
 ISSUE_URL = "https://github.com/gke-labs/kube-agents/issues"
 ISSUE_RE = re.compile(r"^#(\d+)$")
 
-# Judge scores are advisory; the tick every score bar carries sits here.
-JUDGE_THRESHOLD = 0.8
 # The 20-run yardstick the evidence bars are drawn against, borrowed from
 # the screening window in docs/designs/testing-strategy.md. The bars show
 # recorded history depth only -- admission to the gate is measured by the
@@ -63,8 +82,78 @@ JUDGE_THRESHOLD = 0.8
 # (bench/baselines/README.md); the presubmit runs collected here never
 # advance it, so a full bar is not admission.
 SCREENING_WINDOW = 20
-# Trend charts stay readable; older runs fall off the left edge.
-MAX_TREND_POINTS = 10
+
+# The three results a rep (or a task) can carry; anything else is treated as
+# "not measured" rather than guessed at.
+REP_RESULTS = ("pass", "fail", "infra")
+
+# Matrix window: the last N runs that measured at least one task. 30 columns
+# is about two weeks of PR traffic and still fits one screen at 22px cells.
+MATRIX_RUNS = 30
+# The by-day trend keeps at most this many day buckets on screen.
+TREND_DAYS = 30
+# Failure-signature Pareto: reps from runs started within this many days of
+# the data's generated_at, and at most this many bars.
+PARETO_WINDOW_DAYS = 7
+PARETO_MAX_ROWS = 8
+# A run where at least this fraction of its graded tasks failed is a
+# run-level event: the run is broken (a red PR, an outage), so its failures
+# are charged to the run and excluded from per-case aggregates.
+RUN_EVENT_FAIL_FRACTION = 0.8
+# Weekly pass-rate window, in milliseconds (all time math here is epoch ms,
+# matching the JS mirror's Date.parse).
+WEEK_MS = 7 * 24 * 3600 * 1000
+DAY_MS = 24 * 3600 * 1000
+# An unrecognized failure reason is grouped by its first characters.
+REASON_SNIPPET_CHARS = 60
+# Prow's job verdict for a green run (SCHEMA.md: runs[].result).
+RUN_RESULT_GREEN = "SUCCESS"
+
+# --- failure-signature normalization -------------------------------------
+# Deliberately small and documented: a reason that matches nothing renders
+# as its own first-60-chars group with a neutral bar, so an unclassified
+# failure is never silently blamed on infra, the checks, or the agent.
+# Signature substrings (matched case-insensitively against reps[].reason):
+SIG_429 = "http 429"  # endpoint saturation; infra-classed since #1095
+SIG_NOT_REAL_RUN = ("not evidence of a real agent run", "not_a_real_run")
+SIG_PHRASES_ABSENT = "required phrases absent"  # an exact-check miss
+# "check <name>" inside a phrases-absent reason names the exact check.
+CHECK_NAME_RE = re.compile(r"check[ :]+['\"]?([A-Za-z0-9_./-]+)", re.I)
+# Bar-color classification keywords, applied to the raw reason:
+INFRA_REASON_KEYWORDS = ("http 429", "rate limit", "timed out", "timeout", "connection")
+CHECK_REASON_KEYWORDS = (SIG_PHRASES_ABSENT,)
+AGENT_REASON_KEYWORDS = ("false finding",)
+
+# Pareto groups for reps that carry no reason string at all (the collector
+# fallback path, and infra reps whose reason never got recorded). Split by
+# result so an unexplained infra wave is never mistaken for agent failures.
+LABEL_NO_REASON = "(no reason recorded)"
+LABEL_NO_REASON_INFRA = "(infra, no reason recorded)"
+
+# The run-level event rule, stated wherever per-case aggregates are shown.
+RUN_EVENT_CAPTION = "run-level events excluded from per-case stats"
+
+# Matrix cell rendering: CSS class and tooltip text per cell state.
+CELL_CLASSES = {"pass": "c-g", "partial": "c-a", "fail": "c-r", "infra": "c-i", "none": "c-n"}
+CELL_TITLES = {
+    "pass": "passed all reps",
+    "partial": "partial (some reps passed)",
+    "fail": "failed all reps",
+    "infra": "infra — excluded",
+    "none": "not in run",
+}
+
+# Trend chart geometry (SVG user units) and axis furniture.
+TREND_W, TREND_H = 1000, 196
+TREND_PAD_X, TREND_PAD_Y = 34, 28
+# Consecutive event labels alternate between two rows so adjacent markers
+# do not overwrite each other.
+TREND_EVENT_ROW_OFFSET = 10
+TREND_GRIDLINES = (0.25, 0.5, 0.75, 1.0)
+TREND_MAX_X_LABELS = 8
+# Event labels on the chart are clipped so clustered events stay readable;
+# the matrix footnote carries every label in full.
+TREND_EVENT_LABEL_CHARS = 18
 
 esc = html.escape
 
@@ -88,16 +177,6 @@ def is_count(value) -> bool:
         and math.isfinite(value)
         and float(value).is_integer()
     )
-
-RESULT_PILLS = {
-    "pass": '<span class="pill p-pass">PASSED</span>',
-    "fail": '<span class="pill p-fail">FAILED</span>',
-    # Deliberately its own pill: INFRA is never rendered as a failure.
-    "infra": '<span class="pill p-infra">INFRA</span>',
-    "pend": '<span class="pill p-pend">IN BUILD</span>',
-}
-
-HIST_CLASSES = {"pass": "h-pass", "fail": "h-fail", "infra": "h-infra", "na": "h-na"}
 
 
 # --------------------------------------------------------------------------
@@ -128,47 +207,10 @@ def run_tasks(run: dict | None) -> list[dict]:
 
 def measured_runs(data: dict) -> list[dict]:
     """Runs that measured anything: at least one task row. An aborted or
-    deadline-truncated build parses to zero tasks; anchoring the header
-    tiles or the suite table to one would render vacuous 0/0 states
-    ("0 / 0 passed · all passed" on a run that measured nothing). The
-    trend charts and the header sha deliberately stay on sorted_runs."""
+    deadline-truncated build parses to zero tasks; giving one a matrix
+    column or a trend point would chart a run that measured nothing. The
+    header sha deliberately stays on sorted_runs."""
     return [r for r in sorted_runs(data) if run_tasks(r)]
-
-
-def counted_results(run: dict | None) -> tuple[int, int, int]:
-    """(passed, failed, infra) for one run. Only pass+fail gate."""
-    passed = failed = infra = 0
-    for task in run_tasks(run):
-        result = str(task.get("result", "")).lower()
-        if result == "pass":
-            passed += 1
-        elif result == "fail":
-            failed += 1
-        elif result == "infra":
-            infra += 1
-    return passed, failed, infra
-
-
-def pass_fraction(run: dict) -> float | None:
-    passed, failed, _ = counted_results(run)
-    total = passed + failed
-    return passed / total if total else None
-
-
-def median_task_minutes(run: dict | None) -> float | None:
-    durations = [
-        t["duration_s"]
-        for t in run_tasks(run)
-        if isinstance(t.get("duration_s"), (int, float))
-    ]
-    return statistics.median(durations) / 60 if durations else None
-
-
-def latest_task_for(case_name: str, run: dict | None) -> dict | None:
-    for task in run_tasks(run):
-        if task.get("name") == case_name:
-            return task
-    return None
 
 
 def parse_iso(value) -> datetime.datetime | None:
@@ -183,6 +225,19 @@ def parse_iso(value) -> datetime.datetime | None:
     return parsed.astimezone(datetime.timezone.utc)
 
 
+def iso_ms(value) -> float | None:
+    """Epoch milliseconds, the unit the JS mirror gets from Date.parse."""
+    parsed = parse_iso(value)
+    return parsed.timestamp() * 1000 if parsed else None
+
+
+def utc_day(value) -> str | None:
+    """'YYYY-MM-DD' in UTC; the trend's day bucket and the event-marker
+    join key. Mirrors the JS ``toISOString().slice(0, 10)``."""
+    parsed = parse_iso(value)
+    return f"{parsed:%Y-%m-%d}" if parsed else None
+
+
 def run_label(run: dict, index: int) -> str:
     if run.get("pr") is not None:
         return f"#{run['pr']}"
@@ -191,28 +246,196 @@ def run_label(run: dict, index: int) -> str:
 
 
 # --------------------------------------------------------------------------
+# reps, cell states, run-level events (the shared verdict vocabulary)
+
+
+def task_reps(task: dict) -> list[dict]:
+    """The counted repetitions of one task: ``tasks[].reps`` entries with a
+    recognized result when the collector reported them, else one synthetic
+    rep carrying the task's own single ``result``. Empty for a task that
+    measured nothing either way."""
+    reps = []
+    raw = task.get("reps")
+    if isinstance(raw, list):
+        for rep in raw:
+            if not isinstance(rep, dict):
+                continue
+            result = str(rep.get("result", "")).lower()
+            if result in REP_RESULTS:
+                reason = rep.get("reason")
+                reps.append(
+                    {"result": result, "reason": reason if isinstance(reason, str) else None}
+                )
+    if reps:
+        return reps
+    result = str(task.get("result", "")).lower()
+    if result in REP_RESULTS:
+        return [{"result": result, "reason": None}]
+    return []
+
+
+def rep_counts(reps: list[dict]) -> tuple[int, int, int]:
+    passed = failed = infra = 0
+    for rep in reps:
+        if rep["result"] == "pass":
+            passed += 1
+        elif rep["result"] == "fail":
+            failed += 1
+        else:
+            infra += 1
+    return passed, failed, infra
+
+
+def cell_state(task: dict) -> str:
+    """One task's matrix verdict: 'pass' (every graded rep passed),
+    'partial' (some passed, some failed), 'fail' (every graded rep failed),
+    'infra' (every counted rep was infra -- excluded, not failed), or
+    'none' (nothing measured)."""
+    reps = task_reps(task)
+    if not reps:
+        return "none"
+    passed, failed, _ = rep_counts(reps)
+    if passed and failed:
+        return "partial"
+    if failed:
+        return "fail"
+    if passed:
+        return "pass"
+    return "infra"
+
+
+def is_run_event(run: dict) -> bool:
+    """True when at least RUN_EVENT_FAIL_FRACTION of the run's graded tasks
+    (state pass/partial/fail; infra and unmeasured don't grade) failed
+    outright. Such a run is broken as a whole, so its failures are charged
+    to the run, not the cases."""
+    graded = [s for s in (cell_state(t) for t in run_tasks(run)) if s in ("pass", "partial", "fail")]
+    if not graded:
+        return False
+    return graded.count("fail") / len(graded) >= RUN_EVENT_FAIL_FRACTION
+
+
+# --------------------------------------------------------------------------
+# cohorts and windows
+
+
+def merged_final_runs(data: dict) -> list[dict]:
+    """Band-1 cohort: for each PR, its final measured run with
+    ``pr_merged: true`` -- the run whose codebase is (modulo the merge
+    commit) what actually shipped. Runs without a PR number count
+    individually. Empty when no collector has reported pr_merged yet."""
+    runs = [r for r in measured_runs(data) if r.get("pr_merged") is True]
+
+    def key(run: dict):
+        # A run without a PR number is its own cohort entry (identity key).
+        return f"pr:{run['pr']}" if run.get("pr") is not None else id(run)
+
+    final = {key(run): run for run in runs}  # chronological: last one wins
+    return [r for r in runs if final[key(r)] is r]
+
+
+def reference_ms(data: dict) -> float | None:
+    """The time axis anchor: generated_at, else the newest run's start.
+    Deliberately not the wall clock, so the baked HTML and the JS re-render
+    of the same data.json agree."""
+    anchor = iso_ms(data.get("generated_at"))
+    if anchor is not None:
+        return anchor
+    for run in reversed(sorted_runs(data)):
+        anchor = iso_ms(run.get("started"))
+        if anchor is not None:
+            return anchor
+    return None
+
+
+def week_pass_stats(data: dict) -> dict:
+    """Rep-level pass fraction of the merged-PR cohort for the 7 days ending
+    at the reference time ('cur') and the 7 before that ('prev'), plus the
+    current window's run count. A cohort with no usable timestamps counts
+    entirely as current -- better one honest number than none."""
+    anchor = reference_ms(data)
+    cur = {"pass": 0, "fail": 0, "runs": 0}
+    prev = {"pass": 0, "fail": 0}
+    for run in merged_final_runs(data):
+        started = iso_ms(run.get("started"))
+        bucket = None
+        if anchor is None or started is None:
+            bucket = cur
+        elif anchor - WEEK_MS < started <= anchor:
+            bucket = cur
+        elif anchor - 2 * WEEK_MS < started <= anchor - WEEK_MS:
+            bucket = prev
+        if bucket is None:
+            continue
+        passed = failed = 0
+        for task in run_tasks(run):
+            p, f, _ = rep_counts(task_reps(task))
+            passed += p
+            failed += f
+        bucket["pass"] += passed
+        bucket["fail"] += failed
+        if bucket is cur:
+            cur["runs"] += 1
+    def rate(bucket):
+        total = bucket["pass"] + bucket["fail"]
+        return bucket["pass"] / total if total else None
+    return {"cur": rate(cur), "prev": rate(prev), "runs_cur": cur["runs"]}
+
+
+def day_points(data: dict) -> list[tuple[str, float]]:
+    """(day, rep-level pass fraction) per UTC day of the merged-PR cohort,
+    oldest first, capped to the last TREND_DAYS days that measured
+    anything."""
+    buckets: dict[str, list[int]] = {}
+    for run in merged_final_runs(data):
+        day = utc_day(run.get("started"))
+        if day is None:
+            continue
+        bucket = buckets.setdefault(day, [0, 0])
+        for task in run_tasks(run):
+            p, f, _ = rep_counts(task_reps(task))
+            bucket[0] += p
+            bucket[1] += f
+    points = [
+        (day, counts[0] / (counts[0] + counts[1]))
+        for day, counts in sorted(buckets.items())
+        if counts[0] + counts[1]
+    ]
+    return points[-TREND_DAYS:]
+
+
+# --------------------------------------------------------------------------
 # case-notes.yaml (optional flavor; never an error)
 
 
 def load_notes(path: pathlib.Path | None) -> dict[str, dict]:
-    """``{case: {"note": str|None, "issues": [str, ...]}}``. Absent file,
-    empty file, or malformed entry all degrade to "no note"."""
+    """``{case: {"note": str|None, "issues": [str, ...], "badge":
+    str|None}}``. Absent file, empty file, or malformed entry all degrade
+    to "no note"."""
     if path is None or not path.exists():
         return {}
     try:
         raw = yaml.safe_load(path.read_text()) or {}
     except yaml.YAMLError:
         return {}
+    if not isinstance(raw, dict):
+        return {}
+    entries = raw.get("notes")
+    if not isinstance(entries, dict):
+        return {}
     notes = {}
-    for name, entry in (raw.get("notes") or {}).items():
+    for name, entry in entries.items():
         if isinstance(entry, str):
             entry = {"note": entry}
         if not isinstance(entry, dict):
             continue
         note = entry.get("note")
-        issues = [str(i) for i in entry.get("issues") or []]
-        if note or issues:
-            notes[str(name)] = {"note": note, "issues": issues}
+        raw_issues = entry.get("issues")
+        issues = [str(i) for i in raw_issues] if isinstance(raw_issues, list) else []
+        badge = entry.get("badge")
+        badge = str(badge) if isinstance(badge, str) else None
+        if note or issues or badge:
+            notes[str(name)] = {"note": note, "issues": issues, "badge": badge}
     return notes
 
 
@@ -233,6 +456,125 @@ def note_html(entry: dict | None) -> str:
     return f'<div class="tnote">{" · ".join(parts)}</div>'
 
 
+def badge_html(entry: dict | None) -> str:
+    """The held-out / new pill next to a matrix row name. Values come from
+    case-notes.yaml, never from code; an unknown badge renders nothing."""
+    badge = str((entry or {}).get("badge") or "").strip().lower()
+    if badge == "held-out":
+        return '<em class="b-hold">held out</em>'
+    if badge == "new":
+        return '<em class="b-new">new</em>'
+    return ""
+
+
+# --------------------------------------------------------------------------
+# events.yaml (optional; dated markers + the human-judgment counts)
+
+
+def load_events(path: pathlib.Path | None) -> dict:
+    """``{"events": [{"date": "YYYY-MM-DD", "label": str}], "catches":
+    dict|None, "false_reds_7d": value|None}``. Absent or malformed file
+    degrades to no markers and em-dash tiles."""
+    out = {"events": [], "catches": None, "false_reds_7d": None}
+    if path is None or not path.exists():
+        return out
+    try:
+        raw = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError:
+        return out
+    if not isinstance(raw, dict):
+        return out
+    for entry in raw.get("events") or []:
+        if not isinstance(entry, dict):
+            continue
+        date, label = entry.get("date"), entry.get("label")
+        if date is None or label is None:
+            continue
+        out["events"].append({"date": str(date)[:10], "label": str(label)})
+    catches = raw.get("catches")
+    if isinstance(catches, dict):
+        out["catches"] = {
+            "product_bugs": catches.get("product_bugs"),
+            "prs_blocked": catches.get("prs_blocked"),
+            "ledger": str(catches["ledger"]) if catches.get("ledger") is not None else None,
+        }
+    out["false_reds_7d"] = raw.get("false_reds_7d")
+    return out
+
+
+# --------------------------------------------------------------------------
+# failure signatures
+
+
+def reason_signature(reason: str | None) -> str:
+    """The Pareto group a rep's reason string falls into. The map is small
+    on purpose (module docstring: honest over clever); anything unmatched
+    groups by its first REASON_SNIPPET_CHARS characters."""
+    text = (reason or "").strip()
+    if not text:
+        return LABEL_NO_REASON
+    low = text.lower()
+    if SIG_429 in low:
+        return "endpoint saturation (infra)"
+    if any(sig in low for sig in SIG_NOT_REAL_RUN):
+        return "not a real agent run"
+    if SIG_PHRASES_ABSENT in low:
+        match = CHECK_NAME_RE.search(text)
+        if match:
+            return f"exact-check: {match.group(1)}"
+        return "exact-check: required phrases absent"
+    if len(text) > REASON_SNIPPET_CHARS:
+        return text[:REASON_SNIPPET_CHARS] + "…"
+    return text
+
+
+def reason_class(reason: str | None) -> str:
+    """Bar color: infra / check / agent by keyword, 'unknown' (neutral)
+    otherwise -- an unclassified failure is not silently blamed."""
+    low = (reason or "").lower()
+    if any(kw in low for kw in INFRA_REASON_KEYWORDS):
+        return "infra"
+    if any(kw in low for kw in CHECK_REASON_KEYWORDS):
+        return "check"
+    if any(kw in low for kw in AGENT_REASON_KEYWORDS):
+        return "agent"
+    return "unknown"
+
+
+def pareto_groups(data: dict) -> list[dict]:
+    """Non-pass reps of the last PARETO_WINDOW_DAYS, grouped by normalized
+    reason. Run-level events are excluded (charged to the run); runs
+    without a started timestamp cannot be windowed and are skipped unless
+    the data has no time anchor at all."""
+    anchor = reference_ms(data)
+    groups: dict[str, dict] = {}
+    for run in sorted_runs(data):
+        started = iso_ms(run.get("started"))
+        if anchor is not None:
+            if started is None:
+                continue
+            if started <= anchor - PARETO_WINDOW_DAYS * DAY_MS or started > anchor:
+                continue
+        if is_run_event(run):
+            continue
+        for task in run_tasks(run):
+            for rep in task_reps(task):
+                if rep["result"] == "pass":
+                    continue
+                reason = (rep["reason"] or "").strip()
+                if reason:
+                    label, cls = reason_signature(reason), reason_class(reason)
+                elif rep["result"] == "infra":
+                    # No reason, but the result itself says what it was.
+                    label, cls = LABEL_NO_REASON_INFRA, "infra"
+                else:
+                    label, cls = LABEL_NO_REASON, "unknown"
+                group = groups.setdefault(label, {"label": label, "count": 0, "cls": cls})
+                group["count"] += 1
+    ordered = sorted(groups.values(), key=lambda g: (-g["count"], g["label"]))
+    return ordered[:PARETO_MAX_ROWS]
+
+
 # --------------------------------------------------------------------------
 # HTML fragments
 
@@ -249,316 +591,346 @@ def tile(key: str, value_html: str, chip_html: str, detail: str) -> str:
     )
 
 
-def ratio_chip(
-    current: float | None,
-    previous: float | None,
-    unit: str,
-    have_previous_run: bool = False,
-) -> str:
-    """Cheaper/slower chip vs the previous run; flat when nothing moved.
-    "first run" only when there is genuinely no prior run -- a prior run
-    that just failed to report this metric gets no chip at all."""
-    if current is None or previous is None or not previous or not current:
-        if previous is None and not have_previous_run:
-            return delta_chip("flat", "first run")
-        return ""
-    if previous / current >= 1.5:
-        return delta_chip("up", f"▲ {fmt(previous / current, 1)}× cheaper")
-    if current / previous >= 1.5:
-        return delta_chip("flat", f"▼ {fmt(current / previous, 1)}× slower")
-    return delta_chip("flat", f"≈ prev {fmt(previous)}{unit}")
-
-
-def tiles_html(data: dict) -> str:
-    runs = measured_runs(data)
-    latest = runs[-1] if runs else None
-    previous = runs[-2] if len(runs) > 1 else None
+def agent_tiles_html(data: dict, events: dict) -> str:
     tiles = []
 
-    # Latest run
-    if latest:
-        passed, failed, infra = counted_results(latest)
-        counted = passed + failed
-        if failed:
-            chip = delta_chip("flat", f"{failed} failed")
-        elif infra:
-            chip = delta_chip("flat", f"{infra} infra")
-        elif passed:
-            chip = delta_chip("up", "all passed")
-        else:
-            # Unreachable for a measured run, but "all passed" must never
-            # be claimed by a run that measured nothing.
-            chip = ""
-        build_id = str(latest.get("build_id") or "?")
-        detail = f"build {build_id[:8]}… · {latest.get('project') or '?'}"
-        tiles.append(
-            tile(
-                "Latest run",
-                f"{passed}<small>/ {counted} passed</small>",
-                chip,
-                detail,
-            )
-        )
+    # Pass rate, this week vs prior week.
+    stats = week_pass_stats(data)
+    if stats["cur"] is not None:
+        pct = int(fmt(stats["cur"] * 100))
+        chip = ""
+        if stats["prev"] is not None:
+            diff = pct - int(fmt(stats["prev"] * 100))
+            if diff > 0:
+                chip = delta_chip("up", f"▲ +{diff}pt vs prior week")
+            elif diff < 0:
+                chip = delta_chip("flat", f"▼ {diff}pt vs prior week")
+            else:
+                chip = delta_chip("flat", "= prior week")
+        runs = stats["runs_cur"]
+        detail = f"merged-PR cohort · {runs} run{'s' if runs != 1 else ''} this week"
+        tiles.append(tile("Pass rate · this week", f"{pct}<small>%</small>", chip, detail))
     else:
-        detail = "no measured runs yet" if sorted_runs(data) else "no runs on record"
-        tiles.append(tile("Latest run", "—", "", detail))
+        detail = (
+            "no merged-PR runs this week"
+            if merged_final_runs(data)
+            else "no merged-PR runs on record"
+        )
+        tiles.append(tile("Pass rate · this week", "—", "", detail))
 
-    # Domain coverage
-    coverage = data.get("coverage") or {}
+    # Product bugs caught -- human judgment, annotated in events.yaml.
+    catches = events.get("catches") or {}
+    if is_count(catches.get("product_bugs")):
+        value = f"{int(catches['product_bugs'])}"
+        if is_count(catches.get("prs_blocked")):
+            value += f"<small> + {int(catches['prs_blocked'])} PRs blocked</small>"
+        detail = (
+            f"catch ledger {catches['ledger']}" if catches.get("ledger") else "events.yaml annotation"
+        )
+        tiles.append(tile("Product bugs caught", value, "", detail))
+    else:
+        tiles.append(tile("Product bugs caught", "—", "", "not annotated (events.yaml)"))
+
+    # Domain coverage (collector-computed).
+    coverage = data.get("coverage")
+    if not isinstance(coverage, dict):
+        coverage = {}
     covered, total = coverage.get("domains_covered"), coverage.get("domains_total")
     if is_count(covered) and is_count(total):
         covered, total = int(covered), int(total)
-        uncovered = [str(d) for d in coverage.get("uncovered") or []]
+        raw_uncovered = coverage.get("uncovered")
+        uncovered = [str(d) for d in raw_uncovered] if isinstance(raw_uncovered, list) else []
         chip = (
             delta_chip("up", "all covered")
             if covered >= total
             else delta_chip("flat", f"{total - covered} open")
         )
-        detail = (
-            f"uncovered: {', '.join(uncovered)}" if uncovered else "all domains covered"
-        )
-        tiles.append(tile("Domain coverage", f"{covered}<small>/ {total}</small>", chip, detail))
+        cases = [c for c in data.get("cases") or [] if isinstance(c, dict)]
+        blocking = sum(1 for c in cases if c.get("active"))
+        if uncovered:
+            detail = f"uncovered: {', '.join(uncovered)}"
+        else:
+            detail = f"{len(cases)} scenarios · {blocking} blocking"
+        tiles.append(tile("Domains covered", f"{covered}<small>/ {total}</small>", chip, detail))
     else:
-        tiles.append(tile("Domain coverage", "—", "", "not reported"))
-
-    # Median case cost
-    med = median_task_minutes(latest)
-    if med is not None:
-        chip = ratio_chip(med, median_task_minutes(previous), "min", previous is not None)
-        detail = f"median across {len(run_tasks(latest))} cases · latest run"
-        tiles.append(tile("Median case cost", f"{fmt(med, 1)}<small>min</small>", chip, detail))
-    else:
-        tiles.append(tile("Median case cost", "—", "", "no task durations yet"))
-
-    # Wall clock
-    duration = latest.get("duration_s") if latest else None
-    if isinstance(duration, (int, float)):
-        prev_duration = previous.get("duration_s") if previous else None
-        prev_min = prev_duration / 60 if isinstance(prev_duration, (int, float)) else None
-        chip = ratio_chip(duration / 60, prev_min, "min", previous is not None)
-        finished = parse_iso(latest.get("finished"))
-        detail = (
-            f"finished {finished:%Y-%m-%d %H:%M} UTC" if finished else "whole-run wall clock"
-        )
-        tiles.append(tile("Wall clock", f"{fmt(duration / 60)}<small>min</small>", chip, detail))
-    else:
-        tiles.append(tile("Wall clock", "—", "", "not reported"))
+        tiles.append(tile("Domains covered", "—", "", "not reported"))
 
     return "".join(tiles)
 
 
-def score_html(judge) -> str:
-    if not isinstance(judge, (int, float)):
-        return '<span class="cap">—</span>'
-    judge = min(max(float(judge), 0.0), 1.0)
-    return (
-        f'<div class="score"><div class="bar">'
-        f'<div class="fill" style="width:{fmt(judge * 100)}%"></div>'
-        f'<div class="thr" style="left:{JUDGE_THRESHOLD * 100:.0f}%"></div></div>'
-        f'<span class="val">{fmt(judge, 1)}</span></div>'
-    )
+def gate_tiles_html(data: dict, events: dict) -> str:
+    tiles = []
 
-
-def case_row(case: dict, latest_run: dict | None, notes: dict) -> str:
-    name = str(case.get("name") or "?")
-    task = latest_task_for(name, latest_run)
-
-    if task:
-        status = str(task.get("result", "")).lower()
-        if status not in ("pass", "fail", "infra"):
-            status = "pend"
+    # False reds, 7d -- human classification, annotated in events.yaml.
+    false_reds = events.get("false_reds_7d")
+    if is_count(false_reds):
+        tiles.append(tile("False reds · 7d", f"{int(false_reds)}", "", "human-classified · events.yaml"))
     else:
-        measured = [
-            h for h in case.get("last3") or [] if str(h).lower() in ("pass", "fail", "infra")
-        ]
-        status = str(measured[-1]).lower() if measured else "pend"
+        tiles.append(tile("False reds · 7d", "—", "", "not annotated (events.yaml)"))
 
-    last3 = [str(h).lower() for h in (case.get("last3") or [])][-3:]
-    last3 = ["na"] * (3 - len(last3)) + [h if h in HIST_CLASSES else "na" for h in last3]
-    hist = "".join(f'<i class="{HIST_CLASSES[h]}" title="{h}"></i>' for h in last3)
+    # Infra-rep rate over the matrix window.
+    window = measured_runs(data)[-MATRIX_RUNS:]
+    total = infra = 0
+    reps_reported = False
+    for run in window:
+        for task in run_tasks(run):
+            raw = task.get("reps")
+            if isinstance(raw, list) and any(
+                isinstance(r, dict) and str(r.get("result", "")).lower() in REP_RESULTS
+                for r in raw
+            ):
+                reps_reported = True
+            for rep in task_reps(task):
+                total += 1
+                if rep["result"] == "infra":
+                    infra += 1
+    if total:
+        value = f"{fmt(100 * infra / total, 1)}<small>%</small>"
+        detail = (
+            f"{infra} of {total} reps · last {len(window)} runs"
+            if reps_reported
+            else f"task-level fallback · last {len(window)} runs"
+        )
+        tiles.append(tile("Infra-rep rate", value, "", detail))
+    else:
+        tiles.append(tile("Infra-rep rate", "—", "", "no measured runs yet"))
 
-    judge = task.get("outcome_validity") if task else None
-    if judge is None:
-        ov_history = [
-            h for h in case.get("ov_history") or [] if isinstance(h.get("value"), (int, float))
-        ]
-        judge = ov_history[-1]["value"] if ov_history else None
+    # Wall clock of the latest green full run.
+    runs = sorted_runs(data)
+    green = None
+    green_index = -1
+    for index in range(len(runs) - 1, -1, -1):
+        run = runs[index]
+        if (
+            str(run.get("result") or "") == RUN_RESULT_GREEN
+            and run_tasks(run)
+            and isinstance(run.get("duration_s"), (int, float))
+        ):
+            green, green_index = run, index
+            break
+    if green:
+        value = f"{fmt(green['duration_s'] / 60)}<small>min</small>"
+        detail = f"latest green full run · {run_label(green, green_index)}"
+        tiles.append(tile("Wall clock · green run", value, "", detail))
+    else:
+        tiles.append(tile("Wall clock · green run", "—", "", "no green full run on record"))
 
-    duration = task.get("duration_s") if task else None
-    if not isinstance(duration, (int, float)):
-        duration = (case.get("durations") or {}).get("med")
-    duration_text = f"{fmt(duration)}s" if isinstance(duration, (int, float)) else "—"
+    # Queue wait: data.json carries no queued-at timestamp, so this cannot
+    # be computed. An honest em-dash beats an invented number.
+    tiles.append(tile("Queue wait · median", "—", "", "not reported in data.json"))
 
-    domain = case.get("domain")
-    domain_html = f'<span class="tdom">{esc(str(domain))}</span>' if domain else ""
-
-    return (
-        f"<tr><td>{RESULT_PILLS[status]}</td>"
-        f'<td><div class="tname">{esc(name)}</div>{note_html(notes.get(name))}</td>'
-        f"<td>{domain_html}</td>"
-        f'<td><span class="hist">{hist}</span></td>'
-        f"<td>{score_html(judge)}</td>"
-        f'<td class="num">{duration_text}</td></tr>'
-    )
-
-
-def suite_html(data: dict, notes: dict) -> str:
-    runs = measured_runs(data)
-    latest = runs[-1] if runs else None
-    rows = "".join(case_row(c, latest, notes) for c in data.get("cases") or [])
-    if not rows:
-        rows = '<tr><td colspan="6"><span class="cap">no cases on record yet</span></td></tr>'
-    return f"""
-  <h2 id="suite">Test suite</h2>
-  <div class="sub">Latest measured result per case · <b>Result</b> is the gating exact-check verdict · <b>Judge</b> is advisory (threshold tick at {JUDGE_THRESHOLD}) · history dots = last 3 runs</div>
-  <div class="card"><table id="cases">
-    <thead><tr><th>Result</th><th>Test case</th><th>Domain</th><th>History</th><th>Judge (advisory)</th><th style="text-align:right">Duration</th></tr></thead>
-    <tbody>{rows}</tbody>
-  </table></div>
-  <div class="legend">
-    <span><i class="h-pass"></i>pass</span><span><i class="h-fail"></i>fail</span>
-    <span><i class="h-infra"></i>INFRA — excluded from verdict</span><span><i class="h-na"></i>not in run</span>
-  </div>"""
+    return "".join(tiles)
 
 
-def chart_svg(points: list[tuple[str, float]], threshold: float | None = None) -> str:
-    """The spec page's line chart, one to one: dots carry ``data-l`` labels
-    the shared tooltip listener reads."""
+def matrix_html(data: dict, notes: dict, events: dict) -> str:
+    runs = measured_runs(data)[-MATRIX_RUNS:]
+    cases = [
+        c for c in data.get("cases") or [] if isinstance(c, dict) and c.get("active") is not False
+    ]
+    if not runs:
+        return '<div class="cap" style="margin-top:12px">no measured runs yet</div>'
+    if not cases:
+        return '<div class="cap" style="margin-top:12px">no active cases on record yet</div>'
+
+    event_days = {e["date"]: e["label"] for e in events.get("events") or []}
+    run_days = [utc_day(r.get("started")) for r in runs]
+    run_events = [is_run_event(r) for r in runs]
+    task_maps = [{str(t.get("name")): t for t in run_tasks(r)} for r in runs]
+
+    head = ['<div class="mx-row mx-head"><div class="mx-name"></div>']
+    for index, run in enumerate(runs):
+        day = run_days[index]
+        marker = "▲" if day in event_days else ""
+        title = f"{run_label(run, index)} · {day or '?'}"
+        if day in event_days:
+            title += f" · {event_days[day]}"
+        if run_events[index]:
+            title += " · run-level event"
+        head.append(f'<div class="mx-col" title="{esc(title)}">{marker}</div>')
+    head.append("</div>")
+
+    rows = ["".join(head)]
+    for case in cases:
+        name = str(case.get("name") or "?")
+        entry = notes.get(name)
+        row = [f'<div class="mx-row"><div class="mx-name"><span>{esc(name)}</span>{badge_html(entry)}</div>']
+        for index, run in enumerate(runs):
+            task = task_maps[index].get(name)
+            state = cell_state(task) if task else "none"
+            title = f"{name} · {run_label(run, index)} · {CELL_TITLES[state]}"
+            if run_events[index]:
+                title += " · run-level event (charged to the run)"
+            row.append(f'<div class="cell {CELL_CLASSES[state]}" title="{esc(title)}"></div>')
+        row.append("</div>")
+        rows.append("".join(row))
+
+    marks = [
+        f'<span>▲ {esc(day[5:])} {esc(event_days[day])}</span>'
+        for day in sorted(set(d for d in run_days if d in event_days))
+    ]
+    if marks:
+        rows.append(f'<div class="mx-ev">{"".join(marks)}</div>')
+    return f'<div class="mx">{"".join(rows)}</div>'
+
+
+def pareto_html(data: dict) -> str:
+    groups = pareto_groups(data)
+    if not groups:
+        return (
+            '<div class="cap" style="margin-top:12px">'
+            f"no failing or infra reps in the last {PARETO_WINDOW_DAYS} days</div>"
+        )
+    top = groups[0]["count"]
+    rows = []
+    for group in groups:
+        width = fmt(100 * group["count"] / top, 1)
+        rows.append(
+            f'<div class="pa-row"><div class="pa-bar-wrap">'
+            f'<div class="pa-bar pa-{group["cls"]}" style="width:{width}%"></div></div>'
+            f'<div class="pa-count">{group["count"]}</div>'
+            f'<div class="pa-name">{esc(group["label"])}</div></div>'
+        )
+    return "".join(rows)
+
+
+def trend_svg(points: list[tuple[str, float]], events: dict) -> str:
+    """The band-1 by-day pass-fraction line, with vertical event markers on
+    days that carry an events.yaml entry. Dots carry ``data-l`` labels the
+    shared tooltip listener reads."""
     if len(points) < 2:
         return ""
-    width, height, px, py, ymax = 480, 170, 14, 16, 1.0
+    width, height, px, py = TREND_W, TREND_H, TREND_PAD_X, TREND_PAD_Y
 
     def xs(i: int) -> float:
         return px + i * (width - 2 * px) / (len(points) - 1)
 
     def ys(v: float) -> float:
-        return height - py - (v / ymax) * (height - 2 * py)
+        return height - py - v * (height - 2 * py)
 
-    poly = " ".join(f"{fmt(xs(i), 1)},{fmt(ys(v), 1)}" for i, (_, v) in enumerate(points))
-    dots = "".join(
-        f'<circle cx="{fmt(xs(i), 1)}" cy="{fmt(ys(v), 1)}" r="5" fill="var(--accent)" '
-        f'stroke="var(--surface-1)" stroke-width="2" data-l="{esc(label)} · {fmt(v, 2)}"/>'
-        for i, (label, v) in enumerate(points)
-    )
-    xlab = "".join(
-        f'<text x="{fmt(xs(i), 1)}" y="{height - 2}" text-anchor="middle" font-size="10.5" '
-        f'font-weight="600" fill="var(--text-muted)">{esc(label)}</text>'
-        for i, (label, _) in enumerate(points)
-    )
-    thr_line = (
-        f'<line x1="{px}" y1="{fmt(ys(threshold), 1)}" x2="{width - px}" y2="{fmt(ys(threshold), 1)}" '
-        f'stroke="var(--line-2)" stroke-dasharray="3 4"/>'
-        if threshold is not None
-        else ""
-    )
-    return (
-        f'<svg viewBox="0 0 {width} {height}" preserveAspectRatio="none">'
-        f'{thr_line}<line x1="{px}" y1="{fmt(ys(0), 1)}" x2="{width - px}" y2="{fmt(ys(0), 1)}" stroke="var(--line)"/>'
-        f'<polyline points="{poly}" fill="none" stroke="var(--accent)" stroke-width="2.5" '
-        f'stroke-linejoin="round" stroke-linecap="round"/>{dots}{xlab}</svg>'
-    )
-
-
-def rate_points(data: dict) -> list[tuple[str, float]]:
-    points = []
-    for index, run in enumerate(sorted_runs(data)):
-        fraction = pass_fraction(run)
-        if fraction is not None:
-            points.append((run_label(run, index), fraction))
-    return points[-MAX_TREND_POINTS:]
-
-
-def judge_trend_case(data: dict) -> dict | None:
-    """The case with the deepest judge history -- the one with a story."""
-    candidates = [
-        c for c in data.get("cases") or [] if len(c.get("ov_history") or []) >= 2
-    ]
-    if not candidates:
-        return None
-    return max(candidates, key=lambda c: len(c["ov_history"]))
-
-
-def trends_html(data: dict) -> str:
-    # No threshold line here: 0.8 is the judge threshold, and drawing it on
-    # the pass-fraction chart would present it as a pass-rate target.
-    rate = chart_svg(rate_points(data))
-    rate = rate or '<div class="cap" style="margin-top:14px">not enough runs yet</div>'
-
-    # ov_history entries carry build ids; label them with the matching run's
-    # PR when the run is on record -- a raw build-id fragment tells a reader
-    # nothing.
-    labels = {
-        str(run.get("build_id")): run_label(run, index)
-        for index, run in enumerate(sorted_runs(data))
-    }
-    judge_case = judge_trend_case(data)
-    if judge_case:
-        points = [
-            (
-                labels.get(str(h.get("build_id")), str(h.get("build_id") or "?")[:6]),
-                float(h["value"]),
+    parts = [f'<svg viewBox="0 0 {width} {height}" preserveAspectRatio="none">']
+    for grid in TREND_GRIDLINES:
+        parts.append(
+            f'<line x1="{px}" y1="{fmt(ys(grid), 1)}" x2="{width - px}" y2="{fmt(ys(grid), 1)}" stroke="var(--line)"/>'
+            f'<text x="{px - 6}" y="{fmt(ys(grid) + 3, 1)}" text-anchor="end" font-size="9" '
+            f'fill="var(--text-muted)">{fmt(grid * 100)}</text>'
+        )
+    event_days = {e["date"]: e["label"] for e in events.get("events") or []}
+    marker = 0
+    for i, (day, _) in enumerate(points):
+        if day in event_days:
+            label = event_days[day]
+            if len(label) > TREND_EVENT_LABEL_CHARS:
+                label = label[:TREND_EVENT_LABEL_CHARS] + "…"
+            text_y = py - 6 - (marker % 2) * TREND_EVENT_ROW_OFFSET
+            marker += 1
+            parts.append(
+                f'<line x1="{fmt(xs(i), 1)}" y1="{py}" x2="{fmt(xs(i), 1)}" y2="{height - py}" '
+                f'stroke="var(--accent)" stroke-opacity=".35" stroke-dasharray="3 3"/>'
+                f'<text x="{fmt(xs(i), 1)}" y="{text_y}" text-anchor="middle" font-size="9" '
+                f'fill="var(--accent-link,var(--accent))">{esc(label)}</text>'
             )
-            for h in judge_case["ov_history"]
-            if isinstance(h.get("value"), (int, float))
-        ][-MAX_TREND_POINTS:]
-        judge_title = f"{judge_case.get('name', '?')} · judge score"
-        judge = chart_svg(points, threshold=JUDGE_THRESHOLD)
-    else:
-        judge_title = "judge score"
-        judge = ""
-    judge = judge or '<div class="cap" style="margin-top:14px">no judge history yet</div>'
+    poly = " ".join(f"{fmt(xs(i), 1)},{fmt(ys(v), 1)}" for i, (_, v) in enumerate(points))
+    parts.append(
+        f'<polyline points="{poly}" fill="none" stroke="var(--accent)" stroke-width="2.5" '
+        f'stroke-linejoin="round" stroke-linecap="round"/>'
+    )
+    for i, (day, v) in enumerate(points):
+        parts.append(
+            f'<circle cx="{fmt(xs(i), 1)}" cy="{fmt(ys(v), 1)}" r="4" fill="var(--accent)" '
+            f'stroke="var(--surface-1)" stroke-width="2" data-l="{esc(day)} · {fmt(v * 100)}%"/>'
+        )
+    step = max(1, math.ceil(len(points) / TREND_MAX_X_LABELS))
+    for i, (day, _) in enumerate(points):
+        if i % step == 0 or i == len(points) - 1:
+            parts.append(
+                f'<text x="{fmt(xs(i), 1)}" y="{height - 4}" text-anchor="middle" font-size="9.5" '
+                f'font-weight="600" fill="var(--text-muted)">{esc(day[5:])}</text>'
+            )
+    parts.append("</svg>")
+    return "".join(parts)
 
+
+def band_agent_html(data: dict, events: dict) -> str:
+    chart = trend_svg(day_points(data), events)
+    chart = chart or (
+        '<div class="cap" style="margin-top:14px">not enough merged-PR days yet '
+        "(needs runs with pr_merged from the collector)</div>"
+    )
     return f"""
-  <h2 id="trends">Trends</h2>
-  <div class="split">
+  <section class="band">
+    <div class="band-h"><h2 id="agent">The agent</h2><span class="cohort">cohort: final run of each merged PR</span></div>
+    <div class="sub">Measured only where the codebase is what actually shipped.</div>
+    <div class="tiles tiles-3">{agent_tiles_html(data, events)}</div>
     <div class="card pad chartcard">
-      <div class="t">Suite pass fraction, per run</div>
-      <div class="s">pass / (pass + fail) — INFRA excluded</div>
-      <div id="ratechart">{rate}</div>
+      <div class="t">Suite pass fraction, by day</div>
+      <div class="s">merged-PR cohort · pass / (pass + fail) over reps, INFRA excluded · event markers from events.yaml</div>
+      <div id="daytrend">{chart}</div>
     </div>
-    <div class="card pad chartcard">
-      <div class="t">{esc(judge_title)}</div>
-      <div class="s">advisory · threshold tick at {JUDGE_THRESHOLD}</div>
-      <div id="judgechart">{judge}</div>
-    </div>
-  </div>"""
+  </section>"""
 
 
-def evidence_row(case: dict) -> str:
+def band_gate_html(data: dict, notes: dict, events: dict) -> str:
+    matrix_runs = len(measured_runs(data)[-MATRIX_RUNS:])
+    return f"""
+  <section class="band">
+    <div class="band-h"><h2 id="gate">The gate</h2><span class="cohort">cohort: all PR runs · {RUN_EVENT_CAPTION}</span></div>
+    <div class="sub">Is the gate trustworthy — flake forensics, infra tax, and the cost of a run.</div>
+    <div class="tiles">{gate_tiles_html(data, events)}</div>
+    <div class="card pad">
+      <div class="t">Case × run outcome matrix</div>
+      <div class="s">one row per active case, one cell per run · last {matrix_runs} measured runs · ▲ = events.yaml marker · {RUN_EVENT_CAPTION}</div>
+      {matrix_html(data, notes, events)}
+      <div class="legend mx-legend">
+        <span><span class="cell c-g"></span>passed all reps</span>
+        <span><span class="cell c-a"></span>partial</span>
+        <span><span class="cell c-r"></span>failed all reps</span>
+        <span><span class="cell c-i"></span>infra — excluded</span>
+        <span><span class="cell c-n"></span>not in run</span>
+      </div>
+    </div>
+    <div class="card pad">
+      <div class="t">Failure signatures · last {PARETO_WINDOW_DAYS} days</div>
+      <div class="s">non-pass reps grouped by normalized reason · {RUN_EVENT_CAPTION} · gray = infra, violet = check design, amber = agent behaviour, neutral = unclassified</div>
+      {pareto_html(data)}
+    </div>
+  </section>"""
+
+
+def evidence_row(case: dict, notes: dict) -> str:
     name = str(case.get("name") or "?")
     have = case.get("runs_on_record")
-    have = int(have) if isinstance(have, (int, float)) else 0
+    have = int(have) if is_count(have) else 0
     width = min(100.0, 100.0 * have / SCREENING_WINDOW)
-    rate = case.get("pass_rate")
-    rate_text = f"{fmt(rate * 100)}%" if isinstance(rate, (int, float)) else "—"
     presubmit = (
         '<span class="pill p-pass">IN PRESUBMIT</span>'
         if case.get("active")
         else '<span class="pill p-fix">NOT IN PRESUBMIT</span>'
     )
     return (
-        f'<tr><td style="font-weight:650">{esc(name)}</td>'
+        f'<tr><td><div class="tname">{esc(name)}</div>{note_html(notes.get(name))}</td>'
         f'<td><div style="display:flex;align-items:center;gap:10px">'
         f'<div class="prog"><i style="width:{fmt(width)}%"></i></div>'
         f'<span class="cap">{have} of {SCREENING_WINDOW}</span></div></td>'
-        f'<td class="num" style="text-align:left">{rate_text}</td>'
         f"<td>{presubmit}</td></tr>"
     )
 
 
-def evidence_html(data: dict) -> str:
+def evidence_html(data: dict, notes: dict) -> str:
     cases = sorted(
-        data.get("cases") or [],
-        key=lambda c: (-(c.get("runs_on_record") or 0), str(c.get("name") or "")),
+        (c for c in data.get("cases") or [] if isinstance(c, dict)),
+        key=lambda c: (
+            -(int(c["runs_on_record"]) if is_count(c.get("runs_on_record")) else 0),
+            str(c.get("name") or ""),
+        ),
     )
-    rows = "".join(evidence_row(c) for c in cases)
+    rows = "".join(evidence_row(c, notes) for c in cases)
     if not rows:
-        rows = '<tr><td colspan="4"><span class="cap">no cases on record yet</span></td></tr>'
+        rows = '<tr><td colspan="3"><span class="cap">no cases on record yet</span></td></tr>'
     return f"""
   <h2 id="nightly">Evidence on record</h2>
-  <div class="sub">Recorded task appearances per case (all collected runs, infra included), against the {SCREENING_WINDOW}-run yardstick · history depth, not admission progress — the screening window fills only from main-branch runs in the baseline store (bench/baselines/README.md)</div>
+  <div class="sub">Recorded task appearances per case (all collected runs, infra included), against the {SCREENING_WINDOW}-run yardstick · history depth, not admission progress — the screening window fills only from main-branch runs in the baseline store (bench/baselines/README.md) · annotations from case-notes.yaml</div>
   <div class="card"><table id="evidence">
-    <thead><tr><th>Case</th><th>Evidence collected</th><th>Pass rate</th><th>In presubmit</th></tr></thead>
+    <thead><tr><th>Case</th><th>Evidence collected</th><th>In presubmit</th></tr></thead>
     <tbody>{rows}</tbody>
   </table></div>"""
 
@@ -578,13 +950,11 @@ HERO_LEDE = (
 )
 
 
-def hero_html(data: dict) -> str:
-    return f"""
+HERO_HTML = f"""
   <section style="margin-top:30px">
     <span class="eyebrow">Agent evaluation · presubmit</span>
     <h1>Is the agent getting better or worse?</h1>
     <div class="lede">{HERO_LEDE}</div>
-    <div class="tiles" id="tiles">{tiles_html(data)}</div>
   </section>"""
 
 
@@ -592,11 +962,15 @@ def foot_html(data: dict) -> str:
     generated = parse_iso(data.get("generated_at"))
     generated_text = f"{generated:%Y-%m-%d %H:%M} UTC" if generated else "unknown time"
     runs = len(data.get("runs") or [])
+    threshold = fmt(RUN_EVENT_FAIL_FRACTION * 100)
     return (
         f'<div class="foot" id="foot">Every number on this page is computed from '
-        f"<code>data.json</code> (source: {esc(str(data.get('source', '?')))}, "
+        f"<code>data.json</code> (source: {esc(str(data.get('source') or '?'))}, "
         f"generated {generated_text}, {runs} run{'s' if runs != 1 else ''} on record). "
-        f"Row annotations come from <code>case-notes.yaml</code> and are advisory only.</div>"
+        f"Run-level event rule: a run where ≥{threshold}% of its graded tasks failed is "
+        f"charged to the run, not the cases. Event markers and catch counts come from "
+        f"<code>events.yaml</code>; row annotations and badges from "
+        f"<code>case-notes.yaml</code>. All three are advisory only.</div>"
     )
 
 
@@ -606,19 +980,19 @@ EMPTY_STATE_HTML = """
     <h1>Is the agent getting better or worse?</h1>
     <div class="empty" style="margin-top:24px">
       <span class="banner">⏳ No evaluation data yet</span>
-      <p style="margin-top:12px">No runs are on record in <code>data.json</code>. Once the collector publishes its first run, the header tiles, the per-case suite table, the trend charts and the nightly evidence all render from that file automatically — nothing else feeds this page.</p>
+      <p style="margin-top:12px">No runs are on record in <code>data.json</code>. Once the collector publishes its first run, the band tiles, the day trend, the case × run matrix, the failure signatures and the evidence table all render from that file automatically — nothing else feeds this page.</p>
     </div>
   </section>"""
 
 
-def app_html(data: dict, notes: dict) -> str:
+def app_html(data: dict, notes: dict, events: dict) -> str:
     if not (data.get("runs") or data.get("cases")):
         return EMPTY_STATE_HTML
     return (
-        hero_html(data)
-        + suite_html(data, notes)
-        + trends_html(data)
-        + evidence_html(data)
+        HERO_HTML
+        + band_agent_html(data, events)
+        + band_gate_html(data, notes, events)
+        + evidence_html(data, notes)
         + RELEASES_HTML
         + foot_html(data)
     )
@@ -647,16 +1021,17 @@ def bootstrap_json(value) -> str:
     return json.dumps(value, separators=(",", ":")).replace("<", "\\u003c")
 
 
-def render_page(data: dict, notes: dict) -> str:
+def render_page(data: dict, notes: dict, events: dict) -> str:
     page = TEMPLATE.read_text()
     values = {
         "__META__": meta_html(data),
         "__FRESHNESS__": freshness_html(data),
-        "__APP__": app_html(data, notes),
+        "__APP__": app_html(data, notes, events),
         # The live read side: the template's script re-renders from this
         # baked copy on load, then polls data.json every 60s.
         "__DATA_JSON__": bootstrap_json(data),
         "__NOTES_JSON__": bootstrap_json(notes),
+        "__EVENTS_JSON__": bootstrap_json(events),
     }
     for token in values:
         if token not in page:
@@ -684,14 +1059,20 @@ def main(argv: list[str] | None = None) -> int:
         default=str(DEFAULT_NOTES),
         help="case-notes.yaml (optional annotations; absent file is fine)",
     )
+    parser.add_argument(
+        "--events",
+        default=str(DEFAULT_EVENTS),
+        help="events.yaml (optional markers and catch counts; absent file is fine)",
+    )
     args = parser.parse_args(argv)
 
     data = load_data(pathlib.Path(args.data))
     notes = load_notes(pathlib.Path(args.notes))
+    events = load_events(pathlib.Path(args.events))
 
     out_dir = pathlib.Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "index.html").write_text(render_page(data, notes))
+    (out_dir / "index.html").write_text(render_page(data, notes, events))
     shutil.copyfile(args.data, out_dir / "data.json")
     print(f"wrote {out_dir / 'index.html'}")
     return 0

--- a/scripts/eval_dashboard/template/index.html.tmpl
+++ b/scripts/eval_dashboard/template/index.html.tmpl
@@ -43,14 +43,14 @@
   body.viz-root { background:var(--surface-0); color:var(--text-primary);
     font:14.5px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
     -webkit-font-smoothing:antialiased; }
-  .wrap { max-width:1060px; margin:0 auto; padding:0 28px 80px; }
+  .wrap { max-width:1120px; margin:0 auto; padding:0 28px 80px; }
   a { color:var(--accent-link,var(--accent)); text-decoration:none; font-weight:600; }
   b, strong { font-weight:650; }
-  code, .num, .tile .v, .score .val, .cap { font-family:'DM Mono',ui-monospace,SFMono-Regular,Menlo,monospace; }
+  code, .num, .tile .v, .cap, .pa-count { font-family:'DM Mono',ui-monospace,SFMono-Regular,Menlo,monospace; }
   code { font:600 12px ui-monospace,SFMono-Regular,Menlo,monospace; color:var(--text-secondary); }
 
   .top { position:sticky; top:0; z-index:5; background:var(--surface-1); border-bottom:1px solid var(--line); }
-  .top-in { max-width:1060px; margin:0 auto; padding:13px 28px; display:flex; align-items:center; gap:16px; }
+  .top-in { max-width:1120px; margin:0 auto; padding:13px 28px; display:flex; align-items:center; gap:16px; }
   .brand { font-size:15px; font-weight:750; letter-spacing:-.01em; display:flex; align-items:center; gap:9px; }
   .brand .logo { width:22px; height:22px; border-radius:6px; background:var(--accent-deep,var(--accent)); display:inline-flex;
     align-items:center; justify-content:center; color:#fff; font-size:12px; font-weight:800; }
@@ -70,13 +70,23 @@
   h2 { font-size:15px; font-weight:750; letter-spacing:-.01em; margin:40px 0 4px; }
   .sub { font-size:12.5px; color:var(--text-muted); margin-bottom:12px; }
 
+  /* bands */
+  .band { margin-top:38px; }
+  .band-h { display:flex; align-items:baseline; gap:12px; flex-wrap:wrap; }
+  .band-h h2 { margin:0; font-size:12px; font-weight:800; letter-spacing:.14em; text-transform:uppercase;
+    color:var(--accent-link,var(--accent)); }
+  .band-h .cohort { font-size:12px; color:var(--text-muted); }
+  .band .sub { margin-top:3px; }
+  .band .card { margin-top:14px; }
+
   /* metric tiles */
-  .tiles { display:grid; grid-template-columns:repeat(4,1fr); gap:14px; margin-top:24px; }
+  .tiles { display:grid; grid-template-columns:repeat(4,1fr); gap:14px; margin-top:12px; }
+  .tiles-3 { grid-template-columns:repeat(3,1fr); }
   .tile { background:var(--surface-1); border:1px solid var(--line); border-radius:12px;
     padding:16px 18px 14px; box-shadow:var(--shadow); }
   .tile .k { font-size:11.5px; font-weight:700; letter-spacing:.05em; text-transform:uppercase; color:var(--text-muted); }
   .tile .v { font-size:28px; font-weight:800; letter-spacing:-.02em; margin-top:6px; font-variant-numeric:tabular-nums;
-    display:flex; align-items:baseline; gap:10px; }
+    display:flex; align-items:baseline; gap:10px; flex-wrap:wrap; }
   .tile .v small { font-size:13px; color:var(--text-muted); font-weight:600; }
   .delta { font-size:12px; font-weight:750; border-radius:999px; padding:2px 9px; }
   .delta.up { background:var(--good-bg); color:var(--good-text); }
@@ -85,6 +95,9 @@
 
   .card { background:var(--surface-1); border:1px solid var(--line); border-radius:12px; box-shadow:var(--shadow); }
   .pad { padding:18px 20px; }
+  .card .t { font-size:14px; font-weight:750; }
+  .card .s { font-size:12px; color:var(--text-muted); margin-top:1px; }
+  .chartcard svg { display:block; width:100%; height:196px; margin-top:10px; }
 
   /* pills */
   .pill { display:inline-flex; align-items:center; gap:6px; border-radius:6px; padding:3px 9px;
@@ -92,10 +105,9 @@
   .p-pass { background:var(--good-bg); color:var(--good-text); }
   .p-fail { background:var(--crit-bg); color:var(--crit-text); }
   .p-infra { background:var(--ser-bg); color:var(--ser-text); }
-  .p-pend { background:var(--skip-bg); color:var(--text-secondary); }
   .p-fix { background:var(--accent-soft); color:var(--accent-link,var(--accent)); }
 
-  /* case table */
+  /* evidence table */
   table { border-collapse:collapse; width:100%; }
   th { text-align:left; font-size:11px; color:var(--text-muted); text-transform:uppercase;
     letter-spacing:.06em; font-weight:750; padding:10px 16px; border-bottom:1px solid var(--line); }
@@ -105,31 +117,43 @@
   td.num { font-variant-numeric:tabular-nums; font-weight:600; color:var(--text-secondary); text-align:right; }
   .tname { font-weight:700; }
   .tnote { font-size:12px; color:var(--text-muted); margin-top:1px; }
-  .tdom { font-size:11px; font-weight:700; color:var(--text-secondary); background:var(--surface-2);
-    border:1px solid var(--line); border-radius:999px; padding:2px 9px; white-space:nowrap; }
-  .hist { display:inline-flex; gap:3px; vertical-align:middle; }
-  .hist i { width:9px; height:9px; border-radius:50%; }
-  .h-pass{background:var(--good);} .h-fail{background:var(--crit);}
-  .h-infra{background:var(--ser);} .h-na{background:var(--skip-bg); border:1.5px solid var(--line-2);}
-
-  /* score bar */
-  .score { display:flex; align-items:center; gap:9px; min-width:150px; }
-  .score .bar { position:relative; flex:1; height:6px; border-radius:6px; background:var(--surface-2); overflow:visible; }
-  .score .fill { position:absolute; inset:0; right:auto; border-radius:6px; background:var(--accent); }
-  .score .thr { position:absolute; top:-3px; width:2px; height:12px; background:var(--line-2); border-radius:2px; }
-  .score .val { font-size:12.5px; font-weight:750; font-variant-numeric:tabular-nums; width:30px; text-align:right; }
-
-  .legend { font-size:12px; font-weight:550; color:var(--text-secondary); margin-top:10px; display:flex; gap:18px; }
-  .legend span { display:inline-flex; gap:6px; align-items:center; }
-  .legend i { width:9px; height:9px; border-radius:50%; }
-
-  .split { display:grid; grid-template-columns:1.1fr .9fr; gap:14px; }
-  .chartcard .t { font-size:14px; font-weight:750; }
-  .chartcard .s { font-size:12px; color:var(--text-muted); margin-top:1px; }
-  .chartcard svg { display:block; width:100%; height:170px; margin-top:10px; }
   .prog { position:relative; width:100px; height:6px; border-radius:6px; background:var(--surface-2); overflow:hidden; }
   .prog i { position:absolute; inset:0; right:auto; border-radius:6px; background:var(--accent); }
   .cap { font-size:11.5px; color:var(--text-muted); font-weight:550; }
+
+  /* case x run matrix */
+  .mx { overflow-x:auto; margin-top:12px; padding-bottom:2px; }
+  .mx-row { display:flex; align-items:center; gap:3px; margin-bottom:3px; width:max-content; }
+  .mx-name { width:300px; min-width:300px; font-size:12px; white-space:nowrap; overflow:hidden;
+    text-overflow:ellipsis; display:flex; align-items:center; gap:6px; }
+  .mx-name em { font-style:normal; font-size:9.5px; font-weight:700; padding:1px 7px; border-radius:999px; }
+  .b-hold { background:var(--accent-soft); color:var(--accent-link,var(--accent)); }
+  .b-new { background:var(--skip-bg); color:var(--text-muted); }
+  .cell { width:22px; min-width:22px; height:16px; border-radius:3px; }
+  .c-g { background:var(--good); opacity:.85; }
+  .c-a { background:linear-gradient(180deg, var(--warn) 55%, var(--warn-bg) 55%); }
+  .c-r { background:var(--crit);
+    background-image:repeating-linear-gradient(45deg, transparent 0 3px, rgba(0,0,0,.45) 3px 5px); }
+  .c-i { background:transparent; border:1.5px solid var(--text-muted); }
+  .c-n { background:var(--skip-bg); }
+  .mx-head .mx-col { width:22px; min-width:22px; height:13px; text-align:center; font-size:9px;
+    color:var(--accent-link,var(--accent)); }
+  .mx-ev { margin-top:8px; display:flex; gap:16px; flex-wrap:wrap; font-size:11px;
+    color:var(--accent-link,var(--accent)); }
+  .legend { font-size:12px; font-weight:550; color:var(--text-secondary); margin-top:12px; display:flex; gap:18px; flex-wrap:wrap; }
+  .legend span { display:inline-flex; gap:6px; align-items:center; }
+  .mx-legend .cell { display:inline-block; }
+
+  /* failure-signature pareto */
+  .pa-row { display:grid; grid-template-columns:minmax(140px,220px) 34px 1fr; gap:10px; align-items:center; margin-top:10px; }
+  .pa-bar-wrap { background:var(--surface-2); border-radius:4px; height:14px; }
+  .pa-bar { height:14px; border-radius:4px; }
+  .pa-infra { background:var(--text-muted); }
+  .pa-check { background:var(--accent); }
+  .pa-agent { background:var(--warn); }
+  .pa-unknown { background:var(--line-2); }
+  .pa-count { font-size:13px; font-weight:600; text-align:right; font-variant-numeric:tabular-nums; }
+  .pa-name { font-size:12.5px; }
 
   .empty { border:1.5px dashed var(--line-2); border-radius:12px; padding:24px 26px; background:var(--surface-1); }
   .empty b { font-size:14px; }
@@ -140,7 +164,7 @@
   #tip { position:fixed; top:0; left:0; pointer-events:none; background:var(--text-primary);
     color:var(--surface-1); font-size:12px; font-weight:600; padding:4px 9px; border-radius:7px;
     opacity:0; transition:opacity .08s; z-index:9; white-space:nowrap; }
-  .foot { margin-top:44px; font-size:12.5px; color:var(--text-muted); max-width:84ch; }
+  .foot { margin-top:44px; font-size:12.5px; color:var(--text-muted); max-width:90ch; }
 </style>
 </head>
 <body class="viz-root" data-palette="#8b5cf6">
@@ -149,7 +173,7 @@
 <div class="top"><div class="top-in">
   <span class="brand"><span class="logo">ka</span>evals</span>
   <nav class="nav">
-    <a class="on" href="#suite">Test suite</a><a href="#trends">Trends</a>
+    <a class="on" href="#agent">The agent</a><a href="#gate">The gate</a>
     <a href="#nightly">Evidence</a><a href="#release">Releases</a>
   </nav>
   <span class="meta"><span id="headmeta">__META__</span> · <span id="freshness" class="fresh">__FRESHNESS__</span></span>
@@ -188,12 +212,34 @@ document.addEventListener("mousemove",e=>{
 const DASH = {
   bootstrap: __DATA_JSON__,
   notes: __NOTES_JSON__,
+  events: __EVENTS_JSON__,
   refreshMs: 60000,
   freshnessTickMs: 30000,
   staleDefaultS: 7200,
-  judgeThreshold: 0.8,
   screeningWindow: 20,
-  maxTrendPoints: 10,
+  repResults: ["pass", "fail", "infra"],
+  matrixRuns: 30,
+  trendDays: 30,
+  paretoWindowDays: 7,
+  paretoMaxRows: 8,
+  runEventFailFraction: 0.8,
+  weekMs: 7 * 24 * 3600 * 1000,
+  dayMs: 24 * 3600 * 1000,
+  reasonSnippetChars: 60,
+  runResultGreen: "SUCCESS",
+  // Failure-signature maps; mirrors render.py's SIG_* / *_REASON_KEYWORDS.
+  sig429: "http 429",
+  sigNotRealRun: ["not evidence of a real agent run", "not_a_real_run"],
+  sigPhrasesAbsent: "required phrases absent",
+  checkNameRe: /check[ :]+['"]?([A-Za-z0-9_.\/-]+)/i,
+  infraReasonKeywords: ["http 429", "rate limit", "timed out", "timeout", "connection"],
+  checkReasonKeywords: ["required phrases absent"],
+  agentReasonKeywords: ["false finding"],
+  labelNoReason: "(no reason recorded)",
+  labelNoReasonInfra: "(infra, no reason recorded)",
+  trendEventLabelChars: 18,
+  trendEventRowOffset: 10,
+  runEventCaption: "run-level events excluded from per-case stats",
   issueUrl: "https://github.com/gke-labs/kube-agents/issues",
 };
 
@@ -203,14 +249,6 @@ let unreachable = false;
 const esc = (value) => String(value)
   .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
   .replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
-
-const RESULT_PILLS = {
-  pass: '<span class="pill p-pass">PASSED</span>',
-  fail: '<span class="pill p-fail">FAILED</span>',
-  infra: '<span class="pill p-infra">INFRA</span>',
-  pend: '<span class="pill p-pend">IN BUILD</span>',
-};
-const HIST_CLASSES = { pass: "h-pass", fail: "h-fail", infra: "h-infra", na: "h-na" };
 
 /* ---- data.json access (tolerant, mirrors render.py) ---- */
 
@@ -223,40 +261,24 @@ function sortedRuns(data) {
 }
 const runTasks = (run) => (run ? (run.tasks || []).filter((t) => t && typeof t === "object") : []);
 // Runs that measured anything: at least one task row. An aborted build
-// parses to zero tasks; anchoring the tiles or the suite table to one
-// would render vacuous 0/0 states. Trends and the header sha stay on
-// sortedRuns. Mirrors render.py's measured_runs.
+// parses to zero tasks; giving one a matrix column or a trend point would
+// chart a run that measured nothing. Mirrors render.py's measured_runs.
 const measuredRuns = (data) => sortedRuns(data).filter((r) => runTasks(r).length);
-
-function countedResults(run) {
-  let passed = 0, failed = 0, infra = 0;
-  for (const task of runTasks(run)) {
-    const result = String(task.result || "").toLowerCase();
-    if (result === "pass") passed += 1;
-    else if (result === "fail") failed += 1;
-    else if (result === "infra") infra += 1;
-  }
-  return [passed, failed, infra];
-}
-function passFraction(run) {
-  const [passed, failed] = countedResults(run);
-  return passed + failed ? passed / (passed + failed) : null;
-}
-function medianTaskMinutes(run) {
-  const durations = runTasks(run).map((t) => t.duration_s)
-    .filter((d) => typeof d === "number").sort((a, b) => a - b);
-  if (!durations.length) return null;
-  const mid = Math.floor(durations.length / 2);
-  const median = durations.length % 2 ? durations[mid] : (durations[mid - 1] + durations[mid]) / 2;
-  return median / 60;
-}
-const latestTaskFor = (name, run) => runTasks(run).find((t) => t.name === name) || null;
 
 function parseIso(value) {
   if (typeof value !== "string") return null;
-  const ms = Date.parse(value);
+  // render.py's parse_iso assumes UTC for a timezone-naive stamp; bare
+  // Date.parse would read one as *local* time and break baked-vs-live
+  // parity for any viewer outside UTC.
+  let text = value;
+  if (text.includes("T") && !/(?:[zZ]|[+-]\d\d:?\d\d)$/.test(text)) text += "Z";
+  const ms = Date.parse(text);
   return Number.isNaN(ms) ? null : ms;
 }
+const utcDay = (value) => {
+  const ms = parseIso(value);
+  return ms == null ? null : new Date(ms).toISOString().slice(0, 10);
+};
 const utcStamp = (ms) => new Date(ms).toISOString().slice(0, 16).replace("T", " ");
 
 function runLabel(run, index) {
@@ -264,8 +286,120 @@ function runLabel(run, index) {
   const buildId = String(run.build_id || "");
   return buildId ? buildId.slice(0, 6) : `run ${index + 1}`;
 }
+// Whole-number guard, mirroring render.py's is_count (bools are data errors).
+const isCount = (value) => typeof value === "number" && Number.isInteger(value);
 
-/* ---- HTML fragments (mirrors render.py) ---- */
+/* ---- reps, cell states, run-level events (mirrors render.py) ---- */
+
+function taskReps(task) {
+  const reps = [];
+  if (Array.isArray(task.reps)) {
+    for (const rep of task.reps) {
+      if (!rep || typeof rep !== "object") continue;
+      const result = String(rep.result || "").toLowerCase();
+      if (DASH.repResults.includes(result)) {
+        reps.push({ result, reason: typeof rep.reason === "string" ? rep.reason : null });
+      }
+    }
+  }
+  if (reps.length) return reps;
+  const result = String(task.result || "").toLowerCase();
+  if (DASH.repResults.includes(result)) return [{ result, reason: null }];
+  return [];
+}
+
+function repCounts(reps) {
+  let passed = 0, failed = 0, infra = 0;
+  for (const rep of reps) {
+    if (rep.result === "pass") passed += 1;
+    else if (rep.result === "fail") failed += 1;
+    else infra += 1;
+  }
+  return [passed, failed, infra];
+}
+
+function cellState(task) {
+  const reps = taskReps(task);
+  if (!reps.length) return "none";
+  const [passed, failed] = repCounts(reps);
+  if (passed && failed) return "partial";
+  if (failed) return "fail";
+  if (passed) return "pass";
+  return "infra";
+}
+
+function isRunEvent(run) {
+  const graded = runTasks(run).map(cellState)
+    .filter((s) => s === "pass" || s === "partial" || s === "fail");
+  if (!graded.length) return false;
+  return graded.filter((s) => s === "fail").length / graded.length >= DASH.runEventFailFraction;
+}
+
+/* ---- cohorts and windows (mirrors render.py) ---- */
+
+function mergedFinalRuns(data) {
+  const runs = measuredRuns(data).filter((r) => r.pr_merged === true);
+  const key = (run) => (run.pr !== undefined && run.pr !== null ? `pr:${run.pr}` : run);
+  const final = new Map();
+  for (const run of runs) final.set(key(run), run); // chronological: last wins
+  return runs.filter((r) => final.get(key(r)) === r);
+}
+
+function referenceMs(data) {
+  // Deliberately not the wall clock, so the baked HTML and this re-render
+  // of the same data.json agree.
+  const anchor = parseIso(data.generated_at);
+  if (anchor != null) return anchor;
+  const runs = sortedRuns(data);
+  for (let i = runs.length - 1; i >= 0; i -= 1) {
+    const ms = parseIso(runs[i].started);
+    if (ms != null) return ms;
+  }
+  return null;
+}
+
+function weekPassStats(data) {
+  const anchor = referenceMs(data);
+  const cur = { pass: 0, fail: 0, runs: 0 };
+  const prev = { pass: 0, fail: 0 };
+  for (const run of mergedFinalRuns(data)) {
+    const started = parseIso(run.started);
+    let bucket = null;
+    if (anchor == null || started == null) bucket = cur;
+    else if (anchor - DASH.weekMs < started && started <= anchor) bucket = cur;
+    else if (anchor - 2 * DASH.weekMs < started && started <= anchor - DASH.weekMs) bucket = prev;
+    if (!bucket) continue;
+    for (const task of runTasks(run)) {
+      const [p, f] = repCounts(taskReps(task));
+      bucket.pass += p;
+      bucket.fail += f;
+    }
+    if (bucket === cur) cur.runs += 1;
+  }
+  const rate = (b) => (b.pass + b.fail ? b.pass / (b.pass + b.fail) : null);
+  return { cur: rate(cur), prev: rate(prev), runsCur: cur.runs };
+}
+
+function dayPoints(data) {
+  const buckets = new Map();
+  for (const run of mergedFinalRuns(data)) {
+    const day = utcDay(run.started);
+    if (day == null) continue;
+    if (!buckets.has(day)) buckets.set(day, [0, 0]);
+    const bucket = buckets.get(day);
+    for (const task of runTasks(run)) {
+      const [p, f] = repCounts(taskReps(task));
+      bucket[0] += p;
+      bucket[1] += f;
+    }
+  }
+  const points = [...buckets.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1))
+    .filter(([, c]) => c[0] + c[1])
+    .map(([day, c]) => [day, c[0] / (c[0] + c[1])]);
+  return points.slice(-DASH.trendDays);
+}
+
+/* ---- notes, badges, events ---- */
 
 function noteHtml(entry) {
   if (!entry) return "";
@@ -280,250 +414,384 @@ function noteHtml(entry) {
   return parts.length ? `<div class="tnote">${parts.join(" · ")}</div>` : "";
 }
 
+function badgeHtml(entry) {
+  const badge = String((entry && entry.badge) || "").trim().toLowerCase();
+  if (badge === "held-out") return '<em class="b-hold">held out</em>';
+  if (badge === "new") return '<em class="b-new">new</em>';
+  return "";
+}
+
+/* ---- failure signatures (mirrors render.py) ---- */
+
+function reasonSignature(reason) {
+  const text = (reason || "").trim();
+  if (!text) return DASH.labelNoReason;
+  const low = text.toLowerCase();
+  if (low.includes(DASH.sig429)) return "endpoint saturation (infra)";
+  if (DASH.sigNotRealRun.some((sig) => low.includes(sig))) return "not a real agent run";
+  if (low.includes(DASH.sigPhrasesAbsent)) {
+    const match = DASH.checkNameRe.exec(text);
+    return match ? `exact-check: ${match[1]}` : "exact-check: required phrases absent";
+  }
+  // Code points, not UTF-16 units, so the snippet matches Python's text[:N].
+  const chars = Array.from(text);
+  return chars.length > DASH.reasonSnippetChars
+    ? chars.slice(0, DASH.reasonSnippetChars).join("") + "…" : text;
+}
+
+function reasonClass(reason) {
+  const low = (reason || "").toLowerCase();
+  if (DASH.infraReasonKeywords.some((kw) => low.includes(kw))) return "infra";
+  if (DASH.checkReasonKeywords.some((kw) => low.includes(kw))) return "check";
+  if (DASH.agentReasonKeywords.some((kw) => low.includes(kw))) return "agent";
+  return "unknown";
+}
+
+function paretoGroups(data) {
+  const anchor = referenceMs(data);
+  const groups = new Map();
+  for (const run of sortedRuns(data)) {
+    const started = parseIso(run.started);
+    if (anchor != null) {
+      if (started == null) continue;
+      if (started <= anchor - DASH.paretoWindowDays * DASH.dayMs || started > anchor) continue;
+    }
+    if (isRunEvent(run)) continue; // charged to the run, not the cases
+    for (const task of runTasks(run)) {
+      for (const rep of taskReps(task)) {
+        if (rep.result === "pass") continue;
+        const reason = (rep.reason || "").trim();
+        let label, cls;
+        if (reason) {
+          label = reasonSignature(reason);
+          cls = reasonClass(reason);
+        } else if (rep.result === "infra") {
+          // No reason, but the result itself says what it was.
+          label = DASH.labelNoReasonInfra;
+          cls = "infra";
+        } else {
+          label = DASH.labelNoReason;
+          cls = "unknown";
+        }
+        if (!groups.has(label)) groups.set(label, { label, count: 0, cls });
+        groups.get(label).count += 1;
+      }
+    }
+  }
+  return [...groups.values()]
+    .sort((a, b) => b.count - a.count || (a.label < b.label ? -1 : 1))
+    .slice(0, DASH.paretoMaxRows);
+}
+
+/* ---- HTML fragments (mirrors render.py) ---- */
+
 const deltaChip = (cls, text) => `<span class="delta ${cls}">${esc(text)}</span>`;
 const tile = (key, valueHtml, chipHtml, detail) =>
   `<div class="tile"><div class="k">${esc(key)}</div>` +
   `<div class="v">${valueHtml}${chipHtml}</div><div class="d2">${esc(detail)}</div></div>`;
 
-function ratioChip(currentValue, previousValue, unit, havePreviousRun) {
-  // "first run" only when there is genuinely no prior run -- a prior run
-  // that just failed to report this metric gets no chip at all.
-  if (currentValue == null || previousValue == null || !previousValue || !currentValue) {
-    return previousValue == null && !havePreviousRun ? deltaChip("flat", "first run") : "";
-  }
-  if (previousValue / currentValue >= 1.5) {
-    return deltaChip("up", `▲ ${(previousValue / currentValue).toFixed(1)}× cheaper`);
-  }
-  if (currentValue / previousValue >= 1.5) {
-    return deltaChip("flat", `▼ ${(currentValue / previousValue).toFixed(1)}× slower`);
-  }
-  return deltaChip("flat", `≈ prev ${previousValue.toFixed(0)}${unit}`);
-}
-
-function tilesHtml(data) {
-  const runs = measuredRuns(data);
-  const latest = runs[runs.length - 1] || null;
-  const previous = runs.length > 1 ? runs[runs.length - 2] : null;
+function agentTilesHtml(data, events) {
   const tiles = [];
 
-  if (latest) {
-    const [passed, failed, infra] = countedResults(latest);
-    // "all passed" must never be claimed by a run that measured nothing.
-    const chip = failed ? deltaChip("flat", `${failed} failed`)
-      : infra ? deltaChip("flat", `${infra} infra`)
-      : passed ? deltaChip("up", "all passed") : "";
-    const buildId = String(latest.build_id || "?");
-    tiles.push(tile("Latest run", `${passed}<small>/ ${passed + failed} passed</small>`, chip,
-      `build ${buildId.slice(0, 8)}… · ${latest.project || "?"}`));
+  const stats = weekPassStats(data);
+  if (stats.cur != null) {
+    const pct = Math.round(stats.cur * 100);
+    let chip = "";
+    if (stats.prev != null) {
+      const diff = pct - Math.round(stats.prev * 100);
+      chip = diff > 0 ? deltaChip("up", `▲ +${diff}pt vs prior week`)
+        : diff < 0 ? deltaChip("flat", `▼ ${diff}pt vs prior week`)
+        : deltaChip("flat", "= prior week");
+    }
+    tiles.push(tile("Pass rate · this week", `${pct}<small>%</small>`, chip,
+      `merged-PR cohort · ${stats.runsCur} run${stats.runsCur !== 1 ? "s" : ""} this week`));
   } else {
-    tiles.push(tile("Latest run", "—", "",
-      sortedRuns(data).length ? "no measured runs yet" : "no runs on record"));
+    tiles.push(tile("Pass rate · this week", "—", "",
+      mergedFinalRuns(data).length ? "no merged-PR runs this week" : "no merged-PR runs on record"));
   }
 
-  const coverage = data.coverage || {};
-  // Whole numbers only, mirroring render.py's is_count: value_html is raw
-  // (it carries <small>), so anything else must not be interpolated.
-  if (Number.isInteger(coverage.domains_covered) && Number.isInteger(coverage.domains_total)) {
-    const uncovered = (coverage.uncovered || []).map(String);
+  const catches = events.catches || {};
+  if (isCount(catches.product_bugs)) {
+    let value = `${catches.product_bugs}`;
+    if (isCount(catches.prs_blocked)) value += `<small> + ${catches.prs_blocked} PRs blocked</small>`;
+    tiles.push(tile("Product bugs caught", value, "",
+      catches.ledger ? `catch ledger ${catches.ledger}` : "events.yaml annotation"));
+  } else {
+    tiles.push(tile("Product bugs caught", "—", "", "not annotated (events.yaml)"));
+  }
+
+  const coverage = data.coverage && typeof data.coverage === "object"
+    && !Array.isArray(data.coverage) ? data.coverage : {};
+  if (isCount(coverage.domains_covered) && isCount(coverage.domains_total)) {
+    const uncovered = Array.isArray(coverage.uncovered) ? coverage.uncovered.map(String) : [];
     const chip = coverage.domains_covered >= coverage.domains_total
       ? deltaChip("up", "all covered")
       : deltaChip("flat", `${coverage.domains_total - coverage.domains_covered} open`);
-    tiles.push(tile("Domain coverage",
-      `${coverage.domains_covered}<small>/ ${coverage.domains_total}</small>`, chip,
-      uncovered.length ? `uncovered: ${uncovered.join(", ")}` : "all domains covered"));
+    const cases = (data.cases || []).filter((c) => c && typeof c === "object");
+    const blocking = cases.filter((c) => c.active).length;
+    const detail = uncovered.length
+      ? `uncovered: ${uncovered.join(", ")}`
+      : `${cases.length} scenarios · ${blocking} blocking`;
+    tiles.push(tile("Domains covered",
+      `${coverage.domains_covered}<small>/ ${coverage.domains_total}</small>`, chip, detail));
   } else {
-    tiles.push(tile("Domain coverage", "—", "", "not reported"));
-  }
-
-  const med = medianTaskMinutes(latest);
-  if (med != null) {
-    tiles.push(tile("Median case cost", `${med.toFixed(1)}<small>min</small>`,
-      ratioChip(med, medianTaskMinutes(previous), "min", previous != null),
-      `median across ${runTasks(latest).length} cases · latest run`));
-  } else {
-    tiles.push(tile("Median case cost", "—", "", "no task durations yet"));
-  }
-
-  const duration = latest ? latest.duration_s : null;
-  if (typeof duration === "number") {
-    const prevDuration = previous && typeof previous.duration_s === "number"
-      ? previous.duration_s / 60 : null;
-    const finished = latest ? parseIso(latest.finished) : null;
-    tiles.push(tile("Wall clock", `${(duration / 60).toFixed(0)}<small>min</small>`,
-      ratioChip(duration / 60, prevDuration, "min", previous != null),
-      finished != null ? `finished ${utcStamp(finished)} UTC` : "whole-run wall clock"));
-  } else {
-    tiles.push(tile("Wall clock", "—", "", "not reported"));
+    tiles.push(tile("Domains covered", "—", "", "not reported"));
   }
 
   return tiles.join("");
 }
 
-function scoreHtml(judge) {
-  if (typeof judge !== "number") return '<span class="cap">—</span>';
-  const value = Math.min(Math.max(judge, 0), 1);
-  return `<div class="score"><div class="bar">` +
-    `<div class="fill" style="width:${(value * 100).toFixed(0)}%"></div>` +
-    `<div class="thr" style="left:${(DASH.judgeThreshold * 100).toFixed(0)}%"></div></div>` +
-    `<span class="val">${value.toFixed(1)}</span></div>`;
-}
+function gateTilesHtml(data, events) {
+  const tiles = [];
 
-function caseRow(kase, latestRun) {
-  const name = String(kase.name || "?");
-  const task = latestTaskFor(name, latestRun);
-
-  let status;
-  if (task) {
-    status = String(task.result || "").toLowerCase();
-    if (!["pass", "fail", "infra"].includes(status)) status = "pend";
+  if (isCount(events.false_reds_7d)) {
+    tiles.push(tile("False reds · 7d", `${events.false_reds_7d}`, "", "human-classified · events.yaml"));
   } else {
-    const measured = (kase.last3 || [])
-      .map((h) => String(h).toLowerCase())
-      .filter((h) => ["pass", "fail", "infra"].includes(h));
-    status = measured.length ? measured[measured.length - 1] : "pend";
+    tiles.push(tile("False reds · 7d", "—", "", "not annotated (events.yaml)"));
   }
 
-  let last3 = (kase.last3 || []).map((h) => String(h).toLowerCase()).slice(-3);
-  last3 = Array(3 - last3.length).fill("na")
-    .concat(last3.map((h) => (h in HIST_CLASSES ? h : "na")));
-  const hist = last3.map((h) => `<i class="${HIST_CLASSES[h]}" title="${h}"></i>`).join("");
-
-  let judge = task ? task.outcome_validity : null;
-  if (judge == null) {
-    const history = (kase.ov_history || []).filter((h) => typeof h.value === "number");
-    judge = history.length ? history[history.length - 1].value : null;
+  const window = measuredRuns(data).slice(-DASH.matrixRuns);
+  let total = 0, infra = 0, repsReported = false;
+  for (const run of window) {
+    for (const task of runTasks(run)) {
+      if (Array.isArray(task.reps) && task.reps.some((r) => r && typeof r === "object"
+          && DASH.repResults.includes(String(r.result || "").toLowerCase()))) {
+        repsReported = true;
+      }
+      for (const rep of taskReps(task)) {
+        total += 1;
+        if (rep.result === "infra") infra += 1;
+      }
+    }
+  }
+  if (total) {
+    tiles.push(tile("Infra-rep rate", `${(100 * infra / total).toFixed(1)}<small>%</small>`, "",
+      repsReported ? `${infra} of ${total} reps · last ${window.length} runs`
+        : `task-level fallback · last ${window.length} runs`));
+  } else {
+    tiles.push(tile("Infra-rep rate", "—", "", "no measured runs yet"));
   }
 
-  let duration = task ? task.duration_s : null;
-  if (typeof duration !== "number") duration = (kase.durations || {}).med;
-  const durationText = typeof duration === "number" ? `${duration.toFixed(0)}s` : "—";
+  const runs = sortedRuns(data);
+  let green = null, greenIndex = -1;
+  for (let i = runs.length - 1; i >= 0; i -= 1) {
+    if (String(runs[i].result || "") === DASH.runResultGreen && runTasks(runs[i]).length
+        && typeof runs[i].duration_s === "number") {
+      green = runs[i];
+      greenIndex = i;
+      break;
+    }
+  }
+  if (green) {
+    tiles.push(tile("Wall clock · green run", `${(green.duration_s / 60).toFixed(0)}<small>min</small>`,
+      "", `latest green full run · ${runLabel(green, greenIndex)}`));
+  } else {
+    tiles.push(tile("Wall clock · green run", "—", "", "no green full run on record"));
+  }
 
-  const domainHtml = kase.domain ? `<span class="tdom">${esc(kase.domain)}</span>` : "";
+  // Queue wait: data.json carries no queued-at timestamp, so this cannot
+  // be computed. An honest em-dash beats an invented number.
+  tiles.push(tile("Queue wait · median", "—", "", "not reported in data.json"));
 
-  return `<tr><td>${RESULT_PILLS[status]}</td>` +
-    `<td><div class="tname">${esc(name)}</div>${noteHtml(DASH.notes[name])}</td>` +
-    `<td>${domainHtml}</td><td><span class="hist">${hist}</span></td>` +
-    `<td>${scoreHtml(judge)}</td><td class="num">${durationText}</td></tr>`;
+  return tiles.join("");
 }
 
-function suiteHtml(data) {
-  const runs = measuredRuns(data);
-  const latest = runs[runs.length - 1] || null;
-  const rows = (data.cases || []).map((c) => caseRow(c, latest)).join("")
-    || '<tr><td colspan="6"><span class="cap">no cases on record yet</span></td></tr>';
-  return `
-  <h2 id="suite">Test suite</h2>
-  <div class="sub">Latest measured result per case · <b>Result</b> is the gating exact-check verdict · <b>Judge</b> is advisory (threshold tick at ${DASH.judgeThreshold}) · history dots = last 3 runs</div>
-  <div class="card"><table id="cases">
-    <thead><tr><th>Result</th><th>Test case</th><th>Domain</th><th>History</th><th>Judge (advisory)</th><th style="text-align:right">Duration</th></tr></thead>
-    <tbody>${rows}</tbody>
-  </table></div>
-  <div class="legend">
-    <span><i class="h-pass"></i>pass</span><span><i class="h-fail"></i>fail</span>
-    <span><i class="h-infra"></i>INFRA — excluded from verdict</span><span><i class="h-na"></i>not in run</span>
-  </div>`;
-}
+const CELL_CLASSES = { pass: "c-g", partial: "c-a", fail: "c-r", infra: "c-i", none: "c-n" };
+const CELL_TITLES = {
+  pass: "passed all reps",
+  partial: "partial (some reps passed)",
+  fail: "failed all reps",
+  infra: "infra — excluded",
+  none: "not in run",
+};
 
-function chartSvg(points, threshold) {
-  if (points.length < 2) return "";
-  const width = 480, height = 170, px = 14, py = 16, ymax = 1;
-  const xs = (i) => px + (i * (width - 2 * px)) / (points.length - 1);
-  const ys = (v) => height - py - (v / ymax) * (height - 2 * py);
-  const poly = points.map(([, v], i) => `${xs(i).toFixed(1)},${ys(v).toFixed(1)}`).join(" ");
-  const dots = points.map(([label, v], i) =>
-    `<circle cx="${xs(i).toFixed(1)}" cy="${ys(v).toFixed(1)}" r="5" fill="var(--accent)" ` +
-    `stroke="var(--surface-1)" stroke-width="2" data-l="${esc(label)} · ${v.toFixed(2)}"/>`).join("");
-  const xlab = points.map(([label], i) =>
-    `<text x="${xs(i).toFixed(1)}" y="${height - 2}" text-anchor="middle" font-size="10.5" ` +
-    `font-weight="600" fill="var(--text-muted)">${esc(label)}</text>`).join("");
-  const thrLine = threshold != null
-    ? `<line x1="${px}" y1="${ys(threshold).toFixed(1)}" x2="${width - px}" y2="${ys(threshold).toFixed(1)}" ` +
-      `stroke="var(--line-2)" stroke-dasharray="3 4"/>`
-    : "";
-  return `<svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">` +
-    `${thrLine}<line x1="${px}" y1="${ys(0).toFixed(1)}" x2="${width - px}" y2="${ys(0).toFixed(1)}" stroke="var(--line)"/>` +
-    `<polyline points="${poly}" fill="none" stroke="var(--accent)" stroke-width="2.5" ` +
-    `stroke-linejoin="round" stroke-linecap="round"/>${dots}${xlab}</svg>`;
-}
+function matrixHtml(data, notes, events) {
+  const runs = measuredRuns(data).slice(-DASH.matrixRuns);
+  const cases = (data.cases || []).filter((c) => c && typeof c === "object" && c.active !== false);
+  if (!runs.length) {
+    return '<div class="cap" style="margin-top:12px">no measured runs yet</div>';
+  }
+  if (!cases.length) {
+    return '<div class="cap" style="margin-top:12px">no active cases on record yet</div>';
+  }
 
-function ratePoints(data) {
-  const points = [];
-  sortedRuns(data).forEach((run, index) => {
-    const fraction = passFraction(run);
-    if (fraction != null) points.push([runLabel(run, index), fraction]);
+  const eventDays = {};
+  for (const e of events.events || []) eventDays[e.date] = e.label;
+  const runDays = runs.map((r) => utcDay(r.started));
+  const runEvents = runs.map(isRunEvent);
+  const taskMaps = runs.map((r) => {
+    const map = new Map();
+    for (const t of runTasks(r)) map.set(String(t.name), t);
+    return map;
   });
-  return points.slice(-DASH.maxTrendPoints);
-}
 
-function judgeTrendCase(data) {
-  const candidates = (data.cases || []).filter((c) => (c.ov_history || []).length >= 2);
-  if (!candidates.length) return null;
-  return candidates.reduce((best, c) =>
-    (c.ov_history.length > best.ov_history.length ? c : best));
-}
+  const head = ['<div class="mx-row mx-head"><div class="mx-name"></div>'];
+  runs.forEach((run, index) => {
+    const day = runDays[index];
+    const marker = day in eventDays ? "▲" : "";
+    let title = `${runLabel(run, index)} · ${day || "?"}`;
+    if (day in eventDays) title += ` · ${eventDays[day]}`;
+    if (runEvents[index]) title += " · run-level event";
+    head.push(`<div class="mx-col" title="${esc(title)}">${marker}</div>`);
+  });
+  head.push("</div>");
 
-function trendsHtml(data) {
-  // No threshold line here: 0.8 is the judge threshold, and drawing it on
-  // the pass-fraction chart would present it as a pass-rate target.
-  const rate = chartSvg(ratePoints(data))
-    || '<div class="cap" style="margin-top:14px">not enough runs yet</div>';
-
-  const labels = {};
-  sortedRuns(data).forEach((run, index) => { labels[String(run.build_id)] = runLabel(run, index); });
-  const judgeCase = judgeTrendCase(data);
-  let judgeTitle = "judge score", judge = "";
-  if (judgeCase) {
-    const points = judgeCase.ov_history
-      .filter((h) => typeof h.value === "number")
-      .map((h) => [labels[String(h.build_id)] || String(h.build_id || "?").slice(0, 6), h.value])
-      .slice(-DASH.maxTrendPoints);
-    judgeTitle = `${judgeCase.name || "?"} · judge score`;
-    judge = chartSvg(points, DASH.judgeThreshold);
+  const rows = [head.join("")];
+  for (const kase of cases) {
+    const name = String(kase.name || "?");
+    const entry = notes[name];
+    const row = [`<div class="mx-row"><div class="mx-name"><span>${esc(name)}</span>${badgeHtml(entry)}</div>`];
+    runs.forEach((run, index) => {
+      const task = taskMaps[index].get(name);
+      const state = task ? cellState(task) : "none";
+      let title = `${name} · ${runLabel(run, index)} · ${CELL_TITLES[state]}`;
+      if (runEvents[index]) title += " · run-level event (charged to the run)";
+      row.push(`<div class="cell ${CELL_CLASSES[state]}" title="${esc(title)}"></div>`);
+    });
+    row.push("</div>");
+    rows.push(row.join(""));
   }
-  judge = judge || '<div class="cap" style="margin-top:14px">no judge history yet</div>';
 
+  const marks = [...new Set(runDays.filter((d) => d != null && d in eventDays))].sort()
+    .map((day) => `<span>▲ ${esc(day.slice(5))} ${esc(eventDays[day])}</span>`);
+  if (marks.length) rows.push(`<div class="mx-ev">${marks.join("")}</div>`);
+  return `<div class="mx">${rows.join("")}</div>`;
+}
+
+function paretoHtml(data) {
+  const groups = paretoGroups(data);
+  if (!groups.length) {
+    return `<div class="cap" style="margin-top:12px">no failing or infra reps in the last ${DASH.paretoWindowDays} days</div>`;
+  }
+  const top = groups[0].count;
+  return groups.map((g) =>
+    `<div class="pa-row"><div class="pa-bar-wrap">` +
+    `<div class="pa-bar pa-${g.cls}" style="width:${(100 * g.count / top).toFixed(1)}%"></div></div>` +
+    `<div class="pa-count">${g.count}</div>` +
+    `<div class="pa-name">${esc(g.label)}</div></div>`).join("");
+}
+
+function trendSvg(points, events) {
+  if (points.length < 2) return "";
+  const width = 1000, height = 196, px = 34, py = 28;
+  const xs = (i) => px + (i * (width - 2 * px)) / (points.length - 1);
+  const ys = (v) => height - py - v * (height - 2 * py);
+  const parts = [`<svg viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">`];
+  for (const grid of [0.25, 0.5, 0.75, 1.0]) {
+    parts.push(
+      `<line x1="${px}" y1="${ys(grid).toFixed(1)}" x2="${width - px}" y2="${ys(grid).toFixed(1)}" stroke="var(--line)"/>` +
+      `<text x="${px - 6}" y="${(ys(grid) + 3).toFixed(1)}" text-anchor="end" font-size="9" ` +
+      `fill="var(--text-muted)">${Math.round(grid * 100)}</text>`);
+  }
+  const eventDays = {};
+  for (const e of events.events || []) eventDays[e.date] = e.label;
+  let marker = 0;
+  points.forEach(([day], i) => {
+    if (day in eventDays) {
+      let label = eventDays[day];
+      if (label.length > DASH.trendEventLabelChars) {
+        label = label.slice(0, DASH.trendEventLabelChars) + "…";
+      }
+      const textY = py - 6 - (marker % 2) * DASH.trendEventRowOffset;
+      marker += 1;
+      parts.push(
+        `<line x1="${xs(i).toFixed(1)}" y1="${py}" x2="${xs(i).toFixed(1)}" y2="${height - py}" ` +
+        `stroke="var(--accent)" stroke-opacity=".35" stroke-dasharray="3 3"/>` +
+        `<text x="${xs(i).toFixed(1)}" y="${textY}" text-anchor="middle" font-size="9" ` +
+        `fill="var(--accent-link,var(--accent))">${esc(label)}</text>`);
+    }
+  });
+  const poly = points.map(([, v], i) => `${xs(i).toFixed(1)},${ys(v).toFixed(1)}`).join(" ");
+  parts.push(`<polyline points="${poly}" fill="none" stroke="var(--accent)" stroke-width="2.5" ` +
+    `stroke-linejoin="round" stroke-linecap="round"/>`);
+  points.forEach(([day, v], i) => {
+    parts.push(`<circle cx="${xs(i).toFixed(1)}" cy="${ys(v).toFixed(1)}" r="4" fill="var(--accent)" ` +
+      `stroke="var(--surface-1)" stroke-width="2" data-l="${esc(day)} · ${Math.round(v * 100)}%"/>`);
+  });
+  const step = Math.max(1, Math.ceil(points.length / 8));
+  points.forEach(([day], i) => {
+    if (i % step === 0 || i === points.length - 1) {
+      parts.push(`<text x="${xs(i).toFixed(1)}" y="${height - 4}" text-anchor="middle" font-size="9.5" ` +
+        `font-weight="600" fill="var(--text-muted)">${esc(day.slice(5))}</text>`);
+    }
+  });
+  parts.push("</svg>");
+  return parts.join("");
+}
+
+function bandAgentHtml(data, events) {
+  const chart = trendSvg(dayPoints(data), events)
+    || '<div class="cap" style="margin-top:14px">not enough merged-PR days yet (needs runs with pr_merged from the collector)</div>';
   return `
-  <h2 id="trends">Trends</h2>
-  <div class="split">
+  <section class="band">
+    <div class="band-h"><h2 id="agent">The agent</h2><span class="cohort">cohort: final run of each merged PR</span></div>
+    <div class="sub">Measured only where the codebase is what actually shipped.</div>
+    <div class="tiles tiles-3">${agentTilesHtml(data, events)}</div>
     <div class="card pad chartcard">
-      <div class="t">Suite pass fraction, per run</div>
-      <div class="s">pass / (pass + fail) — INFRA excluded</div>
-      <div id="ratechart">${rate}</div>
+      <div class="t">Suite pass fraction, by day</div>
+      <div class="s">merged-PR cohort · pass / (pass + fail) over reps, INFRA excluded · event markers from events.yaml</div>
+      <div id="daytrend">${chart}</div>
     </div>
-    <div class="card pad chartcard">
-      <div class="t">${esc(judgeTitle)}</div>
-      <div class="s">advisory · threshold tick at ${DASH.judgeThreshold}</div>
-      <div id="judgechart">${judge}</div>
+  </section>`;
+}
+
+function bandGateHtml(data, notes, events) {
+  const matrixRuns = measuredRuns(data).slice(-DASH.matrixRuns).length;
+  return `
+  <section class="band">
+    <div class="band-h"><h2 id="gate">The gate</h2><span class="cohort">cohort: all PR runs · ${DASH.runEventCaption}</span></div>
+    <div class="sub">Is the gate trustworthy — flake forensics, infra tax, and the cost of a run.</div>
+    <div class="tiles">${gateTilesHtml(data, events)}</div>
+    <div class="card pad">
+      <div class="t">Case × run outcome matrix</div>
+      <div class="s">one row per active case, one cell per run · last ${matrixRuns} measured runs · ▲ = events.yaml marker · ${DASH.runEventCaption}</div>
+      ${matrixHtml(data, notes, events)}
+      <div class="legend mx-legend">
+        <span><span class="cell c-g"></span>passed all reps</span>
+        <span><span class="cell c-a"></span>partial</span>
+        <span><span class="cell c-r"></span>failed all reps</span>
+        <span><span class="cell c-i"></span>infra — excluded</span>
+        <span><span class="cell c-n"></span>not in run</span>
+      </div>
     </div>
-  </div>`;
+    <div class="card pad">
+      <div class="t">Failure signatures · last ${DASH.paretoWindowDays} days</div>
+      <div class="s">non-pass reps grouped by normalized reason · ${DASH.runEventCaption} · gray = infra, violet = check design, amber = agent behaviour, neutral = unclassified</div>
+      ${paretoHtml(data)}
+    </div>
+  </section>`;
 }
 
 function evidenceRow(kase) {
   const name = String(kase.name || "?");
-  const have = typeof kase.runs_on_record === "number" ? Math.trunc(kase.runs_on_record) : 0;
+  const have = isCount(kase.runs_on_record) ? kase.runs_on_record : 0;
   const width = Math.min(100, (100 * have) / DASH.screeningWindow);
-  const rateText = typeof kase.pass_rate === "number" ? `${Math.round(kase.pass_rate * 100)}%` : "—";
   const presubmit = kase.active
     ? '<span class="pill p-pass">IN PRESUBMIT</span>'
     : '<span class="pill p-fix">NOT IN PRESUBMIT</span>';
-  return `<tr><td style="font-weight:650">${esc(name)}</td>` +
+  return `<tr><td><div class="tname">${esc(name)}</div>${noteHtml(DASH.notes[name])}</td>` +
     `<td><div style="display:flex;align-items:center;gap:10px">` +
     `<div class="prog"><i style="width:${width.toFixed(0)}%"></i></div>` +
     `<span class="cap">${have} of ${DASH.screeningWindow}</span></div></td>` +
-    `<td class="num" style="text-align:left">${rateText}</td><td>${presubmit}</td></tr>`;
+    `<td>${presubmit}</td></tr>`;
 }
 
 function evidenceHtml(data) {
-  const cases = [...(data.cases || [])].sort((a, b) =>
-    ((b.runs_on_record || 0) - (a.runs_on_record || 0))
-    || String(a.name || "").localeCompare(String(b.name || "")));
+  const depth = (c) => (isCount(c.runs_on_record) ? c.runs_on_record : 0);
+  // Code-point name comparison, matching Python's tuple sort.
+  const byName = (a, b) => {
+    const na = String(a.name || ""), nb = String(b.name || "");
+    return na < nb ? -1 : na > nb ? 1 : 0;
+  };
+  const cases = (data.cases || []).filter((c) => c && typeof c === "object")
+    .sort((a, b) => (depth(b) - depth(a)) || byName(a, b));
   const rows = cases.map(evidenceRow).join("")
-    || '<tr><td colspan="4"><span class="cap">no cases on record yet</span></td></tr>';
+    || '<tr><td colspan="3"><span class="cap">no cases on record yet</span></td></tr>';
   return `
   <h2 id="nightly">Evidence on record</h2>
-  <div class="sub">Recorded task appearances per case (all collected runs, infra included), against the ${DASH.screeningWindow}-run yardstick · history depth, not admission progress — the screening window fills only from main-branch runs in the baseline store (bench/baselines/README.md)</div>
+  <div class="sub">Recorded task appearances per case (all collected runs, infra included), against the ${DASH.screeningWindow}-run yardstick · history depth, not admission progress — the screening window fills only from main-branch runs in the baseline store (bench/baselines/README.md) · annotations from case-notes.yaml</div>
   <div class="card"><table id="evidence">
-    <thead><tr><th>Case</th><th>Evidence collected</th><th>Pass rate</th><th>In presubmit</th></tr></thead>
+    <thead><tr><th>Case</th><th>Evidence collected</th><th>In presubmit</th></tr></thead>
     <tbody>${rows}</tbody>
   </table></div>`;
 }
@@ -539,22 +807,25 @@ const HERO_LEDE = "Every pull request runs the agent against a real seeded fleet
   "Exact checks gate; judged scores are recorded, never blocking; infrastructure " +
   "failures never count against a PR.";
 
-const heroHtml = (data) => `
+const HERO_HTML = `
   <section style="margin-top:30px">
     <span class="eyebrow">Agent evaluation · presubmit</span>
     <h1>Is the agent getting better or worse?</h1>
     <div class="lede">${HERO_LEDE}</div>
-    <div class="tiles" id="tiles">${tilesHtml(data)}</div>
   </section>`;
 
 function footHtml(data) {
   const generated = parseIso(data.generated_at);
   const runs = (data.runs || []).length;
+  const threshold = Math.round(DASH.runEventFailFraction * 100);
   return `<div class="foot" id="foot">Every number on this page is computed from ` +
-    `<code>data.json</code> (source: ${esc(data.source || "?")}, ` +
+    `<code>data.json</code> (source: ${esc(String(data.source || "?"))}, ` +
     `generated ${generated != null ? utcStamp(generated) + " UTC" : "unknown time"}, ` +
     `${runs} run${runs !== 1 ? "s" : ""} on record). ` +
-    `Row annotations come from <code>case-notes.yaml</code> and are advisory only.</div>`;
+    `Run-level event rule: a run where ≥${threshold}% of its graded tasks failed is ` +
+    `charged to the run, not the cases. Event markers and catch counts come from ` +
+    `<code>events.yaml</code>; row annotations and badges from ` +
+    `<code>case-notes.yaml</code>. All three are advisory only.</div>`;
 }
 
 const EMPTY_STATE_HTML = `
@@ -563,13 +834,13 @@ const EMPTY_STATE_HTML = `
     <h1>Is the agent getting better or worse?</h1>
     <div class="empty" style="margin-top:24px">
       <span class="banner">⏳ No evaluation data yet</span>
-      <p style="margin-top:12px">No runs are on record in <code>data.json</code>. Once the collector publishes its first run, the header tiles, the per-case suite table, the trend charts and the nightly evidence all render from that file automatically — nothing else feeds this page.</p>
+      <p style="margin-top:12px">No runs are on record in <code>data.json</code>. Once the collector publishes its first run, the band tiles, the day trend, the case × run matrix, the failure signatures and the evidence table all render from that file automatically — nothing else feeds this page.</p>
     </div>
   </section>`;
 
 function appHtml(data) {
   if (!((data.runs || []).length || (data.cases || []).length)) return EMPTY_STATE_HTML;
-  return heroHtml(data) + suiteHtml(data) + trendsHtml(data)
+  return HERO_HTML + bandAgentHtml(data, DASH.events) + bandGateHtml(data, DASH.notes, DASH.events)
     + evidenceHtml(data) + RELEASES_HTML + footHtml(data);
 }
 

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -1,9 +1,14 @@
 """Golden and contract tests for the eval dashboard renderer and publisher.
 
 The fixtures here are built against schema_version 1 of the collector's
-data.json, deliberately in this file rather than shared with the collector:
-the renderer must keep working from the written contract alone, so these
-tests are the contract's teeth on the reading side.
+data.json -- including the optional additive ``tasks[].reps`` and
+``runs[].pr_merged`` fields (SCHEMA.md, "Optional run and task fields"),
+which no collector version emits yet -- deliberately in this file rather
+than shared with the collector: the renderer must keep working from the
+written contract alone, so these tests are the contract's teeth on the
+reading side. Both directions are covered: reps present (rep-level cells,
+cohorts, Pareto) and reps absent (today's production data), which must fall
+back to each task's single result.
 
 The publish tests never touch a bucket. The gsutil argv is asserted as a
 value (``gsutil_command``), and ``publish`` is only ever *executed* against a
@@ -21,108 +26,163 @@ import unittest
 from eval_dashboard import publish, render
 
 REPO_NOTES = pathlib.Path(__file__).resolve().parent / "eval_dashboard" / "case-notes.yaml"
+REPO_EVENTS = pathlib.Path(__file__).resolve().parent / "eval_dashboard" / "events.yaml"
+
+# A reason long enough to exercise the 60-char snippet fallback, carrying an
+# agent-classed keyword ("false finding").
+LONG_REASON = (
+    "false finding on a healthy workload: the agent invented a PDB violation "
+    "that does not exist"
+)
+
+
+def rep(result, reason=None):
+    return {"n": 1, "result": result, "reason": reason}
 
 
 def fixture_data():
-    """Two runs, four cases: one pass, one fail, one INFRA in the latest
-    run, and one active case that has never run (IN BUILD)."""
+    """Six runs against five active cases, telling the whole story:
+
+    - run A (#900, merged, 08-20): prior-week cohort anchor, 4 pass / 1 fail.
+    - run B (#950, merged, 08-30): superseded by run C of the same PR, so it
+      must not appear in the merged-PR cohort at all.
+    - run C (#950, merged, 08-31): final run of PR 950 -- 6 pass / 1 fail,
+      with a partial cell and an all-infra cell.
+    - run D (#951, NOT merged, 08-31): run-level event (4 of 5 graded tasks
+      failed); renders as a column but its failures charge the run.
+    - run E (#952, pr_merged absent, 09-01): the Pareto's raw material --
+      429 reps, not-a-real-run reps, an exact-check miss, a reason-less
+      fail, and a long agent-classed reason.
+    - run F (#953, merged, 09-01, SUCCESS): the latest green full run.
+    """
     return {
         "schema_version": 1,
-        "generated_at": "2026-08-28T14:02:11Z",
+        "generated_at": "2026-09-01T12:00:00Z",
         "source": "logs",
         "runs": [
             {
-                "build_id": "2093054394793725952",
-                "pr": 998,
-                "head_sha": "a28f0b3f00",
-                "project": "kube-agents-evals-2",
-                "started": "2026-08-27T09:00:00Z",
-                "finished": "2026-08-27T10:36:33Z",
-                "result": "FAILURE",
-                "duration_s": 5793,
+                "build_id": "bA", "pr": 900, "pr_merged": True,
+                "started": "2026-08-20T10:00:00Z", "finished": "2026-08-20T11:30:00Z",
+                "result": "FAILURE", "duration_s": 5400,
                 "tasks": [
-                    {"name": "reliability-pdb-probe", "result": "pass", "duration_s": 165, "outcome_validity": 1.0},
-                    {"name": "capacity-pinned-pool-probe", "result": "pass", "duration_s": 300, "outcome_validity": 1.0},
-                    {"name": "compliance-rbac-overgrant", "result": "fail", "duration_s": 1870, "outcome_validity": 0.5},
+                    {"name": "case-a", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"), rep("pass")]},
+                    {"name": "case-b", "result": "pass",
+                     "reps": [rep("pass"), rep("fail", "old flake before fix"), rep("infra")]},
                 ],
             },
             {
-                "build_id": "2093414500000000000",
-                "pr": 1001,
-                "head_sha": "b31c2d40aa",
-                "project": "kube-agents-evals-2",
-                "started": "2026-08-28T09:00:00Z",
-                "finished": "2026-08-28T10:12:00Z",
-                "result": "FAILURE",
-                "duration_s": 4320,
+                "build_id": "bB", "pr": 950, "pr_merged": True,
+                "started": "2026-08-30T09:00:00Z", "finished": "2026-08-30T10:40:00Z",
+                "result": "FAILURE", "duration_s": 6000,
                 "tasks": [
-                    {"name": "reliability-pdb-probe", "result": "pass", "duration_s": 182, "outcome_validity": 1.0},
-                    {"name": "capacity-pinned-pool-probe", "result": "fail", "duration_s": 129, "outcome_validity": 0.0},
-                    {"name": "compliance-rbac-overgrant", "result": "infra", "duration_s": 240},
+                    {"name": "case-a", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"), rep("pass")]},
+                    {"name": "case-b", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"),
+                              rep("fail", "check kanban-columns: required phrases absent")]},
+                ],
+            },
+            {
+                "build_id": "bC", "pr": 950, "pr_merged": True,
+                "started": "2026-08-31T09:00:00Z", "finished": "2026-08-31T10:40:00Z",
+                "result": "FAILURE", "duration_s": 6000,
+                "tasks": [
+                    {"name": "case-a", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"), rep("pass")]},
+                    {"name": "case-b", "result": "pass",
+                     "reps": [rep("fail", "check kanban-columns: required phrases absent"),
+                              rep("pass"), rep("pass")]},
+                    {"name": "case-c", "result": "pass"},
+                    {"name": "case-d", "result": "infra",
+                     "reps": [rep("infra"), rep("infra"), rep("infra")]},
+                ],
+            },
+            {
+                "build_id": "bD", "pr": 951, "pr_merged": False,
+                "started": "2026-08-31T11:00:00Z", "finished": "2026-08-31T12:10:00Z",
+                "result": "FAILURE", "duration_s": 4200,
+                "tasks": [
+                    {"name": "case-a", "result": "fail",
+                     "reps": [rep("fail", "EVENT-ONLY-REASON breakage"),
+                              rep("fail", "EVENT-ONLY-REASON breakage"),
+                              rep("fail", "EVENT-ONLY-REASON breakage")]},
+                    {"name": "case-b", "result": "fail"},
+                    {"name": "case-c", "result": "fail"},
+                    {"name": "case-d", "result": "fail"},
+                    {"name": "case-e", "result": "pass"},
+                ],
+            },
+            {
+                "build_id": "bE", "pr": 952,
+                "started": "2026-09-01T08:00:00Z", "finished": "2026-09-01T09:30:00Z",
+                "result": "FAILURE", "duration_s": 5100,
+                "tasks": [
+                    {"name": "case-a", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"),
+                              rep("fail", "HTTP 429 Too Many Requests from litellm endpoint")]},
+                    {"name": "case-b", "result": "fail",
+                     "reps": [rep("fail", "transcript is not evidence of a real agent run"),
+                              rep("fail", "transcript is not evidence of a real agent run"),
+                              rep("fail", "check kanban-columns: required phrases absent")]},
+                    {"name": "case-c", "result": "infra",
+                     "reps": [rep("infra", "HTTP 429 Too Many Requests")]},
+                    {"name": "case-d", "result": "fail"},
+                    {"name": "case-e", "result": "fail", "reps": [rep("fail", LONG_REASON)]},
+                ],
+            },
+            {
+                "build_id": "bF", "pr": 953, "pr_merged": True, "head_sha": "f6e5d4c00",
+                "started": "2026-09-01T09:00:00Z", "finished": "2026-09-01T11:30:00Z",
+                "result": "SUCCESS", "duration_s": 9000,
+                "tasks": [
+                    {"name": "case-a", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"), rep("pass")]},
+                    {"name": "case-b", "result": "pass",
+                     "reps": [rep("pass"), rep("pass"), rep("pass")]},
+                    {"name": "case-c", "result": "pass"},
                 ],
             },
         ],
         "cases": [
-            {
-                "name": "reliability-pdb-probe",
-                "domain": "reliability",
-                "active": True,
-                "runs_on_record": 4,
-                "pass_rate": 1.0,
-                "last3": ["pass", "pass", "pass"],
-                "durations": {"min": 145, "med": 165, "max": 182},
-                "ov_history": [
-                    {"build_id": "2092000000000000000", "value": 0.5},
-                    {"build_id": "2093054394793725952", "value": 1.0},
-                    {"build_id": "2093414500000000000", "value": 1.0},
-                ],
-            },
-            {
-                "name": "capacity-pinned-pool-probe",
-                "domain": "capacity",
-                "active": True,
-                "runs_on_record": 4,
-                "pass_rate": 0.75,
-                "last3": ["pass", "pass", "fail"],
-                "durations": {"min": 129, "med": 214, "max": 300},
-                "ov_history": [
-                    {"build_id": "2093054394793725952", "value": 1.0},
-                    {"build_id": "2093414500000000000", "value": 0.0},
-                ],
-            },
-            {
-                "name": "compliance-rbac-overgrant",
-                "domain": "fleet-audits",
-                "active": True,
-                "runs_on_record": 4,
-                "pass_rate": 0.5,
-                "last3": ["fail", "fail", "infra"],
-                "durations": {"min": 240, "med": 1055, "max": 1870},
-            },
-            {
-                "name": "autoops-warning-event-triage",
-                "domain": "incident-triage",
-                "active": True,
-                "runs_on_record": 0,
-                "last3": [],
-            },
+            {"name": "case-a", "domain": "reliability", "active": True, "runs_on_record": 6},
+            {"name": "case-b", "domain": "chat-and-routing", "active": True, "runs_on_record": 6},
+            {"name": "case-c", "domain": "capacity", "active": True, "runs_on_record": 4},
+            {"name": "case-d", "domain": "security", "active": True, "runs_on_record": 3},
+            {"name": "case-e", "domain": "gpu", "active": True, "runs_on_record": 2},
+            {"name": "case-f", "domain": "cost", "active": False, "runs_on_record": 0},
         ],
-        "coverage": {
-            "domains_total": 11,
-            "domains_covered": 10,
-            "uncovered": ["incident-triage"],
-        },
+        "coverage": {"domains_total": 11, "domains_covered": 11, "uncovered": []},
     }
 
 
-def render_fixture(data, notes_path=None):
-    """Run the real CLI against a temp dir; returns (html, out_dir)."""
+def fixture_events_yaml():
+    return (
+        "events:\n"
+        '  - date: "2026-08-31"\n'
+        '    label: "#1063 + 360m timeout"\n'
+        "catches:\n"
+        "  product_bugs: 4\n"
+        "  prs_blocked: 2\n"
+        '  ledger: "#1054"\n'
+        "false_reds_7d: 1\n"
+    )
+
+
+def render_fixture(data, notes_path=None, events_path=None, events_yaml=None):
+    """Run the real CLI against a temp dir; returns (html, out_dir, tmp).
+    Notes and events default to *absent* files so the repo's own annotation
+    files never leak into a test; pass events_yaml to write one inline."""
     tmp = tempfile.TemporaryDirectory()
     out_dir = pathlib.Path(tmp.name) / "out"
     data_path = pathlib.Path(tmp.name) / "data.json"
     data_path.write_text(json.dumps(data))
+    if events_yaml is not None:
+        events_path = pathlib.Path(tmp.name) / "events.yaml"
+        events_path.write_text(events_yaml)
     argv = ["--data", str(data_path), "--out-dir", str(out_dir)]
     argv += ["--notes", str(notes_path or pathlib.Path(tmp.name) / "no-notes.yaml")]
+    argv += ["--events", str(events_path or pathlib.Path(tmp.name) / "no-events.yaml")]
     with contextlib.redirect_stdout(io.StringIO()):
         render.main(argv)
     return (out_dir / "index.html").read_text(), out_dir, tmp
@@ -132,9 +192,8 @@ def baked_app(html):
     """The server-rendered fragment only: everything render.py substituted
     for __APP__, and none of the template's own JS source. Assertions
     against the whole page are toothless for any string the JS mirror
-    carries as a literal ("Test suite", "not enough runs yet", the pill
-    markup...), because the template ships that source verbatim in every
-    page."""
+    carries as a literal ("The gate", the legend labels, the tile markup...),
+    because the template ships that source verbatim in every page."""
     return html.split('<div id="app">', 1)[1].split("<script>", 1)[0]
 
 
@@ -143,82 +202,191 @@ def script_source(html):
     return "".join(part.split("</script>", 1)[0] for part in html.split("<script>")[1:])
 
 
-def row_for(html, case_name):
-    rows = [r for r in html.split("<tr>") if case_name in r]
+def daytrend_of(app):
+    if 'id="daytrend"' not in app:
+        raise AssertionError("no daytrend fragment rendered")
+    return app.split('id="daytrend"', 1)[1].split("</div>", 1)[0]
+
+
+def mx_row_for(app, case_name):
+    rows = [r for r in app.split('<div class="mx-row">') if f">{case_name}</span>" in r]
     if not rows:
-        raise AssertionError(f"no table row for {case_name}")
-    return rows[0].split("</tr>")[0]
+        raise AssertionError(f"no matrix row for {case_name}")
+    # The last row's split segment runs on into the event footnote, the
+    # legend and the Pareto; cut it back to the row itself.
+    return rows[0].split('<div class="mx-ev">')[0].split('<div class="legend')[0]
 
 
 class RenderGoldenTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.html, cls.out_dir, cls._tmp = render_fixture(fixture_data())
+        cls.html, cls.out_dir, cls._tmp = render_fixture(
+            fixture_data(), events_yaml=fixture_events_yaml()
+        )
+        cls.app = baked_app(cls.html)
 
     @classmethod
     def tearDownClass(cls):
         cls._tmp.cleanup()
 
-    def test_passed_pill_rendered(self):
-        row = row_for(self.html, "reliability-pdb-probe")
-        self.assertIn('class="pill p-pass">PASSED</span>', row)
+    def test_two_bands_with_cohort_captions(self):
+        self.assertIn('<h2 id="agent">The agent</h2>', self.app)
+        self.assertIn("cohort: final run of each merged PR", self.app)
+        self.assertIn('<h2 id="gate">The gate</h2>', self.app)
+        # The run-level rule is stated verbatim on the gate band and again
+        # in the matrix caption.
+        self.assertEqual(
+            self.app.count("run-level events excluded from per-case stats"), 3
+        )
 
-    def test_failed_pill_rendered(self):
-        row = row_for(self.html, "capacity-pinned-pool-probe")
-        self.assertIn('class="pill p-fail">FAILED</span>', row)
+    def test_week_pass_rate_tile_with_delta_vs_prior_week(self):
+        # This week (window ends at generated_at 09-01T12:00): run C
+        # (6 pass / 1 fail) + run F (7 pass) = 13/14 -> 93%. Run B is the
+        # same PR as C and superseded; run D is unmerged; run E has no
+        # pr_merged. Prior week: run A, 4/5 -> 80%. Delta +13pt.
+        self.assertIn("93<small>%</small>", self.app)
+        self.assertIn("▲ +13pt vs prior week", self.app)
+        self.assertIn("merged-PR cohort · 2 runs this week", self.app)
 
-    def test_infra_is_never_rendered_as_failure(self):
-        # compliance-rbac-overgrant's latest result is infra: its pill says
-        # INFRA, its newest history dot is the infra class, and nothing in
-        # the row claims FAILED.
-        row = row_for(self.html, "compliance-rbac-overgrant")
-        self.assertIn('class="pill p-infra">INFRA</span>', row)
-        self.assertIn('class="h-infra"', row)
-        self.assertNotIn("FAILED", row)
+    def test_product_bugs_tile_from_events_yaml(self):
+        self.assertIn("4<small> + 2 PRs blocked</small>", self.app)
+        self.assertIn("catch ledger #1054", self.app)
 
-    def test_never_run_case_is_in_build(self):
-        row = row_for(self.html, "autoops-warning-event-triage")
-        self.assertIn('class="pill p-pend">IN BUILD</span>', row)
-        self.assertEqual(row.count('class="h-na"'), 3)
+    def test_domains_tile(self):
+        self.assertIn("11<small>/ 11</small>", self.app)
+        self.assertIn("all covered", self.app)
+        self.assertIn("6 scenarios · 5 blocking", self.app)
 
-    def test_freshness_timestamp_from_generated_at(self):
-        self.assertIn("updated 14:02 UTC", self.html)
+    def test_false_reds_tile_from_events_yaml(self):
+        self.assertIn(
+            '<div class="k">False reds · 7d</div><div class="v">1</div>', self.app
+        )
 
-    def test_judge_bar_carries_threshold_tick(self):
-        self.assertIn('class="thr" style="left:80%"', self.html)
+    def test_infra_rep_rate_computed_from_reps(self):
+        # 45 reps across the 6-run window, 5 infra -> 11.1%.
+        self.assertIn("11.1<small>%</small>", self.app)
+        self.assertIn("5 of 45 reps · last 6 runs", self.app)
 
-    def test_uncovered_domain_rendered(self):
-        self.assertIn("uncovered: incident-triage", self.html)
-        self.assertIn("10<small>/ 11</small>", self.html)
+    def test_wall_clock_of_latest_green_full_run(self):
+        # Run F: SUCCESS, 9000s -> 150 min.
+        self.assertIn("150<small>min</small>", self.app)
+        self.assertIn("latest green full run · #953", self.app)
 
-    def test_latest_run_tile_excludes_infra_from_denominator(self):
-        # Latest run: 1 pass, 1 fail, 1 infra -> "1 / 2 passed".
-        self.assertIn("1<small>/ 2 passed</small>", self.html)
+    def test_queue_wait_never_faked(self):
+        self.assertIn(
+            '<div class="k">Queue wait · median</div><div class="v">—</div>', self.app
+        )
+        self.assertIn("not reported in data.json", self.app)
 
-    def test_pass_fraction_chart_excludes_infra(self):
-        # Run #998: 2/3 pass -> 0.67. Run #1001: 1 pass, 1 fail, infra
-        # excluded -> 0.50, not 0.33.
-        self.assertIn("#1001 · 0.50", self.html)
-        self.assertIn("#998 · 0.67", self.html)
+    def test_matrix_cell_states_from_reps(self):
+        # case-a: pass in A/B/C/F, fail-all in D, partial in E.
+        row = mx_row_for(self.app, "case-a")
+        self.assertEqual(row.count("c-g"), 4)
+        self.assertEqual(row.count("c-r"), 1)
+        self.assertEqual(row.count("c-a"), 1)
+        # case-c: absent from A/B (not-run), infra-excluded in E.
+        row = mx_row_for(self.app, "case-c")
+        self.assertEqual(row.count("c-n"), 2)
+        self.assertEqual(row.count("c-i"), 1)
+        # case-d: all-infra reps in C render hollow, not failed.
+        row = mx_row_for(self.app, "case-d")
+        self.assertEqual(row.count("c-i"), 1)
 
-    def test_judge_trend_picks_deepest_history(self):
-        self.assertIn("reliability-pdb-probe · judge score", self.html)
+    def test_reps_absent_task_falls_back_to_single_result(self):
+        # case-d has no reps in D and E (bare result: fail) -> two red cells.
+        row = mx_row_for(self.app, "case-d")
+        self.assertEqual(row.count("c-r"), 2)
 
-    def test_evidence_depth_against_screening_yardstick(self):
-        app = baked_app(self.html)
-        self.assertIn("4 of 20", app)
-        self.assertIn("0 of 20", app)
-        self.assertIn(">IN PRESUBMIT</span>", app)
+    def test_inactive_case_has_no_matrix_row(self):
+        with self.assertRaises(AssertionError):
+            mx_row_for(self.app, "case-f")
+
+    def test_run_level_event_column_renders_but_is_charged_to_the_run(self):
+        # Run D (4 of 5 graded tasks failed) still renders as a column...
+        self.assertIn("run-level event", self.app)
+        row = mx_row_for(self.app, "case-e")
+        self.assertEqual(row.count("c-g"), 1)  # its pass in run D still shows
+        # ...but none of its failure reasons reach the Pareto.
+        self.assertNotIn("EVENT-ONLY-REASON", self.app)
+        # The one reason-less fail counted there is run E's case-d, not the
+        # three reason-less fails of run D.
+        self.assertIn(
+            '<div class="pa-count">1</div><div class="pa-name">(no reason recorded)</div>',
+            self.app,
+        )
+
+    def test_pareto_normalization_and_classes(self):
+        # HTTP 429 reps (one fail + one infra in run E) -> one infra-classed
+        # group.
+        self.assertIn("endpoint saturation (infra)", self.app)
+        self.assertIn('pa-infra" style="width:', self.app)
+        # "required phrases absent" with an extractable check name, seen in
+        # runs B, C and E -> 3, check-classed, and the top bar (100%).
+        self.assertIn(
+            '<div class="pa-count">3</div><div class="pa-name">exact-check: kanban-columns</div>',
+            self.app,
+        )
+        self.assertIn('pa-check" style="width:100.0%', self.app)
+        # NOT_A_REAL_RUN wording gets its own group, neutral-classed.
+        self.assertIn("not a real agent run", self.app)
+        self.assertIn("pa-unknown", self.app)
+        # Anything else groups by its first 60 chars; "false finding" is
+        # agent-classed.
+        self.assertIn(render.esc(LONG_REASON[:60]) + "…", self.app)
+        self.assertIn("pa-agent", self.app)
+        # Reason-less infra reps (run C's case-d) get their own group and
+        # keep the infra class -- the result itself says what they were.
+        self.assertIn(
+            '<div class="pa-count">3</div><div class="pa-name">(infra, no reason recorded)</div>',
+            self.app,
+        )
+
+    def test_day_trend_uses_final_run_per_merged_pr(self):
+        trend = daytrend_of(self.app)
+        # Run B (08-30) is superseded by run C of the same PR: no point.
+        self.assertNotIn("08-30", trend)
+        # Day fractions: C alone on 08-31 (6/7 -> 86%), F alone on 09-01.
+        self.assertIn('data-l="2026-08-31 · 86%"', trend)
+        self.assertIn('data-l="2026-09-01 · 100%"', trend)
+        # Unmerged (D) and unknown (E) runs never chart.
+        self.assertNotIn('data-l="2026-08-31 · 5', trend)
+
+    def test_event_markers_from_events_yaml(self):
+        # Chart labels are clipped at 18 chars so clustered events stay
+        # readable; the matrix footnote carries the full text.
+        self.assertIn("#1063 + 360m timeo…", daytrend_of(self.app))
+        # The matrix column for 08-31 carries the marker and the footnote
+        # names it.
+        self.assertIn("▲ 08-31 #1063 + 360m timeout", self.app)
+
+    def test_evidence_table_slimmed_but_present(self):
+        self.assertIn("Evidence on record", self.app)
+        self.assertIn("6 of 20", self.app)
+        self.assertIn(">IN PRESUBMIT</span>", self.app)
+        self.assertIn(">NOT IN PRESUBMIT</span>", self.app)  # case-f
+
+    def test_superseded_sections_are_gone(self):
+        for marker in (
+            "Latest run",  # hero tile
+            "judge score",  # single-case judge chart
+            "Suite pass fraction, per run",  # per-PR-number x-axis chart
+            "Median case cost",
+            "Test suite",  # per-case table, superseded by the matrix
+        ):
+            self.assertNotIn(marker, self.app)
 
     def test_releases_empty_state_rendered(self):
-        self.assertIn("No RC in the gate window", baked_app(self.html))
+        self.assertIn("No RC in the gate window", self.app)
+
+    def test_freshness_timestamp_from_generated_at(self):
+        self.assertIn("updated 12:00 UTC", self.html)
+
+    def test_head_sha_of_latest_run_in_header(self):
+        self.assertIn("head f6e5d4c", self.html)
 
     def test_data_json_copied_next_to_index(self):
         copied = json.loads((self.out_dir / "data.json").read_text())
-        self.assertEqual(copied["generated_at"], "2026-08-28T14:02:11Z")
-
-    def test_head_sha_of_latest_run_in_header(self):
-        self.assertIn("head b31c2d4", self.html)
+        self.assertEqual(copied["generated_at"], "2026-09-01T12:00:00Z")
 
 
 class RenderToleranceTest(unittest.TestCase):
@@ -232,33 +400,152 @@ class RenderToleranceTest(unittest.TestCase):
         self.assertIn("No evaluation data yet", app)
         self.assertNotIn("__APP__", html)
 
-    def test_optional_fields_absent(self):
-        # The bare minimum the schema allows: no coverage, no durations,
-        # no ov_history, tasks without judge scores, run without pr.
+    def test_todays_production_shape_degrades_gracefully(self):
+        # No reps, no pr_merged anywhere -- exactly what the current
+        # collector emits. The matrix falls back to single results, the
+        # agent band says honestly that it has no cohort, and the infra
+        # tile says it is counting tasks, not reps.
         data = {
             "schema_version": 1,
             "generated_at": "2026-08-28T14:02:11Z",
             "source": "logs",
-            "runs": [{"build_id": "b1", "tasks": [{"name": "x", "result": "pass"}]}],
-            "cases": [{"name": "x"}],
+            "runs": [
+                {"build_id": "b1", "pr": 998, "started": "2026-08-27T09:00:00Z",
+                 "result": "FAILURE", "duration_s": 5793,
+                 "tasks": [
+                     {"name": "case-x", "result": "pass"},
+                     {"name": "case-y", "result": "fail"},
+                     {"name": "case-z", "result": "infra"},
+                 ]},
+            ],
+            "cases": [{"name": "case-x", "active": True},
+                      {"name": "case-y", "active": True},
+                      {"name": "case-z", "active": True}],
         }
         html, _, tmp = render_fixture(data)
         self.addCleanup(tmp.cleanup)
         app = baked_app(html)
-        self.assertIn('class="pill p-pass">PASSED</span>', app)
-        self.assertIn("not enough runs yet", app)
-        self.assertIn("no judge history yet", app)
+        self.assertIn("no merged-PR runs on record", app)
+        self.assertIn("not enough merged-PR days yet", app)
+        self.assertIn("task-level fallback · last 1 runs", app)
+        self.assertEqual(mx_row_for(app, "case-x").count("c-g"), 1)
+        self.assertEqual(mx_row_for(app, "case-y").count("c-r"), 1)
+        self.assertEqual(mx_row_for(app, "case-z").count("c-i"), 1)
 
-    def test_null_project_renders_placeholder_not_none(self):
-        # SCHEMA.md: project is null when the log never reached the lease
-        # line (aborted / deadline-truncated builds). The key is present,
-        # so a plain .get(key, "?") would leak the literal string "None".
-        data = fixture_data()
-        data["runs"][-1]["project"] = None
+    def test_week_boundary_is_exclusive_of_seven_days_ago(self):
+        # A run started exactly 7*24h before generated_at belongs to the
+        # prior week (window is (ref-7d, ref]); one second later is this
+        # week.
+        data = {
+            "schema_version": 1,
+            "generated_at": "2026-09-01T00:00:00Z",
+            "source": "logs",
+            "runs": [
+                {"build_id": "b1", "pr": 1, "pr_merged": True,
+                 "started": "2026-08-25T00:00:00Z",
+                 "tasks": [{"name": "c", "reps": [rep("pass"), rep("fail")]}]},
+                {"build_id": "b2", "pr": 2, "pr_merged": True,
+                 "started": "2026-08-25T00:00:01Z",
+                 "tasks": [{"name": "c", "reps": [rep("pass"), rep("pass"),
+                                                  rep("pass"), rep("fail")]}]},
+            ],
+            "cases": [{"name": "c", "active": True}],
+        }
         html, _, tmp = render_fixture(data)
         self.addCleanup(tmp.cleanup)
-        self.assertNotIn("· None", html)
-        self.assertIn("· ?", html)
+        app = baked_app(html)
+        self.assertIn("75<small>%</small>", app)  # this week: b2 alone, 3/4
+        self.assertIn("▲ +25pt vs prior week", app)  # prior week: b1, 1/2
+        self.assertIn("merged-PR cohort · 1 run this week", app)
+
+    def test_pass_rate_rounding_matches_the_js_rerender(self):
+        # 1/8 = 12.5%: Python's banker's rounding would say 12, JS
+        # Math.round says 13. The baked HTML must agree with the re-render.
+        data = {
+            "schema_version": 1,
+            "generated_at": "2026-09-01T00:00:00Z",
+            "source": "logs",
+            "runs": [
+                {"build_id": "b1", "pr": 1, "pr_merged": True,
+                 "started": "2026-08-31T00:00:00Z",
+                 "tasks": [{"name": "c", "reps": [rep("pass")] + [rep("fail")] * 7}]},
+            ],
+            "cases": [{"name": "c", "active": True}],
+        }
+        html, _, tmp = render_fixture(data)
+        self.addCleanup(tmp.cleanup)
+        self.assertIn("13<small>%</small>", baked_app(html))
+
+    def test_empty_events_file_means_dash_tiles(self):
+        html, _, tmp = render_fixture(fixture_data(), events_yaml="")
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        self.assertIn(
+            '<div class="k">Product bugs caught</div><div class="v">—</div>', app
+        )
+        self.assertIn('<div class="k">False reds · 7d</div><div class="v">—</div>', app)
+        self.assertEqual(app.count("not annotated (events.yaml)"), 2)
+
+    def test_absent_events_file_means_dash_tiles_and_no_markers(self):
+        html, _, tmp = render_fixture(fixture_data())  # no --events file
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        self.assertIn('<div class="k">False reds · 7d</div><div class="v">—</div>', app)
+        self.assertNotIn("mx-ev", app)
+
+    def test_zero_task_run_gets_no_matrix_column(self):
+        data = fixture_data()
+        data["runs"].append({
+            "build_id": "bAborted", "pr": 999,
+            "started": "2026-09-01T10:00:00Z", "finished": "2026-09-01T10:09:00Z",
+            "result": "ABORTED", "duration_s": 540, "tasks": [],
+        })
+        html, _, tmp = render_fixture(data, events_yaml=fixture_events_yaml())
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        # 7 runs on record, 6 measured: 6 matrix columns.
+        self.assertEqual(app.count("mx-col"), 6)
+        self.assertIn("last 6 measured runs", app)
+
+    def test_all_runs_unmeasured_says_so(self):
+        data = {
+            "schema_version": 1,
+            "generated_at": "2026-08-28T14:02:11Z",
+            "source": "logs",
+            "runs": [{"build_id": "b1", "result": "ABORTED", "tasks": []}],
+            "cases": [{"name": "x", "active": True}],
+        }
+        html, _, tmp = render_fixture(data)
+        self.addCleanup(tmp.cleanup)
+        self.assertIn("no measured runs yet", baked_app(html))
+
+    def test_malformed_entries_degrade_instead_of_aborting_the_render(self):
+        # One off-shape entry from a collector must never abort the whole
+        # render (the publish hook would then skip every cycle and the
+        # dashboard would silently go stale).
+        data = fixture_data()
+        data["cases"].append("stray-string")
+        data["cases"].append({"name": "case-bad-depth", "active": True,
+                              "runs_on_record": "6"})
+        data["cases"].append({"name": "case-bool-depth", "active": True,
+                              "runs_on_record": True})
+        data["coverage"] = ["oops"]  # re-typed: tile degrades, no crash
+        html, _, tmp = render_fixture(data)
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        self.assertIn('<div class="k">Domains covered</div><div class="v">—</div>', app)
+        # Non-count depths render as zero evidence, not a crash or a lie.
+        self.assertIn("case-bad-depth", app)
+        self.assertIn("case-bool-depth", app)
+
+    def test_retyped_uncovered_list_degrades(self):
+        data = fixture_data()
+        data["coverage"]["uncovered"] = "abc"  # not a list: ignored, not
+        html, _, tmp = render_fixture(data)  # iterated character-wise
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        self.assertNotIn("uncovered: a, b, c", app)
+        self.assertIn("6 scenarios · 5 blocking", app)
 
     def test_unknown_additive_fields_ignored(self):
         data = fixture_data()
@@ -267,7 +554,7 @@ class RenderToleranceTest(unittest.TestCase):
         data["cases"][0]["novel"] = "yes"
         html, _, tmp = render_fixture(data)
         self.addCleanup(tmp.cleanup)
-        self.assertIn("Test suite", baked_app(html))
+        self.assertIn("Case × run outcome matrix", baked_app(html))
 
     def test_html_in_data_is_escaped(self):
         data = fixture_data()
@@ -275,6 +562,19 @@ class RenderToleranceTest(unittest.TestCase):
         html, _, tmp = render_fixture(data)
         self.addCleanup(tmp.cleanup)
         self.assertNotIn("<script>alert(1)</script>", html)
+
+    def test_hostile_rep_reason_is_escaped_in_the_pareto(self):
+        # reps[].reason is arbitrary log text; it reaches the page only
+        # escaped.
+        data = fixture_data()
+        data["runs"][-2]["tasks"][3]["reps"] = [
+            rep("fail", "<img src=x onerror=alert(2)> boom")
+        ]
+        html, _, tmp = render_fixture(data)
+        self.addCleanup(tmp.cleanup)
+        app = baked_app(html)
+        self.assertNotIn("<img src=x", app)
+        self.assertIn("&lt;img src=x onerror=alert(2)&gt; boom", app)
 
     def test_token_shaped_data_does_not_expand_template_markers(self):
         # A case *named* like a template marker must stay inert text.
@@ -296,99 +596,70 @@ class RenderToleranceTest(unittest.TestCase):
         data["coverage"]["domains_covered"] = '<img src=x onerror=alert(2)>'
         html, _, tmp = render_fixture(data)
         self.addCleanup(tmp.cleanup)
-        # The payload never appears raw: not in the document body, and the
-        # <script> bootstrap emits every '<' as the JSON escape \\u003c.
         self.assertNotIn("<img src=x", html)
         self.assertIn(
-            '<div class="k">Domain coverage</div><div class="v">—</div>'
+            '<div class="k">Domains covered</div><div class="v">—</div>'
             '<div class="d2">not reported</div>',
             html,
         )
-
-    def test_prior_run_without_metric_is_not_called_first_run(self):
-        # Two runs on record, but the earlier one reported no durations at
-        # all: the cost/wall-clock chips stay empty rather than claiming
-        # "first run" on run two.
-        data = fixture_data()
-        for task in data["runs"][0]["tasks"]:
-            task.pop("duration_s", None)
-        data["runs"][0].pop("duration_s", None)
-        html, _, tmp = render_fixture(data)
-        self.addCleanup(tmp.cleanup)
-        # The rendered chip, not the template's JS source (which contains
-        # the words "first run" as a string literal either way).
-        self.assertNotIn('<span class="delta flat">first run</span>', html)
-
-    def test_zero_task_newest_run_does_not_anchor_the_tiles(self):
-        # A build aborted before any task parses to zero task rows. The
-        # tiles and the suite table anchor to the newest *measured* run
-        # instead of rendering "0 / 0 passed · all passed", and the wall
-        # clock does not inherit the aborted run's short duration.
-        data = fixture_data()
-        data["runs"].append({
-            "build_id": "2094501900000000000",
-            "project": None,
-            "started": "2026-08-29T09:00:00Z",
-            "finished": "2026-08-29T09:09:00Z",
-            "result": "ABORTED",
-            "duration_s": 540,
-            "tasks": [],
-        })
-        html, _, tmp = render_fixture(data)
-        self.addCleanup(tmp.cleanup)
-        app = baked_app(html)
-        self.assertNotIn("0<small>/ 0 passed</small>", app)
-        self.assertNotIn("all passed", app)
-        self.assertIn("1<small>/ 2 passed</small>", app)  # newest measured run
-        self.assertIn("72<small>min</small>", app)  # 4320 s, not the 9-min abort
-        self.assertNotIn("9<small>min</small>", app)
-
-    def test_all_runs_unmeasured_says_so(self):
-        data = {
-            "schema_version": 1,
-            "generated_at": "2026-08-28T14:02:11Z",
-            "source": "logs",
-            "runs": [{"build_id": "b1", "result": "ABORTED", "tasks": []}],
-            "cases": [{"name": "x"}],
-        }
-        html, _, tmp = render_fixture(data)
-        self.addCleanup(tmp.cleanup)
-        app = baked_app(html)
-        self.assertIn("no measured runs yet", app)
-        self.assertNotIn("all passed", app)
-
-    def test_rounding_matches_the_js_rerender(self):
-        # Python rounds half to even, JS Math.round/toFixed round half up;
-        # the baked HTML must agree with what the on-load re-render shows.
-        data = fixture_data()
-        data["cases"][1]["pass_rate"] = 0.125  # Math.round(12.5) === 13
-        data["runs"][-1]["tasks"][0]["outcome_validity"] = 0.25  # toFixed(1) === "0.3"
-        html, _, tmp = render_fixture(data)
-        self.addCleanup(tmp.cleanup)
-        self.assertIn(">13%<", html)
-        self.assertIn('<span class="val">0.3</span>', html)
 
 
 class CaseNotesTest(unittest.TestCase):
     def test_absent_notes_file_means_no_notes(self):
         self.assertEqual(render.load_notes(pathlib.Path("/nonexistent/notes.yaml")), {})
 
-    def test_note_and_issue_links_rendered(self):
+    def test_malformed_notes_shapes_degrade_to_no_notes(self):
+        # The docstring's promise: absent, empty, or malformed all mean
+        # "no note", never a crash (a bad case-notes.yaml edit must cost a
+        # note, not the dashboard).
+        shapes = (
+            "- a-top-level-list\n",
+            "notes:\n  - a-list-not-a-mapping\n",
+            "notes:\n  case-a:\n    issues: 123\n",
+            'notes:\n  case-a:\n    issues: "#123"\n',  # scalar, not list
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            for text in shapes:
+                path = pathlib.Path(tmp) / "notes.yaml"
+                path.write_text(text)
+                notes = render.load_notes(path)
+                for entry in notes.values():
+                    self.assertEqual(entry["issues"], [])
+
+    def test_note_and_issue_links_rendered_in_evidence_table(self):
         with tempfile.TemporaryDirectory() as tmp:
             notes_path = pathlib.Path(tmp) / "notes.yaml"
             notes_path.write_text(
                 "notes:\n"
-                "  reliability-pdb-probe:\n"
+                "  case-a:\n"
                 "    note: hardened 08-27\n"
                 '    issues: ["#1010"]\n'
             )
             html, _, tmp_render = render_fixture(fixture_data(), notes_path=notes_path)
             self.addCleanup(tmp_render.cleanup)
-        row = row_for(html, "reliability-pdb-probe")
-        self.assertIn("hardened 08-27", row)
-        self.assertIn('href="https://github.com/gke-labs/kube-agents/issues/1010"', row)
-        # A case with no entry renders without a note, not with an error.
-        self.assertNotIn('class="tnote"', row_for(html, "capacity-pinned-pool-probe"))
+        app = baked_app(html)
+        self.assertIn("hardened 08-27", app)
+        self.assertIn('href="https://github.com/gke-labs/kube-agents/issues/1010"', app)
+
+    def test_badges_come_from_notes_not_code(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            notes_path = pathlib.Path(tmp) / "notes.yaml"
+            notes_path.write_text(
+                "notes:\n"
+                "  case-a:\n"
+                "    badge: held-out\n"
+                "  case-b:\n"
+                "    badge: new\n"
+                "  case-c:\n"
+                "    badge: shiny\n"  # unknown badge renders nothing
+            )
+            html, _, tmp_render = render_fixture(fixture_data(), notes_path=notes_path)
+            self.addCleanup(tmp_render.cleanup)
+        app = baked_app(html)
+        self.assertIn('<em class="b-hold">held out</em>', mx_row_for(app, "case-a"))
+        self.assertIn('<em class="b-new">new</em>', mx_row_for(app, "case-b"))
+        self.assertNotIn("<em", mx_row_for(app, "case-c"))
+        self.assertNotIn("shiny", app)
 
     def test_repo_notes_file_parses_and_carries_seed_annotations(self):
         notes = render.load_notes(REPO_NOTES)
@@ -400,6 +671,38 @@ class CaseNotesTest(unittest.TestCase):
         ):
             self.assertIn(name, notes)
         self.assertEqual(notes["compliance-rbac-overgrant"]["issues"], ["#998", "#985"])
+        self.assertEqual(notes["capacity-pinned-pool-probe"]["badge"], "held-out")
+        self.assertEqual(notes["security-overgrant-remediation-proposal"]["badge"], "new")
+
+
+class EventsTest(unittest.TestCase):
+    def test_absent_events_file_degrades(self):
+        events = render.load_events(pathlib.Path("/nonexistent/events.yaml"))
+        self.assertEqual(events, {"events": [], "catches": None, "false_reds_7d": None})
+
+    def test_malformed_entries_are_dropped_not_fatal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "events.yaml"
+            path.write_text(
+                "events:\n"
+                "  - not-a-mapping\n"
+                "  - date: 2026-08-29\n"  # unquoted: YAML date object
+                "    label: publish fix\n"
+                "  - date: 2026-08-30\n"  # no label: dropped
+                "catches: 7\n"  # wrong type: dropped
+            )
+            events = render.load_events(path)
+        self.assertEqual(events["events"], [{"date": "2026-08-29", "label": "publish fix"}])
+        self.assertIsNone(events["catches"])
+
+    def test_repo_events_file_parses_and_carries_seed_annotations(self):
+        events = render.load_events(REPO_EVENTS)
+        self.assertEqual(len(events["events"]), 4)
+        self.assertEqual(events["events"][0], {"date": "2026-08-27", "label": "kanban redesign"})
+        self.assertEqual(events["catches"]["product_bugs"], 4)
+        self.assertEqual(events["catches"]["prs_blocked"], 2)
+        self.assertEqual(events["catches"]["ledger"], "#1054")
+        self.assertEqual(events["false_reds_7d"], 1)
 
 
 class LiveReadSideTest(unittest.TestCase):
@@ -415,14 +718,14 @@ class LiveReadSideTest(unittest.TestCase):
         data["cases"][0]["novel_field"] = "</script><b>boom</b>"
         data["cases"][0]["other_field"] = "<!--<script>"
         data["stale_after_s"] = 600
-        cls.html, _, cls._tmp = render_fixture(data)
+        cls.html, _, cls._tmp = render_fixture(data, events_yaml=fixture_events_yaml())
 
     @classmethod
     def tearDownClass(cls):
         cls._tmp.cleanup()
 
     def test_bootstrap_data_is_embedded_and_script_safe(self):
-        self.assertIn('"generated_at":"2026-08-28T14:02:11Z"', self.html)
+        self.assertIn('"generated_at":"2026-09-01T12:00:00Z"', self.html)
         # No '<' from data survives into the script block: neither the
         # tag-closing payload nor the comment-opener one.
         self.assertNotIn("</script><b>boom</b>", self.html)
@@ -461,11 +764,33 @@ class LiveReadSideTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             notes_path = pathlib.Path(tmp) / "notes.yaml"
             notes_path.write_text(
-                'notes:\n  reliability-pdb-probe:\n    issues: ["#1010"]\n'
+                'notes:\n  case-a:\n    issues: ["#1010"]\n    badge: held-out\n'
             )
             html, _, tmp_render = render_fixture(fixture_data(), notes_path=notes_path)
             self.addCleanup(tmp_render.cleanup)
-        self.assertIn('"reliability-pdb-probe":{"note":null,"issues":["#1010"]}', html)
+        self.assertIn(
+            '"case-a":{"note":null,"issues":["#1010"],"badge":"held-out"}', html
+        )
+
+    def test_events_travel_with_the_bootstrap(self):
+        self.assertIn(
+            '"events":[{"date":"2026-08-31","label":"#1063 + 360m timeout"}]', self.html
+        )
+        self.assertIn('"false_reds_7d":1', self.html)
+
+    def test_js_mirror_carries_the_shared_thresholds(self):
+        js = script_source(self.html)
+        self.assertIn("runEventFailFraction: 0.8", js)
+        self.assertIn("matrixRuns: 30", js)
+        self.assertIn("paretoWindowDays: 7", js)
+
+    def test_js_parse_iso_normalizes_naive_timestamps_to_utc(self):
+        # render.py's parse_iso assumes UTC for a timezone-naive stamp;
+        # bare Date.parse reads one as local time, so the mirror appends
+        # "Z" -- otherwise every day bucket and week window would shift
+        # for a viewer outside UTC. Contract tripwire on the shipped
+        # script, like the STALE/UNREACHABLE labels.
+        self.assertIn('text += "Z"', script_source(self.html))
 
 
 class PublishTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Redesigns the eval dashboard from a single suite table into a two-band story page. Band 1, "The agent", answers whether the agent is getting better on the cohort where the codebase is what actually shipped — the final `pr_merged` run of each merged PR: a weekly pass-rate tile with a prior-week delta, the human-annotated catch counts, domain coverage, and a by-day pass-fraction trend with named event markers. Band 2, "The gate", answers whether the gate is trustworthy across all PR runs: false-red / infra-rep-rate / wall-clock / queue-wait tiles, a case × run outcome matrix over the last 30 measured runs with rep-level cell states, and a Pareto of failure signatures grouped by a small documented reason-normalization map. Every fragment builder in `render.py` has its JS mirror in the template, as before; the JS-rendered page is pixel-identical to the baked one.

## Why This Change

The current page answers "what happened in the latest run" but not the two questions people actually bring to it: is the agent improving where it matters (merged code, not every red experiment), and can the gate's verdicts be trusted (which failures are flake, which are infra, what a run costs). Without this change the trend chart keeps charting every PR run on a per-PR-number axis — so one broken PR's run drags the line down and reads as an agent regression — and there is nowhere to see per-case flake patterns across runs at all.

## What Changed

- `scripts/eval_dashboard/render.py` — band builders replace the hero/suite/trends builders. New shared vocabulary: `task_reps()` (reads the additive `tasks[].reps` field and falls back to the task's single `result`), `cell_state()` (pass / partial / fail-all / infra-excluded / not-run), `is_run_event()` (a run where ≥80% of graded tasks failed is charged to the run, and its failures are excluded from per-case stats — the rule is stated verbatim in the matrix caption and the footer), `merged_final_runs()` (band-1 cohort), and the failure-signature normalization + classification maps (small and documented at the top of the file; anything unmatched groups by its first 60 chars and renders a neutral bar).
- `scripts/eval_dashboard/template/index.html.tmpl` — the JS mirror of all of the above, plus the Mock A band/matrix/Pareto CSS mapped onto the existing theme variables. The freshness badge, 60-second poll, `__APP__` scoping and `<` bootstrap escaping are unchanged.
- `scripts/eval_dashboard/events.yaml` — new optional annotation file beside `case-notes.yaml`: dated `{date, label}` markers (rendered on the trend and the matrix header) plus the two human-judgment numbers the tiles need (`catches`, `false_reds_7d`). Documented by its own header comment, the same way `case-notes.yaml` documents itself. Absent file → no markers and em-dash tiles.
- `scripts/eval_dashboard/case-notes.yaml` — entries gain an optional `badge:` key (`held-out` / `new`) that the matrix rows render; seeded for the three held-out cases and the new remediation case.
- Removed: the "Latest run" hero tile, the per-PR-number trend chart, the single-case judge chart, the per-case suite table (superseded by the matrix), and the "Median case cost" tile. The old "Evidence on record" table is kept in slimmed form at the bottom — it is the only home for admission-progress depth (`runs_on_record` vs the 20-run yardstick), the IN PRESUBMIT state, and the case-notes annotations with issue links; its pass-rate column is dropped because the matrix now shows per-case outcomes directly.
- The queue-wait tile always renders "—": `data.json` carries no queued-at timestamp, so the number is not computable, and the tile says so instead of inventing one.

## Context

- **Depends on (ordering only, not correctness):** the rep-schema collector PR (branch `feat/dashboard-rep-schema`, not yet open at time of writing) adds `tasks[].reps` and `runs[].pr_merged` to `data.json`. This PR is built against that documented contract with its own fixtures and **degrades safely if deployed first**: with today's production data (neither field present) the matrix falls back to single task results, the merged-PR cohort is empty ("no merged-PR runs on record", "not enough merged-PR days yet"), and the infra tile labels itself "task-level fallback". Merge order therefore does not matter for safety; the agent band only lights up once the collector PR lands.
- Duplicate-work scan (AGENTS.md "Before Starting a Task"): #1141 (same author) touches `collect.py`/`SCHEMA.md` for the hourly refresh periodic, and draft #1082 touches `test_eval_dashboard_collect.py` — neither touches `render.py`, the template, or `test_eval_dashboard.py`, so this is merge-conflict-free overlap, not duplication. No open PR or issue covers the renderer redesign itself; it is lane work under #1022 / #1020.
- `collect.py` is deliberately untouched (owned by #1141 and the rep-schema branch).

## Testing

- `cd scripts && python3 -m unittest discover -p "test_*.py"` — 799 tests, green (56 in `test_eval_dashboard.py`, rewritten for the new layout).
- New coverage: reps-present cell states, reps-absent fallback (today's production shape), run-level-event exclusion from the Pareto, cohort selection (`pr_merged` true/false/null and final-run-per-PR), week-boundary pass-rate math (exact 7-day boundary), empty and absent `events.yaml`, badge rendering from notes, hostile `reps[].reason` escaping, JS-vs-Python rounding parity (12.5% → 13%), and the existing bootstrap `<` escaping tripwires.
- `prettier` could not run locally (no node/npm on this machine; AGENTS.md notes `npx prettier` is unreliable here anyway) — the changed YAML follows the existing files' formatting and CI's prettier check will verify.

### Live validation

Not live-tested against a running installation — this change never touches a cluster: it is the static renderer for the published dashboard page, exercised end to end locally instead:

- Rendered a rich 22-run / 17-case fixture (reps, `pr_merged`, a run-level-event run, a 429 infra-wave run) through the real CLI: `python3 scripts/eval_dashboard/render.py --data demo.json --out-dir out/`.
- Screenshot of that render (headless Chromium, dark theme):

![eval-dashboard-mock-a](https://raw.githubusercontent.com/jayantid/kube-agents/pr-evidence/eval-dashboard-mock-a-39e71f1c2053-20260902T020156Z.png)

_Published 20260902T020156Z at commit 39e71f1c2053 — pre-captured image (dash-server.png)._

- JS-mirror proof: a second copy of the rendered page with the baked `__APP__` fragment replaced by a sentinel (so everything visible is painted by the template's JS from the bootstrap data) screenshots **byte-identical** to the server-rendered page — the mirror executes and produces the same DOM. A JS syntax error would have left the sentinel on screen.
- Degradation check: the current production `data.json` shape (no `reps`, no `pr_merged`) renders the fallback states described under Context (covered by `test_todays_production_shape_degrades_gracefully`, plus a manual render).
- Could not cover: the live 60-second poll loop against a real bucket (file:// preview deliberately skips fetching), and light-theme rendering was only spot-checked — the published page pins `data-theme="dark"`.

## Self-Review

Both required passes ran in contexts that did not write the change — two fresh subagents, each handed the checkout, the diff range (`upstream/main...HEAD`) and the relevant skill, nothing else.

**Adversarial pass** (subagent, fresh context): traced every interpolation site in both builders (element text, `title` attributes, Pareto labels, trend `data-l`, badges, notes, footer), the bootstrap `<`-escaping, week-boundary and threshold math, every division, the run-event exclusion scoping, and Python-vs-JS parity function by function. Findings and dispositions:

- Evidence table crashed on malformed `cases[]` entries (non-dict entry; string/bool `runs_on_record`) where every sibling section degrades — **fixed**: `isinstance` filter plus `is_count` guards in the row and the sort key, mirrored in JS.
- Re-typed `coverage` (non-dict) crashed the Python renderer, and a string `uncovered` iterated character-wise in Python while throwing in JS — **fixed** on both sides (`isinstance` / `Array.isArray` guards); tolerance tests added.
- `load_notes` broke its own "malformed degrades to no note" promise on a top-level list, a list under `notes:`, or scalar `issues` — **fixed** with the guards `load_events` already had; test added.
- Parity: JS `Date.parse` reads a timezone-naive ISO stamp as *local* time where Python assumes UTC, shifting every day bucket and week window for a non-UTC viewer — **fixed**: the JS mirror appends `Z` to naive stamps; a script-source tripwire test pins it.
- Five smaller mirror drifts reachable only from off-contract data (`source: null` rendering, scenario counts over non-dict entries, boolean `runs_on_record`, UTF-16 vs code-point snippet slicing, `localeCompare` vs code-point sort) — **all fixed** on whichever side diverged.
- Matrix fallback said "no measured runs yet" even when the missing input was the case list — **fixed**: split messages.
- Question: run-level-event failures still count in band 1's pass rate and trend. **Deliberate, not fixed**: the rule is scoped to per-case aggregates; band 1's cohort is the final run of each *merged* PR, and a merged PR's own failures are that cohort's signal. Now stated in the module docstring so the next reviewer does not have to ask.
- Question: `false_reds_7d` is a rolling-window claim with no as-of date and nothing to detect staleness. **Deliberately not fixed**: the file header says a stale line is deletable without breaking a render, the tile is labeled "human-classified · events.yaml", and freshness machinery for an advisory hand count is more mechanism than the number warrants.
- Its named residual gap — "the JS mirror was never executed in this pass" — is closed by the Live validation sentinel check above (the JS-rendered page screenshots byte-identical to the baked one in headless Chromium).

**Docs-drift pass** (second subagent, fresh context): checked SCHEMA.md, the docs map, README/docstring prose, and ran `make docs-check` (all five checks green). Findings and dispositions:

- SCHEMA.md did not define `tasks[].reps` / `runs[].pr_merged`, the fields this renderer now reads — **fixed**: documented as optional additive fields in the existing `stale_after_s` style ("no collector version emits them yet").
- `scripts/eval_dashboard/__init__.py` still said "the one optional extra input is case-notes.yaml" — **fixed**: names both annotation files and the badge key.
- Present-tense "a newer collector emits" in two docstrings read as describing a collector that is not in the tree — **fixed**: rephrased to match SCHEMA.md's wording.
- Hand-maintained counts in events.yaml are a drift magnet — **accepted by design**; that is the file's stated purpose, receipts live in the #1054 ledger.

All findings above were re-verified against the final head: full suite green (799 tests), fresh render, and the byte-identical JS/baked screenshot comparison repeated after the fixes.

## Risk & Rollout

Renderer only — no runtime agent code paths, no CI verdict logic, no collector changes. The 15-minute refresh periodic publishes whatever is on `main`, so this layout goes live on merge; a bad render is a display problem, not a gating one (the publish hook is fail-safe by contract — `test_eval_dashboard_publish.py`). New failure mode: a malformed `events.yaml` on `main` — mitigated by tolerant parsing (malformed entries drop, absent file renders em-dashes) and tests. Rollback: revert this commit; the page returns to the current layout on the next publish.

Generated with the help of Claude Code (model: Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
