### PR TITLE
fix(gate): demote rca-remediation-pr — rung-4 collapses on unrelated PRs (#1189)

### DIFF
--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -1252,6 +1252,14 @@ print(m.group(1).strip('\'\"') if m else '')
 #     collapse is the environment's, not the diff's. Enters when #1171's
 #     re-admission bar holds: delegation fixed and a clean 3-day graded
 #     record.
+#   rca-remediation-pr                    -- #1189: demoted 2026-09-02
+#     evening after rung-4 collapses on six unrelated pull requests in
+#     one day. The suite's longest delegation chain, so it integrates
+#     over every environment fault in its window: the #1097 429 storms,
+#     the #1144 proxy EACCES (fix #1183), and #1184's gap (infra-blocked
+#     repetitions graded rather than classified) turn one dirty window
+#     into a correlated collapse. Its own record was 12/13 clean before
+#     the storms. Enters when #1189's re-admission bar holds.
 #
 # If an admitted case reds a pull request its diff cannot explain on a
 # graded failure, demote it here and reference its issue. Demotion is a
@@ -1266,7 +1274,7 @@ print(m.group(1).strip('\'\"') if m else '')
 # agent-kanban-smoke earned its seat back after the 08-27 redesign (a real
 # SRE question graded on kanban_create plus cluster names); the reds that
 # once argued for un-arming it belonged to the old vocabulary check.
-export BOOTSTRAP_ADMITTED="${BOOTSTRAP_ADMITTED:-reliability-pdb-probe,security-overgrant-probe,upgrades-lagging-master-probe,consistency-authorized-networks-probe,cost-idle-pool-probe,obtainability-remediation-proposal,rca-remediation-pr,cluster-agent-crashloop-debug,cluster-agent-crashloop-misleading-symptom,cluster-agent-crashloop-evidence-chain,gpu-stress-test-diagnosis,agent-kanban-smoke}"
+export BOOTSTRAP_ADMITTED="${BOOTSTRAP_ADMITTED:-reliability-pdb-probe,security-overgrant-probe,upgrades-lagging-master-probe,consistency-authorized-networks-probe,cost-idle-pool-probe,obtainability-remediation-proposal,cluster-agent-crashloop-debug,cluster-agent-crashloop-misleading-symptom,cluster-agent-crashloop-evidence-chain,gpu-stress-test-diagnosis,agent-kanban-smoke}"
 
 # Where the evidence itself lives. Unset means bench/baselines/ in the
 # checkout: hermetic, no credential, no network -- and no way for this job to


### PR DESCRIPTION
## Summary

Removes `rca-remediation-pr` from `BOOTSTRAP_ADMITTED` per the demotion protocol. Six rung-4 collapses across six unrelated PRs today (#1112, #1089, #1177, #1175, #1153, #1142) — the full evidence, root-cause decomposition (#1097 storms × #1144 proxy EACCES × #1184 classification gap), and re-admission bar are in #1189.

## Why This Change

Same call as compliance yesterday (#1173), one day later, on the suite's second delegation-heavy case: every cause is environmental, every cause is owned (haoxuw on #1097, Fuxiao-Gao on #1184/#1189, #1183 tide-queued), and none lands tonight. Demoting now means tomorrow morning's merges can't be redded by it; the case keeps running and reporting toward its re-admission bar.

## What Changed

- `hack/ci-eval-pr.sh`: `rca-remediation-pr` removed from the `BOOTSTRAP_ADMITTED` default (12 admitted → 11); held-out entry added to the roster comment referencing #1189.

## Context

- **#1189** — the evidence, root-cause decomposition and re-admission bar for this demotion. Not closed by this PR; it stays open to track re-admission.
- **#1173** — the same demotion applied to `compliance-rbac-overgrant` earlier today. This PR is its mirror, including the merge-time `/override` request.
- **Upstream causes, all owned, none landing tonight:** #1097 (429 storms), #1144 → fix #1183 (proxy EACCES, tide-queued), #1184 (infra-blocked repetitions graded rather than classified).
- **Follow-up, not fixed here (see Self-Review):** two stale admitted-counts, `hack/ci-eval-pr.sh:1220` and `docs/designs/testing-strategy.md:63`.

## Testing

- `bash -n hack/ci-eval-pr.sh` — clean.
- Roster parsed from head `7e3faa6` as the script exports it: **11 entries, `rca-remediation-pr` absent**.
- `git diff upstream/main...7e3faa6` — the only functional change is that one roster entry; the rest is the held-out comment block.
- Roster parsing contract covered by existing gate tests; no test pins the roster contents.

### Live validation

**Not live-tested, and this change cannot reach a running installation:** `hack/ci-eval-pr.sh` executes only inside the Prow presubmit, so there is no cluster, operator or agent pod it touches. The behavioural effect — the case's per-run label moving from FAILED-can-collapse to UNSTABLE-cannot — first appears on the next smoke run after merge.

This section carries more weight than usual because Risk & Rollout requests `/override pull-kube-agents-smoke-test`, so nothing exercises the change before it lands. Verified statically on the head commit in place of a run:

```
count: 11
rca present? -> 0
```

**Not covered:** `grade_case` was not executed against a real run record, so the admitted/held-out branch for this case is first exercised on the next smoke run. No test artifacts created.

## Self-Review

Both passes were run at merge time, in a reviewer's session (@bradhoekstra) that did not write the change, over `upstream/main...7e3faa6`. The Self-Review originally recorded here named neither pass and reported two mechanical checks of the diff; this replaces it.

- **Adversarial.** Looked for: roster entries removed beyond the intended one; a roster the script can no longer parse; `rca-remediation-pr` left referenced somewhere that assumes it is admitted. **No findings.** The diff against current `main` is exactly the one roster entry plus the comment block; the roster parses to the 11 intended entries; surviving references are consistent with a held-out case that still runs — `:1334` deliberately keeps the 700s timeout, which it needs *because* held-out cases continue to execute.
- **Docs-drift.** Looked for: prose in the script or in `docs/` contradicted by the smaller roster. **Two findings, neither fixed here.**
  - `hack/ci-eval-pr.sh:1220` — "Twelve of the twenty active cases are admitted" against a roster of eleven. **Introduced by this PR.**
  - `docs/designs/testing-strategy.md:63` — "Thirteen of the twenty are bootstrap-admitted". **Pre-existing**, stale since #1173 took it to twelve, and widened by this PR.

  Both are prose only and change no behaviour. Neither is fixed in this PR for a specific reason rather than scope: any new commit changes the head SHA, which discards the `/override pull-kube-agents-smoke-test` this PR depends on and restarts the 2.5-hour job the demotion exists to get ahead of. They are recorded in Context for a follow-up that can carry both counts in one edit.

## Risk & Rollout

Reduces what can block; cannot break a run. Revert = one line. **Requesting the #1173 treatment: lgtm + `/override pull-kube-agents-smoke-test` tonight** — this PR exists to unblock tomorrow morning's merges, and its own 2.5h smoke defeats that purpose (and can itself be redded by the case being demoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
