### PR TITLE
build(go): keep the Go builder pin and go.mod's go directive in step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ dev-rebuild-agent: ## Fast local iteration: rebuild and redeploy an agent image 
 mirror-images: ## Mirror the images in images.json into MIRROR_PREFIX (e.g. make mirror-images MIRROR_PREFIX=registry.example.com/kube-agents).
 	@./scripts/mirror_images.sh $(ARGS)
 
-images-check: ## Verify images.json still matches every pin it mirrors, and that the chart renders nothing off a public registry when mirrored (CI runs this).
+images-check: ## Verify images.json still matches every pin it mirrors, that the Go builder pin matches k8s-operator/go.mod, and that the chart renders nothing off a public registry when mirrored (CI runs this).
 	@./hack/check-image-inventory.sh
 
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -76,6 +76,12 @@ FROM ${ENVOY_IMAGE}:${ENVOY_VERSION} AS envoy-bin
 # cross-compiles to TARGETARCH, the architecture of the image being produced.
 # The :-amd64 fallback only fires on builders that don't populate TARGETARCH.
 FROM --platform=$BUILDPLATFORM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS watcher-builder
+# The official golang image sets this already; repeated so a substituted
+# GOLANG_IMAGE cannot reintroduce GOTOOLCHAIN=auto, under which a
+# k8s-operator/go.mod newer than GOLANG_VERSION would download a toolchain the
+# pin does not name instead of failing. Same reason as k8s-operator/Dockerfile
+# (#1138).
+ENV GOTOOLCHAIN=local
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -15,8 +15,9 @@ A bump starts here but rarely ends here. Several images keep a second copy that 
 source for — a chart value, a Dockerfile `ARG` default, a compiled constant in the operator — and
 `make images-check` is what holds them in step. It covers every image the chart renders, on both a
 default and a mirrored install; the build-time bases against their Dockerfile `ARG` defaults; the
-fluent-bit fallback baked into the operator binary; the example manifests; and the kustomize
-integrations, which it requires to name a variable this file owns rather than a literal.
+Go builder pin against the `go` directive in `k8s-operator/go.mod`; the fluent-bit fallback baked
+into the operator binary; the example manifests; and the kustomize integrations, which it requires
+to name a variable this file owns rather than a literal.
 
 Two copies it does not reach, where a stale pin passes every check. An image behind a non-default
 chart toggle is never rendered, so Hindsight (`memory.provider`) and the GitHub token minter
@@ -275,7 +276,10 @@ make docker-build-platform \
 
 Unset args keep their upstream defaults, so an ordinary build is unchanged. Mirror the base
 images first with `INCLUDE=build-time`, and use `crane` or `skopeo` rather than `docker` — the
-Hermes pin is by digest, and a `docker pull`/`push` round trip changes it.
+Hermes pin is by digest, and a `docker pull`/`push` round trip changes it. A mirrored `golang` copy
+is frozen at whichever patch it was copied at, and the builder stages run with `GOTOOLCHAIN=local`,
+so a later bump of the `go` directive in `k8s-operator/go.mod` past that patch fails the rebuild
+instead of downloading a toolchain: re-mirror, or pass a patch-pinned `GOLANG_VERSION`.
 
 ### Registry authentication
 

--- a/hack/check-image-inventory.sh
+++ b/hack/check-image-inventory.sh
@@ -9,11 +9,18 @@
 #   2. A new image appears with no inventory entry. Nothing copies it, and the
 #      air-gapped install fails at pull time on a registry nobody approved.
 #
+# And one that has not happened yet: the Go builder pin matches the inventory
+# but no longer satisfies k8s-operator/go.mod, so the image build fails, or a
+# base without GOTOOLCHAIN=local builds with a toolchain nobody pinned.
+#
 # Run via `make images-check`; CI runs it in validate.yml.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 INVENTORY=images.json
+readonly GO_MOD=k8s-operator/go.mod
+readonly GOLANG_IMAGE_ARG=GOLANG_IMAGE
+readonly GOTOOLCHAIN_PIN='ENV GOTOOLCHAIN=local'
 MIRROR=registry.example.invalid/mirror
 status=0
 
@@ -101,6 +108,51 @@ check_base_image golang deploy/docker/Dockerfile GOLANG_IMAGE GOLANG_VERSION
 check_base_image golang k8s-operator/Dockerfile GOLANG_IMAGE GOLANG_VERSION
 check_base_image distroless-static k8s-operator/Dockerfile DISTROLESS_IMAGE DISTROLESS_VERSION
 check_base_image python examples/inference-replay/replay-proxy/Dockerfile PYTHON_IMAGE PYTHON_VERSION
+
+# The Go builder and k8s-operator/go.mod's `go` directive must name the same
+# major.minor: a builder behind the directive fails the image build (the
+# official golang image sets GOTOOLCHAIN=local, and the Dockerfiles repeat it so
+# a substituted base cannot quietly download a newer toolchain instead, #1138),
+# and a builder ahead of it ships a compiler the directive does not name. A tag
+# that names only a major.minor (`1.27-alpine`) pulls the newest patch from
+# Docker Hub, so equality is the whole check; a mirror populated by
+# `make mirror-images` freezes whichever patch it copied, and a patch-pinned tag
+# (`1.27.3-alpine`) is the answer when the directive outruns that copy. A tag
+# that names a patch or pre-release must also sit at or above the directive.
+# The ENV line is checked too, between the FROM that opens the Go stage and its
+# first RUN: it is the only guard left once a mirror has frozen the patch, and
+# nothing else would notice a reshuffle moving it out of that stage or below the
+# `go build` it has to precede.
+check_go_directive() {
+  local dockerfile=$1 version_arg=$2
+  local builder_tag directive builder_ver builder_mm directive_mm
+  awk -v img="\${$GOLANG_IMAGE_ARG}" '/^FROM / { in_stage = index($0, img) > 0; next } /^RUN / { in_stage = 0 } in_stage' "$dockerfile" |
+    grep -qx "$GOTOOLCHAIN_PIN" ||
+    fail "$dockerfile: no line exactly '$GOTOOLCHAIN_PIN' between the FROM \${$GOLANG_IMAGE_ARG} line and that stage's first RUN, so a substituted $GOLANG_IMAGE_ARG without that default downloads a toolchain the pin does not name instead of failing."
+  builder_tag="$(arg_default "$dockerfile" "$version_arg")"
+  directive="$(sed -n 's/^go[[:space:]][[:space:]]*\([0-9][0-9A-Za-z.]*\).*$/\1/p' "$GO_MOD" | head -n1)"
+  [ -n "$directive" ] || {
+    fail "$GO_MOD has no 'go' directive, so nothing pins the toolchain the operator builds with."
+    return
+  }
+  builder_ver="$(sed -n 's/^\([0-9][0-9A-Za-z.]*\).*$/\1/p' <<<"$builder_tag")"
+  builder_mm="$(sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' <<<"$builder_ver")"
+  directive_mm="$(sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' <<<"$directive")"
+  [ -n "$builder_mm" ] || {
+    fail "$dockerfile: ARG $version_arg defaults to '${builder_tag:-<unset>}', which does not name a Go major.minor, so nothing ties the builder to the 'go $directive' directive in $GO_MOD."
+    return
+  }
+  [ "$builder_mm" = "$directive_mm" ] || {
+    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_mm), but $GO_MOD says 'go $directive' (Go $directive_mm). Move both together: a go.mod ahead of the builder fails the image build, a builder ahead of go.mod ships a compiler the directive does not name."
+    return
+  }
+  [ "$builder_ver" = "$builder_mm" ] ||
+    [ "$(printf '%s\n%s\n' "$directive" "$builder_ver" | sort -V | head -n1)" = "$directive" ] ||
+    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_ver), below the 'go $directive' floor in $GO_MOD, so the image build fails under $GOTOOLCHAIN_PIN."
+}
+
+check_go_directive deploy/docker/Dockerfile GOLANG_VERSION
+check_go_directive k8s-operator/Dockerfile GOLANG_VERSION
 
 # hermes-agent is the one base image whose tag lives outside the Dockerfile —
 # the release workflows read tags.env — so the inventory points at that file
@@ -304,6 +356,6 @@ while IFS=$'\t' read -r file line image; do
 done <<<"$integration_refs"
 
 if [ "$status" -eq 0 ]; then
-  echo "Image inventory check passed: $INVENTORY matches every pin, and the chart mirrors cleanly."
+  echo "Image inventory check passed: $INVENTORY matches every pin, the Go builder pin matches $GO_MOD, and the chart mirrors cleanly."
 fi
 exit "$status"

--- a/k8s-operator/Dockerfile
+++ b/k8s-operator/Dockerfile
@@ -10,6 +10,16 @@ ARG DISTROLESS_VERSION=nonroot
 # Build stage
 FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS builder
 
+# The official golang image sets this already; it is repeated here so a
+# substituted GOLANG_IMAGE (a mirror, an in-house base) cannot reintroduce Go's
+# default GOTOOLCHAIN=auto. Under `auto`, a go.mod `go` directive newer than
+# the builder does not fail the build: Go downloads the newer toolchain and
+# builds with it, so the compiler behind the shipped binary is no longer the
+# one GOLANG_VERSION names or images.json pins, and nothing reports the swap.
+# Under `local` that mismatch is a build failure. hack/check-image-inventory.sh
+# catches the same drift before a build runs. (#1138)
+ENV GOTOOLCHAIN=local
+
 ARG TARGETOS
 ARG TARGETARCH
 ARG TARGETPLATFORM

--- a/tests/test_check_image_inventory_go_directive.py
+++ b/tests/test_check_image_inventory_go_directive.py
@@ -1,0 +1,162 @@
+"""`check_go_directive` in hack/check-image-inventory.sh fails when the Go builder
+pin and k8s-operator/go.mod's `go` directive move apart (#1138).
+
+CI only ever runs the script on a tree where the check passes, so every fail
+path -- and the whole patch-tag branch -- would otherwise execute nowhere.
+The function is lifted from the script's own text and run under bash against
+synthetic go.mod and Dockerfile inputs, so the assertions are against the code
+that ships rather than a copy (the approach of tests/test_ci_teardown_sweep.py).
+"""
+
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "hack" / "check-image-inventory.sh"
+
+# The three functions the check needs, each lifted by name. A rename fails
+# here loudly instead of silently shrinking what is tested.
+_LIFTED_FUNCTIONS = ("fail", "arg_default", "check_go_directive")
+
+# The call sites, asserted present because the lift below supplies its own:
+# a function that is defined and never called keeps every gate green.
+_CALL_SITES = (
+    "check_go_directive deploy/docker/Dockerfile GOLANG_VERSION",
+    "check_go_directive k8s-operator/Dockerfile GOLANG_VERSION",
+)
+
+# What the check requires of the builder stage besides the ARG default, and
+# the FROM line that opens that stage.
+_TOOLCHAIN_PIN = "ENV GOTOOLCHAIN=local"
+_BUILDER_FROM = "FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS builder"
+
+# (builder tag, go directive, expected to pass, fragment the failure names).
+# Pass cases: equal major.minor, whatever the patch; a patch or pre-release
+# tag at or above the directive. Fail cases: either side ahead on major.minor,
+# a patch or pre-release tag below the directive, a tag with no minor.
+_CASES = (
+    ("1.27-alpine", "1.27.0", True, ""),
+    ("1.27-alpine", "1.27.3", True, ""),
+    ("1.27-alpine", "1.27", True, ""),
+    ("1.27.3-alpine", "1.27.0", True, ""),
+    ("1.27.3-alpine", "1.27.3", True, ""),
+    ("1.28rc1-alpine", "1.28rc1", True, ""),
+    ("1.28-alpine", "1.28rc1", True, ""),
+    ("1.27-alpine", "1.28.0", False, "Move both together"),
+    ("1.26-alpine", "1.27.0", False, "Move both together"),
+    ("1.28.0-alpine", "1.27.0", False, "Move both together"),
+    ("1.29.3-bookworm", "1.27.0", False, "Move both together"),
+    ("1.27.0-alpine", "1.27.3", False, "below the 'go 1.27.3' floor"),
+    ("1.28rc1-alpine", "1.28.0", False, "below the 'go 1.28.0' floor"),
+    ("1.28rc1-alpine", "1.28rc2", False, "below the 'go 1.28rc2' floor"),
+    ("1-alpine", "1.27.0", False, "does not name a Go major.minor"),
+    ("alpine", "1.27.0", False, "does not name a Go major.minor"),
+    ("latest", "1.27.0", False, "does not name a Go major.minor"),
+)
+
+
+def _lift(name: str, text: str) -> str:
+    match = re.search(rf"^{re.escape(name)}\(\) \{{\n.*?^\}}\n", text, re.S | re.M)
+    if match is None:
+        raise AssertionError(f"{_SCRIPT} no longer defines {name}()")
+    return match.group(0)
+
+
+def _dockerfile(tag: str) -> str:
+    return f"ARG GOLANG_VERSION={tag}\n{_BUILDER_FROM}\n{_TOOLCHAIN_PIN}\nFROM scratch\n"
+
+
+def _run_check(go_mod: str, dockerfile: str) -> subprocess.CompletedProcess:
+    text = _SCRIPT.read_text()
+    functions = "".join(_lift(name, text) for name in _LIFTED_FUNCTIONS)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        (root / "go.mod").write_text(go_mod)
+        (root / "Dockerfile").write_text(dockerfile)
+        script = (
+            "set -u\nstatus=0\nGO_MOD=go.mod\nGOLANG_IMAGE_ARG=GOLANG_IMAGE\n"
+            f"GOTOOLCHAIN_PIN='{_TOOLCHAIN_PIN}'\n"
+            + functions
+            + "check_go_directive Dockerfile GOLANG_VERSION\nexit $status\n"
+        )
+        return subprocess.run(
+            ["bash", "-c", script], cwd=root, capture_output=True, text=True, check=False
+        )
+
+
+class CheckGoDirectiveTest(unittest.TestCase):
+    def test_builder_tag_against_directive(self):
+        for tag, directive, expect_pass, fragment in _CASES:
+            with self.subTest(tag=tag, directive=directive):
+                result = _run_check(
+                    f"module example.com/x\n\ngo {directive}\n",
+                    _dockerfile(tag),
+                )
+                if expect_pass:
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stderr, "")
+                else:
+                    self.assertEqual(result.returncode, 1, result.stderr)
+                    self.assertIn(fragment, result.stderr)
+
+    def test_directive_is_read_past_toolchain_and_comments(self):
+        result = _run_check(
+            "module example.com/x\n\ntoolchain go1.28.0\ngodebug x=1\ngo 1.27.0 // floor\n",
+            _dockerfile("1.27-alpine"),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_missing_directive_fails(self):
+        result = _run_check("module example.com/x\n", _dockerfile("1.27-alpine"))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("has no 'go' directive", result.stderr)
+
+    def test_unset_arg_fails(self):
+        result = _run_check("module example.com/x\n\ngo 1.27.0\n", f"{_BUILDER_FROM}\n{_TOOLCHAIN_PIN}\n")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("<unset>", result.stderr)
+
+    def test_missing_toolchain_pin_fails(self):
+        result = _run_check(
+            "module example.com/x\n\ngo 1.27.0\n",
+            f"ARG GOLANG_VERSION=1.27-alpine\n{_BUILDER_FROM}\n",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"no line exactly '{_TOOLCHAIN_PIN}'", result.stderr)
+
+    def test_toolchain_pin_in_another_stage_fails(self):
+        result = _run_check(
+            "module example.com/x\n\ngo 1.27.0\n",
+            f"ARG GOLANG_VERSION=1.27-alpine\n{_BUILDER_FROM}\nFROM scratch\n{_TOOLCHAIN_PIN}\n",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"no line exactly '{_TOOLCHAIN_PIN}'", result.stderr)
+
+    def test_toolchain_pin_after_first_run_fails(self):
+        result = _run_check(
+            "module example.com/x\n\ngo 1.27.0\n",
+            f"ARG GOLANG_VERSION=1.27-alpine\n{_BUILDER_FROM}\nRUN go build ./...\n"
+            f"{_TOOLCHAIN_PIN}\nFROM scratch\n",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"no line exactly '{_TOOLCHAIN_PIN}'", result.stderr)
+
+    def test_toolchain_pin_after_intermediate_stage_passes(self):
+        result = _run_check(
+            "module example.com/x\n\ngo 1.27.0\n",
+            f"ARG GOLANG_VERSION=1.27-alpine\nFROM alpine AS other\n{_BUILDER_FROM}\n"
+            f"WORKDIR /w\n{_TOOLCHAIN_PIN}\nFROM scratch\n",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_script_calls_the_check_for_both_dockerfiles(self):
+        text = _SCRIPT.read_text()
+        for call in _CALL_SITES:
+            self.assertIn(call, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Nothing held the Go builder pin (`ARG GOLANG_VERSION=1.27-alpine` in both Dockerfiles) and the `go 1.27.0` directive in `k8s-operator/go.mod` together. This PR adds a check to `make images-check` that fails when they move apart, pins `GOTOOLCHAIN=local` in both builder stages so a substituted base image cannot quietly download a toolchain the pin does not name, and covers the check's fail paths with a unit test. One correction to the issue as filed: the official `golang` image already sets `GOTOOLCHAIN=local`, so a go.mod ahead of the builder already fails the build today. The `ENV` lines only matter for a mirrored or in-house `GOLANG_IMAGE`, and the comments say so.

## Why This Change

`GOLANG_VERSION` and go.mod's `go` directive agree today by coincidence. #1110 moved both together; the next bump of either can move one alone. A builder behind go.mod fails the build with a clear message, but a builder ahead of go.mod ships a compiler the directive does not name, and on a substituted base without `GOTOOLCHAIN=local` a go.mod ahead of the builder downloads a newer toolchain instead of failing, so `images.json` then pins a compiler the shipped binary was not built with. Nothing reported either case.

## What Changed

- `hack/check-image-inventory.sh` gains `check_go_directive`, run for both Dockerfiles. A tag naming only a major.minor (`1.27-alpine`) must equal the directive's major.minor; a patch or pre-release tag must also sit at or above the directive as a full version; and `ENV GOTOOLCHAIN=local` must appear between the `FROM ${GOLANG_IMAGE}` line and that stage's first `RUN`. Each failure names the file, both values, and the consequence.
- `k8s-operator/Dockerfile` and `deploy/docker/Dockerfile` set `ENV GOTOOLCHAIN=local` in their Go builder stages, with a comment saying the official image already does and why it is repeated.
- `tests/test_check_image_inventory_go_directive.py` lifts the function out of the script text and drives it against synthetic go.mod and Dockerfile inputs: 16 tag/directive pairs, the missing-directive, unset-ARG, missing-ENV, ENV-in-wrong-stage, ENV-after-RUN and `toolchain`-line-first cases, and an assertion that the script still calls the check for both Dockerfiles. Reached by the existing `tests/test_*.py` glob.
- The docker-images page and the `make help` line describe the new coverage. The rebuild-from-mirror section now says a mirrored `golang` copy is frozen at its patch, so a later directive bump past it fails the rebuild, and names the two remedies.

## Context

Closes #1138.

The check is an explicit list of two Dockerfiles and one go.mod. Open PR #1212 adds a third Go builder under `a2a/` with its own `go.mod`, which neither this check nor `check_base_image` reaches. Whichever merges second needs a third entry.

The GoReleaser path in `k8s-operator/Dockerfile` copies a prebuilt binary and never runs `go`, so the `ENV` does not cover it. Every `setup-go` step in the workflows reads `go-version-file: k8s-operator/go.mod`, so that path agrees with the directive by construction.

Generated with the help of Claude (Fable 5.1).

## Testing

- `make images-check` passes on the branch. On temp copies it fails with go.mod at `1.28.0`, with `GOLANG_VERSION=1.26-alpine`, and with the `ENV` line moved below the runtime `FROM` of the real operator Dockerfile, each with the intended message.
- `python3 -m pytest tests/test_check_image_inventory_go_directive.py`: 9 passed.
- `make docs-check` passes all five checks; `prettier@3.9.6 --check` on the changed page is clean; `shellcheck -S warning` is clean on the script; `go build ./...` in `k8s-operator/` passes.
- `docker build --platform linux/amd64 --target builder k8s-operator/` and `--target watcher-builder -f deploy/docker/Dockerfile .` both pass. Inside the operator builder image, `go version` reports go1.27.0, `go env GOTOOLCHAIN` reports `local`, and `go version -m /workspace/manager` shows go1.27.0.
- Negative build: a temp copy of `k8s-operator/` with `go 1.28.0` fails at `go mod download` with `go: go.mod requires go >= 1.28.0 (running go 1.27.0; GOTOOLCHAIN=local)`.
- Mechanism the `ENV` guards against: `docker run --network none -e GOTOOLCHAIN=auto golang:1.27-alpine go version` in a module with `go 1.28.0` prints `go: downloading go1.28.0 (linux/amd64)` and fails on the network, where the same image without the override fails immediately with the message above.

### Live validation

Not live-tested against a running installation. The change adds a check to a CI script and an `ENV` to two builder stages that are discarded before the runtime image, so there is nothing for the operator to reconcile and nothing in the pod that differs. The docker builds and the negative builds above are the mechanism proof: the same Dockerfile with only go.mod changed fails, and the same base image with only `GOTOOLCHAIN` changed switches from failing to downloading. No install was touched; the temporary images and directories were removed.

## Self-Review

Both passes ran on every round, each in a fresh subagent handed only the repository, the three-dot range against a freshly fetched `main`, its skill path, and the `make docs-check` output, with the instruction to derive intent from the diff and not read commit messages. Five rounds: each fix invalidated part of the previous read, so both re-ran until the last round returned nothing above LOW or Advisory. Angles covered: line-by-line, removed behaviour, cross-file consumers of `GOLANG_VERSION` and go.mod, security surface, reuse and altitude, repository conventions, scope and tests, sibling PRs, and docs-to-source for every claim on the changed page plus the map, `AGENTS.md`, `INSTALL.md`, and the operator docs.

Fixed:

- The issue's premise, repeated in four comments and the doc sentence, was wrong: the official `golang` image already sets `GOTOOLCHAIN=local`, verified against the pinned image's config and inside the built image (adversarial, MEDIUM, confirmed). Comments now say the `ENV` is for a substituted base.
- The patch-tag branch was a one-sided floor and accepted a builder any number of minors ahead (adversarial, MEDIUM, confirmed). Now major.minor equality first, then the floor.
- "A mismatch fails the build" overstated the direction in the doc and the failure message (adversarial LOW and docs-drift Advisory, same defect). Reworded to say which direction fails the build and which ships an unnamed compiler.
- Patch and rc tags escaped a major.minor-only check; an rc suffix on the directive was dropped by the regex (adversarial, LOW, confirmed, two rounds). Both parse the full version now, and the test covers `1.27.0-alpine` vs `go 1.27.3` and `1.28rc1-alpine` vs `go 1.28rc2`.
- The `ENV` grep matched anywhere in the file, then anywhere in the stage including after `go build` (adversarial LOW confirmed in two rounds, docs-drift Advisory). Scoped to the lines between the Go `FROM` and the stage's first `RUN`, with tests for both escapes.
- No test asserted the two call sites, so a deleted call would keep every gate green (adversarial, LOW, confirmed). Asserted.
- `GO_MOD` was not `readonly` and the `ENV` literal was inline three times (adversarial, LOW). Hoisted.
- GNU-only `\+` in the new `sed` patterns (adversarial, LOW, plausible). Rewritten as POSIX BRE.
- Header comment, `make help` line, pass line, and the page sentence under-described the check; the rebuild-from-mirror section omitted the frozen-patch consequence (docs-drift, Advisory, five findings). Updated.

Not fixed, by decision:

- The `ENV` check is an exact-line match, so `ENV GOTOOLCHAIN=local CGO_ENABLED=0` is rejected (adversarial, LOW, confirmed). Kept strict because the two Dockerfiles use the exact line and a looser regex is more to get wrong; the failure message now says "no line exactly" so it does not claim the pin is absent.
- A major.minor tag against a directive with a newer patch passes even though a stale local image cache or a frozen mirror will fail the build (adversarial, not raised as a finding, noted twice). The script comment and the rebuild section state the trade-off and name the patch-pinned tag as the remedy.

Not this PR's, reported: #1212's third Go builder, above under Context.

Not covered by the passes: no docker build inside the passes themselves (the builds above were run by the author), and no macOS to exercise `sed`, moot after the POSIX rewrite. No test harness existed for this script before; the new one exercises the lifted function, not the script's `set -euo pipefail` wrapper, which the fifth pass checked by hand under the real options.

## Risk & Rollout

Low risk. The check runs only in `make images-check` and can red CI on a future bump that moves one of the two values alone, which is its purpose; the message names the fix. The `ENV` lines change nothing on the official base and turn a silent download into a build failure on a substituted one. Revert by reverting the commit. Merge-conflict warning only with #1182, #913, #965 and #608, which edit other regions of the same script.
