### PR TITLE
ci(docker): cache the platform image layers on pull requests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,6 +51,55 @@ jobs:
       # a transfer from the buildx cache into the daemon, which is why only this
       # build and the gate-test build below -- the two whose output a later step
       # runs or inspects -- pay for it.
+      #
+      # The only build here carrying a remote layer cache, and the only one that
+      # needs one: `platform` is the deepest chain the Dockerfile ships and nearly
+      # all of this job's ~5.5 minutes is spent on it. Measured on a fork: 211s and
+      # 236s uncached, 79s restoring, which takes the job from 5.4 to 3.6 minutes.
+      # The export costs the writing run about 150s, which is why only main pays it.
+      # The two builds below that
+      # share its lineage reuse it without a cache of their own --
+      # entrypoint-gate-test is FROM platform and credential-proxy reaches
+      # agent-base through proxy-tools, so both hit buildkit's local state from this
+      # step. Separate scopes for them would export the same layers again for no
+      # extra hit. Build Replay Proxy is not in that set: it builds from its own
+      # context and shares no stage with this chain, so a cache would have to be its
+      # own, and at ~7s of the job it is not worth one.
+      #
+      # Read on the pull request, build fresh and write on the push to main. The two
+      # events want opposite things and the split is the point.
+      #
+      # A pull request wants speed, and a slightly stale base is fine there because
+      # nothing it builds ships. The push to main must not read the cache: this
+      # workflow's header says the layer budget and the entrypoint gate are checked
+      # only here, and the image they check has to be the one that ships. What ships
+      # is built by docker-publish-ghcr.yml, which carries no cache at all. The
+      # agent-base stage installs its apt packages and `uv pip install
+      # hermes-agent[...]` without version pins, and buildkit keys those layers on the
+      # command string and parent digest, so neither key moves when upstream
+      # publishes. HERMES_AGENT_TAG is digest-pinned in tags.env, so the base image is
+      # not the exposure -- what is installed on top of it is. Restore those layers on
+      # main and the gate would validate one dependency set while the publish shipped
+      # another, which is the after-merge Cloud Build failure this job exists to
+      # prevent. Main pays for a full build today, so building fresh here costs
+      # nothing against the status quo and keeps each merge's export honest.
+      #
+      # Writing only on main is also a budget decision. A cache written on a pull
+      # request ref is restorable by later runs of that same pull request but is
+      # invisible to every other ref, so N branches exporting mode=max copies of an
+      # image this size compete for one repository budget -- already ~17 GB across
+      # ~378 entries when this was written, close enough to eviction to push the
+      # setup-go and CodeQL entries out. One writer per merge keeps a single lineage
+      # every pull request restores from its base. That write is not free either: the
+      # gha backend stores one entry per layer keyed by content digest, so unchanged
+      # layers cost nothing after the first export, but the first one is the whole
+      # lineage. Watch `gh api /repos/gke-labs/kube-agents/actions/cache/usage` after
+      # this merges -- if the total climbs rather than settling, this is why.
+      #
+      # scope= is explicit because buildkit's gha backend defaults every export to
+      # the scope `buildkit`, where docker-publish-k8s-operator.yml already writes a
+      # different image. Two images sharing a scope overwrite each other's index and
+      # both stop hitting.
       - name: Build Platform Agent
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -61,6 +110,8 @@ jobs:
           push: false
           load: true
           tags: platform-agent:latest
+          cache-from: ${{ github.event_name == 'pull_request' && 'type=gha,scope=platform-agent' || '' }}
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max,scope=platform-agent' || '' }}
           build-args: |
             HERMES_AGENT_TAG=${{ env.HERMES_AGENT_TAG }}
 


### PR DESCRIPTION
## Summary

The `Docker Build` job sets up buildx and then builds the `platform` target with no layer cache, so every pull request rebuilds the deepest chain the Dockerfile ships from scratch. This adds a GitHub Actions layer cache that pull requests restore and only pushes to `main` write. Measured on a fork, the `Build Platform Agent` step drops from 211–236s to 79s, taking the job from 5.4 minutes to 3.6.

The read and write directions are deliberately not symmetric, and that asymmetry is the part worth reviewing: `main` still builds from scratch, because the two gates that run only in this workflow have to see the image that actually ships.

## Why This Change

Job count is what makes this repository's CI queue deep, not total compute. A single branch push fans out to 17 workflow runs and 22 jobs, and during a burst earlier today six active branches put 144 runs in the queue in nine minutes. Most of those jobs are short — median under one minute, many 12–20 seconds, so nearly all of their cost is runner allocation. `Docker Build` is the exception at 5.4–5.8 minutes, and roughly 65% of that is the one uncached build step. It is the longest pole in the pull request set and the one worth attacking first.

Without this, every pull request pays a full rebuild of a chain whose upper layers almost never change, and holds a runner slot for four minutes doing it.

## What Changed

- `.github/workflows/docker-build.yml` — `cache-from` on the `Build Platform Agent` step, gated to `pull_request`; `cache-to: type=gha,mode=max` gated to `push`. Both carry an explicit `scope=platform-agent`.

Three things about the shape:

**`main` does not read the cache.** This workflow's own header says the layer budget (#658) and the entrypoint shared-state gate are checked only here, and that they exist to catch what would otherwise surface in Cloud Build after merge. What actually ships is built by `docker-publish-ghcr.yml`, which has no cache. The `apt-get install` and `uv pip install hermes-agent[...]` layers in `agent-base` are unpinned, and buildkit keys those layers on the command string plus parent digest — so a restored layer freezes an old dependency set while the publish installs the current one, and the gate would validate an image that never shipped. `HERMES_AGENT_TAG` is digest-pinned in `tags.env`, so the base image is not the exposure; what gets installed on top of it is. `main` already pays for a full build today, so building fresh costs nothing against the status quo.

**Only the `platform` build carries a cache.** `entrypoint-gate-test` is `FROM platform` and `credential-proxy` reaches `agent-base` through `proxy-tools`, so both hit buildkit's local state from that step already. `Build Replay Proxy` shares no stage with the chain, and at ~7s does not justify one of its own.

**`scope=` is explicit.** Buildkit's gha backend defaults every export to the scope `buildkit`, where `docker-publish-k8s-operator.yml` already writes a different image; two images sharing a scope overwrite each other's index and both stop hitting.

## Context

No related open pull request. Open issue #1069 (*Lane: pool pressure measured — a long queue announces itself*) is adjacent but distinct — it is about measuring pool pressure, not reducing it — so this does not close it. PR #913 (*feat(operator): run the agent shell in a sandbox pod*) adds 22 lines to this same file in a non-overlapping region: a merge conflict is unlikely, but whoever merges second should re-read the comment block, which enumerates which builds share the platform lineage and would need a sentence about a new one.

A pip download cache for `python-tests.yml` was prototyped alongside this and **dropped**: it restored correctly, but install times moved 24–29s → 20–26s, which is noise. Those seconds are resolution and install, not download. It is not in this diff.

Two follow-ups this does not attempt, in rough order of remaining value: path-filtering the advisory workflows, and consolidating the sub-minute workflows so they stop paying a runner allocation each. On the first — branch protection lists 5 required GitHub Actions contexts (`actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`) while roughly 17 more run on every push, so most of the fan-out blocks nothing. Read that as "from branch protection", not as the whole gate: I could not read Prow's required-check list out of `test-infra`, so Tide may require more than branch protection does, and anyone acting on it should confirm there first.

## Testing

- `prettier@3.9.6 --check` (the version `prettier.yml` pins) — clean.
- `actionlint` v1.7.x — clean. This matters more than usual here: the change is two `${{ }}` expressions.
- `make docs-check` — passes. All four generated regions current, 281 files link-checked, map covers all 248 tracked docs, context budget 35.3k/38k.
- No unit tests. No test in this repository asserts anything about workflow files; a regression in one is only observable in CI.

### Live validation

Exercised end to end on a fork (`bradhoekstra/kube-agents`), which runs this workflow unmodified — it carries no `if: github.repository ==` guard because it needs no secrets. A CI workflow cannot reach a kube-agents installation, so per `contributing.md` this stands in for one; the evidence is real runs rather than reasoning.

**Baseline, uncached** — two pre-change pushes that happened to already exist on the fork:

| Run | `Build Platform Agent` | Job |
| --- | --- | --- |
| `cd938d07` | 236s | 5.8 min |
| `522fe30f` | 211s | 5.4 min |

**Write path** — pushed the branch to the fork's `main`, firing the `push` trigger:

- `Build Platform Agent` 386s, job 8.2 min — the ~150s delta over baseline is the `mode=max` export.
- Cache index written as `index-platform-agent-1-f921bd05#1` on `refs/heads/main`. The key confirms both that `cache-to` fired on `push` and that `scope=` took effect — an unscoped export would read `index-buildkit-`, which is where `docker-publish-k8s-operator.yml` writes.
- Export totalled ~1.5 GB across the buildkit blob entries.

**Read path** — opened a pull request on the fork against that `main`, firing the `pull_request` trigger:

- `Build Platform Agent` **79s**, job **3.6 min**, all steps green including `Check image layer budget` and both entrypoint gate steps.
- Restoring the platform layers from the remote cache moves cost into the gate-test build (22s → 56s); the net is still ~2 minutes saved.

Proving the mechanism rather than a coincidence: the two directions were observed producing *different* behaviour on the same commit — `push` exported and did not restore, `pull_request` restored and did not export. The 79s figure is a best case, since the branch changes no Dockerfile content; a pull request editing the Dockerfile mid-chain invalidates from that layer down and will land between 79s and the 211–236s baseline.

**Not covered:** whether a week-old cache diverges from a fresh build in practice. That is the risk `main`'s fresh build is there to contain, and confirming it end to end would mean holding a cache for a week and diffing installed package sets.

**This pull request's own `Docker Build` shows no speedup, and that is expected.** `upstream/main` has never run `cache-to`, so there is nothing yet to restore and `cache-from` misses. Its `Build Platform Agent` step took 216s — inside the 211–236s uncached band, confirming that a miss costs nothing measurable. The first export happens when this merges and `main` next builds; pull requests opened after that are the ones that see 79s. Do not read this run's timing as the change not working — the fork demo above is where both directions were exercised.

**Cleanup:** the fork pull request is closed and the fork's `main` is reset to `522fe30f`. Cache entries on the fork were left to expire on GitHub's 7-day schedule.

## Self-Review

Both required passes ran in **subagents that did not write the change**, each handed only the diff range.

**Adversarial pass** — attacked the trigger-expression logic, scope collisions, whether caching could let a broken image through the gates, and whether the added comments claim more than the code supports. Five findings:

- **Fixed (HIGH): `cache-from` was unconditional, including on `push: main`.** The gates would have validated a cached image while `docker-publish-ghcr.yml` built and shipped an uncached one, diverging via the unpinned `apt-get`/`uv pip install` layers. This is the defect the pass earned its keep on — I had reasoned about the write direction and simply not examined the read direction on `main`. Fixed by gating `cache-from` to `pull_request`. Verified the premises independently before acting: `docker-publish-ghcr.yml` has no cache, and `tags.env` digest-pins the base while the in-Dockerfile installs are unpinned.
- **Fixed (LOW): "The three builds below reuse it" was false for one of the three.** `Build Replay Proxy` builds from its own context and shares no stage. Found independently by both passes.
- **Fixed (LOW): "PR writes help nothing on the next run" was wrong.** A PR-scoped cache *is* restorable by later runs of the same pull request; it is only invisible to other refs. The budget argument stands on its own, so the comment now makes that argument and drops the false one.
- **Addressed (MEDIUM): the budget argument only examined the direction I rejected.** The comment now states the cost of the write it does enable, including that per-layer content-digest keying means unchanged layers cost nothing after the first export, and points at `actions/cache/usage` as the instrument to watch after merge.
- **Not applicable: the pip cache key omitted its `-r` include.** Real, and confirmed by both passes; the pip change was dropped from this PR for unrelated reasons (no measurable benefit), so it is not in this diff.

Confirmed as *not* findings: the `A && B || C` ternary is safe here because `B` is a non-empty string and this workflow has only two triggers; `cache-to: ''` is a no-op rather than a malformed flag, which I verified against the actions-toolkit source (`getList` returns `[]` on empty input, so no `--cache-to` is passed) and then observed on a real run; `permissions: contents: read` suffices because the gha backend uses `ACTIONS_RUNTIME_TOKEN`; and `scope=platform-agent` is disjoint from the only other gha-cache user.

**Docs-drift pass** — no Blocking findings, and no documentation is stale or contradicted. It verified that no doc anywhere describes CI caching, that `docs/site/.../docker-images.md` ("the image builds but doesn't publish") is still true since `push: false` is untouched, that the layer-budget prose in `pull-request-workflow.md` still holds because a restored cache does not change an image's layer count, and that no map row is owed since no files were added. Its two advisory findings were the comment inaccuracies listed above.

One thing I did not fix and am not claiming: the comment's "~17 GB across ~378 entries" is a measurement taken while writing it, not a live figure.

Generated with the help of Claude Opus 5.

## Risk & Rollout

Low blast radius: one workflow file, no runtime code path, nothing that reaches a cluster. The new failure mode is a cache that goes stale against unpinned upstream content, and gating `cache-from` to `pull_request` is what contains it — a stale restore can now cost a pull request a confusing build result, but cannot let a bad image reach the gates or the registry. Reverting is deleting the two lines; existing cache entries then age out on their own in seven days.

Worth watching after merge: `gh api /repos/gke-labs/kube-agents/actions/cache/usage`. The repository was already carrying ~17 GB across ~378 entries, and GitHub evicts LRU on total size, so if the total climbs rather than settling, this export is the first thing to suspect — the largest existing entries are the CodeQL and setup-go caches, which is what would degrade.

