### PR TITLE
ci(gate): demote compliance-rbac-overgrant from BOOTSTRAP_ADMITTED to held-out (#1171)

### DIFF
--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -1217,11 +1217,13 @@ print(m.group(1).strip('\'\"') if m else '')
 # nothing to main's side of the aggregate. Screening replaces it.
 #
 # This roster is what blocks a pull request once the Prow job stops being
-# optional. Twelve of the seventeen active cases are admitted: the ones
+# optional. Twelve of the twenty active cases are admitted: the ones
 # whose recent record shows failures only on their own regressions or on
-# infra classes the harness already excludes from the verdict. Five are
-# held out -- they still run and report on every pull request, and they
-# cannot red one on a GRADED failure. The scope of that promise is rungs
+# infra classes the harness already excludes from the verdict. The rest
+# cannot red one on a GRADED failure: five are held out below with named
+# exits, and the three obtainability activations (#1049) simply run
+# unadmitted while they earn a record. Held-out cases still run and
+# report on every pull request. The scope of that promise is rungs
 # 4 and 6: rungs 1-3 (a forbidden mutation, an erroring check, a record
 # that is not a real run) stay blocking for every case by design,
 # admitted or not -- see grade_case, which evaluates them before it reads
@@ -1243,11 +1245,13 @@ print(m.group(1).strip('\'\"') if m else '')
 #     the lettered-options bar is settled and it has a clean record.
 #   compliance-rbac-overgrant             -- #1171: demoted 2026-09-02
 #     after rung-4 collapses on unrelated pull requests (#1153 was red on
-#     this case alone). The fleet-audit delegation chain is degraded --
-#     partial audits that skip check 2.4 ("access limitations"), runs
-#     that publish no ledger at all -- so the collapse is the
-#     environment's, not the diff's. Enters when #1171's re-admission
-#     bar holds: delegation fixed and a clean 3-day graded record.
+#     this case alone). The fleet-audit delegation chain is degraded:
+#     audits go partial on what the agent reports as "access
+#     limitations", skipping check 2.4 (the cluster-admin-binding check
+#     this case grades), and some runs publish no ledger at all -- so the
+#     collapse is the environment's, not the diff's. Enters when #1171's
+#     re-admission bar holds: delegation fixed and a clean 3-day graded
+#     record.
 #
 # If an admitted case reds a pull request its diff cannot explain on a
 # graded failure, demote it here and reference its issue. Demotion is a

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -1217,16 +1217,16 @@ print(m.group(1).strip('\'\"') if m else '')
 # nothing to main's side of the aggregate. Screening replaces it.
 #
 # This roster is what blocks a pull request once the Prow job stops being
-# optional. Thirteen of the seventeen active cases are admitted: the ones
+# optional. Twelve of the seventeen active cases are admitted: the ones
 # whose recent record shows failures only on their own regressions or on
-# infra classes the harness already excludes from the verdict. Four are
+# infra classes the harness already excludes from the verdict. Five are
 # held out -- they still run and report on every pull request, and they
 # cannot red one on a GRADED failure. The scope of that promise is rungs
 # 4 and 6: rungs 1-3 (a forbidden mutation, an erroring check, a record
 # that is not a real run) stay blocking for every case by design,
 # admitted or not -- see grade_case, which evaluates them before it reads
 # admission. security-overgrant-remediation-proposal (#1066) is simply
-# new: it earns its record like any case, then enters. The other three
+# new: it earns its record like any case, then enters. The other four
 # each have a filed issue naming the exit condition:
 #
 #   capacity-pinned-pool-probe            -- #1010: worker completes its
@@ -1241,6 +1241,13 @@ print(m.group(1).strip('\'\"') if m else '')
 #   autoops-warning-event-triage          -- #1101: 0/5 graded repetitions
 #     on record; admitting it reds every pull request today. Enters when
 #     the lettered-options bar is settled and it has a clean record.
+#   compliance-rbac-overgrant             -- #1171: demoted 2026-09-02
+#     after rung-4 collapses on unrelated pull requests (#1153 was red on
+#     this case alone). The fleet-audit delegation chain is degraded --
+#     partial audits that skip check 2.4 ("access limitations"), runs
+#     that publish no ledger at all -- so the collapse is the
+#     environment's, not the diff's. Enters when #1171's re-admission
+#     bar holds: delegation fixed and a clean 3-day graded record.
 #
 # If an admitted case reds a pull request its diff cannot explain on a
 # graded failure, demote it here and reference its issue. Demotion is a
@@ -1255,7 +1262,7 @@ print(m.group(1).strip('\'\"') if m else '')
 # agent-kanban-smoke earned its seat back after the 08-27 redesign (a real
 # SRE question graded on kanban_create plus cluster names); the reds that
 # once argued for un-arming it belonged to the old vocabulary check.
-export BOOTSTRAP_ADMITTED="${BOOTSTRAP_ADMITTED:-reliability-pdb-probe,security-overgrant-probe,upgrades-lagging-master-probe,consistency-authorized-networks-probe,cost-idle-pool-probe,obtainability-remediation-proposal,rca-remediation-pr,compliance-rbac-overgrant,cluster-agent-crashloop-debug,cluster-agent-crashloop-misleading-symptom,cluster-agent-crashloop-evidence-chain,gpu-stress-test-diagnosis,agent-kanban-smoke}"
+export BOOTSTRAP_ADMITTED="${BOOTSTRAP_ADMITTED:-reliability-pdb-probe,security-overgrant-probe,upgrades-lagging-master-probe,consistency-authorized-networks-probe,cost-idle-pool-probe,obtainability-remediation-proposal,rca-remediation-pr,cluster-agent-crashloop-debug,cluster-agent-crashloop-misleading-symptom,cluster-agent-crashloop-evidence-chain,gpu-stress-test-diagnosis,agent-kanban-smoke}"
 
 # Where the evidence itself lives. Unset means bench/baselines/ in the
 # checkout: hermetic, no credential, no network -- and no way for this job to

--- a/scripts/eval_dashboard/case-notes.yaml
+++ b/scripts/eval_dashboard/case-notes.yaml
@@ -25,7 +25,8 @@ notes:
   cluster-agent-healthy-workload-no-finding:
     badge: held-out
   compliance-rbac-overgrant:
-    issues: ["#998", "#985"]
+    issues: ["#998", "#985", "#1171"]
+    badge: held-out
   gpu-stress-test-diagnosis:
     note: reuse regression under investigation
   security-overgrant-remediation-proposal:

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -671,6 +671,7 @@ class CaseNotesTest(unittest.TestCase):
         ):
             self.assertIn(name, notes)
         self.assertEqual(notes["compliance-rbac-overgrant"]["issues"], ["#998", "#985", "#1171"])
+        self.assertEqual(notes["compliance-rbac-overgrant"]["badge"], "held-out")
         self.assertEqual(notes["capacity-pinned-pool-probe"]["badge"], "held-out")
         self.assertEqual(notes["security-overgrant-remediation-proposal"]["badge"], "new")
 

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -670,7 +670,7 @@ class CaseNotesTest(unittest.TestCase):
             "gpu-stress-test-diagnosis",
         ):
             self.assertIn(name, notes)
-        self.assertEqual(notes["compliance-rbac-overgrant"]["issues"], ["#998", "#985"])
+        self.assertEqual(notes["compliance-rbac-overgrant"]["issues"], ["#998", "#985", "#1171"])
         self.assertEqual(notes["capacity-pinned-pool-probe"]["badge"], "held-out")
         self.assertEqual(notes["security-overgrant-remediation-proposal"]["badge"], "new")
 


### PR DESCRIPTION
## Summary

Demotes `compliance-rbac-overgrant` from `BOOTSTRAP_ADMITTED` to the held-out list, per the demote-same-day protocol written above the roster in `hack/ci-eval-pr.sh`. The case keeps running and reporting on every pull request, but can no longer red one on a graded (rung-4) failure. Tracking issue #1171 carries the failure evidence and the re-admission bar; the dashboard case-notes gain the `held-out` badge and the issue reference so the published dashboard says the same thing the gate does.

## Why This Change

The gate went merge-blocking today (~14:00Z), and this case — the fleet-audits canary — is collapsing on pull requests whose diffs cannot explain it: five all-reps FAILED verdicts across unrelated PRs on 2026-09-02 (#1148, #1090, #1145, #1089, #1153 — builds and rep-level reasons in #1171). **#1153 is red solely on this case**; its diff is auth-retry changes in `forge.py`, nowhere near the bench or the audit path. The collapse is environment-side, not diff-side: delegated audits are losing control-plane reachability to the seeded clusters (partial audits that skip check 2.4 — the check that finds the planted `debug-binding` — with the agent reporting "access limitations" and falling back to raw `curl`), and some runs never publish a ledger at all (evals-9 publish gap 03:33Z–11:28Z, evals-10 03:23Z–13:51Z). Without this change, every PR that draws a degraded eval project stays blocked on a red it did not cause.

## What Changed

- `hack/ci-eval-pr.sh`: `compliance-rbac-overgrant` removed from the `BOOTSTRAP_ADMITTED` default (the one-line fast lever the roster comment prescribes); held-out entry added to the comment block referencing #1171 and its exit condition; admitted/held-out counts updated (twelve admitted, five held out).
- `scripts/eval_dashboard/case-notes.yaml`: `badge: held-out`, `#1171` added to the case's issues.
- `scripts/test_eval_dashboard.py`: expected issues list updated to match.

Deliberately NOT changed: rungs 1–3 stay blocking for this case (mutations, erroring verifiers, empty records still red a PR — the "no agent ran at all" mode seen today is rung 1-3 and demotion correctly does not silence it), and the case itself, its verifier, and the SOP are untouched — the defect is in the environment/delegation chain, and #1171 tracks that fix separately.

## Context

- #1171 — tracking issue (root-cause evidence, blast radius, re-admission bar). Filed first, per the roster protocol.
- Same-day-demotion protocol: the comment block above `BOOTSTRAP_ADMITTED` in `hack/ci-eval-pr.sh` ("If an admitted case reds a pull request its diff cannot explain on a graded failure, demote it here and reference its issue").
- Prior classes on this canary: #1030 (publish path, fixed), #985 (audit SOP latency), #998 (delegation transport). Today's degradation is the #985/#998 family, sharply worse since ~02:00–03:30Z, plus a new publish-nothing mode.
- Un-demotion is one line; #1171 names the bar.

## Testing

- `python3 scripts/test_eval_dashboard.py` — 56 tests, OK (covers case-notes parsing incl. the edited entry).
- `python3 scripts/test_ci_eval_fanout.py` (4 tests, OK) and `python3 scripts/test_ci_eval_trap.py` (5 tests, OK) — the suites that exercise `hack/ci-eval-pr.sh`'s structure.
- `bash -n hack/ci-eval-pr.sh` — clean.

### Live validation

Not live-tested against a running install: the change is CI-gate configuration (an env-var default in the Prow presubmit script) plus dashboard metadata — there is no installation surface to exercise. The behavioural claim ("off the roster means a rung-4 collapse reports UNSTABLE-class instead of blocking") is the existing, tested `bench-gate` admission path (`bench/kube_agents_bench/gate.py`, `_bootstrap_admitted()`); this PR only changes membership. The truth of the roster edit will be visible on this PR's own presubmit run: `compliance-rbac-overgrant` should report with "not admitted, so it cannot collapse" in its UNSTABLE line if it fails reps, exactly as the four existing held-out cases already do on every build.

## Self-Review

Adversarial and docs-drift passes were both run by a fresh-context subagent handed only the repo path and the diff range (it did not write the change). What it looked for: roster-edit mechanics (exact removal, comma integrity, survivors intact), any other place in the repo hard-coding the admitted list or this case's admitted status, the arithmetic in the comment I re-edited, case-notes schema legality of `issues` + `badge` together, date consistency, and doc drift across docs/, AGENTS.md, bench/README.md, and the dashboard SCHEMA. Findings and dispositions:

- **Confirmed — wrong base count** ("Twelve of the seventeen active cases"): the `TASKS` array carries twenty active cases; the three obtainability activations (#1049) are active but neither admitted nor issue-held. The "seventeen" was already stale on upstream/main, but this commit re-asserted it. **Fixed** (second commit): the sentence now says twelve of twenty and accounts for all eight non-admitted cases.
- **Confirmed — misleading phrasing** in the new held-out entry: `skip check 2.4 ("access limitations")` read as if that were check 2.4's name; 2.4 is the cluster-admin-binding check (`compliance_audit_sop.md:182`), and "access limitations" is the agent-reported reason it gets skipped. **Fixed** (second commit).
- **Suspected — test gap**: the new `badge: held-out` was unasserted while neighbouring entries assert theirs. **Fixed** (second commit): badge assertion added.
- **Confirmed clean**: roster line parses to exactly 12 names with no doubled/trailing commas and the same 12 survivors; nothing else in the repo (gate.py, tests, dashboard collect, workflows) hard-codes admission for this case — `test_eval_dashboard_collect.py`'s "active" assertion stays true because held-out cases still run; `issues` + `badge` on one entry is an existing pattern (`capacity-pinned-pool-probe`); no doc states an admitted count or roster, so nothing goes stale. Not fixed because nothing to fix.
- The reviewer noted "#1153 was red on this case alone" is unverifiable from the repo — correct; that evidence is external (build logs) and lives in #1171 with gs:// paths.


## Risk & Rollout

Blast radius is the gate's sensitivity, in one direction: a real product regression that only `compliance-rbac-overgrant` would catch can now merge while the case is held out — that is the accepted cost of un-blocking innocent PRs today, it is time-boxed by #1171's re-admission bar, and rungs 1–3 still block for this case. No runtime code paths touched. Revert is `git revert` of one commit (or re-adding one name to the list). Nothing has to happen at merge time; the next presubmit run of any open PR picks the new default up automatically.
