### PR TITLE
feat(gate): red the suite when automatic selection drops every armed case

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -60,7 +60,7 @@ That evidence is what `baselines/` holds, and admission is computed from it rath
 
 Two speeds, deliberately: the deterministic `Verification*` scores decide whether a repetition passed, and no judged score can fail a repetition on its own. The captured fixtures are the argument — three byte-identical failing runs scored `OutcomeValidity` 0.9, 1.0 and 0.2 while `VerificationCorrectness` held at 0.5 on all three. The judge is given exactly one job (rung 6): catching a **collapse** in judged quality against main's mean at the same version key, at a margin of two standard errors of that measured spread. At three repetitions it cannot see drift, and widening it is a matter of more repetitions or a less variable metric, not a smaller number.
 
-Thresholds are named environment variables, all with the documented default: `EVAL_REPETITIONS`, `DETERMINISTIC_CORRECTNESS_FLOOR`, `EVAL_ADMISSION_RATE`, `EVAL_ADMISSION_MIN_RUNS`, `EVAL_AGGREGATE_MARGIN`, `EVAL_JUDGED_MARGIN`, `EVAL_JUDGED_METRICS`, `EVAL_BASELINE_STORE`, `EVAL_BASELINE_MAX_OBJECTS`, and `BOOTSTRAP_ADMITTED` (the transition bridge — cases that keep blocking before any screening exists).
+Thresholds are named environment variables, all with the documented default: `EVAL_REPETITIONS`, `DETERMINISTIC_CORRECTNESS_FLOOR`, `EVAL_ADMISSION_RATE`, `EVAL_ADMISSION_MIN_RUNS`, `EVAL_AGGREGATE_MARGIN`, `EVAL_JUDGED_MARGIN`, `EVAL_JUDGED_METRICS`, `EVAL_BASELINE_STORE`, `EVAL_BASELINE_MAX_OBJECTS`, and `BOOTSTRAP_ADMITTED` (the transition bridge — cases that keep blocking before any screening exists). `EVAL_TASK_SELECTION` is read too: when it is `auto` and selection dropped every armed case, the suite verdict reds instead of warning.
 
 ## Portal CUJ evaluations
 

--- a/bench/baselines/README.md
+++ b/bench/baselines/README.md
@@ -95,7 +95,9 @@ edit away from being gone.
 
 A store that will not parse is an **error**, never an empty store. Empty means
 "nothing admitted, aggregate advisory", which is a green; a corrupt file
-reaching that state would silently disarm the gate.
+reaching that state would silently disarm the gate. (One exception to that
+green: under `EVAL_TASK_SELECTION=auto`, a run that also failed to grade an
+armed case reds — see the Bootstrap section of `docs/designs/eval-scorer.md`.)
 
 A leftover `<case-id>.json` from the pre-JSONL format is an **error**, not a
 file to skip: skipping it would read as "never screened" and silently de-admit

--- a/bench/kube_agents_bench/gate.py
+++ b/bench/kube_agents_bench/gate.py
@@ -411,9 +411,42 @@ def _cmd_suite(args: argparse.Namespace) -> int:
     #
     # A warning rather than a red. The name might belong to a case that is
     # legitimately absent from this run -- commented out of TASKS, or filtered
-    # -- and redding the job for naming a case it did not run would make the
-    # variable unusable for the transition it exists to cover.
+    # by hand -- and redding the job for naming a case it did not run would
+    # make the variable unusable for the transition it exists to cover. The
+    # one exception is automatic selection, handled below.
     unknown = sorted(_bootstrap_admitted() - {str(c.get("case")) for c in cases})
+
+    # Under EVAL_TASK_SELECTION=auto the "legitimately filtered" escape does
+    # not hold: the filter is a program running on every pull request, and a
+    # subset that dropped every case the gate arms on grades a suite in which
+    # nothing can reach a blocking rung -- a disarmed gate reporting green.
+    # The selection floor (EVAL_ADMITTED_CASES in hack/ci-eval-pr.sh) exists
+    # to keep an admitted case in every subset; this is the backstop that
+    # reds the run if that wiring ever drops one. The trigger is `unknown`
+    # -- an armed case selection FAILED TO GRADE -- not "zero admitted",
+    # which a store outage or stale evidence also produces with the floor
+    # intact and which must stay advisory for the reasons _load_store gives.
+    # When the baseline store replaces BOOTSTRAP_ADMITTED as the source of
+    # admission, extend `unknown` with the store's admitted ids.
+    disarmed = (
+        os.environ.get("EVAL_TASK_SELECTION", "") == "auto"
+        and bool(unknown)
+        and not any(c.get("admitted") for c in cases)
+    )
+    if disarmed:
+        verdict.green = False
+        verdict.reasons.append(
+            "automatic task selection dropped every case the gate arms on "
+            f"({', '.join(unknown)}); nothing this run graded could have "
+            "blocked the merge. The selection floor must carry the admitted "
+            "cases (EVAL_ADMITTED_CASES in hack/ci-eval-pr.sh)."
+        )
+        print(
+            "::error::EVAL_TASK_SELECTION=auto graded no admitted case: "
+            f"selection dropped {', '.join(unknown)}. The selection floor "
+            "must carry the admitted cases (EVAL_ADMITTED_CASES).",
+            file=sys.stderr,
+        )
 
     # Per-case notes, deduplicated. A misspelled EVAL_JUDGED_METRICS name is
     # one configuration mistake, not one per case, and repeating it fourteen
@@ -425,7 +458,7 @@ def _cmd_suite(args: argparse.Namespace) -> int:
     # silently loosens the gate, and the one thing that must not happen is a
     # green nobody knows was measured against nothing.
     banners = []
-    if unknown:
+    if unknown and not disarmed:
         print(
             f"WARNING: BOOTSTRAP_ADMITTED names no graded case: {unknown}",
             file=sys.stderr,

--- a/bench/tests/test_gate.py
+++ b/bench/tests/test_gate.py
@@ -66,6 +66,7 @@ def _clean_env(monkeypatch):
     """The gate reads the environment; CI's must not leak into a test."""
     for name in (
         "BOOTSTRAP_ADMITTED",
+        "EVAL_TASK_SELECTION",
         "JUDGE_MODEL",
         "DETERMINISTIC_CORRECTNESS_FLOOR",
         "EVAL_AGGREGATE_MARGIN",
@@ -347,6 +348,50 @@ def test_a_red_suite_exits_one(tmp_path, capsys):
     assert main(["suite", "--case-result", str(path)]) == 1
     printed = capsys.readouterr().out
     assert "**RED**" in printed and "### Why it is red" in printed
+
+
+def test_auto_selection_that_dropped_the_armed_case_reds_the_suite(tmp_path, capsys, monkeypatch):
+    """The backstop for the selection floor: under automatic selection, an
+    armed case the run failed to grade plus zero admitted cases means the
+    filter dropped the only thing that could block -- a wiring bug, not a
+    judgment call. The red rides in the verdict itself, so the markdown and
+    the JSON artifact agree with the exit code."""
+    monkeypatch.setenv("EVAL_TASK_SELECTION", "auto")
+    monkeypatch.setenv("BOOTSTRAP_ADMITTED", "floor-case")
+    path = case_file(tmp_path, "a", admitted=False)
+    out_json = tmp_path / "verdict.json"
+    rc = main(["suite", "--case-result", str(path), "--json-out", str(out_json)])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "selection dropped floor-case" in captured.err
+    assert "**RED**" in captured.out and "dropped every case the gate arms on" in captured.out
+    assert json.loads(out_json.read_text())["green"] is False
+
+
+def test_auto_selection_with_an_admitted_case_grades_normally(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("EVAL_TASK_SELECTION", "auto")
+    assert main(["suite", "--case-result", str(case_file(tmp_path, "a"))]) == 0
+    assert "dropped every case" not in capsys.readouterr().out
+
+
+def test_a_zero_admitted_run_whose_armed_case_was_graded_stays_advisory(tmp_path, capsys, monkeypatch):
+    """The store-outage shape: everything de-admitted but nothing dropped.
+    _load_store's own comment says an unreachable store must degrade, not
+    red, and the backstop must not reintroduce that failure mode."""
+    monkeypatch.setenv("EVAL_TASK_SELECTION", "auto")
+    monkeypatch.setenv("BOOTSTRAP_ADMITTED", "a")
+    assert main(["suite", "--case-result", str(case_file(tmp_path, "a", admitted=False))]) == 0
+
+
+def test_shadow_selection_keeps_the_warning_only_behaviour(tmp_path, capsys, monkeypatch):
+    """Outside auto, a dropped armed case stays a warning: a human commented
+    the case out, or selection is only shadow-logging."""
+    monkeypatch.setenv("EVAL_TASK_SELECTION", "shadow")
+    monkeypatch.setenv("BOOTSTRAP_ADMITTED", "floor-case")
+    assert main(["suite", "--case-result", str(case_file(tmp_path, "a", admitted=False))]) == 0
+    assert "names no graded case" in capsys.readouterr().out
+    monkeypatch.delenv("EVAL_TASK_SELECTION")
+    assert main(["suite", "--case-result", str(case_file(tmp_path, "b", admitted=False))]) == 0
 
 
 def test_a_missing_case_result_reds_the_suite(tmp_path, capsys):

--- a/docs/designs/eval-scorer.md
+++ b/docs/designs/eval-scorer.md
@@ -905,6 +905,17 @@ in the markdown verdict. It is a warning rather than a red: the list is also leg
 to name a case that is deactivated in the `TASKS` array or skipped on a given run, and redding for
 that would make the bridge harder to hold than the thing it bridges.
 
+**The exception is automatic task selection.** Under `EVAL_TASK_SELECTION=auto` (the change-based
+selector of `hack/eval_triggers.yaml`), "legitimately skipped" stops applying: the filter is a
+program running on every pull request, and a subset that dropped every case the gate arms on
+grades a suite in which nothing can reach a blocking rung — a disarmed gate reporting green,
+invisible in shadow logs because they record picks, not armament. The selection floor is what
+keeps an admitted case in every subset; `bench-gate suite` backstops it by folding a red into the
+verdict when selection ran in `auto`, an armed case went ungraded, and nothing graded was
+admitted. The trigger is the ungraded armed case, not "zero admitted" alone — a store outage or
+stale evidence also de-admits everything with the floor intact, and those must keep degrading to
+advisory rather than redding every open pull request.
+
 ## How "judged scores below main's baseline" is determined
 
 This is rung 6, and it is the only place in the ladder where "it technically passed but got worse"


### PR DESCRIPTION
## Summary

`bench-gate suite` now folds a red into its verdict when automatic task selection (`EVAL_TASK_SELECTION=auto`) dropped every case the gate arms on and nothing graded was admitted. It is the backstop for the selection floor introduced in #1112: with it, a selection bug can cost a red run that names its cause; without it, the same bug produces a green run in which no case could ever have blocked the merge.

## Why This Change

The gate deliberately downgrades "`BOOTSTRAP_ADMITTED` names no graded case" to a warning, because the name may belong to a case a human commented out. Automatic selection breaks that reasoning: the filter is a program running on every pull request, and the escape hatch would fire routinely on a green banner nobody reads — precisely on eval-case-only PRs, where the gate matters most. This was found by `kube-agents-bot`'s review of #1112; the floor fix landed there, and this is the layer that survives the transition to store-based admission (the selector runs pre-install and can never read the store; the gate already computes admission from whichever source is live).

## What Changed

- `bench/kube_agents_bench/gate.py` — in `_cmd_suite`, when `EVAL_TASK_SELECTION=auto`, an armed case went ungraded (`unknown`), and zero graded cases are admitted, the verdict itself turns red: exit code, markdown, and the JSON artifact agree. The trigger is the *ungraded armed case*, not "zero admitted" alone — a store outage or stale evidence de-admits everything with the floor intact, and those keep degrading to advisory per `_load_store`'s own rationale. Outside `auto`, warning-only behaviour is unchanged.
- `bench/tests/test_gate.py` — four new tests: the drop reds (including the JSON artifact asserting `green: false`), an admitted case grades normally, the store-outage shape (zero admitted, armed case graded) stays advisory, and shadow/unset keeps the warning. `EVAL_TASK_SELECTION` joins the autouse env-cleaning fixture.
- `docs/designs/eval-scorer.md` (Bootstrap section), `bench/README.md` (gate env-variable inventory), `bench/baselines/README.md` (the "empty store is a green" claim gains its one exception) — prose kept in step.

## Context

Depends on #1112 (the selector, the floor, and the `EVAL_ADMITTED_CASES` wiring this backstops) — merge after it, and before any Prow-side flip to `EVAL_TASK_SELECTION=auto`. #1112 also carries the `export EVAL_TASK_SELECTION` that makes the variable visible to `bench-gate` as a child process. Sequencing: #1112 (shadow) → this → the flip.

## Testing

- `bench/tests/test_gate.py`: 64 passed (60 existing + 4 new) via `uv run --with pytest python -m pytest tests/test_gate.py` in `bench/`. Coverage on `kube_agents_bench/gate.py`: 96% lines.
- The red-then-green direction was verified by the adversarial pass executing the new tests against the merge base in a throwaway worktree: the drop test fails there (exit 0 pre-change) and passes with the change; the no-misfire tests pass on base too, pinning pre-existing behaviour.
- `make docs-check` clean; pinned `prettier@3.9.6 --check` clean on the three changed Markdown files.

### Live validation

Not live-tested against a running installation: the change is a verdict rule inside `bench-gate suite`, and the red path is unreachable in any live run today — nothing sets `EVAL_TASK_SELECTION=auto` until the Prow-side flip this PR is a prerequisite for. The unit tests exercise the full CLI surface (exit code, stderr, markdown, JSON artifact) that a Prow run consumes.

## Self-Review

Both passes ran as subagents handed the diff range (`refs/kube-agents-base/main...HEAD`), the skill path, and the gate output, instructed to derive intent from the diff and read no commit messages. `make docs-check`, pinned prettier, and the bench suite ran in the main loop. Merged dispositions:

1. **MEDIUM, CONFIRMED (adversarial) — the original trigger ("zero admitted" alone) also fired on store outages and stale evidence, states the gate deliberately keeps advisory, with a misdiagnosing error message.** Fixed: the trigger now additionally requires an armed case selection failed to grade, and a new test pins the store-outage shape as staying green.
2. **MEDIUM, CONFIRMED (adversarial) — the override changed only the exit code; the markdown said GREEN and the JSON artifact recorded `green: true` on a failed job.** Fixed at the altitude the finding suggested: the red is folded into the `SuiteVerdict` itself, so all three surfaces agree; the JSON is now asserted in the test.
3. **MEDIUM, CONFIRMED (adversarial) / Blocking (docs-drift) — the doc paragraph and error text referenced `hack/eval_triggers.yaml` and `EVAL_ADMITTED_CASES`, which exist only in open PR #1112.** Addressed as a stated sequencing dependency (Context above): this PR is coherent only merged after #1112, and the reviewer request is to hold it until then. The error text now points at `EVAL_ADMITTED_CASES in hack/ci-eval-pr.sh` rather than the yaml file.
4. **MEDIUM, PLAUSIBLE (adversarial) — nothing exported `EVAL_TASK_SELECTION` into `bench-gate`'s environment, so a script-default flip to `auto` would prune the matrix with the backstop dark.** Fixed in #1112 (an `export` after the mode validation), where the variable lives; the two PRs now agree on the transport.
5. **LOW, CONFIRMED (both passes) — an unrelated formatting hunk in `eval-scorer.md`.** Fixed: caused by running `prettier@3.6.2` instead of the pinned `3.9.6`; the file was reset to base and only the intended paragraph re-applied (branch diff is 11 added lines).
6. **LOW, CONFIRMED (adversarial) — `bench/README.md`'s gate environment-variable inventory did not gain the new variable.** Fixed.
7. **Advisory (docs-drift) — the unconditional "empty store is a legitimate green" claims in `bench/baselines/README.md` and the `ci-eval-pr.sh` comment gain an undocumented exception.** Fixed in `bench/baselines/README.md` with a one-line cross-reference; the `ci-eval-pr.sh` comment belongs to #1112's file and is accurate until the flip.
8. **Advisory (docs-drift) — `docs/designs/testing-strategy.md` has no task-selection concept.** Deferred with reason: selection ships shadow-only in #1112; the strategy doc gets its §4.2 line when the flip to `auto` is proposed, which is also when this backstop becomes load-bearing.

Angles run clean (adversarial): line-by-line logic, removed-behaviour/CI-weakening audit, operations/security surface, reuse/simplification. Not covered: no live Prow run; the oss-test-infra job config (other repository) is where `auto` would be set.

## Risk & Rollout

Unreachable until armed: no environment sets `EVAL_TASK_SELECTION=auto` today, so merging this changes no run's verdict. When armed, the new failure mode is a red naming the dropped cases — the intended behaviour — and the no-misfire tests pin that outages and stale evidence keep their advisory degradation. Revert is a clean `git revert`.

---

Generated with the help of Claude Code (Fable 5).
