### PR TITLE
fix(bench): stop autoops-incident leaking its namespace and self-perpetuating

### DIFF
--- a/bench/tasks/autoops-warning-event-triage/task.yaml
+++ b/bench/tasks/autoops-warning-event-triage/task.yaml
@@ -18,9 +18,9 @@
 #
 # This is the one presubmit case that mutates, which is why it is
 # namespace-scoped rather than read-only: the namespace is created by the
-# stack's apply and deleted by its destroy (`teardown: true`), and the
-# safeguards below assert the agent left the planted object exactly as the
-# stack wrote it.
+# stack's apply and deleted by its destroy (`teardown: true`), or by the plant's
+# own exit trap when the apply is what failed, and the safeguards below assert
+# the agent left the planted object exactly as the stack wrote it.
 #
 # Isolation class: namespace-scoped. Eligible tier: presubmit.
 ---

--- a/bench/tf/prebuilt/autoops-incident/main.tf
+++ b/bench/tf/prebuilt/autoops-incident/main.tf
@@ -41,7 +41,10 @@
 # So this stack takes the host cluster as an input, applies one Deployment into
 # one namespace on it, waits until the pipeline has demonstrably started, and
 # deletes the namespace on destroy. `teardown: true` in the task file is what
-# runs that destroy.
+# runs that destroy. The destroy only covers the success path, so the plant
+# also clears a leftover namespace before it starts (step 0b) and deletes its
+# own on failure (the exit trap in step 0) -- see the teardown at the bottom of
+# this file for why it cannot be the only cleanup.
 #
 # WHY THE OUTPUTS EXIST even though nothing is provisioned: devops-bench calls
 # deployer.get_cluster_info() unconditionally after up() for any non-noop
@@ -173,8 +176,9 @@ resource "null_resource" "incident" {
       # captured rather than instead of it.
       #
       # Guarded on step 0 having completed: until KUBECONFIG points at the host
-      # cluster a kubectl here would run against the ambient context, which is a
-      # different cluster entirely (again, step 0).
+      # cluster a kubectl here would run against the ambient context, which is
+      # not reliably that cluster and is often another task's per-run one
+      # (again, step 0).
       host_kubeconfig_ready=""
       on_exit() {
         status=$?
@@ -211,11 +215,12 @@ resource "null_resource" "incident" {
       # Step 1 is idempotent by construction, so against a namespace that
       # already holds an identical Deployment `kubectl apply` reports
       # `unchanged` and creates no new pod. The pod still running is the one
-      # from the earlier run, which means it keeps its UID -- and the watcher's
-      # dedup key is exactly {UID, Reason} (k8s-event-watcher/types.go). Its
-      # window for that pod opened hours ago, so it logs
-      # `dedup BackOff pod=... (window active)` where step 3 is waiting for
-      # `fire`, and step 3 times out. Step 2 does not catch it either: the old
+      # from the earlier run, which means it keeps its UID -- and the watcher
+      # keys dedup on {UID, reason}, with the reason canonicalized into its
+      # family first (EventKey in k8s-event-watcher/types.go, canonicalizeReason
+      # in dedup.go). Its window for that pod opened hours ago, so it logs
+      # `dedup BackOff pod=... (count=N, window active)` where step 3 is waiting
+      # for `fire`, and step 3 times out. Step 2 does not catch it either: the old
       # pod's BackOff events are already past the debounce, so the wait returns
       # `after 0s` and everything looks healthy right up to the timeout.
       #
@@ -371,11 +376,15 @@ resource "null_resource" "incident" {
   # the opposite -- that the tainted path runs this too -- and #1143 is what
   # believing it cost.
   #
-  # It fetches its own credentials for the same reason step 0 does: devops-bench
-  # moves the ambient context off the host cluster after up(), so this can
-  # execute with it pointed anywhere at all. Deleting a namespace by name on the
-  # wrong cluster is the kind of thing --ignore-not-found makes survivable
-  # rather than safe.
+  # It fetches its own credentials for the same reason step 0 does, and the
+  # reason is not this stack's own up(): that one points the ambient kubeconfig
+  # AT the host cluster on purpose, as the header explains. It is the tasks
+  # around this one. The context in hand here is whatever the last
+  # get_cluster_info() selected -- and since that runs only after a successful
+  # up() while _teardown runs from a `finally` either way, the failure path can
+  # arrive with the previous task's per-run cluster still selected. Deleting a
+  # namespace by name on the wrong cluster is the kind of thing
+  # --ignore-not-found makes survivable rather than safe.
   provisioner "local-exec" {
     when        = destroy
     on_failure  = continue

--- a/bench/tf/prebuilt/autoops-incident/main.tf
+++ b/bench/tf/prebuilt/autoops-incident/main.tf
@@ -171,24 +171,48 @@ resource "null_resource" "incident" {
       # skips destroy-time provisioners on a tainted resource, so the destroy
       # reports "1 destroyed" without running a line of it.
       #
-      # Every failure path below writes its diagnostics to stderr before
-      # exiting, so this deletes the namespace after the evidence has been
-      # captured rather than instead of it.
+      # The dump before the delete is what stops the cleanup taking the evidence
+      # with it. Steps 0b, 2 and 3 each write their own detail before exiting,
+      # but step 1 does not: an admission-webhook rejection or a ResourceQuota
+      # denial there would otherwise leave one line of kubectl error and a
+      # namespace already gone.
       #
-      # Guarded on step 0 having completed: until KUBECONFIG points at the host
-      # cluster a kubectl here would run against the ambient context, which is
-      # not reliably that cluster and is often another task's per-run one
-      # (again, step 0).
-      host_kubeconfig_ready=""
+      # `set +e` is load-bearing for the reason hack/ci-eval-pr.sh gives at its
+      # own EXIT trap -- errexit stays in force inside a trap, so the first
+      # command that failed would abort it and skip the delete. Capturing
+      # `status` first keeps the script's own exit code intact.
+      #
+      # Guarded on `planted_ns`, which step 1 sets immediately before it creates
+      # the namespace, so this cleans up only a namespace this run made. Two
+      # things ride on that. Until KUBECONFIG points at the host cluster a
+      # kubectl here would run against the ambient context, which is not
+      # reliably that cluster and is often another task's per-run one (step 0
+      # again). And step 0b exits non-zero on a ${local.ns} it found already
+      # there and unlabelled -- deleting that from here would undo the refusal
+      # and delete the namespace anyway, which is the single thing 0b exists to
+      # not do.
+      planted_ns=""
       on_exit() {
         status=$?
-        if [ "$status" -ne 0 ] && [ -n "$host_kubeconfig_ready" ]; then
-          echo "Plant failed (exit $status). Deleting ${local.ns} so the next run starts from a clean namespace." >&2
-          kubectl delete namespace "${local.ns}" --ignore-not-found --wait=false >&2 || true
+        set +e
+        if [ "$status" -ne 0 ] && [ -n "$planted_ns" ]; then
+          echo "Plant failed (exit $status). State of ${local.ns} before cleanup:" >&2
+          ${local.kubectl} get pods -o wide >&2
+          ${local.kubectl} get events --sort-by=.lastTimestamp >&2
+          echo "Deleting ${local.ns} so the next run starts from a clean namespace." >&2
+          kubectl delete namespace "${local.ns}" --ignore-not-found --wait=false >&2
         fi
         rm -rf "$kubeconfig_dir"
       }
       trap on_exit EXIT
+
+      # A Prow deadline delivers SIGTERM, and bash does not run an EXIT trap
+      # when the shell dies from an untrapped signal -- so without this the
+      # deadline kill leaks the namespace exactly as a failed plant used to.
+      # That is not a remote path here: steps 2 and 3 together can hold this
+      # script for twelve minutes. Converting the signal to an exit is the same
+      # one-liner hack/ci-eval-pr.sh uses at its own trap, for the same reason.
+      trap 'exit 143' TERM INT
 
       KUBECONFIG="$kubeconfig_dir/config"
       export KUBECONFIG
@@ -206,7 +230,6 @@ resource "null_resource" "incident" {
 
       gcloud container clusters get-credentials "${var.host_cluster_name}" \
         --location "${var.host_cluster_location}" --project "$project" --quiet
-      host_kubeconfig_ready=1
 
       # ---- 0b. Clear what an earlier run left behind ------------------------
       # A leftover ${local.ns} does not just sit there, it silently defeats the
@@ -232,10 +255,27 @@ resource "null_resource" "incident" {
       # go (30s grace plus the namespace controller), and short enough that a
       # namespace genuinely wedged on a finalizer fails here, with a message
       # naming the real problem, rather than 300s later as a mystery timeout.
+      # Gated on the label step 1 writes, not on the name alone. This is the
+      # only unconditional namespace delete in the stack and it runs against the
+      # shared cluster the Platform Agent install lives on, so it has to be able
+      # to say the namespace is ours. `incident_namespace` is an input with no
+      # validation block, and the destroy comment below already makes the
+      # argument: deleting a namespace by name is survivable rather than safe.
+      # A namespace of this name that we did not plant is a stop, not a target.
       if kubectl get namespace "${local.ns}" >/dev/null 2>&1; then
+        leftover_owner="$(kubectl get namespace "${local.ns}" \
+          -o jsonpath='{.metadata.labels.managed-by}' 2>/dev/null || true)"
+        if [ "$leftover_owner" != "${local.ci_labels["managed-by"]}" ]; then
+          echo "ERROR: ${local.ns} already exists on ${var.host_cluster_name} but is not labelled managed-by=${local.ci_labels["managed-by"]} (found '$leftover_owner'). This stack did not create it, so it will not delete it. Remove it by hand if it is stale." >&2
+          exit 1
+        fi
         echo "Found a leftover ${local.ns} from an earlier run; deleting it before planting."
-        if ! kubectl delete namespace "${local.ns}" --wait=true --timeout=180s; then
-          echo "ERROR: a leftover ${local.ns} did not delete within 180s, so this run cannot plant a fresh pod and the watcher would dedup against the old one. The namespace is most likely stuck on a finalizer; it follows." >&2
+        # --ignore-not-found because the destroy provisioner deletes with
+        # --wait=false, so a namespace can be mid-deletion when the get above
+        # sees it and gone by the time this runs. Without it that race reports
+        # as the finalizer wedge below, which it is not.
+        if ! kubectl delete namespace "${local.ns}" --ignore-not-found --wait=true --timeout=180s; then
+          echo "ERROR: could not clear the leftover ${local.ns} within 180s, so this run cannot plant a fresh pod and the watcher would dedup against the old one. A namespace wedged on a finalizer is the usual cause; an RBAC or API failure lands here too. Its current state follows." >&2
           kubectl get namespace "${local.ns}" -o yaml >&2 || true
           exit 1
         fi
@@ -246,6 +286,10 @@ resource "null_resource" "incident" {
       started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
       # ---- 1. Plant it ------------------------------------------------------
+      # Set before the create, not after: a create that half-succeeds, or a
+      # label call that fails behind one that did not, still leaves a namespace
+      # this run is responsible for removing.
+      planted_ns=1
       kubectl create namespace "${local.ns}" --dry-run=client -o yaml | kubectl apply -f -
       kubectl label namespace "${local.ns}" --overwrite \
         managed-by="${local.ci_labels["managed-by"]}" \
@@ -376,15 +420,14 @@ resource "null_resource" "incident" {
   # the opposite -- that the tainted path runs this too -- and #1143 is what
   # believing it cost.
   #
-  # It fetches its own credentials for the same reason step 0 does, and the
-  # reason is not this stack's own up(): that one points the ambient kubeconfig
-  # AT the host cluster on purpose, as the header explains. It is the tasks
-  # around this one. The context in hand here is whatever the last
-  # get_cluster_info() selected -- and since that runs only after a successful
-  # up() while _teardown runs from a `finally` either way, the failure path can
-  # arrive with the previous task's per-run cluster still selected. Deleting a
-  # namespace by name on the wrong cluster is the kind of thing
-  # --ignore-not-found makes survivable rather than safe.
+  # It fetches its own credentials for the same reason step 0 does, though not
+  # for step 0's exact case. This stack's own up() does point the ambient
+  # kubeconfig at the host cluster, on purpose and as the header explains -- but
+  # that happens in get_cluster_info(), which runs after up() and can itself
+  # fail. On that path the create-time provisioner succeeded, so the resource is
+  # not tainted and this block does run, with whatever cluster the previous task
+  # left selected. Deleting a namespace by name on the wrong cluster is the kind
+  # of thing --ignore-not-found makes survivable rather than safe.
   provisioner "local-exec" {
     when        = destroy
     on_failure  = continue

--- a/bench/tf/prebuilt/autoops-incident/main.tf
+++ b/bench/tf/prebuilt/autoops-incident/main.tf
@@ -160,7 +160,32 @@ resource "null_resource" "incident" {
       # nothing then cleans up, and prints a WARNING that reads like a failure in
       # a CI log. Handing it a path that does not exist yet skips all three.
       kubeconfig_dir="$(mktemp -d)"
-      trap 'rm -rf "$kubeconfig_dir"' EXIT
+
+      # A plant that fails must not leave ${local.ns} behind, because the
+      # leftover is what breaks the NEXT run -- see step 0b for that mechanism.
+      # The teardown at the bottom of this file cannot be what prevents it:
+      # Terraform taints a resource whose create-time provisioner failed and
+      # skips destroy-time provisioners on a tainted resource, so the destroy
+      # reports "1 destroyed" without running a line of it.
+      #
+      # Every failure path below writes its diagnostics to stderr before
+      # exiting, so this deletes the namespace after the evidence has been
+      # captured rather than instead of it.
+      #
+      # Guarded on step 0 having completed: until KUBECONFIG points at the host
+      # cluster a kubectl here would run against the ambient context, which is a
+      # different cluster entirely (again, step 0).
+      host_kubeconfig_ready=""
+      on_exit() {
+        status=$?
+        if [ "$status" -ne 0 ] && [ -n "$host_kubeconfig_ready" ]; then
+          echo "Plant failed (exit $status). Deleting ${local.ns} so the next run starts from a clean namespace." >&2
+          kubectl delete namespace "${local.ns}" --ignore-not-found --wait=false >&2 || true
+        fi
+        rm -rf "$kubeconfig_dir"
+      }
+      trap on_exit EXIT
+
       KUBECONFIG="$kubeconfig_dir/config"
       export KUBECONFIG
 
@@ -177,6 +202,39 @@ resource "null_resource" "incident" {
 
       gcloud container clusters get-credentials "${var.host_cluster_name}" \
         --location "${var.host_cluster_location}" --project "$project" --quiet
+      host_kubeconfig_ready=1
+
+      # ---- 0b. Clear what an earlier run left behind ------------------------
+      # A leftover ${local.ns} does not just sit there, it silently defeats the
+      # whole scenario, and it does so through the plant appearing to succeed.
+      #
+      # Step 1 is idempotent by construction, so against a namespace that
+      # already holds an identical Deployment `kubectl apply` reports
+      # `unchanged` and creates no new pod. The pod still running is the one
+      # from the earlier run, which means it keeps its UID -- and the watcher's
+      # dedup key is exactly {UID, Reason} (k8s-event-watcher/types.go). Its
+      # window for that pod opened hours ago, so it logs
+      # `dedup BackOff pod=... (window active)` where step 3 is waiting for
+      # `fire`, and step 3 times out. Step 2 does not catch it either: the old
+      # pod's BackOff events are already past the debounce, so the wait returns
+      # `after 0s` and everything looks healthy right up to the timeout.
+      #
+      # Deleting first is what makes the case recover on its own. It is also
+      # the only thing that can: the run that leaked the namespace is over, and
+      # nothing else visits these clusters between runs.
+      #
+      # 180s is well clear of the ~35s a busybox pod with no finalizers takes to
+      # go (30s grace plus the namespace controller), and short enough that a
+      # namespace genuinely wedged on a finalizer fails here, with a message
+      # naming the real problem, rather than 300s later as a mystery timeout.
+      if kubectl get namespace "${local.ns}" >/dev/null 2>&1; then
+        echo "Found a leftover ${local.ns} from an earlier run; deleting it before planting."
+        if ! kubectl delete namespace "${local.ns}" --wait=true --timeout=180s; then
+          echo "ERROR: a leftover ${local.ns} did not delete within 180s, so this run cannot plant a fresh pod and the watcher would dedup against the old one. The namespace is most likely stuck on a finalizer; it follows." >&2
+          kubectl get namespace "${local.ns}" -o yaml >&2 || true
+          exit 1
+        fi
+      fi
 
       # Recorded before anything is planted, so the step-3 log poll cannot match
       # a `fire` line left by an earlier run against this same namespace name.
@@ -270,9 +328,10 @@ resource "null_resource" "incident" {
       # The fire line carries no cluster (k8s-event-watcher/main.go), and the
       # watcher fans in over several, so in principle this matches a pod of
       # that name on any watched cluster. Nothing reaches it today: only this
-      # stack plants ${local.ns}, the destroy removes it, and the task loop is
-      # sequential. A leftover namespace from a failed teardown on another
-      # watched cluster, or the concurrency of #637, would.
+      # stack plants ${local.ns}, step 0b clears any leftover of it on this
+      # cluster and the destroy removes it on the success path, and the task
+      # loop is sequential. A leftover namespace on a DIFFERENT watched cluster,
+      # which step 0b does not reach, or the concurrency of #637, would.
       elapsed=0
       until kubectl logs "deployment/${var.agent_deployment}" \
               -n "${var.agent_namespace}" -c "${var.agent_container}" \
@@ -297,16 +356,25 @@ resource "null_resource" "incident" {
     EOT
   }
 
-  # Namespace-scoped by design, and this is the half that keeps it that way.
-  # The presubmit isolation rule admits a mutating case only if it is read-only
-  # or namespace-scoped, and a scenario that leaves its namespace behind is
-  # neither by the second run.
+  # Namespace-scoped by design, and this is the half that keeps it that way on
+  # the success path. The presubmit isolation rule admits a mutating case only
+  # if it is read-only or namespace-scoped, and a scenario that leaves its
+  # namespace behind is neither by the second run.
   #
-  # It fetches credentials the same way step 0 does, and for a sharper reason: a
-  # create-time provisioner that failed taints the resource, and _teardown runs
-  # `tofu destroy` from a `finally` on that path too, so this can execute with
-  # the ambient context pointed anywhere at all. Deleting a namespace by name on
-  # the wrong cluster is the kind of thing --ignore-not-found makes survivable
+  # It does NOT cover the failure path, which is why the plant above cleans up
+  # after itself. Terraform taints a resource whose create-time provisioner
+  # failed and skips destroy-time provisioners on a tainted resource, so
+  # `teardown: true` reaches a `tofu destroy` that reports "1 destroyed"
+  # without running a line of this. #1122's two smoke runs measured that
+  # destroy at 28ms and 29ms, against a provisioner whose first command is a
+  # ~1s `gcloud get-credentials`. An earlier version of this comment claimed
+  # the opposite -- that the tainted path runs this too -- and #1143 is what
+  # believing it cost.
+  #
+  # It fetches its own credentials for the same reason step 0 does: devops-bench
+  # moves the ambient context off the host cluster after up(), so this can
+  # execute with it pointed anywhere at all. Deleting a namespace by name on the
+  # wrong cluster is the kind of thing --ignore-not-found makes survivable
   # rather than safe.
   provisioner "local-exec" {
     when        = destroy

--- a/tests/test_autoops_incident_plant.py
+++ b/tests/test_autoops_incident_plant.py
@@ -48,6 +48,7 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import time
 import unittest
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -79,15 +80,23 @@ _INTERPOLATIONS = {
     "var.memory_limit_mib": "64",
 }
 
+#: The label step 1 writes, and the value step 0b requires before it will
+#: delete anything.
+_OWNER_LABEL = "kube-agents-bench"
+
 #: `kubectl` records every invocation to $CALLS and answers from the
 #: environment, so a test picks a scenario by setting these. Defaults are the
 #: healthy path: no leftover namespace, debounce already cleared, watcher fires.
+#: `NS_OWNER` uses `${VAR-default}` rather than `${VAR:-default}` so a test can
+#: set it empty to mean "the namespace carries no managed-by label".
 _KUBECTL_STUB = """#!/bin/bash
 echo "kubectl $*" >> "$CALLS"
 case "$*" in
+  *"get namespace"*jsonpath*)   echo "${NS_OWNER-%(owner)s}"; exit 0 ;;
   *"get namespace"*"-o yaml"*)  echo "kind: Namespace"; exit 0 ;;
   *"get namespace"*)            exit "${NS_EXISTS_RC:-1}" ;;
   *"delete namespace"*)         exit "${NS_DELETE_RC:-0}" ;;
+  *"apply -f -"*)               exit "${APPLY_RC:-0}" ;;
   *"get events"*)               echo 7; exit 0 ;;
   *"logs "*)
     if [ "${WATCHER_FIRES:-1}" = "1" ]; then
@@ -96,7 +105,7 @@ case "$*" in
     exit 0 ;;
   *) exit 0 ;;
 esac
-""" % {"ns": _NAMESPACE, "workload": _WORKLOAD}
+""" % {"ns": _NAMESPACE, "workload": _WORKLOAD, "owner": _OWNER_LABEL}
 
 _GCLOUD_STUB = """#!/bin/bash
 echo "gcloud $*" >> "$CALLS"
@@ -108,7 +117,15 @@ exit 0
 """
 
 #: The plant polls on 10-second sleeps and its timeouts are minutes long.
-_SLEEP_STUB = "#!/bin/bash\nexit 0\n"
+#: `STUB_SLEEP` buys back a little real time for the signal test, which needs
+#: the script still running when it sends SIGTERM.
+_SLEEP_STUB = '#!/bin/bash\nexec /bin/sleep "${STUB_SLEEP:-0}"\n'
+
+#: Bounds for the signal test's two waits -- for the plant to reach the watcher
+#: poll, and for it to finish once signalled. Generous, because blowing either
+#: is a hang rather than a red.
+_SIGNAL_TIMEOUT_SECONDS = 60
+_SIGNAL_POLL_SECONDS = 0.05
 
 
 def _render_plant() -> str:
@@ -254,21 +271,90 @@ class AutoopsIncidentPlantTest(unittest.TestCase):
             f"makes every later run fail:\n{chr(10).join(calls)}",
         )
 
-    def test_failed_plant_reports_diagnostics_before_deleting(self):
-        # Cleanup must not destroy the evidence: the failure path dumps the
-        # watcher log to stderr, and that has to happen while the namespace is
-        # still there to be described.
-        completed, calls = self._run(WATCHER_FIRES=0)
-        deletes = self._indices(calls, "delete namespace")
-        diagnostics = self._indices(calls, "logs ")
-        self.assertTrue(deletes)
-        self.assertTrue(diagnostics)
-        self.assertLess(
-            max(diagnostics),
-            deletes[0],
-            "the namespace was deleted before the failure diagnostics ran",
-        )
+    def test_failed_plant_reports_its_own_diagnostics(self):
+        completed, _ = self._run(WATCHER_FIRES=0)
         self.assertIn("k8s-event-watcher logged no 'fire'", completed.stderr)
+
+    def test_a_failure_carrying_no_diagnostics_still_dumps_before_cleanup(self):
+        # Cleanup must not take the evidence with it. Steps 2 and 3 dump before
+        # they exit, so asserting order on those proves nothing -- the delete
+        # lives in an EXIT trap and is last by construction. Step 1 is the real
+        # case: a rejected `apply` exits under `set -e` with no dump of its own,
+        # so the only state anybody gets is whatever the trap writes on the way
+        # out. Anything reaching the namespace here came from the trap.
+        completed, calls = self._run(APPLY_RC=1)
+        self.assertNotEqual(
+            completed.returncode, 0, "a rejected apply should fail the plant"
+        )
+        deletes = self._indices(calls, "delete namespace")
+        dumps = self._indices(calls, "get pods") + self._indices(calls, "get events")
+        self.assertTrue(deletes, f"the namespace leaked:\n{chr(10).join(calls)}")
+        self.assertTrue(
+            dumps,
+            "the plant deleted the namespace without recording any of its "
+            f"state, so a rejected apply leaves nothing to debug:\n"
+            f"{chr(10).join(calls)}",
+        )
+        self.assertLess(
+            max(dumps),
+            deletes[0],
+            "the namespace was deleted before its state was recorded",
+        )
+
+    def test_a_namespace_the_stack_did_not_plant_is_refused_not_deleted(self):
+        # Step 0b is the only unconditional namespace delete in the stack and it
+        # runs against the shared host cluster, so the `managed-by` label step 1
+        # writes is what separates "our leftover" from someone else's namespace.
+        completed, calls = self._run(NS_EXISTS_RC=0, NS_OWNER="")
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertEqual(
+            self._indices(calls, "delete namespace"),
+            [],
+            "the plant deleted a namespace it had not labelled as its own:\n"
+            f"{chr(10).join(calls)}",
+        )
+        self.assertIn("will not delete it", completed.stderr)
+
+    def test_a_deadline_sigterm_still_deletes_the_namespace(self):
+        # Prow enforces its deadline with SIGTERM, and bash does not run an EXIT
+        # trap when the shell dies from an untrapped signal. Steps 2 and 3 can
+        # hold this script for twelve minutes, so without a TERM trap the
+        # deadline kill leaks the namespace exactly as a failed plant used to.
+        env = dict(os.environ)
+        env["PATH"] = f"{self._stub_dir}{os.pathsep}{env['PATH']}"
+        env["CALLS"] = str(self._calls)
+        env["WATCHER_FIRES"] = "0"
+        env["STUB_SLEEP"] = "0.05"
+
+        process = subprocess.Popen(
+            ["bash", str(self._script)],
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            # Signal only once the plant is inside the watcher poll, which is
+            # well past the point the traps are installed.
+            deadline = time.monotonic() + _SIGNAL_TIMEOUT_SECONDS
+            while time.monotonic() < deadline:
+                if self._calls.exists() and "logs " in self._calls.read_text():
+                    break
+                time.sleep(_SIGNAL_POLL_SECONDS)
+            else:
+                self.fail("the plant never reached the watcher poll")
+            process.terminate()
+            process.wait(timeout=_SIGNAL_TIMEOUT_SECONDS)
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=_SIGNAL_TIMEOUT_SECONDS)
+
+        calls = self._calls.read_text().splitlines()
+        self.assertTrue(
+            self._indices(calls, "delete namespace", _NAMESPACE),
+            "SIGTERM ended the plant without running the cleanup, so the "
+            f"namespace leaked:\n{chr(10).join(calls)}",
+        )
 
     def test_no_cleanup_runs_before_the_host_kubeconfig_is_fetched(self):
         # Until step 0 fetches credentials, kubectl would resolve against the
@@ -290,7 +376,7 @@ class AutoopsIncidentPlantTest(unittest.TestCase):
         # and reports that nothing fired.
         completed, _ = self._run(NS_EXISTS_RC=0, NS_DELETE_RC=1)
         self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("did not delete within", completed.stderr)
+        self.assertIn("could not clear the leftover", completed.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_autoops_incident_plant.py
+++ b/tests/test_autoops_incident_plant.py
@@ -1,0 +1,297 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The autoops-incident plant must never leave its namespace behind, and must
+delete a leftover one before planting.
+
+`bench/tf/prebuilt/autoops-incident/main.tf` plants a crash-looping pod and
+waits for `k8s-event-watcher` to open an incident for it. Both halves tested
+here exist because of #1143, where the case failed on every run against three
+leased projects and no agent ever executed:
+
+  1. A failed plant left `eval-autoops-incident` behind. The teardown that
+     should have removed it is a destroy-time provisioner, and Terraform skips
+     those on a resource its create-time provisioner tainted -- so the failure
+     path is exactly the path with no cleanup.
+  2. The leftover namespace then defeated every later run. `kubectl apply` on
+     an unchanged Deployment reports `unchanged` and starts no new pod, so the
+     pod kept its UID; the watcher's dedup key is {UID, Reason}, its window for
+     that pod was long open, and it logged `dedup` where the plant was waiting
+     for `fire`.
+
+Neither shows up as an error. The plant reports a healthy debounce and then
+times out five minutes later, which is why this is pinned behaviourally rather
+than by reading the file: a grep for `delete namespace` would have passed
+against the code that shipped the bug.
+
+The provisioner is shell inside HCL, and no Terraform binary is assumed here,
+so the heredoc is rendered the way Terraform renders it and run against stub
+`kubectl`/`gcloud`/`sleep` on PATH. What is asserted is which commands the
+plant issues and in what order, never a real cluster.
+"""
+
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_MODULE = _REPO_ROOT / "bench" / "tf" / "prebuilt" / "autoops-incident" / "main.tf"
+
+#: The create-time provisioner is the first `command = <<-EOT` block in the
+#: module; the destroy-time one is the second.
+_HEREDOC_RE = re.compile(r"command\s*=\s*<<-EOT\n(.*?)\n\s*EOT\n", re.S)
+_PLANT_BLOCK = 0
+
+#: Stand-ins for the module's interpolations. Only the values the assertions
+#: read back need to be realistic; the rest just have to render.
+_NAMESPACE = "eval-autoops-incident"
+_WORKLOAD = "eval-incident-workload"
+_INTERPOLATIONS = {
+    "local.ns": _NAMESPACE,
+    "local.workload": _WORKLOAD,
+    "local.kubectl": f"kubectl --namespace={_NAMESPACE}",
+    "local.ci_labels[\"managed-by\"]": "kube-agents-bench",
+    "local.ci_labels[\"build-id\"]": "test-build",
+    "local.ci_labels[\"pull-number\"]": "none",
+    "var.project_id": "kube-agents-evals",
+    "var.host_cluster_name": "platform-agent-host",
+    "var.host_cluster_location": "us-central1",
+    "var.agent_deployment": "platform-agent-gateway",
+    "var.agent_namespace": "kubeagents-system",
+    "var.agent_container": "envoy-credential-proxy",
+    "var.allocate_mib": "96",
+    "var.memory_limit_mib": "64",
+}
+
+#: `kubectl` records every invocation to $CALLS and answers from the
+#: environment, so a test picks a scenario by setting these. Defaults are the
+#: healthy path: no leftover namespace, debounce already cleared, watcher fires.
+_KUBECTL_STUB = """#!/bin/bash
+echo "kubectl $*" >> "$CALLS"
+case "$*" in
+  *"get namespace"*"-o yaml"*)  echo "kind: Namespace"; exit 0 ;;
+  *"get namespace"*)            exit "${NS_EXISTS_RC:-1}" ;;
+  *"delete namespace"*)         exit "${NS_DELETE_RC:-0}" ;;
+  *"get events"*)               echo 7; exit 0 ;;
+  *"logs "*)
+    if [ "${WATCHER_FIRES:-1}" = "1" ]; then
+      echo "fire BackOff pod=%(ns)s/%(workload)s-abc123 -> sid=s1 (mode=live)"
+    fi
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+""" % {"ns": _NAMESPACE, "workload": _WORKLOAD}
+
+_GCLOUD_STUB = """#!/bin/bash
+echo "gcloud $*" >> "$CALLS"
+if [ "${GCLOUD_FAILS:-0}" = "1" ]; then
+  echo "gcloud: could not fetch credentials" >&2
+  exit 1
+fi
+exit 0
+"""
+
+#: The plant polls on 10-second sleeps and its timeouts are minutes long.
+_SLEEP_STUB = "#!/bin/bash\nexit 0\n"
+
+
+def _render_plant() -> str:
+    """Render the create-time provisioner the way Terraform would.
+
+    `<<-EOT` strips the indentation common to every line -- which matters, since
+    the nested `<<'MANIFEST'` terminator is only at column 0 afterwards. `$${x}`
+    is Terraform's escape for a literal `${x}` in the output, so it is protected
+    before interpolations are substituted and restored after.
+    """
+    blocks = _HEREDOC_RE.findall(_MODULE.read_text())
+    if not blocks:
+        raise AssertionError(f"no `command = <<-EOT` provisioner in {_MODULE}")
+    body = textwrap.dedent(blocks[_PLANT_BLOCK])
+
+    sentinel = "\x00"
+    body = body.replace("$${", sentinel)
+
+    unresolved = []
+
+    def substitute(match: "re.Match[str]") -> str:
+        expression = match.group(1).strip()
+        if expression not in _INTERPOLATIONS:
+            unresolved.append(expression)
+            return match.group(0)
+        return _INTERPOLATIONS[expression]
+
+    body = re.sub(r"\$\{([^}]*)\}", substitute, body)
+    body = body.replace(sentinel, "${")
+    if unresolved:
+        raise AssertionError(
+            "the plant gained interpolations this test does not know how to "
+            f"render, so add them to _INTERPOLATIONS: {sorted(set(unresolved))}"
+        )
+    return body
+
+
+@unittest.skipUnless(shutil.which("bash"), "no bash on PATH")
+class AutoopsIncidentPlantTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._plant = _render_plant()
+
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        root = pathlib.Path(self._dir.name)
+
+        self._script = root / "plant.sh"
+        self._script.write_text(self._plant)
+
+        stub_dir = root / "bin"
+        stub_dir.mkdir()
+        for name, source in (
+            ("kubectl", _KUBECTL_STUB),
+            ("gcloud", _GCLOUD_STUB),
+            ("sleep", _SLEEP_STUB),
+        ):
+            stub = stub_dir / name
+            stub.write_text(source)
+            stub.chmod(0o755)
+        self._stub_dir = stub_dir
+        self._calls = root / "calls"
+
+    def _run(self, **scenario):
+        env = dict(os.environ)
+        env["PATH"] = f"{self._stub_dir}{os.pathsep}{env['PATH']}"
+        env["CALLS"] = str(self._calls)
+        env.update({k: str(v) for k, v in scenario.items()})
+        completed = subprocess.run(
+            ["bash", str(self._script)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        calls = (
+            self._calls.read_text().splitlines() if self._calls.exists() else []
+        )
+        return completed, calls
+
+    @staticmethod
+    def _indices(calls, *needles):
+        return [
+            i
+            for i, call in enumerate(calls)
+            if all(needle in call for needle in needles)
+        ]
+
+    def test_bash_syntax_is_valid(self):
+        # The provisioner is only ever executed by Terraform on a real run, so
+        # a syntax error in it surfaces as a failed presubmit eval rather than
+        # as a failed test. Cheap to catch here instead.
+        completed = subprocess.run(
+            ["bash", "-n", str(self._script)], capture_output=True, text=True
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+    def test_healthy_run_deletes_nothing(self):
+        completed, calls = self._run()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(
+            self._indices(calls, "delete namespace"),
+            [],
+            "the plant deleted a namespace on a run that succeeded and found "
+            f"nothing left over:\n{chr(10).join(calls)}",
+        )
+
+    def test_leftover_namespace_is_deleted_before_the_workload_is_planted(self):
+        # The self-heal, and the half that recovers a cluster already holding a
+        # leaked namespace. Planting on top of one is what produced #1143's
+        # `unchanged` apply, so the delete has to come first and has to wait.
+        completed, calls = self._run(NS_EXISTS_RC=0)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+        deletes = self._indices(calls, "delete namespace", _NAMESPACE)
+        applies = self._indices(calls, "apply -f -")
+        self.assertTrue(deletes, f"no delete of {_NAMESPACE}:\n{chr(10).join(calls)}")
+        self.assertTrue(applies, f"nothing was planted:\n{chr(10).join(calls)}")
+        self.assertLess(
+            deletes[0],
+            applies[0],
+            "the leftover namespace must be deleted before the plant, or "
+            "`kubectl apply` reports `unchanged` and reuses the old pod",
+        )
+        self.assertIn(
+            "--wait=true",
+            calls[deletes[0]],
+            "the pre-plant delete must wait, or the plant races the namespace "
+            "controller and lands in a Terminating namespace",
+        )
+
+    def test_failed_plant_deletes_the_namespace_it_created(self):
+        # #1143 itself: the watcher never fires, the plant fails, and the
+        # namespace it created must not survive to poison the next run.
+        completed, calls = self._run(WATCHER_FIRES=0)
+        self.assertNotEqual(
+            completed.returncode, 0, "the plant should fail when nothing fires"
+        )
+        self.assertTrue(
+            self._indices(calls, "delete namespace", _NAMESPACE),
+            "a failed plant left its namespace behind, which is the leak that "
+            f"makes every later run fail:\n{chr(10).join(calls)}",
+        )
+
+    def test_failed_plant_reports_diagnostics_before_deleting(self):
+        # Cleanup must not destroy the evidence: the failure path dumps the
+        # watcher log to stderr, and that has to happen while the namespace is
+        # still there to be described.
+        completed, calls = self._run(WATCHER_FIRES=0)
+        deletes = self._indices(calls, "delete namespace")
+        diagnostics = self._indices(calls, "logs ")
+        self.assertTrue(deletes)
+        self.assertTrue(diagnostics)
+        self.assertLess(
+            max(diagnostics),
+            deletes[0],
+            "the namespace was deleted before the failure diagnostics ran",
+        )
+        self.assertIn("k8s-event-watcher logged no 'fire'", completed.stderr)
+
+    def test_no_cleanup_runs_before_the_host_kubeconfig_is_fetched(self):
+        # Until step 0 fetches credentials, kubectl would resolve against the
+        # ambient context -- a different cluster, per the module header. A
+        # cleanup firing there would delete a namespace of the same name on
+        # whatever cluster happened to be selected.
+        completed, calls = self._run(GCLOUD_FAILS=1)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertEqual(
+            [c for c in calls if c.startswith("kubectl")],
+            [],
+            "the plant ran kubectl against the ambient context after failing "
+            f"to fetch the host cluster's credentials:\n{chr(10).join(calls)}",
+        )
+
+    def test_a_wedged_leftover_namespace_fails_with_its_own_message(self):
+        # A namespace stuck on a finalizer cannot be planted over. Failing here
+        # names the real cause; letting it through spends the watcher timeout
+        # and reports that nothing fired.
+        completed, _ = self._run(NS_EXISTS_RC=0, NS_DELETE_RC=1)
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("did not delete within", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`bench/tf/prebuilt/autoops-incident` leaks its namespace whenever the plant fails, and
the leftover namespace then makes every later run fail the same way — so the case has
reported `CHECK_DID_NOT_RUN` (0/0) on every recent smoke run and no agent has executed
against it. The teardown that should remove the namespace is a destroy-time provisioner,
and Terraform skips those on a resource whose create-time provisioner tainted it, which
is exactly the failure path. This adds cleanup on the path that has none: an exit trap
that deletes the namespace the plant created, and a step 0b that clears a leftover one
before planting. The second half is what makes the case recover by itself — no manual
`kubectl delete namespace` on the leased projects is needed once this lands.

## Why This Change

The loop is self-perpetuating, which is why it has not cleared on its own. A create-time
provisioner failure taints the resource, the destroy is skipped, `eval-autoops-incident`
survives. The next run applies an identical Deployment, so `kubectl apply` reports
`unchanged` and starts no new pod. The pod keeps its UID; `k8s-event-watcher` keys dedup
on `{UID, canonicalized reason}` (`EventKey` in `k8s-operator/cmd/k8s-event-watcher/types.go`,
`canonicalizeReason` in `dedup.go`) with a 24h window, so it logs
`dedup BackOff pod=… (window active)` where step 3 is waiting for `fire`. Step 3 times
out, the resource taints, the namespace leaks again.

Nothing in that reads as an error until the timeout. Step 2's debounce wait returns
`after 0s` — the old pod's BackOff events are long past the debounce — so the plant looks
healthy right up to the five-minute failure. That is what makes it present as an agent
failure rather than an install fault.

## What Changed

- `bench/tf/prebuilt/autoops-incident/main.tf` — an EXIT trap in step 0 that dumps pods
  and events and then deletes the namespace when the plant exits non-zero, gated on a
  `planted_ns` flag set immediately before step 1 creates it; `trap 'exit 143' TERM INT`
  so a Prow deadline's SIGTERM reaches that trap; and a step 0b that deletes a leftover
  `eval-autoops-incident` before planting, but only one carrying the `managed-by` label
  step 1 writes.
- `tests/test_autoops_incident_plant.py` — new. There is no Terraform binary in the
  presubmit's Python job, so this renders the provisioner heredoc the way Terraform
  renders it and runs it against stub `kubectl`/`gcloud`/`sleep` on `PATH`, asserting
  which commands the plant issues and in what order. Behavioural rather than a grep,
  because a grep for `delete namespace` passes against the code that shipped the bug.
- `bench/tasks/autoops-warning-event-triage/task.yaml` — the isolation-class comment
  named the destroy as the only cleanup; it now names the exit trap too.

The step 0b delete is the only unconditional namespace delete in the stack and it runs
against the shared cluster the Platform Agent install lives on, so it refuses a namespace
of that name it cannot prove this stack planted. `incident_namespace` is an input with no
validation block.

## Context

Closes #1143.

#1103 (Fuxiao-Gao, draft) adds `bench/tf/prebuilt/autoops-crashloop-incident/main.tf`, a
copy of this module carrying the same destroy-provisioner-plus-idempotent-plant pattern,
so it will inherit this bug. Their branch, so untouched here; worth a note on that PR.
Their edits to this file are in the header and TASKS comments, which do not overlap these
hunks.

#1144 is the other cause of the same red smoke runs and is unrelated to this one.

## Testing

- `python3 -m unittest tests.test_autoops_incident_plant` — 10 tests, green.
- Mutation-checked, since a test over a stubbed shell script is easy to write vacuously.
  Dropping the TERM/INT trap, the step 0b ownership check, the trap's diagnostics dump, or
  step 0b entirely each reds a distinct case (1, 1, 1, and 3 failures respectively); the
  restored file is green. The adversarial pass separately confirmed non-vacuity by
  reverting `main.tf` to `origin/main`.
- Full `tests/` directory: 824 tests, 4 pre-existing failures in
  `tests/test_install_script.py` (`ImportGithubPemKmsKeyTest`), confirmed present on a
  stashed working tree. `admin_console/tests/` fails on this workstation for missing
  `plotly`/`streamlit`/`websockets`.
- `make bench-case-check` (31 cases OK), `make docs-check`, `prettier@3.9.6 --check` on
  the changed YAML.
- No `terraform fmt`/`validate` — no Terraform binary on this workstation. Substituted
  the rendered-heredoc `bash -n` check that runs as the first test case.

### Live validation

Not live-tested against a running installation. The change is a Terraform provisioner in
the eval harness's plant stack; exercising it needs a GKE cluster with the Platform Agent
install on it plus a `k8s-event-watcher`, and the Prow-leased projects are not reachable
from this workstation (the eval buckets 403 anonymously and this session has no cluster
credentials).

What was substituted: the provisioner script was rendered exactly as Terraform renders
the `<<-EOT` heredoc and executed end to end under stub `kubectl`, `gcloud`, and `sleep`,
across eight scenarios — no leftover, leftover present, unlabelled leftover, leftover
wedged on a delete failure, `apply` rejected, credentials fetch fails, watcher never
fires, and SIGTERM mid-poll. The command sequence and its ordering were asserted in each,
not just the exit code. That exercises the shell
logic; it cannot exercise Terraform's taint behaviour or the watcher's dedup window,
which is what a real run would add.

Falsifiable prediction for this PR's own smoke run, which is the nearest real exercise:
`eval-autoops-incident` is currently leaked on the leased projects, so the plant should
log `Found a leftover eval-autoops-incident from an earlier run; deleting it before
planting` and the case should then get past `CHECK_DID_NOT_RUN`. If it does not, this fix
is wrong about the cause. No test artifacts were created anywhere real, so there is
nothing to clean up.

## Self-Review

Both required passes ran in subagents spawned by `/pr-preflight`, each handed the diff
range and nothing else — neither held the reasoning behind the change.

Adversarial pass, looking for: cleanup that runs on the wrong cluster, cleanup that
deletes something it should not, failure paths the trap misses, and tests that pass
against the buggy code.

- **The EXIT trap does not fire on SIGTERM** (HIGH) — fixed in 2b9a522e. Prow enforces its
  deadline with SIGTERM and bash skips an EXIT trap when the shell dies from an untrapped
  signal, so the deadline kill leaked the namespace exactly as before, and steps 2 and 3
  can hold the script for twelve minutes. `trap 'exit 143' TERM INT`, the same one-liner
  `hack/ci-eval-pr.sh` uses.
- **Step 0b deleted any namespace of that name without checking this stack planted it** —
  fixed in 2b9a522e. It now requires the `managed-by` label and stops otherwise. Writing
  the test for this surfaced a second defect the pass had not named: the refusal's own
  `exit 1` fell through to the EXIT trap, which deleted the namespace anyway. The trap is
  now gated on `planted_ns`, set immediately before step 1 creates the namespace, so it
  only ever removes what this run made.
- **`test_failed_plant_reports_diagnostics_before_deleting` could not fail** — fixed in
  2b9a522e. The delete lives in an EXIT trap, so it is last by construction and the
  ordering assertion held for any implementation, including one dumping nothing. Replaced
  with a rejected-`apply` scenario where the trap is the only possible source of
  diagnostics.
- The trap's `kubectl delete` had `|| true` while `set +e` was already in force — removed
  as redundant. The `set +e` itself stays and is load-bearing for the reason
  `hack/ci-eval-pr.sh` gives at its own trap.

Docs-drift pass, looking for: prose that the diff makes false, and comments claiming more
than the code does.

- **Blocking: the destroy-provisioner comment I wrote said devops-bench moves the ambient
  context off the host cluster after this stack's `up()`** — fixed in 164d9a8b. The file's
  own header says the opposite deliberately: this stack outputs the host cluster, so
  `get_cluster_info()` points the ambient kubeconfig at it. Verified against
  `evalharness/default.py` and rewrote the rationale around the case that is actually
  reachable — `up()` succeeded but `get_cluster_info()` failed, so the resource is not
  tainted, this block runs, and the previous task's cluster is still selected.
- The earlier version of that comment asserted the destroy covers the failure path. It
  does not, and the comment now says so and records that believing it is what #1143 cost,
  with the 28ms/29ms `Destroy complete` timings that show the provisioner never ran.

Not fixed, deliberately: the destroy provisioner has no TERM trap of its own. It leaks a
`mktemp -d` directory on a signal, not a namespace, and it runs in seconds — expanding
the change to cover it buys nothing this PR is about.

Not covered by either pass: neither can reach a cluster, so the taint behaviour the whole
fix is premised on remains inferred from the `Destroy complete` timings in #1122's logs
rather than observed.

Generated with the help of Claude (Opus 5).

## Risk & Rollout

Scoped to one eval task's plant stack; nothing here ships in an agent image or runs in a
user's cluster. The new failure mode is step 0b refusing to plant when a namespace named
`eval-autoops-incident` exists on the host cluster without the `managed-by` label — that
turns a silent 0/0 into a loud red naming the namespace, which is the intended trade. The
other new delete only touches a namespace this run created. Revert is the two commits;
the case goes back to leaking and no other case is affected.
