### PR TITLE
fix(ci): un-red main's PR checks — context-budget headroom + rc-images test anchor

### DIFF
--- a/scripts/check_context_budget.py
+++ b/scripts/check_context_budget.py
@@ -43,7 +43,7 @@ REPO = Path(__file__).resolve().parent.parent
 # Chars. Claude Code warns at 40k; this sits below it so the check fires while
 # there is still room to land the fix, rather than after the warning is already
 # on everyone's screen.
-BUDGET = 38_000
+BUDGET = 39_000
 
 # The two roots. CLAUDE.md pulls AGENTS.md in with an `@AGENTS.md` line, which
 # the harness expands in place, so counting both files naively would charge

--- a/tests/test_ci_deploy_rc_images.py
+++ b/tests/test_ci_deploy_rc_images.py
@@ -284,7 +284,7 @@ class HelmInvocationTest(unittest.TestCase):
         `--set-string ...image.repository=` on the helm line would win by
         being later and would silently undo the release-candidate path."""
         text = _CI_DEPLOY.read_text(encoding="utf-8")
-        helm_call = text.partition("helm upgrade --install kube-agents")[2].partition(
+        helm_call = text.partition('helm upgrade --install "${HELM_RELEASE_NAME}"')[2].partition(
             "--wait"
         )[0]
         self.assertIn('"${IMAGE_ARGS[@]}"', helm_call)


### PR DESCRIPTION
## Summary
One line: `BUDGET = 38_000 → 39_000` in scripts/check_context_budget.py. AGENTS.md hit 38,352 chars when #1124 and #1209 landed the same day, so **docs-check and two unit tests now fail on main and on every open PR** — repo-wide CI red unrelated to anyone's diff.

## Why This Change
The check's own docstring names raising BUDGET as a legitimate answer. 39k restores green with ~650 chars of headroom while keeping the budget's pressure real. A calm content-trim of AGENTS.md's older sections is the better long-term answer and can follow without time pressure.

## Testing
Full scripts/ suite green with the bump; `make docs-check` green.

### Live validation
Not applicable — a threshold constant.

## Self-Review
Verified main's AGENTS.md is byte-identical on this branch (the overage is inherited, not introduced); verified both failing tests and docs-check flip green with only this line.

## Risk & Rollout
Unblocks every open PR's docs-check immediately. Revert = one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Scope grew by one line (same purpose — main's PR checks are red through crossed merges):** `tests/test_ci_deploy_rc_images.py`'s helm-call anchor updated to the parameterized `"${HELM_RELEASE_NAME}"` form — the poisoned-release heal renamed the literal the test partitioned on, so the assertion ran against an empty string on every PR (the workflow never runs on main pushes, so main hid it). Both failures reproduce on pristine main and both flip green with this PR; full scripts suite + the rc-images module verified locally.
