### PR TITLE
feat(ci): map pool projects kube-agents-evals-16 through evals-30 to GitOps repos

### DIFF
--- a/docs/site/src/content/docs/deploy/ci-pool-projects.md
+++ b/docs/site/src/content/docs/deploy/ci-pool-projects.md
@@ -177,6 +177,21 @@ The evaluation scenarios that exercise the GitOps workflow — the six fleet-aud
 | `kube-agents-evals-13` | `gke-agentic/kube-agents-evals-13-infra` |
 | `kube-agents-evals-14` | `gke-agentic/kube-agents-evals-14-infra` |
 | `kube-agents-evals-15` | `gke-agentic/kube-agents-evals-15-infra` |
+| `kube-agents-evals-16` | `gke-agentic/kube-agents-evals-16-infra` |
+| `kube-agents-evals-17` | `gke-agentic/kube-agents-evals-17-infra` |
+| `kube-agents-evals-18` | `gke-agentic/kube-agents-evals-18-infra` |
+| `kube-agents-evals-19` | `gke-agentic/kube-agents-evals-19-infra` |
+| `kube-agents-evals-20` | `gke-agentic/kube-agents-evals-20-infra` |
+| `kube-agents-evals-21` | `gke-agentic/kube-agents-evals-21-infra` |
+| `kube-agents-evals-22` | `gke-agentic/kube-agents-evals-22-infra` |
+| `kube-agents-evals-23` | `gke-agentic/kube-agents-evals-23-infra` |
+| `kube-agents-evals-24` | `gke-agentic/kube-agents-evals-24-infra` |
+| `kube-agents-evals-25` | `gke-agentic/kube-agents-evals-25-infra` |
+| `kube-agents-evals-26` | `gke-agentic/kube-agents-evals-26-infra` |
+| `kube-agents-evals-27` | `gke-agentic/kube-agents-evals-27-infra` |
+| `kube-agents-evals-28` | `gke-agentic/kube-agents-evals-28-infra` |
+| `kube-agents-evals-29` | `gke-agentic/kube-agents-evals-29-infra` |
+| `kube-agents-evals-30` | `gke-agentic/kube-agents-evals-30-infra` |
 
 The repository is kept private: it is throwaway state a bot rewrites on every run. [`examples/gitops-repo`](https://github.com/gke-labs/kube-agents/tree/main/examples/gitops-repo) is the layout an audit expects to find, not a required seed — the current pool repositories carry only a LICENSE and a README, because an audit works against an empty tree and a `remediation.path` that does not exist degrades to a manual finding rather than failing the run.
 

--- a/hack/ci-deploy.sh
+++ b/hack/ci-deploy.sh
@@ -110,6 +110,21 @@ gitops_repo_for_project() {
     kube-agents-evals-13) echo "gke-agentic/kube-agents-evals-13-infra" ;;
     kube-agents-evals-14) echo "gke-agentic/kube-agents-evals-14-infra" ;;
     kube-agents-evals-15) echo "gke-agentic/kube-agents-evals-15-infra" ;;
+    kube-agents-evals-16) echo "gke-agentic/kube-agents-evals-16-infra" ;;
+    kube-agents-evals-17) echo "gke-agentic/kube-agents-evals-17-infra" ;;
+    kube-agents-evals-18) echo "gke-agentic/kube-agents-evals-18-infra" ;;
+    kube-agents-evals-19) echo "gke-agentic/kube-agents-evals-19-infra" ;;
+    kube-agents-evals-20) echo "gke-agentic/kube-agents-evals-20-infra" ;;
+    kube-agents-evals-21) echo "gke-agentic/kube-agents-evals-21-infra" ;;
+    kube-agents-evals-22) echo "gke-agentic/kube-agents-evals-22-infra" ;;
+    kube-agents-evals-23) echo "gke-agentic/kube-agents-evals-23-infra" ;;
+    kube-agents-evals-24) echo "gke-agentic/kube-agents-evals-24-infra" ;;
+    kube-agents-evals-25) echo "gke-agentic/kube-agents-evals-25-infra" ;;
+    kube-agents-evals-26) echo "gke-agentic/kube-agents-evals-26-infra" ;;
+    kube-agents-evals-27) echo "gke-agentic/kube-agents-evals-27-infra" ;;
+    kube-agents-evals-28) echo "gke-agentic/kube-agents-evals-28-infra" ;;
+    kube-agents-evals-29) echo "gke-agentic/kube-agents-evals-29-infra" ;;
+    kube-agents-evals-30) echo "gke-agentic/kube-agents-evals-30-infra" ;;
     *) return 1 ;;
   esac
 }

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -11,8 +11,9 @@
 # shellcheck source=scripts/installer/gke_dns_endpoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts/installer" && pwd)/gke_dns_endpoint.sh"
 
-# Temporarily pinned to test new evaluation project
-export PROJECT_ID="kube-agents-evals-16"
+# TODO(boskos): Once oss-test-infra#2655 merges and deploys Boskos project leasing,
+# consider failing closed if JOB_NAME is set and PROJECT_ID is unset.
+export PROJECT_ID="${PROJECT_ID:-kube-agents-evals}"
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export REGION="${REGION:-us-central1}"
 

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -11,9 +11,8 @@
 # shellcheck source=scripts/installer/gke_dns_endpoint.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts/installer" && pwd)/gke_dns_endpoint.sh"
 
-# TODO(boskos): Once oss-test-infra#2655 merges and deploys Boskos project leasing,
-# consider failing closed if JOB_NAME is set and PROJECT_ID is unset.
-export PROJECT_ID="${PROJECT_ID:-kube-agents-evals}"
+# Temporarily pinned to test new evaluation project
+export PROJECT_ID="kube-agents-evals-16"
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export REGION="${REGION:-us-central1}"
 

--- a/tests/test_ci_gitops_repo.py
+++ b/tests/test_ci_gitops_repo.py
@@ -57,6 +57,21 @@ _EXPECTED_MAPPING = {
     "kube-agents-evals-13": "gke-agentic/kube-agents-evals-13-infra",
     "kube-agents-evals-14": "gke-agentic/kube-agents-evals-14-infra",
     "kube-agents-evals-15": "gke-agentic/kube-agents-evals-15-infra",
+    "kube-agents-evals-16": "gke-agentic/kube-agents-evals-16-infra",
+    "kube-agents-evals-17": "gke-agentic/kube-agents-evals-17-infra",
+    "kube-agents-evals-18": "gke-agentic/kube-agents-evals-18-infra",
+    "kube-agents-evals-19": "gke-agentic/kube-agents-evals-19-infra",
+    "kube-agents-evals-20": "gke-agentic/kube-agents-evals-20-infra",
+    "kube-agents-evals-21": "gke-agentic/kube-agents-evals-21-infra",
+    "kube-agents-evals-22": "gke-agentic/kube-agents-evals-22-infra",
+    "kube-agents-evals-23": "gke-agentic/kube-agents-evals-23-infra",
+    "kube-agents-evals-24": "gke-agentic/kube-agents-evals-24-infra",
+    "kube-agents-evals-25": "gke-agentic/kube-agents-evals-25-infra",
+    "kube-agents-evals-26": "gke-agentic/kube-agents-evals-26-infra",
+    "kube-agents-evals-27": "gke-agentic/kube-agents-evals-27-infra",
+    "kube-agents-evals-28": "gke-agentic/kube-agents-evals-28-infra",
+    "kube-agents-evals-29": "gke-agentic/kube-agents-evals-29-infra",
+    "kube-agents-evals-30": "gke-agentic/kube-agents-evals-30-infra",
 }
 
 # The fail-closed tests need a project the mapping will never contain, and for


### PR DESCRIPTION
## Summary

Maps evaluation pool projects `kube-agents-evals-16` through `kube-agents-evals-30` to their dedicated private GitOps infrastructure repositories (`gke-agentic/kube-agents-evals-16-infra` through `evals-30-infra`) across `hack/ci-deploy.sh`, `tests/test_ci_gitops_repo.py`, and the CI pool deployment documentation.

## Why This Change

Doubles the Boskos evaluation pool capacity from 15 to 30 projects to accommodate increasing presubmit volume and eliminate Boskos lease queue wait times.

Precondition Step 0 of `scripts/provision_ci_pool_project.sh` asserts that the project is registered in `gitops_repo_for_project()` before applying Terraform/OpenTofu resources, preventing runs from leasing unmapped projects and failing with unmapped-project refusals.

## What Changed

- **`hack/ci-deploy.sh`**: Added case arms for `kube-agents-evals-16` through `30` returning `gke-agentic/kube-agents-evals-<N>-infra`.
- **`tests/test_ci_gitops_repo.py`**: Added `kube-agents-evals-16` through `30` to `_EXPECTED_MAPPING`.
- **`docs/site/src/content/docs/deploy/ci-pool-projects.md`**: Added rows for `evals-16` through `evals-30` to the GitOps repository catalog table.

## Context

- Scales the Boskos `kube-agents-evals-project` pool size from 15 to 30 projects.
- Pairs with the corresponding updates:
  - `gke-internal-test-infra`: Adding `kube-agents-evals-16..30` to Boskos pool overlays (`deployments/gke-agentic-tooling-team/boskos/overlays/boskos-resources.yaml`, Gerrit cl/2245750).
  - `oss-test-infra`: Bumping `max_concurrency: 15` → `max_concurrency: 30` in `pull-kube-agents-smoke-test` (GoogleCloudPlatform/oss-test-infra#2685).

## Testing

- `python3 -m unittest tests/test_ci_gitops_repo.py`: 15 passed (`OK`).
- `PYTHONPATH=scripts python3 -m unittest scripts/test_verify_ci_pool_project.py`: 218 passed (`OK`).
- `bash -n hack/ci-deploy.sh`: Clean syntax check.

### Live Validation

Not live-tested on a merged main runner: this change lands the static project mapping required before newly provisioned projects can be leased.

Verified locally against the verifier and deployment resolver:
```bash
$ python3 scripts/verify_ci_pool_project.py --project-id kube-agents-evals-16
[?] Codebase GitOps Mapping: Mapped to gke-agentic/kube-agents-evals-16-infra in this checkout, not yet on upstream/main
```
Confirmed that `verify_ci_pool_project.py` reads `gitops_repo_for_project()` from `hack/ci-deploy.sh` and correctly resolves `kube-agents-evals-16` to `gke-agentic/kube-agents-evals-16-infra`. Projects 18–30 are actively in the provisioning sequence.

## Self-Review

- **Context**: Both passes ran in the primary agent development session with direct file inspection and automated test suites.
- **Adversarial pass**: Inspected `hack/ci-deploy.sh` case arm formatting to ensure regex matching in `provision_ci_pool_project.sh:184` (`^[[:space:]]*${PROJECT_ID}\)[[:space:]]+echo[[:space:]]+"${GITOPS_REPO}"`) matches without syntax ambiguities. Checked boundary conditions for `_NEVER_MAPPED_PROJECT` (`not-a-pool-project-fixture`) ensuring fail-closed behavior on unmapped IDs. Verified 15 tests in `test_ci_gitops_repo.py` and 218 tests in `test_verify_ci_pool_project.py` pass without errors.
- **Docs drift pass**: Hand-verified `docs/site/src/content/docs/deploy/ci-pool-projects.md` table lines 177–195 to ensure sequential ordering (evals-16..30), correct Markdown formatting, and exact 1:1 parity with the case arms in `hack/ci-deploy.sh`. Ran `scripts/generate_docs.py --check` confirming no drift across mechanical targets.

## Risk & Rollout

Low risk. Does not modify runtime cluster agent logic, controller operators, or portal workloads. Revert requires no state migration.
