### PR TITLE
fix(dashboard): the domains tile said "blocking" while counting "in presubmit"

### DIFF
--- a/scripts/eval_dashboard/render.py
+++ b/scripts/eval_dashboard/render.py
@@ -646,11 +646,15 @@ def agent_tiles_html(data: dict, events: dict) -> str:
             else delta_chip("flat", f"{total - covered} open")
         )
         cases = [c for c in data.get("cases") or [] if isinstance(c, dict)]
-        blocking = sum(1 for c in cases if c.get("active"))
+        # ``active`` means "runs in presubmit" (named in the TASKS array), NOT
+        # "can red a PR" -- admission is BOOTSTRAP_ADMITTED's roster, which the
+        # collector does not read yet. Until a cases[].admitted field exists,
+        # calling this count "blocking" overstates the gate.
+        in_presubmit = sum(1 for c in cases if c.get("active"))
         if uncovered:
             detail = f"uncovered: {', '.join(uncovered)}"
         else:
-            detail = f"{len(cases)} scenarios · {blocking} blocking"
+            detail = f"{len(cases)} scenarios · {in_presubmit} in presubmit"
         tiles.append(tile("Domains covered", f"{covered}<small>/ {total}</small>", chip, detail))
     else:
         tiles.append(tile("Domains covered", "—", "", "not reported"))

--- a/scripts/eval_dashboard/template/index.html.tmpl
+++ b/scripts/eval_dashboard/template/index.html.tmpl
@@ -528,10 +528,12 @@ function agentTilesHtml(data, events) {
       ? deltaChip("up", "all covered")
       : deltaChip("flat", `${coverage.domains_total - coverage.domains_covered} open`);
     const cases = (data.cases || []).filter((c) => c && typeof c === "object");
-    const blocking = cases.filter((c) => c.active).length;
+    // ``active`` means "runs in presubmit", NOT "can red a PR" -- admission is
+    // BOOTSTRAP_ADMITTED's roster, which the collector does not read yet.
+    const inPresubmit = cases.filter((c) => c.active).length;
     const detail = uncovered.length
       ? `uncovered: ${uncovered.join(", ")}`
-      : `${cases.length} scenarios · ${blocking} blocking`;
+      : `${cases.length} scenarios · ${inPresubmit} in presubmit`;
     tiles.push(tile("Domains covered",
       `${coverage.domains_covered}<small>/ ${coverage.domains_total}</small>`, chip, detail));
   } else {

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -255,7 +255,7 @@ class RenderGoldenTest(unittest.TestCase):
     def test_domains_tile(self):
         self.assertIn("11<small>/ 11</small>", self.app)
         self.assertIn("all covered", self.app)
-        self.assertIn("6 scenarios · 5 blocking", self.app)
+        self.assertIn("6 scenarios · 5 in presubmit", self.app)
 
     def test_false_reds_tile_from_events_yaml(self):
         self.assertIn(
@@ -545,7 +545,7 @@ class RenderToleranceTest(unittest.TestCase):
         self.addCleanup(tmp.cleanup)
         app = baked_app(html)
         self.assertNotIn("uncovered: a, b, c", app)
-        self.assertIn("6 scenarios · 5 blocking", app)
+        self.assertIn("6 scenarios · 5 in presubmit", app)
 
     def test_unknown_additive_fields_ignored(self):
         data = fixture_data()


### PR DESCRIPTION
## Summary

The "Domains covered" tile's detail line read **"28 scenarios · 19 blocking"** on the live dashboard, but only the 13 cases in `BOOTSTRAP_ADMITTED` can red a PR. `cases[].active` means "named in the TASKS array" — runs in presubmit — and the renderer was labeling that count *blocking*, hold-outs included. This changes the label to what the number actually is: **"in presubmit"**.

## Why This Change

The gate went merge-blocking today; the first question anyone asks the dashboard is "what can red my PR?" and the tile answered it wrong by 6 cases (including all three documented hold-outs). Spotted by Jayanti reading the live page against the roster.

## What Changed

- `scripts/eval_dashboard/render.py` and `scripts/eval_dashboard/template/index.html.tmpl`: label + variable rename, with a comment stating the active-vs-admitted distinction. Both sides changed per the Python/JS parity contract.
- `scripts/test_eval_dashboard.py`: the two assertions on the detail string updated.

## Context

Proper fix is a `cases[].admitted` field (collector parses the `BOOTSTRAP_ADMITTED` default with the same whitespace-or-comma contract `gate.py` uses) so the tile can say "13 blocking · 20 in presubmit" — deferred because `collect.py` is contested by #1142's in-flight conflict resolution; will follow it.

## Testing

- `python3 -m unittest discover -s scripts` — full suite green (dashboard files: 89).

### Live validation

Not live-tested: label-only change; the next dashboard refresh publishes it. The wrong label is live right now, which is the urgency.

## Self-Review

Hostile re-read: checked every other occurrence of "blocking" in the renderer — the page intro ("judged scores are recorded, never blocking") is accurate and untouched; no other tile derives from `active`. JS and Python outputs verified string-identical for the changed line via the existing parity tests.

## Risk & Rollout

Two-word label change; revert is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)