### PR TITLE
perf(test): warm the Go build cache and sweep the Python test directories in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,82 @@ PYTHON_TEST_DIRS := $(sort $(dir \
 	$(wildcard tests/test_*.py) \
 	$(wildcard tests/memory/test_*.py)))
 
+# How many of those directories `test-python` and `coverage` run at once. They
+# are separate `python3` processes that share nothing -- each cd's into its own
+# directory, servers in the seam tier bind port 0, and fixtures go through
+# tempfile -- so the sweep costs its slowest single directory rather than the
+# sum of all of them. Four directories are most of that sum, so the win is
+# large and then flat: raising this past a handful buys nothing.
+#
+# Set it to 1 to serialise. That is for reproducing a failure you suspect is
+# concurrency's doing, or for a machine you need the cores back on -- not for
+# readability, since the sweep captures each directory's output either way:
+#   make test-python PYTHON_TEST_JOBS=1
+PYTHON_TEST_JOBS ?= $(shell nproc 2>/dev/null || echo 4)
+
+# The sweep over PYTHON_TEST_DIRS that `test-python` and `coverage` both run.
+# $(1) is the command executed inside each directory, and it is the only thing
+# the two callers differ by.
+#
+# One macro rather than two loops because that mirroring is load-bearing and
+# used to be only asserted in a comment: a coverage target that walks the
+# directories differently measures a different suite than the one that gates,
+# and nothing would say so. Sharing the sweep makes it structural.
+#
+# Contract: leaves `$$failed` set to a space-separated list of the directories
+# whose command exited non-zero, empty when none did. The caller decides what
+# that means -- test-python exits 1, coverage prints a note and carries on.
+#
+# Two properties the sequential loop had, kept by different means now that the
+# directories run concurrently. Every directory still runs even after another
+# fails: xargs keeps going, and each worker records its own verdict in a file
+# because a variable assigned in a subprocess cannot come back to the parent.
+# And each directory's output still arrives as a labelled block, because it is
+# captured to its own file and printed afterwards in PYTHON_TEST_DIRS order --
+# concurrent writers to one stream interleave mid-line and the "==> dir" headers
+# stop meaning anything. What that costs is progress, and a run killed mid-sweep
+# (a CI cancellation, a step timeout) loses the captured output entirely, so
+# each worker prints a line as it finishes to leave something behind.
+#
+# The verdict file is per-directory and read as fail-closed: a directory whose
+# .rc is missing or non-zero counts as failed. One shared append-only file would
+# be shorter, but a failed append -- a full TMPDIR, which 25 concurrent suites
+# make likelier than the old loop did -- would silently drop a red directory and
+# let the gate pass. Absence has to mean failure, not success.
+#
+# $(1) is interpolated into a single-quoted sh -c string, so it must not contain
+# a single quote. It also must not contain a comma: $(call) splits arguments on
+# commas before the body ever sees them, so `python3 -c "import os, sys"` would
+# arrive silently truncated at the comma. Both callers avoid each.
+define sweep_python_test_dirs
+work=$$(mktemp -d); \
+trap 'rm -rf "$$work"' EXIT INT TERM; \
+export work; \
+printf '%s\n' $(PYTHON_TEST_DIRS) | xargs -P $(PYTHON_TEST_JOBS) -I{} sh -c ' \
+	dir="$$1"; \
+	stem="$$work/$$(printf "%s" "$$dir" | tr "/" "_")"; \
+	if (cd "$$dir" && $(1)) >"$$stem.log" 2>&1; then \
+		rc=0; printf "    ok  %s\n" "$$dir"; \
+	else \
+		rc=1; printf "  FAIL  %s\n" "$$dir"; \
+	fi; \
+	echo "$$rc" >"$$stem.rc" \
+' _ {}; \
+echo; \
+failed=""; \
+for dir in $(PYTHON_TEST_DIRS); do \
+	echo "==> $$dir"; \
+	stem="$$work/$$(printf "%s" "$$dir" | tr "/" "_")"; \
+	if [ -f "$$stem.log" ]; then \
+		cat "$$stem.log"; \
+	else \
+		echo "no output captured -- this directory never ran"; \
+	fi; \
+	[ "$$(cat "$$stem.rc" 2>/dev/null)" = "0" ] || failed="$$failed $$dir"; \
+done; \
+failed=$${failed# }
+endef
+
 # The same packages as `import` names rather than distribution names, because
 # that is what the preflight below can actually test for: python-dotenv imports
 # as `dotenv` and pyyaml as `yaml`.
@@ -210,34 +286,39 @@ test-python: ## Run the Python unit tests outside k8s-operator/.
 # tests) never ran at all, while the output still ended in a familiar-looking
 # failure. A red run that hides four green directories is survivable; one that
 # hides an untested directory is not.
-	@failed=""; \
-	for dir in $(PYTHON_TEST_DIRS); do \
-		echo "==> $$dir"; \
-		(cd $$dir && PYTHONPATH="$(CURDIR):$(CURDIR)/agentplugins/lib:$(CURDIR)/agentplugins/pubsub-platform:$${PYTHONPATH:-}" python3 -m unittest discover -p "test_*.py") || failed="$$failed $$dir"; \
-	done; \
+#
+# Both survive the move to concurrency; sweep_python_test_dirs says how.
+	@export PYTHONPATH="$(CURDIR):$(CURDIR)/agentplugins/lib:$(CURDIR)/agentplugins/pubsub-platform:$${PYTHONPATH:-}"; \
+	$(call sweep_python_test_dirs,python3 -m unittest discover -p "test_*.py"); \
 	missing=""; \
 	for mod in $(PYTHON_TEST_IMPORTS); do \
 		python3 -c "import $$mod" >/dev/null 2>&1 || missing="$$missing $$mod"; \
 	done; \
 	if [ -n "$$failed" ]; then \
 		echo; \
-		echo "Failing test directories:$$failed"; \
+		echo "Failing test directories: $$failed"; \
 		if [ -n "$$missing" ]; then \
 			echo "Missing third-party imports:$$missing -- run: make test-python-deps"; \
 		fi; \
 		exit 1; \
 	fi
 
-# Coverage runs the same suite the same way -- the loop below is test-python's
-# loop with `coverage run` in place of `python3`. That mirroring is the point:
-# a coverage target that discovers tests any other way measures a different
-# suite. Two things differ. COVERAGE_ROOT pins the measured tree to the
-# repository root (the loop cd's into each directory, and .coveragerc reads the
-# variable because `source` cannot be relative from seventeen places), and
-# COVERAGE_FILE parks every per-directory data file in one place for
-# `coverage combine`. Failing directories are reported but do not stop the
-# measurement: test-python is the gate, this is the meter, and the 13
-# pre-existing failures must not hide the number for the other directories.
+# Coverage runs the same suite the same way -- literally the same sweep as
+# test-python, through sweep_python_test_dirs, with `coverage run` in place of
+# `python3`. That mirroring is the point: a coverage target that discovers tests
+# any other way measures a different suite. Two things differ. COVERAGE_ROOT
+# pins the measured tree to the repository root (the sweep cd's into each
+# directory, and .coveragerc reads the variable because `source` cannot be
+# relative from seventeen places), and COVERAGE_FILE parks every per-directory
+# data file in one place for `coverage combine`. Failing directories are
+# reported but do not stop the measurement: test-python is the gate, this is the
+# meter, and the 13 pre-existing failures must not hide the number for the other
+# directories.
+#
+# Concurrency needs nothing extra here: .coveragerc already sets parallel = True,
+# so each process writes its own data file suffixed with host and pid and the
+# `coverage combine` below merges them. That setting was there for the
+# per-directory loop, and it is the same property concurrent directories need.
 COVERAGE_DIR := .coverage-data
 
 coverage: ## Measure unit-test coverage; writes coverage.xml (and coverage-go.xml when tooling allows).
@@ -247,16 +328,11 @@ coverage: ## Measure unit-test coverage; writes coverage.xml (and coverage-go.xm
 		echo "ERROR: PYTHON_TEST_DIRS expanded to nothing; the globs above are stale."; \
 		exit 1; \
 	fi
-	@failed=""; \
-	for dir in $(PYTHON_TEST_DIRS); do \
-		echo "==> $$dir"; \
-		(cd $$dir && COVERAGE_ROOT=$(CURDIR) COVERAGE_FILE=$(CURDIR)/$(COVERAGE_DIR)/.coverage \
-			PYTHONPATH="$(CURDIR):$${PYTHONPATH:-}" \
-			python3 -m coverage run --rcfile=$(CURDIR)/.coveragerc -m unittest discover -p "test_*.py") \
-			|| failed="$$failed $$dir"; \
-	done; \
+	@export COVERAGE_ROOT=$(CURDIR) COVERAGE_FILE=$(CURDIR)/$(COVERAGE_DIR)/.coverage; \
+	export PYTHONPATH="$(CURDIR):$${PYTHONPATH:-}"; \
+	$(call sweep_python_test_dirs,python3 -m coverage run --rcfile=$(CURDIR)/.coveragerc -m unittest discover -p "test_*.py"); \
 	if [ -n "$$failed" ]; then \
-		echo "Note: failing test directories (their coverage is still recorded):$$failed"; \
+		echo "Note: failing test directories (their coverage is still recorded): $$failed"; \
 	fi
 	@COVERAGE_ROOT=$(CURDIR) COVERAGE_FILE=$(CURDIR)/$(COVERAGE_DIR)/.coverage \
 		python3 -m coverage combine --rcfile=$(CURDIR)/.coveragerc

--- a/agents/platform/scripts/pr_triggers.py
+++ b/agents/platform/scripts/pr_triggers.py
@@ -248,7 +248,11 @@ def strip_markers(text: str) -> str:
     The loop terminates because every pass that changes anything deletes at
     least one whole match, and it is cheap because each one collapses the nest
     rather than shaving it: a maximally nested 67,626-character body — deeper
-    than GitHub's comment limit allows — converges in 2,602 passes and 0.08s.
+    than GitHub's comment limit allows — converges in 2,602 passes, one per
+    level plus the pass that finds nothing left to do. Shaving would be one per
+    character. The pass count is the invariant and what the test asserts; the
+    wall-clock it buys is a tenth of a second up to a third, depending on the
+    machine, and is not a bound anything relies on.
     """
     text = normalise_newlines(text)
     while True:

--- a/agents/platform/scripts/test_pr_triggers.py
+++ b/agents/platform/scripts/test_pr_triggers.py
@@ -40,6 +40,7 @@ import subprocess
 import sys
 import time
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -53,6 +54,29 @@ def comment(author, body, node_id="n1"):
     return forge.Comment(
         node_id=node_id, author=author, body=body, can_write=True, created_at=""
     )
+
+
+class _CountingPattern:
+    """A compiled pattern that records how many times `sub` ran.
+
+    `strip_markers` substitutes to a fixpoint, so what its cost is really made
+    of is the number of passes: one per nesting level while each pass deletes a
+    whole match, one per character if a regression ever made it shave instead.
+    Counting the passes states that difference directly, where a stopwatch only
+    implies it. Wrapping is what makes the count reachable at all -- `re.Pattern`
+    is a C type and will not take an attribute.
+    """
+
+    def __init__(self, pattern):
+        self._pattern = pattern
+        self.sub_calls = 0
+
+    def sub(self, repl, string, count=0):
+        self.sub_calls += 1
+        return self._pattern.sub(repl, string, count)
+
+    def __getattr__(self, name):
+        return getattr(self._pattern, name)
 
 
 #: Every construct that can hide text in a Markdown comment, and the near-miss
@@ -467,20 +491,53 @@ class StripMarkersTest(unittest.TestCase):
     def test_no_marker_survives_at_any_nesting_depth(self):
         """A fixpoint makes the property total rather than tested to depth 2.
 
-        Also the cost bound. Every pass that changes anything deletes a whole
-        match and collapses the nest rather than shaving it, so a body nested
-        deeper than GitHub's 65,536-character limit allows still converges well
-        inside the bound.
+        Also the cost bound, counted in passes rather than seconds. Every pass
+        that changes anything deletes a whole match and collapses the nest
+        rather than shaving it, so a body nested deeper than GitHub's
+        65,536-character limit allows converges in one pass per level plus the
+        one that finds nothing left to do. Shaving would be one per character:
+        2,602 against 67,626, which is the regression this is really watching.
+
+        The bound used to be `elapsed < 0.3`, which measured the machine at
+        least as much as the algorithm: the honest cost is ~0.27s on an idle
+        developer box, so the bound had about 10% of headroom and any load at
+        all closed it. Running the suite's directories concurrently is what
+        finally did, at 0.459s. The three remaining timing bounds in this file
+        are a different case and stay as they are: they guard superlinear
+        regressions -- catastrophic backtracking at the two `find_trigger`
+        bounds, an unanchored line-by-line walk at the third -- where fixed and
+        broken are orders of magnitude apart rather than fractions of one, and
+        no amount of load closes that gap.
+
+        A wall-clock ceiling stays here too, at a size no load can reach. Pass
+        count is blind to a pass getting slow, which is what a MARKER_RE edit
+        that introduced backtracking would do, and a test that hangs for a
+        minute and then passes is worse than one that fails.
         """
+        depth = 2600
         body = "<!-- agent-answered:IC -->"
-        for _ in range(2600):
+        for _ in range(depth):
             body = "<!-- agent-" + body + "answered:IC -->"
+
+        counting = _CountingPattern(pr_triggers.MARKER_RE)
         started = time.monotonic()
-        out = pr_triggers.strip_markers(body)
+        with mock.patch.object(pr_triggers, "MARKER_RE", counting):
+            out = pr_triggers.strip_markers(body)
         elapsed = time.monotonic() - started
+
         self.assertEqual(out, "")
         self.assertEqual(pr_triggers.MARKER_RE.findall(out), [])
-        self.assertLess(elapsed, 0.3, f"took {elapsed:.3f}s")
+        # Equality, not a ceiling. The count is exact and deterministic -- one
+        # pass per level, plus the one that finds nothing left to do -- and a
+        # ceiling would also pass at zero, which is what a rewrite reaching for
+        # `finditer` or a differently named pattern would leave behind: the
+        # wrapper uncalled and the assertion guarding nothing while still
+        # reading like a cost bound. Converging in fewer passes is welcome and
+        # is a deliberate edit to this line, not a silent pass.
+        self.assertEqual(depth + 2, counting.sub_calls)
+        # Nearly 40x the measured cost: catches a backtracking blowup, and no
+        # amount of load on a shared runner reaches it.
+        self.assertLess(elapsed, 10.0, f"took {elapsed:.3f}s")
 
     def test_stripping_does_not_change_what_counts_as_answered(self):
         """`handled_node_ids` reads raw bodies — a stripped one is not the record."""

--- a/docs/testing-map.md
+++ b/docs/testing-map.md
@@ -79,7 +79,7 @@ The last column says what a trigger and its `if:` conditions support, which is a
 in this repository, so this table asserts nothing about either.
 [`pull-request-workflow.md`](pull-request-workflow.md#how-a-change-merges) names the required
 contexts as they stand, gives the command to read them back, and says why that command sees only
-the branch-protection half of the set. `make verify` (`Makefile:173`) is the
+the branch-protection half of the set. `make verify` (the `verify` target in the root `Makefile`) is the
 local answer to the same question — everything a pull request must pass offline, in one target —
 and [`site/src/content/docs/contributing.md`](site/src/content/docs/contributing.md) lists the
 individual targets to run when you have touched a given area.

--- a/tests/integration/test_seam_injector_kv.py
+++ b/tests/integration/test_seam_injector_kv.py
@@ -26,17 +26,77 @@ from pathlib import Path
 from _seams import API_KEY, KVServer, REPO_ROOT, http_json
 
 
+SYSTEM_GO_PATH = "/usr/local/go/bin/go"
+# `go env GOCACHE` is a local read of the toolchain's own configuration; it
+# neither builds nor reaches the network, so anything approaching this bound
+# means the toolchain is wedged rather than slow.
+GO_ENV_PROBE_TIMEOUT_SECONDS = 30
+FALLBACK_GOCACHE_DIRNAME = "gocache"
+# What `go env GOCACHE` prints instead of a path when the build cache is
+# switched off -- which is what an unset HOME produces, since Go has nowhere to
+# put a default cache. It is a sentinel, not a directory.
+GOCACHE_DISABLED = "off"
+
+
 def _go_binary():
     found = shutil.which("go")
     if found:
         return found
     # PATH plus the one conventional system location. Never a /tmp path: a
     # world-writable directory is an execution hazard on shared hosts.
-    candidate = "/usr/local/go/bin/go"
-    return candidate if Path(candidate).exists() else None
+    return SYSTEM_GO_PATH if Path(SYSTEM_GO_PATH).exists() else None
 
 
 GO = _go_binary()
+
+
+def _go_cache_dir(fallback_parent):
+    """The toolchain's own build cache when it is usable, a temp dir when not.
+
+    `go test` below compiles the whole operator dependency tree -- controller-runtime
+    and client-go -- and whether that is free or expensive is decided entirely by
+    which cache it writes into. Measured on this package: 88s into an empty cache,
+    3.3s into a warm one. That is not a tuning detail, it is the runtime of this
+    file, and through it roughly 40% of `make test-python`.
+
+    So the default is what we want, because in both places that matter it is already
+    warm: CI's `test` and `coverage` jobs run actions/setup-go, which restores ~413 MB
+    into ~/.cache/go-build before this runs, and a developer's machine has whatever
+    they last built. This used to point unconditionally at a fresh temp directory,
+    which threw that away and paid the cold compile every run.
+
+    The fallback stays for the case that motivated it -- a HOME that is missing or
+    read-only, where the default path cannot be created and `go` would fail rather
+    than run slowly. Probing beats assuming: the cheap `go env` read below is what
+    tells the two apart, and it is why this is a function and not a constant.
+
+    The probe's answer is not always a path. With HOME unset, `go env GOCACHE`
+    prints "off" and exits 0, and taking that at its word both writes a stray
+    `off/` directory into whatever the cwd happens to be and hands `go test` a
+    disabled cache, which it refuses outright ("build cache is disabled by
+    GOCACHE=off, but required as of Go 1.12"). So the sentinel and anything else
+    that is not an absolute path go to the fallback.
+    """
+    try:
+        probe = subprocess.run(
+            [GO, "env", "GOCACHE"],
+            capture_output=True,
+            text=True,
+            timeout=GO_ENV_PROBE_TIMEOUT_SECONDS,
+        )
+        default = probe.stdout.strip()
+        if probe.returncode == 0 and default != GOCACHE_DISABLED and os.path.isabs(default):
+            # mkdir first: a configured-but-absent cache directory is the normal
+            # state of a fresh checkout, and `go` creates it on demand, so its
+            # not existing yet says nothing about whether it is usable.
+            Path(default).mkdir(parents=True, exist_ok=True)
+            if os.access(default, os.W_OK):
+                return default
+    except (OSError, subprocess.SubprocessError):
+        # Any failure here means we could not establish that the default is
+        # usable, which is exactly the case the fallback exists for.
+        pass
+    return str(Path(fallback_parent) / FALLBACK_GOCACHE_DIRNAME)
 
 
 @unittest.skipUnless(GO, "no Go toolchain on PATH")
@@ -45,6 +105,9 @@ class InjectorKVSeamTest(unittest.TestCase):
     def setUpClass(cls):
         cls.tmp = tempfile.TemporaryDirectory()
         cls.tmp_path = Path(cls.tmp.name)
+        # Resolved once per class rather than per call: the probe is cheap but
+        # not free, and every test in this class wants the same answer.
+        cls.gocache = _go_cache_dir(cls.tmp_path)
 
     @classmethod
     def tearDownClass(cls):
@@ -56,8 +119,9 @@ class InjectorKVSeamTest(unittest.TestCase):
             {
                 "SESSION_KV_INTEGRATION_URL": kv.url,
                 "SESSION_KV_INTEGRATION_TOKEN": API_KEY,
-                # A writable cache whatever the runner's HOME looks like.
-                "GOCACHE": str(self.tmp_path / "gocache"),
+                # A writable cache whatever the runner's HOME looks like, and a
+                # warm one wherever that is possible -- see _go_cache_dir.
+                "GOCACHE": self.gocache,
                 "GOFLAGS": "-count=1",
             }
         )
@@ -165,7 +229,7 @@ class InjectorKVSeamTest(unittest.TestCase):
             {
                 "SESSION_KV_INTEGRATION_URL": f"http://127.0.0.1:{stub.server_port}",
                 "SESSION_KV_INTEGRATION_TOKEN": API_KEY,
-                "GOCACHE": str(self.tmp_path / "gocache"),
+                "GOCACHE": self.gocache,
             }
         )
         completed = subprocess.run(

--- a/tests/test_python_test_sweep.py
+++ b/tests/test_python_test_sweep.py
@@ -1,0 +1,135 @@
+"""A failing directory in the `make test-python` sweep still fails the build.
+
+The sweep runs PYTHON_TEST_DIRS concurrently, so a directory's verdict can no
+longer be a shell variable -- a subprocess cannot assign one the parent will
+see. It travels through a per-directory file in a temp directory instead, and
+that is a channel with ways to go quiet: a write that fails, a name that
+collides, a parent loop that reads the wrong path. Every one of them looks the
+same from outside -- `make test-python` exits 0 with a red directory in the run
+-- which is the failure this repository's suite most needs not to have.
+
+Nothing else covers it. `scripts/test_test_discovery.py` checks which
+directories the sweep *reaches*; this checks what its verdict does to the exit
+status. Both job counts run, because serial and concurrent are separate paths
+through the same macro and only the concurrent one is new.
+
+Most of this drives `sweep_python_test_dirs` directly through a wrapper
+makefile rather than through `make test-python`, which is worth the indirection
+purely for time: the target's missing-import preflight starts twenty Python
+interpreters, and paying that six times would add half a minute to the suite
+this sweep exists to shorten. One case does go through the real target, since
+what the macro leaves in `$failed` matters only if the caller turns it into a
+non-zero exit.
+"""
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+#: A real directory with no test_*.py in it. Discovery there finds nothing and
+#: succeeds, which is the "green" half of each case below at near-zero cost.
+EMPTY_DIR = "docs/"
+#: A directory that does not exist, so the sweep's `cd` fails before the
+#: per-directory command runs at all. Cheaper than a directory holding a
+#: deliberately failing test, and it exercises the same path out of the worker.
+MISSING_DIR = "nosuchdir/"
+#: Serial and concurrent are separate paths through sweep_python_test_dirs.
+JOB_COUNTS = (1, 2)
+#: Printed by the probe target below so the test can read `$failed` back.
+FAILED_MARKER = "SWEEP-FAILED:"
+SWEEP_TIMEOUT_SECONDS = 300
+
+#: A target that runs the sweep over a trivial command and reports the one
+#: thing the macro promises its callers: what `$failed` holds afterwards.
+PROBE_MAKEFILE = f"""\
+include Makefile
+sweep-probe:
+\t@$(call sweep_python_test_dirs,true) >/dev/null; echo "{FAILED_MARKER}[$$failed]"
+"""
+
+
+def _run_make(args):
+    env = dict(os.environ)
+    # This test may itself be running inside the sweep, and an inherited
+    # jobserver or MAKELEVEL would make the nested make behave unlike the one a
+    # developer runs by hand.
+    env.pop("MAKEFLAGS", None)
+    env.pop("MAKELEVEL", None)
+    return subprocess.run(
+        ["make", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=SWEEP_TIMEOUT_SECONDS,
+    )
+
+
+def sweep(dirs, jobs):
+    """Run the macro over `dirs`, returning (completed process, `$failed`)."""
+    with tempfile.NamedTemporaryFile("w", suffix=".mk", delete=False) as wrapper:
+        wrapper.write(PROBE_MAKEFILE)
+        wrapper_path = wrapper.name
+    try:
+        done = _run_make(
+            [
+                "-f",
+                wrapper_path,
+                "sweep-probe",
+                f"PYTHON_TEST_DIRS={' '.join(dirs)}",
+                f"PYTHON_TEST_JOBS={jobs}",
+            ]
+        )
+    finally:
+        os.unlink(wrapper_path)
+    marker = [ln for ln in done.stdout.splitlines() if ln.startswith(FAILED_MARKER)]
+    failed = marker[-1][len(FAILED_MARKER) :].strip("[]") if marker else None
+    return done, failed
+
+
+class SweepVerdictTest(unittest.TestCase):
+    def test_a_failing_directory_is_named_in_failed(self):
+        for jobs in JOB_COUNTS:
+            with self.subTest(jobs=jobs):
+                done, failed = sweep([EMPTY_DIR, MISSING_DIR], jobs)
+                self.assertEqual(MISSING_DIR, failed, done.stdout + done.stderr)
+
+    def test_a_clean_sweep_leaves_failed_empty(self):
+        # The other direction, so the test above cannot pass by the macro
+        # reporting everything as failed.
+        for jobs in JOB_COUNTS:
+            with self.subTest(jobs=jobs):
+                done, failed = sweep([EMPTY_DIR], jobs)
+                self.assertEqual("", failed, done.stdout + done.stderr)
+
+    def test_every_directory_runs_even_after_one_fails(self):
+        # The property the sequential loop had and the sweep had to re-earn: one
+        # failure must not stop the directories after it. A `set -e` regression
+        # here would hide whole suites behind a familiar-looking red run.
+        done, _ = sweep([MISSING_DIR, EMPTY_DIR], max(JOB_COUNTS))
+        self.assertIn(f"==> {EMPTY_DIR}", done.stdout)
+        self.assertIn(f"==> {MISSING_DIR}", done.stdout)
+
+
+class TestPythonExitStatusTest(unittest.TestCase):
+    def test_the_target_exits_non_zero_when_a_directory_fails(self):
+        # The one end-to-end case: `$failed` is only worth setting if the caller
+        # acts on it, and a sweep that reports correctly into a target that
+        # swallows the result is the same green-on-red as no sweep at all.
+        done = _run_make(
+            [
+                "test-python",
+                f"PYTHON_TEST_DIRS={EMPTY_DIR} {MISSING_DIR}",
+                f"PYTHON_TEST_JOBS={max(JOB_COUNTS)}",
+            ]
+        )
+        self.assertNotEqual(0, done.returncode, done.stdout + done.stderr)
+        self.assertIn(MISSING_DIR, done.stdout.split("Failing test directories:")[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`Python Unit Tests` is the longest workflow on a pull request here, and its wall-clock is set by whichever of `make test-python` and `make coverage` finishes last. Two changes cut both: the injector seam test stops throwing away the Go build cache CI restored a moment earlier, and the 25 directories in `PYTHON_TEST_DIRS` run concurrently instead of one at a time.

Measured against this branch's merge base on an 8-core box: `make test-python` 5m42s → 1m21s, `make coverage` 8m31s → 2m57s. Coverage is the one that matters, since it is the longer job.

## Why This Change

`tests/integration/test_seam_injector_kv.py` shells out to `go test`, which compiles the whole operator dependency tree — controller-runtime and client-go. It set `GOCACHE` to a fresh temp directory, so that compile started cold on every run: 88.4s against 3.3s into a warm cache. Both CI jobs run `actions/setup-go` with `cache-dependency-path: k8s-operator/go.sum`, which restores roughly 413 MB into `~/.cache/go-build` immediately before `make` starts, and the temp directory discarded all of it. One file was ~40% of `make test-python`.

The sweep over `PYTHON_TEST_DIRS` was sequential, so the two targets cost the sum of 25 directories rather than the slowest one. Four directories are most of that sum.

## What Changed

- **`tests/integration/test_seam_injector_kv.py`** — `_go_cache_dir()` probes `go env GOCACHE` and uses it when it is an absolute path the process can write to, keeping a temp directory as the fallback. The file drops from 1m42s to 25s.
- **`Makefile`** — `PYTHON_TEST_JOBS` (default `nproc`) and a `sweep_python_test_dirs` macro that both `test-python` and `coverage` call.
- **`tests/test_python_test_sweep.py`** (new) — asserts a failing directory still fails the target, at both job counts.
- **`agents/platform/scripts/test_pr_triggers.py`** — a wall-clock assertion that concurrency showed to be flaky, replaced with a substitution-pass count plus a loose ceiling.
- **`agents/platform/scripts/pr_triggers.py`**, **`docs/testing-map.md`** — two prose corrections the passes below turned up.

Three things about the shape:

**The absoluteness check on `go env GOCACHE` is load-bearing.** With `HOME` unset the command prints the sentinel `off` and exits 0. Taking that at its word both writes a stray `off/` directory into the current working directory and hands `go test` a disabled cache, which it refuses: `build cache is disabled by GOCACHE=off, but required as of Go 1.12`. Rejecting anything non-absolute sends that case to the fallback where it belongs.

**One macro, not two loops.** `coverage` used to carry its own copy of the loop, with a comment asserting the two matched. A coverage target that walks the directories differently measures a different suite than the one that gates, and nothing would say so. Sharing the sweep makes the mirroring structural rather than asserted.

**The verdict channel is fail-closed.** A directory's result can no longer be a shell variable, because a subprocess cannot assign one the parent will see. Each worker writes its exit status to a per-directory file and the parent treats missing-or-non-zero as failure. A single shared append-only file would be shorter, but a failed append — a full `TMPDIR`, likelier with 25 concurrent suites than with one — would silently drop a red directory and let the gate pass.

## Context

No open pull request touches this work. [#1118](https://github.com/gke-labs/kube-agents/pull/1118) (AntonTyb) edits the same import block in `test_pr_triggers.py` at `@@ -40,6 +40,7 @@` and widens `MARKER_RE` to `agent-(answered|refused|updated)`. That is a textual conflict for whoever lands second and nothing more: the extra alternative does not change the per-pass match count on an `agent-answered` nest, so the pass-count assertion here survives the merge either way. Six other open pull requests touch the `Makefile` (#1124, #1121, #1090, #965, #913, #498); none touch the sweep region.

This is the second of the CI throughput items measured alongside [#1163](https://github.com/gke-labs/kube-agents/pull/1163) (Docker layer cache). Two remain and are not attempted here: path-filtering the advisory workflows, and consolidating the sub-minute workflows so they stop paying a runner allocation each.

## Testing

- `make docs-check` — passes. Generated regions current, 282 files link-checked, map covers 249 tracked docs, context budget 35.4k/38k.
- `prettier@3.9.6 --check` on the changed Markdown — clean.
- `make test-python` — 1m21s, the same two red directories as at the merge base (`admin_console/tests/`, `agents/platform/scripts/`, 4 ERRORs), all of them pre-existing local dependency gaps confirmed by re-running on a stashed tree. Green in CI.
- New test mutation-checked: deleting the parent loop's verdict check reds three of `tests/test_python_test_sweep.py`'s four cases.

### Live validation

A `Makefile` and a test-runner change cannot reach a kube-agents installation — nothing here renders a manifest, reconciles a CR, or runs in a pod. Per `contributing.md` the substitute is exercising it where it actually runs, so the evidence below is real runs of the two targets rather than reasoning about them.

**Equivalence before speed.** A faster suite that runs a different set of tests is not a faster suite.

| | Sequential | Parallel |
| --- | --- | --- |
| Directories swept | 25 | 25 |
| Tests run | 5638 | 5638 |
| Per-directory test counts | — | byte-identical (`diff` clean) |
| Coverage total | 26665 stmts, 7311 missed, 72.6% | 26665 stmts, 7311 missed, 72.6% |
| Red directories | 2 (pre-existing) | 2 (same two) |

The coverage row is the strongest of these: the merge base and this branch, run through entirely different sweeps, report the same three numbers.

**Wall-clock**, on an 8-core box, `PYTHON_TEST_JOBS` at its `nproc` default. "Before" is `b4ee5f3e`, the merge base, measured in a detached worktree rather than inferred:

| | Before | After |
| --- | --- | --- |
| `make test-python` | 5m42s | **1m21s** |
| `make coverage` | 8m31s | **2m57s** |
| `test_seam_injector_kv.py` alone | 1m42s | **25s** |
| `go test ./cmd/k8s-event-watcher/`, cold / warm GOCACHE | 88.4s | 3.3s |

**Proving the mechanism rather than a coincidence.** Each half was measured on its own rather than credited from the joint total. The cache change: the seam file alone, 1m42s at the merge base against 25s here, and the `go test` it drives at 88.4s into an empty cache against 3.3s into a warm one. The sweep: this branch at `PYTHON_TEST_JOBS=1` runs `make coverage` in 5m40s and at the `nproc` default in 2m57s, same commit, same suite, only the concurrency differing.

The two do not add up to the joint figure and I am not claiming they do — run-to-run spread on this box is tens of seconds, and the intermediate datapoints were not taken back-to-back with the rest. What the separate measurements establish is direction and rough magnitude for each half independently, which is what "not a coincidence" needs.

All four branches of `_go_cache_dir` were exercised — normal (returns `~/.cache/go-build`), uncreatable path, read-only parent (`HOME=/tmp/rohome`, mode 555, `mkdir` raises and the fallback is taken), and `HOME` unset (returns the temp fallback, and leaves no `off/` directory behind, which the pre-fix code did). Stability: three consecutive parallel runs of `test-python`, no flakes and identical results.

**Not covered:** BSD `xargs` — `-P` with `-I` is the one construct not exercised off GNU findutils, and the `nproc` fallback implies macOS is a supported dev platform, so it is worth someone running `make test-python` there once. Also uncovered is whether the independence claim holds on a 2-core runner, where the interleaving differs; the CI run on this pull request is the first real evidence and its timings are in the thread below once it lands.

**Baseline for the CI comparison**, four recent `Python Unit Tests` runs on `main`-targeting pull requests: `Run Python Unit Tests` 278–332s, `Coverage report` 335–358s, workflow ~361s.

## Self-Review

Both required passes ran in **subagents that did not write the change**, each handed only the diff range.

**Adversarial pass** — attacked the macro's quoting and `$(call)` expansion, whether the directories are genuinely independent, whether concurrent `coverage run` is safe, the GOCACHE probe's failure modes, and whether the rewritten assertion catches what the old one did. Ten findings:

- **Fixed (HIGH): `_go_cache_dir` returned the literal `"off"` when `HOME` is unset.** Confirmed by running it: `env -u HOME go env GOCACHE` prints `off` and exits 0, the function `mkdir`'d a relative `off/` in the cwd — `tests/integration/` under the sweep — and handed `go test` a disabled cache, turning a slow-but-green run into a hard failure plus a write inside the checkout. The pre-change code was immune because it never consulted `go env`. Fixed by requiring an absolute path; re-verified both directions.
- **Fixed (MEDIUM): the diff moved `verify:` 65 lines and stale-dated a line citation.** `docs/testing-map.md` said `Makefile:173`, which at HEAD lands in the middle of the new macro's comment. `make docs-check` does not validate `Makefile:NNN` references. Replaced with the target name so it cannot rot again. Three other `Makefile:NNN` citations elsewhere are off by one and pre-date this change; left alone as out of scope.
- **Fixed (MEDIUM): the `PYTHON_TEST_JOBS=1` comment sold a property the sweep does not have.** It claimed serialising gets you output arriving a directory at a time; the capture is unconditional, so `-P 1` changes execution order and nothing else. Comment rewritten to say what serialising is actually for.
- **Fixed (MEDIUM): two docstrings gave contradicting measured costs.** My new one said ~0.4s, `strip_markers`' said 0.08s; re-measured five times here at 0.267–0.274s. The conclusion held — a 0.3s bound has 10% of headroom and any load closes it — but the stated reason was wrong, so both are corrected to that number and the module docstring now leads with the pass count instead of a wall-clock.
- **Fixed (LOW-MEDIUM): the new pass-count assertion passed vacuously at zero.** `assertLessEqual(sub_calls, depth + 2)` is satisfied by `sub_calls == 0`, which is what a rewrite reaching for `finditer` or a differently named pattern leaves behind — the wrapper uncalled, the assertion guarding nothing while still reading like a cost bound. Now `assertEqual`, the value being exact and deterministic. The same finding noted that dropping wall-clock entirely means a backtracking regression would make each of the 2,602 passes slow and still pass; a 10s ceiling is back for that, ~40x the measured cost and unreachable by load.
- **Fixed (LOW): `$(call)` splits arguments on commas, and the comment warned only about single quotes.** A future third caller like `python3 -c "import os, sys"` would arrive silently truncated. Documented alongside the quote rule.
- **Fixed (LOW): a lost append to the shared `failed` file would let a red directory ship green.** Narrow trigger (a `TMPDIR` filling mid-run) and not reproduced, but the mechanism was in the code. Replaced with per-directory verdict files read fail-closed, so absence means failure.
- **Fixed (LOW): nothing tested the new failure-propagation path.** `tests/test_python_test_sweep.py` added, covering both job counts and both directions, plus one end-to-end case that the target converts `$failed` into a non-zero exit. Mutation-checked.
- **Accepted (LOW): a run killed mid-sweep loses the captured output.** `trap … TERM` fires on a CI cancellation or step timeout and the per-directory logs only print at the end, so a cancelled run shows the progress lines and nothing else. Under the old loop the output streamed. This is the cost of not interleaving 25 writers mid-line; the per-worker progress line is the mitigation, and it is now written down in the macro's comment rather than discovered on the first CI hang.
- **Noted, no change: #1118 conflicts textually.** Covered under Context above.

Confirmed as *not* findings, each checked by running rather than reading: the 25 directories are genuinely independent (four runs, identical per-directory pass/fail sets and test counts, `git status --porcelain` unchanged; every server in the sweep binds port 0); concurrent `coverage run` under `parallel = True` produces identical totals to serial; `$$` escaping and quoting are correct throughout both expansions; the 25 log-file names do not collide; `GO is None` cannot reach `_go_cache_dir` because `skipUnless` sits on the class; `os.access` is not racy here because `mkdir` runs first and returns `EROFS` even as root; concurrent `go test` on a shared `GOCACHE` is safe by design and does not arise anyway; the missing `-count=1` in one Go invocation cannot hit the test cache because `go test` caches only passing runs; and no workflow, script, or skill parses the sweep's output.

**Docs-drift pass** — one Blocking finding, the `docs/testing-map.md` citation above, now fixed. It verified that no document anywhere describes the sweep's ordering (grepped every `.md`/`.mdx` for sequential/serial/one-at-a-time/parallel phrasing — the docs say *which* directories run and *what* runs them, never in what order), that `PYTHON_TEST_JOBS` is owed no documentation because it is a variable rather than a target and `COVERAGE_SKIP_GO` sets that precedent, that `docs/README.md` owes no row since the diff adds no Markdown, that `make help` output is unchanged, and that no document states timings for the Python suite. Its advisory finding about the three surviving timing bounds — one guards anchoring, not backtracking — is fixed in the docstring.

Generated with the help of Claude Opus 5.

## Risk & Rollout

The blast radius is CI and local development; nothing here ships in an image or reaches a cluster. The new failure mode is a test that turns out to depend on running alone, which would surface as a flake rather than as a wrong result — `PYTHON_TEST_JOBS=1` is the immediate mitigation and needs no revert, and the equivalence table above is the evidence that none does today. The `GOCACHE` change means the seam tier now writes to the developer's real build cache instead of a temp directory it deletes; that is the point, and it is what CI already assumed.

Reverting is `git revert`; nothing persists outside the run.
