### PR TITLE
docs: add the two merge mechanics to the presubmit-gate section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,14 @@ welcome — otherwise keep working while the eval crew classifies it. One `/rete
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 
+Two merge mechanics follow (#1202). A plain `/override` (admins only) stamps the base SHA at
+override time, so the next merge to `main` re-triggers the job over your green context;
+`/override-sticky` survives base moves, and either is only for a red the eval crew classified
+as not the pull request's. An unresolved review thread blocks the merge silently: approved,
+green, and unmerged means check threads first, then the `err` field in
+[tide-history](https://oss.gprow.dev/tide-history) — mechanics and the measured incident in
+[how a change merges](docs/pull-request-workflow.md#how-a-change-merges).
+
 ## Automated Review After Opening a Pull Request
 
 Every pull request here is reviewed automatically by `kube-agents-bot`, a GitHub App that runs a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,8 +370,8 @@ welcome — otherwise keep working while the eval crew classifies it. One `/rete
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 
-Two merge mechanics follow (#1202). A plain `/override` (admins only) stamps the base SHA at
-override time, so the next merge to `main` re-triggers the job over your green context;
+Two merge mechanics follow (#1202). A plain `/override` (admins only) expires with the next
+merge to `main` — Tide re-triggers the job over your green context;
 `/override-sticky` survives base moves, and either is only for a red the eval crew classified
 as not the pull request's. An unresolved review thread blocks the merge silently: approved,
 green, and unmerged means check threads first, then the `err` field in

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -291,7 +291,10 @@ waiting on it.
 
 `/hold` parks an otherwise-mergeable pull request without withdrawing anything else, and
 `/hold cancel` releases it — #1045 held that way for a smoke test. `/override <context>`, which only
-a repository admin can use, forces a required check that cannot pass on its own.
+a repository admin can use, forces a required check that cannot pass on its own — and expires: the
+forced status embeds the base SHA at override time, so the next merge to `main` invalidates it and
+Tide re-runs the job. `/override-sticky` writes the `[prow:skip-retest]` sentinel instead, which
+Tide accepts regardless of base, so it survives `main` moving (#1202).
 
 **Branch protection is not the gate and reads as though there is none.** `main` requires ten
 contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`,
@@ -320,7 +323,11 @@ reach for.** Every open pull request reads `BLOCKED` or `DIRTY` and none ever re
 `main` restricts pushes to the `google-oss-prow` app and GitHub scores that restriction as a block
 on the querying user. #1065 read `BLOCKED` while carrying both labels and while `tide` reported
 `In merge pool.` Ask Tide instead — its status on the head commit states its own reason — and
-[oss.gprow.dev/tide](https://oss.gprow.dev/tide) shows the queue.
+[oss.gprow.dev/tide](https://oss.gprow.dev/tide) shows the queue. One reason the status omits: a
+merge attempt that failed — an unresolved review thread, most often — is retried every ~85
+seconds and recorded only in the `err` field of
+[tide-history](https://oss.gprow.dev/tide-history); #1122 sat approved for 5h46m and 231
+attempts that way.
 
 ```bash
 # Why Tide has not merged it: its own reason first, then the labels it wants.


### PR DESCRIPTION
## Summary

The #1202 merge-timeline investigation surfaced two operational rules that cost hours when learned live: a plain `/override` stamps the base SHA at override time and is invalidated by the next merge to `main` (Tide re-runs the job over the overridden green context — `/override-sticky`'s `[prow:skip-retest]` sentinel is what survives base moves), and an unresolved review thread blocks a merge with no visible reason (Tide retries every ~85 seconds and records why only in tide-history's `err` field). This PR writes both down: the rules in AGENTS.md's behavioural-presubmit-gate section, the mechanics and the measured incident in `docs/pull-request-workflow.md`'s canonical "How a change merges" section.

## Why This Change

Both mechanics were rediscovered the expensive way during the post-gate merge crunch: several PRs needed a second override after `main` moved, and #1122 sat fully approved and green for 5h46m through 231 silent merge attempts over two unresolved threads. Nothing in the repo documented either. Without this change the next contributor hits the same walls; documenting them is step 1 of #1202's recommendation ("document `/override-sticky` and the resolve-your-threads rule in the gate section of AGENTS.md").

## What Changed

- `AGENTS.md`, "The behavioural presubmit gate": one new paragraph stating the two rules — override expiry (`/override-sticky` survives; either form only for a red the eval crew classified as not the PR's) and the silent thread block, with the check-threads-then-tide-history diagnostic — pointing at the workflow doc for the mechanics. Net +414 chars against the always-loaded context budget (0.3k headroom remains, better than the naive version).
- `docs/pull-request-workflow.md`, "How a change merges": the existing `/override` sentence gains the expiry mechanism and `/override-sticky`'s sentinel (this page is canonical for merge mechanics, so the detail lives here); the ask-Tide paragraph gains the tide-history `err` pointer with the #1122 numbers, since the head-commit `tide` status omits exactly this class of blocker.

## Context

- gke-labs/kube-agents#1202 — the merge-throughput issue whose from-zero timeline analysis established both mechanics; this PR is item 1 of its "next steps" comment.
- GoogleCloudPlatform/oss-test-infra#2687 — the upstream Tide diagnosis (freshness rule, `prowJobsFromContexts` and the `[prow:skip-retest]` sentinel, batch mechanics).
- `/override-sticky` and the sentinel verified against upstream source: `kubernetes-sigs/prow` `pkg/plugins/override/override.go` (`/override-sticky` command) and `pkg/config/config.go` (`SkipRetestSentinel`).

Generated with the help of Claude Code (Fable 5).

## Testing

- `make docs-check` passes: generated regions, relative links (283 files), terminology, docs map, and the context budget (37.8k of 38,000 chars, 0.2k under).
- Prettier: not runnable on the authoring machine (no node toolchain). Risk is low — the repo uses prettier defaults (`proseWrap: preserve`), the edits are plain wrapped paragraphs with no tables or lists — and the `prettier` CI check gates it either way.

### Live validation

Not live-tested: docs-only — two Markdown files, no runtime code path, nothing for an installation to reconcile or a pod to pick up. `make docs-check` (above) is the full mechanical check for these files.

## Self-Review

Both passes ran in subagent contexts handed the diff range and nothing else (adversarial and docs-drift, one clean context each). Merged findings and dispositions:

- **Override/thread mechanics landed only in AGENTS.md while `docs/pull-request-workflow.md#how-a-change-merges` is the declared canonical home; duplication of the ~85s/5h46m numbers across both files; actors unnamed (admin-only, eval-crew classification)** (both passes; the adversarial pass graded the canonical/actor half Blocking) — fixed: the mechanism detail (base-SHA stamping, sentinel) and the incident numbers now live only in the workflow doc; AGENTS.md keeps the terse rules ("expires with the next merge to `main`"), names the actors ("admins only", "the eval crew classified"), and links the canonical section. The base-SHA clause initially survived in both files; the bot's strict pass caught the disposition overclaim and ee020f90 trimmed it from AGENTS.md.
- **Thread rule restates the existing "Leave no conversation unresolved" bullet** — partially fixed: the remedy sentence ("resolve as you address findings") was dropped as duplicate; the rule's one-line statement stays in the gate section deliberately, because that is where "approved, green, why is it not merging" confusion arises and where #1202 said to put it. The bullet keeps the requirement; the gate paragraph carries only the silence + diagnostic.
- **Context budget nearly exhausted (0.1k headroom as first drafted)** — fixed by the move above: the addition shrank from 717 to 443 chars; 0.2k headroom remains.
- **`/override-sticky` / `[prow:skip-retest]` unverifiable in-tree** — fixed by verification, not text: confirmed in `kubernetes-sigs/prow` source (override plugin and `SkipRetestSentinel`), cited under Context.
- **"The one reason the status omits" overclaims uniqueness from one incident** — fixed: now "One reason the status omits".
- **Nit: plain `/override` left with no stated use** — not fixed as such: the workflow doc now states both forms and their difference; which to post is the operator's call and prescribing it further is beyond what one incident window supports.

Angles checked clean: no contradictions elsewhere (site contributing guide, PR template, chatops, `.agents/rules/`); docs map needs no edit (no new file); link style and inline issue citations match house style; new lines wrap ≤ 100 chars.

## Risk & Rollout

Low risk: two Markdown files, no runtime code paths touched. Revert is a one-commit revert. The one operational hazard would be documenting a command that does not exist on this Prow deployment; `/override-sticky` is verified present in the upstream override plugin that oss-prow deploys, and #1202's investigation observed it working. Docs-only diffs skip the smoke presubmit by path filter, so this gates nothing behind a long job.
