### PR TITLE
ci: keep a green smoke-test result valid when main moves

### DIFF
--- a/.agents/rules/github_actions.md
+++ b/.agents/rules/github_actions.md
@@ -14,7 +14,7 @@ the comment together.
 ## Guard automatically-triggered credentialed workflows against forks
 
 A workflow that needs this repository's secrets and starts on its own — `push`, a tag, `schedule`,
-or `workflow_run` — carries `if: github.repository == 'gke-labs/kube-agents'` on every job. A fork
+`status`, or `workflow_run` — carries `if: github.repository == 'gke-labs/kube-agents'` on every job. A fork
 inherits those triggers but none of the secrets, so an unguarded job fails there on every sync and
 mails the fork owner. Put the guard on each job rather than trusting the skip to cascade through
 `needs`; an `always()` added later removes the implicit `success()` and the job runs anyway.

--- a/.github/workflows/smoke-test-sticky.yml
+++ b/.github/workflows/smoke-test-sticky.yml
@@ -1,0 +1,90 @@
+name: Smoke Test Sticky Status
+
+# Keep a green `pull-kube-agents-smoke-test` result valid when `main` moves.
+#
+# Tide credits a presubmit only against the base SHA it ran on, which crier
+# records as a `BaseSHA:<sha>` suffix on the commit status. Every merge to
+# `main` therefore turns every other pull request's green smoke run stale, and
+# the 1.5-3.5h job runs again for a pull request whose head has not changed
+# (#1179, #1202). `scripts/pin_smoke_status.py` re-pins that suffix to the new
+# head of `main` -- for every open pull request on each push to `main`, and for
+# one commit when its green arrives after `main` has already moved -- so a pull
+# request green at its own head merges without a fresh-base retest. What that
+# gives up is testing the combination with the `main` it lands on before the
+# merge; until a scheduled eval run on `main` exists, a bad combination is
+# found by the next pull request's run. docs/pull-request-workflow.md "How a
+# change merges" owns that statement; the script's docstring says why this is
+# a BaseSHA pin and not Prow's `[prow:skip-retest]` sentinel, and when to swap.
+#
+# What it does NOT change: a push creates a new head with no status, so the
+# job runs as before; `/test pull-kube-agents-smoke-test` on the same head
+# posts `pending`, which is newer and wins (`/retest` does not -- it reruns
+# only failed contexts); a red is never touched, and neither is an admin
+# `/override`.
+#
+# It races Tide's sync loop: a sync that sees the stale statuses before the
+# sweep has re-pinned them starts the retest, and crier's `pending` then wins.
+# So the job carries nothing it does not need -- the runner's own python3 runs
+# a stdlib-only script -- and has no concurrency group: GitHub keeps one
+# pending run per group and cancels the older one, which would drop a pin,
+# while two runs pinning the same commit to the same head are harmless.
+#
+# A status created with GITHUB_TOKEN does not fire `status` again, so the
+# re-post cannot loop; a push to `main` is only ever Tide's merge.
+
+on:
+  status:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  pin:
+    name: Pin green smoke-test statuses to the head of main
+    # The repository guard is required of any credentialed workflow that starts
+    # on its own (AGENTS.md, Pull Request Hygiene). A push to main always
+    # sweeps; a status event qualifies only when it is the smoke test, green,
+    # and not an admin override -- the script checks the same things again and
+    # is the reference, this expression is what keeps the other statuses off a
+    # runner.
+    if: >-
+      github.repository == 'gke-labs/kube-agents' &&
+      (github.event_name == 'push' ||
+        (github.event.context == 'pull-kube-agents-smoke-test' &&
+          github.event.state == 'success' &&
+          !startsWith(github.event.description, 'Overridden by')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the default branch: the script
+      statuses: write # re-post the smoke-test status on pull request heads
+    steps:
+      # The default branch, never a pull request head: this job holds a
+      # writable token and must not run code from a fork.
+      - name: Checkout the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Nothing from the event is needed, not even GITHUB_SHA: two merges
+      # seconds apart start two sweeps with no ordering between them, so the
+      # script reads the head of main just before each write rather than
+      # pinning to the head this run started with.
+      - name: Re-pin every open pull request after the merge
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/pin_smoke_status.py sweep
+
+      # Event fields go in through the environment, never into the script
+      # text: the description is free text written by another app. The script
+      # resolves the head of main itself and re-posts only if this status is
+      # still the latest on its context.
+      - name: Re-pin this commit's green if main has already moved
+        if: github.event_name == 'status'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATUS_ID: ${{ github.event.id }}
+          SHA: ${{ github.event.sha }}
+        run: python3 scripts/pin_smoke_status.py status --sha "$SHA" --status-id "$STATUS_ID"

--- a/.github/workflows/smoke-test-sticky.yml
+++ b/.github/workflows/smoke-test-sticky.yml
@@ -12,7 +12,8 @@ name: Smoke Test Sticky Status
 # request green at its own head merges without a fresh-base retest. What that
 # gives up is testing the combination with the `main` it lands on before the
 # merge; until a scheduled eval run on `main` exists, a bad combination is
-# found by the next pull request's run. docs/pull-request-workflow.md "How a
+# found by the next smoke run that actually starts after it, on whichever pull
+# request that is. docs/pull-request-workflow.md "How a
 # change merges" owns that statement; the script's docstring says why this is
 # a BaseSHA pin and not Prow's `[prow:skip-retest]` sentinel, and when to swap.
 #
@@ -27,7 +28,10 @@ name: Smoke Test Sticky Status
 # So the job carries nothing it does not need -- the runner's own python3 runs
 # a stdlib-only script -- and has no concurrency group: GitHub keeps one
 # pending run per group and cancels the older one, which would drop a pin,
-# while two runs pinning the same commit to the same head are harmless.
+# while two runs pinning the same commit to the same head are harmless. The
+# price is the Actions tab: every status event on the repository -- Tide's own
+# `tide` context on each sync, every CI context on every push -- starts a run
+# here that the `if:` skips, hundreds a day, free in minutes.
 #
 # A status created with GITHUB_TOKEN does not fire `status` again, so the
 # re-post cannot loop; a push to `main` is only ever Tide's merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,10 +350,9 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
 three repetitions each — and has been merge-blocking since 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677). It is slow — recent green runs took 1.5 to 3.5 hours
 against a 360-minute ceiling — and a new push restarts it, so open the pull request early and
-batch changes rather than stacking pushes. A merge elsewhere need not restart it: a green status
-is re-pinned to the new head of `main`, when that lands before Tide's next sync, so Tide keeps
-crediting it
-([`docs/pull-request-workflow.md`](docs/pull-request-workflow.md#how-a-change-merges)).
+batch changes rather than stacking pushes. A merge elsewhere usually does not: a green status is
+re-pinned to the new head of `main` so Tide keeps crediting it
+([how a change merges](docs/pull-request-workflow.md#how-a-change-merges)).
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
 of its repetitions — one failed repetition out of three does nothing on its own. Or any case,
@@ -373,10 +372,10 @@ welcome — otherwise keep working while the eval crew classifies it. One `/rete
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 
-Two merge mechanics follow (#1202). A plain `/override` (admins only) expires with the next
-merge to `main` — Tide re-triggers the job over your green context;
-`/override-sticky` survives base moves, and either is only for a red the eval crew classified
-as not the pull request's. An unresolved review thread blocks the merge silently: approved,
+Two merge mechanics follow (#1202). A plain `/override` (admins only) is only for a red the eval
+crew classified as not the pull request's, and it expires with the next merge to `main`, so repeat
+it if `main` moves first; `/override-sticky` is not in the Prow build this repository merges
+through and is silently ignored. An unresolved review thread blocks the merge silently: approved,
 green, and unmerged means check threads first, then the `err` field in
 [tide-history](https://oss.gprow.dev/tide-history) — mechanics and the measured incident in
 [how a change merges](docs/pull-request-workflow.md#how-a-change-merges).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,10 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
 three repetitions each — and has been merge-blocking since 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677). It is slow — recent green runs took 1.5 to 3.5 hours
 against a 360-minute ceiling — and a new push restarts it, so open the pull request early and
-batch changes rather than stacking pushes.
+batch changes rather than stacking pushes. A merge elsewhere need not restart it: a green status
+is re-pinned to the new head of `main`, when that lands before Tide's next sync, so Tide keeps
+crediting it
+([`docs/pull-request-workflow.md`](docs/pull-request-workflow.md#how-a-change-merges)).
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
 of its repetitions — one failed repetition out of three does nothing on its own. Or any case,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,8 +350,8 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
 three repetitions each — and has been merge-blocking since 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677). It is slow — recent green runs took 1.5 to 3.5 hours
 against a 360-minute ceiling — and a new push restarts it, so open the pull request early and
-batch changes rather than stacking pushes. A merge elsewhere usually does not: a green status is
-re-pinned to the new head of `main` so Tide keeps crediting it
+batch changes rather than stacking pushes. Another pull request merging usually does not: a green
+status is re-pinned to the new head of `main` so Tide keeps crediting it
 ([how a change merges](docs/pull-request-workflow.md#how-a-change-merges)).
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
@@ -372,12 +372,12 @@ welcome — otherwise keep working while the eval crew classifies it. One `/rete
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 
-Two merge mechanics follow (#1202). A plain `/override` (admins only) is only for a red the eval
-crew classified as not the pull request's, and it expires with the next merge to `main`, so repeat
-it if `main` moves first; `/override-sticky` is not in the Prow build this repository merges
-through and is silently ignored. An unresolved review thread blocks the merge silently: approved,
-green, and unmerged means check threads first, then the `err` field in
-[tide-history](https://oss.gprow.dev/tide-history) — mechanics and the measured incident in
+Two more mechanics (#1202). A plain `/override` (admins only) is only for a red the eval crew
+classified as not the pull request's, and it expires with the next merge to `main`, so repeat it if
+`main` moves first — the re-pin leaves an admin's override alone; `/override-sticky` is not in the
+Prow build this repository merges through and is silently ignored. An unresolved review thread
+blocks the merge silently: approved, green, and unmerged means check threads first, then the `err`
+field in [tide-history](https://oss.gprow.dev/tide-history) — detail in
 [how a change merges](docs/pull-request-workflow.md#how-a-change-merges).
 
 ## Automated Review After Opening a Pull Request

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -318,6 +318,26 @@ gh api repos/gke-labs/kube-agents/branches/main/protection \
   --jq '.required_status_checks.contexts'
 ```
 
+**A green smoke run stays valid when `main` moves — usually.** Tide credits a Prow presubmit only
+against the base SHA it ran on — crier records it as a `BaseSHA:<sha>` suffix on the commit status
+— so on its own every merge to `main` would invalidate every other pull request's green
+`pull-kube-agents-smoke-test` and re-run the whole job for a pull request whose head has not
+changed. [`smoke-test-sticky.yml`](../.github/workflows/smoke-test-sticky.yml) re-pins that suffix
+to the new head of `main` — for every open pull request against `main` on each push to `main`, and
+for one commit when its green arrives after `main` has already moved — with a note in the
+description saying so, and Tide reads the result as current. It is a race against Tide's roughly
+once-a-minute sync: when the sweep lands first, a pull request green at its own head merges without
+a fresh-base retest, one per sync once no batch is in flight; when Tide's sync lands first it
+starts the retest as before (a batch, when two or more qualify), crier's `pending` is then the
+newer status, and the sweep leaves it alone. A push still starts a fresh run;
+`/test pull-kube-agents-smoke-test` on the same head posts `pending`, which wins until that run
+reports (`/retest` does not, because it reruns only failed contexts); a red is never touched, and
+neither is an admin `/override`. What this trades away is testing the combination with the `main`
+it lands on before the merge; until a scheduled eval run on `main` exists, a bad combination is
+found by the next pull request's run. Prow's own form of this — a `[prow:skip-retest]` sentinel
+written by `/override-sticky` — is upstream since mid-2026 and not in the Prow build this
+repository merges through; `scripts/pin_smoke_status.py` says when to switch.
+
 **`mergeStateStatus` cannot answer "is this ready to merge" here, and it is the natural thing to
 reach for.** Every open pull request reads `BLOCKED` or `DIRTY` and none ever reads `CLEAN`, because
 `main` restricts pushes to the `google-oss-prow` app and GitHub scores that restriction as a block

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -293,8 +293,12 @@ waiting on it.
 `/hold cancel` releases it — #1045 held that way for a smoke test. `/override <context>`, which only
 a repository admin can use, forces a required check that cannot pass on its own — and expires: the
 forced status embeds the base SHA at override time, so the next merge to `main` invalidates it and
-Tide re-runs the job. `/override-sticky` writes the `[prow:skip-retest]` sentinel instead, which
-Tide accepts regardless of base, so it survives `main` moving (#1202).
+Tide re-runs the job, so an override has to be repeated if `main` moves before Tide merges (#1202).
+Prow's `/override-sticky` would write the `[prow:skip-retest]` sentinel instead, which Tide accepts
+regardless of base — but it is not in the Prow build this repository merges through: the
+[plugin help](https://oss.gprow.dev/command-help?repo=gke-labs%2Fkube-agents) lists only
+`/override`, and the command is silently ignored. A green run of the job is a different matter,
+below.
 
 **Branch protection is not the gate and reads as though there is none.** `main` requires ten
 contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`,

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -292,8 +292,9 @@ waiting on it.
 `/hold` parks an otherwise-mergeable pull request without withdrawing anything else, and
 `/hold cancel` releases it — #1045 held that way for a smoke test. `/override <context>`, which only
 a repository admin can use, forces a required check that cannot pass on its own — and expires: the
-forced status embeds the base SHA at override time, so the next merge to `main` invalidates it and
-Tide re-runs the job, so an override has to be repeated if `main` moves before Tide merges (#1202).
+forced status embeds the base SHA at override time, so the next merge to `main` invalidates it,
+Tide re-runs the job, and the override has to be repeated if `main` moves before Tide merges
+(#1202).
 Prow's `/override-sticky` would write the `[prow:skip-retest]` sentinel instead, which Tide accepts
 regardless of base — but it is not in the Prow build this repository merges through: the
 [plugin help](https://oss.gprow.dev/command-help?repo=gke-labs%2Fkube-agents) lists only
@@ -326,7 +327,7 @@ gh api repos/gke-labs/kube-agents/branches/main/protection \
 against the base SHA it ran on — crier records it as a `BaseSHA:<sha>` suffix on the commit status
 — so on its own every merge to `main` would invalidate every other pull request's green
 `pull-kube-agents-smoke-test` and re-run the whole job for a pull request whose head has not
-changed. [`smoke-test-sticky.yml`](../.github/workflows/smoke-test-sticky.yml) re-pins that suffix
+changed (#1179, #1202). [`smoke-test-sticky.yml`](../.github/workflows/smoke-test-sticky.yml) re-pins that suffix
 to the new head of `main` — for every open pull request against `main` on each push to `main`, and
 for one commit when its green arrives after `main` has already moved — with a note in the
 description saying so, and Tide reads the result as current. It is a race against Tide's roughly
@@ -339,8 +340,8 @@ reports (`/retest` does not, because it reruns only failed contexts); a red is n
 neither is an admin `/override`. What this trades away is testing the combination with the `main`
 it lands on before the merge; until a scheduled eval run on `main` exists, a bad combination is
 found by the next pull request's run. Prow's own form of this — a `[prow:skip-retest]` sentinel
-written by `/override-sticky` — is upstream since mid-2026 and not in the Prow build this
-repository merges through; `scripts/pin_smoke_status.py` says when to switch.
+written by `/override-sticky` — is upstream but not in the Prow build this repository merges
+through; `scripts/pin_smoke_status.py` says when to switch.
 
 **`mergeStateStatus` cannot answer "is this ready to merge" here, and it is the natural thing to
 reach for.** Every open pull request reads `BLOCKED` or `DIRTY` and none ever reads `CLEAN`, because

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -339,7 +339,8 @@ newer status, and the sweep leaves it alone. A push still starts a fresh run;
 reports (`/retest` does not, because it reruns only failed contexts); a red is never touched, and
 neither is an admin `/override`. What this trades away is testing the combination with the `main`
 it lands on before the merge; until a scheduled eval run on `main` exists, a bad combination is
-found by the next pull request's run. Prow's own form of this — a `[prow:skip-retest]` sentinel
+found by the next smoke run that actually starts after it — a push or `/test` on whichever pull
+request that is, whose author then sees a red that is not theirs. Prow's own form of this — a `[prow:skip-retest]` sentinel
 written by `/override-sticky` — is upstream but not in the Prow build this repository merges
 through; `scripts/pin_smoke_status.py` says when to switch.
 

--- a/scripts/pin_smoke_status.py
+++ b/scripts/pin_smoke_status.py
@@ -22,18 +22,23 @@ It is best-effort against Tide's own clock. Tide syncs about once a minute,
 and a sync that sees the stale statuses before the sweep has re-pinned them
 starts the retest -- as a batch, when two or more pull requests qualify --
 and crier's `pending` is then the newer word, which this leaves alone. So the
-sweep is kept short (no dependencies, one read per open pull request plus the
-head of `main` before each write), takes the pull requests Tide is actually
-waiting on first, and is still a race that is sometimes lost. Two merges seconds apart start two sweeps with no ordering
+sweep is kept short (no dependencies, one read per open pull request, and two
+more -- `main` again, the status again -- only for the ones it writes), takes
+the pull requests Tide is actually waiting on first, and is still a race that
+is sometimes lost. Two merges seconds apart start two sweeps with no ordering
 between them, so a pin is always made to the head of `main` as read just
 before the write, never to the head the run started with.
 
 What it will not do: touch a status that is not `success`, touch an admin
 `/override`, pin a pull request that does not target `main` (Tide keys the
 base SHA on the pull request's own base branch), or overwrite a newer status
-on the same context. The read and the write are two calls, so a `pending`
-that lands between them is buried; that window is a few hundred milliseconds
-and its cost is the trade-off above, taken a little early.
+on the same context. Deciding and writing are separate calls, and a throttled
+call retries with a delay of seconds to a minute, so the status is read a
+second time immediately before the write and the write is dropped if a newer
+one has landed. What stays open is the POST itself. One pull request failing
+-- a head force-pushed away mid-sweep, a call out of retries -- is logged and
+the sweep goes on, because every pull request after it would otherwise wait
+for the next merge; the failure still sets the exit status.
 """
 
 import argparse
@@ -82,12 +87,18 @@ def split_description(description):
 
 
 def pinned_description(description, main_sha):
-    """The same status, its base pinned to `main_sha`, within GitHub's limit."""
+    """The same status, its base pinned to `main_sha`, within GitHub's limit.
+
+    The note is dropped whole when it does not fit: a sliced one would not be
+    recognised by the next pin and would stack.
+    """
     human, _ = split_description(description)
-    human = f"{human} {PIN_NOTE}".strip()
     suffix = f"{BASE_SHA_DELIMITER}{main_sha}"
     room = MAX_DESCRIPTION - len(suffix)
-    return human[:room].rstrip() + suffix
+    noted = f"{human} {PIN_NOTE}".strip()
+    if len(noted) > room:
+        noted = human[:room].rstrip()
+    return noted + suffix
 
 
 def skip_reason(status, main_sha):
@@ -128,22 +139,45 @@ def targets_main(api, sha):
     return any(p["head"]["sha"] == sha for p in open_pulls_against_main(api))
 
 
-def pin_head(api, sha, main_sha, status_id=None, dry_run=False, check_base=True):
+#: Compares equal to no SHA, so `skip_reason` can be asked the questions that need no `main`.
+_NO_MAIN = object()
+
+
+def _resolve(main_sha):
+    return main_sha() if callable(main_sha) else main_sha
+
+
+def pin_head(api, sha, main_sha, status_id=None, dry_run=False, check_base=True, expected_main=None):
     """Re-pin one commit's smoke status. Returns what happened, for the log.
 
-    `main_sha` is a SHA or a callable returning one; the callable is read just
-    before the write, so a sweep that overlaps a newer one cannot pin backwards.
+    `main_sha` is a SHA or a callable returning one. `expected_main` is the head
+    of `main` a stale base is compared against -- a sweep reads it once for all
+    its pull requests -- and defaults to `main_sha` itself. Two reads sit
+    between deciding and writing: `main` again, so a sweep overlapping a newer
+    one cannot pin backwards, and the status again, so a `pending` that landed
+    meanwhile -- a push, `/test`, or Tide's own retest -- is not buried under a
+    stale success. Neither read is made for a status that is left alone.
     """
     if check_base and not targets_main(api, sha):
         return f"{sha[:SHORT_SHA]}: not the head of an open pull request against {MAIN_BRANCH}"
     status = latest_status(api, sha)
     if status_id is not None and status is not None and str(status.get("id")) != str(status_id):
         return f"{sha[:SHORT_SHA]}: status {status_id} is no longer the latest (now {status.get('id')}); leaving it"
-    if status is not None and status.get("state") == SUCCESS:
-        main_sha = main_sha() if callable(main_sha) else main_sha
-    reason = skip_reason(status, main_sha)
+    reason = skip_reason(status, _NO_MAIN)
     if reason:
         return f"{sha[:SHORT_SHA]}: {reason}"
+    main_now = expected_main if expected_main is not None else _resolve(main_sha)
+    reason = skip_reason(status, main_now)
+    if reason is None and expected_main is not None and callable(main_sha):
+        main_now = main_sha()  # just before the write, not as of the start of the sweep
+        reason = skip_reason(status, main_now)
+    if reason:
+        return f"{sha[:SHORT_SHA]}: {reason}"
+    latest = latest_status(api, sha)
+    if latest is None or str(latest.get("id")) != str(status.get("id")):
+        newer = latest.get("id") if latest else "none"
+        return f"{sha[:SHORT_SHA]}: status {status.get('id')} was superseded while deciding (now {newer}); leaving it"
+    main_sha = main_now
     payload = {
         "state": SUCCESS,
         "context": CONTEXT,
@@ -162,12 +196,24 @@ def in_tide_pool(pull_request):
 
 
 def sweep(api, main_sha, dry_run=False):
-    """Every open pull request's head, after a push to main; the pool first."""
-    outcomes = []
+    """Every open pull request's head, after a push to main; the pool first.
+
+    Returns (outcomes, failures). One pull request's failure does not end the
+    sweep -- every pull request after it would otherwise wait for the next
+    merge, and a lost pin costs a 1.5-3.5h retest -- but it is counted, so the
+    run can exit non-zero and be seen.
+    """
+    expected = _resolve(main_sha)  # once, for the comparisons; each write re-reads it
+    outcomes, failures = [], 0
     pulls = sorted(open_pulls_against_main(api), key=lambda p: not in_tide_pool(p))
     for pull_request in pulls:
-        outcomes.append(pin_head(api, pull_request["head"]["sha"], main_sha, dry_run=dry_run, check_base=False))
-    return outcomes
+        sha = pull_request["head"]["sha"]
+        try:
+            outcomes.append(pin_head(api, sha, main_sha, dry_run=dry_run, check_base=False, expected_main=expected))
+        except Exception as error:  # noqa: BLE001 -- one pull request must not end the sweep
+            failures += 1
+            outcomes.append(f"{sha[:SHORT_SHA]}: failed, moving on: {error}")
+    return outcomes, failures
 
 
 def main_head(api):
@@ -199,12 +245,12 @@ def main(argv=None):
     api = GitHubAPI(args.repo, token, user_agent=USER_AGENT)
     main_sha = args.main_sha or (lambda: main_head(api))
     if args.mode == "status":
-        outcomes = [pin_head(api, args.sha, main_sha, status_id=args.status_id, dry_run=args.dry_run)]
+        outcomes, failures = [pin_head(api, args.sha, main_sha, status_id=args.status_id, dry_run=args.dry_run)], 0
     else:
-        outcomes = sweep(api, main_sha, dry_run=args.dry_run)
+        outcomes, failures = sweep(api, main_sha, dry_run=args.dry_run)
     for outcome in outcomes:
         log(outcome)
-    return 0
+    return 1 if failures else 0
 
 
 if __name__ == "__main__":

--- a/scripts/pin_smoke_status.py
+++ b/scripts/pin_smoke_status.py
@@ -201,7 +201,10 @@ def sweep(api, main_sha, dry_run=False):
     Returns (outcomes, failures). One pull request's failure does not end the
     sweep -- every pull request after it would otherwise wait for the next
     merge, and a lost pin costs a 1.5-3.5h retest -- but it is counted, so the
-    run can exit non-zero and be seen.
+    run can exit non-zero and be seen. Each outcome is logged as it happens,
+    not after the loop: the log is the only record of the writes this makes,
+    and a runner killed mid-sweep must not take the record of the ones already
+    made with it.
     """
     expected = _resolve(main_sha)  # once, for the comparisons; each write re-reads it
     outcomes, failures = [], 0
@@ -209,10 +212,12 @@ def sweep(api, main_sha, dry_run=False):
     for pull_request in pulls:
         sha = pull_request["head"]["sha"]
         try:
-            outcomes.append(pin_head(api, sha, main_sha, dry_run=dry_run, check_base=False, expected_main=expected))
+            outcome = pin_head(api, sha, main_sha, dry_run=dry_run, check_base=False, expected_main=expected)
         except Exception as error:  # noqa: BLE001 -- one pull request must not end the sweep
             failures += 1
-            outcomes.append(f"{sha[:SHORT_SHA]}: failed, moving on: {error}")
+            outcome = f"{sha[:SHORT_SHA]}: failed, moving on: {error}"
+        log(outcome)
+        outcomes.append(outcome)
     return outcomes, failures
 
 
@@ -245,11 +250,9 @@ def main(argv=None):
     api = GitHubAPI(args.repo, token, user_agent=USER_AGENT)
     main_sha = args.main_sha or (lambda: main_head(api))
     if args.mode == "status":
-        outcomes, failures = [pin_head(api, args.sha, main_sha, status_id=args.status_id, dry_run=args.dry_run)], 0
-    else:
-        outcomes, failures = sweep(api, main_sha, dry_run=args.dry_run)
-    for outcome in outcomes:
-        log(outcome)
+        log(pin_head(api, args.sha, main_sha, status_id=args.status_id, dry_run=args.dry_run))
+        return 0
+    _, failures = sweep(api, main_sha, dry_run=args.dry_run)
     return 1 if failures else 0
 
 

--- a/scripts/pin_smoke_status.py
+++ b/scripts/pin_smoke_status.py
@@ -22,9 +22,9 @@ It is best-effort against Tide's own clock. Tide syncs about once a minute,
 and a sync that sees the stale statuses before the sweep has re-pinned them
 starts the retest -- as a batch, when two or more pull requests qualify --
 and crier's `pending` is then the newer word, which this leaves alone. So the
-sweep is kept short (no dependencies, one read per open pull request), takes
-the pull requests Tide is actually waiting on first, and is still a race that
-is sometimes lost. Two merges seconds apart start two sweeps with no ordering
+sweep is kept short (no dependencies, one read per open pull request plus the
+head of `main` before each write), takes the pull requests Tide is actually
+waiting on first, and is still a race that is sometimes lost. Two merges seconds apart start two sweeps with no ordering
 between them, so a pin is always made to the head of `main` as read just
 before the write, never to the head the run started with.
 

--- a/scripts/pin_smoke_status.py
+++ b/scripts/pin_smoke_status.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Keep a green `pull-kube-agents-smoke-test` status valid when `main` moves.
+
+Tide credits a presubmit only against the base SHA it ran on. Crier writes that
+SHA into the commit status as a `BaseSHA:<sha>` suffix, and Tide reads it back
+(`prowJobsFromContexts`) so a result outlives the ProwJob object -- as long as
+the SHA still names the head of `main`. Every merge to `main` therefore turns
+every other pull request's green smoke run stale, and Tide re-runs the 1.5-3.5h
+job for a pull request whose head has not changed (#1179, #1202).
+
+This re-pins the suffix. On every push to `main` it sweeps the open pull
+requests and re-posts each green smoke status with `BaseSHA:` set to the new
+head; when a green arrives after `main` has already moved past the base it
+ran on, the `status` event does the same for that one commit. The description
+says what happened, so a reader is not told the run was against a base it was
+not. Tide's newer form of this -- a `[prow:skip-retest]` sentinel that
+`/override-sticky` writes -- is upstream since July 2026 but not in the Prow
+build this repository merges through (its plugin help does not list
+`/override-sticky`); when it is, append the sentinel here and stop pinning.
+
+It is best-effort against Tide's own clock. Tide syncs about once a minute,
+and a sync that sees the stale statuses before the sweep has re-pinned them
+starts the retest -- as a batch, when two or more pull requests qualify --
+and crier's `pending` is then the newer word, which this leaves alone. So the
+sweep is kept short (no dependencies, one read per open pull request), takes
+the pull requests Tide is actually waiting on first, and is still a race that
+is sometimes lost. Two merges seconds apart start two sweeps with no ordering
+between them, so a pin is always made to the head of `main` as read just
+before the write, never to the head the run started with.
+
+What it will not do: touch a status that is not `success`, touch an admin
+`/override`, pin a pull request that does not target `main` (Tide keys the
+base SHA on the pull request's own base branch), or overwrite a newer status
+on the same context. The read and the write are two calls, so a `pending`
+that lands between them is buried; that window is a few hundred milliseconds
+and its cost is the trade-off above, taken a little early.
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from github_api import GitHubAPI, log  # noqa: E402
+
+CONTEXT = "pull-kube-agents-smoke-test"
+#: `contextDescriptionBaseSHADelimiter` in kubernetes-sigs/prow, pkg/config/config.go.
+BASE_SHA_DELIMITER = " BaseSHA:"
+#: What the override plugin writes; its statuses are an admin's decision, not ours.
+OVERRIDE_PREFIX = "Overridden by"
+#: Left in the human-readable part so the description does not claim a run it did not have.
+PIN_NOTE = "(base pinned to main by smoke-test-sticky)"
+#: GitHub rejects a longer status description; Prow's `contextDescriptionMaxLen` agrees.
+MAX_DESCRIPTION = 140
+SUCCESS = "success"
+MAIN_BRANCH = "main"
+MAIN_REF = f"heads/{MAIN_BRANCH}"
+USER_AGENT = "kube-agents-smoke-test-sticky"
+#: Tide's pool wants both; a pull request carrying them is the one a stale base costs hours.
+POOL_LABELS = frozenset({"lgtm", "approved"})
+HOLD_LABEL_PREFIX = "do-not-merge"
+SHORT_SHA = 8
+_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def split_description(description):
+    """(human-readable part, base SHA or None) of a crier-shaped description.
+
+    Crier left-pads the suffix with U+2001 so it lines up in the GitHub UI; that
+    is Unicode whitespace, which `str.split()` collapses. A previous pin note is
+    dropped so re-pinning does not stack them.
+    """
+    text = " ".join((description or "").split())
+    human, _, base_sha = text.partition(BASE_SHA_DELIMITER)
+    human = " ".join(human.replace(PIN_NOTE, "").split())
+    return human, (base_sha if _SHA.fullmatch(base_sha) else None)
+
+
+def pinned_description(description, main_sha):
+    """The same status, its base pinned to `main_sha`, within GitHub's limit."""
+    human, _ = split_description(description)
+    human = f"{human} {PIN_NOTE}".strip()
+    suffix = f"{BASE_SHA_DELIMITER}{main_sha}"
+    room = MAX_DESCRIPTION - len(suffix)
+    return human[:room].rstrip() + suffix
+
+
+def skip_reason(status, main_sha):
+    """Why a status is left alone, or None when it should be pinned."""
+    if status is None:
+        return f"no {CONTEXT} status on the commit"
+    if status.get("state") != SUCCESS:
+        return f"state is {status.get('state')!r}, not {SUCCESS}"
+    description = status.get("description") or ""
+    if description.startswith(OVERRIDE_PREFIX):
+        return "an admin override, which is not ours to extend"
+    _, base_sha = split_description(description)
+    if base_sha == main_sha:
+        return "already pinned to the head of main"
+    return None
+
+
+def latest_status(api, sha):
+    """The most recent status for CONTEXT on `sha`, from the combined status."""
+    combined = api.get(f"/repos/{api.repo}/commits/{sha}/status")
+    for status in combined.get("statuses") or []:
+        if status.get("context") == CONTEXT:
+            return status
+    return None
+
+
+def open_pulls_against_main(api):
+    return api.get_all(f"/repos/{api.repo}/pulls?state=open&base={MAIN_BRANCH}")
+
+
+def targets_main(api, sha):
+    """Whether `sha` is the head of an open pull request against main.
+
+    Matched against the open list rather than `/commits/{sha}/pulls`: that
+    endpoint returns nothing for a head that lives in a fork, which is where
+    nearly every pull request here comes from.
+    """
+    return any(p["head"]["sha"] == sha for p in open_pulls_against_main(api))
+
+
+def pin_head(api, sha, main_sha, status_id=None, dry_run=False, check_base=True):
+    """Re-pin one commit's smoke status. Returns what happened, for the log.
+
+    `main_sha` is a SHA or a callable returning one; the callable is read just
+    before the write, so a sweep that overlaps a newer one cannot pin backwards.
+    """
+    if check_base and not targets_main(api, sha):
+        return f"{sha[:SHORT_SHA]}: not the head of an open pull request against {MAIN_BRANCH}"
+    status = latest_status(api, sha)
+    if status_id is not None and status is not None and str(status.get("id")) != str(status_id):
+        return f"{sha[:SHORT_SHA]}: status {status_id} is no longer the latest (now {status.get('id')}); leaving it"
+    if status is not None and status.get("state") == SUCCESS:
+        main_sha = main_sha() if callable(main_sha) else main_sha
+    reason = skip_reason(status, main_sha)
+    if reason:
+        return f"{sha[:SHORT_SHA]}: {reason}"
+    payload = {
+        "state": SUCCESS,
+        "context": CONTEXT,
+        "target_url": status.get("target_url") or "",
+        "description": pinned_description(status.get("description"), main_sha),
+    }
+    if not dry_run:
+        api.post(f"/repos/{api.repo}/statuses/{sha}", payload)
+    return f"{sha[:SHORT_SHA]}: pinned to {main_sha[:SHORT_SHA]}: {payload['description']}"
+
+
+def in_tide_pool(pull_request):
+    """Carries the labels Tide merges on and no hold: the ones a stale base costs hours."""
+    labels = {label.get("name") for label in pull_request.get("labels") or []}
+    return POOL_LABELS <= labels and not any(str(name).startswith(HOLD_LABEL_PREFIX) for name in labels)
+
+
+def sweep(api, main_sha, dry_run=False):
+    """Every open pull request's head, after a push to main; the pool first."""
+    outcomes = []
+    pulls = sorted(open_pulls_against_main(api), key=lambda p: not in_tide_pool(p))
+    for pull_request in pulls:
+        outcomes.append(pin_head(api, pull_request["head"]["sha"], main_sha, dry_run=dry_run, check_base=False))
+    return outcomes
+
+
+def main_head(api):
+    return api.get(f"/repos/{api.repo}/git/ref/{MAIN_REF}")["object"]["sha"]
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/name")
+    sub = parser.add_subparsers(dest="mode", required=True)
+    status = sub.add_parser("status", help="one commit, from a status event")
+    status.add_argument("--sha", required=True)
+    status.add_argument("--status-id", required=True, help="the event's status id; a newer one wins")
+    sweep_ = sub.add_parser("sweep", help="every open pull request against main, after a push to main")
+    # On the subcommands, not the parser: argparse rejects a parent option
+    # given after the subcommand, and the workflow writes them after it.
+    for command in (status, sweep_):
+        command.add_argument("--main-sha", help="pin to this instead of the head of main as read before each write")
+        command.add_argument("--dry-run", action="store_true", help="log what would be posted, post nothing")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not args.repo or not token:
+        print("GITHUB_REPOSITORY (or --repo) and GITHUB_TOKEN are required", file=sys.stderr)
+        return 2
+    api = GitHubAPI(args.repo, token, user_agent=USER_AGENT)
+    main_sha = args.main_sha or (lambda: main_head(api))
+    if args.mode == "status":
+        outcomes = [pin_head(api, args.sha, main_sha, status_id=args.status_id, dry_run=args.dry_run)]
+    else:
+        outcomes = sweep(api, main_sha, dry_run=args.dry_run)
+    for outcome in outcomes:
+        log(outcome)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_pin_smoke_status.py
+++ b/scripts/test_pin_smoke_status.py
@@ -48,11 +48,16 @@ class FakeAPI:
         self.main = main
         self.posts = []
         self.list_calls = []
+        self.ref_reads = 0
+        self.broken = set()  # heads whose status read fails, as a force-pushed-away head does
 
     def get(self, path):
         if path.endswith(f"/git/ref/{pin.MAIN_REF}"):
+            self.ref_reads += 1
             return {"object": {"sha": self.main}}
         sha = path.rsplit("/commits/", 1)[1].split("/")[0]
+        if sha in self.broken:
+            raise RuntimeError(f"HTTP 422 No commit found for SHA: {sha}")
         return {"statuses": self.statuses.get(sha, [])}
 
     def get_all(self, path):
@@ -85,6 +90,13 @@ class DescriptionTest(unittest.TestCase):
         got = pin.pinned_description("x" * 200, MAIN)
         self.assertEqual(len(got), pin.MAX_DESCRIPTION)
         self.assertTrue(got.endswith(f"BaseSHA:{MAIN}"))
+
+    def test_a_note_that_does_not_fit_is_dropped_whole_not_sliced(self):
+        """A fragment like "(base" would not be recognised by the next pin and would stack."""
+        got = pin.pinned_description("x" * 85, MAIN)
+        self.assertLessEqual(len(got), pin.MAX_DESCRIPTION)
+        self.assertNotIn("(base", got)
+        self.assertEqual(pin.split_description(got), ("x" * 85, MAIN))
 
     def test_a_description_without_a_base_gets_one(self):
         self.assertEqual(pin.split_description("Job succeeded.")[1], None)
@@ -157,6 +169,39 @@ class PinHeadTest(unittest.TestCase):
         self.assertIn("already pinned", pin.pin_head(api, HEAD, lambda: pin.main_head(api)))
         self.assertEqual(api.posts, [])
 
+    def test_a_status_that_arrives_while_deciding_wins(self):
+        """A `pending` posted between the first read and the write must not be buried."""
+
+        class RacedAPI(FakeAPI):
+            def get(self, path):
+                result = super().get(path)
+                if "/commits/" in path:  # the next read sees a fresh run's pending
+                    self.statuses[HEAD] = [status(id=2, state="pending", description="Job triggered.")]
+                return result
+
+        api = RacedAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)])
+        outcome = pin.pin_head(api, HEAD, MAIN, status_id=1)
+        self.assertIn("superseded while deciding", outcome)
+        self.assertEqual(api.posts, [])
+
+    def test_a_sweep_compares_against_its_one_read_but_writes_the_fresh_head(self):
+        """expected_main is the sweep's single read; the write re-reads main so it never pins backwards."""
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)], main="9" * 40)
+        outcome = pin.pin_head(api, HEAD, lambda: pin.main_head(api), expected_main=MAIN)
+        self.assertIn("pinned to 99999999", outcome)
+        self.assertEqual(api.ref_reads, 1)
+
+    def test_a_fresh_read_that_finds_the_status_current_posts_nothing(self):
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)], main=OLD)
+        outcome = pin.pin_head(api, HEAD, lambda: pin.main_head(api), expected_main=MAIN)
+        self.assertIn("already pinned", outcome)
+        self.assertEqual(api.posts, [])
+
+    def test_no_read_of_main_is_spent_on_a_status_left_alone(self):
+        api = FakeAPI(statuses={HEAD: [status(state="failure")]}, pulls=[pull(HEAD)])
+        pin.pin_head(api, HEAD, lambda: pin.main_head(api))
+        self.assertEqual(api.ref_reads, 0)
+
     def test_dry_run_posts_nothing(self):
         api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)])
         self.assertIn("pinned", pin.pin_head(api, HEAD, MAIN, dry_run=True))
@@ -174,9 +219,10 @@ class SweepTest(unittest.TestCase):
             },
             pulls=[pull(sha) for sha in (stale, current, red, none)] + [pull("5" * 40, base="release-1")],
         )
-        outcomes = pin.sweep(api, MAIN)
-        self.assertEqual(len(outcomes), 4)
+        outcomes, failures = pin.sweep(api, MAIN)
+        self.assertEqual((len(outcomes), failures), (4, 0))
         self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [stale])
+        self.assertEqual(len(api.list_calls), 1)
 
     def test_the_pool_is_swept_first(self):
         first, second, held = "6" * 40, "7" * 40, "8" * 40
@@ -186,6 +232,25 @@ class SweepTest(unittest.TestCase):
         )
         pin.sweep(api, MAIN)
         self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [first, second, held])
+
+    def test_main_is_read_once_for_the_sweep_and_once_more_per_write(self):
+        stale, current = "1" * 40, "2" * 40
+        api = FakeAPI(
+            statuses={stale: [status()], current: [status(description=f"Job succeeded. BaseSHA:{MAIN}")]},
+            pulls=[pull(stale), pull(current)],
+        )
+        pin.sweep(api, lambda: pin.main_head(api))
+        self.assertEqual(api.ref_reads, 2)
+        self.assertEqual(len(api.posts), 1)
+
+    def test_one_pull_request_failing_does_not_end_the_sweep(self):
+        broken, fine = "1" * 40, "2" * 40
+        api = FakeAPI(statuses={fine: [status()]}, pulls=[pull(broken), pull(fine)])
+        api.broken.add(broken)
+        outcomes, failures = pin.sweep(api, MAIN)
+        self.assertEqual(failures, 1)
+        self.assertIn("failed, moving on", outcomes[0])
+        self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [fine])
 
     def test_the_sweep_asks_github_for_pull_requests_against_main_only(self):
         api = FakeAPI()
@@ -206,6 +271,26 @@ class ArgumentsTest(unittest.TestCase):
 
 
 class MainTest(unittest.TestCase):
+    def _run(self, api, argv):
+        with unittest.mock.patch.dict("os.environ", {"GITHUB_TOKEN": "t"}), unittest.mock.patch.object(
+            pin, "GitHubAPI", lambda *args, **kwargs: api
+        ):
+            return pin.main(["--repo", "gke-labs/kube-agents", *argv])
+
+    def test_status_mode_forwards_the_status_id_and_reads_main_itself(self):
+        api = FakeAPI(statuses={HEAD: [status(id=2, state="pending")]}, pulls=[pull(HEAD)])
+        self.assertEqual(self._run(api, ["status", "--sha", HEAD, "--status-id", "1"]), 0)
+        self.assertEqual(api.posts, [])  # the id check saw the newer pending
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)], main="9" * 40)
+        self.assertEqual(self._run(api, ["status", "--sha", HEAD, "--status-id", "1"]), 0)
+        self.assertTrue(api.posts[0][1]["description"].endswith("9" * 40))  # no --main-sha: read from GitHub
+
+    def test_a_sweep_with_a_failure_exits_non_zero(self):
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD), pull("1" * 40)])
+        api.broken.add("1" * 40)
+        self.assertEqual(self._run(api, ["sweep"]), 1)
+        self.assertEqual(len(api.posts), 1)
+
     def test_refuses_to_run_without_a_token(self):
         env = {k: v for k, v in __import__("os").environ.items() if k not in ("GITHUB_TOKEN",)}
         with unittest.mock.patch.dict("os.environ", env, clear=True):

--- a/scripts/test_pin_smoke_status.py
+++ b/scripts/test_pin_smoke_status.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Tests for pin_smoke_status.py -- the re-pinning that keeps a green smoke run valid.
+
+Run: cd scripts && python3 -m unittest test_pin_smoke_status
+
+Every wrong answer here fails green: a status that should have been pinned is
+left stale and Tide quietly re-runs a 1.5-3.5h job; a status that should have
+been left alone -- a red, an override, a newer `pending` -- is overwritten with
+a success. So the guards get one test each, and the description builder is
+driven with what crier actually writes, U+2001 padding included.
+"""
+
+import sys
+import unittest
+import unittest.mock
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import pin_smoke_status as pin
+
+MAIN = "a" * 40
+OLD = "b" * 40
+HEAD = "c" * 40
+CRIER = "Job succeeded." + " " * 20 + "BaseSHA:" + OLD
+URL = "https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1/pull-kube-agents-smoke-test/1"
+
+
+def pull(sha, base="main", labels=()):
+    return {"head": {"sha": sha}, "base": {"ref": base}, "labels": [{"name": name} for name in labels]}
+
+
+def status(**overrides):
+    base = {"id": 1, "context": pin.CONTEXT, "state": "success", "description": CRIER, "target_url": URL}
+    base.update(overrides)
+    return base
+
+
+class FakeAPI:
+    """Just enough of `GitHubAPI` for the functions that call it."""
+
+    def __init__(self, statuses=None, pulls=(), main=MAIN):
+        self.repo = "gke-labs/kube-agents"
+        self.statuses = statuses or {}
+        self.pulls = list(pulls)
+        self.main = main
+        self.posts = []
+        self.list_calls = []
+
+    def get(self, path):
+        if path.endswith(f"/git/ref/{pin.MAIN_REF}"):
+            return {"object": {"sha": self.main}}
+        sha = path.rsplit("/commits/", 1)[1].split("/")[0]
+        return {"statuses": self.statuses.get(sha, [])}
+
+    def get_all(self, path):
+        self.list_calls.append(path)
+        assert path.endswith("/pulls?state=open&base=main"), path
+        return [p for p in self.pulls if p["base"]["ref"] == "main"]
+
+    def post(self, path, payload):
+        self.posts.append((path, payload))
+
+
+class DescriptionTest(unittest.TestCase):
+    def test_crier_padding_is_collapsed_and_the_base_replaced(self):
+        got = pin.pinned_description(CRIER, MAIN)
+        self.assertEqual(got, f"Job succeeded. {pin.PIN_NOTE} BaseSHA:{MAIN}")
+        self.assertLessEqual(len(got), pin.MAX_DESCRIPTION)
+
+    def test_the_base_sha_still_parses_the_way_prow_reads_it(self):
+        """BaseSHAFromContextDescription: split on the delimiter, exactly two parts, a 40-char tail."""
+        parts = pin.pinned_description(CRIER, MAIN).split(pin.BASE_SHA_DELIMITER)
+        self.assertEqual(len(parts), 2)
+        self.assertEqual(parts[1], MAIN)
+        self.assertNotIn(pin.BASE_SHA_DELIMITER, pin.PIN_NOTE)
+
+    def test_re_pinning_does_not_stack_the_note(self):
+        twice = pin.pinned_description(pin.pinned_description(CRIER, OLD), MAIN)
+        self.assertEqual(twice.count(pin.PIN_NOTE), 1)
+
+    def test_a_long_human_part_is_cut_ahead_of_the_suffix(self):
+        got = pin.pinned_description("x" * 200, MAIN)
+        self.assertEqual(len(got), pin.MAX_DESCRIPTION)
+        self.assertTrue(got.endswith(f"BaseSHA:{MAIN}"))
+
+    def test_a_description_without_a_base_gets_one(self):
+        self.assertEqual(pin.split_description("Job succeeded.")[1], None)
+        self.assertTrue(pin.pinned_description("Job succeeded.", MAIN).endswith(MAIN))
+
+    def test_a_malformed_base_is_not_mistaken_for_one(self):
+        self.assertIsNone(pin.split_description("Job succeeded. BaseSHA:ABC")[1])
+
+
+class GuardTest(unittest.TestCase):
+    def test_a_stale_green_is_pinned(self):
+        self.assertIsNone(pin.skip_reason(status(), MAIN))
+
+    def test_a_green_already_at_main_is_left_alone(self):
+        self.assertIn("already pinned", pin.skip_reason(status(description=f"Job succeeded. BaseSHA:{MAIN}"), MAIN))
+
+    def test_anything_not_green_is_left_alone(self):
+        for state in ("pending", "failure", "error"):
+            self.assertIn(state, pin.skip_reason(status(state=state), MAIN))
+
+    def test_an_admin_override_is_left_alone(self):
+        self.assertIn("override", pin.skip_reason(status(description="Overridden by someone BaseSHA:" + OLD), MAIN))
+
+    def test_a_commit_with_no_smoke_status_is_left_alone(self):
+        self.assertIn("no pull-kube-agents-smoke-test status", pin.skip_reason(None, MAIN))
+
+
+class PinHeadTest(unittest.TestCase):
+    def test_pins_and_keeps_the_target_url(self):
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)])
+        outcome = pin.pin_head(api, HEAD, MAIN, status_id=1)
+        self.assertIn("pinned", outcome)
+        (path, payload), = api.posts
+        self.assertEqual(path, f"/repos/gke-labs/kube-agents/statuses/{HEAD}")
+        self.assertEqual(payload["state"], "success")
+        self.assertEqual(payload["target_url"], URL)
+        self.assertTrue(payload["description"].endswith(MAIN))
+
+    def test_a_newer_status_on_the_context_wins(self):
+        """The event's success was followed by a `pending` from a fresh run."""
+        api = FakeAPI(statuses={HEAD: [status(id=2, state="pending", description="Job triggered.")]}, pulls=[pull(HEAD)])
+        self.assertIn("no longer the latest", pin.pin_head(api, HEAD, MAIN, status_id=1))
+        self.assertEqual(api.posts, [])
+
+    def test_only_the_smoke_context_is_read(self):
+        api = FakeAPI(statuses={HEAD: [status(context="tide", state="pending"), status()]}, pulls=[pull(HEAD)])
+        pin.pin_head(api, HEAD, MAIN)
+        self.assertEqual(len(api.posts), 1)
+
+    def test_a_pull_request_against_another_branch_is_not_pinned_to_main(self):
+        """Tide keys the base SHA on the pull request's own base branch."""
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD, base="release-1")])
+        self.assertIn("not the head of an open pull request against main", pin.pin_head(api, HEAD, MAIN))
+        self.assertEqual(api.posts, [])
+
+    def test_a_commit_that_heads_no_open_pull_request_is_not_pinned(self):
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[])
+        self.assertIn("not the head of an open pull request", pin.pin_head(api, HEAD, MAIN))
+        self.assertEqual(api.posts, [])
+
+    def test_the_head_of_main_is_read_just_before_the_write(self):
+        """Two sweeps from back-to-back merges must not pin backwards."""
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)], main="9" * 40)
+        outcome = pin.pin_head(api, HEAD, lambda: pin.main_head(api))
+        self.assertIn("pinned to 99999999", outcome)
+        self.assertTrue(api.posts[0][1]["description"].endswith("9" * 40))
+
+    def test_a_late_read_that_finds_the_status_already_current_posts_nothing(self):
+        api = FakeAPI(statuses={HEAD: [status(description=f"Job succeeded. BaseSHA:{MAIN}")]}, pulls=[pull(HEAD)])
+        self.assertIn("already pinned", pin.pin_head(api, HEAD, lambda: pin.main_head(api)))
+        self.assertEqual(api.posts, [])
+
+    def test_dry_run_posts_nothing(self):
+        api = FakeAPI(statuses={HEAD: [status()]}, pulls=[pull(HEAD)])
+        self.assertIn("pinned", pin.pin_head(api, HEAD, MAIN, dry_run=True))
+        self.assertEqual(api.posts, [])
+
+
+class SweepTest(unittest.TestCase):
+    def test_only_stale_greens_across_the_open_pull_requests_are_pinned(self):
+        stale, current, red, none = "1" * 40, "2" * 40, "3" * 40, "4" * 40
+        api = FakeAPI(
+            statuses={
+                stale: [status()],
+                current: [status(description=f"Job succeeded. BaseSHA:{MAIN}")],
+                red: [status(state="failure")],
+            },
+            pulls=[pull(sha) for sha in (stale, current, red, none)] + [pull("5" * 40, base="release-1")],
+        )
+        outcomes = pin.sweep(api, MAIN)
+        self.assertEqual(len(outcomes), 4)
+        self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [stale])
+
+    def test_the_pool_is_swept_first(self):
+        first, second, held = "6" * 40, "7" * 40, "8" * 40
+        api = FakeAPI(
+            statuses={sha: [status()] for sha in (first, second, held)},
+            pulls=[pull(second), pull(held, labels=("lgtm", "approved", "do-not-merge/hold")), pull(first, labels=("lgtm", "approved"))],
+        )
+        pin.sweep(api, MAIN)
+        self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [first, second, held])
+
+    def test_the_sweep_asks_github_for_pull_requests_against_main_only(self):
+        api = FakeAPI()
+        pin.sweep(api, MAIN)
+        self.assertEqual(api.list_calls, ["/repos/gke-labs/kube-agents/pulls?state=open&base=main"])
+
+
+class ArgumentsTest(unittest.TestCase):
+    """The workflow writes the options after the subcommand; argparse must take them there."""
+
+    def test_sweep_takes_main_sha_after_the_subcommand(self):
+        args = pin._parse_args(["sweep", "--main-sha", MAIN])
+        self.assertEqual((args.mode, args.main_sha, args.dry_run), ("sweep", MAIN, False))
+
+    def test_status_takes_its_identifiers_and_the_shared_options(self):
+        args = pin._parse_args(["status", "--sha", HEAD, "--status-id", "7", "--dry-run"])
+        self.assertEqual((args.mode, args.sha, args.status_id, args.dry_run), ("status", HEAD, "7", True))
+
+
+class MainTest(unittest.TestCase):
+    def test_refuses_to_run_without_a_token(self):
+        env = {k: v for k, v in __import__("os").environ.items() if k not in ("GITHUB_TOKEN",)}
+        with unittest.mock.patch.dict("os.environ", env, clear=True):
+            self.assertEqual(pin.main(["--repo", "o/r", "sweep"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pin_smoke_status.py
+++ b/scripts/test_pin_smoke_status.py
@@ -252,6 +252,16 @@ class SweepTest(unittest.TestCase):
         self.assertIn("failed, moving on", outcomes[0])
         self.assertEqual([path.rsplit("/", 1)[1] for path, _ in api.posts], [fine])
 
+    def test_each_outcome_is_logged_before_the_next_pull_request_is_touched(self):
+        """A runner killed mid-sweep must not take the record of the writes already made with it."""
+        first, second = "1" * 40, "2" * 40
+        api = FakeAPI(statuses={sha: [status()] for sha in (first, second)}, pulls=[pull(first), pull(second)])
+        logged = []
+        with unittest.mock.patch.object(pin, "log", lambda message: logged.append((message, len(api.posts)))):
+            pin.sweep(api, MAIN)
+        self.assertEqual([posts_so_far for _, posts_so_far in logged], [1, 2])
+        self.assertTrue(logged[0][0].startswith(first[:8]))
+
     def test_the_sweep_asks_github_for_pull_requests_against_main_only(self):
         api = FakeAPI()
         pin.sweep(api, MAIN)

--- a/tests/test_smoke_test_sticky_workflow.py
+++ b/tests/test_smoke_test_sticky_workflow.py
@@ -1,0 +1,97 @@
+"""Tests for the wiring in .github/workflows/smoke-test-sticky.yml.
+
+The workflow re-pins green `pull-kube-agents-smoke-test` statuses to the head
+of `main` so Tide keeps crediting them after `main` moves. The pinning itself is
+`scripts/pin_smoke_status.py`, tested beside it. What this file pins is the
+YAML: which events reach a runner, the guards on the job-level `if:`, the
+token's scope, and that each event runs the script in the right mode -- an
+`if:` is where a guard can be dropped without any other test going red.
+"""
+
+import pathlib
+import re
+import shlex
+import sys
+import unittest
+
+import yaml
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "smoke-test-sticky.yml"
+
+_JOB = "pin"
+_CONTEXT = "pull-kube-agents-smoke-test"
+_FORK_GUARD = "github.repository == 'gke-labs/kube-agents'"
+_SCRIPT = "scripts/pin_smoke_status.py"
+_SCRIPTS = _REPO_ROOT / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+import pin_smoke_status  # noqa: E402
+
+_PINNED_ACTION = re.compile(r"^[\w.-]+/[\w.-]+@[0-9a-f]{40}$")  # the version comment is stripped by the YAML parser
+
+
+def _load():
+    # PyYAML resolves a bare `on:` key to the boolean True (YAML 1.1), which is
+    # why this is not spelled workflow["on"].
+    return yaml.safe_load(_WORKFLOW.read_text())
+
+
+class SmokeTestStickyWorkflowTest(unittest.TestCase):
+    def setUp(self):
+        self.workflow = _load()
+        self.triggers = self.workflow[True]
+        self.job = self.workflow["jobs"][_JOB]
+        self.condition = self.job["if"]
+        self.steps = {step["name"]: step for step in self.job["steps"]}
+
+    def test_it_starts_on_status_events_and_pushes_to_main_only(self):
+        self.assertEqual(sorted(self.triggers), ["push", "status"])
+        self.assertEqual(self.triggers["push"], {"branches": ["main"]})
+
+    def test_the_job_carries_the_fork_guard(self):
+        self.assertIn(_FORK_GUARD, self.condition)
+
+    def test_a_status_event_must_be_a_green_smoke_test_and_not_an_override(self):
+        self.assertIn(f"github.event.context == '{_CONTEXT}'", self.condition)
+        self.assertIn("github.event.state == 'success'", self.condition)
+        self.assertIn("!startsWith(github.event.description, 'Overridden by')", self.condition)
+        self.assertIn("github.event_name == 'push' ||", self.condition)
+
+    def test_the_token_can_write_statuses_and_read_the_checkout_and_nothing_else(self):
+        self.assertEqual(self.workflow["permissions"], {})
+        self.assertEqual(self.job["permissions"], {"contents": "read", "statuses": "write"})
+
+    def test_the_checkout_does_not_keep_credentials(self):
+        self.assertEqual(self.steps["Checkout the default branch"]["with"], {"persist-credentials": False})
+
+    def test_every_action_is_pinned_to_a_commit(self):
+        for step in self.job["steps"]:
+            if "uses" in step:
+                self.assertRegex(step["uses"], _PINNED_ACTION)
+
+    def test_a_push_sweeps_and_a_status_pins_one_commit(self):
+        sweep = self.steps["Re-pin every open pull request after the merge"]
+        self.assertEqual(sweep["if"], "github.event_name == 'push'")
+        self.assertEqual(sweep["run"].strip(), f"python3 {_SCRIPT} sweep")
+        one = self.steps["Re-pin this commit's green if main has already moved"]
+        self.assertEqual(one["if"], "github.event_name == 'status'")
+        self.assertIn(f"{_SCRIPT} status --sha \"$SHA\" --status-id \"$STATUS_ID\"", one["run"])
+        self.assertEqual(one["env"]["STATUS_ID"], "${{ github.event.id }}")
+        self.assertEqual(one["env"]["SHA"], "${{ github.event.sha }}")
+
+    def test_each_step_s_command_line_parses_as_the_script_expects(self):
+        """argparse rejects a parent option after the subcommand; the order in `run:` is the contract."""
+        for step in self.steps.values():
+            if "run" not in step:
+                continue
+            argv = shlex.split(step["run"])
+            self.assertEqual(argv[:2], ["python3", _SCRIPT])
+            args = pin_smoke_status._parse_args([re.sub(r"^\$\w+$", "0" * 40, token) for token in argv[2:]])
+            self.assertIn(args.mode, ("sweep", "status"))
+
+    def test_nothing_queues_behind_a_concurrency_group(self):
+        """One pending run per group and the older is cancelled: a dropped pin."""
+        self.assertNotIn("concurrency", self.workflow)
+        self.assertNotIn("concurrency", self.job)


### PR DESCRIPTION
## Summary

Tide credits `pull-kube-agents-smoke-test` only against the base SHA the run used, so every merge to `main` expired every other pull request's green and re-ran the 1.5–3.5 h job on a head that had not changed. This adds a small `status`/`push` workflow that re-pins the `BaseSHA:` suffix crier writes into the status to the new head of `main`, for every open pull request after each merge and for one commit when its green lands after `main` has already moved. Tide then reads the result as current and merges a pull request that is green at its own head without a fresh-base retest. The workflow touches only crier's own `success` statuses: never a pending, a failure, or an admin `/override`. It also corrects the paragraph #1209 added to `AGENTS.md`: `/override-sticky` is not available on the Prow this repository merges through.

## Why This Change

Since the gate went merge-blocking (oss-test-infra#2677), Tide's freshness rule has turned one slow job into many. Today's tide-history for `main` shows #1124 re-triggered at 11:49, 13:16, 15:03, 16:12 and 17:17 UTC, each time by an unrelated merge landing mid-run, and the audit on #1202 counts 19 of 24 post-fix runs ending with no verdict, mostly for this reason. Without this, approval-to-merge latency stays bounded by one job duration per merge, and the escape valve stays `/override`, which itself expires on the next merge (it had to be repeated on #1177, #1190 and #1191 today).

There is no Prow setting for "required but not retested". Tide's retest set is exactly the required presubmits, so `optional: true` would also drop the merge gate; `optional: true` plus a Tide `required-if-present-contexts` entry fails Tide's own config validation; and upstream's `[prow:skip-retest]` sentinel (what `/override-sticky` writes) is not in the deployed build. The live plugin help at `oss.gprow.dev/plugin-help.js` lists only `/override [context1] [context2]`, with the description that predates the sentinel series (2026-06-29), and all components run the same `v20260812-b5681a827` image, so Tide there cannot honour it either. Re-pinning the base is the mechanism that exists on this Prow today.

## What Changed

- `.github/workflows/smoke-test-sticky.yml`: `on: status` and `on: push` to `main`; job guarded by `github.repository == 'gke-labs/kube-agents'`; `permissions: contents: read, statuses: write`; checks out the default branch only, never a pull request head; event fields pass through `env:`, not into script text. A status the workflow posts with `GITHUB_TOKEN` does not fire `status` again, so it cannot loop.
- `scripts/pin_smoke_status.py`: stdlib-only, on `scripts/github_api.py`. `sweep` re-pins every open pull request against `main`, Tide-pool ones first; `status` re-pins one commit and only if that status is still the latest on its context, so a `pending` from `/test` or from Tide's own retest always wins. The head of `main` is read just before each write so two overlapping sweeps cannot pin backwards. A note in the description says the base was pinned; the `target_url` is kept; the result stays within GitHub's 140 characters and still parses the way Tide reads it.
- `AGENTS.md` gate section and `docs/pull-request-workflow.md` "How a change merges": the mechanics, the race with Tide's sync (when Tide's sync lands first the retest starts as before and the sweep leaves it alone), what this trades away, and the correction that `/override-sticky` is silently ignored here. `.agents/rules/github_actions.md` adds `status` to the triggers that need the fork guard.

## Context

- #1202 (merge throughput; jayantid), where the re-pin was proposed on 2026-09-03; #1179 (the observed green discarded on a base move); oss-test-infra#2687 (the Tide diagnosis).
- The trade: the combination of a pull request with the `main` it lands on is no longer tested before the merge. Until oss-test-infra#2665 / #2682 give `main` a scheduled eval run, a bad combination is found by the next pull request's run. jayantid's latest comment on #1202 recommends measuring for a few days before more changes; this is a repository-side workflow rather than Prow config, and it targets the "verdict starvation" line item in that same audit, but it is a behaviour change to the gate and should be read as one.
- Not done on purpose: the `[prow:skip-retest]` sentinel is not written, because Tide here ignores it and its effect could not be validated; the script's docstring names the trigger for switching (the plugin help listing `/override-sticky`). Admin overrides are deliberately not extended.
- `AGENTS.md` is now 37.8k of the 38.0k always-loaded budget; the next addition to it has to pay for itself.
- Generated with the help of Claude.

## Testing

- `python3 -m unittest scripts.test_pin_smoke_status tests.test_smoke_test_sticky_workflow`: 44 tests, OK. `scripts/` discovery: 868 tests, OK. `tests/` discovery: 1121 tests, 6 failures, all in `test_package_release_bundle` because this machine has no `zip` binary; unrelated.
- `actionlint` v1.7.12 on the workflow: clean. `prettier --check` on the four changed text files: clean. `make docs-check`: links, terminology, docs map and context budget all pass.
- Read-only dry run of the sweep against this repository at `main` = 50e85c30 (`GITHUB_TOKEN=... python3 scripts/pin_smoke_status.py --repo gke-labs/kube-agents sweep --dry-run`): 64 open pull requests against `main`: 17 stale greens would be re-pinned, 17 pending and 15 failed left alone, 2 admin overrides left alone, 13 heads with no smoke status skipped. Nothing was posted.

### Live validation

A `status`-triggered workflow runs only from a repository's default branch, and the job guard skips forks, so the workflow cannot be exercised from a pull request. It was exercised on 2026-09-03 at 20:28 UTC on `bradhoekstra/kube-agents` with this branch's head plus one commit retargeting the guard to that repository, pushed as `tmp/sticky-livetest`, made the fork's default branch, and heading throwaway pull request bradhoekstra/kube-agents#20 into the fork's `main` (at `50e85c30`). Three crier-shaped statuses were posted on that head (`ce2017d3`), each with a stale `BaseSHA:0000…0001`:

1. `success`, "Job succeeded." — run 33802439635 executed and logged `ce2017d3: pinned to 50e85c30: Job succeeded. (base pinned to main by smoke-test-sticky) BaseSHA:50e85c30…`; the combined status then read exactly that, with `state=success`.
2. `success`, "Overridden by someone" — run 33802470009 was skipped by the job-level `if:`; the combined status still read the override with its original `BaseSHA:0000…0001`.
3. `pending`, "Job triggered." — run 33802486510 was skipped by the job-level `if:`; the combined status still read `pending` with the original base.

The fork's default branch was restored to `main`, pull request #20 closed and its branch deleted; nothing remains on the fork. Not covered live: the `push` path, because a push to a fork's `main` runs the workflow file on that ref, which would mean merging the workflow into the fork's `main`; it is the same script in `sweep` mode, which the read-only dry run above exercised against this repository's 64 real open pull requests. The first merge after this lands is the acceptance check: tide-history for `main` should show a `MERGE` of a green-at-head pull request with no preceding `TRIGGER` for it, and that head's `pull-kube-agents-smoke-test` status should carry `(base pinned to main by smoke-test-sticky)`.

## Self-Review

Two passes, each in a fresh general-purpose subagent handed only the checkout and the diff range `upstream/main...HEAD`.

- Docs-drift pass: seven findings, six applied in the third commit (the gate paragraph now says the re-pin leaves an override alone, and pays for it within the context budget; "elsewhere" got a referent; a doubled "so"; #1179/#1202 cited where the workflow header says the statement is owned; a date dropped in favour of the script's; the sweep's read count stated honestly). Not applied: a summary-cell nicety in `docs/README.md`, because `check_docs_map.py` passes and the row's keywords already cover the section.
- Adversarial pass: no blockers; four should-fix and four nits, all but one applied in the fourth commit. Applied: the sweep let one failing call end the whole sweep (now logged, skipped, and reported through the exit status); the read-to-write window was described as a few hundred milliseconds but a throttled call retries for up to a minute (the status is now read a second time immediately before the write and a newer one wins; a test drives the race); the head of `main` was read once per green rather than once per sweep (now once for the comparisons plus once per write); the docs claimed a bad combination is found by "the next pull request's run" when every pinned pull request runs nothing (reworded: the next smoke run that actually starts, on whichever pull request that is); a pin note that did not fit was sliced into a fragment the next pin could not recognise (dropped whole); the single-list-call and `main()` wiring test gaps; the Actions-tab noise is now stated in the header. Not applied: bounding how old a pinned green may be, or scoping the sweep to Tide's pool, which is a design choice about how much of the retest to give up rather than a defect; stated under Risk. It also confirmed the Tide parse of a re-pinned description, the token scope and checkout posture (zizmor clean), the `status_id` check, and that no required context on `main` is `app_id`-scoped to Prow.

## Risk & Rollout

Blast radius is one commit status context on open pull requests of this repository, written by a workflow token scoped to `statuses: write`. The sweep re-pins every open pull request's green on every merge, so a green from weeks ago is still credited on the day it is approved; the alternative, re-pinning only pull requests already in Tide's pool, would buy one retest per pull request at approval time in exchange for a bounded age. This lands with the unbounded form because that is what removes the retest; if the age matters more, the change is one filter in `sweep`. New failure modes: the sweep loses the race to Tide's sync and the retest starts as before (no worse than today); a `pending` that lands in the few hundred milliseconds between the script's read and its write is buried until that run reports, which then wins. Nothing else changes: a push still starts a fresh run, a red still blocks, `/override` behaves as today. Revert by deleting the workflow; statuses already re-pinned keep crediting until their heads change. Nothing has to happen at merge time; the workflow is live on the next `status` or `push` event after the merge.
