### PR TITLE
fix(ci): heartbeat the Boskos lease through teardown, and report teardown step failures truthfully

### DIFF
--- a/hack/boskos_heartbeat.sh
+++ b/hack/boskos_heartbeat.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Boskos lease heartbeat daemon
+# ==============================================================================
+# POSTs the Boskos client's /update call every
+# BOSKOS_HEARTBEAT_INTERVAL_SECONDS so the lease's LastUpdate stays fresh and
+# the reaper (ranch.Reset, ~5m window) does not reclaim the project while a
+# CI phase still runs. Covers what the Prow wrapper's own heartbeat does not
+# — teardown, where a slow sweep outliving the lease turned the final
+# release into a 401 (2026-09-01, kube-agents-evals-4).
+#
+# Liveness travels on its own channel: per-beat lines go to
+# BOSKOS_HEARTBEAT_LOG, stdout carries only start, ok<->fail transitions,
+# and a stop summary. At the ~5m window a 30s cadence tolerates 9 missed
+# beats, so a 3-minute hang (6 beats) keeps the lease; a pod frozen past the
+# window loses it, which is the reclaim working as intended.
+#
+# Usage (backgrounded, killed by the caller's EXIT trap):
+#   ./hack/boskos_heartbeat.sh & HEARTBEAT_PID=$!
+#   trap 'kill "${HEARTBEAT_PID}" 2>/dev/null || true' EXIT
+#
+# Disabled (single notice, exit 0) unless BOSKOS_HOST, BOSKOS_RESOURCE_NAME,
+# and BOSKOS_OWNER_NAME are all set. Pool resource names are DNS-safe, so
+# the query string needs no URL encoding.
+
+set -uo pipefail
+
+BOSKOS_HEARTBEAT_INTERVAL_SECONDS="${BOSKOS_HEARTBEAT_INTERVAL_SECONDS:-30}"
+# State every kube-agents lease is held in while a job owns it; /update 401s
+# on an owner mismatch and 409s on a state mismatch, so both must match the
+# acquire call the Prow wrapper made.
+BOSKOS_RESOURCE_STATE="${BOSKOS_RESOURCE_STATE:-busy}"
+# Per-beat detail lands here, off the job log. ARTIFACTS is set by Prow.
+BOSKOS_HEARTBEAT_LOG="${BOSKOS_HEARTBEAT_LOG:-${ARTIFACTS:-/tmp}/boskos-heartbeat.log}"
+# A beat must never wedge the loop behind a slow server: cap each call well
+# under the interval so a timed-out beat still leaves room for the next one.
+CURL_MAX_TIME_SECONDS=10
+LOG_PREFIX="boskos-heartbeat:"
+
+if [ -z "${BOSKOS_HOST:-}" ] || [ -z "${BOSKOS_RESOURCE_NAME:-}" ] || [ -z "${BOSKOS_OWNER_NAME:-}" ]; then
+  echo "${LOG_PREFIX} disabled (BOSKOS_HOST/BOSKOS_RESOURCE_NAME/BOSKOS_OWNER_NAME not all set)"
+  exit 0
+fi
+
+UPDATE_URL="${BOSKOS_HOST}/update?name=${BOSKOS_RESOURCE_NAME}&owner=${BOSKOS_OWNER_NAME}&state=${BOSKOS_RESOURCE_STATE}"
+
+beats_sent=0
+beats_failed=0
+# "" until the first beat resolves, then ok|fail; transitions are the only
+# per-beat events worth a line on the job log.
+last_status=""
+
+summary() {
+  echo "${LOG_PREFIX} stopping for ${BOSKOS_RESOURCE_NAME}: ${beats_sent} beats sent, ${beats_failed} failed (detail: ${BOSKOS_HEARTBEAT_LOG})"
+  exit 0
+}
+trap summary TERM INT
+
+mkdir -p "$(dirname "${BOSKOS_HEARTBEAT_LOG}")" 2>/dev/null || true
+echo "${LOG_PREFIX} started for ${BOSKOS_RESOURCE_NAME} (owner ${BOSKOS_OWNER_NAME}, every ${BOSKOS_HEARTBEAT_INTERVAL_SECONDS}s, detail: ${BOSKOS_HEARTBEAT_LOG})"
+
+while true; do
+  # curl -w emits a code even on failure ("000", or "200000" when the
+  # connection dies after headers), so normalise to the LAST three digits
+  # rather than appending a fallback that doubles it up.
+  http_code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time "${CURL_MAX_TIME_SECONDS}" \
+    -X POST "${UPDATE_URL}" 2>>"${BOSKOS_HEARTBEAT_LOG}")" || true
+  http_code="${http_code:(-3)}"
+  [ -n "${http_code}" ] || http_code="000"
+  beats_sent=$((beats_sent + 1))
+  if [ "${http_code}" = "200" ]; then
+    status="ok"
+  else
+    status="fail"
+    beats_failed=$((beats_failed + 1))
+  fi
+  echo "$(date -u +'%Y-%m-%dT%H:%M:%SZ') ${status} http=${http_code}" >>"${BOSKOS_HEARTBEAT_LOG}"
+  if [ "${status}" != "${last_status}" ]; then
+    if [ "${status}" = "fail" ]; then
+      # 401 here means the lease is already lost (owner mismatch) — the exact
+      # signal that used to surface only as a failed release at job end.
+      echo "${LOG_PREFIX} beat FAILED for ${BOSKOS_RESOURCE_NAME} (http=${http_code}); continuing"
+    elif [ -n "${last_status}" ]; then
+      echo "${LOG_PREFIX} recovered for ${BOSKOS_RESOURCE_NAME}"
+    fi
+    last_status="${status}"
+  fi
+  sleep "${BOSKOS_HEARTBEAT_INTERVAL_SECONDS}"
+done

--- a/hack/ci-teardown.sh
+++ b/hack/ci-teardown.sh
@@ -46,6 +46,26 @@ readonly SECRET_NAME_PREFIX_RE='^secret/'
 readonly CHART_CRD_DIR="charts/kube-agents/crds/"
 readonly CRD_DELETE_TIMEOUT="5m"
 
+# Exit nonzero when any step failed; default off so the Prow wrapper still
+# reaches its Boskos release — the honest signal is the ✗ lines and the final
+# summary. `readonly VAR="${VAR:-default}"` throughout this block: env still
+# overrides, and the step tests lift `readonly ` head lines along.
+readonly CI_TEARDOWN_STRICT="${CI_TEARDOWN_STRICT:-0}"
+
+# Bounds for the sweep deletes in Steps 3 and 4 (Steps 1 and 2 carry their
+# own budgets above). --timeout bounds the wait-for-deletion phase; the
+# request timeout bounds each API call, the phase an unreachable control
+# plane hangs — where the 2026-09-01 incident spent 546s.
+readonly SWEEP_DELETE_TIMEOUT="${CI_TEARDOWN_SWEEP_TIMEOUT:-60s}"
+readonly KUBECTL_REQUEST_TIMEOUT="${CI_TEARDOWN_KUBECTL_REQUEST_TIMEOUT:-30s}"
+
+# Endpoint and owner convention the Prow wrapper leases with
+# (BOSKOS_OWNER="${JOB_NAME}-${BUILD_ID}", oss-test-infra
+# prow/prowjobs/gke-labs/kube-agents/kube-agents-presubmits.yaml), so the
+# heartbeat below arms itself with no wrapper change. If the convention ever
+# changes, beats 401 — one loud daemon line, harmless to the teardown.
+readonly PROW_BOSKOS_DEFAULT_HOST="http://boskos.boskos.svc.cluster.local"
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
@@ -78,8 +98,43 @@ if [[ "$CURRENT_CTX" != "$EXPECTED_CTX" ]]; then
   exit 1
 fi
 
+# The Prow wrapper kills its boskosctl heartbeat BEFORE invoking this script
+# (so an orphaned heartbeat cannot 401-spam a released resource), which left
+# every teardown lease-blind against Boskos's ~5m reaper: on 2026-09-01 a
+# 546s CRD delete outlived the window, the pool re-leased the project
+# mid-teardown, and the final release got 401 OwnerNotMatch. The daemon
+# below heartbeats for exactly this script's lifetime; the EXIT trap kills
+# it before the wrapper's release, so the orphan problem cannot come back.
+# Outside Prow (no JOB_NAME/BUILD_ID) nothing is derived and the daemon
+# disables itself with one line; explicit BOSKOS_* env overrides everything.
+if [ -n "${JOB_NAME:-}" ] && [ -n "${BUILD_ID:-}" ]; then
+  export BOSKOS_HOST="${BOSKOS_HOST:-${PROW_BOSKOS_DEFAULT_HOST}}"
+  export BOSKOS_RESOURCE_NAME="${BOSKOS_RESOURCE_NAME:-${PROJECT_ID}}"
+  export BOSKOS_OWNER_NAME="${BOSKOS_OWNER_NAME:-${JOB_NAME}-${BUILD_ID}}"
+fi
+"${SCRIPT_DIR}/boskos_heartbeat.sh" &
+HEARTBEAT_PID=$!
+trap 'kill "${HEARTBEAT_PID}" 2>/dev/null || true' EXIT
+
 START_TIME=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleaning Up GKE Resources ==="
+
+# Truthful step accounting: every step still runs on every path (no step may
+# stop the sweep of the ones after it), but a failed step now prints ✗ and is
+# counted instead of being masked by an unconditional ✓. Defined below
+# START_TIME on purpose: the step tests lift the file from that line, and the
+# lifted steps call this function.
+FAILED_STEPS=0
+FAILED_STEP_NAMES=""
+finish_step() { # <name> <exit-status>
+  if [ "$2" -eq 0 ]; then
+    echo "✓ $1 finished in $((SECONDS - STEP_START))s"
+  else
+    echo "✗ $1 FAILED (status $2) after $((SECONDS - STEP_START))s; continuing"
+    FAILED_STEPS=$((FAILED_STEPS + 1))
+    FAILED_STEP_NAMES="${FAILED_STEP_NAMES}${FAILED_STEP_NAMES:+, }$1"
+  fi
+}
 
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agents release ==="
@@ -112,7 +167,11 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 1: Uninstalling the kube-agent
 # (pkg/action/uninstall.go), which drops them without it, and returns only
 # `failed to delete release: <name>`. That line was all CI recorded for the
 # 25 hours #1172 went unnoticed.
-if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}" --debug; then
+# --ignore-not-found: the wrapper also runs this script at job start to sweep
+# a hard-killed predecessor, where no release exists and that is not a failure.
+UNINSTALL_STATUS=0
+if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "${RELEASE_UNINSTALL_TIMEOUT}" --debug --ignore-not-found; then
+  UNINSTALL_STATUS=1
   if RELEASE_HISTORY_JSON="$(helm history "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" -o json 2>/dev/null)" \
     && grep -Eq "${HELM_DEPLOYED_STATUS_RE}" <<<"${RELEASE_HISTORY_JSON}"; then
     echo "WARNING: helm uninstall failed with a deployed revision still recorded; leaving the release record for the next lease to upgrade over (#1172)"
@@ -125,7 +184,7 @@ if ! helm uninstall "${HELM_RELEASE_NAME}" -n "${NAMESPACE}" --wait --timeout "$
     echo "✓ Release-record fallback deleted ${RECORD_SECRETS_COUNT} Helm record Secret(s)"
   fi
 fi
-echo "✓ Release uninstall finished in $((SECONDS - STEP_START))s"
+finish_step "Release uninstall" "${UNINSTALL_STATUS}"
 
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 2: Deleting CRDs ==="
@@ -140,13 +199,18 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 2: Deleting CRDs ==="
 # a run killed mid-install) is still swept. Unreadable counts as "may survive":
 # keeping a CRD costs one lease's tidiness, deleting one costs the project.
 CRD_STEP_RESULT="deleted"
+# 0 for the outcomes the design intends (deleted, or kept on purpose under a
+# surviving record); 1 for the ones it does not (a timed-out delete, an
+# unreadable record probe), so finish_step counts them into the summary.
+CRD_STEP_STATUS=0
 PROBE_ERROR_LOG="$(mktemp)"
 if RELEASE_RECORD_NAMES="$(kubectl get secret -n "${NAMESPACE}" \
   -l "${HELM_RELEASE_SECRET_SELECTOR}" -o name 2>"${PROBE_ERROR_LOG}")"; then
   if [ -n "${RELEASE_RECORD_NAMES}" ]; then
     echo "WARNING: a ${HELM_RELEASE_NAME} release record survived Step 1; keeping the CRDs so the next lease's Helm can read its own manifest (#1172)"
     CRD_STEP_RESULT="skipped, release record survived Step 1"
-  elif kubectl delete -f "${CHART_CRD_DIR}" --ignore-not-found --timeout "${CRD_DELETE_TIMEOUT}"; then
+  elif kubectl delete -f "${CHART_CRD_DIR}" --ignore-not-found --timeout "${CRD_DELETE_TIMEOUT}" \
+    --request-timeout="${KUBECTL_REQUEST_TIMEOUT}"; then
     CRD_STEP_RESULT="deleted"
   else
     # Bounded rather than hung: the CRDs may be left Terminating, which the
@@ -154,6 +218,7 @@ if RELEASE_RECORD_NAMES="$(kubectl get secret -n "${NAMESPACE}" \
     # now run and the log says which happened.
     echo "WARNING: the CRD delete did not finish within ${CRD_DELETE_TIMEOUT}; continuing so the sweeps still run (#1172)"
     CRD_STEP_RESULT="delete timed out or failed after ${CRD_DELETE_TIMEOUT}"
+    CRD_STEP_STATUS=1
   fi
 else
   # The reason matters and used to go to /dev/null: a missing namespace is a
@@ -161,9 +226,10 @@ else
   # below treats them alike.
   echo "WARNING: could not read the ${HELM_RELEASE_NAME} release records; keeping the CRDs (#1172). kubectl said: $(tr '\n' ' ' <"${PROBE_ERROR_LOG}")"
   CRD_STEP_RESULT="skipped, release records unreadable"
+  CRD_STEP_STATUS=1
 fi
 rm -f "${PROBE_ERROR_LOG}"
-echo "✓ CRD step (${CRD_STEP_RESULT}) finished in $((SECONDS - STEP_START))s"
+finish_step "CRD step (${CRD_STEP_RESULT})" "${CRD_STEP_STATUS}"
 
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kube-agents resources ==="
@@ -184,13 +250,15 @@ echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 3: Sweeping cluster-scoped kub
 # which Step 2 already deletes by file because Helm's crds/ convention installs
 # them unlabelled.
 #
-# One kind per call, each `|| true`: an API group missing from this cluster
-# (ValidatingAdmissionPolicy needs 1.30+) or one flaky delete must not stop
-# the sweep of the kinds that do exist, and nothing here may change the
-# teardown's exit code. This block must stay reachable on every path through
-# the script — steps before it end in `|| true` or run as `if` conditions,
-# and there is no `set -e`; the only early exits are the two
-# must-not-delete-the-wrong-cluster guards above.
+# One kind per call, failures counted but never fatal: an API group missing
+# from this cluster (ValidatingAdmissionPolicy needs 1.30+) or one flaky
+# delete must not stop the sweep of the kinds that do exist. This block must
+# stay reachable on every path through the script — steps before it end in
+# `|| true`, run as `if` conditions, or feed finish_step, and there is no
+# `set -e`; the only early exits are the two must-not-delete-the-wrong-cluster
+# guards above. A failed kind is real, though: on 2026-09-01 the VAP delete
+# was skipped because API discovery failed against a down control plane, and
+# the old unconditional ✓ hid it.
 SWEEP_SELECTOR="app.kubernetes.io/part-of=kube-agents"
 SWEEP_KINDS=(
   validatingadmissionpolicies.admissionregistration.k8s.io
@@ -200,10 +268,34 @@ SWEEP_KINDS=(
   clusterroles.rbac.authorization.k8s.io
   clusterrolebindings.rbac.authorization.k8s.io
 )
-for SWEEP_KIND in "${SWEEP_KINDS[@]}"; do
-  kubectl delete "${SWEEP_KIND}" -l "${SWEEP_SELECTOR}" --ignore-not-found || true
-done
-echo "✓ Cluster-scoped sweep finished in $((SECONDS - STEP_START))s"
+# A kind whose API group this cluster does not serve ("doesn't have a
+# resource type") is counted absent, not failed: VAP needs 1.30+, the
+# cert-manager and managed-collection groups exist only where those are
+# installed, and a permanent ✗ on healthy clusters would teach readers to
+# ignore the one that matters. Any other error is a real failure.
+sweep_kinds() { # <label> <namespace-or-""> <kind...>
+  local label="$1" ns="$2" failed=0 absent=0 total=0 out
+  shift 2
+  for kind in "$@"; do
+    total=$((total + 1))
+    # shellcheck disable=SC2086
+    if out="$(kubectl delete "${kind}" ${ns:+-n "${ns}"} -l "${SWEEP_SELECTOR}" \
+      --ignore-not-found --timeout="${SWEEP_DELETE_TIMEOUT}" \
+      --request-timeout="${KUBECTL_REQUEST_TIMEOUT}" 2>&1)"; then
+      echo "${out}"
+    else
+      echo "${out}"
+      if grep -q "doesn't have a resource type" <<<"${out}"; then
+        absent=$((absent + 1))
+      else
+        failed=$((failed + 1))
+      fi
+    fi
+  done
+  finish_step "${label} (${failed}/${total} kinds failed, ${absent} absent)" "${failed}"
+}
+
+sweep_kinds "Cluster-scoped sweep" "" "${SWEEP_KINDS[@]}"
 
 STEP_START=$SECONDS
 echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Step 4: Sweeping namespaced kube-agents resources ==="
@@ -246,10 +338,14 @@ SWEEP_NAMESPACED_KINDS=(
   issuers.cert-manager.io
   persistentvolumeclaims
 )
-for SWEEP_KIND in "${SWEEP_NAMESPACED_KINDS[@]}"; do
-  kubectl delete "${SWEEP_KIND}" -n "${NAMESPACE}" -l "${SWEEP_SELECTOR}" --ignore-not-found || true
-done
-echo "✓ Namespaced sweep finished in $((SECONDS - STEP_START))s"
+sweep_kinds "Namespaced sweep" "${NAMESPACE}" "${SWEEP_NAMESPACED_KINDS[@]}"
 
 TOTAL_DURATION=$((SECONDS - START_TIME))
-echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="
+if [ "${FAILED_STEPS}" -eq 0 ]; then
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup Complete (Total Duration: ${TOTAL_DURATION}s) ==="
+else
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Cleanup FINISHED WITH ${FAILED_STEPS} FAILED STEP(S): ${FAILED_STEP_NAMES} (Total Duration: ${TOTAL_DURATION}s) ==="
+  if [ "${CI_TEARDOWN_STRICT}" = "1" ]; then
+    exit 1
+  fi
+fi

--- a/tests/test_boskos_heartbeat.py
+++ b/tests/test_boskos_heartbeat.py
@@ -1,0 +1,181 @@
+"""Tests for hack/boskos_heartbeat.sh against a fake Boskos /update endpoint.
+
+Behavioural, not timing-based: every assertion waits for a condition with a
+generous deadline instead of demanding N beats in T seconds, so a loaded or
+slow machine cannot fail a healthy daemon. What is pinned: beats carry the
+right identity and keep coming; stdout stays quiet while the detail log
+records; a 401 is reported once per transition and does not stop the loop;
+beats resume after a hang; missing env disables the daemon with one line.
+"""
+
+import os
+import signal
+import subprocess
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import parse_qs, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HEARTBEAT_SCRIPT = REPO_ROOT / "hack" / "boskos_heartbeat.sh"
+
+# Scaled-down interval so beats arrive quickly; correctness never depends on
+# the loop hitting this period exactly.
+TEST_INTERVAL_SECONDS = "0.2"
+# Ceiling for any wait_until: far above worst-case scheduling noise, never
+# slept in full on a healthy run.
+WAIT_DEADLINE_SECONDS = 30.0
+# Production ratio, asserted as arithmetic only: 30s beats against the ~5m
+# Boskos reaper window leave a 10-beat budget.
+PRODUCTION_INTERVAL_SECONDS = 30
+PRODUCTION_EXPIRY_SECONDS = 5 * 60
+LEASE_OWNER = "pull-kube-agents-smoke-test"
+LEASE_NAME = "kube-agents-evals-4"
+LEASE_STATE = "busy"
+
+
+def wait_until(condition, deadline=WAIT_DEADLINE_SECONDS):
+    """Poll until condition() is truthy; return its last value."""
+    end = time.monotonic() + deadline
+    while time.monotonic() < end:
+        value = condition()
+        if value:
+            return value
+        time.sleep(0.05)
+    return condition()
+
+
+class _FakeBoskos(BaseHTTPRequestHandler):
+    updates = []  # (name, owner, state)
+    owner = LEASE_OWNER
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path != "/update":
+            self.send_response(404)
+            self.end_headers()
+            return
+        q = parse_qs(parsed.query)
+        name, owner, state = (q.get(k, [""])[0] for k in ("name", "owner", "state"))
+        _FakeBoskos.updates.append((name, owner, state))
+        # ranch.Update: owner mismatch -> OwnerNotMatch -> handlers.go 401.
+        self.send_response(200 if owner == _FakeBoskos.owner else 401)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+class BoskosHeartbeatTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeBoskos)
+        cls.host = f"http://127.0.0.1:{cls.server.server_port}"
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def setUp(self):
+        _FakeBoskos.updates.clear()
+        _FakeBoskos.owner = LEASE_OWNER
+        self.tmp = TemporaryDirectory()
+        self.beat_log = Path(self.tmp.name) / "boskos-heartbeat.log"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _spawn(self, **env_overrides):
+        env = {
+            **os.environ,
+            "BOSKOS_HOST": self.host,
+            "BOSKOS_RESOURCE_NAME": LEASE_NAME,
+            "BOSKOS_OWNER_NAME": LEASE_OWNER,
+            "BOSKOS_RESOURCE_STATE": LEASE_STATE,
+            "BOSKOS_HEARTBEAT_INTERVAL_SECONDS": TEST_INTERVAL_SECONDS,
+            "BOSKOS_HEARTBEAT_LOG": str(self.beat_log),
+            **env_overrides,
+        }
+        return subprocess.Popen(
+            ["bash", str(HEARTBEAT_SCRIPT)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            env=env,
+        )
+
+    def _stop(self, proc):
+        proc.send_signal(signal.SIGTERM)
+        try:
+            return proc.communicate(timeout=10)[0]
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            return proc.communicate()[0]
+
+    def _await_beats(self, n):
+        count = wait_until(lambda: len(_FakeBoskos.updates) >= n)
+        self.assertGreaterEqual(
+            len(_FakeBoskos.updates), n,
+            f"expected >= {n} beats within {WAIT_DEADLINE_SECONDS}s",
+        )
+        return count
+
+    def test_beats_repeat_with_correct_identity(self):
+        proc = self._spawn()
+        self._await_beats(3)
+        self._stop(proc)
+        for name, owner, state in _FakeBoskos.updates:
+            self.assertEqual((name, owner, state), (LEASE_NAME, LEASE_OWNER, LEASE_STATE))
+
+    def test_stdout_stays_quiet_while_detail_log_records(self):
+        proc = self._spawn()
+        self._await_beats(5)
+        stdout = self._stop(proc)
+        # Job-log channel: start line and stop summary only.
+        lines = [ln for ln in stdout.splitlines() if ln.strip()]
+        self.assertLessEqual(len(lines), 3, f"stdout flooded:\n{stdout}")
+        detail = wait_until(lambda: self.beat_log.read_text().splitlines())
+        self.assertGreaterEqual(len(detail), 3)
+        self.assertTrue(any(" ok http=200" in ln for ln in detail), detail)
+
+    def test_owner_mismatch_logs_one_transition_and_loop_survives(self):
+        _FakeBoskos.owner = "someone-else"  # every beat now 401s
+        proc = self._spawn()
+        self._await_beats(3)
+        stdout = self._stop(proc)
+        failed_lines = [ln for ln in stdout.splitlines() if "FAILED" in ln]
+        self.assertEqual(len(failed_lines), 1, stdout)
+        self.assertIn("http=401", failed_lines[0])
+
+    def test_beats_resume_after_a_hang(self):
+        # The production question is only "does a beat land after the hang,
+        # inside the expiry budget" — the budget itself is arithmetic.
+        self.assertGreater(
+            PRODUCTION_EXPIRY_SECONDS // PRODUCTION_INTERVAL_SECONDS, 6,
+            "a 3-minute hang (6 beats at 30s) must fit the reaper window",
+        )
+        proc = self._spawn()
+        self._await_beats(2)
+        os.kill(proc.pid, signal.SIGSTOP)
+        time.sleep(1.5)  # several intervals of enforced silence
+        frozen_count = len(_FakeBoskos.updates)
+        os.kill(proc.pid, signal.SIGCONT)
+        wait_until(lambda: len(_FakeBoskos.updates) > frozen_count)
+        self._stop(proc)
+        self.assertGreater(len(_FakeBoskos.updates), frozen_count,
+                           "no beat resumed after SIGCONT")
+
+    def test_disabled_without_boskos_env(self):
+        proc = self._spawn(BOSKOS_HOST="")
+        stdout, _ = proc.communicate(timeout=10)[0], proc.wait()
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("disabled", stdout)
+        self.assertEqual(_FakeBoskos.updates, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_ci_teardown_status.py
+++ b/tests/test_ci_teardown_status.py
@@ -1,0 +1,196 @@
+"""Tests for hack/ci-teardown.sh step accounting and lease heartbeat.
+
+Runs the real script with stub gcloud/kubectl/helm binaries. The failure
+scenario reproduces the 2026-09-01 incident on kube-agents-evals-4: the CRD
+delete dies against an unreachable control plane and the
+ValidatingAdmissionPolicy sweep is skipped by a failed API discovery. The old
+script printed an unconditional checkmark over both; these tests pin the
+truthful behaviour, the strict-exit opt-in, and that a Boskos heartbeat runs
+for the teardown's whole duration.
+"""
+
+import subprocess
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import parse_qs, urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEARDOWN = REPO_ROOT / "hack" / "ci-teardown.sh"
+
+PROJECT = "kube-agents-evals-4"
+EXPECTED_CONTEXT = f"gke_{PROJECT}_us-central1_platform-agent-host"
+
+STUB_GCLOUD = "#!/bin/bash\nexit 0\n"
+STUB_HELM = '#!/bin/bash\necho "release uninstalled"\nexit 0\n'
+
+# KUBECTL_MODE=ok: everything succeeds. KUBECTL_MODE=incident: the CRD delete
+# fails with connection refused and the VAP kind fails discovery — the
+# 2026-09-01 log, verbatim failure modes.
+STUB_KUBECTL = f"""#!/bin/bash
+if [[ "$1 $2" == "config current-context" ]]; then
+  echo "{EXPECTED_CONTEXT}"; exit 0
+fi
+if [[ "$1" == "get" ]]; then
+  exit 0  # empty read: no Helm release records survive Step 1
+fi
+if [[ "$KUBECTL_MODE" == "incident" ]]; then
+  if [[ "$1" == "delete" && "$2" == "-f" ]]; then
+    echo 'dial tcp 34.123.149.88:443: connect: connection refused' >&2; exit 1
+  fi
+  if [[ "$*" == *validatingadmissionpolicies.admissionregistration.k8s.io* ]]; then
+    echo 'error: the server doesn'"'"'t have a resource type "validatingadmissionpolicies"' >&2; exit 1
+  fi
+fi
+echo "deleted"; exit 0
+"""
+
+
+class _FakeBoskos(BaseHTTPRequestHandler):
+    updates = []  # (name, owner)
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        q = parse_qs(parsed.query)
+        _FakeBoskos.updates.append(
+            (q.get("name", [""])[0], q.get("owner", [""])[0])
+        )
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *args):
+        pass
+
+
+class CiTeardownStatusTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.server = ThreadingHTTPServer(("127.0.0.1", 0), _FakeBoskos)
+        cls.boskos_host = f"http://127.0.0.1:{cls.server.server_port}"
+        threading.Thread(target=cls.server.serve_forever, daemon=True).start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+
+    def setUp(self):
+        _FakeBoskos.updates.clear()
+        self.tmp = TemporaryDirectory()
+        bin_dir = Path(self.tmp.name) / "bin"
+        bin_dir.mkdir()
+        for name, body in (
+            ("gcloud", STUB_GCLOUD),
+            ("helm", STUB_HELM),
+            ("kubectl", STUB_KUBECTL),
+        ):
+            stub = bin_dir / name
+            stub.write_text(body)
+            stub.chmod(0o755)
+        self.bin_dir = bin_dir
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _run(self, kubectl_mode, extra_env=None):
+        import os
+
+        env = {
+            **os.environ,
+            "PATH": f"{self.bin_dir}:{os.environ['PATH']}",
+            "PROJECT_ID": PROJECT,
+            "KUBECTL_MODE": kubectl_mode,
+            "BOSKOS_HEARTBEAT_LOG": str(Path(self.tmp.name) / "beats.log"),
+        }
+        # Scrub the Prow/Boskos identity the suite may inherit from its own CI
+        # environment (JOB_NAME/BUILD_ID are always set in Prow): without
+        # this, the script under test derives a real owner and heartbeats the
+        # REAL in-cluster Boskos from inside the presubmit.
+        for key in ("JOB_NAME", "BUILD_ID", "BOSKOS_HOST",
+                    "BOSKOS_RESOURCE_NAME", "BOSKOS_OWNER_NAME"):
+            env.pop(key, None)
+        env.update(extra_env or {})
+        return subprocess.run(
+            ["bash", str(TEARDOWN)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+        )
+
+    def test_clean_teardown_reports_all_checkmarks_and_exit_zero(self):
+        result = self._run("ok")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("✓ Release uninstall finished", result.stdout)
+        self.assertIn("✓ CRD step (deleted) finished", result.stdout)
+        self.assertIn("Cleanup Complete", result.stdout)
+        self.assertNotIn("✗", result.stdout)
+
+    def test_incident_failures_are_reported_not_masked(self):
+        result = self._run("incident")
+        # Default stays exit 0: the wrapper must still reach its release.
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("✗ CRD step (delete timed out or failed", result.stdout)
+        # The VAP kind erroring "doesn't have a resource type" counts absent,
+        # not failed: real on 1.29 clusters, and false-✗ noise everywhere else.
+        self.assertIn("(0/6 kinds failed, 1 absent)", result.stdout)
+        self.assertIn("FINISHED WITH 1 FAILED STEP(S)", result.stdout)
+        self.assertNotIn("Cleanup Complete", result.stdout)
+
+    def test_strict_mode_exits_nonzero_on_failure(self):
+        result = self._run("incident", {"CI_TEARDOWN_STRICT": "1"})
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertIn("FINISHED WITH 1 FAILED STEP(S)", result.stdout)
+
+    def test_heartbeat_disabled_without_boskos_env_single_line(self):
+        result = self._run("ok")
+        disabled = [
+            ln for ln in result.stdout.splitlines() if "boskos-heartbeat: disabled" in ln
+        ]
+        self.assertEqual(len(disabled), 1, result.stdout)
+
+    def test_heartbeat_identity_derived_from_prow_env(self):
+        # Inside Prow (JOB_NAME/BUILD_ID present) the teardown derives the
+        # lease identity the wrapper used — owner "${JOB_NAME}-${BUILD_ID}",
+        # resource PROJECT_ID — with no BOSKOS_* wiring from the job config.
+        result = self._run(
+            "ok",
+            {
+                "BOSKOS_HOST": self.boskos_host,  # env override of the in-cluster default
+                "JOB_NAME": "pull-kube-agents-smoke-test",
+                "BUILD_ID": "2094805894989615104",
+                "BOSKOS_HEARTBEAT_INTERVAL_SECONDS": "0.1",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertGreaterEqual(len(_FakeBoskos.updates), 1, result.stdout)
+        name, owner = _FakeBoskos.updates[0]
+        self.assertEqual(name, PROJECT)
+        self.assertEqual(owner, "pull-kube-agents-smoke-test-2094805894989615104")
+
+    def test_heartbeat_beats_during_teardown(self):
+        result = self._run(
+            "ok",
+            {
+                "BOSKOS_HOST": self.boskos_host,
+                "BOSKOS_RESOURCE_NAME": PROJECT,
+                "BOSKOS_OWNER_NAME": "pull-kube-agents-smoke-test",
+                "BOSKOS_HEARTBEAT_INTERVAL_SECONDS": "0.1",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("boskos-heartbeat: started", result.stdout)
+        self.assertGreaterEqual(len(_FakeBoskos.updates), 1)
+        self.assertTrue(all(n == PROJECT for n, _ in _FakeBoskos.updates))
+        # The daemon must not outlive the script.
+        time.sleep(0.5)
+        beats_after_exit = len(_FakeBoskos.updates)
+        time.sleep(0.5)
+        self.assertEqual(len(_FakeBoskos.updates), beats_after_exit,
+                         "heartbeat daemon leaked past teardown exit")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`hack/ci-teardown.sh` now keeps the job's Boskos lease alive for exactly as long as it runs, and reports each step's real outcome — a failed step prints `✗` and lands in a final `FINISHED WITH N FAILED STEP(S)` summary instead of being masked by an unconditional ✓. A new `hack/boskos_heartbeat.sh` daemon carries the liveness signal on its own channel (the Boskos `/update` call), adding ~3 lines to the job log instead of one per beat. The branch is rebased over #1185 and layers onto its release-record fallback and gated CRD delete.

## Why This Change

The Prow wrapper kills its `boskosctl heartbeat` before invoking teardown, so every teardown runs lease-blind against Boskos's ~5-minute reaper. On 2026-09-01, a 546s CRD delete against an unreachable control plane on `kube-agents-evals-4` outlived that window: the reaper reclaimed the project mid-teardown, the pool re-leased it to a concurrent build (build 2094805894989615104 leased and released it while the first job was still deleting), and the original job's release failed with `401 Unauthorized` (Boskos `OwnerNotMatch`). The same teardown printed `✓ CRD deletion finished in 546s` over the failure and silently skipped the ValidatingAdmissionPolicy sweep when API discovery failed — the #1006 leftover-resources failure mode with a green checkmark on it.

## What Changed

- `hack/boskos_heartbeat.sh` (new): POSTs the Boskos client's `/update` (same `name`/`owner`/`state` query `boskosctl` sends, verified against `sigs.k8s.io/boskos` client source) every 30s. Job log gets start/transition/stop lines only; per-beat detail goes to `${ARTIFACTS}/boskos-heartbeat.log`. A 401 on a beat is reported once per transition — the lease-lost signal that previously surfaced only as a failed release at job end. At the ~5m reaper window, 30s beats tolerate 9 consecutive misses.
- `hack/ci-teardown.sh`: starts the daemon for the script's lifetime and kills it from the EXIT trap **before** the wrapper's release runs, so the orphaned-heartbeat problem the wrapper's `cleanup()` defends against cannot return. Inside Prow the lease identity is derived from what the pod already has — `PROJECT_ID` (exported by the wrapper), owner `${JOB_NAME}-${BUILD_ID}` (the wrapper's own convention), and the fixed in-cluster Boskos URL — so no oss-test-infra change is needed to arm it; explicit `BOSKOS_*` env overrides all three, and outside Prow the daemon disables itself with one line.
- `hack/ci-teardown.sh`: truthful step accounting via `finish_step` — layered over #1185's steps without changing their logic: Step 1's uninstall-with-fallback reports ✗ when the uninstall failed (and gains `--ignore-not-found` so the job-start sweep with no release is not a failure), the gated CRD step reports ✗ on a timed-out delete or unreadable record probe (designed skips stay ✓), and both sweeps report `N/M kinds failed, K absent` — a kind whose API group the cluster does not serve counts absent, not failed, so healthy clusters do not accumulate false ✗. Exit code stays 0 unless `CI_TEARDOWN_STRICT=1`. Sweep deletes gain `--timeout=60s --request-timeout=30s`; Step 1/2 keep #1185's 10m/5m budgets, so fitting a full abort teardown inside the wrapper's 5m `grace_period` still requires the oss-test-infra `grace_period` raise (see Context).
- `tests/test_ci_teardown_status.py`, `tests/test_boskos_heartbeat.py` (new, 11 tests): run the real scripts; covered by the existing `tests/test_*.py` Makefile glob. Heartbeat tests are condition-based (wait-until with generous deadlines), not timing-based, so slow or loaded machines cannot fail a healthy daemon.

## Context

- Root-cause investigation of the 2026-09-01 incident (Prow build logs in `gs://kube-agents-prow` for PR #1089 builds around 15:13Z show the lease changing hands mid-teardown) and of the eval-slot saturation in #1097 — this PR fixes the teardown/lease half; the endpoint-slot half lives in the Hermes runtime, not this repo.
- Rebased over #1185 (merged) after its landing conflicted with the first push; #1180 (open) also touches this script for a different purpose — whichever merges second rebases.
- Out-of-repo follow-ups: raising the job's `grace_period` in oss-test-infra so even an everything-hangs abort teardown reaches its release, and the Boskos pool expiry value (gke-internal/test-infra) if a wider window is wanted.

## Testing

- 41 tests pass over the merged script: the 11 added here plus #1185's 30 (`test_ci_teardown_release_record`, `test_ci_teardown_sweep`, `test_ci_deploy_release_guard`), locally and in the `Run Python Unit Tests` check.
- The incident replay: stub kubectl failing with the incident's exact errors — the pre-#1185 script printed all ✓ and exited 0; this branch reports the failed CRD step and the absent VAP kind, and summarizes.
- The heartbeat suite ran 5x consecutively without flake after the condition-based rewrite; the teardown suite also passes with `JOB_NAME`/`BUILD_ID` set, proving the tests scrub inherited CI identity rather than heartbeating the real Boskos from inside a presubmit.
- `make docs-check` green; `bash -n` on all touched scripts.

### Live validation

This change's production surface is the Prow presubmit, which cannot run outside CI. It was exercised end-to-end against a real stack standing in for it: a kind cluster with the real `kube-agents` chart installed (operator, LiteLLM, CRDs; `podMonitoring` off — no GKE-managed CRDs off-GKE), the real upstream Boskos server backed by that cluster's CRD storage, the real Boskos reaper (60s expiry, 1-minute sweep — scaled from prod's ~5m), and the real `boskosctl` acquiring `busy` leases under the production owner convention. Only `gcloud` was stubbed (no GKE control plane to `get-credentials` against). A CR with an uncleared finalizer made CRD deletion stall, reproducing the incident's slow-teardown shape. The lease lifecycle mirrored production each time: acquire → real `boskosctl heartbeat` → kill it (as `cleanup()` does) → teardown → release.

Control (old script): the reaper reclaimed the lease mid-teardown, the script printed `✓ CRD deletion finished in 81s` + `Cleanup Complete` over it, and the release failed with the incident's exact error: `failed to release resource "kube-agents-evals-test": status 401 Unauthorized`.

This branch, at the merged head, same conditions: the daemon's beats (`ok http=200`, 11/11 at 30s cadence in the detail log) rode through a 308s teardown including the CRD delete hitting #1185's 5m bound; the lease was still `busy/pull-kube-agents-smoke-test-9999` when teardown ended; the release succeeded (`released resource "kube-agents-evals-test"`, exit 0); the log truthfully reported `✗ CRD step (delete timed out or failed after 5m) FAILED (status 1) after 301s` and the final summary; the daemon added 3 lines to the job log and did not outlive the script. Two earlier rerun attempts were invalidated by the host machine suspending mid-experiment (beats gapped for hours; the reaper correctly reclaimed) — an artifact of a sleeping laptop, and incidentally a live demonstration of silence-means-reclaim behaving as designed.

Not covered: the real in-cluster Boskos URL and the exact production reaper expiry (pool config lives in gke-internal/test-infra); the derived owner convention is taken from the wrapper's source in oss-test-infra and will 401 loudly-but-harmlessly if that convention ever changes. Test artifacts (kind cluster, local Boskos, stub dir) were torn down.

## Self-Review

Adversarial and docs-drift passes ran in clean subagent contexts (fresh contexts handed the diff range and the verified wrapper facts, not the authoring conversation); the automated review's findings after opening are folded in below.

Adversarial pass:
- **Fixed (Blocking):** the teardown test suite inherited `os.environ`, so inside Prow it would have armed the heartbeat against the real in-cluster Boskos. `_run` scrubs the five identity variables; verified by running the suite with them set.
- **Fixed:** kubectl `--timeout` bounds only the deletion wait; sweep deletes and the CRD delete gained `--request-timeout=30s` for the connect/discovery phase a dead control plane hangs.
- **Fixed:** curl's `-w` plus a fallback echo could log `http=000000`; beats normalise to the last three digits.
- **Fixed (cosmetic):** counts printed as `(exit N)`; now `(status N)`.
- Verified clean by the pass: quoting/word-splitting, `set -u` holes, EXIT-trap daemon lifetime (no leak, confirmed by execution), GNU/bash portability for the kubekins image.

Docs-drift pass:
- **Fixed:** the daemon header and test constants said 10-minute expiry while the teardown comment said 5; aligned to the ~5m window the wrapper's comments name (the automated review caught two further stale references in the test module docstring — also fixed).
- No repo doc describes the old teardown contract, so nothing went stale; no new Markdown, so no docs-map entry owed.

Automated review (kube-agents-bot) findings:
- **Fixed (merge-blocking):** heartbeat tests asserted beat counts against wall-clock windows and flaked on a stock machine; rewritten to condition-based waits (`wait_until` with a 30s ceiling) that pin behavior — beats repeat, identity correct, one transition line per 401, beats resume after a SIGSTOP hang — with no timing arithmetic. 5 consecutive clean runs.
- **Fixed (description drift):** three claims the rebase resolution had dropped from the code ("helm 3m", `--ignore-not-found`, the grace-period budget comment). `--ignore-not-found` is re-added (it also fixes the job-start sweep reporting a false ✗); the helm/CRD budgets deliberately stay #1185's 10m/5m readonly values, and every body claim about budgets now matches the code.
- **Fixed:** the two stale 10-minute comments in the test module.

Post-rebase additions this section still owes a reviewer: the `finish_step` layering over #1185's steps is covered by #1185's own 30 tests passing unmodified except for none — no #1185 test was edited; the absent-vs-failed sweep calibration is new logic added after live validation showed 3 false ✗ on a cluster without cert-manager/managed-collection groups, and is pinned by the incident test.

## Risk & Rollout

The daemon is fail-soft: missing env disables it with one line, an unreachable or disagreeing Boskos yields logged-once failed beats, and it cannot outlive the script — worst case is today's behavior plus a few log lines. Behavior changes with real blast radius: sweep deletes now carry 60s/30s bounds (healthy sweeps run in seconds; a hung one now surfaces as ✗ instead of hanging the job), and `CI_TEARDOWN_STRICT` defaults off so no caller's exit-code contract changes at merge. Revert is a single commit revert with no persistent state. The derived owner convention couples this repo to the wrapper's naming; if oss-test-infra changes it, beats 401 visibly and teardown is unaffected.

---
Generated with the help of Claude (Fable 5).
