### PR TITLE
ci: pin the presubmit to kube-agents-evals-16 (DO NOT MERGE)

### DIFF
--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -14,6 +14,30 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts/installer" && pwd)/gke_d
 # TODO(boskos): Once oss-test-infra#2655 merges and deploys Boskos project leasing,
 # consider failing closed if JOB_NAME is set and PROJECT_ID is unset.
 export PROJECT_ID="${PROJECT_ID:-kube-agents-evals}"
+
+# ─── TEMPORARY PIN — REVERT BEFORE MERGE ─────────────────────────────────────
+# Pins this pull request's presubmit to kube-agents-evals-16, to prove #1051's
+# fix end to end: the project has had the fleet_reader_token_creators binding
+# applied by hand, so a run against it must NOT emit the
+# "kubeconfig keeps the runner's own credential" warning that every other
+# project's runs emit three times. Absence of that warning is the result.
+#
+# -16 rather than a live pool project because it is not registered in Boskos
+# yet, so no other pull request can lease it and a bad run breaks nothing.
+#
+# The assignment is unconditional on purpose. The Prow job exports
+# PROJECT_ID="${LEASED_PROJECT}" *before* sourcing this file, so the `:-`
+# default above cannot override a lease and a pin written that way would be
+# silently ignored. Boskos still leases a project and leaves it idle; deploy,
+# eval and teardown all follow PROJECT_ID, so -16 is what gets used and what
+# gets cleaned up, and the idle lease is released as normal.
+#
+# This must not merge: on main it would send every presubmit to one project,
+# serialising the pool behind it. Precedent: 442cbf53 (#995), reverted by
+# 8e42c3b4 before that branch merged.
+export PROJECT_ID="kube-agents-evals-16"
+# ─────────────────────────────────────────────────────────────────────────────
+
 export GCP_PROJECT_ID="${PROJECT_ID}"
 export REGION="${REGION:-us-central1}"
 


### PR DESCRIPTION
## Summary

**DO NOT MERGE.** Pins this pull request's presubmit to `kube-agents-evals-16` so one real run can prove #1051's fix end to end. The binding that closes #1051 has been applied to `-16` by hand; a run against it must not emit the `kubeconfig keeps the runner's own credential` warning that every other pool project's runs emit three times. The absence of that warning is the result this PR exists to produce.

Revert the pin before this branch goes anywhere near merge. Precedent: `442cbf53` on #995, reverted by `8e42c3b4`.

## Why This Change

`seeded-fleet-reader@<project>` is provisioned on every pool project and impersonated on none, because `scripts/provision_ci_pool_project.sh` applies the fleet stack with `fleet_reader_token_creators` at its empty default. Every eval run attempts the impersonation, is denied, warns, and falls back to the Prow runner's own read-write credential against a fleet every open pull request shares. #1051 has the full mechanism.

Freshly measured on the 30 most recent `pull-kube-agents-smoke-test` builds (latest 2026-09-03 11:21Z): six reached `hack/fleet-kubeconfigs.sh`, and **all six warned, three times each** — once per seeded cluster. No exceptions. Projects `evals-2`, `-5`, `-6`, `-12`, `-13`, `-15`. Three of those did not exist when #1051 was filed, which is what rules out "a few old projects missed a step" and points at the provisioning script itself.

The fix is a Terraform variable and a backfill. Before backfilling fifteen live projects that every open pull request grades against, one project should demonstrate it works.

## What Changed

`hack/ci-env.sh` only: an unconditional `export PROJECT_ID="kube-agents-evals-16"`.

Unconditional matters. Prow exports `PROJECT_ID` from the Boskos lease *before* sourcing this file, so the `${PROJECT_ID:-...}` default above it cannot override a lease, and a pin written that way is silently ignored. Boskos still leases a project and leaves it idle; deploy, eval and teardown all follow `PROJECT_ID`, so `-16` is what gets used and what gets cleaned up, and the idle lease is released as normal.

`kube-agents-evals-16` rather than a live pool project because it is not registered in Boskos yet, so no other pull request can lease it and a bad run breaks nothing. It is fully provisioned — host cluster, all three seeded clusters, the reader service account, and remote state at the `seeded-fleet` prefix — so it is a representative target rather than a special case. As a side effect the run gives `-16` its first real exercise before Boskos registration, which is what #995 did for `-7`.

## Context

Trial run for #1051, whose owning lane is #903. The mapping for `evals-16` comes from #1194, merged as `65fafd5f`, which this branch is based on.

Does not close anything. The pull request that closes #1051 passes the variable in `scripts/provision_ci_pool_project.sh` and pins the binding in `scripts/verify_ci_pool_project.py`; it is written once this run comes back clean.

## Testing

- `bash -n hack/ci-env.sh` — clean.
- The pin overrides a lease: `PROJECT_ID=kube-agents-evals-7 source hack/ci-env.sh` yields `PROJECT_ID=kube-agents-evals-16` and `GCP_PROJECT_ID=kube-agents-evals-16`. This is the property the whole change depends on, and the one a `:-` default would break.
- `gitops_repo_for_project kube-agents-evals-16` resolves to `gke-agentic/kube-agents-evals-16-infra` from `main`, and an unmapped project still exits 1.
- No test asserts the pin, deliberately — a test pinning the presubmit to one project is the thing that must not survive to `main`.

### Live validation

This pull request **is** the live validation, for #1051 rather than for itself. Preconditions established before it was opened, against `kube-agents-evals-16`:

- `gcloud container clusters list` — `platform-agent-host`, `seeded-a`, `seeded-b`, `seeded-c` all RUNNING, the three seeded ones labelled `managed-by=kube-agents-seeded-fleet`.
- `seeded-fleet-reader@kube-agents-evals-16.iam.gserviceaccount.com` exists.
- Its IAM policy held **no bindings at all** before the fix — the gap, confirmed on this specific project rather than inferred.
- `roles/iam.serviceAccountTokenCreator` for `serviceAccount:prowjob-default-sa@kube-agents-prow.iam.gserviceaccount.com` then applied via `tofu apply` on `bench/tf/fleet` with that project's state backend.

**Pass condition:** the run reaches `hack/fleet-kubeconfigs.sh` and writes seven fixture roles with no `keeps the runner's own credential` warning. **Fail condition:** the warning appears, which would mean the binding is not sufficient and #1051's proposed fix is incomplete.

Result to be recorded here once the run completes.

## Self-Review

Reviewed for the two ways a pin goes wrong.

- **Can it merge by accident?** The title and the in-file banner both say DO NOT MERGE, but neither blocks Tide. Mitigation is that it needs `lgtm` plus an `OWNERS` approval, and the diff is one obvious line. Holding it with `/hold` as well is worth doing if it sits open.
- **Can it affect another pull request?** No. The pin is branch-local, `-16` is unregistered in Boskos, and the leased project is left idle rather than deployed to — the same behaviour `442cbf53` was observed to produce.
- **Would it survive a rebase unnoticed?** It is the only change on the branch, so a rebase cannot bury it under unrelated commits.
- **Does it need the docs passes?** No prose or generated region is touched; `make docs-check` has nothing to say about a one-line export. The adversarial pass was not run in a separate context for this one, on the grounds that the diff is a single unconditional assignment whose only failure mode is the one tested above. Flagging that rather than claiming a pass that did not happen.

Two things not covered: the run may fail on ledger scenarios if `BENCH_GITHUB_TOKEN` does not yet cover `gke-agentic/kube-agents-evals-16-infra`, which is unrelated to the fleet credential and lands after the step under test; and `shellcheck` is not installed locally, so only `bash -n` ran.

## Risk & Rollout

Confined to one branch and one unregistered project. Nothing on `main` changes, no other pull request's lease behaviour changes, and the revert is deleting the branch.

The standing risk is the pin merging, which would send every presubmit to `-16` and serialise the pool behind it. That is what the title, the banner comment, and this section exist to prevent.

---

Generated with the help of Claude Code.
