### PR TITLE
fix(bench): grade a deployer death before any agent ran as infrastructure, not a scoring crash

### DIFF
--- a/bench/kube_agents_bench/scoring.py
+++ b/bench/kube_agents_bench/scoring.py
@@ -145,6 +145,34 @@ DEFAULT_JUDGED_MARGIN = 0.5
 #: duplication cannot drift silently.
 INFRA_FAILURE_MARKER = "KUBE_AGENTS_INFRA_FAILURE"
 
+#: Field values from devops-bench's ``_build_failed_record``: ``status`` is
+#: ``"failed"`` on every failed record, and ``verification_status`` is
+#: ``"not_evaluated"`` when verification did not run -- which has TWO
+#: producers, not one. The exception path writes it when the deployer never
+#: came up, and also when infrastructure WAS up but its own verification
+#: retry crashed while building the failed record. That second producer, and
+#: the fact that a failed record always carries an empty trajectory (the
+#: builder overlays ``_empty_record`` and never copies the agent's trajectory,
+#: even when an agent ran), are why these values narrow the provisioning-death
+#: shape but cannot identify it: ``classify_rep`` also requires the error
+#: signature below. Duplicated rather than imported for the same reason as
+#: the marker above: the scorer reads records as plain JSON and must not
+#: import ``devops_bench``.
+FAILED_RECORD_STATUS = "failed"
+VERIFICATION_NEVER_RAN = "not_evaluated"
+
+#: How devops-bench's ``SubprocessError`` renders a command that exited
+#: non-zero (``devops_bench/core/errors.py``): this prefix, one ``": "``, then
+#: the command line itself, with any stderr on later lines. ``classify_rep``
+#: accepts a scoreless failed record as a provisioning death only when the
+#: command after the prefix is the task's own deployer -- the registry key and
+#: the binary agree for every deployer devops-bench ships (``"tofu"`` shells
+#: ``tofu``), and nothing downstream of ``deployer.up()`` shells that binary,
+#: so an agent-step or verifier crash cannot produce the signature. A crash
+#: whose error does not match stays a blocking rung-2 record, which is the
+#: fail-closed side of the trade.
+PROVISION_FAILURE_PREFIX = "command failed with exit code "
+
 
 class Rung(IntEnum):
     """The verdict ladder, evaluated in order, stopping at the first match.
@@ -191,8 +219,13 @@ class RunRecord:
     #: but evaluated zero tasks, which is the resource-preparation signature.
     empty_record: bool
     #: False when the record exists but carries no ``scores`` map at all --
-    #: the scoring pass crashed.
+    #: the scoring pass crashed, unless the record is the provision-failure
+    #: shape, which never had a run to score. See ``classify_rep``.
     has_scores: bool
+    #: ``verification_status`` as devops-bench wrote it -- ``"evaluated"``,
+    #: ``"not_evaluated"`` or ``"skipped_no_infra"`` -- and None on a record
+    #: that predates the field.
+    verification_status: str | None
     setup_id: str | None
     scoring_version: str | None
     agent_model: str | None
@@ -295,6 +328,7 @@ def load_run(run_dir: str | Path) -> RunRecord | None:
             error=rec.get("error") or (rec.get("errors") or None),
             empty_record=empty,
             has_scores=bool(scores),
+            verification_status=_as_str(rec.get("verification_status")),
             setup_id=_as_str(manifest.get("setupId")),
             scoring_version=_as_str(row.get("scoringVersion")),
             agent_model=_as_str(manifest.get("model")),
@@ -416,6 +450,32 @@ def _failed_checks(record: RunRecord) -> list[str]:
     return out
 
 
+def _provision_death(error: Any, deployer: str) -> str | None:
+    """The first line of ``error`` when it is the deployer's own command
+    failing, else None.
+
+    Matches ``SubprocessError``'s rendering -- ``PROVISION_FAILURE_PREFIX``,
+    one ``": "``, then the command line -- and only when the command is the
+    task's deployer (``tofu`` or ``tofu apply ...``, never ``gcloud ...``).
+    ``error`` may be the ``errors`` list rather than the scalar: ``load_run``
+    falls back to it when the scalar is empty, and the first entry is the
+    same text ``_build_failed_record`` writes to both.
+    """
+    if isinstance(error, (list, tuple)):
+        error = error[0] if error else None
+    if error is None:
+        return None
+    first_line = str(error).splitlines()[0] if str(error) else ""
+    if not first_line.startswith(PROVISION_FAILURE_PREFIX):
+        return None
+    _, sep, command = first_line.partition(": ")
+    if not sep:
+        return None
+    if command == deployer or command.startswith(deployer + " "):
+        return first_line
+    return None
+
+
 def classify_rep(
     spec: CaseSpec,
     run_dir: str | Path | None,
@@ -425,10 +485,12 @@ def classify_rep(
 ) -> RepResult:
     """Grade one repetition against rungs 1-3, then the correctness floor.
 
-    Preserves the presubmit's existing three-way run classification exactly:
-    a missing or empty record is INFRA on a task with infrastructure and a
-    blocking failure on a ``noop`` task, and a record with no ``scores`` map
-    blocks either way.
+    Preserves the presubmit's existing three-way run classification: a missing
+    or empty record is INFRA on a task with infrastructure and a blocking
+    failure on a ``noop`` task. A record with no ``scores`` map blocks -- the
+    scoring pass crashed -- unless it is devops-bench's provision-failure
+    shape on a task with infrastructure, which is INFRA for the same reason
+    the missing record is: the deployer died before there was a run to score.
     """
     record = load_run(run_dir) if run_dir is not None else None
     where = None if run_dir is None or str(run_dir) == MISSING else str(run_dir)
@@ -485,6 +547,47 @@ def classify_rep(
             "the harness exhausted its retries without reaching the agent "
             f"({INFRA_FAILURE_MARKER}): the record is scored, but there is no "
             "answer in it to grade",
+        )
+
+    # The provisioning-death shape: ``deployer.up()`` raised before any agent
+    # was launched, and devops-bench's ``_build_failed_record`` wrote the
+    # exception text with an empty trajectory, an empty scores map, and
+    # ``verification_status="not_evaluated"``. No scoring pass crashed here;
+    # none was ever reached, because there was no run to score. On a task
+    # with infrastructure that is resource preparation, not the pull request
+    # -- the reading the missing-record branch above already gives to a
+    # *weaker* signal, since this record states what died rather than leaving
+    # it inferred.
+    #
+    # The field guards narrow the shape but cannot finish the identification,
+    # because both have a second producer (see the constants): a failed record
+    # carries an empty trajectory even when an agent ran, and
+    # "not_evaluated" is also written when the exception path's own
+    # verification retry crashes after a live provision. Grading THAT record
+    # as weather would silence rung 2 on a deterministically broken check
+    # runner for as long as it stayed broken. What finishes it is the error
+    # itself: the run died in the task's own deployer command, a signature
+    # nothing downstream of a live provision can produce. Anything else --
+    # a verifier crash, a factory typo in the task file, a credentials fetch
+    # -- fails closed and blocks below, exactly as before this branch.
+    #
+    # Same noop carve-out as the missing record: a task that provisions
+    # nothing has no provisioning to fail, so on ``noop`` this shape falls
+    # through and blocks below.
+    died_on = _provision_death(record.error, spec.deployer)
+    if (
+        has_infra
+        and not record.has_scores
+        and record.status == FAILED_RECORD_STATUS
+        and record.verification_status == VERIFICATION_NEVER_RAN
+        and not record.trajectory
+        and died_on is not None
+    ):
+        return rep(
+            "infra",
+            f"the run died provisioning, before any agent ran ({died_on}); "
+            f"deployer={spec.deployer} had infrastructure to fail on, so this "
+            "is resource preparation, not the pull request",
         )
 
     if not record.has_scores:

--- a/bench/tests/test_harness.py
+++ b/bench/tests/test_harness.py
@@ -1537,7 +1537,13 @@ def test_an_agent_error_without_the_marker_is_still_graded(results_json: Any) ->
 
 
 def test_a_scoreless_record_still_blocks(results_json: Any) -> None:
-    """The blocking branch must survive the marker check being inserted above it."""
+    """The blocking branch must survive the checks inserted above it.
+
+    Not the provisioning-death shape: this record has no ``status="failed"``,
+    no ``verification_status``, and no error naming the deployer's command,
+    so even on an infra deployer it blocks. ``test_scoring.py``'s
+    ``fail_the_provision`` tests own the carve-out.
+    """
     path = results_json(AgentResult(output="", trajectory=[]), scores={})
 
     rep = _classify(path, "opentofu")

--- a/bench/tests/test_scoring.py
+++ b/bench/tests/test_scoring.py
@@ -168,6 +168,34 @@ def fail_the_status(rec):
     rec["error"] = "the harness raised before the agent replied"
 
 
+def fail_the_provision(rec):
+    """devops-bench's provision-failure record, field for field.
+
+    Captured from `results_autoops-warning-event-triage_rep1.json` of prow
+    build 2094723554879737856 (PR #1090): `TFDeployer.up()` raised
+    `SubprocessError`, and `_build_failed_record` wrote the exception text
+    with `status="failed"`, `verification_status="not_evaluated"`, an empty
+    trajectory and an empty scores map. No agent ran and no scoring pass ran.
+    """
+    rec["status"] = "failed"
+    error = (
+        "command failed with exit code 1: tofu apply -auto-approve"
+        " -input=false -var incident_namespace=eval-autoops-incident"
+        "\nstderr: Error: local-exec provisioner error"
+    )
+    rec["error"] = error
+    rec["errors"] = [error]
+    rec["output"] = ""
+    rec["scores"] = {}
+    rec["tools"] = []
+    rec["trajectory"] = []
+    rec["tokens"] = {}
+    rec["latency"] = 0.0
+    rec["validated"] = False
+    rec["verification_report"] = []
+    rec["verification_status"] = "not_evaluated"
+
+
 def drop_the_scores_map(rec):
     rec.pop("scores", None)
 
@@ -622,6 +650,141 @@ def test_the_transport_marker_has_no_noop_carve_out(noop_spec, make_run):
     verdict = grade_case(noop_spec, [run], admitted=True)
     assert verdict.rung is Rung.INFRA
     assert verdict.blocking is False
+
+
+def test_a_provision_failure_is_infrastructure_not_a_scoring_crash(tofu_spec, make_run):
+    """The autoops-warning-event-triage presubmit crash of 2026-09-01/02.
+
+    `tofu apply` failed before any agent ran, devops-bench wrote its
+    provision-failure record (see `fail_the_provision`), and the ladder read
+    the empty scores map as "the scoring pass crashed" -- rung 2, blocking,
+    admission-blind -- for an OpenTofu failure that says nothing about the
+    pull request. The record states what died and it was not the scorer.
+    """
+    run = make_run(mutate=fail_the_provision)
+    verdict = grade_case(tofu_spec, [run, run, run], admitted=True)
+    assert verdict.rung is Rung.INFRA
+    assert verdict.blocking is False
+    assert verdict.reps[0].outcome == "infra"
+    # The verdict names the command that failed, not a scorer that did not run.
+    assert "tofu apply" in verdict.reps[0].reason
+    assert "no scores map" not in verdict.reps[0].reason
+    # ...and only the first line of it: the stderr tail stays in the record.
+    assert "local-exec" not in verdict.reps[0].reason
+
+
+def test_a_provision_failure_beside_a_scored_repetition_does_not_gate(tofu_spec, make_run):
+    """One repetition died in `tofu apply`; the others ran and passed."""
+    verdict = grade_case(
+        tofu_spec,
+        [make_run(mutate=fail_the_provision), make_run(), make_run()],
+        admitted=True,
+    )
+    assert verdict.rung is not Rung.CHECK_DID_NOT_RUN
+    assert verdict.blocking is False
+    assert verdict.passes == 2
+    assert len(verdict.scored_reps) == 2
+
+
+def test_a_provision_shaped_record_still_blocks_on_a_noop_task(noop_spec, make_run):
+    """A noop task has no provisioning to fail: the shape must be a crash.
+
+    Same carve-out as the missing record. devops-bench's exception path can
+    write `verification_status="not_evaluated"` for a crash before the agent
+    on any deployer, and on a task that provisions nothing that crash is the
+    harness, not infrastructure.
+    """
+    verdict = grade_case(noop_spec, [make_run(mutate=fail_the_provision)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+    assert verdict.blocking is True
+
+
+def test_a_verifier_crash_after_the_agent_ran_still_blocks(tofu_spec, make_run):
+    """devops-bench's OTHER `not_evaluated` producer must stay rung 2.
+
+    A failed record never carries a trajectory -- `_build_failed_record`
+    drops it even when an agent ran -- and `verification_status` is also
+    "not_evaluated" when the exception path's own verification retry crashed
+    after a live provision. So the field shape of that record is identical
+    to a provisioning death, and only the error text tells them apart: this
+    one names the crash, not the deployer's command. Grading it infra would
+    silence rung 2 on a deterministically broken check runner for as long as
+    it stayed broken.
+    """
+    def verifier_crashed(rec):
+        fail_the_provision(rec)
+        error = "verification crashed: KeyError: 'resource_property'"
+        rec["error"] = error
+        rec["errors"] = [error]
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=verifier_crashed)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+    assert verdict.blocking is True
+    assert "no scores map" in verdict.reason
+
+
+def test_a_command_failure_outside_the_deployer_still_blocks(tofu_spec, make_run):
+    """Only the deployer's own binary is the provisioning signature.
+
+    A `SubprocessError` from anything else -- here the credentials fetch --
+    has the same prefix but a different command, and fails closed.
+    """
+    def gcloud_died(rec):
+        fail_the_provision(rec)
+        error = "command failed with exit code 1: gcloud container clusters get-credentials host"
+        rec["error"] = error
+        rec["errors"] = [error]
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=gcloud_died)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+    assert verdict.blocking is True
+
+
+def test_a_provision_shape_with_no_error_still_blocks(tofu_spec, make_run):
+    """A scoreless failed record that names nothing gets no infra excuse."""
+    def errorless(rec):
+        fail_the_provision(rec)
+        rec["error"] = None
+        rec["errors"] = []
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=errorless)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+
+
+def test_a_record_predating_verification_status_still_blocks(tofu_spec, make_run):
+    """A record without the field cannot claim the shape."""
+    def legacy(rec):
+        fail_the_provision(rec)
+        del rec["verification_status"]
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=legacy)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+
+
+def test_the_errors_list_fallback_reaches_the_provision_branch(tofu_spec, make_run):
+    """`load_run` falls back to the `errors` list when the scalar is empty.
+
+    `_build_failed_record` writes the same text to both, so the fallback must
+    grade the same as the scalar.
+    """
+    def scalar_lost(rec):
+        fail_the_provision(rec)
+        rec["error"] = ""
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=scalar_lost)], admitted=True)
+    assert verdict.rung is Rung.INFRA
+    assert "tofu apply" in verdict.reps[0].reason
+
+
+def test_a_scoreless_record_whose_verification_ran_still_blocks(tofu_spec, make_run):
+    """`verification_status="evaluated"` means infra was up: not the shape."""
+    def verified_but_unscored(rec):
+        fail_the_provision(rec)
+        rec["verification_status"] = "evaluated"
+
+    verdict = grade_case(tofu_spec, [make_run(mutate=verified_but_unscored)], admitted=True)
+    assert verdict.rung is Rung.CHECK_DID_NOT_RUN
+    assert verdict.blocking is True
 
 
 def test_an_ordinary_error_is_still_graded(noop_spec, make_run):

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -1246,9 +1246,11 @@ print(m.group(1).strip('\'\"') if m else '')
 # graded failure, demote it here and reference its issue. Demotion is a
 # one-line same-day edit to this list -- this file, not the Prow config,
 # is deliberately the fast lever. It is the lever for rung-4 reds ONLY: a
-# rung-1-3 red (mutation, erroring verifier, empty record) does not stop
-# when its case leaves this list, because those classes signal a broken
-# case or install, not flake, and the fix is on that side.
+# rung-1-3 red (mutation, erroring verifier, an empty record on a task
+# that provisions nothing -- a record whose deployer died before any
+# agent ran grades INFRA and reds nobody) does not stop when its case
+# leaves this list, because those classes signal a broken case or
+# install, not flake, and the fix is on that side.
 #
 # agent-kanban-smoke earned its seat back after the 08-27 redesign (a real
 # SRE question graded on kanban_create plus cluster names); the reds that


### PR DESCRIPTION
## Summary

`autoops-warning-event-triage` has been redding every recent smoke run with the rung-2 verdict "results.json carries a record with no scores map: the run or its scoring pass crashed". No scoring pass crashed in any of those runs: the case's `tofu apply` died (its 300s wait for a k8s-event-watcher `fire` line timed out), devops-bench wrote its documented provision-failure record — `status="failed"`, the `SubprocessError` text on `error`, empty trajectory, empty scores map, `verification_status="not_evaluated"` — and `classify_rep` read the empty scores map as a crashed scorer. Rung 2 is blocking and admission-blind, so an OpenTofu provisioning death reds the suite for every open pull request. This PR teaches the ladder to grade that exact record shape as INFRA on a task with infrastructure, the same reading the missing-record branch already gives to a weaker signal, while keeping every other scoreless record blocking.

## Why This Change

The crash message is currently the repo-wide blocker for a green smoke, and it points at the wrong component. Evidence, from the prow artifacts:

- [PR #1090 build 2094723554879737856](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1090/pull-kube-agents-smoke-test/2094723554879737856) — all 3 reps blocked, `results_autoops-warning-event-triage_rep1.json` carries `"error": "command failed with exit code 1: tofu apply -auto-approve ... -var project_id=kube-agents-evals-8"`, `"scores": {}`, `"verification_status": "not_evaluated"`, empty trajectory.
- [PR #1089 build 2094820631685107712](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1089/pull-kube-agents-smoke-test/2094820631685107712) and [PR #1142 build 2094994686782476288](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1142/pull-kube-agents-smoke-test/2094994686782476288) — same record shape; in the latter, reps 1 and 3 passed and rep 2 alone died in `tofu apply`, and the single provisioning death still redded the case at rung 2.

The suspicion that #1122's check rename caused this does not survive the timeline: the crash appears on main checkouts `d509d97` (Sep 1 09:46Z), `22ae6be` (16:12Z) and `cd938d0` (20:54Z), all of which predate #1122's merge (`56997dc`, Sep 2 02:02Z), and PR #1141's smoke went green on a checkout (`0ed57ee`) that contains #1122. The provisioning deaths themselves are an environment problem — the watcher's fire is being withheld (its own log shows `quota-suppressed BackOff pod=eval-autoops-incident/... — daemon dropped the alert`, i.e. the `ALERT_DAILY_LIMIT_WARNING` ceiling); that is tracked in #1101 and is not this PR. What this PR fixes is the gate misattributing that infrastructure failure to the scoring pass and blocking on it. Without it, any single `tofu apply` death in any tofu-deployer case reds the suite, admitted or not, and gating (oss-test-infra#2677) cannot flip.

## What Changed

- `bench/kube_agents_bench/scoring.py` — `classify_rep` gains a provisioning-death branch between the transport-marker check and the no-scores-map block. The field shape alone cannot carry the decision: devops-bench's `_build_failed_record` drops the trajectory even when an agent ran, and its exception path also writes `"not_evaluated"` when its own verification retry crashes after a live provision. So the branch additionally requires the error to be the task's own deployer command failing (`command failed with exit code N: tofu ...`) — a signature nothing downstream of a live provision can produce, since only `deployer.up()` shells that binary. Everything else fails closed and still blocks: a verifier crash after the agent ran, a command failure in any other binary (e.g. the `gcloud` credentials fetch), a record with no error, a record predating `verification_status`, and the whole shape on a `noop` task, which has no provisioning to blame. `RunRecord` now reads `verification_status`; the two devops-bench field values and the `SubprocessError` prefix are named module constants with the contract documented beside them.
- `bench/tests/test_scoring.py` — `fail_the_provision` reproduces the captured CI record field for field, plus nine tests: the infra reading and its verdict text, mixed provision-death/scored reps, and one fail-closed test per guard.
- `bench/tests/test_harness.py`, `hack/ci-eval-pr.sh` — two comments whose "a scoreless/empty record always blocks" phrasing this change made stale.

## Context

- #1101 (autoops tracking issue) — carries the full RCA of why the plant times out, posted alongside this PR.
- Exonerates #1122; #1146 fixed a different, real mechanism in the same plant (leftover namespace defeating watcher dedup) and its 0b/exit-trap machinery is untouched here.
- Blocks: making `pull-kube-agents-smoke-test` merge-blocking (kubernetes/oss-test-infra#2677) needs main to be able to produce a green smoke.

## Testing

- `bench/tests` full suite: 627 passed (was 623; 4 net-new of 9 added tests replace none).
- Red-then-green: the new tests were written first and fail on main with exactly the production misgrade (`CHECK_DID_NOT_RUN` where `INFRA` is asserted).
- Replayed the real failing artifact through the fixed ladder — `results_autoops-warning-event-triage_rep1.json` from PR #1090 build 2094723554879737856, unmodified, against the real `tasks/autoops-warning-event-triage/task.yaml` spec:

  ```
  before: outcome=blocked rung=CHECK_DID_NOT_RUN
          reason=results.json carries a record with no scores map: the run or its scoring pass crashed
  after:  outcome=infra rung=None
          reason=the run died provisioning, before any agent ran (command failed with exit code 1:
          tofu apply -auto-approve -input=false -var incident_namespace=eval-autoops-incident ...);
          deployer=tofu had infrastructure to fail on, so this is resource preparation, not the pull request
  case (3 provision-death reps): rung=INFRA blocking=False
  ```

### Live validation

Not live-tested against a running kube-agents installation: this change is presubmit gate code (`bench/kube_agents_bench/scoring.py`), which no install executes — its only runtime is the Prow job, and its input contract is `results.json`. The mechanism was proven against that contract directly: the unmodified failing record downloaded from the prow artifacts of build 2094723554879737856 grades blocked-rung-2 on main and INFRA with this change (transcript above), and the fail-closed shapes (verifier crash, non-deployer command, no error, legacy record, noop task) all still block. The next smoke run on this PR is itself the live exercise of the changed path.

## Self-Review

Both required passes ran in fresh subagent contexts handed the diff range and the pinned devops-bench checkout, not this session's reasoning.

- **Adversarial pass (subagent):** found one blocker in the first cut — the branch originally relied on `verification_status="not_evaluated"` meaning "infra never came up" and on an empty trajectory meaning "no agent ran", and neither holds upstream: `_build_failed_record` drops the trajectory unconditionally, and `"not_evaluated"` is also written when the exception path's verification retry crashes after the agent ran, so a deterministically broken check runner would have become permanent non-blocking weather. **Fixed** by requiring the deployer-command error signature; the bypass shape it constructed is now the test `test_a_verifier_crash_after_the_agent_ran_still_blocks`. Its should-fix (comments asserting the false contract) and both unpinned guards (`error=None`, missing `verification_status`) are **fixed** with corrected prose and one test each; its nit (`errors`-list fallback rendering a Python repr) is **fixed** in `_provision_death` and pinned. It verified branch ordering, the noop carve-out, and magic-constant compliance clean.
- **Docs-drift pass (subagent):** grepped the ladder vocabulary repo-wide; found two passages this change makes stale (`test_a_scoreless_record_still_blocks`'s blanket docstring, and `hack/ci-eval-pr.sh`'s "empty record" rung-1-3 exemplar) — both **fixed** in this diff. It also flagged two pre-existing imprecisions this change widens but did not create (`docs/designs/eval-scorer.md:164` "`infra` (no record came back at all)" and `docs/designs/testing-strategy.md:140`'s infra parenthetical), **deliberately not fixed here**: both were already wrong for the transport-marker infra case (#959/#1095) before this change, and correcting design-doc ladder prose is its own reviewable change rather than a rider on a gate fix; noted in #1101 so it is not lost.

## Risk & Rollout

Blast radius is one branch in `classify_rep`, reachable only by a record that is simultaneously scoreless, `status="failed"`, `verification_status="not_evaluated"`, trajectory-free, and carrying its own deployer's `SubprocessError` text — devops-bench's provisioning-death shape and nothing else observed in any captured artifact. The new failure mode to weigh is a real pull request that breaks `tofu apply` itself: its smoke now reports INFRA instead of redding, which is the same standing trade the gate already makes for a missing record on a tofu task, and `grade_suite` still reds when every case dies on infrastructure. Revert is a clean single-commit revert with no data or config migration; nothing has to happen at merge time.
