### PR TITLE
docs: bring AGENTS.md back under the context budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
   - `cluster/`: The Cluster Agent profile _template_ (persona, scoped config, and runtime-debugging skills). The Platform Agent scaffolds this into per-cluster Hermes profiles at runtime; it is not deployed directly.
 - `.agents/skills/`: Repository-level skills, not shipped in the agent images — review skills (adversarial change review, security audits, docs-drift, skill quality) run against pull requests and clusters, with `review-preflight` running the pre-PR set of them in a context that did not write the change, plus the `install-kube-agents`/`uninstall-kube-agents`/`upgrade-kube-agents` lifecycle skills that drive the repository's installer scripts.
 - `.agents/rules/`: Repository-level rules an agent follows, one file per family and none shipped in the agent images — `core_engineering.md` for the code itself, `github_actions.md` for workflow authoring, `pre_pr_review.md` for the mechanics of the two pre-PR passes. This file states each rule and links there for the form it takes; the split keeps `AGENTS.md` inside the context budget `scripts/check_context_budget.py` enforces.
-- `a2a/`: Go module for the agent-to-agent bus — wire-protocol library, `a2a` topics CLI, and agent profiles per `docs/designs/spec-a2a-payloads.md`. Nothing imports it yet.
+- `a2a/`: Go module for the agent-to-agent bus — wire-protocol library and `a2a` topics CLI per `docs/designs/spec-a2a-payloads.md`, plus agent profiles. Nothing imports it yet.
 - `charts/`: Canonical Helm charts (`kube-agents`) for deploying the Kube-Agents operator and profiles.
 - `terraform/`: Companion reusable Terraform modules (`gke-cluster`, `kube-agents-iam`, `chat-pubsub`, `github-minter`, `gke-backup-plan`, `drift-pubsub`) for infrastructure provisioning, plus `examples/full-install/`, the single-apply composition that installs the Helm chart on top. `drift-pubsub` is not yet part of that composition.
 - `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
@@ -66,7 +66,7 @@ The ten homes, what runs each, and how far "runs on a pull request" is from "gat
 
 ## Agent Setup & Integration
 
-This repository is primarily configuration and documentation for AI agents. The exceptions are the Go modules — the operator in `k8s-operator/` and the A2A bus in `a2a/` — which require compilation (see Local Validation Checks below).
+This repository is primarily configuration and documentation for AI agents. The main exceptions are the Go modules — the operator in `k8s-operator/` and the A2A bus in `a2a/` — which require compilation (see Local Validation Checks below).
 
 To use these agents:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This repository contains the Kubernetes Agentic Harness (`kube-agents`). It is a
   - `cluster/`: The Cluster Agent profile _template_ (persona, scoped config, and runtime-debugging skills). The Platform Agent scaffolds this into per-cluster Hermes profiles at runtime; it is not deployed directly.
 - `.agents/skills/`: Repository-level skills, not shipped in the agent images — review skills (adversarial change review, security audits, docs-drift, skill quality) run against pull requests and clusters, with `review-preflight` running the pre-PR set of them in a context that did not write the change, plus the `install-kube-agents`/`uninstall-kube-agents`/`upgrade-kube-agents` lifecycle skills that drive the repository's installer scripts.
 - `.agents/rules/`: Repository-level rules an agent follows, one file per family and none shipped in the agent images — `core_engineering.md` for the code itself, `github_actions.md` for workflow authoring, `pre_pr_review.md` for the mechanics of the two pre-PR passes. This file states each rule and links there for the form it takes; the split keeps `AGENTS.md` inside the context budget `scripts/check_context_budget.py` enforces.
-- `a2a/`: Go module for the agent-to-agent bus — the JetStream wire-protocol library and conformance suite for `docs/designs/spec-a2a-payloads.md`, the `a2a` topics CLI, and declarative agent profiles. Nothing imports or invokes it yet; components arrive behind the mode switch.
+- `a2a/`: Go module for the agent-to-agent bus — wire-protocol library, `a2a` topics CLI, and agent profiles per `docs/designs/spec-a2a-payloads.md`. Nothing imports it yet.
 - `charts/`: Canonical Helm charts (`kube-agents`) for deploying the Kube-Agents operator and profiles.
 - `terraform/`: Companion reusable Terraform modules (`gke-cluster`, `kube-agents-iam`, `chat-pubsub`, `github-minter`, `gke-backup-plan`, `drift-pubsub`) for infrastructure provisioning, plus `examples/full-install/`, the single-apply composition that installs the Helm chart on top. `drift-pubsub` is not yet part of that composition.
 - `deploy/`: Deployment infrastructure code (Dockerfile, Kustomize bases, shared runtime assets).
@@ -66,7 +66,7 @@ The ten homes, what runs each, and how far "runs on a pull request" is from "gat
 
 ## Agent Setup & Integration
 
-This repository is primarily a configuration and documentation repository for AI agents. The main exceptions are the Go modules — the Kubernetes operator in `k8s-operator/` and the A2A bus module in `a2a/` — which require compilation (see Local Validation Checks below).
+This repository is primarily configuration and documentation for AI agents. The exceptions are the Go modules — the operator in `k8s-operator/` and the A2A bus in `a2a/` — which require compilation (see Local Validation Checks below).
 
 To use these agents:
 


### PR DESCRIPTION
## Summary

Two prose trims to AGENTS.md, no content lost. #1124's repo-layout bullet tipped the always-loaded instruction files 98 characters over the 38,000-character budget, which fails **Documentation Checks** and its mirror test in `scripts/test_context_budget.py` — both red on `main` since `5c9f2e5e`, and inherited by every open pull request's merge.

## Why This Change

`scripts/check_context_budget.py` names two remedies: trim, or argue for raising `BUDGET` in the pull request. This takes the trim — the overage is 98 characters and the newest bullet compresses that far without losing a fact. If the budget itself is due for a raise (three workstreams have now collided with it inside a week), that argument belongs in a change that makes it deliberately, not in the unbreak.

## What Changed

Two sentences in AGENTS.md: the `a2a/` repo-layout bullet (same facts, fewer words) and the compilation-exceptions sentence (drops restatements). Post-trim the script reports under budget with roughly the same margin `main` carried before #1124.

## Context

No issue was auto-filed — `main-broken-notify` watches Operator Tests, and this breaks Documentation Checks and Run Python Unit Tests instead. Found because #1121's merge-CI inherited the failures.

## Testing

- `python3 scripts/check_context_budget.py` — passes.
- `cd scripts && python3 -m unittest test_context_budget` — OK (the two tests red on `main` go green).
- `make docs-check` — passes.

### Live validation

Not live-tested: a docs-prose trim reaches no running system; the failing checks themselves are the mechanism.

## Risk & Rollout

None beyond CI: merging turns Documentation Checks and the Python suite green on `main` and stops every open PR inheriting the failure. The margin is thin again after this — the durable fix is either continued discipline or a deliberately argued budget raise; this PR takes no position beyond unbreaking.

## Self-Review

Both required passes ran in fresh subagent contexts (the PR opened before they returned — same disclosed trade as #1119, because the breakage blocks every open pull request — and this section was folded once they landed). They converged on the same defect in my own trim, fixed in `0937316a`:

- **The rewritten `a2a/` bullet mis-attached the spec pointer** (Blocking/MEDIUM CONFIRMED, found independently by both passes): "per `spec-a2a-payloads.md`" hung off the whole list, and on the nearest-attachment reading off the profiles — whose spec of record is `spec-subagent-profiles.md`, per `a2a/profiles/profile.go`'s own header. The pointer now scopes to the wire protocol and CLI. A trim that manufactures a wrong claim in the always-loaded navigation file is worse than the characters it saved.
- **"The exceptions" overclaimed exhaustiveness** (LOW PLAUSIBLE): `admin_console/` and `bench/` are application code too; "main" returns.
- Both fixes together cost nine characters against the 32-character margin (23 remain — noted so review-round edits budget for it).
- Everything else the trims dropped was audited fact-by-fact: each survives at its canonical home (JetStream and the A2A conformance suite in the testing map and docs map, the mode-switch gating in the NATS deployment spec), the "nothing imports or invokes it" claim was verified against the tree in its surviving weaker form, and no other document quotes the pre-trim spellings. The passes' one procedural note stands: the red-then-green test for this change is the budget gate itself, failing on base and passing at head.

Generated with the help of Claude.
