### PR TITLE
fix(tests): accept keyword arguments in resolve_repo mock in fleet audit e2e test

### DIFF
--- a/tests/e2e/test_agent_fleet_audit.py
+++ b/tests/e2e/test_agent_fleet_audit.py
@@ -452,8 +452,8 @@ def test_audit_report_github_api_lifecycle_mocked(
         audit_report.SCRATCH_DIR = str(tmp_path)
         audit_report.set_workspace(workspace)
         audit_report.run_cmd = mock_run_cmd
-        audit_report.refresh_credentials = lambda repo=None: None
-        audit_report.resolve_repo = lambda: "test-org-kube-agent/agents-repo"
+        audit_report.refresh_credentials = lambda *args, **kwargs: None
+        audit_report.resolve_repo = lambda *args, **kwargs: "test-org-kube-agent/agents-repo"
         audit_report.repo_root = lambda: workspace
 
         valid_check = audit_report.AUDITS[audit_id].checks[0] if audit_id in audit_report.AUDITS and audit_report.AUDITS[audit_id].checks else "single-zone-nodepool"


### PR DESCRIPTION
## Summary

Updates the `resolve_repo` and `refresh_credentials` mocks in `test_audit_report_github_api_lifecycle_mocked` to accept variable arguments (`*args, **kwargs`). This fixes an unexpected keyword argument `audit_id` TypeError introduced by the multi-repo support changes in #504.

## Why This Change

In #504 (`a6904de1`), `audit_report.py` was updated to pass keyword arguments when resolving repository targets (e.g. `resolve_repo(audit_id=audit_id, repo=opt_repo)`). However, `tests/e2e/test_agent_fleet_audit.py` still mocked `audit_report.resolve_repo` with a zero-argument lambda (`lambda: "test-org-kube-agent/agents-repo"`), causing all 7 parameterized test cases of `test_audit_report_github_api_lifecycle_mocked` to fail with:
`FATAL: test_audit_report_github_api_lifecycle_mocked.<locals>.<lambda>() got an unexpected keyword argument 'audit_id'`.

## What Changed

- In `tests/e2e/test_agent_fleet_audit.py`, updated `audit_report.resolve_repo` and `audit_report.refresh_credentials` mocks to accept `*args, **kwargs`.

## Context

Fixes test regression introduced in #504.

## Testing

- Verified mocked `audit_report.main(["finish", ...])` runs cleanly to completion with exit code 0.
- Ran all 391 unit tests in `tests/`: 390 passed, 1 skipped.
- Ran `make docs-check`: clean pass.

### Live validation

Not live-tested: this change is restricted to an E2E test mock fixture in `tests/e2e/test_agent_fleet_audit.py`. It touches no deployed images, CRDs, or runtime operator code.

## Self-Review

- Verified that `resolve_repo` callers in `audit_report.py` pass `audit_id` and `repo` keyword arguments, which `*args, **kwargs` cleanly handles while returning the mock repository string.
- Verified that `refresh_credentials` mock is similarly guarded.
- No docs or production code modified.

## Risk & Rollout

Low risk, test-only fix. Does not touch production code or runtime agent behaviors.

Generated with the help of Google Deepmind AI.
