### PR TITLE
fix(ci): gate teardown's CRD delete and sweep namespaced orphans

### DIFF
--- a/docs/site/src/content/docs/reference/resource-labels.md
+++ b/docs/site/src/content/docs/reference/resource-labels.md
@@ -99,6 +99,13 @@ existed before the upgrade stay unlabelled until they are recreated. They will n
 `-l app.kubernetes.io/part-of=kube-agents` query above. The constraint above means Hindsight's
 claim stays unlabelled permanently, not just until recreation.
 
+Claims backed by a `volumeClaimTemplates` entry are permanently unlabelled for the same reason
+wherever they come from, not only under Kustomize: `buildRWOVolumeClaimTemplates` sets a name and
+nothing else on the template's `metadata`, so an agent declaring RWO `spec.deployment.storages`
+gets claims the part-of query cannot reach either. Claims the controller creates directly —
+`<agent>-data`, `system-metadata`, and non-RWO custom storage — go through `withCommonLabels` and
+are labelled.
+
 ## Query recipes
 
 Everything one PlatformAgent owns, including its cluster-scoped RBAC:

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -24,6 +24,17 @@ set -euo pipefail
 # env allowlist letting it through to the container.
 readonly EVAL_ALERT_DAILY_LIMIT_WARNING="0"
 
+# The release step 5 installs, and — for the poisoned-record guard (#1172) —
+# the label pair Helm stamps on every release-record Secret it writes
+# (`owner=helm` plus `name=<release>`), selecting every revision's record of
+# this release and nothing else in the namespace.
+readonly HELM_RELEASE_NAME="kube-agents"
+readonly HELM_RELEASE_SECRET_SELECTOR="owner=helm,name=${HELM_RELEASE_NAME}"
+# What a healthy revision looks like in `helm history -o json` output. The
+# encoder emits compact `"status":"deployed"`; the pattern tolerates spacing
+# so a Helm formatting change cannot silently blind the guard.
+readonly HELM_DEPLOYED_STATUS_RE='"status"[[:space:]]*:[[:space:]]*"deployed"'
+
 # ─── 1. Validation & Pre-checks ───────────────────────────────────────────────
 if [ -z "${GEMINI_API_KEY:-}" ]; then
   echo "ERROR: GEMINI_API_KEY environment variable is required"
@@ -295,8 +306,48 @@ echo "✓ Container image builds finished in $((SECONDS - STEP_START))s"
 # test's.
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying the kube-agents chart ==="
+
+# ─── 5a. Heal a poisoned release record (#1172) ───────────────────────────────
+# A failed or killed prior run can leave the release record behind with no
+# deployed revision: its teardown's `helm uninstall` failed, or the teardown
+# was killed mid-uninstall — the cause no teardown-side fallback can cover.
+# `helm upgrade --install` below then takes the upgrade path and dies with
+# `UPGRADE FAILED: "kube-agents" has no deployed releases`, instantly
+# failing whichever PR drew this pool project. Heal it here, at lease time,
+# where every cause of the no-deployed-revision state converges. (A release
+# stuck `pending-upgrade` *above* a deployed revision is a different state —
+# upgrade then fails on Helm's in-progress lock, but that run's own teardown
+# uninstall clears it, so it burns one run rather than poisoning the pool.)
+#
+# The probe is `helm history -o json` because it reads the same store the
+# failing code path reads: Helm's upgrade errors in Releases.Deployed()
+# (pkg/action/upgrade.go) when no release-record Secret carries status
+# "deployed", and `helm history` lists exactly those record Secrets with
+# their statuses. "History succeeds but no revision is deployed" is
+# therefore precisely the state upgrade rejects — including a latest-failed
+# release with an older deployed revision, which upgrades fine and is left
+# alone. One call; a healthy or absent release costs the probe and nothing
+# more.
+if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
+  && ! grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
+  echo "WARNING: the ${HELM_RELEASE_NAME} release record exists with no deployed revision —"
+  echo "         a previous run left this pool project poisoned (#1172). Clearing the"
+  echo "         record before installing."
+  # --no-hooks: the pre-delete hook waits on an operator a failed install
+  # never started. If even the uninstall cannot clear it, drop the
+  # release-record Secrets directly — with no deployed revision there is
+  # nothing real for Helm to unwind, and the record is all that blocks the
+  # install. Both failing leaves the record in place, so let set -e stop
+  # the run here, before the upgrade fails less legibly. No --wait and no
+  # hooks means Helm's uninstall timeout would bound nothing, so none is
+  # passed.
+  helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --no-hooks \
+    || kubectl delete secret -n "${NAMESPACE}" -l "${HELM_RELEASE_SECRET_SELECTOR}" --ignore-not-found
+  echo "✓ Cleared the poisoned ${HELM_RELEASE_NAME} release record"
+fi
+
 API_SERVER_KEY="${API_SERVER_KEY:-$(openssl rand -hex 16)}"
-helm upgrade --install kube-agents ./charts/kube-agents \
+helm upgrade --install "${HELM_RELEASE_NAME}" ./charts/kube-agents \
   --namespace "${NAMESPACE}" --create-namespace \
   --set-string "operator.image.repository=${AR_REPO}/kube-agents-operator" \
   --set-string "operator.image.tag=${TAG}" \

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -6,12 +6,16 @@
 # Preserves static cluster & GCP IAM setup for fast re-use across PR runs.
 #
 # One `helm uninstall` (the release owns every Kubernetes object ci-deploy.sh
-# created) plus an explicit CRD delete, since the chart leaves CRDs behind by
-# Helm's own design, plus an unconditional label sweep of every cluster-scoped
-# kind the chart or the operator can create — because a run killed mid-install
-# leaves cluster-scoped objects with no Helm release record for `helm
-# uninstall` to act on, and Helm then refuses to adopt them on the project's
-# next lease (#1006).
+# created) plus a CRD delete, since the chart leaves CRDs behind by Helm's own
+# design, plus an unconditional label sweep of every cluster-scoped and
+# namespaced kind the chart or the operator can create *with the part-of label*
+# — because a run killed mid-install leaves objects with no Helm release record
+# for `helm uninstall` to act on, and Helm then refuses to adopt them on the
+# project's next lease (#1006). Step 4 names the kinds the label cannot reach.
+#
+# The CRD delete is the one conditional step: a release record that outlives
+# Step 1 needs its CRDs, or the next lease can neither uninstall nor upgrade
+# over it (#1172).
 # ==============================================================================
 
 set -uo pipefail
@@ -32,6 +36,15 @@ readonly RELEASE_UNINSTALL_TIMEOUT="10m"
 # name prefix `kubectl delete -o name` prints per deleted Secret.
 readonly HELM_DEPLOYED_STATUS_RE='"status"[[:space:]]*:[[:space:]]*"deployed"'
 readonly SECRET_NAME_PREFIX_RE='^secret/'
+# The chart's CRDs, and a bound on waiting for them to go. `kubectl delete`
+# defaults to waiting forever, and deleting a CRD blocks on
+# customresourcecleanup.apiextensions.k8s.io until every CR of that kind is
+# gone — which a PlatformAgent finalizer no live operator can clear never is.
+# Unbounded, that hangs teardown until Prow's job timeout and Steps 3 and 4
+# never run, leaving exactly the orphans they exist to sweep. Five minutes is
+# well clear of the 206s a healthy-but-slow delete has been observed to take.
+readonly CHART_CRD_DIR="charts/kube-agents/crds/"
+readonly CRD_DELETE_TIMEOUT="5m"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
@@ -80,9 +93,9 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agent
 # greets the project's next lease as `UPGRADE FAILED: "kube-agents" has no
 # deployed releases` at ci-deploy.sh's `helm upgrade --install` — and the
 # poisoned run's own teardown cannot remove it either, so the state is
-# self-sustaining until something drops the record. Step 3's sweep already
-# handles the cluster-scoped objects the release owned, so this strands
-# nothing a failed uninstall was not going to strand anyway.
+# self-sustaining until something drops the record. The sweeps in Steps 3 and
+# 4 already handle the objects the release owned, so this strands nothing a
+# failed uninstall was not going to strand anyway.
 #
 # The deployed-revision gate is what makes the fallback safe on a *healthy*
 # release whose uninstall failed transiently (pre-delete hook stuck, --wait
@@ -94,7 +107,12 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agent
 # rest of the file: nothing here may change the teardown's exit code, and
 # the fallback logs what it deleted so a red run's artifacts show the heal
 # happened.
-if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}"; then
+#
+# --debug because Helm hands deleteRelease's real errors to cfg.Log
+# (pkg/action/uninstall.go), which drops them without it, and returns only
+# `failed to delete release: <name>`. That line was all CI recorded for the
+# 25 hours #1172 went unnoticed.
+if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}" --debug; then
   if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
     && grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
     echo "WARNING: helm uninstall failed with a deployed revision still recorded; leaving the release record for the next lease to upgrade over (#1172)"
@@ -112,9 +130,40 @@ echo "✓ Release uninstall finished in $((SECONDS - STEP_START))s"
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 2: Deleting CRDs ==="
 # Helm leaves crds/ objects behind by design; a PR evaluation cluster should
-# not accumulate them.
-kubectl delete -f charts/kube-agents/crds/ --ignore-not-found || true
-echo "✓ CRD deletion finished in $((SECONDS - STEP_START))s"
+# not accumulate them. Only when no release record survived Step 1, though.
+# Both of Helm's routes over a surviving record need the CRDs: `uninstall`
+# resolves a REST mapping for every object in the stored manifest, which
+# contains a PlatformAgent, and `upgrade` never reinstalls crds/. Delete them
+# under a record and the next lease can do neither — #1172, where every re-run
+# deleted the CRDs again and re-armed the trap. No record means the next lease
+# is a fresh install, which reinstalls crds/ itself, so #1006's case (CRDs from
+# a run killed mid-install) is still swept. Unreadable counts as "may survive":
+# keeping a CRD costs one lease's tidiness, deleting one costs the project.
+CRD_STEP_RESULT="deleted"
+PROBE_ERROR_LOG="$(mktemp)"
+if RELEASE_RECORD_NAMES="$(kubectl get secret -n "${NAMESPACE}" \
+  -l "${HELM_RELEASE_SECRET_SELECTOR}" -o name 2>"${PROBE_ERROR_LOG}")"; then
+  if [ -n "${RELEASE_RECORD_NAMES}" ]; then
+    echo "WARNING: a ${HELM_RELEASE_NAME} release record survived Step 1; keeping the CRDs so the next lease's Helm can read its own manifest (#1172)"
+    CRD_STEP_RESULT="skipped, release record survived Step 1"
+  elif kubectl delete -f "${CHART_CRD_DIR}" --ignore-not-found --timeout "${CRD_DELETE_TIMEOUT}"; then
+    CRD_STEP_RESULT="deleted"
+  else
+    # Bounded rather than hung: the CRDs may be left Terminating, which the
+    # next lease's fresh install can still collide with, but Steps 3 and 4
+    # now run and the log says which happened.
+    echo "WARNING: the CRD delete did not finish within ${CRD_DELETE_TIMEOUT}; continuing so the sweeps still run (#1172)"
+    CRD_STEP_RESULT="delete timed out or failed after ${CRD_DELETE_TIMEOUT}"
+  fi
+else
+  # The reason matters and used to go to /dev/null: a missing namespace is a
+  # knowably-empty read, an RBAC or API-server failure is not, and the branch
+  # below treats them alike.
+  echo "WARNING: could not read the ${HELM_RELEASE_NAME} release records; keeping the CRDs (#1172). kubectl said: $(tr '\n' ' ' <"${PROBE_ERROR_LOG}")"
+  CRD_STEP_RESULT="skipped, release records unreadable"
+fi
+rm -f "${PROBE_ERROR_LOG}"
+echo "✓ CRD step (${CRD_STEP_RESULT}) finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kube-agents resources ==="
@@ -155,6 +204,52 @@ for SWEEP_KIND in "${SWEEP_KINDS[@]}"; do
   kubectl delete "${SWEEP_KIND}" -l "${SWEEP_SELECTOR}" --ignore-not-found || true
 done
 echo "✓ Cluster-scoped sweep finished in $((SECONDS - STEP_START))s"
+
+STEP_START=$SECONDS
+echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 4: Sweeping namespaced kube-agents resources ==="
+# The same sweep, one scope down, for the same reason: once the release stops
+# accounting for a namespaced object, nothing else deletes it. Teardown never
+# deletes the kubeagents-system namespace, and the operator's children are
+# reaped by owner-reference GC, which stops resolving owners as soon as Step 2
+# removes the PlatformAgent CRD.
+#
+# Same selector as Step 3: every object the operator creates is stamped with
+# app.kubernetes.io/part-of=kube-agents — through applyManaged, or, on the two
+# paths that bypass it, through withCommonLabels on the PVC and commonLabels
+# handed to ReconcileServiceAccount. Helm's release records are Secrets
+# labelled owner=helm carrying none of the chart's labels, so this sweep cannot
+# delete one — whether a record survives stays Step 1's decision. The chart's
+# own CRs are absent for the same reason: on the delete path Step 2 takes them
+# with their CRDs, and on the keep path they are what the next lease upgrades
+# over.
+#
+# The claims the operator creates itself are labelled and swept; the ones it
+# materialises from a StatefulSet's volumeClaimTemplates are not, because that
+# ObjectMeta carries a name and nothing else. That is hindsight's claim and any
+# RWO custom storage, and deleting the StatefulSet leaves them behind — no
+# selector reaches either. PVCs sweep last so the workloads releasing them are
+# already deleted, or kubernetes.io/pvc-protection holds the delete open.
+SWEEP_NAMESPACED_KINDS=(
+  deployments.apps
+  statefulsets.apps
+  jobs.batch
+  services
+  configmaps
+  secrets
+  serviceaccounts
+  roles.rbac.authorization.k8s.io
+  rolebindings.rbac.authorization.k8s.io
+  networkpolicies.networking.k8s.io
+  poddisruptionbudgets.policy
+  podmonitorings.monitoring.googleapis.com
+  certificates.cert-manager.io
+  issuers.cert-manager.io
+  persistentvolumeclaims
+)
+for SWEEP_KIND in "${SWEEP_NAMESPACED_KINDS[@]}"; do
+  kubectl delete "${SWEEP_KIND}" -n "${NAMESPACE}" -l "${SWEEP_SELECTOR}" --ignore-not-found || true
+done
+echo "✓ Namespaced sweep finished in $((SECONDS - STEP_START))s"
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -16,6 +16,23 @@
 
 set -uo pipefail
 
+# The release ci-deploy.sh installs; Step 1 uninstalls it and, when that
+# fails, falls back on deleting its record Secrets by the label pair Helm
+# stamps on every record it writes (`owner=helm` plus `name=<release>`) —
+# selecting every revision's record of this release and nothing else in the
+# namespace (#1172).
+readonly HELM_RELEASE_NAME="kube-agents"
+readonly HELM_RELEASE_SECRET_SELECTOR="owner=helm,name=${HELM_RELEASE_NAME}"
+# Bounds the uninstall's --wait; generous because the chart's pre-delete hook
+# waits for the operator to clear the PlatformAgent finalizer.
+readonly RELEASE_UNINSTALL_TIMEOUT="10m"
+# What a healthy revision looks like in `helm history -o json` (the encoder
+# emits compact `"status":"deployed"`; the pattern tolerates spacing so a
+# Helm formatting change cannot silently blind the fallback's check), and the
+# name prefix `kubectl delete -o name` prints per deleted Secret.
+readonly HELM_DEPLOYED_STATUS_RE='"status"[[:space:]]*:[[:space:]]*"deployed"'
+readonly SECRET_NAME_PREFIX_RE='^secret/'
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
@@ -56,7 +73,40 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agent
 # The chart's pre-delete hook removes the PlatformAgent CR and waits for the
 # operator to clear its finalizer, so one uninstall replaces the old
 # per-step teardown scripts (09 LiteLLM, 08 CR, 07 secrets, 03 operator).
-helm uninstall kube-agents -n "${NAMESPACE}" --wait --timeout 10m || true
+#
+# When the uninstall fails and no revision is deployed, fall back to
+# deleting the release-record Secrets directly (#1172). Teardown never
+# deletes the namespace, so a no-deployed-revision record that survives here
+# greets the project's next lease as `UPGRADE FAILED: "kube-agents" has no
+# deployed releases` at ci-deploy.sh's `helm upgrade --install` — and the
+# poisoned run's own teardown cannot remove it either, so the state is
+# self-sustaining until something drops the record. Step 3's sweep already
+# handles the cluster-scoped objects the release owned, so this strands
+# nothing a failed uninstall was not going to strand anyway.
+#
+# The deployed-revision gate is what makes the fallback safe on a *healthy*
+# release whose uninstall failed transiently (pre-delete hook stuck, --wait
+# past the timeout): its record is exactly what lets the next lease take the
+# clean upgrade path over the surviving objects, so it stays. With no
+# deployed revision the record is pure poison, and a probe that itself
+# fails loses nothing — the delete is --ignore-not-found against a record
+# that, if it exists at all, is already unusable. Same discipline as the
+# rest of the file: nothing here may change the teardown's exit code, and
+# the fallback logs what it deleted so a red run's artifacts show the heal
+# happened.
+if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}"; then
+  if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
+    && grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
+    echo "WARNING: helm uninstall failed with a deployed revision still recorded; leaving the release record for the next lease to upgrade over (#1172)"
+  else
+    echo "WARNING: helm uninstall failed with no deployed revision; removing any release record left behind so the next lease starts clean (#1172)"
+    RECORD_SECRETS_DELETED="$(kubectl delete secret -n "${NAMESPACE}" \
+      -l "${HELM_RELEASE_SECRET_SELECTOR}" --ignore-not-found -o name)" || true
+    RECORD_SECRETS_COUNT="$(printf '%s\n' "${RECORD_SECRETS_DELETED}" | grep -c "${SECRET_NAME_PREFIX_RE}")" || true
+    echo "${RECORD_SECRETS_DELETED}"
+    echo "✓ Release-record fallback deleted ${RECORD_SECRETS_COUNT} Helm record Secret(s)"
+  fi
+fi
 echo "✓ Release uninstall finished in $((SECONDS - STEP_START))s"
 
 STEP_START=$SECONDS
@@ -89,8 +139,9 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kub
 # (ValidatingAdmissionPolicy needs 1.30+) or one flaky delete must not stop
 # the sweep of the kinds that do exist, and nothing here may change the
 # teardown's exit code. This block must stay reachable on every path through
-# the script — steps before it end in `|| true` and there is no `set -e`; the
-# only early exits are the two must-not-delete-the-wrong-cluster guards above.
+# the script — steps before it end in `|| true` or run as `if` conditions,
+# and there is no `set -e`; the only early exits are the two
+# must-not-delete-the-wrong-cluster guards above.
 SWEEP_SELECTOR="app.kubernetes.io/part-of=kube-agents"
 SWEEP_KINDS=(
   validatingadmissionpolicies.admissionregistration.k8s.io

--- a/tests/test_ci_deploy_release_guard.py
+++ b/tests/test_ci_deploy_release_guard.py
@@ -1,0 +1,233 @@
+"""The deploy heals a poisoned Helm release record before `upgrade --install`.
+
+#1172: a pool project can arrive at deploy carrying a `kube-agents` release
+record with no deployed revision — teardown's `helm uninstall` failed and
+left the record behind, or teardown was killed mid-uninstall, which no
+teardown-side fallback can cover. `helm upgrade --install` then takes the
+upgrade path and dies with `UPGRADE FAILED: "kube-agents" has no deployed
+releases`, instantly failing whichever PR drew the project. The guard in
+`hack/ci-deploy.sh` probes `helm history -o json` — the same release-record
+Secrets whose statuses Helm's upgrade path queries — and clears the record
+(uninstall `--no-hooks`, falling back to deleting the record Secrets) when
+the release exists with no `deployed` revision.
+
+These tests pin:
+
+* an absent release (fresh project) and a healthy release (any revision
+  `deployed`) are left alone — one probe call, no uninstall, no delete;
+* a release whose revisions are all failed/pending is uninstalled
+  `--no-hooks`, and a successful uninstall issues no Secret delete;
+* when even the uninstall fails, the record Secrets are deleted by the
+  `owner=helm,name=kube-agents` selector with --ignore-not-found;
+* when both clears fail, the guard aborts under `set -e` rather than
+  letting the upgrade fail less legibly with the record still in place.
+
+The guard is lifted from the script's own text and executed under bash with
+stubbed helm/kubectl, the same approach as tests/test_ci_teardown_sweep.py.
+"""
+
+import json
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_DEPLOY = _REPO_ROOT / "hack" / "ci-deploy.sh"
+
+# The guard's own boundaries in hack/ci-deploy.sh. Asserted present below, so
+# moving the block fails here loudly instead of silently testing nothing.
+_GUARD_START = "# ─── 5a. Heal a poisoned release record"
+_GUARD_END = "API_SERVER_KEY="
+
+# Repeated here on purpose rather than parsed out of the script: a test that
+# derives the expected selector from the code under test asserts nothing.
+_RECORD_SELECTOR = "owner=helm,name=kube-agents"
+
+_NAMESPACE = "kubeagents-system"
+
+# helm history -o json output shapes, as the real encoder emits them
+# (compact keys, one object per revision).
+_HISTORY_HEALTHY = json.dumps(
+    [
+        {"revision": 1, "status": "superseded"},
+        {"revision": 2, "status": "deployed"},
+        {"revision": 3, "status": "failed"},
+    ]
+)
+_HISTORY_POISONED = json.dumps(
+    [
+        {"revision": 1, "status": "pending-install"},
+        {"revision": 2, "status": "failed"},
+    ]
+)
+
+
+def _deploy_text():
+    return _CI_DEPLOY.read_text(encoding="utf-8")
+
+
+def _head_constants(text):
+    """The file-head `readonly` declarations the lifted guard reads."""
+    head = text[: text.find(_GUARD_START)]
+    return "\n".join(
+        line for line in head.splitlines() if line.startswith("readonly ")
+    )
+
+
+def _guard_block(text):
+    start = text.find(_GUARD_START)
+    assert start != -1, f"{_GUARD_START!r} not found in hack/ci-deploy.sh"
+    end = text.find(_GUARD_END, start)
+    assert end != -1, f"{_GUARD_END!r} not found after the guard"
+    return text[start:end]
+
+
+class CiDeployReleaseGuardTest(unittest.TestCase):
+    maxDiff = None
+
+    def _run_guard(
+        self, history_json="", history_exit=0, uninstall_exit=0, kubectl_exit=0
+    ):
+        """Run the lifted guard with recording stubs.
+
+        Returns (returncode, call argv lines, stdout, stderr). The helm stub
+        answers `history` with the given JSON and exit code and `uninstall`
+        with the given exit code; kubectl records and exits as asked.
+        """
+        text = _deploy_text()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            log = tmp_path / "calls.log"
+            log.touch()
+            history_file = tmp_path / "history.json"
+            history_file.write_text(history_json, encoding="utf-8")
+            helm_stub = bin_dir / "helm"
+            helm_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "helm $*" >> "{log}"\n'
+                'case "$1" in\n'
+                f'  history) cat "{history_file}"; exit {history_exit} ;;\n'
+                f"  uninstall) exit {uninstall_exit} ;;\n"
+                "  *) exit 0 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            kubectl_stub = bin_dir / "kubectl"
+            kubectl_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "kubectl $*" >> "{log}"\n'
+                f"exit {kubectl_exit}\n",
+                encoding="utf-8",
+            )
+            for stub in (helm_stub, kubectl_stub):
+                stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+            # set -euo pipefail mirrors the script's own header; NAMESPACE is
+            # the one variable the lifted guard reads that the head sets.
+            proc = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    + _head_constants(text)
+                    + "\n"
+                    + _guard_block(text),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+                env=get_isolated_test_env(
+                    bin_dir=bin_dir, overrides={"NAMESPACE": _NAMESPACE}
+                ),
+            )
+            calls = log.read_text(encoding="utf-8").splitlines()
+        return proc.returncode, calls, proc.stdout, proc.stderr
+
+    def _helm_uninstalls(self, calls):
+        return [c for c in calls if c.startswith("helm uninstall")]
+
+    def _record_deletes(self, calls):
+        return [
+            c
+            for c in calls
+            if c.startswith("kubectl delete secret") and _RECORD_SELECTOR in c.split()
+        ]
+
+    # --- healthy and absent releases pay one probe and nothing else ---------
+
+    def test_an_absent_release_is_left_alone(self):
+        """A fresh project: `helm history` fails (release: not found)."""
+        rc, calls, out, err = self._run_guard(history_json="", history_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._helm_uninstalls(calls), [])
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertEqual(
+            len(calls), 1, f"a fresh project must cost exactly the probe: {calls}"
+        )
+
+    def test_a_release_with_a_deployed_revision_is_left_alone(self):
+        """Any `deployed` revision means the upgrade path works, even with a
+        failed revision on top of it."""
+        rc, calls, out, err = self._run_guard(history_json=_HISTORY_HEALTHY)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._helm_uninstalls(calls), [])
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertEqual(
+            len(calls), 1, f"a healthy release must cost exactly the probe: {calls}"
+        )
+
+    # --- the poisoned record is healed ---------------------------------------
+
+    def test_a_poisoned_release_is_uninstalled_without_hooks(self):
+        rc, calls, out, err = self._run_guard(history_json=_HISTORY_POISONED)
+        self.assertEqual(rc, 0, err)
+        uninstalls = self._helm_uninstalls(calls)
+        self.assertEqual(
+            len(uninstalls), 1, f"expected one uninstall of the poisoned record: {calls}"
+        )
+        argv = uninstalls[0].split()
+        self.assertIn("--no-hooks", argv)
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        # The uninstall succeeded, so the Secret-level fallback stays unused.
+        self.assertEqual(self._record_deletes(calls), [])
+        # And the heal is loud: a later reader of a red run's log must see it.
+        self.assertIn("poisoned", out.lower())
+
+    def test_a_failed_uninstall_falls_back_to_deleting_the_record_secrets(self):
+        rc, calls, out, err = self._run_guard(
+            history_json=_HISTORY_POISONED, uninstall_exit=1
+        )
+        self.assertEqual(rc, 0, err)
+        deletes = self._record_deletes(calls)
+        self.assertEqual(
+            len(deletes), 1, f"expected the record-Secret fallback to fire: {calls}"
+        )
+        argv = deletes[0].split()
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        self.assertIn("--ignore-not-found", argv)
+
+    def test_both_clears_failing_aborts_before_the_upgrade(self):
+        """Uninstall red AND the record delete red: the record is still in
+        place, so `set -e` must stop the run here rather than let the
+        upgrade fail less legibly — a later `|| true` on that line would
+        ship this regression silently."""
+        rc, calls, out, err = self._run_guard(
+            history_json=_HISTORY_POISONED, uninstall_exit=1, kubectl_exit=1
+        )
+        self.assertNotEqual(rc, 0, "a guard that cannot clear the record must abort")
+
+    # --- the file itself ------------------------------------------------------
+
+    def test_ci_deploy_parses(self):
+        subprocess.run(["bash", "-n", str(_CI_DEPLOY)], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_teardown_release_record.py
+++ b/tests/test_ci_teardown_release_record.py
@@ -26,6 +26,15 @@ These tests pin the fallback's four properties:
 * a failing kubectl neither stops the steps after the fallback nor changes
   the teardown's exit code, which nothing in the script may do.
 
+Step 2 then asks the same question before deleting the chart's CRDs, and its
+three branches are pinned here too. Both of Helm's routes over a surviving
+record need those CRDs — `uninstall` resolves a REST mapping for every object
+in the stored manifest, which contains a PlatformAgent, and `upgrade` never
+reinstalls `crds/` — so deleting them under a record leaves the next lease able
+to do neither. That held `kube-agents-evals-4` from 2026-09-01 14:33 UTC until
+a human repaired it the following afternoon, every re-run deleting the CRDs
+again on the way past. An unreadable probe keeps them for the same reason.
+
 The steps are lifted from the script's own text and executed under bash with
 stubbed kubectl/helm, the same approach as tests/test_ci_teardown_sweep.py.
 """
@@ -50,6 +59,7 @@ _STEPS_START = "START_TIME=$SECONDS"
 # Repeated here on purpose rather than parsed out of the script: a test that
 # derives the expected selector from the code under test asserts nothing.
 _RECORD_SELECTOR = "owner=helm,name=kube-agents"
+_CRD_DELETE_PREFIX = "kubectl delete -f charts/kube-agents/crds/"
 
 # What the stubbed `kubectl delete secret ... -o name` prints when it is asked
 # for the release record: two record Secrets, the way a release with a failed
@@ -60,6 +70,11 @@ _STUB_RECORD_NAMES = (
 )
 
 _NAMESPACE = "kubeagents-system"
+
+# What the stubbed probe writes to stderr when it fails: the real message for
+# the one unreadable state that is knowably empty, so the test can show the
+# log now carries the distinction the branch itself cannot make.
+_PROBE_STDERR = f'Error from server (NotFound): namespaces "{_NAMESPACE}" not found'
 
 # helm history -o json output shapes, as the real encoder emits them.
 _HISTORY_DEPLOYED = json.dumps(
@@ -101,7 +116,15 @@ def _teardown_steps(text):
 class CiTeardownReleaseRecordTest(unittest.TestCase):
     maxDiff = None
 
-    def _run_steps(self, kubectl_exit=0, uninstall_exit=0, history_json="", history_exit=1):
+    def _run_steps(
+        self,
+        kubectl_exit=0,
+        uninstall_exit=0,
+        history_json="",
+        history_exit=1,
+        records=(),
+        crd_delete_exit=0,
+    ):
         """Run the teardown steps with recording stubs.
 
         Returns (returncode, call argv lines, stdout, stderr). Each stub
@@ -111,6 +134,13 @@ class CiTeardownReleaseRecordTest(unittest.TestCase):
         delete, so the fallback's count log can be asserted. `history_exit`
         defaults red — the poisoned run's record is typically unreadable the
         same way its uninstall failed.
+
+        `kubectl get` is answered separately, from `records`, because Step 2
+        probes the same selector Step 1 deletes by and the two must be able to
+        disagree: after a successful uninstall Helm has removed its records,
+        so the probe reads empty while the delete would have printed names.
+        The default empty matches that — and note the probe is also subject to
+        `kubectl_exit`, which is how the unreadable branch is reached.
         """
         text = _teardown_text()
         with tempfile.TemporaryDirectory() as tmp:
@@ -136,6 +166,17 @@ class CiTeardownReleaseRecordTest(unittest.TestCase):
             kubectl_stub.write_text(
                 "#!/usr/bin/env bash\n"
                 f'echo "kubectl $*" >> "{log}"\n'
+                'if [[ "$1" == "get" ]]; then\n'
+                + "".join(f'  echo "{name}"\n' for name in records)
+                + f"  [[ {kubectl_exit} -ne 0 ]] && echo '{_PROBE_STDERR}' >&2\n"
+                + f"  exit {kubectl_exit}\n"
+                "fi\n"
+                # The CRD delete answers separately so a test can reach Step
+                # 2's timed-out branch, which needs a readable probe (else the
+                # keep branch fires first) and a red delete.
+                'if [[ "$1" == "delete" && "$2" == "-f" ]]; then\n'
+                f"  exit {crd_delete_exit}\n"
+                "fi\n"
                 f'if [[ "$*" == *"{_RECORD_SELECTOR}"* && {kubectl_exit} -eq 0 ]]; then\n'
                 + "".join(f'  echo "{name}"\n' for name in _STUB_RECORD_NAMES)
                 + "fi\n"
@@ -169,6 +210,9 @@ class CiTeardownReleaseRecordTest(unittest.TestCase):
             for c in calls
             if c.startswith("kubectl delete secret") and _RECORD_SELECTOR in c.split()
         ]
+
+    def _crd_deletes(self, calls):
+        return [c for c in calls if c.startswith(_CRD_DELETE_PREFIX)]
 
     # --- the fallback fires when the uninstall fails ------------------------
 
@@ -222,17 +266,120 @@ class CiTeardownReleaseRecordTest(unittest.TestCase):
         self.assertEqual(self._record_deletes(calls), [])
         self.assertIn("leaving the release record", out)
 
+    # --- Step 2 asks the same question before deleting the CRDs -------------
+
+    def test_no_surviving_record_deletes_the_crds(self):
+        """The common path, and #1006's: nothing to strand, and the next lease
+        is a fresh install, which reinstalls crds/ itself."""
+        rc, calls, out, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(len(self._crd_deletes(calls)), 1, calls)
+
+    def test_a_surviving_record_keeps_the_crds(self):
+        """Both of Helm's routes over a record need the CRDs — `uninstall`
+        resolves a REST mapping for every object in the stored manifest, which
+        contains a PlatformAgent, and `upgrade` never reinstalls crds/. Delete
+        them under a record and the next lease can do neither (#1172)."""
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1,
+            history_json=_HISTORY_DEPLOYED,
+            history_exit=0,
+            records=_STUB_RECORD_NAMES[:1],
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._crd_deletes(calls), [], out)
+        self.assertIn("release record survived Step 1", out)
+
+    def test_an_unreadable_probe_keeps_the_crds(self):
+        """Unreadable has to count as "may survive": keeping a CRD costs one
+        lease's tidiness, deleting one costs the project."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, kubectl_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._crd_deletes(calls), [], out)
+        self.assertIn("could not read", out)
+
+    def test_the_probe_reads_records_by_helms_own_labels(self):
+        """A probe on the chart's part-of label would find no record at all —
+        Helm stamps owner=helm and none of the chart's labels — so the gate
+        would open on every run and nothing would look wrong."""
+        rc, calls, out, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        probes = [c for c in calls if c.startswith("kubectl get secret")]
+        self.assertEqual(len(probes), 1, calls)
+        argv = probes[0].split()
+        self.assertIn(_RECORD_SELECTOR, argv)
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+
+    def test_the_crd_step_reports_which_branch_it_took(self):
+        """#1172 went 25 hours unnoticed because the log said only ✓."""
+        for branch, kwargs in (
+            ("deleted", {}),
+            ("skipped", {"kubectl_exit": 1}),
+            ("delete timed out or failed", {"crd_delete_exit": 1}),
+        ):
+            with self.subTest(branch=branch):
+                rc, calls, out, err = self._run_steps(**kwargs)
+                self.assertEqual(rc, 0, err)
+                self.assertIn(f"CRD step ({branch}", out)
+
+    def test_the_crd_delete_is_bounded(self):
+        """`kubectl delete` waits forever by default, and a CRD delete blocks
+        on customresourcecleanup until every CR of that kind is gone — which a
+        PlatformAgent finalizer no live operator can clear never is. Unbounded,
+        that hangs teardown past Prow's job timeout and Steps 3 and 4, whose
+        own comment says they must stay reachable on every path, never run."""
+        rc, calls, out, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        deletes = self._crd_deletes(calls)
+        self.assertEqual(len(deletes), 1, calls)
+        self.assertIn("--timeout", deletes[0].split(), deletes[0])
+
+    def test_a_crd_delete_that_does_not_finish_still_reaches_the_sweeps(self):
+        """The point of bounding it: the run continues, says so, and stays
+        green, so the orphans Steps 3 and 4 exist to remove still go."""
+        rc, calls, out, err = self._run_steps(crd_delete_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("did not finish within", out)
+        self.assertIn("Step 3", out)
+        self.assertIn("Step 4", out)
+
+    def test_the_uninstall_asks_helm_for_the_real_error(self):
+        """Without --debug Helm returns only `failed to delete release: <name>`
+        and hands the cause to cfg.Log, which drops it. That one line was all
+        CI recorded for the 25 hours #1172 went unnoticed, so the flag is the
+        change's diagnostic and not a convenience."""
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1, history_json=_HISTORY_POISONED, history_exit=0
+        )
+        self.assertEqual(rc, 0, err)
+        uninstalls = [c for c in calls if c.startswith("helm uninstall")]
+        self.assertEqual(len(uninstalls), 1, calls)
+        self.assertIn("--debug", uninstalls[0].split(), uninstalls[0])
+
+    def test_an_unreadable_probe_says_why(self):
+        """The reason used to go to /dev/null. A missing namespace is a
+        knowably-empty read and an RBAC failure is not; the branch treats them
+        alike, so the log is the only place the difference survives."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, kubectl_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("namespaces", out)
+        self.assertIn("not found", out)
+
     # --- the exit-code contract holds ---------------------------------------
 
     def test_a_failing_kubectl_neither_stops_teardown_nor_reds_it(self):
-        """Fallback delete red, CRD delete red, sweep red — the teardown
+        """Fallback delete red, record probe red, sweep red — the teardown
         still exits 0 and still reaches the steps after Step 1."""
         rc, calls, out, err = self._run_steps(uninstall_exit=1, kubectl_exit=1)
         self.assertEqual(rc, 0, err)
-        # Step 2 (the CRD delete by file) still ran after the failed fallback.
+        # Step 2 ran, and with its probe red it cannot rule out a surviving
+        # record, so it keeps the CRDs rather than re-arming #1172's trap.
+        self.assertIn("could not read", out)
+        # And the steps after it ran too.
         self.assertTrue(
-            any(c.startswith("kubectl delete -f") for c in calls),
-            f"the CRD delete never ran after a failed record fallback: {calls}",
+            any(c.startswith("kubectl delete clusterroles") for c in calls),
+            f"the cluster-scoped sweep never ran: {calls}",
         )
 
 

--- a/tests/test_ci_teardown_release_record.py
+++ b/tests/test_ci_teardown_release_record.py
@@ -1,0 +1,240 @@
+"""Step 1's fallback removes the Helm release record when the uninstall fails.
+
+#1172: `helm uninstall` in `hack/ci-teardown.sh` can fail and the `|| true`
+discipline then reports the teardown green with the release-record Secrets
+(`owner=helm,name=kube-agents`, in a namespace teardown never deletes) still
+in place. The next PR that Boskos hands the project meets them at
+`hack/ci-deploy.sh`'s `helm upgrade --install`, which takes the upgrade path
+against a release with no deployed revision and dies with `UPGRADE FAILED:
+"kube-agents" has no deployed releases` — and that run's own teardown cannot
+remove the record either, so the project stays poisoned until a human
+intervenes (three runs burned on 2026-09-02 alone).
+
+These tests pin the fallback's four properties:
+
+* when `helm uninstall` fails and no revision is `deployed` (or the record
+  cannot be read at all), the release-record Secrets are deleted by the
+  `owner=helm,name=kube-agents` selector, namespaced, with
+  --ignore-not-found, and the log says how many records went;
+* when `helm uninstall` fails but a revision IS deployed — a healthy
+  release whose uninstall failed transiently — the record stays: it is what
+  lets the next lease take the clean upgrade path over the surviving
+  objects, and deleting it would force a fresh install into adoption
+  conflicts;
+* when `helm uninstall` succeeds, the record is Helm's to manage and the
+  fallback stays out of it — no record delete is issued;
+* a failing kubectl neither stops the steps after the fallback nor changes
+  the teardown's exit code, which nothing in the script may do.
+
+The steps are lifted from the script's own text and executed under bash with
+stubbed kubectl/helm, the same approach as tests/test_ci_teardown_sweep.py.
+"""
+
+import json
+import pathlib
+import stat
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_TEARDOWN = _REPO_ROOT / "hack" / "ci-teardown.sh"
+
+# Everything from here to end-of-file is the teardown proper — the steps that
+# run once the auth and context guards have passed. Asserted present below, so
+# a rename fails here loudly instead of silently shrinking what is tested.
+_STEPS_START = "START_TIME=$SECONDS"
+
+# Repeated here on purpose rather than parsed out of the script: a test that
+# derives the expected selector from the code under test asserts nothing.
+_RECORD_SELECTOR = "owner=helm,name=kube-agents"
+
+# What the stubbed `kubectl delete secret ... -o name` prints when it is asked
+# for the release record: two record Secrets, the way a release with a failed
+# revision on top of an initial one really looks.
+_STUB_RECORD_NAMES = (
+    "secret/sh.helm.release.v1.kube-agents.v1",
+    "secret/sh.helm.release.v1.kube-agents.v2",
+)
+
+_NAMESPACE = "kubeagents-system"
+
+# helm history -o json output shapes, as the real encoder emits them.
+_HISTORY_DEPLOYED = json.dumps(
+    [
+        {"revision": 1, "status": "superseded"},
+        {"revision": 2, "status": "deployed"},
+    ]
+)
+_HISTORY_POISONED = json.dumps(
+    [
+        {"revision": 1, "status": "pending-install"},
+        {"revision": 2, "status": "failed"},
+    ]
+)
+
+
+def _teardown_text():
+    return _CI_TEARDOWN.read_text(encoding="utf-8")
+
+
+def _head_constants(text):
+    """The file-head `readonly` declarations the lifted steps read.
+
+    The no-magic-constants rule puts names at the top of the file, above
+    _STEPS_START, so the lift has to carry them along.
+    """
+    head = text[: text.find(_STEPS_START)]
+    return "\n".join(
+        line for line in head.splitlines() if line.startswith("readonly ")
+    )
+
+
+def _teardown_steps(text):
+    start = text.find(_STEPS_START)
+    assert start != -1, f"{_STEPS_START!r} not found in hack/ci-teardown.sh"
+    return text[start:]
+
+
+class CiTeardownReleaseRecordTest(unittest.TestCase):
+    maxDiff = None
+
+    def _run_steps(self, kubectl_exit=0, uninstall_exit=0, history_json="", history_exit=1):
+        """Run the teardown steps with recording stubs.
+
+        Returns (returncode, call argv lines, stdout, stderr). Each stub
+        appends its argv to a log; helm answers `uninstall` and `history`
+        with the requested exit codes and JSON, and kubectl additionally
+        prints the two record-Secret names when it is invoked as the record
+        delete, so the fallback's count log can be asserted. `history_exit`
+        defaults red — the poisoned run's record is typically unreadable the
+        same way its uninstall failed.
+        """
+        text = _teardown_text()
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            bin_dir = tmp_path / "bin"
+            bin_dir.mkdir()
+            log = tmp_path / "calls.log"
+            log.touch()
+            history_file = tmp_path / "history.json"
+            history_file.write_text(history_json, encoding="utf-8")
+            helm_stub = bin_dir / "helm"
+            helm_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "helm $*" >> "{log}"\n'
+                'case "$1" in\n'
+                f"  uninstall) exit {uninstall_exit} ;;\n"
+                f'  history) cat "{history_file}"; exit {history_exit} ;;\n'
+                "  *) exit 0 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            kubectl_stub = bin_dir / "kubectl"
+            kubectl_stub.write_text(
+                "#!/usr/bin/env bash\n"
+                f'echo "kubectl $*" >> "{log}"\n'
+                f'if [[ "$*" == *"{_RECORD_SELECTOR}"* && {kubectl_exit} -eq 0 ]]; then\n'
+                + "".join(f'  echo "{name}"\n' for name in _STUB_RECORD_NAMES)
+                + "fi\n"
+                f"exit {kubectl_exit}\n",
+                encoding="utf-8",
+            )
+            for stub in (helm_stub, kubectl_stub):
+                stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+            proc = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    "set -uo pipefail\n"
+                    + _head_constants(text)
+                    + "\n"
+                    + _teardown_steps(text),
+                ],
+                capture_output=True,
+                text=True,
+                cwd=_REPO_ROOT,
+                env=get_isolated_test_env(
+                    bin_dir=bin_dir, overrides={"NAMESPACE": _NAMESPACE}
+                ),
+            )
+            calls = log.read_text(encoding="utf-8").splitlines()
+        return proc.returncode, calls, proc.stdout, proc.stderr
+
+    def _record_deletes(self, calls):
+        return [
+            c
+            for c in calls
+            if c.startswith("kubectl delete secret") and _RECORD_SELECTOR in c.split()
+        ]
+
+    # --- the fallback fires when the uninstall fails ------------------------
+
+    def test_failed_uninstall_with_no_deployed_revision_deletes_the_record(self):
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1, history_json=_HISTORY_POISONED, history_exit=0
+        )
+        self.assertEqual(rc, 0, err)
+        deletes = self._record_deletes(calls)
+        self.assertEqual(
+            len(deletes),
+            1,
+            f"expected exactly one release-record delete after a failed "
+            f"helm uninstall of a no-deployed-revision release: {calls}",
+        )
+        argv = deletes[0].split()
+        self.assertIn("-n", argv)
+        self.assertIn(_NAMESPACE, argv)
+        self.assertIn("--ignore-not-found", argv)
+
+    def test_an_unreadable_record_is_deleted_too(self):
+        """`helm history` red (record corrupt, or gone mid-probe): nothing
+        to lose — the delete is --ignore-not-found against a record that,
+        if it exists, is already unusable."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, history_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(len(self._record_deletes(calls)), 1, calls)
+
+    def test_the_fallback_logs_how_many_records_it_deleted(self):
+        """A red run's artifacts must show the heal happened; the stub
+        deletes two record Secrets, so the log has to say two."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1)
+        self.assertEqual(rc, 0, err)
+        self.assertIn("deleted 2", out)
+
+    # --- and stays out of the way everywhere else ---------------------------
+
+    def test_successful_uninstall_issues_no_record_delete(self):
+        rc, calls, out, err = self._run_steps(uninstall_exit=0)
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._record_deletes(calls), [])
+
+    def test_a_deployed_revision_keeps_its_record(self):
+        """A healthy release whose uninstall failed transiently: the record
+        is what lets the next lease take the clean upgrade path over the
+        surviving objects, so the fallback must not delete it."""
+        rc, calls, out, err = self._run_steps(
+            uninstall_exit=1, history_json=_HISTORY_DEPLOYED, history_exit=0
+        )
+        self.assertEqual(rc, 0, err)
+        self.assertEqual(self._record_deletes(calls), [])
+        self.assertIn("leaving the release record", out)
+
+    # --- the exit-code contract holds ---------------------------------------
+
+    def test_a_failing_kubectl_neither_stops_teardown_nor_reds_it(self):
+        """Fallback delete red, CRD delete red, sweep red — the teardown
+        still exits 0 and still reaches the steps after Step 1."""
+        rc, calls, out, err = self._run_steps(uninstall_exit=1, kubectl_exit=1)
+        self.assertEqual(rc, 0, err)
+        # Step 2 (the CRD delete by file) still ran after the failed fallback.
+        self.assertTrue(
+            any(c.startswith("kubectl delete -f") for c in calls),
+            f"the CRD delete never ran after a failed record fallback: {calls}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_teardown_sweep.py
+++ b/tests/test_ci_teardown_sweep.py
@@ -1,4 +1,4 @@
-"""The teardown's cluster-scoped sweep runs on every path, whatever Helm says.
+"""The teardown's label sweeps run on every path, whatever Helm says.
 
 #961 gave the chart its first cluster-scoped resources (two
 ValidatingAdmissionPolicies and their bindings), and #1006 is what happened
@@ -16,6 +16,13 @@ rather than a decoration:
   have failed, because the aborted-run case is the whole point;
 * a failing kubectl neither stops the sweep at the first kind nor changes
   the teardown's exit code.
+
+#1172 added the same sweep one scope down. Nothing else deletes a namespaced
+object the release stops accounting for: teardown never deletes the namespace,
+and owner-reference GC stops resolving owners once the PlatformAgent CRD goes.
+The three properties above apply to it, plus one — it must select by the
+part-of label and leave Helm's release-record Secrets, labelled owner=helm,
+alone. Whether a record survives is Step 1's decision.
 
 The steps are lifted from the script's own text and executed under bash with
 stubbed kubectl/helm, so the assertions are against the code that ships
@@ -57,7 +64,41 @@ _SWEPT_KINDS = (
     "clusterrolebindings.rbac.authorization.k8s.io",
 )
 
+# The #1172 audit: every namespaced kind the chart renders or the operator
+# applies, all of which carry the part-of label — from kube-agents.labels in
+# the chart's templates, and from commonLabels() in the operator's Go.
+# Hand-copied for the reason above. The chart's own CRs are absent: the CRD
+# delete takes them on one path and the next lease's upgrade needs them on the
+# other.
+#
+# persistentvolumeclaims is in the list because reconcilePVC creates the
+# operator's own claims through withCommonLabels, so they are labelled and
+# selectable. The claims that come from a StatefulSet's volumeClaimTemplates
+# are not — that ObjectMeta carries a name and nothing else — which is why
+# hindsight's claim and any RWO custom storage survive the sweep.
+_SWEPT_NAMESPACED_KINDS = (
+    "deployments.apps",
+    "statefulsets.apps",
+    "jobs.batch",
+    "services",
+    "configmaps",
+    "secrets",
+    "serviceaccounts",
+    "roles.rbac.authorization.k8s.io",
+    "rolebindings.rbac.authorization.k8s.io",
+    "networkpolicies.networking.k8s.io",
+    "poddisruptionbudgets.policy",
+    "podmonitorings.monitoring.googleapis.com",
+    "certificates.cert-manager.io",
+    "issuers.cert-manager.io",
+    "persistentvolumeclaims",
+)
+
+_NAMESPACE = "kubeagents-system"
 _SELECTOR = "app.kubernetes.io/part-of=kube-agents"
+# Step 1's fallback selects release records by Helm's own labels. Named here so
+# the sweep test can assert the two selectors never converge.
+_RECORD_SELECTOR = "owner=helm,name=kube-agents"
 
 
 def _teardown_steps():
@@ -166,6 +207,96 @@ class CiTeardownSweepTest(unittest.TestCase):
         for kind in _SWEPT_KINDS:
             with self.subTest(kind=kind):
                 self.assertTrue(any(kind in c.split() for c in sweeps), sweeps)
+
+    # --- (d) the namespaced sweep, same three properties ---------------------
+
+    def test_every_audited_namespaced_kind_is_swept_by_label(self):
+        rc, calls, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        sweeps = self._sweep_calls(calls)
+        for kind in _SWEPT_NAMESPACED_KINDS:
+            with self.subTest(kind=kind):
+                matching = [c for c in sweeps if kind in c.split()]
+                self.assertEqual(
+                    len(matching), 1, f"expected exactly one sweep of {kind}: {sweeps}"
+                )
+                argv = matching[0].split()
+                self.assertIn(_SELECTOR, argv)
+                self.assertIn("--ignore-not-found", argv)
+                self.assertIn("-n", argv)
+                self.assertIn(_NAMESPACE, argv)
+
+    def test_claims_are_swept_after_the_workloads_that_mount_them(self):
+        """A PVC still mounted by a running pod does not delete: the
+        kubernetes.io/pvc-protection finalizer holds it open until the pod is
+        gone, and `kubectl delete` waits. Deleting the Deployment and the
+        StatefulSet first is what keeps that wait short, so the ordering is a
+        property of the step rather than an accident of how the list was
+        typed."""
+        rc, calls, err = self._run_steps()
+        self.assertEqual(rc, 0, err)
+        sweeps = self._sweep_calls(calls)
+
+        def index_of(kind):
+            for i, call in enumerate(sweeps):
+                if kind in call.split():
+                    return i
+            self.fail(f"{kind} never swept: {sweeps}")
+
+        claim_at = index_of("persistentvolumeclaims")
+        for workload in ("deployments.apps", "statefulsets.apps"):
+            with self.subTest(workload=workload):
+                self.assertLess(
+                    index_of(workload),
+                    claim_at,
+                    f"{workload} must be deleted before persistentvolumeclaims",
+                )
+
+    def test_the_namespaced_sweep_never_deletes_a_helm_release_record(self):
+        """Helm's records are Secrets, and the sweep deletes Secrets. It must
+        select them by the chart's part-of label — which no record carries —
+        and never by owner=helm, which every record carries. Whether a record
+        survives is Step 1's decision (#1180), not this sweep's.
+
+        Run with a red helm deliberately. That is the only path on which Step
+        1's fallback issues its own `kubectl delete secret -l owner=helm,...`,
+        so it is the only run where both selectors are in flight and the
+        assertion has two things to tell apart. An earlier version of this test
+        ran the green path and filtered on `"secrets" in call.split()`, which
+        the fallback's singular `secret` could not match either way: it
+        inspected nothing and passed against a script with no Step 4 at all.
+        """
+        rc, calls, err = self._run_steps(helm_exit=1)
+        self.assertEqual(rc, 0, err)
+        secret_deletes = [
+            c
+            for c in calls
+            if c.startswith("kubectl delete") and {"secret", "secrets"} & set(c.split())
+        ]
+        by_owner = [c for c in secret_deletes if _RECORD_SELECTOR in c.split()]
+        by_part_of = [c for c in secret_deletes if _SELECTOR in c.split()]
+        # Both must be present, or this is again asserting over an empty list.
+        self.assertEqual(
+            len(by_owner), 1, f"expected Step 1's record delete: {secret_deletes}"
+        )
+        self.assertEqual(
+            len(by_part_of), 1, f"expected Step 4's Secret sweep: {secret_deletes}"
+        )
+        self.assertNotIn(_RECORD_SELECTOR, by_part_of[0].split(), by_part_of[0])
+        self.assertNotIn(_SELECTOR, by_owner[0].split(), by_owner[0])
+
+    def test_namespaced_sweep_survives_earlier_failures(self):
+        """The aborted-run case one scope down: helm red, kubectl red, and
+        every kind still attempted."""
+        for label, kwargs in (("helm", {"helm_exit": 1}), ("kubectl", {"kubectl_exit": 1})):
+            with self.subTest(failing=label):
+                rc, calls, err = self._run_steps(**kwargs)
+                self.assertEqual(rc, 0, err)
+                sweeps = self._sweep_calls(calls)
+                for kind in _SWEPT_NAMESPACED_KINDS:
+                    self.assertTrue(
+                        any(kind in c.split() for c in sweeps), f"{kind}: {sweeps}"
+                    )
 
     # --- the file itself -----------------------------------------------------
 

--- a/tests/test_ci_teardown_sweep.py
+++ b/tests/test_ci_teardown_sweep.py
@@ -61,10 +61,18 @@ _SELECTOR = "app.kubernetes.io/part-of=kube-agents"
 
 
 def _teardown_steps():
+    """The lifted steps, prefixed with the file-head `readonly` constants.
+
+    The no-magic-constants rule declares names at the top of the file, above
+    _STEPS_START, so the lift carries them along or `set -u` kills the run.
+    """
     text = _CI_TEARDOWN.read_text(encoding="utf-8")
     start = text.find(_STEPS_START)
     assert start != -1, f"{_STEPS_START!r} not found in hack/ci-teardown.sh"
-    return text[start:]
+    constants = "\n".join(
+        line for line in text[:start].splitlines() if line.startswith("readonly ")
+    )
+    return constants + "\n" + text[start:]
 
 
 class CiTeardownSweepTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

`hack/ci-teardown.sh` deleted the chart's CRDs on every run, including runs where a Helm release record survived Step 1. Both of Helm's routes over a surviving record need those CRDs, so a run that hit that combination left the pool project unable to uninstall or upgrade, and every later lease deleted the CRDs again on its way past. This gates the CRD delete on the release record being gone, bounds it so it cannot hang the job, turns on `--debug` so the next failure of this shape is diagnosable from the build log, and adds a namespaced label sweep alongside the cluster-scoped one so orphaned objects in `kubeagents-system` are cleaned up rather than accumulating. #1180 fixed the release record itself; this fixes what strands it.

## Why This Change

Helm resolves a REST mapping for **every** object in a release's stored manifest before it deletes anything, and the kube-agents manifest contains a `PlatformAgent`. Remove that CRD and the mapping fails, so `helm uninstall` dies having deleted nothing. `helm upgrade` is no escape either: Helm installs `crds/` on install only, never on upgrade. A release record plus no CRDs is therefore a state with no way out, and teardown's own next run re-created it. Both halves, reproduced below against a project this branch's own teardown had just poisoned on purpose:

```
Error: UPGRADE FAILED: "kube-agents" has no deployed releases
Error: failed to delete release: kube-agents
```

`kube-agents-evals-4` sat in that state from 2026-09-01 14:33 UTC until it was repaired by hand the following afternoon, failing every PR Boskos handed it. Nothing in the build log said so: Step 1 swallowed the failure, and Helm reports only the second line above — the cause goes to `cfg.Log` (`pkg/action/uninstall.go`), which is dropped without `--debug`. Three ✓ marks and a green teardown, for 25 hours.

#1180 closed most routes into the state: when the uninstall fails and no revision is `deployed`, it deletes the orphaned record so the next lease starts clean. Two routes it cannot close, and the gate is what makes them safe.

- **The record delete can itself fail.** It is `|| true`, so the run continues with the record intact and Step 2 then deletes the CRDs out from under it.
- **A `deployed` revision that does survive is kept on purpose**, so the next lease can `helm upgrade` over the surviving objects. That branch cannot work while Step 2 deletes the CRDs, because upgrade never reinstalls them.

Poisoned projects are also a magnet rather than a slow leak: a run that fails at deploy releases its Boskos lease in about 25 minutes against roughly 2.5 hours for a healthy run, so one bad project in the pool takes a disproportionate share of the leases.

## What Changed

`hack/ci-teardown.sh`, four changes:

- **Step 2 asks before deleting.** It probes for a surviving `owner=helm,name=kube-agents` record and keeps the CRDs when it finds one — or when the probe itself fails, because unreadable has to count as "may survive". No record means the next lease is a fresh install, which reinstalls `crds/` itself, so #1006's case (CRDs from a run killed mid-install) is still swept. The step logs which of its four branches it took, and an unreadable probe now logs what kubectl actually said rather than sending it to `/dev/null`.
- **The CRD delete is bounded.** `kubectl delete` waits indefinitely by default, and deleting a CRD blocks on `customresourcecleanup.apiextensions.k8s.io` until every CR of that kind is gone — which a `PlatformAgent` finalizer no live operator can clear never is. `--timeout 5m` turns a silent hang past Prow's job deadline into a warning and a run that continues to the sweeps.
- **`--debug` on the Step 1 uninstall**, so the cause is in the artifacts next time.
- **Step 4: a namespaced sweep** mirroring Step 3's, over the fifteen namespaced kinds the chart renders or the operator applies. Every one carries `app.kubernetes.io/part-of=kube-agents` — from `kube-agents.labels` in the chart's templates, and from `commonLabels()` in the operator's Go — so one selector covers both scopes. Nothing else reaps these: teardown never deletes `kubeagents-system`, and the operator's children rely on owner-reference GC, which stops resolving owners once the PlatformAgent CRD is gone. PVCs sweep last, so the workloads releasing them are already deleted and `pvc-protection` does not hold the delete open.

The sweep cannot delete a Helm release record — records carry `owner=helm` and none of the chart's labels — so whether a record survives stays Step 1's decision. Two things it cannot reach, stated in the code: the chart's own CRs (the CRD delete takes them on one path, and the next lease's upgrade needs them on the other) and claims backed by a `volumeClaimTemplates` entry, whose `metadata` carries a name and nothing else.

## Context

Follow-up to #1180 (jayantid), which fixed the release-record half of #1172 — the teardown fallback and the deploy-side guard — and is the base this branch is cut from. Issue #1172 is assigned to me; jayantid and I agreed to land #1180 as the quick fix and take the CRD-ordering root cause and the orphan sweep separately, which is this PR.

One consequence worth naming: #1180's deploy-side guard tries `helm uninstall --no-hooks` before falling back to deleting the record Secret. Against #1172's actual state that first branch could never work — the CRDs were already gone, so the uninstall dies at REST mapping, which the fourth pass below captures verbatim — so the fallback was always what fired. Gating the CRD delete makes that first branch reachable for the first time.

Closes #1172.

## Testing

- `make test-python` — `tests/` runs 948 tests with 4 failures and 1 error, none from this change. The four are `test_install_script.ImportGithubPemKmsKeyTest`, which short-circuits on "Go is not installed" on this machine and is red on the base commit too. The error is `test_mode_grep`, which walks the repository and trips on a `.claude/worktrees/` checkout belonging to another local session; CI has no such directory.
- The two teardown modules: 24 tests, green.
- Every assertion was seen red before its fix. Against `e489aa62`'s script the two modules fail 30 assertions; the ones that stay green there are #1180's and #1006's own, which the base already satisfies. Each new guard was also reverted individually — drop `persistentvolumeclaims` and 4 go red, drop `--timeout`, `--debug`, or the probe's stderr capture and the matching test goes red.
- `bash -n hack/ci-teardown.sh`, `make docs-check` — both clean.

New coverage:

- `tests/test_ci_teardown_release_record.py` — Step 2's four branches (no record → delete, record survives → keep, probe unreadable → keep, delete timed out → warn and continue), that the probe uses Helm's own labels rather than the chart's, that the delete carries a timeout, that a timed-out delete still reaches Steps 3 and 4, that the uninstall carries `--debug`, and that an unreadable probe says why. Its kubectl stub answers `get` and `delete -f` separately from the record delete: the three must be able to disagree, or the branches are unreachable.
- `tests/test_ci_teardown_sweep.py` — every namespaced kind swept by label, namespaced, with `--ignore-not-found`; claims swept after the workloads that mount them; the sweep survives a red helm and a red kubectl; and Step 4's selector never converges with Step 1's `owner=helm`.

### Live validation

Five passes on `hangdng-gkedemos`, whose `platform-agent-host` cluster in `us-central1` matches what `ci-env.sh` expects, so `hack/ci-teardown.sh` ran unmodified. A demo project rather than a pool project on purpose: a manual teardown run takes no Boskos lease, so testing on a pool project races the presubmits.

These five ran against the gate and the sweep as first written, and do not reach the current head: the PVC kind, the CRD-delete timeout, and the probe's stderr capture went in afterwards in response to the review passes below, and are covered by unit tests only. What the passes establish about the gate, its branch logic, and the sweep is unaffected by those three additions.

- **Clean uninstall.** `✓ CRD step (deleted)`; Step 4 issued its deletes and Step 3 its six; exit 0 in 43s; the namespace left holding only `kube-root-ca.crt` and `default`.
- **Failed pre-delete hook** — unpullable `platformAgent.cleanupHook.image`, `activeDeadlineSeconds=60`. Helm reported `job kube-agents-cr-cleanup failed: DeadlineExceeded`, #1180's fallback removed the record, and the gate took the delete branch. Helm persists `status: uninstalling` *before* it runs pre-delete hooks, so a hook failure leaves no `deployed` revision and #1180 heals it unaided — which is why the next pass reaches the keep branch a different way. First run where the sweeps had real work: Step 3 removed four ValidatingAdmissionPolicy objects and the ClusterRole pair, Step 4 removed fifteen namespaced objects including `job.batch/kube-agents-cr-cleanup` — the failed hook Job, which is the object the namespaced sweep exists for.
- **Record survives Step 1** — the branch this PR adds, reached by the route that can actually produce it: a ValidatingAdmissionPolicy denying DELETE on `sh.helm.release.v1.kube-agents.*`, which fails Helm's own purge *and* #1180's `|| true` fallback delete. Result: `✓ Release-record fallback deleted 0 Helm record Secret(s)`, then `WARNING: a kube-agents release record survived Step 1; keeping the CRDs` and `✓ CRD step (skipped, release record survived Step 1)`. Both CRDs and the record Secret still present afterwards. Helm's `Failed to purge the release` text was visible only because of the `--debug` in this diff. Re-running with the policy removed then cleared the project; that recovery run is where Step 2 took 206s against the 1–2s every other pass took, which is what the new timeout is sized against.
- **The counterfactual, on `main`'s script.** Same wedged state, `git show HEAD~1` swapped in: `✓ CRD deletion finished in 1s` with no branch line, both CRDs gone, the record still present, the run ending after Step 3. `helm upgrade --install` (what `ci-deploy.sh` runs next) then failed with `UPGRADE FAILED: "kube-agents" has no deployed releases`, and `helm uninstall` (what that lease's own teardown runs) with `failed to delete release: kube-agents`. That is #1172, reproduced.
- **Recovery from `main`'s damage.** This branch's teardown, run against the project `main` had just poisoned, healed it: the fallback removed the record, the CRDs were deleted, the sweeps ran, the namespace came back empty. Its `--debug` output is where the mechanism finally shows:

```
uninstall: Failed to delete release: [unable to build kubernetes objects for delete:
resource mapping not found for name: "platform-agent" namespace: "kubeagents-system"
from "": no matches for kind "PlatformAgent" in version "kubeagents.x-k8s.io/v1alpha1"
ensure CRDs are installed first]
```

## Self-Review

The adversarial and docs-drift passes were each run in a fresh context handed only the diff range and told not to read this description. An earlier version of this section recorded them as run in the authoring context instead, which is the one configuration `AGENTS.md` says they must not run in; `kube-agents-bot` was right to call that out, and re-running them properly found a defect neither it nor I had caught.

Angles covered: kinds the sweep misses, objects it must not touch, whether the gate can be wrong in the direction that poisons a project, exit-code and `set -u` discipline, quoting, whether each test fails when its fix is reverted, and whether any prose or code comment now states something the source contradicts.

**Fixed:**

- **The sweep missed the operator's PersistentVolumeClaims.** Both passes found this independently and it was the most serious thing in the change. `reconcilePVC` creates `<agent>-data`, `system-metadata`, and custom claims, and `reconcilePersistentVolumeClaim` calls `withCommonLabels` before `Create`, which stamps `app.kubernetes.io/part-of=kube-agents` (`manifest_helpers.go:86,90`). Labelled, namespaced, and absent from the kind list — so teardown left billed persistent disks behind on the one swept kind that costs money, and the next lease's evaluation would have started against the previous PR's agent data volume. Added, swept last, with an ordering test.
- **Two code comments named a mechanism that does not exist.** "Every object the operator creates goes through `applyManaged`" — `reconcilePersistentVolumeClaim` and `ReconcileServiceAccount` both bypass it. The label conclusion held for ServiceAccounts, so this was not a second coverage gap, but the false chokepoint is *why* the kind list was short: auditing `applyManaged`'s callers yields no PVC. Rewritten to name both paths.
- **"One gap this cannot close: hindsight's PVC"** read as *PVCs are unreachable*, which is what let the omission through. Only `volumeClaimTemplates`-backed claims are — hindsight's, and in the operator any RWO `spec.deployment.storages`, since `buildRWOVolumeClaimTemplates` sets a name and nothing else. Corrected, and `reference/resource-labels.md` corrected with it: it named hindsight as the only permanent case, so the code comment would otherwise have contradicted the doc.
- **A test that could not fail.** `test_the_namespaced_sweep_never_deletes_a_helm_release_record` ran the green-helm path, where Step 1's fallback issues no record delete at all, and filtered on `"secrets"` while the fallback's argv says `secret`. It asserted over an empty list and passed against a script with no Step 4. An earlier version of this section called the property "pinned by a test rather than left to inspection" — that claim was false. It now runs with a red helm and asserts both selectors are present and disjoint.
- **The CRD delete was unbounded, and this change had put Step 4 behind it.** An earlier version of this section argued that was out of scope because the wait is unchanged from `main`. That reasoning does not survive adding a new step behind the hang, next to a Step 3 comment saying it must stay reachable on every path. Now `--timeout 5m` — clear of the 206s a healthy-but-slow delete took live — with the run continuing, staying green, and naming the branch on expiry.
- **`--debug` had no test**, though the comment beside it argues it is the change's entire diagnostic value. One assertion.
- **The probe discarded the reason it failed** — `2>/dev/null`, on the step whose sibling had just gained `--debug` for exactly that reason. A missing namespace is a knowably-empty read and an RBAC failure is not; the branch treats them alike, so the log is the only place that difference can survive. Now captured and printed.

**Not fixed:**

- **`volumeClaimTemplates` claims still survive the sweep** — hindsight's, and RWO custom storage. No selector can reach them. Closing it means a retention policy on the chart's and the operator's StatefulSets, which changes what ships rather than what teardown does. Stated in the code and in `resource-labels.md` so the gap is not mistaken for coverage.
- **The keep branch can grade a PR against the previous lease's CRD.** Raised by the adversarial pass as an open question rather than a defect: `upgrade` never reinstalls `crds/`, so a PR that changes the CRD schema, evaluated on a project whose last lease kept the CRDs, is measured against the old schema — a wrong result rather than a visible failure. The alternative on that branch is #1172, which is worse, and every other branch reinstalls. The fix belongs in `ci-deploy.sh` reconciling `crds/` before its upgrade, not here.

**Examined and clean:** the gate cannot fail in the dangerous direction — every probe failure, including a missing namespace, falls to the keep side, and the opposite error costs the next lease nothing since a fresh install adopts CRDs it finds; Step 4 cannot delete a release record, now pinned by a test capable of failing, and the third live pass confirms it; exit-code discipline holds with a red kubectl throughout; `set -u` is satisfied on every path; all fifteen kind names and their API groups are correct and cover every namespaced kind the chart renders, the list having been built by auditing `charts/kube-agents/templates/` rather than one live install; Step 2 before Step 4 is the right order, since reversing it guarantees the finalizer hang; and `make docs-check` passes with no map, link, or terminology change owed.

**Not covered:** neither pass had a cluster, so the timeout's behaviour against a genuinely stuck CRD is reasoned from `kubectl` semantics and the operator source rather than observed. `shellcheck` is not installed on this machine; only `bash -n` ran.

## Risk & Rollout

The change is confined to teardown, which runs after a PR's evaluation has finished, so a defect here cannot fail the run that triggered it — it shows up as a dirty project on the next lease.

The new failure mode is the opposite of #1172's: a probe that wrongly reports a surviving record leaves CRDs behind on a project that did not need them. That costs the next lease nothing, because a fresh install adopts CRDs it finds and Helm's `crds/` install is idempotent, and the log names the branch either way. The timeout's expiry can leave a CRD `Terminating`, which the next fresh install can collide with — but what it replaces is a teardown that never returns at all, and the log now says which happened. The namespaced sweep is strictly additive deletion under a label no object outside this install carries.

Revert is a straight revert of the commit; teardown returns to deleting the CRDs unconditionally.

---

Generated with the help of Claude Code.
