### PR TITLE
feat(ci): let the eval pipeline install a release candidate's published images

### DIFF
--- a/bench/baselines/README.md
+++ b/bench/baselines/README.md
@@ -93,6 +93,16 @@ be judged against. That is enforced twice — the `JOB_TYPE` condition in
 `PULL_NUMBER` is set — because a guard living only in shell is one careless
 edit away from being gone.
 
+A release-candidate run does not append either, and it is the case the sentence
+above does not cover: the candidate is a commit on `main`, and the run measuring
+it is a periodic with no `PULL_NUMBER`, so it satisfies both conditions exactly.
+`RC_COMMIT_SHA` being set is the third condition, enforced in the same two
+places. It has to be, because the mistake is not correctable afterwards:
+`VersionKey` names the setup, the scoring version, the judge and the two content
+versions, and nothing about which build produced a sample, so a candidate's
+record and `main`'s are the same record once written — and the candidate would
+then be judged non-inferior to a window it had just moved.
+
 A store that will not parse is an **error**, never an empty store. Empty means
 "nothing admitted, aggregate advisory", which is a green; a corrupt file
 reaching that state would silently disarm the gate.
@@ -241,8 +251,9 @@ uv run bench-gate record \
   --lines-out /tmp/appended.jsonl
 ```
 
-It refuses to run with `PULL_NUMBER` set. It is also unconditional on the
-verdict, deliberately — see above.
+It refuses to run with `PULL_NUMBER` or `RC_COMMIT_SHA` set; `--force` overrides
+both, for tests and local screening. It is also unconditional on the verdict,
+deliberately — see above.
 
 With `EVAL_BASELINE_STORE` pointing at a bucket the append lands and the loop
 closes. Against the default local store it does not: the store lives in git,

--- a/bench/kube_agents_bench/gate.py
+++ b/bench/kube_agents_bench/gate.py
@@ -525,6 +525,21 @@ def _cmd_record(args: argparse.Namespace) -> int:
         )
         return 2
 
+    if os.environ.get("RC_COMMIT_SHA") and not args.force:
+        # Same invariant, second way in. A release-candidate eval is a periodic
+        # with no PULL_NUMBER, so the check above lets it through, and a record
+        # written from one is indistinguishable afterwards: VersionKey names the
+        # setup, the scoring version, the judge and the two content versions,
+        # and nothing about which build produced the sample. The candidate would
+        # then be judged non-inferior to a window it had just moved.
+        print(
+            "::error::refusing to record a baseline with RC_COMMIT_SHA set "
+            f"({os.environ['RC_COMMIT_SHA']}): a release candidate is measured "
+            "against main's window, not added to it",
+            file=sys.stderr,
+        )
+        return 2
+
     cases = _read_case_results(args.case_result)
     if isinstance(cases, str):
         print(f"::error::{cases}", file=sys.stderr)
@@ -709,7 +724,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     record.add_argument(
         "--force",
         action="store_true",
-        help="append even with PULL_NUMBER set; for tests and local screening",
+        help="append even with PULL_NUMBER or RC_COMMIT_SHA set; for tests and local screening",
     )
     record.set_defaults(func=_cmd_record)
 

--- a/bench/tests/test_gate.py
+++ b/bench/tests/test_gate.py
@@ -74,6 +74,7 @@ def _clean_env(monkeypatch):
         "EVAL_JUDGED_MARGIN",
         "EVAL_JUDGED_METRICS",
         "PULL_NUMBER",
+        "RC_COMMIT_SHA",
         "PULL_BASE_SHA",
         "GIT_COMMIT",
         "EVAL_BASELINE_STORE",
@@ -503,6 +504,18 @@ def test_record_refuses_to_run_on_a_pull_request(tmp_path, monkeypatch, capsys):
     store = store_with(tmp_path)
     assert run_record(store, case_file(tmp_path, "a")) == 2
     assert "only runs on main" in capsys.readouterr().err
+    assert list(store.glob("*.jsonl")) == []
+
+
+def test_record_refuses_to_run_on_a_release_candidate(tmp_path, monkeypatch, capsys):
+    """The other way into the same invariant. An RC eval is a periodic with no
+    PULL_NUMBER, so the check above lets it through — and a record written from
+    one cannot be told apart later, because VersionKey carries no field naming
+    the build a sample came from."""
+    monkeypatch.setenv("RC_COMMIT_SHA", "b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe")
+    store = store_with(tmp_path)
+    assert run_record(store, case_file(tmp_path, "a")) == 2
+    assert "release candidate is measured against" in capsys.readouterr().err
     assert list(store.glob("*.jsonl")) == []
 
 

--- a/docs/designs/eval-scorer.md
+++ b/docs/designs/eval-scorer.md
@@ -663,6 +663,15 @@ bar upward until nothing could clear it and nothing could fall back below it.
 `hack/ci-eval-pr.sh`, and an independent refusal inside `bench-gate record` when `PULL_NUMBER` is
 set. A guard living only in shell is one careless edit from being gone.
 
+**Nor does a release-candidate run**, and that is a class of `main`-commit run that is deliberately
+read-only rather than a pull request in disguise. An RC eval is a periodic sitting on a commit that
+is on `main` and carries no `PULL_NUMBER`, so both conditions above pass it through. `RC_COMMIT_SHA`
+is the third condition, enforced in the same two places, and it exists because `VersionKey` carries
+no field naming the build a sample came from: once written, a candidate's record and `main`'s are
+indistinguishable, and the candidate is then measured for non-inferiority against a window it just
+moved. `bench/baselines/README.md` is canonical for the rule; this paragraph records why the
+read-only class exists.
+
 Two independent reasons, and the weaker one is the one usually cited. The narrow reason is
 self-admission: a case that wrote its own evidence could be admitted by the very diff that makes it
 pass. The broader reason is that **a branch is not `main`.** The baseline answers "how does this

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -4,6 +4,11 @@
 # ==============================================================================
 # The evaluation cluster and its IAM are pre-configured; this script builds
 # the PR's images and deploys the kube-agents chart onto that cluster.
+#
+# Setting RC_COMMIT_SHA switches it to the release-candidate path: no build at
+# all, and the chart's published GHCR images at that commit instead. Section 2a
+# is the whole of the difference, and with the variable unset nothing below
+# behaves differently from the day this line was added.
 # ==============================================================================
 
 set -euo pipefail
@@ -47,6 +52,85 @@ export AGENT_IMAGE="${AR_REPO}/platform-agent"
 export AGENT_TAG="${TAG}"
 export IMAGE_TAG="${TAG}"
 
+# ─── 2a. Image Source: Pull Request Build, or Published Release Candidate ─────
+# RC_COMMIT_SHA unset is the presubmit and everything this script did before the
+# variable existed: build the pull request's images into the leased project's
+# Artifact Registry and install those. Set, it is the release-candidate eval —
+# the candidate's images are already published, so there is nothing to build and
+# rebuilding would measure a different artefact than the one being released.
+#
+# hack/resolve-rc-target.sh produces the value and documents why the caller, not
+# this script, checks the tree out at that commit.
+#
+# The two paths differ in registry AND in image name: Artifact Registry carries
+# `kube-agents-operator`, the published one is `k8s-operator`. That is why the
+# RC path drops the repository overrides rather than rewriting them — the chart
+# already defaults every image to the published GHCR path, so only the tag has
+# to be said. The same drop is what carries the credential-proxy sidecar across:
+# it is not a chart value at all, the operator derives it from the agent image by
+# rewriting the trailing path element and keeping the tag
+# (resolveCredentialProxyImage in k8s-operator/internal/controller/
+# platformagent_manifests.go), so it follows whichever repository the agent uses
+# without being named here. Both plugin images default to enabled=false and are
+# not rendered on either path.
+if [ -n "${RC_COMMIT_SHA:-}" ]; then
+  # Sourced inside the branch, deliberately. The presubmit path must not acquire
+  # a second file's exports and functions just because this one exists.
+  # shellcheck source=scripts/release/common.sh
+  source "${SCRIPT_DIR}/../scripts/release/common.sh"
+  RC_REGISTRY_PREFIX="$(get_registry_prefix)"
+
+  # The checkout contract, enforced rather than only documented. Only the images
+  # come from RC_COMMIT_SHA; the chart, the CRDs, bench/tasks and bench/tf/fleet
+  # all come from the tree this runs in, so a caller that sets the variable
+  # without checking the tree out first gets a run that installs the candidate's
+  # images against another revision's everything-else and reports an ordinary
+  # green verdict for a combination that will never ship. Nothing else in the
+  # run can notice that, which is why it fails here instead of warning.
+  RC_TREE_SHA="$(git -C "${SCRIPT_DIR}/.." rev-parse HEAD 2>/dev/null || echo "")"
+  if [ "${RC_TREE_SHA}" != "${RC_COMMIT_SHA}" ]; then
+    echo "ERROR: RC_COMMIT_SHA is ${RC_COMMIT_SHA} but this tree is at ${RC_TREE_SHA:-an unknown commit}."
+    echo "       Check the tree out at the candidate first, then re-run:"
+    echo "         git checkout --detach ${RC_COMMIT_SHA}"
+    echo "       hack/resolve-rc-target.sh's header explains why the checkout is"
+    echo "       the caller's job and cannot be done from inside this script."
+    exit 1
+  fi
+
+  # Cheap, and 15 minutes earlier than the alternative. Without it a missing
+  # image surfaces as `helm --wait` timing out on ImagePullBackOff, which reads
+  # as a broken chart rather than an unpublished commit. resolve-rc-target.sh
+  # checks the same thing; this repeats it because RC_COMMIT_SHA can be set by
+  # hand, and because that script is not what a Prow job is obliged to call.
+  if ! check_commit_images_exist "${RC_COMMIT_SHA}"; then
+    echo "ERROR: ${RC_REGISTRY_PREFIX} has no complete image set at ${RC_COMMIT_SHA}."
+    echo "       Required: ${REQUIRED_RELEASE_IMAGES[*]}"
+    echo "       docker-publish-ghcr.yml runs on every push to main; a queued or"
+    echo "       failed run leaves the commit with no images to install."
+    exit 1
+  fi
+
+  export TAG="${RC_COMMIT_SHA}"
+  export IMG="${RC_REGISTRY_PREFIX}/k8s-operator:${TAG}"
+  export AGENT_IMAGE="${RC_REGISTRY_PREFIX}/platform-agent"
+  export AGENT_TAG="${TAG}"
+  export IMAGE_TAG="${TAG}"
+
+  IMAGE_ARGS=(
+    --set-string "operator.image.tag=${TAG}"
+    --set-string "platformAgent.deployment.image.tag=${TAG}"
+  )
+  DEPLOY_SOURCE="release candidate ${RC_COMMIT_SHA:0:7} from ${RC_REGISTRY_PREFIX}"
+else
+  IMAGE_ARGS=(
+    --set-string "operator.image.repository=${AR_REPO}/kube-agents-operator"
+    --set-string "operator.image.tag=${TAG}"
+    --set-string "platformAgent.deployment.image.repository=${AR_REPO}/platform-agent"
+    --set-string "platformAgent.deployment.image.tag=${TAG}"
+  )
+  DEPLOY_SOURCE="PR #${PULL_NUMBER:-local} build (${TAG})"
+fi
+
 export MODEL_PROVIDER="gemini"
 export MODEL_DEFAULT_NAME="gemini-3.1-pro-preview"
 # Default to enforcing CMEK database encryption on CI evaluation clusters.
@@ -70,12 +154,16 @@ export SLACK_ENABLED="false"
 # "None" and those scenarios stop at step 0 with nothing to clone.
 #
 # CI supplies the value and deliberately does NOT lean on the chart default.
-# Everything this job deploys — chart, operator, agent — is built from the pull
-# request, so a PR that blanks `platformAgent.integration.github.gitRepo` in
-# values.yaml, or breaks the CR-to-SETTINGS.md rendering, is precisely the
-# regression the eval should catch as a failed scenario. It can only catch it
-# if the value the run is supposed to use arrives from outside the artefacts
-# under test. Note this is a *correctness* argument, not the containment
+# On the presubmit path everything this job deploys — chart, operator, agent —
+# is built from the pull request, so a PR that blanks
+# `platformAgent.integration.github.gitRepo` in values.yaml, or breaks the
+# CR-to-SETTINGS.md rendering, is precisely the regression the eval should catch
+# as a failed scenario. It can only catch it if the value the run is supposed to
+# use arrives from outside the artefacts under test. The release-candidate path
+# installs published images instead of built ones, which narrows what is under
+# test without changing this argument: the chart still comes from the checkout,
+# and supplying the value from outside is what keeps either artefact from
+# choosing it. Note this is a *correctness* argument, not the containment
 # boundary: what a run can actually write to is fixed by which repositories the
 # GitHub App is installed on, which no PR can change. See
 # docs/site/src/content/docs/deploy/ci-pool-projects.md.
@@ -246,7 +334,7 @@ else
 fi
 
 START_TIME=$SECONDS
-echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying PR #${PULL_NUMBER:-local} (${TAG}) to Namespace: ${NAMESPACE} ==="
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying ${DEPLOY_SOURCE} to Namespace: ${NAMESPACE} ==="
 
 # ─── 3. Cluster Auth ──────────────────────────────────────────────────────────
 STEP_START=$SECONDS
@@ -259,27 +347,45 @@ gcloud container clusters get-credentials "$CLUSTER_NAME" --region "$REGION" --p
 echo "✓ Cluster authentication finished in $((SECONDS - STEP_START))s"
 
 # ─── 4. Build Container Images ────────────────────────────────────────────────
-STEP_START=$SECONDS
-echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Building Container Images (platform, credential-proxy, operator) ==="
-# One submit, not three. The two agent images share the agent-base chain, so
-# building them as consecutive steps on one worker lets the second reuse the
-# first's layers instead of rebuilding that chain on a cold daemon; the operator
-# build runs alongside them. See the header of cloudbuild-ci.yaml, and #635.
-# Set REQUIRE_CACHE=true in the job environment to fail the build on a cache
-# miss instead of cold-building. Default false so a broken cache source cannot
-# block the PR that fixes it.
-export CACHE_IMAGE="${CACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest}"
-# The postsubmit's mode=max cache manifests; CACHE_IMAGE stays the fallback.
-export BUILDCACHE_IMAGE="${BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:buildcache}"
-export PROXY_BUILDCACHE_IMAGE="${PROXY_BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/credential-proxy:buildcache}"
-gcloud builds submit --config="deploy/docker/cloudbuild-ci.yaml" \
-  --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_CACHE_IMAGE=${CACHE_IMAGE},_BUILDCACHE_IMAGE=${BUILDCACHE_IMAGE},_PROXY_BUILDCACHE_IMAGE=${PROXY_BUILDCACHE_IMAGE},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_KUBE_AGENTS_VERSION=${TAG},_REQUIRE_CACHE=${REQUIRE_CACHE:-false}" \
-  --project="${PROJECT_ID}" "${BUILD_WORKER_ARGS[@]}" --quiet .
-echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
+# Skipped whole on the release-candidate path: the candidate's images are what
+# is being evaluated, and a rebuild from the same source is a different artefact
+# — different base-image digests, different build timestamps, and a different
+# _KUBE_AGENTS_VERSION baked in as the remote-MCP User-Agent. An eval that graded
+# a rebuild would not be grading the thing the release ships.
+if [ -n "${RC_COMMIT_SHA:-}" ]; then
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Skipping image builds: installing published images at ${RC_COMMIT_SHA:0:7} ==="
+else
+  STEP_START=$SECONDS
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Building Container Images (platform, credential-proxy, operator) ==="
+  # One submit, not three. The two agent images share the agent-base chain, so
+  # building them as consecutive steps on one worker lets the second reuse the
+  # first's layers instead of rebuilding that chain on a cold daemon; the operator
+  # build runs alongside them. See the header of cloudbuild-ci.yaml, and #635.
+  # Set REQUIRE_CACHE=true in the job environment to fail the build on a cache
+  # miss instead of cold-building. Default false so a broken cache source cannot
+  # block the PR that fixes it.
+  export CACHE_IMAGE="${CACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:latest}"
+  # The postsubmit's mode=max cache manifests; CACHE_IMAGE stays the fallback.
+  export BUILDCACHE_IMAGE="${BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/platform-agent:buildcache}"
+  export PROXY_BUILDCACHE_IMAGE="${PROXY_BUILDCACHE_IMAGE:-us-docker.pkg.dev/kube-agents-prow/kube-agents/credential-proxy:buildcache}"
+  gcloud builds submit --config="deploy/docker/cloudbuild-ci.yaml" \
+    --substitutions="_PLATFORM_URI=${AR_REPO}/platform-agent:${TAG},_PROXY_URI=${AR_REPO}/credential-proxy:${TAG},_OPERATOR_URI=${AR_REPO}/kube-agents-operator:${TAG},_CACHE_IMAGE=${CACHE_IMAGE},_BUILDCACHE_IMAGE=${BUILDCACHE_IMAGE},_PROXY_BUILDCACHE_IMAGE=${PROXY_BUILDCACHE_IMAGE},_HERMES_AGENT_TAG=${HERMES_AGENT_TAG},_KUBE_AGENTS_VERSION=${TAG},_REQUIRE_CACHE=${REQUIRE_CACHE:-false}" \
+    --project="${PROJECT_ID}" "${BUILD_WORKER_ARGS[@]}" --quiet .
+  echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
+fi
 
 # ─── 5. Chart Deployment ──────────────────────────────────────────────────────
 # One helm release carries the whole install — operator, credentials Secret,
 # agent CR, and LiteLLM — so there is nothing to apply piecemeal or keep in order.
+#
+# The chart is `./charts/kube-agents`, out of the checkout, on both paths. On the
+# release-candidate path that makes the checkout load-bearing: the images come
+# from RC_COMMIT_SHA and the chart, CRDs and eval tasks come from whatever tree
+# this runs in, so the caller has to have checked the tree out at that commit
+# first or the run grades the candidate's images against another revision's
+# everything-else. hack/resolve-rc-target.sh is where that contract is written
+# down, and .github/workflows/deploy-environment.yml is the existing precedent
+# for honouring it with a checkout step.
 # Webhooks stay at the chart's default (off): a PR evaluation cluster carries
 # no cert-manager, and admission-webhook coverage belongs to the operator's
 # own test suite rather than this smoke pipeline.
@@ -298,10 +404,7 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying the kube-agents chart ===
 API_SERVER_KEY="${API_SERVER_KEY:-$(openssl rand -hex 16)}"
 helm upgrade --install kube-agents ./charts/kube-agents \
   --namespace "${NAMESPACE}" --create-namespace \
-  --set-string "operator.image.repository=${AR_REPO}/kube-agents-operator" \
-  --set-string "operator.image.tag=${TAG}" \
-  --set-string "platformAgent.deployment.image.repository=${AR_REPO}/platform-agent" \
-  --set-string "platformAgent.deployment.image.tag=${TAG}" \
+  "${IMAGE_ARGS[@]}" \
   --set-string "platformAgent.harness.clusterName=${CLUSTER_NAME}" \
   --set-string "platformAgent.harness.location=${REGION}" \
   --set-string "platformAgent.harness.projectId=${PROJECT_ID}" \

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -245,6 +245,10 @@ publish_eval_dashboard() {
     echo "eval-dashboard publish skipped: PULL_NUMBER=${PULL_NUMBER} is set: a pull request never writes the dashboard"
     return 0
   fi
+  if [ -n "${RC_COMMIT_SHA:-}" ]; then
+    echo "eval-dashboard publish skipped: RC_COMMIT_SHA=${RC_COMMIT_SHA} is set: a release-candidate run measures a candidate, it does not report main's history"
+    return 0
+  fi
   if [ -z "${EVAL_DASHBOARD_TARGET:-}" ]; then
     echo "eval-dashboard publish skipped: EVAL_DASHBOARD_TARGET is not set (the Prow job config arms this later)"
     return 0
@@ -1542,10 +1546,23 @@ profile_begin "record + final gate"
 # closes. Unset, the store is the git checkout and this job has no push
 # credential, so the append dies with the workspace; --lines-out is what
 # survives, as a Prow artefact somebody lands by hand in the meantime.
+#
+# RC_COMMIT_SHA is the third condition and the one that is not about pull
+# requests. A release-candidate eval is a periodic with no PULL_NUMBER, so it
+# satisfies the two conditions above exactly, and without this it would file the
+# candidate's results as main's. That is not a mistake anybody can undo later:
+# VersionKey in bench/kube_agents_bench/baselines.py is setup_id,
+# scoring_version, judge_model, fleet and verifiers, with no field naming the
+# build a sample came from, so an RC record and a main record are the same
+# record once written. The candidate would then be measured for non-inferiority
+# against a window it had just moved.
 case "${JOB_TYPE:-}" in
   postsubmit | periodic) EVAL_IS_MAIN_RUN="true" ;;
   *) EVAL_IS_MAIN_RUN="false" ;;
 esac
+if [ -n "${RC_COMMIT_SHA:-}" ]; then
+  EVAL_IS_MAIN_RUN="false"
+fi
 if [ "${EVAL_IS_MAIN_RUN}" = "true" ] && [ -z "${PULL_NUMBER:-}" ]; then
   echo ">>> [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Recording baseline evidence from main <<<"
   # Never fatal. Bookkeeping must not be the reason a merge to main reds.
@@ -1553,6 +1570,8 @@ if [ "${EVAL_IS_MAIN_RUN}" = "true" ] && [ -z "${PULL_NUMBER:-}" ]; then
     "${CASE_RESULTS[@]}" \
     --lines-out "${ARTIFACT_DIR}/baseline-append.jsonl") || \
     echo "WARNING: recording baseline evidence failed; the verdict below is unaffected."
+elif [ -n "${RC_COMMIT_SHA:-}" ]; then
+  echo "Release-candidate run (RC_COMMIT_SHA=${RC_COMMIT_SHA}): the baseline store is read, never written — the candidate is judged against main's window, not added to it."
 else
   echo "Not a main-branch recorder run (JOB_TYPE=${JOB_TYPE:-unset}): the baseline store is read, never written."
 fi

--- a/hack/resolve-rc-target.sh
+++ b/hack/resolve-rc-target.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Resolve the release candidate an eval run should be measured against
+# ==============================================================================
+# Prints the candidate's commit SHA on stdout. Everything else goes to stderr,
+# so the caller can do:
+#
+#   RC_COMMIT_SHA="$(hack/resolve-rc-target.sh)"
+#   git checkout --detach "${RC_COMMIT_SHA}"
+#   RC_COMMIT_SHA="${RC_COMMIT_SHA}" hack/ci-deploy.sh
+#
+# The checkout is the caller's job and not this script's, and not
+# hack/ci-deploy.sh's either. Bash reads a script incrementally as it executes,
+# so a script that checks out a different revision of itself is rewriting the
+# bytes the interpreter has not read yet. .github/workflows/deploy-environment.yml
+# already settles this the same way — a second actions/checkout step at the
+# candidate's SHA, before anything that reads the tree runs.
+#
+# Checking out matters because only the images come from the candidate. The
+# chart, the CRDs, bench/tasks, and the seeded fleet in bench/tf/fleet all come
+# from whatever tree the job happens to be sitting on, so without the checkout
+# an "RC eval" grades the candidate's images against main's everything-else.
+# ==============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/common.sh
+source "${SCRIPT_DIR}/../scripts/release/common.sh"
+
+# The candidate tags rc-create-tag.yml writes. The `_validated` marker
+# rc-tag-validated.yml adds is a sibling tag on the same commit rather than a
+# replacement — rc_2609021231_fdba3a7 and rc_2609021231_fdba3a7_validated both
+# exist once the pipeline passes — so the filter below drops markers from the
+# list of candidates, and does not drop candidates that have been validated.
+#
+# The target is the newest candidate either way, and deliberately: an eval
+# normally runs before the marker exists, and when it does not, re-measuring the
+# newest candidate is right where walking back to an older unvalidated one would
+# grade something already superseded. The marker is worth saying out loud, so
+# there is a note below, but it is not a reason to pick a different commit.
+readonly RC_TAG_GLOB="rc_*"
+
+RC_TAG="${RC_TAG:-}"
+
+if [ -z "${RC_TAG}" ]; then
+  release_fetch_tags
+  RC_TAG="$(git tag -l --sort=-v:refname "${RC_TAG_GLOB}" 2>/dev/null |
+    grep -v '_validated$' | head -n 1 || echo "")"
+  if [ -z "${RC_TAG}" ]; then
+    echo "❌ ERROR: no ${RC_TAG_GLOB} tag found. Set RC_TAG explicitly, or wait for rc-scheduler.yml to cut a candidate." >&2
+    exit 1
+  fi
+fi
+
+# `refs/tags/<name>` first, so a branch that happens to share a candidate's name
+# cannot answer ahead of the tag — the sibling lookups in common.sh are anchored
+# the same way. The unqualified form stays as the fallback because RC_TAG is
+# also how a caller names a target that is not a tag at all, a raw SHA being the
+# usual one.
+resolve_rc_commit() {
+  git rev-parse --verify "refs/tags/${RC_TAG}^{commit}" 2>/dev/null ||
+    git rev-parse --verify "${RC_TAG}^{commit}" 2>/dev/null
+}
+
+if ! RC_COMMIT_SHA="$(resolve_rc_commit)"; then
+  release_fetch_tags
+  if ! RC_COMMIT_SHA="$(resolve_rc_commit)"; then
+    echo "❌ ERROR: cannot resolve a commit from release candidate tag '${RC_TAG}'." >&2
+    exit 1
+  fi
+fi
+
+# Through common.sh rather than a local `git tag --points-at`, so this reads the
+# marker the same way the RC and promotion gates do — anchored on the
+# `rc_*_validated` family, so no neighbouring tag family can answer for it.
+if is_rc_candidate_commit_already_validated "${RC_COMMIT_SHA}"; then
+  echo "ℹ️ Note: ${RC_TAG} (${RC_COMMIT_SHA:0:7}) already carries a validation marker; measuring it again." >&2
+fi
+
+# Fail here rather than 15 minutes into `helm --wait`. An eval run installs
+# images it did not build, so "the publish workflow has not finished for this
+# commit" is a real and recoverable state — docker-publish-ghcr.yml runs on
+# every push to main with no paths filter, and a queued or failed run leaves a
+# main commit with no images at all. The candidate is normally chosen because
+# its images exist, so this firing means something moved underneath it.
+#
+# All six of REQUIRED_RELEASE_IMAGES, deliberately, though an eval install
+# renders only four of them — both plugins default to enabled=false. The gate
+# asks "is this commit published", and that is the release path's question with
+# the release path's answer; a shorter list here would be a second definition of
+# a published commit, disagreeing with verify_release_eligibility.sh about which
+# candidates exist. The cost is that a publish run which drops only a plugin
+# image blocks an eval that would not have installed it. Reach for the shorter
+# list only after deciding the two definitions should differ.
+registry_prefix="$(get_registry_prefix)"
+if ! check_commit_images_exist "${RC_COMMIT_SHA}"; then
+  echo "❌ ERROR: ${registry_prefix} is missing at least one of the required images at ${RC_COMMIT_SHA:0:7}:" >&2
+  for img in "${REQUIRED_RELEASE_IMAGES[@]}"; do
+    if registry_image_exists "${registry_prefix}/${img}:${RC_COMMIT_SHA}"; then
+      echo "   ✓ ${img}" >&2
+    else
+      echo "   ✗ ${img}" >&2
+    fi
+  done
+  exit 1
+fi
+
+if [ -n "${RC_TARGET_OUTPUT:-}" ]; then
+  {
+    echo "rc_tag=${RC_TAG}"
+    echo "rc_commit_sha=${RC_COMMIT_SHA}"
+  } >>"${RC_TARGET_OUTPUT}"
+fi
+
+echo "======================================================================" >&2
+echo "🏷️ RELEASE CANDIDATE EVAL TARGET" >&2
+echo "Release Tag:    ${RC_TAG}" >&2
+echo "Commit SHA:     ${RC_COMMIT_SHA}" >&2
+echo "Images:         ${registry_prefix}/<image>:${RC_COMMIT_SHA}" >&2
+echo "======================================================================" >&2
+
+echo "${RC_COMMIT_SHA}"

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -160,7 +160,11 @@ reproduce, and because a value deleted from the web form fails the same way as o
    `REGISTRY_PREFIX` is read too but is **optional and set on no environment**, so do not go
    looking for it: the repository scope holds no variables at all, the workflows forward an empty
    string, and `get_registry_prefix` falls back to `DEFAULT_REGISTRY_PREFIX`. Set it only to point
-   an environment at a registry other than `ghcr.io/gke-labs/kube-agents`.
+   an environment at a registry other than `ghcr.io/gke-labs/kube-agents`. If you do, note that
+   `registry_image_exists` — the probe `check_commit_images_exist` runs per image — has a docker-free
+   fallback only for `ghcr.io`. Every release-path caller runs on a GitHub Actions runner with docker
+   and so takes the `docker manifest inspect` branch regardless; a caller without docker pointed at
+   another registry gets a warning and a "missing image" answer.
 
    Two of those earn a line of their own because getting them wrong is silent rather than loud.
    `GITOPS_ORG`/`GITOPS_REPO` name the repository the token minter is scoped to and the suite

--- a/scripts/release/common.sh
+++ b/scripts/release/common.sh
@@ -14,6 +14,13 @@ export DEFAULT_REGISTRY_PREFIX="ghcr.io/gke-labs/kube-agents"
 export DEFAULT_RELEASE_REPO="gke-labs/kube-agents"
 export DEFAULT_INITIAL_VERSION="0.1.0"
 
+# The registry the docker-free existence probe below knows how to query, and the
+# manifest media types that probe must accept. Omitting the OCI types gets a
+# MANIFEST_UNKNOWN carrying "Accept header does not support OCI manifests" — a
+# 404 that reads as a missing image rather than as a wrong header.
+export GHCR_REGISTRY_HOST="ghcr.io"
+export GHCR_MANIFEST_ACCEPT="application/vnd.oci.image.index.v1+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.docker.distribution.manifest.v2+json"
+
 # Declarative registry of all required release container images
 export REQUIRED_RELEASE_IMAGES=(
   "k8s-operator"
@@ -283,6 +290,69 @@ get_registry_prefix() {
   fi
 }
 
+# Checks whether one fully-qualified image reference exists in its registry.
+#
+# `docker manifest inspect` is the preferred probe and the only one here that
+# works against every registry. It is guarded because not every caller has
+# docker: the Prow job image has none — hack/ci-deploy.sh builds through
+# `gcloud builds submit` for exactly that reason — and an unguarded call there
+# fails for every image, so the caller reports a publish outage when the real
+# problem is a missing binary. The fallback is the GHCR registry API, which
+# needs only curl and answers anonymously for a public package.
+registry_image_exists() {
+  local img="$1"
+
+  if command -v docker >/dev/null 2>&1; then
+    # Spelled out rather than `docker manifest inspect ...; return`, which
+    # propagates $? correctly but only survives errexit while every caller keeps
+    # this function in a condition context. They all do today; the next one
+    # written as a plain statement would kill the script on a missing image
+    # instead of getting a 1 back.
+    if docker manifest inspect "${img}" >/dev/null 2>&1; then
+      return 0
+    fi
+    return 1
+  fi
+
+  case "${img}" in
+    "${GHCR_REGISTRY_HOST}"/*) ;;
+    *)
+      echo "⚠️ Warning: cannot probe ${img}: no docker on PATH and no API fallback for this registry." >&2
+      return 1
+      ;;
+  esac
+
+  # Split the reference the way the registry API does, so this branch accepts
+  # what the docker branch above accepts. A digest reference separates on `@`,
+  # a tag on the last `:` — but only when that colon comes after the last `/`,
+  # since a registry host may carry a port. Anything else is the whole path with
+  # no reference, which the API spells `latest`.
+  local path="${img#"${GHCR_REGISTRY_HOST}"/}"
+  local last_segment="${path##*/}"
+  local repo reference
+  if [ "${path}" != "${path#*@}" ]; then
+    repo="${path%%@*}"
+    reference="${path#*@}"
+  elif [ "${last_segment}" != "${last_segment%:*}" ]; then
+    repo="${path%:*}"
+    reference="${path##*:}"
+  else
+    repo="${path}"
+    reference="latest"
+  fi
+
+  local token
+  token="$(curl -fsSL "https://${GHCR_REGISTRY_HOST}/token?scope=repository:${repo}:pull&service=${GHCR_REGISTRY_HOST}" 2>/dev/null |
+    sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+  if [ -z "${token}" ]; then
+    return 1
+  fi
+  curl -fsSL -o /dev/null -I \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: ${GHCR_MANIFEST_ACCEPT}" \
+    "https://${GHCR_REGISTRY_HOST}/v2/${repo}/manifests/${reference}" >/dev/null 2>&1
+}
+
 # Checks if all required candidate container images exist in GHCR for a specific commit SHA
 check_commit_images_exist() {
   local sha="$1"
@@ -291,7 +361,7 @@ check_commit_images_exist() {
 
   for img in "${REQUIRED_RELEASE_IMAGES[@]}"; do
     local target_img="${registry_prefix}/${img}:${sha}"
-    if ! docker manifest inspect "${target_img}" >/dev/null 2>&1; then
+    if ! registry_image_exists "${target_img}"; then
       return 1
     fi
   done

--- a/scripts/test_eval_dashboard_publish.py
+++ b/scripts/test_eval_dashboard_publish.py
@@ -49,6 +49,7 @@ def run_hook(
     pull_number: str = "",
     artifacts: str = "",
     timeout_s: str = "",
+    rc_commit_sha: str = "",
 ) -> subprocess.CompletedProcess:
     """Exit a `set -euo pipefail` shell with `exit_code`, real trap installed.
 
@@ -64,6 +65,7 @@ def run_hook(
             f'SCRIPT_DIR="{script_dir}"',
             f'export JOB_TYPE="{job_type}"',
             f'export PULL_NUMBER="{pull_number}"',
+            f'export RC_COMMIT_SHA="{rc_commit_sha}"',
             # Always pinned: the suite itself runs under Prow, where a real
             # $ARTIFACTS is set, and the hook copies its log there.
             f'export ARTIFACTS="{artifacts}"',
@@ -162,6 +164,29 @@ class PublishHookFailSafeTest(unittest.TestCase):
                     pull_number="1043",
                 )
                 self.assert_skipped_once(result, code, "PULL_NUMBER=1043")
+
+    def test_a_release_candidate_run_never_publishes(self):
+        """An RC eval is a periodic with no PULL_NUMBER -- the exact shape the
+        two gates above let through. It measures a candidate rather than main's
+        history, so publishing from one would overwrite the dashboard everyone
+        reads with a run about a different artefact."""
+        marker = (
+            "import pathlib, sys\n"
+            "pathlib.Path(sys.path[0], 'collect.py.ran').touch()\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack = dashboard_stubs(pathlib.Path(tmp), marker)
+            for code in (0, 7):
+                result = run_hook(
+                    code,
+                    fake_hack,
+                    target="gs://kube-agents-dashboards/evals/",
+                    job_type="periodic",
+                    rc_commit_sha="b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe",
+                )
+                self.assert_skipped_once(result, code, "RC_COMMIT_SHA=")
+            dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
+            self.assertEqual(list(dash.glob("*.ran")), [])
 
     def test_missing_collect_py_skips_fast_and_preserves_the_exit_code(self):
         """This PR may merge before the siblings that add scripts/eval_dashboard/."""

--- a/tests/test_ci_deploy_rc_images.py
+++ b/tests/test_ci_deploy_rc_images.py
@@ -1,0 +1,296 @@
+"""The smoke pipeline installs published images when RC_COMMIT_SHA is set.
+
+`hack/ci-deploy.sh` builds the pull request's images and installs those. A
+release-candidate eval must not: the candidate's images are already published,
+and a rebuild from the same source is a different artefact — different base
+digests, a different `_KUBE_AGENTS_VERSION` baked in — so grading a rebuild
+would not grade what the release ships.
+
+`RC_COMMIT_SHA` is the whole switch, and two properties matter more than the
+feature itself.
+
+The first is that the presubmit path is untouched. Every pull request in the
+repository runs it, so a regression here is a repository-wide outage, and the
+switch is unset on every one of those runs — which makes the unset path the
+thing most worth pinning.
+
+The second is that the release-candidate path names only tags. The published
+operator image is `k8s-operator`; the one Artifact Registry carries is
+`kube-agents-operator`, so a repository override copied across from the
+presubmit path would 404. Dropping the override is also what carries the
+credential-proxy sidecar: it is not a chart value, the operator derives it from
+the agent image (`resolveCredentialProxyImage`), so it follows whichever
+repository the agent uses only as long as nothing overrides that repository.
+
+The tests lift the real sections out of the real file and run them, the way
+scripts/test_eval_dashboard_publish.py does, rather than grepping for flags —
+a guard that greps passes for a section that has been commented out.
+"""
+
+import pathlib
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+from tests.testing.common import create_mock_git_repo
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_DEPLOY = _REPO_ROOT / "hack" / "ci-deploy.sh"
+
+_RC_SHA = "b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe"
+_PRESUBMIT_TAG = "pr-1024-a3dc868"
+_AR_REPO = "us-central1-docker.pkg.dev/kube-agents-evals/kube-agents"
+_GHCR_PREFIX = "ghcr.io/gke-labs/kube-agents"
+
+# The two sections under test, delimited by the banner that follows each.
+_IMAGE_SOURCE_SECTION = (r"^# ─── 2a\. Image Source.*?", r"^export MODEL_PROVIDER=")
+_BUILD_SECTION = (r"^# ─── 4\. Build Container Images.*?", r"^# ─── 5\. Chart Deployment")
+
+
+def lifted(start: str, stop: str) -> str:
+    """A run of top-level statements as written, lifted from the script."""
+    src = _CI_DEPLOY.read_text(encoding="utf-8")
+    match = re.search(rf"{start}(?={stop})", src, re.S | re.M)
+    if match is None:  # pragma: no cover - a re-banner should say so loudly
+        raise AssertionError(f"no section matching {start!r} in {_CI_DEPLOY}")
+    return match.group(0)
+
+
+def fake_candidate_tree(tmp: str, images_exist: bool) -> tuple[pathlib.Path, str]:
+    """A stub tree standing in for a checkout at the candidate.
+
+    Returns the `hack/` directory section 2a's SCRIPT_DIR points at, and the
+    commit the tree is sitting on. Two things need it to be a real repository:
+    section 2a sources `${SCRIPT_DIR}/../scripts/release/common.sh`, which is
+    what lets a test choose whether the candidate's images are published
+    without reaching a registry, and it then asks `git rev-parse HEAD` there to
+    enforce the checkout contract.
+    """
+    _, repo, git = create_mock_git_repo(tmp)
+    root = pathlib.Path(repo)
+    (root / "hack").mkdir()
+    release = root / "scripts" / "release"
+    release.mkdir(parents=True)
+    (release / "common.sh").write_text(
+        textwrap.dedent(
+            f"""\
+            export REQUIRED_RELEASE_IMAGES=(k8s-operator platform-agent credential-proxy)
+            get_registry_prefix() {{ echo "{_GHCR_PREFIX}"; }}
+            check_commit_images_exist() {{ return {0 if images_exist else 1}; }}
+            """
+        )
+    )
+    git("add", "-A")
+    git("commit", "-m", "feat: a release candidate")
+    return root / "hack", git("rev-parse", "HEAD").stdout.strip()
+
+
+def run_image_source(
+    script_dir: pathlib.Path, rc_commit_sha: str
+) -> subprocess.CompletedProcess:
+    """Run section 2a and print the decision it reached, one field per line."""
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            f'SCRIPT_DIR="{script_dir}"',
+            f'export RC_COMMIT_SHA="{rc_commit_sha}"',
+            f'export AR_REPO="{_AR_REPO}"',
+            f'export TAG="{_PRESUBMIT_TAG}"',
+            'export PULL_NUMBER="1024"',
+            # Section 2 sets these just above the lifted section; the release
+            # candidate branch overwrites them and the presubmit path must not.
+            f'export IMG="{_AR_REPO}/kube-agents-operator:{_PRESUBMIT_TAG}"',
+            f'export AGENT_IMAGE="{_AR_REPO}/platform-agent"',
+            lifted(*_IMAGE_SOURCE_SECTION),
+            'echo "TAG=${TAG}"',
+            'echo "IMG=${IMG}"',
+            'echo "AGENT_IMAGE=${AGENT_IMAGE}"',
+            'echo "DEPLOY_SOURCE=${DEPLOY_SOURCE}"',
+            'for arg in "${IMAGE_ARGS[@]}"; do echo "ARG=${arg}"; done',
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def run_build_section(rc_commit_sha: str) -> subprocess.CompletedProcess:
+    """Run section 4 with `gcloud` stubbed, so a build announces itself."""
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            f'export RC_COMMIT_SHA="{rc_commit_sha}"',
+            f'export AR_REPO="{_AR_REPO}"',
+            f'export TAG="{_PRESUBMIT_TAG}"',
+            'export PROJECT_ID="kube-agents-evals"',
+            'export HERMES_AGENT_TAG="v0"',
+            "BUILD_WORKER_ARGS=(--machine-type=e2-highcpu-8)",
+            'gcloud() { echo "BUILD SUBMITTED"; }',
+            lifted(*_BUILD_SECTION),
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
+
+
+def fields(result: subprocess.CompletedProcess) -> dict[str, str]:
+    out = {}
+    for line in result.stdout.splitlines():
+        key, _, value = line.partition("=")
+        if key != "ARG":
+            out[key] = value
+    return out
+
+
+def image_args(result: subprocess.CompletedProcess) -> list[str]:
+    return [
+        line.partition("=")[2]
+        for line in result.stdout.splitlines()
+        if line.startswith("ARG=")
+    ]
+
+
+class PresubmitPathUnchangedTest(unittest.TestCase):
+    """RC_COMMIT_SHA unset is every pull request in the repository."""
+
+    def test_the_four_artifact_registry_flags_are_what_helm_gets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, _ = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha="")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            image_args(result),
+            [
+                "--set-string",
+                f"operator.image.repository={_AR_REPO}/kube-agents-operator",
+                "--set-string",
+                f"operator.image.tag={_PRESUBMIT_TAG}",
+                "--set-string",
+                f"platformAgent.deployment.image.repository={_AR_REPO}/platform-agent",
+                "--set-string",
+                f"platformAgent.deployment.image.tag={_PRESUBMIT_TAG}",
+            ],
+            "the presubmit's Helm image flags must be exactly what they were "
+            "before RC_COMMIT_SHA existed: every pull request runs this path.",
+        )
+
+    def test_the_tag_and_image_exports_are_left_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, _ = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha="")
+        got = fields(result)
+        self.assertEqual(got["TAG"], _PRESUBMIT_TAG)
+        self.assertEqual(
+            got["IMG"], f"{_AR_REPO}/kube-agents-operator:{_PRESUBMIT_TAG}"
+        )
+        self.assertEqual(got["AGENT_IMAGE"], f"{_AR_REPO}/platform-agent")
+
+    def test_the_images_are_still_built(self) -> None:
+        result = run_build_section(rc_commit_sha="")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("BUILD SUBMITTED", result.stdout)
+
+
+class ReleaseCandidatePathTest(unittest.TestCase):
+    def test_only_tags_are_set_and_no_repository_is_overridden(self) -> None:
+        """The published operator image is `k8s-operator` and the Artifact
+        Registry one is `kube-agents-operator`, so an override copied from the
+        presubmit path would 404. The chart already defaults every image to the
+        published path; only the tag has to be said."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, rc_sha = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha=rc_sha)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            image_args(result),
+            [
+                "--set-string",
+                f"operator.image.tag={rc_sha}",
+                "--set-string",
+                f"platformAgent.deployment.image.tag={rc_sha}",
+            ],
+        )
+
+    def test_no_flag_names_the_artifact_registry(self) -> None:
+        """Stated separately from the equality above because this is the
+        property the credential-proxy sidecar rides on: the operator derives
+        the proxy image from the agent's repository, so overriding that
+        repository moves the proxy to a registry the candidate never
+        published to."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, rc_sha = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha=rc_sha)
+        for arg in image_args(result):
+            self.assertNotIn(_AR_REPO, arg)
+            self.assertNotIn("image.repository", arg)
+
+    def test_the_exported_references_name_the_published_images(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, rc_sha = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha=rc_sha)
+        got = fields(result)
+        self.assertEqual(got["TAG"], rc_sha)
+        self.assertEqual(got["IMG"], f"{_GHCR_PREFIX}/k8s-operator:{rc_sha}")
+        self.assertEqual(got["AGENT_IMAGE"], f"{_GHCR_PREFIX}/platform-agent")
+        self.assertIn(rc_sha[:7], got["DEPLOY_SOURCE"])
+
+    def test_a_commit_with_no_published_images_stops_the_deploy(self) -> None:
+        """Fifteen minutes earlier than the alternative. Without this the
+        missing image surfaces as `helm --wait` timing out on
+        ImagePullBackOff, which reads as a broken chart rather than as a
+        commit docker-publish-ghcr.yml has not finished publishing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, rc_sha = fake_candidate_tree(tmp, images_exist=False)
+            result = run_image_source(fake_hack, rc_commit_sha=rc_sha)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("no complete image set", result.stdout)
+        self.assertIn(rc_sha, result.stdout)
+
+    def test_a_tree_at_another_commit_stops_the_deploy(self) -> None:
+        """Only the images come from the candidate. The chart, the CRDs, and
+        bench/tasks come from whatever tree the job is sitting on, so an
+        RC_COMMIT_SHA that does not match HEAD grades the candidate's images
+        against another commit's everything-else — and nothing about the run
+        would say so. The checkout is the caller's job, per
+        hack/resolve-rc-target.sh's header, which makes "the caller forgot" a
+        state this has to name rather than absorb."""
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack, rc_sha = fake_candidate_tree(tmp, images_exist=True)
+            result = run_image_source(fake_hack, rc_commit_sha=_RC_SHA)
+        self.assertNotEqual(rc_sha, _RC_SHA)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn(_RC_SHA, result.stdout)
+        self.assertIn(rc_sha, result.stdout)
+        self.assertIn("git checkout --detach", result.stdout)
+
+    def test_nothing_is_built(self) -> None:
+        result = run_build_section(rc_commit_sha=_RC_SHA)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(
+            "BUILD SUBMITTED",
+            result.stdout,
+            "a release-candidate eval must grade the published images, not a "
+            "rebuild of the same source.",
+        )
+        self.assertIn("Skipping image builds", result.stdout)
+
+
+class HelmInvocationTest(unittest.TestCase):
+    def test_the_release_takes_its_image_flags_from_the_array(self) -> None:
+        """Section 2a decides; section 5 must not decide again. A second
+        `--set-string ...image.repository=` on the helm line would win by
+        being later and would silently undo the release-candidate path."""
+        text = _CI_DEPLOY.read_text(encoding="utf-8")
+        helm_call = text.partition("helm upgrade --install kube-agents")[2].partition(
+            "--wait"
+        )[0]
+        self.assertIn('"${IMAGE_ARGS[@]}"', helm_call)
+        self.assertNotIn("image.repository", helm_call)
+        self.assertNotIn("image.tag", helm_call)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_common.py
+++ b/tests/test_release_common.py
@@ -20,6 +20,7 @@ from tests.testing.common import (
     MOCK_DEFAULT_RELEASE_REPO,
     TRUTHY_BOOLEAN_INPUTS,
     VALID_GA_RELEASE_TAGS,
+    create_minimal_tools_bin,
     create_mock_git_repo,
     get_isolated_test_env,
 )
@@ -845,14 +846,21 @@ class RegistryImageProbeTest(unittest.TestCase):
     _REPOSITORY_PATH = "gke-labs/kube-agents/platform-agent"
     _DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
 
-    def _run(self, func_call, bin_dir, env=None):
-        """common.sh sourced with PATH pinned to bin_dir plus the base utilities.
+    def _bin(self, tmp):
+        """A PATH holding the base utilities, symlinked, and no docker.
 
-        Pinned rather than prepended: this suite is about what happens when
-        docker is ABSENT, and a developer laptop with Docker Desktop installed
-        would otherwise find it further down the inherited PATH.
+        Most of this suite is about what happens when docker is ABSENT, so the
+        binary has to be absent from PATH rather than merely shadowed. Naming
+        system directories does not achieve that: `ubuntu-latest` ships docker
+        at `/usr/bin/docker`, which put the real binary in front of six of
+        these cases and let them pass on a laptop with no docker installed
+        while failing in CI.
         """
-        overrides = {"PATH": f"{bin_dir}:/usr/bin:/bin"}
+        return create_minimal_tools_bin(tmp)
+
+    def _run(self, func_call, bin_dir, env=None):
+        """common.sh sourced with PATH pinned to bin_dir, and nothing else."""
+        overrides = {"PATH": str(bin_dir)}
         overrides.update(env or {})
         return subprocess.run(
             ["bash", "-c", f'source "{_COMMON_SH}"\n{func_call}'],
@@ -864,37 +872,42 @@ class RegistryImageProbeTest(unittest.TestCase):
 
     def test_docker_is_used_when_it_is_there(self):
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_docker_binary(tmp, existing_images=[self._IMAGE])
-            found = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_docker_binary(bin_dir, existing_images=[self._IMAGE])
+            found = self._run(f'registry_image_exists "{self._IMAGE}"', bin_dir)
             self.assertEqual(found.returncode, 0, found.stderr)
-            missing = self._run(f'registry_image_exists "{self._IMAGE}x"', tmp)
+            missing = self._run(f'registry_image_exists "{self._IMAGE}x"', bin_dir)
             self.assertNotEqual(missing.returncode, 0)
 
     def test_a_published_image_is_found_without_docker(self):
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_ghcr_curl_binary(tmp)
-            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_ghcr_curl_binary(bin_dir)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', bin_dir)
             self.assertEqual(proc.returncode, 0, proc.stderr)
 
     def test_an_unpublished_image_is_still_missing_without_docker(self):
         """The fallback must not turn into an unconditional yes."""
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_ghcr_curl_binary(tmp, manifest_status=1)
-            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_ghcr_curl_binary(bin_dir, manifest_status=1)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', bin_dir)
             self.assertNotEqual(proc.returncode, 0)
 
     def test_an_unauthenticated_registry_is_missing_rather_than_present(self):
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_ghcr_curl_binary(tmp, token_response="")
-            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_ghcr_curl_binary(bin_dir, token_response="")
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', bin_dir)
             self.assertNotEqual(proc.returncode, 0)
 
     def test_another_registry_without_docker_says_why(self):
         """Reporting "missing" for a registry the fallback cannot query is a
         lie about the image. It still fails, but it must say what it is."""
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_ghcr_curl_binary(tmp)
-            proc = self._run(f'registry_image_exists "{self._FOREIGN_IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_ghcr_curl_binary(bin_dir)
+            proc = self._run(f'registry_image_exists "{self._FOREIGN_IMAGE}"', bin_dir)
             self.assertNotEqual(proc.returncode, 0)
             self.assertIn("no docker on PATH", proc.stderr)
 
@@ -910,8 +923,9 @@ class RegistryImageProbeTest(unittest.TestCase):
         thing. Asserting only the exit code leaves both the URL and the header
         free to be anything, so this reads the request the mock recorded."""
         with tempfile.TemporaryDirectory() as tmp:
-            _, log_path = create_mock_ghcr_curl_binary(tmp)
-            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            bin_dir = self._bin(tmp)
+            _, log_path = create_mock_ghcr_curl_binary(bin_dir)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', bin_dir)
             self.assertEqual(proc.returncode, 0, proc.stderr)
 
             probe = self._manifest_probe(pathlib.Path(log_path))
@@ -933,9 +947,10 @@ class RegistryImageProbeTest(unittest.TestCase):
         has to accept it too — splitting it on the last colon would ask for a
         repository named `…@sha256` and a tag of hex."""
         with tempfile.TemporaryDirectory() as tmp:
-            _, log_path = create_mock_ghcr_curl_binary(tmp)
+            bin_dir = self._bin(tmp)
+            _, log_path = create_mock_ghcr_curl_binary(bin_dir)
             image = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/platform-agent@{self._DIGEST}"
-            proc = self._run(f'registry_image_exists "{image}"', tmp)
+            proc = self._run(f'registry_image_exists "{image}"', bin_dir)
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn(
                 f"https://ghcr.io/v2/{self._REPOSITORY_PATH}/manifests/{self._DIGEST}",
@@ -946,9 +961,10 @@ class RegistryImageProbeTest(unittest.TestCase):
         """No tag and no digest means `latest` to a registry. Left unhandled it
         becomes an empty reference and a URL ending in `/manifests/`."""
         with tempfile.TemporaryDirectory() as tmp:
-            _, log_path = create_mock_ghcr_curl_binary(tmp)
+            bin_dir = self._bin(tmp)
+            _, log_path = create_mock_ghcr_curl_binary(bin_dir)
             image = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/platform-agent"
-            proc = self._run(f'registry_image_exists "{image}"', tmp)
+            proc = self._run(f'registry_image_exists "{image}"', bin_dir)
             self.assertEqual(proc.returncode, 0, proc.stderr)
             self.assertIn(
                 f"https://ghcr.io/v2/{self._REPOSITORY_PATH}/manifests/latest",
@@ -958,10 +974,11 @@ class RegistryImageProbeTest(unittest.TestCase):
     def test_the_commit_check_stops_reporting_a_publish_outage(self):
         """The regression the guard exists for, at the level callers use."""
         with tempfile.TemporaryDirectory() as tmp:
-            create_mock_ghcr_curl_binary(tmp)
+            bin_dir = self._bin(tmp)
+            create_mock_ghcr_curl_binary(bin_dir)
             proc = self._run(
                 f'check_commit_images_exist "{MOCK_SAMPLE_COMMIT_SHA}"',
-                tmp,
+                bin_dir,
                 env={"REGISTRY_PREFIX": MOCK_DEFAULT_REGISTRY_PREFIX},
             )
             self.assertEqual(proc.returncode, 0, proc.stderr)

--- a/tests/test_release_common.py
+++ b/tests/test_release_common.py
@@ -30,6 +30,7 @@ from tests.testing.release import (
     MOCK_SAMPLE_SHORT_SHA,
     MOCK_TARGET_RELEASE_TAG,
     create_mock_docker_binary,
+    create_mock_ghcr_curl_binary,
 )
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -822,6 +823,148 @@ source "{_COMMON_SH}"
                     f"{script} re-implements the breaking-change test instead of calling common.sh",
                 )
                 self.assertIn("commit_messages_have_breaking_change", body, f"{script} does not call the helper")
+
+
+class RegistryImageProbeTest(unittest.TestCase):
+    """`registry_image_exists` must not read "no docker" as "no image".
+
+    `docker manifest inspect` is the probe that works against every registry,
+    and three other call sites in common.sh already check for the binary before
+    using it. `check_commit_images_exist` did not, so on a machine with no
+    docker it reported every image missing — which `find_latest_built_commit`
+    turns into "no commit in the last 30 has published images", a publish
+    outage that is really a missing binary. The Prow job image is exactly such
+    a machine: hack/ci-deploy.sh builds through `gcloud builds submit` because
+    there is no docker daemon there, and hack/resolve-rc-target.sh runs in the
+    same place.
+    """
+
+    _IMAGE = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/platform-agent:{MOCK_SAMPLE_COMMIT_SHA}"
+    # Deliberately not ghcr.io: the curl fallback speaks one registry's API.
+    _FOREIGN_IMAGE = f"us-central1-docker.pkg.dev/p/r/platform-agent:{MOCK_SAMPLE_COMMIT_SHA}"
+    _REPOSITORY_PATH = "gke-labs/kube-agents/platform-agent"
+    _DIGEST = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+    def _run(self, func_call, bin_dir, env=None):
+        """common.sh sourced with PATH pinned to bin_dir plus the base utilities.
+
+        Pinned rather than prepended: this suite is about what happens when
+        docker is ABSENT, and a developer laptop with Docker Desktop installed
+        would otherwise find it further down the inherited PATH.
+        """
+        overrides = {"PATH": f"{bin_dir}:/usr/bin:/bin"}
+        overrides.update(env or {})
+        return subprocess.run(
+            ["bash", "-c", f'source "{_COMMON_SH}"\n{func_call}'],
+            capture_output=True,
+            text=True,
+            env=get_isolated_test_env(overrides=overrides),
+            cwd=str(_REPO_ROOT),
+        )
+
+    def test_docker_is_used_when_it_is_there(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_docker_binary(tmp, existing_images=[self._IMAGE])
+            found = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            self.assertEqual(found.returncode, 0, found.stderr)
+            missing = self._run(f'registry_image_exists "{self._IMAGE}x"', tmp)
+            self.assertNotEqual(missing.returncode, 0)
+
+    def test_a_published_image_is_found_without_docker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_ghcr_curl_binary(tmp)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_an_unpublished_image_is_still_missing_without_docker(self):
+        """The fallback must not turn into an unconditional yes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_ghcr_curl_binary(tmp, manifest_status=1)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            self.assertNotEqual(proc.returncode, 0)
+
+    def test_an_unauthenticated_registry_is_missing_rather_than_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_ghcr_curl_binary(tmp, token_response="")
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            self.assertNotEqual(proc.returncode, 0)
+
+    def test_another_registry_without_docker_says_why(self):
+        """Reporting "missing" for a registry the fallback cannot query is a
+        lie about the image. It still fails, but it must say what it is."""
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_ghcr_curl_binary(tmp)
+            proc = self._run(f'registry_image_exists "{self._FOREIGN_IMAGE}"', tmp)
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("no docker on PATH", proc.stderr)
+
+    def _manifest_probe(self, log_path):
+        """The one logged call that is not the token request."""
+        calls = [line for line in log_path.read_text().splitlines() if "/manifests/" in line]
+        self.assertEqual(len(calls), 1, log_path.read_text())
+        return calls[0]
+
+    def test_the_probe_carries_the_url_and_headers_ghcr_answers_on(self):
+        """GHCR returns 404, not 401, for a manifest request that omits the OCI
+        media types — a false "image missing" indistinguishable from the real
+        thing. Asserting only the exit code leaves both the URL and the header
+        free to be anything, so this reads the request the mock recorded."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, log_path = create_mock_ghcr_curl_binary(tmp)
+            proc = self._run(f'registry_image_exists "{self._IMAGE}"', tmp)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            probe = self._manifest_probe(pathlib.Path(log_path))
+            self.assertIn(
+                f"https://ghcr.io/v2/{self._REPOSITORY_PATH}/manifests/{MOCK_SAMPLE_COMMIT_SHA}",
+                probe,
+            )
+            self.assertIn("Authorization: Bearer t", probe)
+            for media_type in (
+                "application/vnd.oci.image.index.v1+json",
+                "application/vnd.oci.image.manifest.v1+json",
+                "application/vnd.docker.distribution.manifest.list.v2+json",
+                "application/vnd.docker.distribution.manifest.v2+json",
+            ):
+                self.assertIn(media_type, probe)
+
+    def test_a_digest_reference_is_probed_as_a_digest(self):
+        """`<repo>@sha256:…` is what the docker branch accepts, so the fallback
+        has to accept it too — splitting it on the last colon would ask for a
+        repository named `…@sha256` and a tag of hex."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, log_path = create_mock_ghcr_curl_binary(tmp)
+            image = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/platform-agent@{self._DIGEST}"
+            proc = self._run(f'registry_image_exists "{image}"', tmp)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn(
+                f"https://ghcr.io/v2/{self._REPOSITORY_PATH}/manifests/{self._DIGEST}",
+                self._manifest_probe(pathlib.Path(log_path)),
+            )
+
+    def test_a_reference_less_image_is_probed_at_latest(self):
+        """No tag and no digest means `latest` to a registry. Left unhandled it
+        becomes an empty reference and a URL ending in `/manifests/`."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, log_path = create_mock_ghcr_curl_binary(tmp)
+            image = f"{MOCK_DEFAULT_REGISTRY_PREFIX}/platform-agent"
+            proc = self._run(f'registry_image_exists "{image}"', tmp)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn(
+                f"https://ghcr.io/v2/{self._REPOSITORY_PATH}/manifests/latest",
+                self._manifest_probe(pathlib.Path(log_path)),
+            )
+
+    def test_the_commit_check_stops_reporting_a_publish_outage(self):
+        """The regression the guard exists for, at the level callers use."""
+        with tempfile.TemporaryDirectory() as tmp:
+            create_mock_ghcr_curl_binary(tmp)
+            proc = self._run(
+                f'check_commit_images_exist "{MOCK_SAMPLE_COMMIT_SHA}"',
+                tmp,
+                env={"REGISTRY_PREFIX": MOCK_DEFAULT_REGISTRY_PREFIX},
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_resolve_rc_target.py
+++ b/tests/test_resolve_rc_target.py
@@ -1,0 +1,163 @@
+"""`hack/resolve-rc-target.sh` names the candidate an eval run is measured on.
+
+Its stdout is consumed as `RC_COMMIT_SHA="$(hack/resolve-rc-target.sh)"`, so
+the contract is narrower than "prints something useful": stdout carries the
+commit SHA and nothing else, and every diagnostic goes to stderr. A summary
+line that drifts onto stdout does not fail — it silently becomes part of the
+SHA the Prow job then tries to check out.
+
+The rest is which candidate it picks and when it refuses. Refusing matters
+because the images are somebody else's to publish: `docker-publish-ghcr.yml`
+runs on every push to main with no paths filter, and a queued or failed run
+leaves a main commit with no images at all, which `helm --wait` would otherwise
+turn into a 15-minute ImagePullBackOff that reads as a broken chart.
+"""
+
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import (
+    MOCK_DEFAULT_REGISTRY_PREFIX,
+    create_minimal_tools_bin,
+    create_mock_git_repo,
+    get_isolated_test_env,
+)
+from tests.testing.release import create_mock_ghcr_curl_binary
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "hack" / "resolve-rc-target.sh"
+
+_OLDER_RC = "rc_2609010800_aaaaaaa"
+_NEWER_RC = "rc_2609021200_bbbbbbb"
+_NEWEST_RC = "rc_2609030900_ccccccc"
+# A sibling of _NEWEST_RC on the same commit, which is how rc-tag-validated.yml
+# writes it: the candidate keeps its bare tag forever and gains a marker beside
+# it. A fixture that made the marker a replacement would let a resolver that
+# walked back to an older candidate look correct.
+_NEWEST_RC_MARKER = f"{_NEWEST_RC}_validated"
+
+
+class ResolveRcTargetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = pathlib.Path(self._tmp.name)
+        # A str, not `root`: create_mock_git_repo takes `temp_dir.name` from
+        # anything that has one, and a pathlib.Path has a `.name` — the last
+        # component. Handing it the Path builds the mock repo at a relative
+        # `tmpXXXXXXXX/repo`, so the fixtures land in whatever directory the
+        # suite was started from and no cleanup ever removes them.
+        _, self.repo, self.git = create_mock_git_repo(self._tmp.name)
+        self.bin_dir = create_minimal_tools_bin(root)
+        # The script probes through common.sh's `registry_image_exists`, which
+        # falls back to the GHCR API when there is no docker — and there is
+        # none in a `create_minimal_tools_bin` PATH, which is the Prow job
+        # image's shape too.
+        create_mock_ghcr_curl_binary(self.bin_dir)
+
+        # Three candidates on three commits, the newest already validated.
+        self.shas = {}
+        for tag in (_OLDER_RC, _NEWER_RC, _NEWEST_RC):
+            (pathlib.Path(self.repo) / f"{tag}.txt").write_text(tag)
+            self.git("add", "-A")
+            self.git("commit", "-m", f"feat: {tag}")
+            self.git("tag", tag)
+            self.shas[tag] = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("tag", _NEWEST_RC_MARKER)
+
+    def run_script(self, env=None, manifest_status=0):
+        if manifest_status:
+            create_mock_ghcr_curl_binary(self.bin_dir, manifest_status=manifest_status)
+        overrides = {
+            "PATH": str(self.bin_dir),
+            "REGISTRY_PREFIX": MOCK_DEFAULT_REGISTRY_PREFIX,
+        }
+        overrides.update(env or {})
+        return subprocess.run(
+            ["bash", str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env=get_isolated_test_env(overrides=overrides),
+            cwd=self.repo,
+        )
+
+    def test_stdout_is_the_commit_sha_and_nothing_else(self):
+        """`$(...)` captures stdout whole. A summary line that lands there
+        becomes part of the SHA rather than an extra line somebody notices."""
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), self.shas[_NEWEST_RC])
+        self.assertEqual(len(result.stdout.strip().splitlines()), 1)
+        self.assertIn("RELEASE CANDIDATE EVAL TARGET", result.stderr)
+
+    def test_the_newest_candidate_is_the_default(self):
+        """Newest, not newest-unvalidated. Walking back to an older candidate
+        because the newest carries a marker would grade a commit the pipeline
+        has already superseded."""
+        result = self.run_script()
+        self.assertEqual(result.stdout.strip(), self.shas[_NEWEST_RC])
+        self.assertIn(_NEWEST_RC, result.stderr)
+
+    def test_a_marker_is_reported_and_does_not_change_the_target(self):
+        """The `_validated` marker sits beside the candidate tag on the same
+        commit, so the filter that drops markers from the candidate list must
+        not be read as dropping validated candidates."""
+        result = self.run_script()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), self.shas[_NEWEST_RC])
+        self.assertIn("already carries a validation marker", result.stderr)
+
+    def test_a_marker_tag_is_never_itself_the_target(self):
+        """`rc_*_validated` sorts above its own candidate under -v:refname, so
+        an unfiltered list would hand the marker's name to `git rev-parse` and
+        resolve — silently naming the target after a tag that records an
+        outcome rather than a candidate."""
+        result = self.run_script()
+        self.assertNotIn(f"Release Tag:    {_NEWEST_RC_MARKER}", result.stderr)
+        self.assertIn(f"Release Tag:    {_NEWEST_RC}", result.stderr)
+
+    def test_an_explicit_tag_wins(self):
+        result = self.run_script(env={"RC_TAG": _OLDER_RC})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), self.shas[_OLDER_RC])
+
+    def test_an_unknown_tag_is_an_error_not_a_fallback(self):
+        result = self.run_script(env={"RC_TAG": "rc_2609021200_nosuch"})
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("cannot resolve a commit", result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_a_commit_with_no_published_images_is_refused(self):
+        result = self.run_script(manifest_status=1)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("missing at least one of the required images", result.stderr)
+        # The per-image breakdown, so the reader knows whether this is one
+        # unpublished image or a publish run that never started.
+        self.assertIn("platform-agent", result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_a_repository_with_no_candidates_says_so(self):
+        """The marker tag is deliberately left in place. `rc_*` matches it, so
+        a filter that only sorted would resolve `..._validated` here and report
+        a target where there is no candidate at all."""
+        for tag in (_OLDER_RC, _NEWER_RC, _NEWEST_RC):
+            self.git("tag", "-d", tag)
+        result = self.run_script()
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("no rc_* tag found", result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_the_output_file_carries_the_tag_and_the_sha(self):
+        out = pathlib.Path(self._tmp.name) / "rc-target.env"
+        result = self.run_script(env={"RC_TARGET_OUTPUT": str(out)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            out.read_text().splitlines(),
+            [f"rc_tag={_NEWEST_RC}", f"rc_commit_sha={self.shas[_NEWEST_RC]}"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/testing/release.py
+++ b/tests/testing/release.py
@@ -156,6 +156,57 @@ exit 0
     return docker_path, log_path
 
 
+MOCK_GHCR_TOKEN_RESPONSE = '{"token":"t"}'
+MOCK_GHCR_CURL_LOG = "curl.log"
+# The exit code the mock uses for a call it does not recognise, distinct from
+# the 1 a real curl returns for a 404 so a test can tell "the probe ran and the
+# image is absent" from "the probe was not built the way the API needs".
+MOCK_GHCR_CURL_UNEXPECTED_EXIT = 99
+
+
+def create_mock_ghcr_curl_binary(
+    bin_dir,
+    log_file=None,
+    manifest_status=0,
+    token_response=MOCK_GHCR_TOKEN_RESPONSE,
+):
+    """Creates a mock curl answering common.sh's anonymous GHCR probe.
+
+    It asserts the shape of the request rather than answering anything: a
+    manifest call has to carry `/v2/<repo>/manifests/<ref>`, a bearer token,
+    and the OCI `Accept` header, because GHCR returns 404 for a manifest
+    request that omits those media types. A mock that answered any argument
+    list would leave that header untested — deleting it from common.sh is a
+    change that breaks every real probe and no fake one.
+    """
+    bin_path = pathlib.Path(bin_dir)
+    bin_path.mkdir(parents=True, exist_ok=True)
+    curl_path = bin_path / "curl"
+    log_path = log_file if log_file else (bin_path / MOCK_GHCR_CURL_LOG)
+
+    curl_path.write_text(
+        f"""#!/bin/sh
+echo "mock curl: $*" >> "{log_path}"
+case "$*" in
+  *'/token?scope=repository:'*':pull'*) printf '%s' '{token_response}'; exit 0 ;;
+esac
+for required in '/v2/' '/manifests/' 'Authorization: Bearer ' \\
+  'Accept: application/vnd.oci.image.index.v1+json'; do
+  case "$*" in
+    *"$required"*) ;;
+    *)
+      echo "mock curl: manifest probe missing '$required': $*" >&2
+      exit {MOCK_GHCR_CURL_UNEXPECTED_EXIT}
+      ;;
+  esac
+done
+exit {manifest_status}
+"""
+    )
+    curl_path.chmod(0o755)
+    return curl_path, log_path
+
+
 def create_mock_cosign_binary(bin_dir, log_file=None, fail_sign=False):
     """Creates a mock cosign CLI supporting sign commands."""
     bin_path = pathlib.Path(bin_dir)


### PR DESCRIPTION
## Summary

Setting `RC_COMMIT_SHA` switches `hack/ci-deploy.sh` from building the pull request's images into a leased project's Artifact Registry to installing the images already published at that commit, and stops the eval run that follows from filing its numbers as `main`'s. A new `hack/resolve-rc-target.sh` names the candidate. Nothing sets `RC_COMMIT_SHA` yet, so on merge this changes no run: it is the first slice of #1024, and the Prow job that turns it on is the next one.

## Why This Change

Issue #1024 wants the full eval suite run against a release candidate. The suite already runs on presubmits, so the obvious move is to point that machinery at an RC — but two things stop it from working as-is.

The first is that `hack/ci-deploy.sh` builds what it installs. A rebuild from a candidate's source is not the candidate's artefact: different base-image digests, a different `_KUBE_AGENTS_VERSION` baked in as the remote-MCP User-Agent. An eval that graded a rebuild would not be grading what the release ships, which is the whole point of the exercise.

The second is worse, and it is why the baseline guards are in this PR rather than a later one. An RC eval is a Prow periodic sitting on a commit that is on `main`, with no `PULL_NUMBER` — which satisfies both of the recorder's existing conditions exactly, so it would append the candidate's results to `main`'s baseline store. That is not correctable afterwards. `VersionKey` in `bench/kube_agents_bench/baselines.py` is `(setup_id, scoring_version, judge_model, fleet, verifiers)`, with no field naming the build a sample came from, so an RC record and a `main` record are the same record once written. The candidate would then be measured for non-inferiority against a window it had just moved. The guard has to land before the job that would start writing, not after.

## What Changed

- **`hack/ci-deploy.sh`** — a new section 2a decides where images come from. `RC_COMMIT_SHA` unset is the presubmit and is unchanged. Set, it skips section 4's `gcloud builds submit` entirely and installs the published images. The two registries differ in image *name* as well as host — Artifact Registry carries `kube-agents-operator`, the published one is `k8s-operator` — so the RC path drops the repository overrides and names only tags. That drop is also what carries the credential-proxy sidecar, which is not a chart value at all: the operator derives it from the agent image by rewriting the trailing path element and keeping the tag (`resolveCredentialProxyImage`), so it follows the agent's repository as long as nothing overrides it. The RC branch also refuses to run unless the tree is checked out at `RC_COMMIT_SHA`, since everything that is not an image comes from the tree.
- **`hack/resolve-rc-target.sh`** (new) — newest `rc_*` tag, resolved to a commit, refused unless all six `REQUIRED_RELEASE_IMAGES` are published there. Stdout is the SHA alone so a caller can use `RC_COMMIT_SHA="$(hack/resolve-rc-target.sh)"`; every diagnostic goes to stderr. Checking the tree out at that commit is deliberately the *caller's* job — bash reads a script incrementally, so a script cannot check out a different revision of itself, and `deploy-environment.yml` already settles this with a second checkout step.
- **`hack/ci-eval-pr.sh`** — declines to record a baseline and declines to publish the dashboard when `RC_COMMIT_SHA` is set.
- **`bench/kube_agents_bench/gate.py`** — `bench-gate record` refuses at the entry point too, for a caller that reaches it another way. Same invariant, second way in, matching the existing `PULL_NUMBER` refusal.
- **`scripts/release/common.sh`** — `check_commit_images_exist` called `docker manifest inspect` unguarded, so on a machine with no docker it failed for every image and the caller reported a publish outage when the real problem was a missing binary. It now probes through a new `registry_image_exists`, which prefers docker and falls back to the GHCR registry API over curl.
- **Docs** — `bench/baselines/README.md` and `docs/designs/eval-scorer.md` both documented the baseline-write rule as two conditions, both about pull requests; both now carry the third. `scripts/release/README.md` notes that the docker-free probe fallback covers `ghcr.io` only.

Two comments in `hack/ci-deploy.sh` claimed "everything this job deploys — chart, operator, agent — is built from the pull request". That stops being true on the RC path, so both now say which path they describe. The correctness argument they were making survives: the chart still comes from the checkout on both paths, which is what makes the caller's checkout load-bearing on the RC path.

## Context

- Part of #1024. Follow-ups, in order: the oss-test-infra Prow job that calls the resolver, checks out the SHA and runs `ci-deploy`; the full-matrix and run-identity work in `hack/ci-eval-pr.sh`; the pipeline trigger and RC commit status; the dashboard Releases section.
- `hack/ci-eval-pr.sh` overlaps with haoxuw's #1025 / PR #1112, and `scripts/eval_dashboard/` with jayantid's #1141, #1142, #1145. The edits here are three small additions to `ci-eval-pr.sh` and none to `scripts/eval_dashboard/`, so this is a merge-conflict note rather than duplicated work.
- Depends on nothing. #1068 is already merged and is why `REQUIRED_RELEASE_IMAGES` has six entries rather than four.

## Testing

- `tests/` (excluding `tests/integration/` and `tests/e2e/`): 975 pass, 16 skipped, 707 subtests pass. Three pre-existing failures in `tests/test_eval_dashboard_refresh.py` are not from this branch — they reproduce with the branch stashed, on the merge base.
- New coverage: `tests/test_ci_deploy_rc_images.py` (10 cases) and `tests/test_resolve_rc_target.py` (9 cases), both new files, plus 9 cases in `tests/test_release_common.py`'s new `RegistryImageProbeTest` and 1 in `scripts/test_eval_dashboard_publish.py`.
- `bench/tests/test_gate.py`: 61 pass, including the new `test_record_refuses_to_run_on_a_release_candidate`.
- `make docs-check`: passes.
- `prettier@3.9.6 --write` on the three changed Markdown files: no reformatting needed.
- `bash -n` on all four changed shell scripts.
- The two `ci-deploy.sh` tests lift sections 2a and 4 out of the real file by regex and execute them against stubs, rather than grepping for flags — a guard that greps passes for a section somebody has commented out. Most of them pin the `RC_COMMIT_SHA`-unset path, because every pull request in the repository runs it and a regression there is a repository-wide outage.
- Not run locally: `shellcheck` (not installed on this machine; CI runs it) and `tests/integration/` (its seam servers need `uvicorn`, absent here). The diff touches neither. No Go or Dockerfile changes, so no `go build` or image-layer budget check.

### Live validation

Exercised against the real repository and real `ghcr.io`, from a machine with **no docker on `PATH`** — which is the Prow job image's shape, and precisely the false negative the `registry_image_exists` guard fixes. No cluster was touched and nothing was deployed, so there is nothing to clean up.

`hack/resolve-rc-target.sh` against the live tag graph, picking the newest candidate on its own:

```
$ hack/resolve-rc-target.sh
ℹ️ Note: rc_2609021231_fdba3a7 (fdba3a7) already carries a validation marker; measuring it again.
❌ ERROR: ghcr.io/gke-labs/kube-agents is missing at least one of the required images at fdba3a7:
   ✓ k8s-operator
   ✓ platform-agent
   ✓ credential-proxy
   ✓ replay-proxy
   ✗ pubsub-platform
   ✗ gke-stockout-investigator
$ echo $?
1
```

That refusal is correct rather than a bug, and I proved the mechanism rather than accepting the coincidence. Probing each of the six packages directly, `pubsub-platform` and `gke-stockout-investigator` return HTTP 200 at `latest` and 404 at `fdba3a7` — the packages exist and are public, the images at that commit do not. The reason is ancestry: `git merge-base --is-ancestor` puts `fdba3a7` 11 commits *behind* `b4ee5f3e` (#1068), which is the commit that added those two build steps to `docker-publish-ghcr.yml` and those two entries to `REQUIRED_RELEASE_IMAGES`. All six return 200 at `b4ee5f3e` and at today's `main` head `667565d5`.

The success path, forced onto a post-#1068 commit with the `RC_TAG` override:

```
$ RC_TAG=b4ee5f3e... RC_TARGET_OUTPUT=/tmp/rc-target.env hack/resolve-rc-target.sh
======================================================================
🏷️ RELEASE CANDIDATE EVAL TARGET
Release Tag:    b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe
Commit SHA:     b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe
Images:         ghcr.io/gke-labs/kube-agents/<image>:b4ee5f3e...
======================================================================
$ echo $?
0
$ od -c /tmp/rc-sha.txt | tail -2      # stdout is the SHA and a newline, nothing else
0000040    a   b   9   4   8   3   f   e  \n
$ cat /tmp/rc-target.env
rc_tag=b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe
rc_commit_sha=b4ee5f3eb9c2aceb7f03460d2e573278ab9483fe
```

**Worth knowing:** until `rc-scheduler.yml` cuts a candidate from a post-#1068 commit, the resolver refuses every RC in the tag graph. That state clears on its own with the next scheduled cut and blocks nothing today, since no job calls this yet — but the follow-up Prow job should not be armed before a candidate with all six images exists.

**What I could not cover.** The deploy itself. `hack/ci-deploy.sh`'s RC branch needs a leased eval project and a GKE cluster, which I have neither of, so it is covered by lifting sections 2a and 4 out of the real script and running them against stubs — real code, stubbed registry and `gcloud`. Unverified against a live install: that a leased eval project's GKE cluster can actually pull from GHCR. The four images the chart renders are public (200 anonymously, shown above), so this should be free, but `ci-deploy.sh` has only ever reached Artifact Registry and I would not call it proven until the follow-up job runs. If it turns out a pull secret is needed, that is a change to the follow-up, not to this diff.

## Self-Review

Both required passes ran in subagents handed the diff range `b4ee5f3e..HEAD` and nothing else — neither held the reasoning that produced the change.

**Docs-drift pass.** Looked for prose anywhere in the repository made false or incomplete by the diff, and for map/testing-map coverage of the new files.

- *Blocking, fixed.* `bench/baselines/README.md` documented the baseline-write rule as "enforced twice", both conditions about pull requests. An RC run is a periodic on a `main` commit with no `PULL_NUMBER`, so a reader concludes it appends — and it does not. Now carries the third condition and why it is not correctable afterwards. The by-hand `bench-gate record` paragraph was stale the same way and now names both variables and `--force`.
- *Fixed, though the pass raised it as non-blocking.* `docs/designs/eval-scorer.md` is the design record for the baseline gate, and a deliberately read-only class of `main`-commit run is a design decision with no home in it. Added a paragraph beside the existing pair.
- *Fixed, non-blocking.* `scripts/release/README.md`'s `REGISTRY_PREFIX` paragraph invites pointing an environment at another registry; the new docker-free fallback covers `ghcr.io` only. Latent rather than currently false — every release-path caller is a GitHub Actions runner with docker — but worth the clause.
- *Not fixed, deliberately.* The pass noted `registry_image_exists` is absent from `scripts/release/README.md:35`'s helper enumeration. That enumeration is already non-exhaustive — `check_commit_images_exist` itself is not in it, appearing only later at line 249 — so adding one helper to a list that does not claim completeness makes the list no more trustworthy. The behaviour that matters to a reader of that file is documented in the `REGISTRY_PREFIX` clause above instead.
- *Not fixed, deliberately.* `bench/tasks/DRAFTS.md:43` says `ci-deploy.sh` installs the PR's own images "on each run". The paragraph's subject is eval-project provisioning on the presubmit path, where it stays exactly true; qualifying it would add a caveat about a path that paragraph is not about.
- *Clean, checked:* `docs/testing-map.md` and AGENTS.md "Where Tests Go" (the two new files land in `tests/`, which `Makefile:142`'s glob already reaches — no new test directory, so the `PYTHON_TEST_DIRS` rule is not engaged); `docs/README.md` map (the diff adds no Markdown document, and there is no `hack/README.md`); the identifier-sources table; `ci-pool-projects.md`, whose every claim about `ci-deploy.sh` survives untouched.

**Adversarial pass.** Looked for ways the RC path can install or grade the wrong thing, ways the presubmit path can regress, tests that pass for the wrong reason, and error paths that mislead. Seven findings; five fixed, two answered.

- *Fixed — the one that could have graded the wrong commit.* `ci-deploy.sh` trusted that the tree had been checked out at `RC_COMMIT_SHA`. Only the images come from the candidate; the chart, the CRDs, and `bench/tasks` come from whatever tree the job sits on, so a caller who set the variable and skipped the checkout would grade the candidate's images against another commit's everything-else, silently. Section 2a now compares `RC_COMMIT_SHA` against `git rev-parse HEAD` and fails with the `git checkout --detach` command, rather than pointing the reader back at a header comment. Covered by `test_a_tree_at_another_commit_stops_the_deploy`.
- *Fixed — two mutations the tests could not see.* The pass demonstrated that deleting the `Accept:` header from the GHCR probe, and rewriting the manifest URL path to `/v2/<repo>/BROKEN/<ref>`, both left the entire suite green. Both break every real probe: GHCR answers 404, not 401, for a manifest request without the OCI media types, which is a false "image missing" indistinguishable from the real one. The mock curl is now shared (`tests/testing/release.py`), asserts the URL, the bearer token and the header before answering, and logs the request so three cases can read it back. Both demonstrated mutations now fail, as does dropping digest-reference handling.
- *Fixed.* `registry_image_exists` ended in a bare `docker manifest inspect …` whose exit status is only safe while every caller keeps the function in a condition context. They all do today; the next caller written as a plain statement would kill the script under `errexit` instead of getting a 1 back. Spelled out as an explicit `return 0` / `return 1`.
- *Fixed.* The same function split image references on the last colon, so `<repo>@sha256:…` would have asked for a repository named `…@sha256`, and a reference-less image for an empty reference. Neither shape reaches it from this diff's callers — every one passes `<repo>:<sha>` — but the docker branch accepts both, and a fallback that accepts less than the primary is a trap for the caller that finds it. Now splits on `@` first, then a colon in the last path segment, defaulting to `latest`. Three new cases.
- *Fixed.* `resolve-rc-target.sh` resolved a tag once and, on failure, reported "cannot resolve a commit" without trying a fetch — a stale clone reads as a bad tag. It now retries after `release_fetch_tags` on the explicit-`RC_TAG` path, which is the path that skips the fetch at the top.
- *Answered, documented rather than changed.* The resolver demands all six `REQUIRED_RELEASE_IMAGES` though an eval install renders only four; both plugin images default to `enabled=false`. A publish run that dropped only a plugin image would block an eval that would not have installed it. Keeping the six is deliberate: the gate's question is "is this commit published", and a shorter list here would be a second definition of a published commit, disagreeing with `verify_release_eligibility.sh` about which candidates exist. Now said in a comment, with what to weigh before shortening it.
- *Answered, not changed.* Section 2a's RC branch exports `IMG`, `AGENT_IMAGE`, `AGENT_TAG` and `IMAGE_TAG`, and the pass observed nothing reads them — `helm` takes the array. Confirmed: the only reader of `IMAGE_TAG` anywhere is `install.sh`, which `ci-deploy.sh` does not call. They are inert on the presubmit path too, and mirroring its shape is what makes the two branches diffable. Deleting pre-existing inert exports is a separate change.
- *Answered — an open question the pass raised rather than a defect.* Whether RC eval artifacts could be folded into the existing dashboard. They cannot, as the code stands: `hack/ci-eval-pr.sh` passes `--pr-glob gs://kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/*/pull-kube-agents-smoke-test/*`, scoped to both `pr-logs/pull/` and the presubmit job name, while a periodic writes under `logs/<job>/`. Skipping the publish is therefore right for this slice; the Releases section is follow-up work, and `scripts/eval_dashboard/` is jayantid's area.
- *What the pass could not cover, in its own words:* it did not execute `bench/tests/test_gate.py`, had no `shellcheck`, ran no `gh` query for overlapping work, and reached no Prow or GKE. The first three are covered above and in Testing; the last is the gap **Live validation** names.

**Found by CI, after opening.** `Run Agent Startup Tests` and `Run Python Unit Tests` both failed on the first commit, and both were the same defect in my test setup rather than in the change. `RegistryImageProbeTest` pinned `PATH` to `{bin_dir}:/usr/bin:/bin`, and `ubuntu-latest` ships docker at `/usr/bin/docker` — so six cases whose subject is what the probe does when docker is *absent* found the real binary and probed ghcr.io for a fixture SHA. They passed locally because the machine I wrote them on has no docker at all, which is the same blind spot in reverse. `PATH` is now a `create_minimal_tools_bin` directory and nothing else, as `tests/test_resolve_rc_target.py` already did; verified by putting a docker stub where the test process can see it and confirming the probe subprocess still reports none (2d6ca577).

**Found while verifying, before either pass.** Two defects I caught myself and fixed, recorded because a reviewer should know the tests were wrong once:

- `tests/test_resolve_rc_target.py` littered the repository root, one fixture directory per test. `create_mock_git_repo` takes `temp_dir.name` from anything that has one, and a `pathlib.Path` has `.name` — the last component. Handing it a `Path` built the mock repo at a *relative* `tmpXXXXXXXX/repo`. Now passes a `str`, with a comment saying why.
- A comment in `hack/resolve-rc-target.sh` claimed the default target is "the newest candidate still without a validation marker". It is not, and cannot be: `rc-tag-validated.yml` writes `_validated` as a *sibling* tag on the same commit, so `rc_2609021231_fdba3a7` and `rc_2609021231_fdba3a7_validated` both exist and the `grep -v '_validated$'` filter never excludes a validated candidate. The code's actual behaviour is right — walking back to an older unvalidated candidate would grade a commit the pipeline has already superseded — so the comment was corrected rather than the code, the marker check now goes through the canonical `is_rc_candidate_commit_already_validated`, and the fixture was rebuilt to model the marker as a sibling. My original fixture put the marker on its own commit with no bare tag, which is what let the wrong claim look tested. Two cases were added for the corrected behaviour.

**One deliberate deviation from the engineering rules.** `.agents/rules/core_engineering.md` asks for `readonly NAME=...` for Bash constants. The two new constants in `scripts/release/common.sh` use `export` instead, because that file has zero `readonly` today and is sourced by many scripts — a re-source would hard-error under `set -e`. The new `hack/resolve-rc-target.sh` is not sourced by anything and uses `readonly` as the rule asks.

## Risk & Rollout

Nothing in the repository sets `RC_COMMIT_SHA`, so on merge every path behaves as it does today and no release this week is affected. Reverting is reverting the commit.

The one change that is *not* dormant is `check_commit_images_exist`'s internals, which the release path does call — `verify_release_eligibility.sh`, from `release-publish.yml`. That job runs on `ubuntu-latest`, where docker is preinstalled, so it takes the `docker manifest inspect` branch and behaves exactly as before; the new fallback is reachable only where the old code was already broken. The new failure mode it introduces is the inverse of the one it fixes: a non-GHCR registry probed from a machine without docker now warns and answers "missing" rather than erroring, which is the conservative direction and is documented.

---

Generated with the help of Claude Opus 5 (Claude Code).
