### PR TITLE
fix(ci): heal stuck Helm release records at teardown and at deploy

### DIFF
--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -24,6 +24,17 @@ set -euo pipefail
 # env allowlist letting it through to the container.
 readonly EVAL_ALERT_DAILY_LIMIT_WARNING="0"
 
+# The release step 5 installs, and — for the poisoned-record guard (#1172) —
+# the label pair Helm stamps on every release-record Secret it writes
+# (`owner=helm` plus `name=<release>`), selecting every revision's record of
+# this release and nothing else in the namespace.
+readonly HELM_RELEASE_NAME="kube-agents"
+readonly HELM_RELEASE_SECRET_SELECTOR="owner=helm,name=${HELM_RELEASE_NAME}"
+# What a healthy revision looks like in `helm history -o json` output. The
+# encoder emits compact `"status":"deployed"`; the pattern tolerates spacing
+# so a Helm formatting change cannot silently blind the guard.
+readonly HELM_DEPLOYED_STATUS_RE='"status"[[:space:]]*:[[:space:]]*"deployed"'
+
 # ─── 1. Validation & Pre-checks ───────────────────────────────────────────────
 if [ -z "${GEMINI_API_KEY:-}" ]; then
   echo "ERROR: GEMINI_API_KEY environment variable is required"
@@ -295,8 +306,48 @@ echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 # test's.
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying the kube-agents chart ==="
+
+# ─── 5a. Heal a poisoned release record (#1172) ───────────────────────────────
+# A failed or killed prior run can leave the release record behind with no
+# deployed revision: its teardown's `helm uninstall` failed, or the teardown
+# was killed mid-uninstall — the cause no teardown-side fallback can cover.
+# `helm upgrade --install` below then takes the upgrade path and dies with
+# `UPGRADE FAILED: "kube-agents" has no deployed releases`, instantly
+# failing whichever PR drew this pool project. Heal it here, at lease time,
+# where every cause of the no-deployed-revision state converges. (A release
+# stuck `pending-upgrade` *above* a deployed revision is a different state —
+# upgrade then fails on Helm's in-progress lock, but that run's own teardown
+# uninstall clears it, so it burns one run rather than poisoning the pool.)
+#
+# The probe is `helm history -o json` because it reads the same store the
+# failing code path reads: Helm's upgrade errors in Releases.Deployed()
+# (pkg/action/upgrade.go) when no release-record Secret carries status
+# "deployed", and `helm history` lists exactly those record Secrets with
+# their statuses. "History succeeds but no revision is deployed" is
+# therefore precisely the state upgrade rejects — including a latest-failed
+# release with an older deployed revision, which upgrades fine and is left
+# alone. One call; a healthy or absent release costs the probe and nothing
+# more.
+if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
+  && ! grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
+  echo "WARNING: the ${HELM_RELEASE_NAME} release record exists with no deployed revision —"
+  echo "         a previous run left this pool project poisoned (#1172). Clearing the"
+  echo "         record before installing."
+  # --no-hooks: the pre-delete hook waits on an operator a failed install
+  # never started. If even the uninstall cannot clear it, drop the
+  # release-record Secrets directly — with no deployed revision there is
+  # nothing real for Helm to unwind, and the record is all that blocks the
+  # install. Both failing leaves the record in place, so let set -e stop
+  # the run here, before the upgrade fails less legibly. No --wait and no
+  # hooks means Helm's uninstall timeout would bound nothing, so none is
+  # passed.
+  helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --no-hooks \
+    || kubectl delete secret -n "${NAMESPACE}" -l "${HELM_RELEASE_SECRET_SELECTOR}" --ignore-not-found
+  echo "✓ Cleared the poisoned ${HELM_RELEASE_NAME} release record"
+fi
+
 API_SERVER_KEY="${API_SERVER_KEY:-$(openssl rand -hex 16)}"
-helm upgrade --install kube-agents ./charts/kube-agents \
+helm upgrade --install "${HELM_RELEASE_NAME}" ./charts/kube-agents \
   --namespace "${NAMESPACE}" --create-namespace \
   --set-string "operator.image.repository=${AR_REPO}/kube-agents-operator" \
   --set-string "operator.image.tag=${TAG}" \

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -16,6 +16,23 @@
 
 set -uo pipefail
 
+# The release ci-deploy.sh installs; Step 1 uninstalls it and, when that
+# fails, falls back on deleting its record Secrets by the label pair Helm
+# stamps on every record it writes (`owner=helm` plus `name=<release>`) —
+# selecting every revision's record of this release and nothing else in the
+# namespace (#1172).
+readonly HELM_RELEASE_NAME="kube-agents"
+readonly HELM_RELEASE_SECRET_SELECTOR="owner=helm,name=${HELM_RELEASE_NAME}"
+# Bounds the uninstall's --wait; generous because the chart's pre-delete hook
+# waits for the operator to clear the PlatformAgent finalizer.
+readonly RELEASE_UNINSTALL_TIMEOUT="10m"
+# What a healthy revision looks like in `helm history -o json` (the encoder
+# emits compact `"status":"deployed"`; the pattern tolerates spacing so a
+# Helm formatting change cannot silently blind the fallback's check), and the
+# name prefix `kubectl delete -o name` prints per deleted Secret.
+readonly HELM_DEPLOYED_STATUS_RE='"status"[[:space:]]*:[[:space:]]*"deployed"'
+readonly SECRET_NAME_PREFIX_RE='^secret/'
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
@@ -56,7 +73,40 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agent
 # The chart's pre-delete hook removes the PlatformAgent CR and waits for the
 # operator to clear its finalizer, so one uninstall replaces the old
 # per-step teardown scripts (09 LiteLLM, 08 CR, 07 secrets, 03 operator).
-helm uninstall kube-agents -n "${NAMESPACE}" --wait --timeout 10m || true
+#
+# When the uninstall fails and no revision is deployed, fall back to
+# deleting the release-record Secrets directly (#1172). Teardown never
+# deletes the namespace, so a no-deployed-revision record that survives here
+# greets the project's next lease as `UPGRADE FAILED: "kube-agents" has no
+# deployed releases` at ci-deploy.sh's `helm upgrade --install` — and the
+# poisoned run's own teardown cannot remove it either, so the state is
+# self-sustaining until something drops the record. Step 3's sweep already
+# handles the cluster-scoped objects the release owned, so this strands
+# nothing a failed uninstall was not going to strand anyway.
+#
+# The deployed-revision gate is what makes the fallback safe on a *healthy*
+# release whose uninstall failed transiently (pre-delete hook stuck, --wait
+# past the timeout): its record is exactly what lets the next lease take the
+# clean upgrade path over the surviving objects, so it stays. With no
+# deployed revision the record is pure poison, and a probe that itself
+# fails loses nothing — the delete is --ignore-not-found against a record
+# that, if it exists at all, is already unusable. Same discipline as the
+# rest of the file: nothing here may change the teardown's exit code, and
+# the fallback logs what it deleted so a red run's artifacts show the heal
+# happened.
+if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}"; then
+  if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
+    && grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
+    echo "WARNING: helm uninstall failed with a deployed revision still recorded; leaving the release record for the next lease to upgrade over (#1172)"
+  else
+    echo "WARNING: helm uninstall failed with no deployed revision; removing any release record left behind so the next lease starts clean (#1172)"
+    RECORD_SECRETS_DELETED="$(kubectl delete secret -n "${NAMESPACE}" \
+      -l "${HELM_RELEASE_SECRET_SELECTOR}" --ignore-not-found -o name)" || true
+    RECORD_SECRETS_COUNT="$(printf '%s\n' "${RECORD_SECRETS_DELETED}" | grep -c "${SECRET_NAME_PREFIX_RE}")" || true
+    echo "${RECORD_SECRETS_DELETED}"
+    echo "✓ Release-record fallback deleted ${RECORD_SECRETS_COUNT} Helm record Secret(s)"
+  fi
+fi
 echo "✓ Release uninstall finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
@@ -89,8 +139,9 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kub
 # (ValidatingAdmissionPolicy needs 1.30+) or one flaky delete must not stop
 # the sweep of the kinds that do exist, and nothing here may change the
 # teardown's exit code. This block must stay reachable on every path through
-# the script — steps before it end in `|| true` and there is no `set -e`; the
-# only early exits are the two must-not-delete-the-wrong-cluster guards above.
+# the script — steps before it end in `|| true` or run as `if` conditions,
+# and there is no `set -e`; the only early exits are the two
+# must-not-delete-the-wrong-cluster guards above.
 SWEEP_SELECTOR="app.kubernetes.io/part-of=kube-agents"
 SWEEP_KINDS=(
   validatingadmissionpolicies.admissionregistration.k8s.io

--- a/tests/test_ci_deploy_release_guard.py
+++ b/tests/test_ci_deploy_release_guard.py
@@ -1,0 +1,233 @@
+"""The deploy heals a poisoned Helm release record before `upgrade --install`.
+
+#1172: a pool project can arrive at deploy carrying a `kube-agents` release
+record with no deployed revision — teardown's `helm uninstall` failed and
+left the record behind, or teardown was killed mid-uninstall, which no
+teardown-side fallback can cover. `helm upgrade --install` then takes the
+upgrade path and dies with `UPGRADE FAILED: "kube-agents" has no deployed
+releases`, instantly failing whichever PR drew the project. The guard in
+`hack/ci-deploy.sh` probes `helm history -o json` — the same release-record
+Secrets whose statuses Helm's upgrade path queries — and clears the record
+(uninstall `--no-hooks`, falling back to deleting the record Secrets) when
+the release exists with no `deployed` revision.
+
+These tests pin:
+
+* an absent release (fresh project) and a healthy release (any revision
+  `deployed`) are left alone — one probe call, no uninstall, no delete;
+* a release whose revisions are all failed/pending is uninstalled
+  `--no-hooks`, and a successful uninstall issues no Secret delete;
+* when even the uninstall fails, the record Secrets are deleted by the
+  `owner=helm,name=kube-agents` selector with --ignore-not-found;
+* when both clears fail, the guard aborts under `set -e` rather than
+  letting the upgrade fail less legibly with the record still in place.
+
+The guard is lifted from the script's own text and executed under bash with
+stubbed helm/kubectl, the same approach as tests/test_ci_teardown_sweep.py.
+"""
+
+import json
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_DEPLOY = _REPO_ROOT / "hack" / "ci-deploy.sh"
+
+# The guard's own boundaries in hack/ci-deploy.sh. Asserted present below, so
+# moving the block fails here loudly instead of silently testing nothing.
+_GUARD_START = "# ─── 5a. Heal a poisoned release record"
+_GUARD_END = "API_SERVER_KEY="
+
+# Repeated here on purpose rather than parsed out of the script: a test that
+# derives the expected selector from the code under test asserts nothing.
+_RECORD_SELECTOR = "owner=helm,name=kube-agents"
+
+_NAMESPACE = "kubeagents-system"
+
+# helm history -o json output shapes, as the real encoder emits them
+# (compact keys, one object per revision).
+_HISTORY_HEALTHY = json.dumps(
+    [
+        {"revision": 1, "status": "superseded"},
+        {"revision": 2, "status": "deployed"},
+        {"revision": 3, "status": "failed"},
+    ]
+)
+_HISTORY_POISONED = json.dumps(
+    [
+        {"revision": 1, "status": "pending-install"},
+        {"revision": 2, "status": "failed"},
+    ]
+)
+
+
+def _deploy_text():
+    return _CI_DEPLOY.read_text(encoding="utf-8")
+
+
+def _head_constants(text):
+    """The file-head `readonly` declarations the lifted guard reads."""
+    head = text[: text.find(_GUARD_START)]
+    return "\n".join(
+        line for line in head.splitlines() if line.startswith("readonly ")
+    )
+
+
+def _guard_block(text):
+    start = text.find(_GUARD_START)
+    assert start != -1, f"{_GUARD_START!r} not found in hack/ci-deploy.sh"
+    end = text.find(_GUARD_END, start)
+    assert end != -1, f"{_GUARD_END!r} not found after the guard"
+    return text[start:end]
+
+
+class CiDeployReleaseGuardTest(unittest.TestCase):
+    maxDiff = None
+
+    def _run_guard(
+        self, history_json="", history_exit=0, uninstall_exit=0, kubectl_exit=0
+    ):
+        """Run the lifted guard with recording stubs.
+
+        Returns (returncode, call argv lines, stdout, stderr). The helm stub
+        answers `history` with the given JSON and exit code and `uninstall`
+        with the given exit code; kubectl records and exits as asked.
+        """
+        text = _deploy_text()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            log = tmp_path / "calls.log"
+            log.touch()
+            history_file = tmp_path / "history.json"
+            history_file.write_text(history_json, encoding="utf-8")
+            helm_stub = bin_dir / "helm"
+            helm_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "helm $*" >> "{log}"\n'
+                'case "$1" in\n'
+                f'  history) cat "{history_file}"; exit {history_exit} ;;\n'
+                f"  uninstall) exit {uninstall_exit} ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            kubectl_stub = bin_dir / "kubectl"
+            kubectl_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "kubectl $*" >> "{log}"\n'
+                f"exit {kubectl_exit}\n",
+                encoding="utf-8",
+            )
+            for stub in (helm_stub, kubectl_stub):
+                stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+            # set -euo pipefail mirrors the script's own header; NAMESPACE is
+            # the one variable the lifted guard reads that the head sets.
+            proc = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    + _head_constants(text)
+                    + "\n"
+                    + _guard_block(text),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+                env=get_isolated_test_env(
+                    bin_dir=bin_dir, overrides={"NAMESPACE": _NAMESPACE}
+                ),
+            )
+            calls = log.read_text(encoding="utf-8").splitlines()
+        return proc.returncode, calls, proc.stdout, proc.stderr
+
+    def _helm_uninstalls(self, calls):
+        return [c for c in calls if c.startswith("helm uninstall")]
+
+    def _record_deletes(self, calls):
+        return [
+            c
+            for c in calls
+            if c.startswith("kubectl delete secret") and _RECORD_SELECTOR in c.split()
+        ]
+
+    # --- healthy and absent releases pay one probe and nothing else ---------
+
+    def test_an_absent_release_is_left_alone(self):
+        """A fresh project: `helm history` fails (release: not found)."""
+        rc, calls, out, err = self._run_guard(history_json="", history_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._helm_uninstalls(calls), [])
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertEqual(
+            len(calls), 1, f"a fresh project must cost exactly the probe: {calls}"
+        )
+
+    def test_a_release_with_a_deployed_revision_is_left_alone(self):
+        """Any `deployed` revision means the upgrade path works, even with a
+        failed revision on top of it."""
+        rc, calls, out, err = self._run_guard(history_json=_HISTORY_HEALTHY)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._helm_uninstalls(calls), [])
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertEqual(
+            len(calls), 1, f"a healthy release must cost exactly the probe: {calls}"
+        )
+
+    # --- the poisoned record is healed ---------------------------------------
+
+    def test_a_poisoned_release_is_uninstalled_without_hooks(self):
+        rc, calls, out, err = self._run_guard(history_json=_HISTORY_POISONED)
+        self.assertEqual(rc, 0, err)
+        uninstalls = self._helm_uninstalls(calls)
+        self.assertEqual(
+            len(uninstalls), 1, f"expected one uninstall of the poisoned record: {calls}"
+        )
+        argv = uninstalls[0].split()
+        self.assertIn("--no-hooks", argv)
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        # The uninstall succeeded, so the Secret-level fallback stays unused.
+        self.assertEqual(self._record_deletes(calls), [])
+        # And the heal is loud: a later reader of a red run's log must see it.
+        self.assertIn("poisoned", out.lower())
+
+    def test_a_failed_uninstall_falls_back_to_deleting_the_record_secrets(self):
+        rc, calls, out, err = self._run_guard(
+            history_json=_HISTORY_POISONED, uninstall_exit=1
+        )
+        self.assertEqual(rc, 0, err)
+        deletes = self._record_deletes(calls)
+        self.assertEqual(
+            len(deletes), 1, f"expected the record-Secret fallback to fire: {calls}"
+        )
+        argv = deletes[0].split()
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        self.assertIn("--ignore-not-found", argv)
+
+    def test_both_clears_failing_aborts_before_the_upgrade(self):
+        """Uninstall red AND the record delete red: the record is still in
+        place, so `set -e` must stop the run here rather than let the
+        upgrade fail less legibly — a later `|| true` on that line would
+        ship this regression silently."""
+        rc, calls, out, err = self._run_guard(
+            history_json=_HISTORY_POISONED, uninstall_exit=1, kubectl_exit=1
+        )
+        self.assertNotEqual(rc, 0, "a guard that cannot clear the record must abort")
+
+    # --- the file itself ------------------------------------------------------
+
+    def test_ci_deploy_parses(self):
+        subprocess.run(["bash", "-n", str(_CI_DEPLOY)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_teardown_release_record.py
+++ b/tests/test_ci_teardown_release_record.py
@@ -1,0 +1,240 @@
+"""Step 1's fallback removes the Helm release record when the uninstall fails.
+
+#1172: `helm uninstall` in `hack/ci-teardown.sh` can fail and the `|| true`
+discipline then reports the teardown green with the release-record Secrets
+(`owner=helm,name=kube-agents`, in a namespace teardown never deletes) still
+in place. The next PR that Boskos hands the project meets them at
+`hack/ci-deploy.sh`'s `helm upgrade --install`, which takes the upgrade path
+against a release with no deployed revision and dies with `UPGRADE FAILED:
+"kube-agents" has no deployed releases` — and that run's own teardown cannot
+remove the record either, so the project stays poisoned until a human
+intervenes (three runs burned on 2026-09-02 alone).
+
+These tests pin the fallback's four properties:
+
+* when `helm uninstall` fails and no revision is `deployed` (or the record
+  cannot be read at all), the release-record Secrets are deleted by the
+  `owner=helm,name=kube-agents` selector, namespaced, with
+  --ignore-not-found, and the log says how many records went;
+* when `helm uninstall` fails but a revision IS deployed — a healthy
+  release whose uninstall failed transiently — the record stays: it is what
+  lets the next lease take the clean upgrade path over the surviving
+  objects, and deleting it would force a fresh install into adoption
+  conflicts;
+* when `helm uninstall` succeeds, the record is Helm's to manage and the
+  fallback stays out of it — no record delete is issued;
+* a failing kubectl neither stops the steps after the fallback nor changes
+  the teardown's exit code, which nothing in the script may do.
+
+The steps are lifted from the script's own text and executed under bash with
+stubbed kubectl/helm, the same approach as tests/test_ci_teardown_sweep.py.
+"""
+
+import json
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_TEARDOWN = _REPO_ROOT / "hack" / "ci-teardown.sh"
+
+# Everything from here to end-of-file is the teardown proper — the steps that
+# run once the auth and context guards have passed. Asserted present below, so
+# a rename fails here loudly instead of silently shrinking what is tested.
+_STEPS_START = "START_TIME=$SECONDS"
+
+# Repeated here on purpose rather than parsed out of the script: a test that
+# derives the expected selector from the code under test asserts nothing.
+_RECORD_SELECTOR = "owner=helm,name=kube-agents"
+
+# What the stubbed `kubectl delete secret ... -o name` prints when it is asked
+# for the release record: two record Secrets, the way a release with a failed
+# revision on top of an initial one really looks.
+_STUB_RECORD_NAMES = (
+    "secret/sh.helm.release.v1.kube-agents.v1",
+    "secret/sh.helm.release.v1.kube-agents.v2",
+)
+
+_NAMESPACE = "kubeagents-system"
+
+# helm history -o json output shapes, as the real encoder emits them.
+_HISTORY_DEPLOYED = json.dumps(
+    [
+        {"revision": 1, "status": "superseded"},
+        {"revision": 2, "status": "deployed"},
+    ]
+)
+_HISTORY_POISONED = json.dumps(
+    [
+        {"revision": 1, "status": "pending-install"},
+        {"revision": 2, "status": "failed"},
+    ]
+)
+
+
+def _teardown_text():
+    return _CI_TEARDOWN.read_text(encoding="utf-8")
+
+
+def _head_constants(text):
+    """The file-head `readonly` declarations the lifted steps read.
+
+    The no-magic-constants rule puts names at the top of the file, above
+    _STEPS_START, so the lift has to carry them along.
+    """
+    head = text[: text.find(_STEPS_START)]
+    return "\n".join(
+        line for line in head.splitlines() if line.startswith("readonly ")
+    )
+
+
+def _teardown_steps(text):
+    start = text.find(_STEPS_START)
+    assert start != -1, f"{_STEPS_START!r} not found in hack/ci-teardown.sh"
+    return text[start:]
+
+
+class CiTeardownReleaseRecordTest(unittest.TestCase):
+    maxDiff = None
+
+    def _run_steps(self, kubectl_exit=0, uninstall_exit=0, history_json="", history_exit=1):
+        """Run the teardown steps with recording stubs.
+
+        Returns (returncode, call argv lines, stdout, stderr). Each stub
+        appends its argv to a log; helm answers `uninstall` and `history`
+        with the requested exit codes and JSON, and kubectl additionally
+        prints the two record-Secret names when it is invoked as the record
+        delete, so the fallback's count log can be asserted. `history_exit`
+        defaults red — the poisoned run's record is typically unreadable the
+        same way its uninstall failed.
+        """
+        text = _teardown_text()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            log = tmp_path / "calls.log"
+            log.touch()
+            history_file = tmp_path / "history.json"
+            history_file.write_text(history_json, encoding="utf-8")
+            helm_stub = bin_dir / "helm"
+            helm_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "helm $*" >> "{log}"\n'
+                'case "$1" in\n'
+                f"  uninstall) exit {uninstall_exit} ;;\n"
+                f'  history) cat "{history_file}"; exit {history_exit} ;;\n'
+                "  *) exit 0 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            kubectl_stub = bin_dir / "kubectl"
+            kubectl_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "kubectl $*" >> "{log}"\n'
+                f'if [[ "$*" == *"{_RECORD_SELECTOR}"* && {kubectl_exit} -eq 0 ]]; then\n'
+                + "".join(f'  echo "{name}"\n' for name in _STUB_RECORD_NAMES)
+                + "fi\n"
+                f"exit {kubectl_exit}\n",
+                encoding="utf-8",
+            )
+            for stub in (helm_stub, kubectl_stub):
+                stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+            proc = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "set -uo pipefail\n"
+                    + _head_constants(text)
+                    + "\n"
+                    + _teardown_steps(text),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+                env=get_isolated_test_env(
+                    bin_dir=bin_dir, overrides={"NAMESPACE": _NAMESPACE}
+                ),
+            )
+            calls = log.read_text(encoding="utf-8").splitlines()
+        return proc.returncode, calls, proc.stdout, proc.stderr
+
+    def _record_deletes(self, calls):
+        return [
+            c
+            for c in calls
+            if c.startswith("kubectl delete secret") and _RECORD_SELECTOR in c.split()
+        ]
+
+    # --- the fallback fires when the uninstall fails ------------------------
+
+    def test_failed_uninstall_with_no_deployed_revision_deletes_the_record(self):
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1, history_json=_HISTORY_POISONED, history_exit=0
+        )
+        self.assertEqual(rc, 0, err)
+        deletes = self._record_deletes(calls)
+        self.assertEqual(
+            len(deletes),
+            1,
+            f"expected exactly one release-record delete after a failed "
+            f"helm uninstall of a no-deployed-revision release: {calls}",
+        )
+        argv = deletes[0].split()
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        self.assertIn("--ignore-not-found", argv)
+
+    def test_an_unreadable_record_is_deleted_too(self):
+        """`helm history` red (record corrupt, or gone mid-probe): nothing
+        to lose — the delete is --ignore-not-found against a record that,
+        if it exists, is already unusable."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, history_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(len(self._record_deletes(calls)), 1, calls)
+
+    def test_the_fallback_logs_how_many_records_it_deleted(self):
+        """A red run's artifacts must show the heal happened; the stub
+        deletes two record Secrets, so the log has to say two."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("deleted 2", out)
+
+    # --- and stays out of the way everywhere else ---------------------------
+
+    def test_successful_uninstall_issues_no_record_delete(self):
+        rc, calls, out, err = self._run_steps(uninstall_exit=0)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._record_deletes(calls), [])
+
+    def test_a_deployed_revision_keeps_its_record(self):
+        """A healthy release whose uninstall failed transiently: the record
+        is what lets the next lease take the clean upgrade path over the
+        surviving objects, so the fallback must not delete it."""
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1, history_json=_HISTORY_DEPLOYED, history_exit=0
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertIn("leaving the release record", out)
+
+    # --- the exit-code contract holds ---------------------------------------
+
+    def test_a_failing_kubectl_neither_stops_teardown_nor_reds_it(self):
+        """Fallback delete red, CRD delete red, sweep red — the teardown
+        still exits 0 and still reaches the steps after Step 1."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, kubectl_exit=1)
+        self.assertEqual(rc, 0, err)
+        # Step 2 (the CRD delete by file) still ran after the failed fallback.
+        self.assertTrue(
+            any(c.startswith("kubectl delete -f") for c in calls),
+            f"the CRD delete never ran after a failed record fallback: {calls}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_teardown_sweep.py
+++ b/tests/test_ci_teardown_sweep.py
@@ -61,10 +61,18 @@ _SELECTOR = "app.kubernetes.io/part-of=kube-agents"
 
 
 def _teardown_steps():
+    """The lifted steps, prefixed with the file-head `readonly` constants.
+
+    The no-magic-constants rule declares names at the top of the file, above
+    _STEPS_START, so the lift carries them along or `set -u` kills the run.
+    """
     text = _CI_TEARDOWN.read_text(encoding="utf-8")
     start = text.find(_STEPS_START)
     assert start != -1, f"{_STEPS_START!r} not found in hack/ci-teardown.sh"
-    return text[start:]
+    constants = "\n".join(
+        line for line in text[:start].splitlines() if line.startswith("readonly ")
+    )
+    return constants + "\n" + text[start:]
 
 
 class CiTeardownSweepTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

A failed `helm uninstall` in `hack/ci-teardown.sh` leaves the release-record Secrets behind in `kubeagents-system` — a namespace teardown never deletes — and the next PR that Boskos hands the project dies at `hack/ci-deploy.sh`'s `helm upgrade --install` with `UPGRADE FAILED: "kube-agents" has no deployed releases`. The state is self-sustaining, because the poisoned run's own teardown cannot remove the record either. This PR removes the record on both sides: teardown falls back to deleting the record Secrets when its uninstall fails and no revision is deployed, and deploy probes for the poisoned state at lease time and clears it before installing. The mechanism analysis is @bradhoekstra's, from #1172; the teardown fallback is his sketch, hardened.

## Why This Change

`kube-agents-evals-4` has burned at least three runs on 2026-09-02 alone (builds on #1169 and #1173 twice), and with the presubmit gate now merge-blocking, each occurrence costs an innocent PR a full retest cycle against a coin flip. Without this change the pool stays a minefield: any teardown whose uninstall fails — or that is killed mid-uninstall — poisons its project for every subsequent lease until a human deletes the record by hand.

## What Changed

- `hack/ci-teardown.sh` Step 1: when `helm uninstall` fails, probe `helm history` and — only when no revision is `deployed` — delete the release-record Secrets (`owner=helm,name=kube-agents`, `--ignore-not-found`), logging how many records went so a red run's artifacts show the heal. A deployed revision keeps its record: it is what lets the next lease take the clean upgrade path over the surviving objects. Nothing changes the teardown's exit code; the fallback runs entirely inside `if` conditions and `|| true` assignments.
- `hack/ci-deploy.sh`: a guard immediately before `helm upgrade --install` probes `helm history -o json` and, when the release exists with no `deployed` revision, clears it — `helm uninstall --no-hooks` first (the pre-delete hook waits on an operator a failed install never started), falling back to deleting the record Secrets — logging loudly that a poisoned record was healed. A healthy or absent release costs the one probe call and nothing more. This side covers the cause no teardown fallback can: a teardown killed mid-uninstall.
- The probe reads the same store the failing code path reads: Helm's upgrade errors in `Releases.Deployed()` when no release-record Secret carries status `deployed`, and `helm history` lists exactly those Secrets with their statuses — including the latest-failed-with-older-deployed shape, which upgrades fine and is left alone.
- New constants named per `.agents/rules/core_engineering.md`; the untouched `helm upgrade --install` line now takes `${HELM_RELEASE_NAME}` so the guard and the release it guards cannot desynchronize.
- `tests/test_ci_teardown_release_record.py`, `tests/test_ci_deploy_release_guard.py`: the script text is lifted and executed under bash with stubbed `helm`/`kubectl` (the `test_ci_teardown_sweep.py` approach), pinning the fallback, the deployed-revision gate, the guard's heal-and-leave-alone behavior, the abort when both clears fail, and the teardown exit-code contract. `tests/test_ci_teardown_sweep.py`'s lift now carries the file-head `readonly` constants, which the new code requires under `set -u`.

## Context

Fixes #1172 (diagnosis and teardown-side sketch by @bradhoekstra). Duplicate evidence in #1176 (closed as dup). The deploy-side guard is the pairing proposed in the follow-up comment on #1172: teardown-side hygiene fixes the case where teardown runs; it cannot fix a teardown killed mid-uninstall, which deploy-side self-heal covers at the only moment that matters. The two together make the class unreachable. Whoever's smoke run next draws `kube-agents-evals-4` with this branch gets the field test for free — see Live validation.

## Testing

- `bash -n hack/ci-teardown.sh hack/ci-deploy.sh` — both parse.
- New suites written red-first: against unmodified scripts, 6 of the behavioral tests fail (no record delete issued, no count log, guard anchor absent); green at HEAD. An independent verification pass re-confirmed red/green by reverting the two scripts and re-running.
- Full `tests/` discovery (935 tests) and `tests/integration/` (27): green except pre-existing, environment-dependent failures (`test_install_script.ImportGithubPemKmsKeyTest`, three integration seam suites) that fail identically on `upstream/main` on the same machine and touch nothing this PR changes.
- `make docs-check` green (all five checks).

### Live validation

Not live-tested against a poisoned project: this path needs a Boskos pool project with a stuck release record, and I have no cluster access from this environment. The stub tests prove the logic at the bash level — every branch of both scripts' new code runs under the scripts' own `set` flags with recorded `helm`/`kubectl` calls. What I could not cover: real Helm/API-server behavior (uninstall semantics against an `uninstalling`-status record, adoption behavior), asserted from Helm 3 source rather than execution. There is a fitting irony available, though: `kube-agents-evals-4` is currently poisoned in exactly this way, so if this PR's own smoke run draws that project, the deploy-side guard gets its field test on its first outing — and heals the fleet's open wound in the process.

Partial field evidence already in: this PR's own smoke run ([build 2095211107370143744](https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1180/pull-kube-agents-smoke-test/2095211107370143744)) drew `kube-agents-evals-14` (not the poisoned `evals-4`, which stays for a later run to heal), and the job's pre-clean exercised the teardown fallback's release-absent branch against a real cluster:

```
Error: uninstall: Release not loaded: kube-agents: release: not found
WARNING: helm uninstall failed with no deployed revision; removing any release record left behind so the next lease starts clean (#1172)
No resources found
✓ Release-record fallback deleted 0 Helm record Secret(s)
✓ Release uninstall finished in 2s
```

Probe ran, count was logged, the teardown's exit code and the steps after it were untouched, and the deploy guard then let the healthy install through with no extra round trips. The poisoned-record branches remain covered by the stub tests only.

## Self-Review

Both passes ran in contexts that did not write the change — two subagents handed the repo, the diff range (`upstream/main...HEAD`), and nothing else: one adversarial (`review-adversarial`), one docs-drift (`review-docs-drift`). Findings and dispositions, one merged list:

- **Fallback fired on any uninstall failure, deleting the record of a still-deployed release** (adversarial, should-fix) — confirmed: a transient failure (stuck hook, `--wait` timeout) on a healthy release would have deleted the record that enables the next lease's clean upgrade, forcing a fresh install into adoption conflicts. **Fixed**: the teardown fallback is now gated on the same no-deployed-revision probe the deploy guard uses; a new test pins that a deployed revision keeps its record.
- **Magic constants on touched lines in teardown** (`kube-agents`, `10m`, the `'^secret/'` pattern) (adversarial, should-fix) — **fixed**: named `HELM_RELEASE_NAME`, `RELEASE_UNINSTALL_TIMEOUT`, `SECRET_NAME_PREFIX_RE` at the top of the file.
- **`--timeout` without `--wait` and with `--no-hooks` bounds nothing in the guard's uninstall** (adversarial, nit) — **fixed** by removing the inert flag and its constant, with a comment saying why none is passed.
- **`helm upgrade --install kube-agents` hardcoded the name the new constant claims to own** (adversarial, nit) — **fixed**: the upgrade line takes `${HELM_RELEASE_NAME}`; a one-token change on an otherwise untouched line, justified because this PR introduced the dual source.
- **Noisy WARNING on a clean project when uninstall fails because nothing was installed** (adversarial, nit) — **fixed** via the gate (the message now states which state was found) and wording that does not assert a record existed.
- **The both-clears-fail abort path was untested** (adversarial, nit) — **fixed**: `test_both_clears_failing_aborts_before_the_upgrade` pins that a later `|| true` on that line cannot ship silently.
- **`pending-upgrade` above a deployed revision is not healed** (adversarial, question) — **deliberately not handled**: that is Helm's in-progress lock, a different state from #1172's; it burns one run and that run's own teardown uninstall clears it. The guard's comment now scopes its claim to the no-deployed-revision state instead of "every cause".
- **Stale Step 3 comment ("steps before it end in `|| true`")** (docs-drift, non-blocking) — **fixed**: amended to "end in `|| true` or run as `if` conditions".
- **Line-number drift in `docs/testing-map.md` re: Makefile globs** (docs-drift, non-blocking, pre-existing) — **not fixed here**: this PR does not touch the Makefile and did not cause the drift; flagging it in this list is the disposition.
- Docs-drift found no prose this diff invalidates, no map entry owed (new files are `.py` under `tests/`, outside the map's scope, inside the existing `PYTHON_TEST_DIRS` glob), and `make docs-check` green.

Generated with the help of Claude Code.

## Risk & Rollout

Blast radius is the CI smoke pipeline only; no chart, operator, or agent code paths change. New failure modes: (1) the deploy guard aborts the run when a poisoned record can be neither uninstalled nor deleted — previously the run failed anyway, less legibly, one step later; (2) the teardown fallback deletes record Secrets that a concurrent operation might own — impossible under Boskos, which leases a project to one run at a time. If the probe regex ever misreads Helm's JSON, the worst case on the false-negative side is today's behavior (upgrade fails as before), and the false-positive side is gated to releases whose uninstall already failed. Revert is a clean `git revert`; nothing has to happen at merge time. The currently poisoned `kube-agents-evals-4` is healed by the first post-merge run that leases it (or by this PR's own smoke run, if it draws it).
