### PR TITLE
ci: turn off the Warning-alert daily cap on eval installs

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -8,6 +8,22 @@
 
 set -euo pipefail
 
+# The session daemon caps Warning alerts at 5 per UTC day, fleet-wide per
+# install (ALERT_DAILY_LIMIT_WARNING, #641). That cap is alert-storm
+# protection for a human-watched channel; an eval install's whole job is
+# generating alerts. Every smoke build that leases a pool project that day
+# spends the same shared budget on its own crash-loop scenarios, and once it
+# is gone the daemon quota-suppresses the very alert
+# autoops-warning-event-triage waits 300s for, timing out the plant (#1101).
+# 0 is the documented off-switch — `_alert_daily_limit` in
+# agents/platform/scripts/session_kv_server.py parses it as "cap off" and
+# `_claim_alert_quota` lets `limit <= 0` through uncapped — and setting it
+# here, on the deploy, leaves the production
+# default untouched. tests/test_ci_deploy_alert_quota.py pins the whole
+# chain: this flag, the chart rendering it onto the CR, and the operator's
+# env allowlist letting it through to the container.
+readonly EVAL_ALERT_DAILY_LIMIT_WARNING="0"
+
 # ─── 1. Validation & Pre-checks ───────────────────────────────────────────────
 if [ -z "${GEMINI_API_KEY:-}" ]; then
   echo "ERROR: GEMINI_API_KEY environment variable is required"
@@ -298,6 +314,8 @@ helm upgrade --install kube-agents ./charts/kube-agents \
   --set-string "litellm.modelProvider=${MODEL_PROVIDER}" \
   --set-string "litellm.modelDefaultName=${MODEL_DEFAULT_NAME}" \
   --set "platformAgent.deployment.availability.runtimeClassName=" \
+  --set-string "platformAgent.deployment.env[0].name=ALERT_DAILY_LIMIT_WARNING" \
+  --set-string "platformAgent.deployment.env[0].value=${EVAL_ALERT_DAILY_LIMIT_WARNING}" \
   --wait --timeout 15m
 echo "✓ Chart deployment finished in $((SECONDS - STEP_START))s"
 

--- a/tests/test_ci_deploy_alert_quota.py
+++ b/tests/test_ci_deploy_alert_quota.py
@@ -1,0 +1,107 @@
+"""The smoke pipeline's Helm release turns the Warning-alert daily cap off.
+
+`session_kv_server.py` caps Warning alerts at 5 per UTC day, fleet-wide per
+install (`ALERT_DAILY_LIMIT_WARNING`, #641). On an eval install that cap
+suppresses the alerts the bench scenarios exist to generate: every smoke build
+leasing the same pool project that day spends the shared budget, and once it
+is gone the `autoops-warning-event-triage` plant waits 300s for an alert the
+daemon has already dropped (#1101). `hack/ci-deploy.sh` therefore sets the
+variable to `0` — the daemon's documented off-switch, pinned uncapped by
+`test_zero_limit_never_suppresses` in
+`agents/platform/scripts/test_session_kv_server.py` — without touching the
+production default.
+
+The value rides three hops to reach the daemon, and each can break silently:
+the `--set-string` in `ci-deploy.sh` (dropping it re-reds the eval, but only
+on the days the shared budget happens to run out), the chart template that
+renders `platformAgent.deployment.env` onto the PlatformAgent CR, and the
+operator's sandbox env allowlist, which drops any `spec.deployment.env` entry
+it does not recognise rather than erroring. One test per hop.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import unittest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_DEPLOY = _REPO_ROOT / "hack" / "ci-deploy.sh"
+_CHART = _REPO_ROOT / "charts" / "kube-agents"
+_OPERATOR_MANIFESTS = (
+    _REPO_ROOT / "k8s-operator" / "internal" / "controller" / "platformagent_manifests.go"
+)
+
+_ENV_NAME_FLAG = '--set-string "platformAgent.deployment.env[0].name=ALERT_DAILY_LIMIT_WARNING"'
+_ENV_VALUE_FLAG = (
+    '--set-string "platformAgent.deployment.env[0].value=${EVAL_ALERT_DAILY_LIMIT_WARNING}"'
+)
+_OFF_SWITCH = 'readonly EVAL_ALERT_DAILY_LIMIT_WARNING="0"'
+
+
+class CiDeployAlertQuotaTest(unittest.TestCase):
+    def test_helm_release_uncaps_warning_alerts(self) -> None:
+        text = _CI_DEPLOY.read_text()
+        for needle in (_ENV_NAME_FLAG, _ENV_VALUE_FLAG, _OFF_SWITCH):
+            self.assertIn(
+                needle,
+                text,
+                "hack/ci-deploy.sh must pass ALERT_DAILY_LIMIT_WARNING=0 to the "
+                "chart: the daemon's 5/day fleet-wide Warning cap otherwise "
+                "suppresses the alerts bench scenarios plant (#1101), and the "
+                "failure is intermittent, not immediate.",
+            )
+
+    def test_the_operator_allowlist_carries_the_variable(self) -> None:
+        # The operator copies spec.deployment.env into the container only for
+        # allowlisted names and silently drops the rest, so removing this entry
+        # would leave the --set in ci-deploy.sh rendering onto the CR and
+        # reaching nothing.
+        text = _OPERATOR_MANIFESTS.read_text()
+        self.assertIn(
+            '"ALERT_DAILY_LIMIT_WARNING":',
+            text,
+            "safeSandboxEnvOverrides no longer allowlists "
+            "ALERT_DAILY_LIMIT_WARNING; the eval deploy's override in "
+            "hack/ci-deploy.sh is silently dropped without it.",
+        )
+
+
+class HelmRendersTheOverrideTest(unittest.TestCase):
+    """The --set pair actually lands on the rendered PlatformAgent CR.
+
+    A mistyped values key would render a CR with no env block at all rather
+    than fail, so only a real `helm template` can show the hop works. Skips
+    where the binary is absent (a contributor's laptop) and runs in CI, which
+    installs one.
+    """
+
+    def test_rendered_cr_carries_the_env_var(self) -> None:
+        if shutil.which("helm") is None:
+            self.skipTest("helm not installed")
+        rendered = subprocess.run(
+            [
+                "helm",
+                "template",
+                "t",
+                str(_CHART),
+                "--set-string",
+                "platformAgent.harness.clusterName=c",
+                "--set-string",
+                "platformAgent.harness.location=us-central1",
+                "--set-string",
+                "platformAgent.harness.projectId=p",
+                "--set-string",
+                "platformAgent.deployment.env[0].name=ALERT_DAILY_LIMIT_WARNING",
+                "--set-string",
+                "platformAgent.deployment.env[0].value=0",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        self.assertIn('name: "ALERT_DAILY_LIMIT_WARNING"', rendered)
+        self.assertIn('value: "0"', rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Prow eval deploy now sets `ALERT_DAILY_LIMIT_WARNING=0` on the PlatformAgent CR, turning off the session daemon's daily Warning-alert ceiling on eval installs only. The cap is alert-storm protection for a human-watched channel; an eval install's whole job is generating alerts, and the 5/day fleet-wide default is spent by the smoke builds themselves, after which the daemon quota-suppresses the very alert `autoops-warning-event-triage` waits 300s for. Production defaults are untouched — the override rides the Helm release in `hack/ci-deploy.sh` and nothing else.

## Why This Change

#1101's RCA: every recent `autoops-warning-event-triage` provisioning death traces to `session_kv_server.py`'s Warning quota (introduced in #641, 5 per UTC day, fleet-wide per install). Each smoke build leasing a Boskos pool project that day spends the shared budget on its own crash-loop scenarios, and once it is gone the watcher's inject comes back `suppressed` (`quota-suppressed BackOff ... daemon dropped the alert` in the daemon log), so the plant's 300s poll times out intermittently. #1147 makes that timeout grade INFRA instead of redding the run, but the case still cannot build a clean pass record while its alert gets suppressed. Without this change the case's admission to the gate stays blocked on a race between kubelet's BackOff cadence, the remaining budget, and the 300s window.

## What Changed

- `hack/ci-deploy.sh`: the Helm release passes `platformAgent.deployment.env[0]` = `ALERT_DAILY_LIMIT_WARNING=0`. The value is named (`EVAL_ALERT_DAILY_LIMIT_WARNING`) at the top of the script with the reasoning; `0` is the daemon's documented off-switch (`_alert_daily_limit` parses it as "cap off", `_claim_alert_quota` lets `limit <= 0` through uncapped, pinned by the existing `test_zero_limit_never_suppresses`).
- `tests/test_ci_deploy_alert_quota.py` (new, modeled on `tests/test_ci_deploy_runtime_class.py`): pins each hop the value rides — the `--set` pair in the deploy script, the chart rendering the env entry onto the CR (a real `helm template`, skipped where helm is absent), and the operator's `safeSandboxEnvOverrides` allowlist, which silently drops non-allowlisted `spec.deployment.env` entries.

Only Warning is uncapped. The failing case and the smoke scenarios' churn are Warning-severity; Critical (10/day) has not been observed suppressing an eval, and widening the override is a separate decision.

## Context

- #1101 — the RCA; its "Remaining environment work" names exactly this change (`ALERT_DAILY_LIMIT_WARNING=0` on eval installs).
- Companion to #1147 (grades the plant's provisioning death INFRA); this PR removes the suppression itself so the case can build the clean record #1101 asks for. Part of the gating path.
- #641 introduced the ceiling as production alert-storm protection; this PR does not change its default.
- Checked open PRs for competing work: none touch `hack/ci-deploy.sh`'s helm flags or set this variable.

## Testing

- `python3 -m unittest tests.test_ci_deploy_alert_quota`: 3/3 pass locally with helm 3.16.4 on PATH (the render test is exercised, not skipped).
- Rendered the chart with the deploy's exact flags: the PlatformAgent CR carries `env: [{name: "ALERT_DAILY_LIMIT_WARNING", value: "0"}]`, value quoted as the CRD's string type requires.
- `bash -n hack/ci-deploy.sh`.
- Full `tests/` discovery suite (the Makefile's invocation): green except four pre-existing failures in `test_install_script.ImportGithubPemKmsKeyTest`, which need a Go toolchain this machine lacks ("Go is not installed" path in the script under test); unrelated to this diff, and CI's runner ships Go.

### Live validation

This PR's own `pull-kube-agents-smoke-test` runs are the live exercise — the job deploys with the changed script, so the installs it graded ran with the override (project `kube-agents-evals-13`, images `pr-1148-a6efde3`; builds [2095051967679172608](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1148/pull-kube-agents-smoke-test/2095051967679172608) and [2095078977927385088](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1148/pull-kube-agents-smoke-test/2095078977927385088)):

- Zero `quota-suppressed` lines in either build's logs — against a pool project whose budget was already spent under the old default: PR #1118's run on the same project earlier the same UTC day (build 2095049456767471616, pre-change deploy) lost all 3 `autoops-warning-event-triage` reps to the quota (`results.json carries a record with no scores map`, the #1101 shape).
- With the override in place the plant fires: run 1 got the watcher's `fire BackOff pod=eval-autoops-incident/... → sid=k8s-evt-...` accepted by the daemon and the case's first clean scored pass in days (rep 3, `VerificationCorrectness=1.0`); run 2 provisioned all 3 reps in ~27s each — the 300s+ provisioning deaths are gone entirely. Remaining rep failures are judged report-wording checks (the #1122 calibration domain) and, once in run 1, the plant's step-3 poll race that #1101 tracks as its own follow-up and #1147 grades INFRA.
- Both runs' RED verdicts come from rotating cases with no mechanism in common with alert quotas (run 1: `compliance-rbac-overgrant`, UNSTABLE 2/3 on the pre-change deploy that same morning; run 2: `rca-remediation-pr` plus two empty-trajectory NOT_A_REAL_RUN infra shapes), which is the gate-wide flakiness #1101 describes.

What no single run can show is the storm side of the trade-off (an eval install under a genuinely collapsing cluster posting unbounded Warnings); that is accepted in Risk & Rollout. Before the run, the plumbing was also traced hop by hop, each hop pinned by a test in this PR or upstream:

1. `hack/ci-deploy.sh` passes the `--set-string` pair on the one `helm upgrade --install` the eval path runs (pinned by the new test).
2. `charts/kube-agents/templates/platform-agent-cr.yaml` renders `.Values.platformAgent.deployment.env` onto the CR's `spec.deployment.env`, quoting the value into the CRD's string type — verified with a real `helm template` using the deploy's exact flags (also the new test's third case).
3. The operator copies `spec.deployment.env` onto the agent container after its own env (custom wins, `mergeEnvVars`), filtered by `safeSandboxEnvOverrides` in `k8s-operator/internal/controller/platformagent_manifests.go`, which allowlists `ALERT_DAILY_LIMIT_WARNING`; the operator's own Go tests (`platformagent_manifests_test.go`) already pin exactly `ALERT_DAILY_LIMIT_WARNING=0` surviving the filter onto the gateway Deployment — the same `platform-agent-gateway` the deploy script's rollout gate waits on.
4. `deploy/shared/docker-entrypoint.sh` launches `session_kv_server.py` as a child of that container, so it inherits the env; `_alert_daily_limit("ALERT_DAILY_LIMIT_WARNING", 5)` reads it at import and `_claim_alert_quota` short-circuits uncapped at `limit <= 0`, pinned by `test_zero_limit_never_suppresses`.


## Self-Review

Both passes ran in fresh subagent contexts handed only the diff range (`origin/main..HEAD`), not this session's reasoning.

- **Adversarial pass** hunted: a wrong off-switch value (refuted against `_alert_daily_limit`/`_claim_alert_quota` and their tests), `env[0]` index collisions (`values.yaml` defaults `env: []`; no other flag touches the path), the operator allowlist dropping the var (allowlisted, Go-test-pinned), chart value-type mishandling (`| quote` + `--set-string`), bash quoting, test/script drift, and repo-rule violations (no-magic-constants, Where Tests Go). Findings: (1) the script comment attributed the `limit <= 0` branch to `_alert_daily_limit` instead of `_claim_alert_quota` — **fixed**, folded into this commit; (2) the text-pin test's `assertIn` would stay green if the flags were commented out rather than deleted — **deliberately not changed**: it is the same pattern as the merged `tests/test_ci_deploy_runtime_class.py`, and the eval itself re-reds if the flag disappears; the test's docstring says the failure is intermittent, which is why the pin exists at all.
- **Docs-drift pass**: no Blocking findings. `agents/platform/docs/session_management.md` already documents `value: "0" # uncapped` via `spec.deployment.env`; `ci-pool-projects.md` never enumerates the release's `--set` flags (same treatment as the existing runtimeClassName override); the new test file needs no `docs/README.md` map entry (the map covers Markdown only) and lands in the home `docs/testing-map.md` assigns shell-script tests. One non-blocking suggestion — a pointer comment in `bench/tf/prebuilt/autoops-incident/variables.tf` co-locating the quota risk with the scenario — **not taken**: that file is not otherwise touched by this change, and the chain is documented at the setting site and in the test docstring.

Generated with the help of Claude Code (Fable 5).

## Risk & Rollout

Blast radius is the CI eval deploy only: the variable is set on one `helm upgrade` in `hack/ci-deploy.sh`, so no production install, chart default, or daemon default changes. New failure mode: an eval install with a genuinely storming cluster posts unbounded Warning alerts into its own (unwatched) eval channel — chat volume on a throwaway install, bounded by the watcher's dedup window. Revert = delete the two `--set-string` lines and the readonly (the new test names them and fails, by design). Nothing has to happen at merge time; the next deploy picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
