### PR TITLE
docs(workflow): record the four checks promoted to required contexts

### DIFF
--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -293,13 +293,17 @@ waiting on it.
 `/hold cancel` releases it — #1045 held that way for a smoke test. `/override <context>`, which only
 a repository admin can use, forces a required check that cannot pass on its own.
 
-**Branch protection is not the gate and reads as though there is none.** `main` requires six
-contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests` —
-and conversation resolution, but **zero** approving reviews, because approval is Tide's business
-rather than GitHub's. A reader who checks the repository settings for the review requirement
-therefore finds nothing and concludes wrongly.
+**Branch protection is not the gate and reads as though there is none.** `main` requires ten
+contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`,
+`Run Python Unit Tests`, `Documentation Checks`, `Validate Conventional Commit PR Title`, and
+`Agent instructions cite assets that exist` — and conversation resolution, but **zero** approving
+reviews, because approval is Tide's business rather than GitHub's. A reader who checks the
+repository settings for the review requirement therefore finds nothing and concludes wrongly.
 
-Those six are not the whole required set either. Tide also requires every Prow presubmit not marked
+The last four joined the set on 2026-09-02; before that they reported on every pull request without
+gating one.
+
+Those ten are not the whole required set either. Tide also requires every Prow presubmit not marked
 `optional`, and those are configured in `oss-test-infra` rather than in branch protection —
 `pull-kube-agents-smoke-test` dropped its `optional: true` on 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677), so the behavioural presubmit gates every merge from that
@@ -350,7 +354,7 @@ Four states that look like somebody else's problem and are not:
   `/request-review` is the override. Answering every bot thread does not summon one by itself, so
   an author who has done everything asked of them can still be sitting with nobody assigned.
 - **A red check that is not required.** It blocks no merge and is not the author's problem — but
-  "required" means both lists above, not branch protection's six alone, and `tide` is what actually
+  "required" means both lists above, not branch protection's ten alone, and `tide` is what actually
   knows. Ask it before treating a failing job as work owed, and before concluding one is not.
 - **`mergeable: UNKNOWN`.** GitHub computes mergeability lazily and the first query only triggers
   the job, so a conflict reads as conflict-free until you ask twice.


### PR DESCRIPTION
## Summary

`docs/pull-request-workflow.md` is the one page in this repository that names the required
branch-protection contexts on `main`, and it said six. Branch protection was changed on 2026-09-02
to require ten. This updates the page to match, in the two places that stated the count.

## Why This Change

The page exists so that a contributor can tell whether a red check is work they owe. It named six
contexts and omitted four that now block a merge — `Run Python Unit Tests`, `Documentation Checks`,
`Validate Conventional Commit PR Title`, and `Agent instructions cite assets that exist`. Left
alone, a contributor reading the "A red check that is not required" bullet counts the six named
above it, finds four more red checks, and concludes those four are advisory. They are required, and
the pull request will not merge.

## What Changed

- `docs/pull-request-workflow.md` — the required-context list in "How a change merges" goes from
  six names to ten, and the "A red check that is not required" bullet 60 lines further down, which
  restated the count as "branch protection's six alone", now says ten. Both had to move: the second
  one is the reason the first one matters.
- One sentence dating the promotion, so a reader can interpret an older pull request.

No timings and no reference to the change that motivated the promotion. A measured job duration
drifts silently as the suite grows and nothing in `make docs-check` would catch it, and the
reasoning belongs in the issue rather than on a reference page.

## Context

Closes #1178, which proposed the promotion and records the reasoning, the measurements, and the
`gh api` call that applied it.

`docs/testing-map.md` and `docs/site/src/content/docs/contributing.md` both defer to this page for
which checks are required rather than restating the set, so neither needs an edit — verified by the
docs-drift pass below rather than assumed.

Related but not overlapping: #1177 (open) parallelises the Python test sweep, which is what makes
requiring that job comfortable rather than marginal. This PR does not depend on it and does not
mention it.

## Testing

- `make docs-check` — passes, all five checks.
- `prettier --write` on the changed file at the repo-pinned version — no reformatting.

### Live validation

The change documents a live configuration change, and the configuration is what was validated. The
ten contexts were read back from the GitHub API after the change was applied, and the list in the
diff was checked against that output name-by-name and in order:

```
$ gh api repos/gke-labs/kube-agents/branches/main/protection \
    --jq '.required_status_checks.contexts'
["cla/google","actionlint","build","prettier","validate","Run Controller Tests",
 "Run Python Unit Tests","Documentation Checks","Validate Conventional Commit PR Title",
 "Agent instructions cite assets that exist"]
```

`required_approving_review_count: 0` and `required_conversation_resolution: true` were also
confirmed, since the surrounding sentence asserts both. Each context kept its `app_id` pin
(`15368` for the Actions jobs, `42202` for `cla/google`), so a same-named check from another app
cannot satisfy the requirement.

Not live-tested against a kube-agents installation: this is prose about repository configuration
and touches no cluster, operator, or agent surface. No test artifacts to clean up, and no lease
taken because nothing on a shared install was mutated.

## Self-Review

Both required passes ran in subagents handed the diff range and nothing else — neither had the
context that wrote the change. Looked for: a stale restatement of the count elsewhere in the repo,
unverifiable or drifting numbers, claims about GitHub behaviour that are not actually how GitHub
behaves, citation conventions, and the AGENTS.md documentation rules.

Findings and disposition — five raised, four fixed, one rejected:

- **The same page still said "six" 60 lines down** (line 357, "A red check that is not required").
  Both passes caught it independently; my own grep had missed it because the phrasing is
  "branch protection's six alone". **Fixed.** This was the most consequential finding — it sits in
  the bullet aimed at exactly the reader the page is for.
- **The first draft justified the promotion with "#1177 had taken the Python suite to under two
  minutes ... inside the 238s `build` sets as the critical path".** #1177 is open, so the premise
  had not landed, and both figures were measured on its branch rather than on `main`. **Fixed by
  deleting the claim rather than correcting it.** Re-measuring across 25 recent `main` commits (22
  samples each) gives `Run Python Unit Tests` median 291s against `build` median 328s, so the
  underlying conclusion holds without #1177 — but a measured duration on a reference page drifts
  silently, and the page's job is to name the required set, not to argue for it.
- **The first draft claimed a pull request whose head predates 2026-09-02 "has never reported them,
  and reads as permanently pending until it is rebased or pushed to".** False as a general rule:
  promoting a context does not un-report a check run already on the head SHA. **Fixed by deleting
  the sentence.** The two real causes — the workflow not existing when the commit was pushed
  (#467), and a fork pull request whose runs await maintainer approval (#735, #798, #876) — are
  pre-existing properties of any required context, not something this change introduces, and
  `/override` is already documented two paragraphs above.
- **Citing `(#1178)` inline read as though an open issue performed the change**, where the page's
  convention cites landed changes as provenance, and AGENTS.md forbids documenting pull-request
  status. **Fixed:** the inline citation is gone and the issue is referenced once, as `Closes`, in
  Context above.
- **Rejected:** the adversarial pass attributed #467's missing checks to `python-tests.yml` having
  once carried a paths filter. It never had one — `git log -S"paths:"` on that file returns
  nothing, and the comment it was reading (`python-tests.yml:72-76`) says the filter that kept
  tests from running was `k8s-operator-test.yml`'s `k8s-operator/**`, a different workflow. #467's
  head simply predates the workflow by a week. The finding's conclusion — that my date-based
  predicate was wrong — was right for a different reason, and the sentence is gone either way.

Both passes independently confirmed the ten names and their order against the live API, and that no
other document in the repository states the required set or its count.

Not covered: nothing in this repository compares this paragraph against the live branch-protection
API, so the list can drift again silently. That is pre-existing and out of scope here; a check for
it would be a reasonable follow-up.

## Risk & Rollout

Documentation only — no runtime code paths, no manifests, no CI behaviour. Reverting is reverting
the commit. Nothing has to happen at merge time.

Generated with the help of Claude Opus 5.
