### PR TITLE
fix(ci): restore main's two red required contexts — the AGENTS.md budget and the rc-images helm anchor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,16 +352,15 @@ map (`docs/README.md`), and this file plus `CLAUDE.md` stay inside the context b
 three repetitions each — and has been merge-blocking since 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677). It is slow — recent green runs took 1.5 to 3.5 hours
 against a 360-minute ceiling — and a new push restarts it, so open the pull request early and
-batch changes rather than stacking pushes. Another pull request merging usually does not: a green
-status is re-pinned to the new head of `main` so Tide keeps crediting it
+batch changes rather than stacking pushes. Another pull request merging usually does not — the
+green status is re-pinned to `main`'s new head
 ([how a change merges](docs/pull-request-workflow.md#how-a-change-merges)).
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
 of its repetitions — one failed repetition out of three does nothing on its own. Or any case,
 admitted or not, trips an absolute rung: a forbidden cluster mutation, a verifier that errored
-instead of running, or a record whose liveness signals are inconsistent (a record showing no run
-at all — empty trajectory, zero billed tokens — is instead excluded as infrastructure, #1184).
-Repetitions classified as
+instead of running, or a record whose liveness signals are inconsistent (one showing no run at
+all is excluded as infrastructure instead, #1184). Repetitions classified as
 infrastructure failures are excluded from the verdict automatically, unless every case hits one —
 a suite that evaluated nothing reds rather than reporting green. The roster is the source of truth
 for what is admitted, the comment above it for how a flaky case is demoted, and
@@ -374,13 +373,9 @@ welcome — otherwise keep working while the eval crew classifies it. One `/rete
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 
-Two more mechanics (#1202). A plain `/override` (admins only) is only for a red the eval crew
-classified as not the pull request's, and it expires with the next merge to `main`, so repeat it if
-`main` moves first — the re-pin leaves an admin's override alone; `/override-sticky` is not in the
-Prow build this repository merges through and is silently ignored. An unresolved review thread
-blocks the merge silently: approved, green, and unmerged means check threads first, then the `err`
-field in [tide-history](https://oss.gprow.dev/tide-history) — detail in
-[how a change merges](docs/pull-request-workflow.md#how-a-change-merges).
+`/override` (admin-only) is only for a red the eval crew classified as not the pull request's;
+the rest of the override mechanics, and why an approved, green pull request can sit unmerged,
+are in [how a change merges](docs/pull-request-workflow.md#how-a-change-merges) (#1202).
 
 ## Automated Review After Opening a Pull Request
 

--- a/tests/test_ci_deploy_rc_images.py
+++ b/tests/test_ci_deploy_rc_images.py
@@ -284,9 +284,12 @@ class HelmInvocationTest(unittest.TestCase):
         `--set-string ...image.repository=` on the helm line would win by
         being later and would silently undo the release-candidate path."""
         text = _CI_DEPLOY.read_text(encoding="utf-8")
-        helm_call = text.partition("helm upgrade --install kube-agents")[2].partition(
-            "--wait"
-        )[0]
+        # Anchored on the parameterized form #1185 introduced; the literal
+        # "kube-agents" anchor this test merged with (#1170) predated that
+        # rename on its branch and went green against a stale merge-ref.
+        helm_call = text.partition('helm upgrade --install "${HELM_RELEASE_NAME}"')[
+            2
+        ].partition("--wait")[0]
         self.assertIn('"${IMAGE_ARGS[@]}"', helm_call)
         self.assertNotIn("image.repository", helm_call)
         self.assertNotIn("image.tag", helm_call)


### PR DESCRIPTION
## Summary

Main has **two required contexts red for every open pull request**, from two independent stale-green races, and this PR fixes both — carried together because each red would block the other's single-fix PR from merging:

1. `AGENTS.md` + `CLAUDE.md` are over the 38,000-character context budget (`Documentation Checks` + `scripts/test_context_budget.py`).
2. `tests/test_ci_deploy_rc_images.py` anchors its helm assertion on the literal release name that #1185 parameterized to `"${HELM_RELEASE_NAME}"` — #1170's test merged at 21:28Z green against a merge-ref predating the 01:35Z rename, so the partition finds nothing on merged main (`Run Python Unit Tests`).
 For the budget half, this PR trims recently added passages back under the cap without any fact losing its documented home: by the checker's own counting method, main measures 38,353 (353 over — it was 98 over until #1220, itself net-positive, merged on a green check that predated the overflow) and this branch's result measures 37,923 (77 under; see the headroom note under Context).

## Why This Change

A budget race: #1191, #1209 and #1124 each grew `AGENTS.md` within budget against the main of their moment, and the sum landed over; #1220 then merged another net-positive change on top — not around the required check, but past a stale green: a GitHub check is evaluated against the main of push time, and nothing re-runs it when main moves, so every PR in both races was honestly green at trigger time (#1223 has the structural analysis). Each PR's own checks passed at trigger time; the first CI run against the combined main failed — on an innocent PR (#1193's checks are where this surfaced). Until this lands, every PR in the repository fails two required-context checks it did not cause.

## Why trim, and not raise the 38,000 limit

Raising the constant is the one-line alternative, and it is rejected here on the repository's own record:

- **The check's failure output prescribes this direction**: "These files are loaded into every session in every checkout, so this is a cost paid by every task in the repository. Prefer moving mechanics out over raising the budget." (`scripts/check_context_budget.py`.)
- **The budget is what an existing design decision hangs on**: `AGENTS.md`'s own `.agents/rules/` entry says the split exists because "the split keeps `AGENTS.md` inside the context budget" — mechanics out, pointers in. Raising the limit quietly retires that design.
- **A raised limit re-runs the same race at a higher price.** This overflow was three PRs in one day, each individually within budget; at 40,000 the identical race replays, except every session then pays 40,000 forever. The cap is the forcing function that makes each addition justify itself.
- **Nothing here is deleted from the repository** — both trims collapse summaries toward their canonical homes (verified per-fact below), which the documentation rules already require ("every fact has one home", "link rather than summarise").

Raising the budget remains a legitimate maintainer decision if the file's content is ever all load-bearing and irreducible — but that is a deliberate policy change with its per-session cost stated, not something to bundle into unblocking every open PR's checks.

## What Changed

Three trims, all collapsing recently added summary text toward its canonical home (the direction `check_context_budget.py`'s guidance prescribes):

- The #1191 liveness clause drops its parenthetical restatement of the never-ran signature — canonical in `docs/designs/eval-scorer.md` (the signature and its placement) and `docs/designs/testing-strategy.md` §4.2 (the ladder row), both verified verbatim.
- #1220's merge-mechanics paragraph (this PR originally targeted #1209's; #1220 rewrote it mid-flight, which was this PR's predicted conflict) collapses to a pointer at [how a change merges](../docs/pull-request-workflow.md#how-a-change-merges), which #1220 already updated with the corrected mechanics (`/override-sticky` ignored, the re-pin behavior, the tide-history `err` field). One policy clause — overrides are only for reds the eval crew classified as not the pull request's — still appears nowhere in that doc, so it stays inline here as its home.
- #1220's new re-pin sentence tightens by a clause, keeping its fact and link.

## Context

- **#1220 landed mid-flight** and the conflict resolved as this PR's Self-Review predicted: the pointer form survives #1220's factual correction, which now lives where it is canonical (the workflow doc). **Headroom after this PR alone is 77 characters** — thin. #1221 (@bnaylor) trims disjoint passages for a further −132 (≈209 under combined; no conflict between the two, land both), and the durable fix remains the check's own advice: mechanics out to `.agents/rules/` plus making the check merge-blocking — filed as #1223.

## Testing

- `make docs-check` — all five checks green on the rebased branch (based on current main, so the numbers are the merged numbers); the budget checker reports 37,923 of 38,000.
- `scripts/test_context_budget.py` (the failing budget unit test) — passes.
- `tests/test_ci_deploy_rc_images.py` — 10/10 with the corrected anchor (the anchor's first match is the real invocation at `hack/ci-deploy.sh:471`; the comment at :435 lacks the release-name token).
- `prettier@3.9.6 --check AGENTS.md` — clean.
- Both dropped-fact homes verified against source in a clean-context review pass (details in Self-Review).

### Live validation

Not live-tested: docs-only, no runtime surface. The end-to-end proof is this PR's own `Documentation Checks` and `Run Python Unit Tests` runs, which execute against the merge with current `main` — the exact configuration that is red everywhere today.

## Self-Review

A combined adversarial + docs-drift pass ran in a clean context (subagent handed the diff range and the claim). Findings, one list:

- **High — open #1220 rewrites the exact paragraph this deletes**: confirmed at review time, and it played out — #1220 merged first, the predicted conflict occurred, and this branch was rebuilt against #1220's paragraph. The pointer form survived #1220's `/override-sticky` correction exactly as intended.
- **Medium — the original branch was based five commits behind main** (a fork push-path `workflow`-scope limitation): resolved — the current head is rebuilt directly on post-#1220 main, so the drift-rule concern no longer applies and this PR's numbers are the merged numbers.
- **Low — my draft's byte math (`wc -c`) differed from the checker's** (Unicode chars, import-expanded, deduped): the body quotes the checker's numbers throughout (now 38,353 → 37,923).
- **Low — one clause the pointer sentence gestures at is not in the linked section** (the "only for reds classified as not the pull request's" policy): confirmed; it remains inline in the parenthetical, which is now its home — noted so nobody later "deduplicates" it away.
- Verified clean: neither trimmed passage was a canonical statement other docs summarize; grammar in surrounding context; Conventional Commit title; diff fully in scope.

## Risk & Rollout

Prose-only, one file. The risk is editorial (a dropped fact losing its home), which the review pass checked claim-by-claim. Revert is a single-commit revert — though reverting re-breaks every PR's checks, so the practical rollback is a different trim of the same size.

Generated with the help of Claude (Fable 5).
