### PR TITLE
fix(chat): append transition-announcing events atomically with the status change

### DIFF
--- a/admin_console/chat/service.py
+++ b/admin_console/chat/service.py
@@ -109,17 +109,14 @@ class ChatService:
         interaction = self.store.transition(
             interaction_id,
             frozenset({InteractionStatus.WAITING_FOR_APPROVAL}),
+            event="approval.resolved",
+            event_data={"choice": choice},
             status=InteractionStatus.RUNNING,
             approval=None,
         )
         if interaction is None:
             self._required(interaction_id)
             raise ValueError("interaction is not waiting for approval")
-        self.store.append_event(
-            interaction_id,
-            "approval.resolved",
-            {"choice": choice},
-        )
         self._control_executor.submit(self._send_approval, interaction_id, choice)
         return self._required(interaction_id)
 
@@ -127,13 +124,13 @@ class ChatService:
         updated = self.store.transition(
             interaction_id,
             NONTERMINAL_INTERACTION_STATUSES,
+            event="interaction.cancelled",
             status=InteractionStatus.CANCELLED,
             error="Interaction cancelled by the caller.",
             approval=None,
         )
         if updated is None:
             return self._required(interaction_id)
-        self.store.append_event(interaction_id, "interaction.cancelled")
         if updated.root_run_id:
             try:
                 self._backend_factory().stop(
@@ -172,11 +169,11 @@ class ChatService:
         started = self.store.transition(
             interaction_id,
             frozenset({InteractionStatus.QUEUED}),
+            event="interaction.started",
             status=InteractionStatus.RUNNING,
         )
         if started is None:
             return
-        self.store.append_event(interaction_id, "interaction.started")
         try:
             result = self._backend_factory().run(
                 interaction.agent_id,
@@ -248,17 +245,13 @@ class ChatService:
             updated = self.store.transition(
                 interaction_id,
                 frozenset({InteractionStatus.RUNNING}),
+                event="approval.requested",
+                event_data=result.approval or {},
                 **changes,
                 status=InteractionStatus.WAITING_FOR_APPROVAL,
                 approval=result.approval or {},
             )
-            if updated is not None:
-                self.store.append_event(
-                    interaction_id,
-                    "approval.requested",
-                    result.approval or {},
-                )
-            else:
+            if updated is None:
                 self._stop_cancelled_result(interaction_id, result.run_id)
 
     def _stop_cancelled_result(self, interaction_id: str, run_id: str) -> None:
@@ -299,9 +292,11 @@ class ChatService:
                 if result.status == "cancelled"
                 else InteractionStatus.FAILED
             )
-            updated = self.store.transition(
+            self.store.transition(
                 interaction_id,
                 NONTERMINAL_INTERACTION_STATUSES,
+                event=f"interaction.{status.value}",
+                event_data={"error": error},
                 **changes,
                 status=status,
                 output=result.output,
@@ -310,28 +305,19 @@ class ChatService:
                     "Inspect the root run and gateway logs before retrying.",
                 ),
             )
-            if updated is not None:
-                self.store.append_event(
-                    interaction_id,
-                    f"interaction.{status.value}",
-                    {"error": error},
-                )
             return
 
         updated = self.store.transition(
             interaction_id,
             frozenset({InteractionStatus.RUNNING}),
+            event="root.completed",
+            event_data={"output": result.output},
             **changes,
             status=InteractionStatus.WAITING_FOR_TASKS,
             output=result.output,
         )
         if updated is None:
             return
-        self.store.append_event(
-            interaction_id,
-            "root.completed",
-            {"output": result.output},
-        )
         self._settle_tasks(interaction_id)
 
     def _settle_tasks(self, interaction_id: str) -> None:
@@ -395,43 +381,37 @@ class ChatService:
                         f"{task.task_id}: {task.error or task.status}"
                         for task in failed
                     )
-                    updated = self.store.transition(
+                    self.store.transition(
                         interaction_id,
                         frozenset({InteractionStatus.WAITING_FOR_TASKS}),
+                        event="interaction.failed",
+                        event_data={"error": detail},
                         status=InteractionStatus.FAILED,
                         error=f"Delegated work failed: {detail}",
                         diagnostics=(
                             "Open Task Kanban for the failed task and inspect its latest run.",
                         ),
                     )
-                    if updated is not None:
-                        self.store.append_event(
-                            interaction_id,
-                            "interaction.failed",
-                            {"error": detail},
-                        )
                 else:
-                    updated = self.store.transition(
+                    self.store.transition(
                         interaction_id,
                         frozenset({InteractionStatus.WAITING_FOR_TASKS}),
+                        event="interaction.completed",
                         status=InteractionStatus.COMPLETED,
                     )
-                    if updated is not None:
-                        self.store.append_event(interaction_id, "interaction.completed")
                 return
             time.sleep(self._poll_interval)
 
-        updated = self.store.transition(
+        self.store.transition(
             interaction_id,
             frozenset({InteractionStatus.WAITING_FOR_TASKS}),
+            event="interaction.timed_out",
             status=InteractionStatus.TIMED_OUT,
             error="Delegated work did not reach a terminal state before the deadline.",
             diagnostics=(
                 "Inspect active tasks in Task Kanban, then retry with a longer evaluator timeout.",
             ),
         )
-        if updated is not None:
-            self.store.append_event(interaction_id, "interaction.timed_out")
 
     @staticmethod
     def _project_tasks(result: TaskUpdateResult) -> tuple[TaskProjection, ...]:
@@ -489,19 +469,15 @@ class ChatService:
             return
         guidance = str(getattr(exc, "guidance", "") or diagnostic)
         message = str(exc) or type(exc).__name__
-        updated = self.store.transition(
+        self.store.transition(
             interaction_id,
             NONTERMINAL_INTERACTION_STATUSES,
+            event="interaction.failed",
+            event_data={"error": message},
             status=InteractionStatus.FAILED,
             error=message,
             diagnostics=(guidance,),
         )
-        if updated is not None:
-            self.store.append_event(
-                interaction_id,
-                "interaction.failed",
-                {"error": message},
-            )
 
     def _required(self, interaction_id: str) -> Interaction:
         interaction = self.store.get(interaction_id)

--- a/admin_console/chat/store.py
+++ b/admin_console/chat/store.py
@@ -36,6 +36,9 @@ class InteractionStoreProtocol(Protocol):
         self,
         interaction_id: str,
         expected: frozenset[InteractionStatus],
+        *,
+        event: str | None = None,
+        event_data: dict | None = None,
         **changes,
     ) -> Interaction | None: ...
 
@@ -100,9 +103,17 @@ class InteractionStore:
         self,
         interaction_id: str,
         expected: frozenset[InteractionStatus],
+        *,
+        event: str | None = None,
+        event_data: dict | None = None,
         **changes,
     ) -> Interaction | None:
-        """Apply a state change only when the current status is expected."""
+        """Apply a state change only when the current status is expected.
+
+        ``event`` is appended in the same critical section as the status
+        change: a waiter woken by the new status can never read the event
+        stream from before the event that announces it (#1210).
+        """
         with self._condition:
             current = self._interactions.get(interaction_id)
             if current is None:
@@ -111,8 +122,21 @@ class InteractionStore:
                 return None
             updated = replace(current, updated_at=utc_now(), **changes)
             self._interactions[interaction_id] = updated
+            if event is not None:
+                self._append_event_locked(interaction_id, event, event_data)
             self._condition.notify_all()
             return updated
+
+    def _append_event_locked(
+        self,
+        interaction_id: str,
+        event: str,
+        data: dict | None,
+    ) -> InteractionEvent:
+        events = self._events[interaction_id]
+        item = InteractionEvent(len(events) + 1, event, utc_now(), data or {})
+        events.append(item)
+        return item
 
     def append_event(
         self,
@@ -123,9 +147,7 @@ class InteractionStore:
         with self._condition:
             if interaction_id not in self._interactions:
                 raise KeyError(interaction_id)
-            events = self._events[interaction_id]
-            item = InteractionEvent(len(events) + 1, event, utc_now(), data or {})
-            events.append(item)
+            item = self._append_event_locked(interaction_id, event, data)
             self._condition.notify_all()
             return item
 
@@ -384,9 +406,18 @@ class SQLiteInteractionStore:
         self,
         interaction_id: str,
         expected: frozenset[InteractionStatus],
+        *,
+        event: str | None = None,
+        event_data: dict | None = None,
         **changes,
     ) -> Interaction | None:
-        """Apply a state change only when the current status is expected."""
+        """Apply a state change only when the current status is expected.
+
+        ``event`` is written on the same connection, inside the same lock,
+        as the status change: a waiter woken by the new status can never
+        read the event stream from before the event that announces it
+        (#1210). The ``with connection`` context commits both or neither.
+        """
         with self._condition, self._connect() as connection:
             row = connection.execute(
                 "SELECT payload FROM interactions WHERE interaction_id = ?",
@@ -407,8 +438,37 @@ class SQLiteInteractionStore:
                     interaction_id,
                 ),
             )
+            if event is not None:
+                self._insert_event(connection, interaction_id, event, event_data)
             self._notify(interaction_id)
             return updated
+
+    @staticmethod
+    def _insert_event(
+        connection: sqlite3.Connection,
+        interaction_id: str,
+        event: str,
+        data: dict | None,
+    ) -> InteractionEvent:
+        row = connection.execute(
+            "SELECT COALESCE(MAX(sequence), 0) FROM interaction_events "
+            "WHERE interaction_id = ?",
+            (interaction_id,),
+        ).fetchone()
+        item = InteractionEvent(int(row[0]) + 1, event, utc_now(), data or {})
+        connection.execute(
+            "INSERT INTO interaction_events "
+            "(interaction_id, sequence, event, occurred_at, data) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                interaction_id,
+                item.sequence,
+                item.event,
+                item.occurred_at.isoformat(),
+                json.dumps(item.data, separators=(",", ":"), sort_keys=True),
+            ),
+        )
+        return item
 
     def append_event(
         self,
@@ -423,24 +483,7 @@ class SQLiteInteractionStore:
             ).fetchone()
             if exists is None:
                 raise KeyError(interaction_id)
-            row = connection.execute(
-                "SELECT COALESCE(MAX(sequence), 0) FROM interaction_events "
-                "WHERE interaction_id = ?",
-                (interaction_id,),
-            ).fetchone()
-            item = InteractionEvent(int(row[0]) + 1, event, utc_now(), data or {})
-            connection.execute(
-                "INSERT INTO interaction_events "
-                "(interaction_id, sequence, event, occurred_at, data) "
-                "VALUES (?, ?, ?, ?, ?)",
-                (
-                    interaction_id,
-                    item.sequence,
-                    item.event,
-                    item.occurred_at.isoformat(),
-                    json.dumps(item.data, separators=(",", ":"), sort_keys=True),
-                ),
-            )
+            item = self._insert_event(connection, interaction_id, event, data)
             self._notify(interaction_id)
             return item
 
@@ -504,8 +547,15 @@ class SQLiteInteractionStore:
             interaction = _decode_interaction(raw)
             if interaction.terminal:
                 continue
-            self.update(
+            # transition(event=...) rather than update-then-append: the same
+            # atomicity the live paths guarantee — a terminal status is never
+            # durable without the event announcing it, even if the process
+            # dies again mid-recovery.
+            updated = self.transition(
                 interaction_id,
+                frozenset({interaction.status}),
+                event="interaction.recovery_failed",
+                event_data={"previousStatus": interaction.status.value},
                 status=InteractionStatus.FAILED,
                 error="The portal API restarted before this interaction completed.",
                 diagnostics=(
@@ -514,12 +564,8 @@ class SQLiteInteractionStore:
                 ),
                 approval=None,
             )
-            self.append_event(
-                interaction_id,
-                "interaction.recovery_failed",
-                {"previousStatus": interaction.status.value},
-            )
-            recovered += 1
+            if updated is not None:
+                recovered += 1
         return recovered
 
     def prune(self, *, retention_days: int = 7, maximum: int = 1_000) -> int:

--- a/admin_console/tests/test_interaction_api.py
+++ b/admin_console/tests/test_interaction_api.py
@@ -78,7 +78,7 @@ class ScriptedBackend:
         self.prompts.append(kwargs["prompt"])
         if self.root.status == "waiting_for_approval":
             kwargs["on_update"](self.root)
-            self.approval_resolved.wait(timeout=2)
+            self.approval_resolved.wait(timeout=15)
             return ChatRunResult(
                 run_id=self.root.run_id,
                 session_id=self.root.session_id,
@@ -117,7 +117,7 @@ class BlockingBackend(ScriptedBackend):
     def run(self, *args, **kwargs) -> ChatRunResult:
         self.run_calls += 1
         self.started.set()
-        self.release.wait(timeout=2)
+        self.release.wait(timeout=15)
         return self.root
 
 
@@ -137,7 +137,7 @@ class CancellableBackend(ScriptedBackend):
             )
         )
         self.started.set()
-        self.stopped.wait(timeout=2)
+        self.stopped.wait(timeout=15)
         return ChatRunResult(
             run_id=self.root.run_id,
             session_id=self.root.session_id,
@@ -190,20 +190,36 @@ class InteractionApiTest(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
         return response.json()["interactionId"]
 
+    # Ceiling, not a floor: condition waits return the moment the condition
+    # holds, so a generous value costs healthy runs nothing and only bounds a
+    # genuinely hung test. Never assert on elapsed time.
+    WAIT_CEILING_SECONDS = 15.0
+
+    def wait_until(self, condition, message: str, timeout: float | None = None):
+        """Poll until condition() is truthy and return its value; fail loudly
+        on timeout instead of falling through to a misleading assertion."""
+        deadline = time.monotonic() + (timeout or self.WAIT_CEILING_SECONDS)
+        while time.monotonic() < deadline:
+            value = condition()
+            if value:
+                return value
+            time.sleep(0.005)
+        self.fail(message)
+
     def wait_for_terminal(
         self,
         client: TestClient,
         interaction_id: str,
     ) -> dict:
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline:
+        def terminal_payload():
             payload = client.get(
                 f"/api/v1/interactions/{interaction_id}"
             ).json()
-            if payload["terminal"]:
-                return payload
-            time.sleep(0.005)
-        self.fail("interaction did not become terminal")
+            return payload if payload["terminal"] else None
+
+        return self.wait_until(
+            terminal_payload, "interaction did not become terminal"
+        )
 
     def test_completed_root_is_not_terminal_until_delegated_work_settles(self):
         backend = ScriptedBackend(
@@ -275,13 +291,17 @@ class InteractionApiTest(unittest.TestCase):
             max_workers=1,
         )
         first = service.start(agent_id="platform-agent", input_text="first")
-        self.assertTrue(backend.started.wait(timeout=1))
+        self.assertTrue(backend.started.wait(timeout=15))
         second = service.start(agent_id="platform-agent", input_text="second")
 
         cancelled = service.cancel(second.interaction_id)
         backend.release.set()
-        service.wait(first.interaction_id, timeout=2)
-        time.sleep(0.05)
+        service.wait(first.interaction_id, timeout=15)
+        # The root executor is a single FIFO worker here, so a sentinel
+        # submitted now completes only after the cancelled interaction's
+        # _run_root turn already ran — after this line, an absent
+        # "interaction.started" is absent forever, not merely not-yet.
+        service._executor.submit(lambda: None).result(timeout=15)
 
         self.assertEqual(cancelled.status, InteractionStatus.CANCELLED)
         self.assertEqual(service.get(second.interaction_id).status, InteractionStatus.CANCELLED)
@@ -293,10 +313,10 @@ class InteractionApiTest(unittest.TestCase):
         backend = CancellableBackend()
         service = ChatService(lambda: backend, poll_interval=0.001, task_timeout=1)
         interaction = service.start(agent_id="platform-agent", input_text="long run")
-        self.assertTrue(backend.started.wait(timeout=1))
+        self.assertTrue(backend.started.wait(timeout=15))
 
         cancelled = service.cancel(interaction.interaction_id)
-        final = service.wait(interaction.interaction_id, timeout=2)
+        final = service.wait(interaction.interaction_id, timeout=15)
 
         self.assertEqual(cancelled.status, InteractionStatus.CANCELLED)
         self.assertEqual(cancelled.root_run_id, backend.root.run_id)
@@ -415,15 +435,18 @@ class InteractionApiTest(unittest.TestCase):
         )
         client, _ = client_for(backend, max_workers=1)
         interaction_id = self.start(client)
-        deadline = time.monotonic() + 2
-        waiting = {}
-        while time.monotonic() < deadline:
-            waiting = client.get(
-                f"/api/v1/interactions/{interaction_id}"
-            ).json()
-            if waiting["status"] == "waiting_for_approval":
-                break
-            time.sleep(0.005)
+        waiting = self.wait_until(
+            lambda: (
+                payload
+                if (
+                    payload := client.get(
+                        f"/api/v1/interactions/{interaction_id}"
+                    ).json()
+                )["status"] == "waiting_for_approval"
+                else None
+            ),
+            "interaction never reached waiting_for_approval",
+        )
         self.assertEqual(waiting["approval"]["tool"], "kubectl")
 
         response = client.post(
@@ -461,12 +484,13 @@ class InteractionApiTest(unittest.TestCase):
         backend.run = run_with_completion
         client, _ = client_for(backend)
         interaction_id = self.start(client)
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline:
-            waiting = client.get(f"/api/v1/interactions/{interaction_id}").json()
-            if waiting["status"] == "waiting_for_approval":
-                break
-            time.sleep(0.005)
+        self.wait_until(
+            lambda: client.get(f"/api/v1/interactions/{interaction_id}").json()[
+                "status"
+            ]
+            == "waiting_for_approval",
+            "interaction never reached waiting_for_approval",
+        )
 
         response = client.post(
             f"/api/v1/interactions/{interaction_id}/approval",
@@ -491,11 +515,11 @@ class InteractionApiTest(unittest.TestCase):
         )
         client, service = client_for(backend)
         interaction_id = self.start(client)
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline:
-            if service.get(interaction_id).status == InteractionStatus.WAITING_FOR_APPROVAL:
-                break
-            time.sleep(0.005)
+        self.wait_until(
+            lambda: service.get(interaction_id).status
+            == InteractionStatus.WAITING_FOR_APPROVAL,
+            "interaction never reached waiting_for_approval",
+        )
 
         def approve_once() -> bool:
             try:
@@ -506,7 +530,7 @@ class InteractionApiTest(unittest.TestCase):
 
         with ThreadPoolExecutor(max_workers=16) as executor:
             accepted = list(executor.map(lambda _: approve_once(), range(16)))
-        result = service.wait(interaction_id, timeout=2)
+        result = service.wait(interaction_id, timeout=15)
 
         self.assertEqual(sum(accepted), 1)
         self.assertEqual(backend.approvals, ["once"])
@@ -765,7 +789,7 @@ class InteractionApiTest(unittest.TestCase):
                 agent_id="platform-agent",
                 input_text="Is the cluster healthy?",
             )
-            completed = service.wait(interaction.interaction_id, timeout=2)
+            completed = service.wait(interaction.interaction_id, timeout=15)
             self.assertEqual(completed.status, InteractionStatus.COMPLETED)
 
             reopened = SQLiteInteractionStore(path)
@@ -776,6 +800,89 @@ class InteractionApiTest(unittest.TestCase):
             self.assertEqual(persisted.tool_calls[0].name, "kanban_create")
             self.assertEqual(events[-1].event, "interaction.completed")
             self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
+    def test_terminal_event_is_atomic_with_the_terminal_status(self):
+        """#1210: a waiter woken by terminal status must see the terminal
+        event, which holds only when the event is appended inside
+        transition(). Data-flow, not timing: the store records every event
+        routed through the non-atomic append_event API, and the terminal
+        event must never be among them — a revert to the old
+        transition-then-append pattern fails this on any machine, loaded or
+        not, with no sleeps to miss the window."""
+
+        class RecordingStore(SQLiteInteractionStore):
+            appended: list[str] = []
+
+            def append_event(self, interaction_id, event, data=None):
+                RecordingStore.appended.append(event)
+                return super().append_event(interaction_id, event, data)
+
+        RecordingStore.appended.clear()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "interactions.db"
+            service = ChatService(
+                lambda: ScriptedBackend(),
+                store=RecordingStore(path),
+                poll_interval=0.001,
+                quiet_polls=2,
+                task_timeout=1,
+            )
+            interaction = service.start(
+                agent_id="platform-agent",
+                input_text="Is the cluster healthy?",
+            )
+            completed = service.wait(interaction.interaction_id, timeout=15)
+            self.assertEqual(completed.status, InteractionStatus.COMPLETED)
+            # The moment wait() returns, the event is already durable — even
+            # through a fresh connection to the same file.
+            events = SQLiteInteractionStore(path).events_after(
+                interaction.interaction_id
+            )
+            self.assertEqual(events[-1].event, "interaction.completed")
+            self.assertNotIn(
+                "interaction.completed",
+                RecordingStore.appended,
+                "terminal event must travel inside transition(), not through"
+                " the non-atomic append_event API",
+            )
+
+    def test_transition_event_appends_atomically_or_not_at_all(self):
+        """transition(event=...) appends exactly when the transition applies:
+        a refused transition (wrong expected status) must leave no event."""
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "interactions.db"
+            store = SQLiteInteractionStore(path)
+            now = datetime.now(UTC)
+            interaction = Interaction(
+                interaction_id="ix_atomic",
+                agent_id="platform-agent",
+                profile="default",
+                session_id="portal_atomic",
+                input_text="Inspect the cluster",
+                status=InteractionStatus.WAITING_FOR_TASKS,
+                created_at=now,
+                updated_at=now,
+            )
+            store.create(interaction)
+            refused = store.transition(
+                "ix_atomic",
+                frozenset({InteractionStatus.RUNNING}),  # actual status differs
+                event="interaction.completed",
+                status=InteractionStatus.COMPLETED,
+            )
+            self.assertIsNone(refused)
+            self.assertEqual(store.events_after("ix_atomic"), ())
+            applied = store.transition(
+                "ix_atomic",
+                frozenset({interaction.status}),
+                event="interaction.completed",
+                event_data={"why": "atomic"},
+                status=InteractionStatus.COMPLETED,
+            )
+            self.assertIsNotNone(applied)
+            events = store.events_after("ix_atomic")
+            self.assertEqual(events[-1].event, "interaction.completed")
+            self.assertEqual(events[-1].data, {"why": "atomic"})
 
     def test_sqlite_store_ignores_additive_fields_from_another_version(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -845,7 +952,7 @@ class InteractionApiTest(unittest.TestCase):
                 agent_id="platform-agent",
                 input_text=secret_prompt,
             )
-            completed = service.wait(interaction.interaction_id, timeout=2)
+            completed = service.wait(interaction.interaction_id, timeout=15)
             persisted = store.get(interaction.interaction_id)
 
         self.assertEqual(backend.prompts, [secret_prompt])


### PR DESCRIPTION
## Summary

`store.transition()` gains optional `event`/`event_data`, appended inside the same critical section as the status change — the same lock for the in-memory store; the same lock, connection, and commit for SQLite — so a transition and the event announcing it are one atomic unit, and a refused transition appends nothing. All ten transition-then-append pairs in `ChatService` (and the restart-recovery path in the store) fold into it, and the test file's own scheduling dependencies are removed.

## Why This Change

`test_sqlite_store_preserves_terminal_interaction_and_events` flaked in CI (#1210): `service.wait()` returns the instant the interaction row turns terminal, but the event announcing the transition was written by a *second, separate* store call — so a reader waking on the status could see the event stream from before `interaction.completed` existed. The flake was the symptom; the bug is a durable half-done state observable by any consumer, on every run, on every machine — CI's loaded schedulers were merely the first to catch the worker thread inside the gap. Reproduced deterministically before fixing: stalling `append_event` by 50ms made `wait()` return COMPLETED with the last persisted event still `tasks.observed`, the verbatim CI failure.

## What Changed

- `admin_console/chat/store.py`: `transition(event=..., event_data=...)` on the protocol and both implementations; the append happens inside the existing critical section (memory) / the same transaction (SQLite — the `with connection` context commits status UPDATE and event INSERT together or neither). `recover_incomplete` uses it too, so a terminal status is never durable without its announcing event even across a crash mid-recovery.
- `admin_console/chat/service.py`: all ten transition-then-append sites fold into the atomic form — terminal (`interaction.started`→RUNNING gate, `completed`, `failed`×3, `cancelled`×2, `timed_out`) and the mid-flight pairs whose status/event gap the HTTP API exposed to pollers (`approval.requested`, `approval.resolved`, `root.completed`). Behavior is otherwise identical: every old site appended iff the transition applied, which is exactly the new predicate.
- `admin_console/tests/test_interaction_api.py`: two regression tests — the terminal event must never travel through the non-atomic `append_event` API (pure data flow; fails deterministically on the pre-fix code on any machine), and `transition(event=...)` appends exactly when the transition applies, including the refused case. The suite's own chance-dependence is removed: the pre-cancel test's absence assertion now follows a single-worker-executor sentinel (a real happens-after edge) instead of `time.sleep(0.05)`; three silent fall-through poll loops now use a `wait_until` helper that fails loudly on timeout; all wait ceilings are a generous 15s, which costs healthy runs nothing because condition waits return on the condition.

## Context

Closes #1210. The issue's root-cause analysis was verified correct by execution, and its proposed fix (1) — append atomically as part of `store.transition()` — is what this implements; option (1b) (append before transition) was rejected because it inverts the observable ordering for event-stream consumers, and option (2) (make `wait()` await the event) couples the waiter to event naming.

## Testing

- Full `admin_console` suite: 187 passed + 24 subtests, and the interaction file passed 6 consecutive stress runs.
- Negative control, verified twice (by me and independently by the adversarial review pass): with `origin/main`'s `service.py`/`store.py` and this branch's tests, the atomicity regression test fails on exactly the intended assertion — data flow, not timing.
- The suite no longer contains `time.sleep`-then-assert patterns, silent poll-loop fall-throughs, or sub-2s handshake ceilings.

### Live validation

Not live-tested against a running installation: the change is internal to the admin-console portal service (an in-process race between a worker thread's two writes and a waiter's read), with no operator, agent-pod, or cluster surface to observe — the layer the change claims to touch is the store's write path, which the deterministic regression tests exercise directly, including durability through a fresh SQLite connection the moment `wait()` returns.

## Self-Review

Both passes ran in clean subagent contexts handed the diff range, not the authoring conversation.

Adversarial pass — dispositions:
- **Fixed:** `recover_incomplete` still wrote a terminal status non-atomically (update-then-append), contradicting the invariant the new docstring states categorically; folded into `transition(event=...)` expecting the just-observed status.
- **Fixed (cosmetic):** one regression test used `timeout=5` beside the class's 15s ceiling; unified.
- Verified clean by the pass, by execution where it mattered: no deadlock (both stores' Conditions are RLock-backed and the new in-lock paths acquire nothing); SQLite notify-before-commit is safe because the lock is released only after the transaction commits; sequence numbering correct in both stores; all ten call-site folds preserve observable behavior one-for-one; the `**changes`-capturing-`event` hazard is unreachable (no dynamic-key callers exist); the executor-sentinel happens-after argument holds (`_executor` runs only `_run_root`, approvals go to a separate control executor, `_settle_tasks` runs inline); red-then-green confirmed against origin/main.
- Reported, left alone: `start()`'s create+`interaction.queued` and `_settle_tasks`'s update+`tasks.observed` remain two-step, but they announce non-terminal states that no waiter gates on — converting them would widen the diff without closing an observable gap.

Docs-drift pass — no findings: no doc describes the old two-call shape, the new docstring claims were verified true against both implementations (including commit-both-or-neither), no Markdown added so no docs-map entry owed, `make docs-check` green. One pre-existing target-vs-current event-vocabulary gap in `docs/designs/admin-console.md` predates this PR and is explicitly out of its scope.

## Risk & Rollout

Small blast radius: two files in the admin console plus their tests; the store protocol change is additive with defaults, and no implementation outside this package exists. The one behavioral delta beyond atomicity is intentional — event-stream consumers can no longer observe a status without its announcing event. Revert is a single commit revert with no data migration; existing SQLite files are untouched (no schema change).

---
Generated with the help of Claude (Fable 5).
