### PR TITLE
fix(proxy): allowlist the discovery reads the networking audit's leaf reads depend on

### DIFF
--- a/agents/platform/cron/jobs.json
+++ b/agents/platform/cron/jobs.json
@@ -99,7 +99,7 @@
         "expr": "0 8 * * *",
         "display": "0 8 * * *"
       },
-      "prompt": "Run the daily GCP networking fabric and VPC IPAM audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 209 lines of it, before you run anything. Its five checks are section 2, lines 38-77, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
+      "prompt": "Run the daily GCP networking fabric and VPC IPAM audit. Read the SOP at 'governance/gcp_networking_fabric_sop.md' in your profile home — all 210 lines of it, before you run anything. Its five checks are section 2, lines 38-78, so a read that stops early skips almost the entire audit and reports a clean fleet it never looked at. Then execute it exactly, using the fleet-audit skill to open and close the audit run.",
       "skills": ["fleet-audit"],
       "enabled": true,
       "deliver": "all"

--- a/agents/platform/governance/gcp_networking_fabric_sop.md
+++ b/agents/platform/governance/gcp_networking_fabric_sop.md
@@ -47,6 +47,7 @@ gcloud compute networks subnets list --format=json
 #### 2.2 Cloud NAT gateway port allocation saturation (`cloud-nat-exhaustion`)
 
 - **Severity**: `critical`
+- **Discovery**: `gcloud compute routers list --project=$PROJECT --format=json` — binds `$ROUTER` and `$REGION`; run the command below once per router whose `nats` list is non-empty. A router with no `nats` entry is a BGP router, not a NAT gateway: skip it rather than reading its empty mapping as a gateway without IPs. A project with no NAT router has nothing to inspect: record the check in `checks_run` with the discovery command, not in `limitations`.
 - **Command**: `gcloud compute routers get-nat-mapping-info $ROUTER --region=$REGION --project=$PROJECT --format=json`
 - **Condition**: Cloud NAT mapping indicates allocated ports exceed 80% available port capacity per VM or gateway lacks auto-allocated IP addresses.
 - **Remediation**: Increase `minPortsPerVm` or add additional NAT IP addresses in Cloud Router specification.

--- a/agents/platform/scripts/command_policy.py
+++ b/agents/platform/scripts/command_policy.py
@@ -300,23 +300,37 @@ GCLOUD_READ_COMMANDS: frozenset[tuple[str, ...]] = frozenset(
         ("compute", "backend-services", "list"),
         ("compute", "disks", "describe"),
         ("compute", "disks", "list"),
+        # Not spelled by any SOP. A live install refused both under
+        # gcp.read-only while the model investigated the fabric (#1126); they
+        # are the read side of the firewall rules the networking SOP's Red
+        # Lines forbid modifying, and list/describe is all that is granted.
+        ("compute", "firewall-rules", "describe"),
+        ("compute", "firewall-rules", "list"),
         ("compute", "forwarding-rules", "describe"),
         ("compute", "forwarding-rules", "list"),
         # The daily `gcp-networking-fabric-audit` cron executes
-        # governance/gcp_networking_fabric_sop.md exactly, and of the reads
-        # that SOP issues only forwarding-rules list was in this set --
-        # four of its five checks had no data source. Same shape as the
-        # stockout gap below: the job runs, reports, and measures nothing.
+        # governance/gcp_networking_fabric_sop.md exactly, and the networks,
+        # routers and security-policies entries were derived from the command
+        # spellings that SOP carries. A SOP spelling assumes its arguments are
+        # already bound, so a leaf read listed on its own can be unreachable:
+        # `routers get-nat-mapping-info $ROUTER` was listed while `routers
+        # list`, the only way to bind $ROUTER, was not, and the audit's one
+        # critical NAT check never ran (#1126). Grant a discovery read
+        # alongside every leaf read that needs one; `networks describe` and
+        # `routers describe` are the detail reads behind the two lists.
         # `compute project-info describe` is the stockout SOP's quota
         # remediation read. The writes one word away (networks create,
-        # security-policies create, project-info add-metadata) stay
-        # refused, and the tests assert it.
+        # routers create, firewall-rules create, security-policies create,
+        # project-info add-metadata) stay refused, and the tests assert it.
+        ("compute", "networks", "describe"),
         ("compute", "networks", "list"),
         ("compute", "networks", "subnets", "describe"),
         ("compute", "networks", "subnets", "list"),
         ("compute", "networks", "subnets", "list-usable"),
         ("compute", "project-info", "describe"),
+        ("compute", "routers", "describe"),
         ("compute", "routers", "get-nat-mapping-info"),
+        ("compute", "routers", "list"),
         ("compute", "security-policies", "list"),
         # The daily `stockout-prevention` cron reads these three and nothing
         # else can stand in for them: reservations list is the committed
@@ -395,6 +409,9 @@ _GCLOUD_FLAGS_WITH_VALUE = frozenset(
         "--instance-selection-machine-types", "--size", "--types", "--zones",
         "--machine-type", "--provisioning-model", "--target-distribution-shape",
         "--instance-selection",
+        # `compute routers list` scopes by --regions (plural), the router
+        # analogue of the --zones trap above.
+        "--regions",
         # `billing budgets list` requires it.
         "--billing-account",
         # `container ai profiles manifests create` selectors, from its gcloud

--- a/agents/platform/scripts/test_command_policy.py
+++ b/agents/platform/scripts/test_command_policy.py
@@ -939,22 +939,69 @@ class TheAllowlistCoversWhatTheProductActuallyRuns(unittest.TestCase):
         # spellings.
         for argv, desc in (
             (["gcloud", "compute", "networks", "list", "--project=p",
-              "--format=json"], "SOP:60 VPC inventory"),
+              "--format=json"], "SOP:66 VPC inventory"),
             (["gcloud", "compute", "networks", "subnets", "list",
-              "--format=json"], "SOP:26 subnet inventory"),
+              "--format=json"], "SOP:31 subnet inventory"),
             (["gcloud", "compute", "networks", "subnets", "list-usable",
-              "--project=p", "--format=json"], "SOP:38 usable ranges"),
+              "--project=p", "--format=json"], "SOP:43 usable ranges"),
             (["gcloud", "compute", "networks", "subnets", "describe",
-              "gke-pods-subnet", "--region=us-central1"], "SOP:164 subnet detail"),
+              "gke-pods-subnet", "--region=us-central1"], "SOP:170 subnet detail"),
+            (["gcloud", "compute", "routers", "list", "--project=p",
+              "--format=json"], "SOP:50 router discovery"),
             (["gcloud", "compute", "routers", "get-nat-mapping-info", "r",
-              "--region=us-central1", "--project=p"], "SOP:45 NAT mappings"),
+              "--region=us-central1", "--project=p"], "SOP:51 NAT mappings"),
             (["gcloud", "compute", "security-policies", "list", "--project=p",
-              "--format=json"], "SOP:68 Cloud Armor inventory"),
+              "--format=json"], "SOP:74 Cloud Armor inventory"),
             (["gcloud", "compute", "project-info", "describe"],
-             "stockout SOP:199 quota remediation read"),
+             "stockout SOP:204 quota remediation read"),
         ):
             with self.subTest(desc=desc):
                 self.assertTrue(evaluate(argv).allowed, desc)
+
+    def test_a_leaf_read_ships_with_the_discovery_read_that_binds_its_argument(self):
+        # The allowlist was derived from SOP command spellings, and a SOP
+        # spelling arrives with its arguments already bound: check 2.2 reads
+        # `get-nat-mapping-info $ROUTER`, so that verb was listed and `routers
+        # list` -- the only way to learn a router's name -- was not. The check
+        # never ran on a live install, and the model retried the refusal seven
+        # times in five minutes (#1126). The SOP now spells the discovery step,
+        # but the rule outlives the SOP text: do not remove a discovery read
+        # here because no SOP line contains it. `--regions` is the flag
+        # `routers list` scopes by; an entry whose flags are not in the arity
+        # table is refused as unreadable before the entry is consulted.
+        for argv, desc in (
+            (["gcloud", "compute", "routers", "list", "--regions=us-central1",
+              "--project=p", "--format=json"], "routers list by region"),
+            (["gcloud", "compute", "routers", "describe", "r",
+              "--region=us-central1", "--project=p"], "router NAT config"),
+            (["gcloud", "compute", "routers", "get-nat-mapping-info", "r",
+              "--region=us-central1", "--project=p"], "the leaf read"),
+            (["gcloud", "compute", "networks", "describe", "n", "--project=p"],
+             "network detail behind networks list"),
+            # Not SOP reads: refused on the live install in #1126 during a
+            # networking investigation, granted as read-only inventory.
+            (["gcloud", "compute", "firewall-rules", "list",
+              "--filter=network:default", "--project=p"], "firewall inventory"),
+            (["gcloud", "compute", "firewall-rules", "describe", "f",
+              "--project=p"], "firewall rule detail"),
+        ):
+            with self.subTest(desc=desc):
+                self.assertTrue(evaluate(argv).allowed, desc)
+
+    def test_a_verb_gcloud_does_not_have_is_not_granted_by_a_neighbour(self):
+        # Two spellings the model guessed on the live install (#1126) are not
+        # gcloud commands at all: `routers list-usable` borrows the subnets
+        # verb, and `compute firewalls` is not a group in the SDK. Neither
+        # is listed, and neither may be reached through the prefix scan from
+        # an entry that is.
+        for argv, desc in (
+            (["gcloud", "compute", "routers", "list-usable", "--project=p"],
+             "routers list-usable"),
+            (["gcloud", "compute", "firewalls", "list", "--project=p"],
+             "firewalls list"),
+        ):
+            with self.subTest(desc=desc):
+                self.assertFalse(evaluate(argv).allowed, desc)
 
     def test_the_stockout_sop_spellings_reach_their_allowlist_entries(self):
         # The capacity-history and machine-types entries were added for this
@@ -993,8 +1040,16 @@ class TheAllowlistCoversWhatTheProductActuallyRuns(unittest.TestCase):
              "subnets expand-ip-range"),
             (["gcloud", "compute", "project-info", "add-metadata",
               "--metadata=k=v"], "project-info add-metadata"),
+            (["gcloud", "compute", "networks", "update", "n"], "networks update"),
             (["gcloud", "compute", "routers", "create", "r"], "routers create"),
             (["gcloud", "compute", "routers", "update", "r"], "routers update"),
+            (["gcloud", "compute", "routers", "delete", "r"], "routers delete"),
+            (["gcloud", "compute", "firewall-rules", "create", "f"],
+             "firewall-rules create"),
+            (["gcloud", "compute", "firewall-rules", "update", "f"],
+             "firewall-rules update"),
+            (["gcloud", "compute", "firewall-rules", "delete", "f"],
+             "firewall-rules delete"),
             (["gcloud", "compute", "security-policies", "create", "p"],
              "security-policies create"),
             (["gcloud", "billing", "budgets", "create", "--billing-account=A"],

--- a/docs/designs/multi-project-scope.md
+++ b/docs/designs/multi-project-scope.md
@@ -63,7 +63,7 @@ closed on 2026-08-28 with a comment that `main` handles multi-project IAM and re
 natively through Terraform and Helm. It does not: the IAM module above takes one project, and no
 reconciler reads more than one. Epic #618 filed multi-project onboarding as its phase 3 and pointed it at #588.
 #953 (the agent cannot route a request that does not name a cluster) and #1126 (the broker's read
-allowlist withholds discovery reads a leaf read needs) are the same problem seen from the agent's
+allowlist withheld discovery reads a leaf read needs) are the same problem seen from the agent's
 side: the fleet it can enumerate is narrower than the fleet it is asked about.
 
 ## 2. What already generalises
@@ -80,7 +80,7 @@ Cluster Agent is named, stored, or driven:
   for a cluster in another project is verified against the right project today.
 - `create_profile()` fetches credentials with `--project=<P>` (`cluster_agent_profile.py:235-243`).
 - The credential broker passes `--project` through as a value-taking flag
-  (`agents/platform/scripts/command_policy.py:378`), takes the project from the kubeconfig context
+  (`agents/platform/scripts/command_policy.py:392`), takes the project from the kubeconfig context
   name (`credential_proxy.py:1168-1190`), and re-issues `get-credentials` with the target's project
   (`:2496`). It does not pin a project. Only IAM stops a cross-project call.
 - The scoped service account pool is already keyed on a per-row project. `scoped_clusters`
@@ -201,7 +201,7 @@ silently. An organisation policy that forbids the Asset API is an open question 
 path.
 
 The discovery verb is absent from the broker's read allowlist. `GCLOUD_READ_COMMANDS`
-(`command_policy.py:277-363`) admits `container clusters list` and `projects list` but no `asset`
+(`command_policy.py:277-377`) admits `container clusters list` and `projects list` but no `asset`
 command. This is the class of gap #1126 describes: a discovery read the leaf reads depend on,
 refused fail-closed with no signal. Adding `("asset", "search-all-resources")` is part of phase 2, with the resolver that needs it,
 and so is adding `--scope` and `--asset-types` to `_GCLOUD_FLAGS_WITH_VALUE`: the broker refuses a


### PR DESCRIPTION
## Summary

The credential proxy's gcloud read allowlist grants `compute routers get-nat-mapping-info` but not `compute routers list`, the only way to learn the router name that read requires. The daily `gcp-networking-fabric-audit` cron has therefore never run its one `critical` Cloud NAT check and publishes a `limitations` string blaming the wrong command. This PR grants the discovery and detail reads behind the SOP's networking checks, makes the SOP spell the discovery step, and turns the tests from "every spelling the SOP contains" into "every read the audit needs".

## Why This Change

`GCLOUD_READ_COMMANDS` in `agents/platform/scripts/command_policy.py` was populated from the SOPs' literal command spellings, and a SOP spelling arrives with its arguments already bound. On a live install the audit retried `compute routers list` seven times in five minutes, recorded `cloud-nat-exhaustion` on neither target's `checks_run`, and wrote "router get-nat-mapping-info not available in this profile" into its ledger issue, which is the command that was already allowed. Anyone fixing the gap from the ledger would allowlist an entry that is already there. The SOP test was green throughout because the SOP does not spell the discovery read either.

## What Changed

- `command_policy.py`: adds `compute routers list`/`describe`, `compute networks describe`, and `compute firewall-rules list`/`describe` to the allowlist, and `--regions` to the flag arity table so `routers list` is reachable. The allowlist comment now states the rule (a leaf read ships with the discovery read that binds its argument) and each entry's provenance, instead of describing the previous gap in the past tense.
- Two spellings the model tried on the live install are not gcloud commands (`routers list-usable`, `compute firewalls list`) and are asserted refused rather than added. `compute instances describe`, which the issue also lists, is left out: its consumer is the GCE fleet audit, whose gap also needs `instances list` decided alongside it and deserves its own issue.
- `gcp_networking_fabric_sop.md` check 2.2 gains a Discovery line: `routers list` binds `$ROUTER`/`$REGION`, and only routers with a non-empty `nats` list are inspected, so a BGP-only router is not read as a NAT gateway without IPs.
- `cron/jobs.json`: the networking prompt's pinned SOP line count and section range follow the SOP edit (210 lines, section 2 at 38-78).
- `test_command_policy.py`: the SOP test asserts `routers list` with a comment saying why it is there when the SOP did not spell it; a new test covers the discovery-to-leaf chain and the firewall reads; the write neighbours one word away (`routers create/update/delete`, `firewall-rules create/update/delete`, `networks update`) are asserted refused; stale `SOP:NN` labels renumbered.
- `docs/designs/multi-project-scope.md`: two line citations into `command_policy.py` shifted by the insert; one sentence about #1126 moved to past tense.

## Context

Closes #1126.

Open PRs #885 and #926 both add flags at the same `--zones` anchor in `_GCLOUD_FLAGS_WITH_VALUE` as this branch's `--regions`, so whichever merges second will need a trivial conflict resolution there.

Follow-up worth filing: the daily `gce-compute-fleet-audit` has the same leaf-without-discovery shape. Its SOP spells `instances describe $VM --zone=$ZONE` and `instances get-serial-port-output`, and its skill script issues `instances list`, none of which the allowlist grants today.

Generated with the help of Claude (Fable 5.1).

## Testing

- `python3 -m unittest test_command_policy` in `agents/platform/scripts`: 79 tests OK. Against `main`'s `command_policy.py` with this branch's test file, 7 subtests fail (the six new discovery/detail spellings and the `routers list` SOP row), so the new tests are red-to-green.
- `make test-python`: every directory that fails on this branch fails identically on `upstream/main` in this environment (missing `fastapi`, `uvicorn`, `helm`, and a Playwright suite); the failure sets are byte-identical for `agents/platform/scripts/`.
- `make docs-check`: generated regions current, links resolve, terminology and map coverage pass, AGENTS.md at 37.8k of the 38,000-char budget.
- Pinned `prettier@3.9.6 --check` on the changed Markdown: clean.

### Live validation

Install: `bhoekstra-gkedemos` / `kube-agents-cluster` (us-central1), namespace `kubeagents-system`, operator and agent at `dns-endpoint-7dac349`. That deployed proxy predates #723's allowlist entirely, so two `credential-proxy` images were built with `--target credential-proxy`: a control from `upstream/main` @ `32c5538b` and the fix from this branch, each swapped in by setting the operator's `CREDENTIAL_PROXY_IMAGE` env and letting it recreate `platform-agent-gateway` (3/3 Ready each time). Commands ran from the `platform-agent` container's `/opt/data` through the proxy's `gcloud` wrapper.

Control image (before):

```
$ gcloud compute networks list --project=bhoekstra-gkedemos --format="value(name)"
default
$ gcloud compute routers get-nat-mapping-info nat-router --region=us-central1 --project=bhoekstra-gkedemos --format=json
[ { "instanceName": "gke-kube-agents-cluster-default-pool-a8aad227-mxws", ...
$ gcloud compute routers list --project=bhoekstra-gkedemos
Agents hold read-only access to Google Cloud. ... missing from GCLOUD_READ_COMMANDS in command_policy.py
policy rule: gcp.read-only                                  (exit 126)

envoy-credential-proxy log:
WARNING credential-proxy command refused rule=gcp.read-only hint=compute.routers.list
```

The neighbouring read and the leaf read both work, and only the discovery read is refused, with the issue's exact hint.

Fix image (after), same pod layout:

```
$ gcloud compute routers list --project=bhoekstra-gkedemos --format="value(name,region.basename(),nats[0].name)"
nat-router	us-central1	nat-config
$ gcloud compute routers list --regions=us-central1 --project=bhoekstra-gkedemos --format="value(name)"
nat-router
$ R=$(gcloud compute routers list ... --format="value(name)"); REG=$(... --format="value(region.basename())")
bound ROUTER=nat-router REGION=us-central1
$ gcloud compute routers get-nat-mapping-info "$R" --region="$REG" --project=bhoekstra-gkedemos --format="value(instanceName)"
gke-kube-agents-cluster-default-pool-a8aad227-mxws
$ gcloud compute routers describe nat-router --region=us-central1 ... --format="value(nats[0].name)"
nat-config
$ gcloud compute networks describe default --project=bhoekstra-gkedemos --format="value(name)"
default
$ gcloud compute firewall-rules list --project=bhoekstra-gkedemos --format="value(name)" | head -2
allow-http
allow-https

Refused, exit 126 each, envoy-credential-proxy log:
rule=gcp.read-only hint=compute.routers.create
rule=gcp.read-only hint=compute.firewall-rules.create
rule=gcp.read-only hint=compute.routers.delete
rule=gcp.read-only hint=compute.routers.list-usable
rule=gcp.read-only hint=compute.instances.describe
```

The SOP chain runs with nothing hand-supplied: discovery binds the router and region, the leaf read returns the NAT mapping. The image's `/opt/defaults/scripts/command_policy.py` was checked to carry `routers list` and not `instances describe` before deploying.

Not covered: the cron-driven end state (`cloud-nat-exhaustion` in the project target's `checks_run`, no NAT `limitations` string). This install has `gitRepo: ""`, so `fleet-audit start` cannot open a ledger issue, and its agent image is 318 commits behind `main`. The proxy-level allow and refuse decisions are the mechanism the issue reports.

Cleanup: operator env restored to `credential-proxy:dns-endpoint-7dac349`, pod back at 3/3 on the original three images, the three test tags deleted from Artifact Registry, live-test lease released.

## Self-Review

Passes: `review-adversarial` and `review-docs-drift`, each in its own subagent handed the diff range, the skill path, and the `make docs-check` output, told to derive intent from the diff and not read commit bodies or plan files. Docs-drift was re-run in a fresh subagent after the fixes below because they moved SOP prose and line citations; the adversarial findings were addressed by removals and comment prose, so that pass was not re-run. Neither pass had a cluster; the live validation above is what covers that.

- **MEDIUM, CONFIRMED (adversarial).** Three of the new entries had no consumer in the networking SOP while the comment said all were SOP-derived, and `instances describe` reproduced the very shape being fixed: the GCE fleet audit spells it while `instances list` stays refused. Fixed: `instances describe` dropped and named in Context as a follow-up; `firewall-rules list/describe` kept with their provenance stated in the comment (refused on the live install during a networking investigation, list/describe only, the read side of what the SOP's Red Lines forbid modifying).
- **Blocking (docs-drift).** `multi-project-scope.md:83` cited the flag table at a line the insert moved. Fixed, with the range citation on line 204; the re-run confirmed both land and that these are the only two citations into `command_policy.py` in the tree.
- **LOW, PLAUSIBLE (adversarial).** The Discovery step treated every Cloud Router as a NAT gateway; a BGP-only router returns an empty mapping that reads like a gateway with no IPs. Fixed: the SOP now inspects only routers whose `nats` list is non-empty, which `routers list --format=json` carries (checked against the live project).
- **Advisory (docs-drift).** Test label `stockout SOP:199` pointed at a "Do NOT flag" bullet; the read is at line 204. Fixed while renumbering the neighbouring labels.
- **Advisory (docs-drift, re-run).** The design doc described #1126 in the present tense. Fixed with a one-word tense change.
- **Advisory (docs-drift).** The cron prompt's hard-coded SOP line counts are a drift magnet. Not changed: pre-existing, kept correct here, and guarded by `test_cron_prompts_cite_the_real_sop_geography`, which passes on this head.
- **Adversarial angles with nothing found:** exact-tuple prefix matching means each new 3-tuple matches only itself; `--regions` parses in both `=` and split forms; `routers nats list` and `networks list-peering-routes` stay refused; all reads sit under the GSA's existing `compute.viewer`; no IAM, RBAC, or NetworkPolicy change; no new literals outside module-level constants and tests; red-to-green confirmed against `main`'s policy file.
- **Noted, not a finding:** two of the "all entries" tests in `test_command_policy.py` describe themselves as literal lists and do not carry the new entries, but they did not carry the previous commit's additions either, and the new chain test fails if any entry or `--regions` is dropped.

## Risk & Rollout

Widens the proxy's gcloud read allowlist by five `list`/`describe` verbs on resources whose siblings are already granted, all under a role the agent's GSA already holds; no write verb changes. Revert is a plain revert of the commit. Nothing has to happen at merge time; the sidecar picks the change up on its next image build.
