### PR TITLE
feat(ci): drive the release-candidate eval

### DIFF
--- a/hack/ci-eval-rc.sh
+++ b/hack/ci-eval-rc.sh
@@ -129,7 +129,8 @@ readonly RESOLVE_SCRIPT="resolve-rc-target.sh"
 # be in memory before it happens, and control must never return to the file.
 main() {
   local script_dir repo_root rc_commit_sha rc_tag original_ref
-  local artifacts_dir summary_path verdict_path deck_url eval_status
+  local artifacts_dir summary_path verdict_path deck_url
+  local deploy_status eval_status verdict
 
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   repo_root="$(cd "${script_dir}/.." && pwd)"
@@ -243,16 +244,36 @@ main() {
   export RC_COMMIT_SHA="${rc_commit_sha}"
   export EVAL_TIER="${RC_EVAL_TIER}"
 
+  # errexit is suspended for both steps, for the same reason: whatever happens,
+  # this run owes Prow an artifact saying what happened. A bare invocation here
+  # aborts main() on the spot, which skips the summary below and leaves a
+  # deploy failure legible only to somebody willing to read the raw log --
+  # and makes the summary's own "did not reach the verdict step" branch
+  # unreachable. Measured against a real candidate: ci-deploy.sh exits non-zero
+  # before it reaches a cluster if the environment is short a variable, which
+  # is an ordinary Tuesday for a job whose config is maintained in another
+  # repository.
   echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying release candidate ${rc_commit_sha:0:7} ==="
-  "${script_dir}/${DEPLOY_SCRIPT}"
+  deploy_status=0
+  "${script_dir}/${DEPLOY_SCRIPT}" || deploy_status=$?
 
-  # errexit is suspended for the eval alone. A red verdict is this job's
-  # OUTPUT, not its failure -- this lane is non-gating by charter -- so the
-  # status is captured, reported, and handed back at the end rather than
-  # skipping the summary that says where to read it.
-  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Evaluating release candidate ${rc_commit_sha:0:7} (tier: ${RC_EVAL_TIER}) ==="
+  # A failed deploy is not a red verdict. Nothing was measured, so saying RED
+  # would report a judgement on the candidate that this run never formed --
+  # the one reading that matters, because the whole lane exists to answer
+  # "is this candidate worse than main".
   eval_status=0
-  "${script_dir}/${EVAL_SCRIPT}" || eval_status=$?
+  if [ "${deploy_status}" -ne 0 ]; then
+    verdict="NOT RUN"
+    echo "ERROR: deploying ${rc_tag} (${rc_commit_sha:0:7}) failed with status ${deploy_status}, so the candidate was never evaluated. This is not a verdict on the candidate." >&2
+  else
+    echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Evaluating release candidate ${rc_commit_sha:0:7} (tier: ${RC_EVAL_TIER}) ==="
+    "${script_dir}/${EVAL_SCRIPT}" || eval_status=$?
+    if [ "${eval_status}" -eq 0 ]; then
+      verdict="GREEN"
+    else
+      verdict="RED"
+    fi
+  fi
 
   # ─── Reporting: make the verdict findable without a credential ────────────
   deck_url=""
@@ -264,7 +285,7 @@ main() {
   echo "🏷️ RELEASE CANDIDATE EVAL"
   echo "Candidate:   ${rc_tag} (${rc_commit_sha})"
   echo "Tier:        ${RC_EVAL_TIER}"
-  echo "Verdict:     $([ "${eval_status}" -eq 0 ] && echo "GREEN" || echo "RED") (advisory: this lane gates nothing)"
+  echo "Verdict:     ${verdict} (advisory: this lane gates nothing)"
   if [ -n "${deck_url}" ]; then
     echo "Artifacts:   ${deck_url}"
   fi
@@ -281,7 +302,7 @@ main() {
       echo "| Candidate | \`${rc_tag}\` |"
       echo "| Commit | \`${rc_commit_sha}\` |"
       echo "| Tier | \`${RC_EVAL_TIER}\` |"
-      echo "| Verdict | $([ "${eval_status}" -eq 0 ] && echo "GREEN" || echo "RED") |"
+      echo "| Verdict | ${verdict} |"
       if [ -n "${deck_url}" ]; then
         echo "| Run | ${deck_url} |"
       fi
@@ -292,6 +313,10 @@ main() {
       echo
       if [ -f "${verdict_path}" ]; then
         echo "Per-case detail is in \`${RC_VERDICT_FILE}\` alongside this file."
+      elif [ "${deploy_status}" -ne 0 ]; then
+        echo "The candidate was never evaluated: deploying it failed with"
+        echo "status ${deploy_status}. Nothing here is a judgement on the"
+        echo "candidate. The build log above is where it stopped."
       else
         echo "No \`${RC_VERDICT_FILE}\` was written: the run did not reach the"
         echo "verdict step. The build log above is where it stopped."
@@ -302,11 +327,16 @@ main() {
 
   # The restore hint is the EXIT trap's, so that the failure paths get it too.
 
-  # The eval's own status is preserved rather than forced to 0. Which one the
-  # job reports is the JOB's decision (an `|| true` in its config), kept there
-  # so "non-gating" is one line in the config a reader can see, instead of a
-  # swallowed exit code here that makes a red run indistinguishable from a
-  # green one to anything reading exit statuses.
+  # The failing step's own status is preserved rather than forced to 0. Which
+  # one the job reports is the JOB's decision (an `|| true` in its config),
+  # kept there so "non-gating" is one line in the config a reader can see,
+  # instead of a swallowed exit code here that makes a red run
+  # indistinguishable from a green one to anything reading exit statuses.
+  # Deploy first: on that path eval_status is 0 because the eval never ran,
+  # and returning it would call a run that measured nothing a success.
+  if [ "${deploy_status}" -ne 0 ]; then
+    exit "${deploy_status}"
+  fi
   exit "${eval_status}"
 }
 

--- a/hack/ci-eval-rc.sh
+++ b/hack/ci-eval-rc.sh
@@ -3,8 +3,10 @@
 # Release-candidate eval (the periodic job's entrypoint)
 # ==============================================================================
 # Resolve the newest release candidate, check it out, deploy its published
-# images, and run the full eval catalog against them. Non-gating: the verdict
-# is reported, and nothing here can hold up a release.
+# images, and evaluate them. Non-gating: the verdict is reported, and nothing
+# here can hold up a release. How wide that evaluation is depends on a tier
+# switch that has not landed yet -- see RC_EVAL_TIER below, which is the one
+# place in this file describing something the repository does not have.
 #
 # The four steps, and why they need a driver at all:
 #
@@ -53,28 +55,42 @@
 #   JOB_NAME/BUILD_ID Prow's. Both set, the summary carries the run's Deck URL
 #                     so the verdict is findable without a credential.
 #
+# NOT a whole job: the four steps stop at the verdict, and teardown is the job
+# config's to run -- as a separate step, unconditionally, whatever this script
+# exits with. hack/ci-teardown.sh explains what a leased project left holding a
+# live install does to the next lease that gets it (#1006), and this lane
+# borrows the same pool the presubmit eval does, so skipping it is the one way
+# a non-gating lane can still cost somebody a run.
+#
 # The path of this file is a CONTRACT: the periodic job in oss-test-infra
 # invokes hack/ci-eval-rc.sh by name. Do not rename it.
 # ==============================================================================
 
 set -euo pipefail
 
-# The tier exported to ci-eval-pr.sh. `nightly` and not a value of this lane's
-# own, because the tier switch is #1175's and its default branch rejects
+# The tier exported to ci-eval-pr.sh. NOTHING READS IT TODAY: the switch that
+# would is #1175's and is not on main, so `grep EVAL_TIER` finds only this file.
+# Every run therefore measures the presubmit matrix, and the NOTE below prints
+# for every candidate rather than only for old ones. That is a smaller run than
+# the lane intends, not a wrong one, which is why it is a note and not a
+# failure. The export is here so the lane widens to the full catalog on the day
+# that switch merges, with no edit to this file.
+#
+# `nightly` and not a value of this lane's own, because #1175's switch rejects
 # anything it does not know: a value invented here would exit 1 the day the two
 # land together. What distinguishes this run from the main-branch nightly is
 # RC_COMMIT_SHA, which ci-eval-pr.sh already reads as the third condition on
 # the baseline store, so the tier does not have to carry that meaning too.
-#
-# Against a candidate whose tree predates the switch the variable is simply
-# unread and the run measures the presubmit matrix. That is a smaller run than
-# intended, not a wrong one, so it is a note below rather than a failure.
 readonly RC_EVAL_TIER="nightly"
 
 # Written by resolve-rc-target.sh through RC_TARGET_OUTPUT: the tag and commit
 # in key=value form, for anything downstream that needs to know what was
 # measured without parsing a log.
 readonly RC_TARGET_FILE="rc-target.env"
+
+# The key read back out of that file. A cross-file contract with the writer in
+# resolve-rc-target.sh, so it is named for the same reason the filename is.
+readonly RC_TARGET_TAG_KEY="rc_tag"
 
 # This script's own artifact. The verdict file is bench-gate's, named here so
 # the summary can point at it; keep in step with the --markdown-out in
@@ -96,7 +112,8 @@ readonly DEPLOY_RC_MARKER="RC_COMMIT_SHA"
 
 # The same question asked of the candidate's ci-eval-pr.sh, with a softer
 # answer: absent, the tier switch is not there to read and the run measures
-# the presubmit matrix.
+# the presubmit matrix. Absent is the norm until #1175 lands, so expect this
+# one to fire on every candidate for now.
 readonly EVAL_TIER_MARKER="EVAL_TIER"
 
 # The siblings this script drives. Named because each name is a contract with
@@ -126,6 +143,19 @@ main() {
     echo "rc eval skipped: PULL_NUMBER=${PULL_NUMBER} is set: a pull request measures itself, never a release candidate"
     exit 0
   fi
+  # PULL_NUMBER alone is one condition short. Prow sets it for presubmits, but
+  # a batch job carries PULL_REFS and no PULL_NUMBER, so it would walk through
+  # the check above and have the tree replaced underneath the merge it is
+  # testing. Both siblings gate on the job shape as well -- ci-eval-pr.sh at
+  # its baseline-store append, ci-dashboard-refresh.sh at its gs:// write --
+  # and there is no reason for this one to be the weaker of the three.
+  case "${JOB_TYPE:-periodic}" in
+    periodic | postsubmit) ;;
+    *)
+      echo "rc eval skipped: JOB_TYPE=${JOB_TYPE:-} is not a main-branch job shape; only a periodic or postsubmit measures a release candidate"
+      exit 0
+      ;;
+  esac
 
   # Recorded before anything moves, so a local run can be put back. Prow
   # workspaces are disposable and this is only ever printed, never restored:
@@ -136,6 +166,14 @@ main() {
   if [ "${original_ref}" = "HEAD" ]; then
     original_ref="$(git -C "${repo_root}" rev-parse HEAD)"
   fi
+  # On an EXIT trap rather than inline, because every interesting way to leave
+  # a detached tree behind is a failure path: the marker refusal below, an
+  # errexit abort inside ci-deploy.sh, a Prow deadline. Printing the hint only
+  # on success would withhold it from exactly the runs that need it. The guard
+  # keeps it quiet on the paths that never moved the tree.
+  RC_EVAL_CHECKOUT_DONE="false"
+  RC_EVAL_ORIGINAL_REF="${original_ref}"
+  trap 'if [ "${RC_EVAL_CHECKOUT_DONE}" = "true" ]; then echo "This tree is detached at $(git -C "'"${repo_root}"'" rev-parse --short HEAD 2>/dev/null || echo unknown); \`git checkout ${RC_EVAL_ORIGINAL_REF}\` restores it."; fi' EXIT
 
   artifacts_dir="${ARTIFACTS:-}"
   if [ -n "${artifacts_dir}" ] && [ ! -d "${artifacts_dir}" ]; then
@@ -156,7 +194,7 @@ main() {
   rc_commit_sha="$("${script_dir}/${RESOLVE_SCRIPT}")"
   rc_tag="${RC_TAG:-}"
   if [ -z "${rc_tag}" ] && [ -n "${RC_TARGET_OUTPUT:-}" ] && [ -f "${RC_TARGET_OUTPUT}" ]; then
-    rc_tag="$(sed -n 's/^rc_tag=//p' "${RC_TARGET_OUTPUT}" | tail -n 1)"
+    rc_tag="$(sed -n "s/^${RC_TARGET_TAG_KEY}=//p" "${RC_TARGET_OUTPUT}" | tail -n 1)"
   fi
   rc_tag="${rc_tag:-${rc_commit_sha}}"
 
@@ -173,7 +211,16 @@ main() {
   fi
 
   echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Checking out ${rc_tag} (${rc_commit_sha:0:7}); this tree was ${original_ref} ==="
-  git -C "${repo_root}" checkout --detach "${rc_commit_sha}"
+  # The pre-check above deliberately ignores untracked files -- a Prow
+  # workspace legitimately holds build output -- which leaves one case it
+  # cannot see: an untracked file at a path the candidate tracks, where git
+  # refuses rather than clobbering it. Widening the pre-check would fail runs
+  # that are fine, so the explanation is attached to the abort instead.
+  if ! git -C "${repo_root}" checkout --detach "${rc_commit_sha}"; then
+    echo "ERROR: checking out ${rc_tag} (${rc_commit_sha:0:7}) failed, so nothing was measured. If git named untracked files above, the workspace is holding files the candidate tracks; clear them and re-run." >&2
+    exit 1
+  fi
+  RC_EVAL_CHECKOUT_DONE="true"
 
   # The candidate's ci-deploy.sh is what runs next, and a candidate cut before
   # the RC deploy path landed does not have one that can install published
@@ -185,7 +232,7 @@ main() {
     exit 1
   fi
   if ! grep -q "${EVAL_TIER_MARKER}" "${script_dir}/${EVAL_SCRIPT}"; then
-    echo "NOTE: ${rc_tag} predates the ${RC_EVAL_TIER} tier, so this run measures the presubmit matrix rather than the full catalog. The verdict is valid for the cases it ran."
+    echo "NOTE: ${rc_tag} carries no ${EVAL_TIER_MARKER} switch, so this run measures the presubmit matrix rather than the full ${RC_EVAL_TIER} catalog. Expected until that switch lands; the verdict is valid for the cases it ran."
   fi
 
   # ─── Steps 3 and 4: deploy the candidate, then grade it ───────────────────
@@ -253,7 +300,7 @@ main() {
     echo "rc eval summary: ${summary_path}"
   fi
 
-  echo "This tree is detached at ${rc_commit_sha:0:7}; \`git checkout ${original_ref}\` restores it."
+  # The restore hint is the EXIT trap's, so that the failure paths get it too.
 
   # The eval's own status is preserved rather than forced to 0. Which one the
   # job reports is the JOB's decision (an `|| true` in its config), kept there

--- a/hack/ci-eval-rc.sh
+++ b/hack/ci-eval-rc.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Release-candidate eval (the periodic job's entrypoint)
+# ==============================================================================
+# Resolve the newest release candidate, check it out, deploy its published
+# images, and run the full eval catalog against them. Non-gating: the verdict
+# is reported, and nothing here can hold up a release.
+#
+# The four steps, and why they need a driver at all:
+#
+#   1. hack/resolve-rc-target.sh   -> the candidate's commit SHA
+#   2. git checkout --detach       -> the tree becomes the candidate's
+#   3. hack/ci-deploy.sh           -> installs the candidate's published images
+#   4. hack/ci-eval-pr.sh          -> runs the catalog against them
+#
+# Step 2 needs a caller that outlives it. Bash reads a script incrementally as
+# it executes and keeps a byte offset into the file, so a script that rewrites
+# its own file mid-run can resume at that offset in different content. What
+# happens then is not defined by anything you can check: measured on this
+# repository it ranges from every step running normally to one silently
+# skipped, varying with the file's size and where the read buffer happened to
+# land. `git checkout` usually lands on the benign side because it replaces
+# the file rather than truncating it, leaving the descriptor bash holds
+# pointed at the intact original -- but "usually", for a failure that produces
+# a green run with steps missing from it, is not a property to build on.
+#
+# So this file removes the question instead of answering it. Everything below
+# is inside main(), which bash parses into memory in full before running any
+# of it, and which exits rather than returning. Past `main "$@"` the file is
+# never read from disk again, so it does not matter what the candidate's tree
+# holds in its place -- a different version, or for any candidate cut before
+# this lane existed, nothing at all. tests/test_ci_eval_rc.py runs that case
+# against a real checkout that deletes this script mid-run.
+#
+# What runs after step 2 is the CANDIDATE's ci-deploy.sh and ci-eval-pr.sh,
+# not this checkout's, and deliberately -- resolve-rc-target.sh's header has
+# the reasoning. Only the images being the candidate's, while the chart, the
+# CRDs and bench/tasks stay on main, would grade a build nobody is shipping.
+# The corollary is that a candidate predating the RC deploy path cannot be
+# measured by it, which is what the DEPLOY_RC_MARKER check below reports.
+#
+# Environment:
+#   RC_EVAL_ENABLED   any non-empty value arms this script. Unset = dormant,
+#                     one skip line, exit 0. The Prow job config arms it; until
+#                     the companion oss-test-infra job exists this file is
+#                     inert wherever it runs.
+#   RC_TAG            pin a candidate instead of resolving the newest one.
+#                     Passed through to resolve-rc-target.sh.
+#   PULL_NUMBER       Prow's. Set = a pull request, which never measures a
+#                     release candidate; skip.
+#   ARTIFACTS         Prow's. When set, receives rc-target.env and the
+#                     summary below alongside the verdict ci-eval-pr.sh writes.
+#   JOB_NAME/BUILD_ID Prow's. Both set, the summary carries the run's Deck URL
+#                     so the verdict is findable without a credential.
+#
+# The path of this file is a CONTRACT: the periodic job in oss-test-infra
+# invokes hack/ci-eval-rc.sh by name. Do not rename it.
+# ==============================================================================
+
+set -euo pipefail
+
+# The tier exported to ci-eval-pr.sh. `nightly` and not a value of this lane's
+# own, because the tier switch is #1175's and its default branch rejects
+# anything it does not know: a value invented here would exit 1 the day the two
+# land together. What distinguishes this run from the main-branch nightly is
+# RC_COMMIT_SHA, which ci-eval-pr.sh already reads as the third condition on
+# the baseline store, so the tier does not have to carry that meaning too.
+#
+# Against a candidate whose tree predates the switch the variable is simply
+# unread and the run measures the presubmit matrix. That is a smaller run than
+# intended, not a wrong one, so it is a note below rather than a failure.
+readonly RC_EVAL_TIER="nightly"
+
+# Written by resolve-rc-target.sh through RC_TARGET_OUTPUT: the tag and commit
+# in key=value form, for anything downstream that needs to know what was
+# measured without parsing a log.
+readonly RC_TARGET_FILE="rc-target.env"
+
+# This script's own artifact. The verdict file is bench-gate's, named here so
+# the summary can point at it; keep in step with the --markdown-out in
+# hack/ci-eval-pr.sh.
+readonly RC_SUMMARY_FILE="rc-eval-summary.md"
+readonly RC_VERDICT_FILE="eval-verdict.md"
+
+# Deck serves what raw GCS refuses anonymously, so this is the form of the
+# link a reader can actually open. Periodic build directories live under
+# logs/<job>/<build>; a presubmit's are elsewhere, which is why the summary
+# only builds a URL when Prow supplied both halves.
+readonly PROW_DECK_BUILD_BASE="https://oss.gprow.dev/view/gs/kube-agents-prow/logs"
+
+# Grepped for in the CANDIDATE's ci-deploy.sh after the checkout. Its presence
+# is what says the candidate's tree can install published images instead of
+# building; without it ci-deploy.sh would build the candidate's source into the
+# leased project and measure something that was never published.
+readonly DEPLOY_RC_MARKER="RC_COMMIT_SHA"
+
+# The same question asked of the candidate's ci-eval-pr.sh, with a softer
+# answer: absent, the tier switch is not there to read and the run measures
+# the presubmit matrix.
+readonly EVAL_TIER_MARKER="EVAL_TIER"
+
+# The siblings this script drives. Named because each name is a contract with
+# hack/ -- the marker greps above read the same files the invocations below
+# run, and a rename that moved one and not the other would leave this grepping
+# a file nobody was about to execute.
+readonly DEPLOY_SCRIPT="ci-deploy.sh"
+readonly EVAL_SCRIPT="ci-eval-pr.sh"
+readonly RESOLVE_SCRIPT="resolve-rc-target.sh"
+
+# ─── Everything below runs inside main() ────────────────────────────────────
+# See the header: the checkout in step 2 rewrites this file, so the body has to
+# be in memory before it happens, and control must never return to the file.
+main() {
+  local script_dir repo_root rc_commit_sha rc_tag original_ref
+  local artifacts_dir summary_path verdict_path deck_url eval_status
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "${script_dir}/.." && pwd)"
+
+  # ─── Dormancy and trust gates (exit 0: nothing to do, or must not do it) ──
+  if [ -z "${RC_EVAL_ENABLED:-}" ]; then
+    echo "rc eval skipped: RC_EVAL_ENABLED is not set (the Prow job config arms this later)"
+    exit 0
+  fi
+  if [ -n "${PULL_NUMBER:-}" ]; then
+    echo "rc eval skipped: PULL_NUMBER=${PULL_NUMBER} is set: a pull request measures itself, never a release candidate"
+    exit 0
+  fi
+
+  # Recorded before anything moves, so a local run can be put back. Prow
+  # workspaces are disposable and this is only ever printed, never restored:
+  # an automatic checkout on the way out would run while the tree is the one
+  # the eval just graded, and a failed restore would be a second failure
+  # obscuring the first.
+  original_ref="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")"
+  if [ "${original_ref}" = "HEAD" ]; then
+    original_ref="$(git -C "${repo_root}" rev-parse HEAD)"
+  fi
+
+  artifacts_dir="${ARTIFACTS:-}"
+  if [ -n "${artifacts_dir}" ] && [ ! -d "${artifacts_dir}" ]; then
+    mkdir -p "${artifacts_dir}"
+  fi
+
+  # ─── Step 1: which candidate ──────────────────────────────────────────────
+  # stdout is the SHA and nothing else; the banner and every diagnostic go to
+  # stderr. RC_TARGET_OUTPUT lands the tag alongside it as an artifact, which
+  # is also how the tag reaches the summary below without a second resolve --
+  # a second call could legitimately answer differently if a candidate is cut
+  # between them.
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Resolving the release candidate to measure ==="
+  if [ -n "${artifacts_dir}" ]; then
+    export RC_TARGET_OUTPUT="${artifacts_dir}/${RC_TARGET_FILE}"
+    : >"${RC_TARGET_OUTPUT}"
+  fi
+  rc_commit_sha="$("${script_dir}/${RESOLVE_SCRIPT}")"
+  rc_tag="${RC_TAG:-}"
+  if [ -z "${rc_tag}" ] && [ -n "${RC_TARGET_OUTPUT:-}" ] && [ -f "${RC_TARGET_OUTPUT}" ]; then
+    rc_tag="$(sed -n 's/^rc_tag=//p' "${RC_TARGET_OUTPUT}" | tail -n 1)"
+  fi
+  rc_tag="${rc_tag:-${rc_commit_sha}}"
+
+  # ─── Step 2: become the candidate ─────────────────────────────────────────
+  # A tracked file modified in the workspace makes the checkout abort with
+  # git's own message, which names the file but not why a job that never
+  # edits anything is holding one. Prow starts from a clean clone, so this
+  # firing means an earlier step wrote into the tree; saying so here is worth
+  # the four lines it costs to diagnose from a build log.
+  if [ -n "$(git -C "${repo_root}" status --porcelain --untracked-files=no)" ]; then
+    echo "ERROR: the working tree has modified tracked files, so checking out ${rc_tag} would abort partway." >&2
+    git -C "${repo_root}" status --short --untracked-files=no >&2
+    exit 1
+  fi
+
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Checking out ${rc_tag} (${rc_commit_sha:0:7}); this tree was ${original_ref} ==="
+  git -C "${repo_root}" checkout --detach "${rc_commit_sha}"
+
+  # The candidate's ci-deploy.sh is what runs next, and a candidate cut before
+  # the RC deploy path landed does not have one that can install published
+  # images. Caught here rather than 15 minutes into a build that would have
+  # measured the wrong artefact.
+  if ! grep -q "${DEPLOY_RC_MARKER}" "${script_dir}/${DEPLOY_SCRIPT}"; then
+    echo "ERROR: ${rc_tag} (${rc_commit_sha:0:7}) predates the release-candidate deploy path: its hack/${DEPLOY_SCRIPT} has no ${DEPLOY_RC_MARKER} handling and would build the candidate from source instead of installing its published images." >&2
+    echo "       Measure a candidate cut after that path landed, or pin one with RC_TAG." >&2
+    exit 1
+  fi
+  if ! grep -q "${EVAL_TIER_MARKER}" "${script_dir}/${EVAL_SCRIPT}"; then
+    echo "NOTE: ${rc_tag} predates the ${RC_EVAL_TIER} tier, so this run measures the presubmit matrix rather than the full catalog. The verdict is valid for the cases it ran."
+  fi
+
+  # ─── Steps 3 and 4: deploy the candidate, then grade it ───────────────────
+  # RC_COMMIT_SHA is what puts ci-deploy.sh on the published-image path and
+  # what keeps ci-eval-pr.sh from filing the candidate's results as main's:
+  # no field of the baseline store's VersionKey names the build a sample came
+  # from, so a candidate recorded into main's window is not undoable.
+  export RC_COMMIT_SHA="${rc_commit_sha}"
+  export EVAL_TIER="${RC_EVAL_TIER}"
+
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Deploying release candidate ${rc_commit_sha:0:7} ==="
+  "${script_dir}/${DEPLOY_SCRIPT}"
+
+  # errexit is suspended for the eval alone. A red verdict is this job's
+  # OUTPUT, not its failure -- this lane is non-gating by charter -- so the
+  # status is captured, reported, and handed back at the end rather than
+  # skipping the summary that says where to read it.
+  echo "=== [$(date -u +'%Y-%m-%dT%H:%M:%SZ')] Evaluating release candidate ${rc_commit_sha:0:7} (tier: ${RC_EVAL_TIER}) ==="
+  eval_status=0
+  "${script_dir}/${EVAL_SCRIPT}" || eval_status=$?
+
+  # ─── Reporting: make the verdict findable without a credential ────────────
+  deck_url=""
+  if [ -n "${JOB_NAME:-}" ] && [ -n "${BUILD_ID:-}" ]; then
+    deck_url="${PROW_DECK_BUILD_BASE}/${JOB_NAME}/${BUILD_ID}"
+  fi
+
+  echo "======================================================================"
+  echo "🏷️ RELEASE CANDIDATE EVAL"
+  echo "Candidate:   ${rc_tag} (${rc_commit_sha})"
+  echo "Tier:        ${RC_EVAL_TIER}"
+  echo "Verdict:     $([ "${eval_status}" -eq 0 ] && echo "GREEN" || echo "RED") (advisory: this lane gates nothing)"
+  if [ -n "${deck_url}" ]; then
+    echo "Artifacts:   ${deck_url}"
+  fi
+  echo "======================================================================"
+
+  if [ -n "${artifacts_dir}" ]; then
+    summary_path="${artifacts_dir}/${RC_SUMMARY_FILE}"
+    verdict_path="${artifacts_dir}/${RC_VERDICT_FILE}"
+    {
+      echo "# Release candidate eval — ${rc_tag}"
+      echo
+      echo "| | |"
+      echo "| --- | --- |"
+      echo "| Candidate | \`${rc_tag}\` |"
+      echo "| Commit | \`${rc_commit_sha}\` |"
+      echo "| Tier | \`${RC_EVAL_TIER}\` |"
+      echo "| Verdict | $([ "${eval_status}" -eq 0 ] && echo "GREEN" || echo "RED") |"
+      if [ -n "${deck_url}" ]; then
+        echo "| Run | ${deck_url} |"
+      fi
+      echo
+      echo "Advisory. This lane reports and does not gate: a red verdict here"
+      echo "does not hold a release, and the non-inferiority comparison stays"
+      echo "advisory while the baseline store is maturing."
+      echo
+      if [ -f "${verdict_path}" ]; then
+        echo "Per-case detail is in \`${RC_VERDICT_FILE}\` alongside this file."
+      else
+        echo "No \`${RC_VERDICT_FILE}\` was written: the run did not reach the"
+        echo "verdict step. The build log above is where it stopped."
+      fi
+    } >"${summary_path}"
+    echo "rc eval summary: ${summary_path}"
+  fi
+
+  echo "This tree is detached at ${rc_commit_sha:0:7}; \`git checkout ${original_ref}\` restores it."
+
+  # The eval's own status is preserved rather than forced to 0. Which one the
+  # job reports is the JOB's decision (an `|| true` in its config), kept there
+  # so "non-gating" is one line in the config a reader can see, instead of a
+  # swallowed exit code here that makes a red run indistinguishable from a
+  # green one to anything reading exit statuses.
+  exit "${eval_status}"
+}
+
+main "$@"

--- a/hack/resolve-rc-target.sh
+++ b/hack/resolve-rc-target.sh
@@ -5,16 +5,33 @@
 # Prints the candidate's commit SHA on stdout. Everything else goes to stderr,
 # so the caller can do:
 #
-#   RC_COMMIT_SHA="$(hack/resolve-rc-target.sh)"
-#   git checkout --detach "${RC_COMMIT_SHA}"
-#   RC_COMMIT_SHA="${RC_COMMIT_SHA}" hack/ci-deploy.sh
+#   main() {
+#     local rc_commit_sha
+#     rc_commit_sha="$(hack/resolve-rc-target.sh)"
+#     git checkout --detach "${rc_commit_sha}"
+#     RC_COMMIT_SHA="${rc_commit_sha}" hack/ci-deploy.sh
+#     exit $?
+#   }
+#   main "$@"
 #
 # The checkout is the caller's job and not this script's, and not
-# hack/ci-deploy.sh's either. Bash reads a script incrementally as it executes,
-# so a script that checks out a different revision of itself is rewriting the
-# bytes the interpreter has not read yet. .github/workflows/deploy-environment.yml
-# already settles this the same way — a second actions/checkout step at the
-# candidate's SHA, before anything that reads the tree runs.
+# hack/ci-deploy.sh's either. .github/workflows/deploy-environment.yml already
+# settles this the same way — a second actions/checkout step at the candidate's
+# SHA, before anything that reads the tree runs.
+#
+# The main() wrapper is not decoration. Bash reads a script incrementally as it
+# executes, keeping a byte offset into the file, so a script that rewrites its
+# own file mid-run can resume at that offset in different content. A checkout
+# is usually the benign case — it replaces a file by rename, leaving the
+# descriptor bash holds pointed at the intact original — but a tool that
+# rewrites in place instead truncates the live inode, and then the offset lands
+# in whatever is there now. "Usually", for a failure whose signature is a green
+# run with steps missing from it, is not a property to build on. Wrapping the
+# body removes the question: bash parses main() into memory in full before
+# running any of it, and the exit means control never returns to the file. Copy
+# the shape above rather than the three bare statements it wraps.
+# hack/ci-eval-rc.sh is the worked example, and tests/test_ci_eval_rc.py pins
+# the property by emptying that file mid-run.
 #
 # Checking out matters because only the images come from the candidate. The
 # chart, the CRDs, bench/tasks, and the seeded fleet in bench/tf/fleet all come

--- a/tests/test_ci_eval_rc.py
+++ b/tests/test_ci_eval_rc.py
@@ -1,0 +1,411 @@
+"""The release-candidate eval driver survives checking out the candidate.
+
+`hack/ci-eval-rc.sh` runs four steps — resolve the candidate, check it out,
+deploy its published images, evaluate them — and the second one moves the
+ground under the first. Bash reads a script incrementally as it executes, so a
+script that checks out a revision where its own file differs resumes at the
+same byte offset in a different file. The failure is silent: the remaining
+steps disappear and the shell exits 0. `test_bash_self_rewrite_silently_drops_
+steps` demonstrates that on the bare mechanism, and it is the reason the whole
+driver lives inside `main()` and exits rather than returning.
+
+Everything else here runs the real script — copied into a throwaway git
+repository with its three siblings stubbed — rather than grepping it, because a
+guard that greps passes for a section someone has commented out. The stubs
+append to a trace file OUTSIDE the repository, so the checkout cannot erase the
+evidence of what ran before it.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+from tests.testing.common import create_mock_git_repo
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_CI_EVAL_RC = _REPO_ROOT / "hack" / "ci-eval-rc.sh"
+
+_RC_TAG = "rc_2609021231_fdba3a7"
+_JOB_NAME = "ci-kube-agents-eval-rc"
+_BUILD_ID = "2095176282760286208"
+_EXPECTED_DECK_URL = (
+    f"https://oss.gprow.dev/view/gs/kube-agents-prow/logs/{_JOB_NAME}/{_BUILD_ID}"
+)
+
+# A stub ci-deploy.sh has to carry this for the driver's predates-the-RC-path
+# guard to let it through; the real marker is the variable ci-deploy.sh reads.
+_DEPLOY_RC_MARKER = "RC_COMMIT_SHA"
+
+
+def _stub(trace: pathlib.Path, name: str, body: str = "", exit_code: int = 0) -> str:
+    """A sibling script that records that it ran, with what, and in what order."""
+    return textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        {{
+          echo "STEP {name}"
+          echo "  RC_COMMIT_SHA=${{RC_COMMIT_SHA:-unset}}"
+          echo "  TIER=${{EVAL_TIER:-unset}}"
+          echo "  HEAD=$(git rev-parse HEAD)"
+        }} >> "{trace}"
+        {body}
+        exit {exit_code}
+        """
+    )
+
+
+class RcEvalDriverTestCase(unittest.TestCase):
+    """Runs the real hack/ci-eval-rc.sh against a stubbed candidate tree."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self._tmp.cleanup)
+        self.base = pathlib.Path(self._tmp.name)
+        # Both live outside the repository: a checkout must not be able to
+        # delete the record of what happened before it.
+        self.trace = self.base / "trace.txt"
+        self.trace.write_text("", encoding="utf-8")
+        self.artifacts = self.base / "artifacts"
+        self.artifacts.mkdir()
+
+    def build_repo(
+        self,
+        *,
+        driver_at_candidate: bool = True,
+        deploy_supports_rc: bool = True,
+        eval_supports_tier: bool = True,
+        eval_exit_code: int = 0,
+    ) -> tuple[pathlib.Path, str]:
+        """A repository with a candidate commit and a later HEAD to start from.
+
+        Returns the repository root and the candidate's SHA. `hack/` is
+        populated at the candidate commit, because the candidate's tree is what
+        runs after the checkout — that is the whole point of doing one.
+        """
+        # A str, not the Path: create_mock_git_repo treats anything with a
+        # `.name` as a TemporaryDirectory, and Path.name is its basename.
+        _, repo, git = create_mock_git_repo(str(self.base))
+        root = pathlib.Path(repo)
+        hack = root / "hack"
+        hack.mkdir()
+
+        shutil.copy(_CI_EVAL_RC, hack / "ci-eval-rc.sh")
+
+        # resolve-rc-target.sh's real contract: the SHA on stdout, everything
+        # else on stderr, the tag written through RC_TARGET_OUTPUT. The SHA it
+        # must print is not known until the commit exists, so it is patched in
+        # below once the tree has been committed.
+        (hack / "resolve-rc-target.sh").write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "STEP resolve" >> "{self.trace}"
+                echo "resolving" >&2
+                if [ -n "${{RC_TARGET_OUTPUT:-}}" ]; then
+                  echo "rc_tag={_RC_TAG}" >> "${{RC_TARGET_OUTPUT}}"
+                  echo "rc_commit_sha=__CANDIDATE_SHA__" >> "${{RC_TARGET_OUTPUT}}"
+                fi
+                echo "__CANDIDATE_SHA__"
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        # The guard greps the candidate's ci-deploy.sh for the marker, so a
+        # stub standing in for a candidate that predates the path must not
+        # mention it ANYWHERE — including in the trace lines _stub emits,
+        # which is why that variant is written out longhand.
+        if deploy_supports_rc:
+            deploy_stub = _stub(
+                self.trace,
+                "deploy",
+                body=f'echo "  marker {_DEPLOY_RC_MARKER}" >> "{self.trace}"',
+            )
+        else:
+            deploy_stub = textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "STEP deploy" >> "{self.trace}"
+                echo "  building from source" >> "{self.trace}"
+                """
+            )
+        (hack / "ci-deploy.sh").write_text(deploy_stub, encoding="utf-8")
+
+        # The tier note keys off the string EVAL_TIER appearing in the
+        # candidate's ci-eval-pr.sh, so the stub for a candidate that predates
+        # the tier must not mention it anywhere — including in its trace lines.
+        if eval_supports_tier:
+            eval_stub = _stub(self.trace, "eval", exit_code=eval_exit_code)
+        else:
+            eval_stub = textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "STEP eval" >> "{self.trace}"
+                exit {eval_exit_code}
+                """
+            )
+        (hack / "ci-eval-pr.sh").write_text(eval_stub, encoding="utf-8")
+
+        for script in hack.iterdir():
+            script.chmod(0o755)
+
+        if not driver_at_candidate:
+            (hack / "ci-eval-rc.sh").unlink()
+
+        git("add", "-A")
+        git("commit", "-m", "feat: the release candidate")
+        candidate = git("rev-parse", "HEAD").stdout.strip()
+
+        # The resolver can only name the candidate once it exists, and the
+        # patched copy must be the one at HEAD rather than at the candidate:
+        # the driver runs the resolver BEFORE the checkout.
+        resolver = hack / "resolve-rc-target.sh"
+        resolver.write_text(
+            resolver.read_text(encoding="utf-8").replace(
+                "__CANDIDATE_SHA__", candidate
+            ),
+            encoding="utf-8",
+        )
+        # HEAD moves past the candidate so the checkout is a real move, and
+        # the driver is restored here whether or not the candidate carries it.
+        shutil.copy(_CI_EVAL_RC, hack / "ci-eval-rc.sh")
+        (hack / "ci-eval-rc.sh").chmod(0o755)
+        resolver.chmod(0o755)
+        (root / "later.txt").write_text("a commit after the candidate\n")
+        git("add", "-A")
+        git("commit", "-m", "chore: main has moved on")
+
+        return root, candidate
+
+    def run_driver(self, root: pathlib.Path, **env) -> subprocess.CompletedProcess:
+        environ = {
+            **os.environ,
+            "RC_EVAL_ENABLED": "1",
+            "ARTIFACTS": str(self.artifacts),
+            "JOB_NAME": _JOB_NAME,
+            "BUILD_ID": _BUILD_ID,
+        }
+        environ.pop("PULL_NUMBER", None)
+        environ.pop("RC_TAG", None)
+        for key, value in env.items():
+            if value is None:
+                environ.pop(key, None)
+            else:
+                environ[key] = value
+        return subprocess.run(
+            ["bash", str(root / "hack" / "ci-eval-rc.sh")],
+            cwd=root,
+            env=environ,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def steps(self) -> list[str]:
+        return [
+            line.split(" ", 1)[1]
+            for line in self.trace.read_text(encoding="utf-8").splitlines()
+            if line.startswith("STEP ")
+        ]
+
+    # ─── Dormancy and the trust boundary ────────────────────────────────────
+
+    def test_dormant_until_the_job_config_arms_it(self):
+        """Unset RC_EVAL_ENABLED is every context that is not the RC periodic."""
+        root, _ = self.build_repo()
+        result = self.run_driver(root, RC_EVAL_ENABLED=None)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("RC_EVAL_ENABLED is not set", result.stdout)
+        self.assertEqual(self.steps(), [], "a dormant run must not resolve or deploy")
+
+    def test_a_pull_request_never_measures_a_candidate(self):
+        """PULL_NUMBER set is a presubmit, which grades itself, not a release."""
+        root, _ = self.build_repo()
+        result = self.run_driver(root, PULL_NUMBER="1170")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("PULL_NUMBER=1170", result.stdout)
+        self.assertEqual(self.steps(), [])
+
+    # ─── The four steps ─────────────────────────────────────────────────────
+
+    def test_runs_resolve_checkout_deploy_eval_in_that_order(self):
+        root, candidate = self.build_repo()
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.steps(), ["resolve", "deploy", "eval"])
+        # The checkout is the step with no stub of its own: both later steps
+        # report the HEAD they ran at, and it has to be the candidate's.
+        trace = self.trace.read_text(encoding="utf-8")
+        self.assertEqual(
+            trace.count(f"HEAD={candidate}"),
+            2,
+            f"deploy and eval must both run at the candidate:\n{trace}",
+        )
+
+    def test_deploy_and_eval_receive_the_candidate_and_the_tier(self):
+        """RC_COMMIT_SHA is what keeps the candidate out of main's baseline."""
+        root, candidate = self.build_repo()
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        trace = self.trace.read_text(encoding="utf-8")
+        self.assertEqual(trace.count(f"RC_COMMIT_SHA={candidate}"), 2, trace)
+        # `nightly`, not a value of this lane's own: #1175's switch exits 1 on
+        # anything it does not know, so inventing `rc` here would break the day
+        # the two land together.
+        self.assertEqual(trace.count("TIER=nightly"), 2, trace)
+
+    def test_survives_a_candidate_whose_tree_lacks_the_driver(self):
+        """The checkout deletes the running script; the run must finish anyway.
+
+        This is the case the `main()` wrapper exists for, and it is not
+        hypothetical: every candidate cut before this file merged is one.
+        """
+        root, candidate = self.build_repo(driver_at_candidate=False)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(
+            self.steps(),
+            ["resolve", "deploy", "eval"],
+            "steps after the checkout were dropped -- the driver is being "
+            f"re-read from disk after it moves:\n{result.stdout}",
+        )
+        self.assertFalse((root / "hack" / "ci-eval-rc.sh").exists())
+        self.assertIn(candidate[:7], result.stdout)
+
+    def test_refuses_a_dirty_tree_before_touching_the_checkout(self):
+        """git's own abort names the file but not why a CI job is holding one."""
+        root, _ = self.build_repo()
+        (root / "hack" / "ci-deploy.sh").write_text(
+            "#!/usr/bin/env bash\nexit 0\n", encoding="utf-8"
+        )
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("modified tracked files", result.stdout)
+        self.assertIn("hack/ci-deploy.sh", result.stdout)
+        self.assertEqual(self.steps(), ["resolve"])
+
+    # ─── Guards on what the candidate's own tree can do ─────────────────────
+
+    def test_refuses_a_candidate_predating_the_rc_deploy_path(self):
+        """Without it, ci-deploy.sh builds and the run grades an unshipped build."""
+        root, _ = self.build_repo(deploy_supports_rc=False)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("predates the release-candidate deploy path", result.stdout)
+        self.assertEqual(
+            self.steps(), ["resolve"], "the refusal must land before deploying"
+        )
+
+    def test_notes_but_allows_a_candidate_predating_the_tier(self):
+        """A smaller matrix than intended is a note; it is not a wrong verdict."""
+        root, _ = self.build_repo(eval_supports_tier=False)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertIn("predates the nightly tier", result.stdout)
+        self.assertEqual(self.steps(), ["resolve", "deploy", "eval"])
+
+    # ─── Reporting ──────────────────────────────────────────────────────────
+
+    def test_a_red_verdict_is_reported_not_swallowed(self):
+        """Non-gating is the job config's `|| true`, not a hidden exit 0 here."""
+        root, _ = self.build_repo(eval_exit_code=1)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("RED", result.stdout)
+        summary = (self.artifacts / "rc-eval-summary.md").read_text(encoding="utf-8")
+        self.assertIn("| Verdict | RED |", summary)
+        self.assertIn("does not hold a release", summary)
+
+    def test_writes_the_target_and_summary_artifacts(self):
+        root, candidate = self.build_repo()
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+
+        target = (self.artifacts / "rc-target.env").read_text(encoding="utf-8")
+        self.assertIn(f"rc_tag={_RC_TAG}", target)
+        self.assertIn(f"rc_commit_sha={candidate}", target)
+
+        summary = (self.artifacts / "rc-eval-summary.md").read_text(encoding="utf-8")
+        self.assertIn(_RC_TAG, summary)
+        self.assertIn(candidate, summary)
+        self.assertIn("| Verdict | GREEN |", summary)
+        # The link is the whole of "results anyone can find" this lane is
+        # allowed to ship: no credential is widened to post it anywhere.
+        self.assertIn(_EXPECTED_DECK_URL, summary)
+
+    def test_no_deck_link_when_prow_did_not_supply_one(self):
+        """A laptop run gets a summary without a fabricated URL in it."""
+        root, _ = self.build_repo()
+        result = self.run_driver(root, JOB_NAME=None, BUILD_ID=None)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        summary = (self.artifacts / "rc-eval-summary.md").read_text(encoding="utf-8")
+        self.assertNotIn("| Run |", summary)
+        self.assertNotIn("oss.gprow.dev", summary)
+
+
+class MainWrapperTestCase(unittest.TestCase):
+    """Why hack/ci-eval-rc.sh puts its whole body inside main().
+
+    Not a test of this repository's code: it pins the property the driver's
+    shape buys, on the bare mechanism, for a reader who finds the wrapper
+    ornamental.
+
+    There is deliberately no companion test asserting that the UNWRAPPED form
+    breaks. It does, sometimes — a step vanishing from an otherwise green run
+    is the shape it takes — but whether it does on any given script depends on
+    the file's size and where bash's read buffer lands, and measurements on
+    this repository produced both outcomes from the same construct. A test
+    asserting the failure would be asserting a coincidence. The wrapper is
+    here because that coin is not worth flipping, and what is testable is that
+    the wrapped form does not flip it at all.
+    """
+
+    # In-place truncation, which is the hostile case: it keeps the inode bash
+    # has open, so unlike a git checkout it cannot leave the original content
+    # readable behind the descriptor. printf rather than a heredoc because
+    # this body gets indented into main() below, and an indented heredoc
+    # terminator ends nothing.
+    _REWRITE = (
+        "printf '%s\\n'"
+        " '#!/usr/bin/env bash'"
+        " 'echo \"a different file entirely\"'"
+        ' > "$0"\n'
+    )
+
+    def test_a_wrapped_body_runs_every_step_after_rewriting_its_own_file(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+            script = pathlib.Path(tmp) / "s.sh"
+            # Padded past bash's read buffer: an unpadded script is small
+            # enough to be buffered whole, which makes the rewrite a no-op for
+            # the interpreter and the test vacuous.
+            padding = "".join(f'p{i}="filler filler filler"\n' for i in range(400))
+            script.write_text(
+                "#!/usr/bin/env bash\nset -euo pipefail\n"
+                + padding
+                + "main() {\n"
+                + '  echo "step 1"\n'
+                + textwrap.indent(self._REWRITE, "  ")
+                + '  echo "step 2"\n  echo "step 3"\n  exit 0\n}\nmain "$@"\n',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                ["bash", str(script)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout)
+        for step in ("step 1", "step 2", "step 3"):
+            self.assertIn(step, result.stdout, result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ci_eval_rc.py
+++ b/tests/test_ci_eval_rc.py
@@ -87,6 +87,7 @@ class RcEvalDriverTestCase(unittest.TestCase):
         deploy_supports_rc: bool = True,
         eval_supports_tier: bool = True,
         eval_exit_code: int = 0,
+        deploy_exit_code: int = 0,
         truncate_driver_from_deploy: bool = False,
     ) -> tuple[pathlib.Path, str]:
         """A repository with a candidate commit and a later HEAD to start from.
@@ -144,7 +145,9 @@ class RcEvalDriverTestCase(unittest.TestCase):
                 # from only because the candidate's copy of it is byte-identical
                 # to HEAD's, so the checkout left the file alone.
                 deploy_body += f'\n: > "{hack / "ci-eval-rc.sh"}"'
-            deploy_stub = _stub(self.trace, "deploy", body=deploy_body)
+            deploy_stub = _stub(
+                self.trace, "deploy", body=deploy_body, exit_code=deploy_exit_code
+            )
         else:
             deploy_stub = textwrap.dedent(
                 f"""\
@@ -381,6 +384,25 @@ class RcEvalDriverTestCase(unittest.TestCase):
         self.assertIn("EVAL_TIER", evaluator)
 
     # ─── Reporting ──────────────────────────────────────────────────────────
+
+    def test_a_failed_deploy_is_reported_and_is_not_a_verdict(self):
+        """Found live: a real ci-deploy.sh exiting non-zero wrote no artifact.
+
+        The deploy was invoked bare, so errexit aborted the run before the
+        summary — which left the summary's own "did not reach the verdict step"
+        branch unreachable and a Prow run with nothing but a log to read. It
+        must not report RED either: nothing was measured, and RED is a
+        judgement on the candidate that this run never formed.
+        """
+        root, _ = self.build_repo(deploy_exit_code=3)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 3, "the deploy's own status survives")
+        self.assertEqual(self.steps(), ["resolve", "deploy"], "the eval must not run")
+        self.assertIn("NOT RUN", result.stdout)
+        self.assertNotIn("RED", result.stdout)
+        summary = (self.artifacts / "rc-eval-summary.md").read_text(encoding="utf-8")
+        self.assertIn("| Verdict | NOT RUN |", summary)
+        self.assertIn("never evaluated", summary)
 
     def test_a_red_verdict_is_reported_not_swallowed(self):
         """Non-gating is the job config's `|| true`, not a hidden exit 0 here."""

--- a/tests/test_ci_eval_rc.py
+++ b/tests/test_ci_eval_rc.py
@@ -47,6 +47,10 @@ _EXPECTED_DECK_URL = (
 # guard to let it through; the real marker is the variable ci-deploy.sh reads.
 _DEPLOY_RC_MARKER = "RC_COMMIT_SHA"
 
+# The tier switch's variable. The driver exports it and greps the candidate for
+# it; nothing on main reads it yet.
+_EVAL_TIER_MARKER = "EVAL_TIER"
+
 
 def _stub(trace: pathlib.Path, name: str, body: str = "", exit_code: int = 0) -> str:
     """A sibling script that records that it ran, with what, and in what order."""
@@ -369,19 +373,33 @@ class RcEvalDriverTestCase(unittest.TestCase):
         deploy = (_REPO_ROOT / "hack" / "ci-deploy.sh").read_text(encoding="utf-8")
         self.assertIn(_DEPLOY_RC_MARKER, deploy)
 
-    @unittest.expectedFailure
     def test_the_tier_marker_is_a_string_the_real_ci_eval_pr_reads(self):
-        """Expected to fail until the EVAL_TIER switch (#1175) lands.
+        """The driver's export and the candidate's switch must be one string.
 
-        The driver exports EVAL_TIER and greps the candidate for it, but
-        nothing on main reads it, so today the note fires on every candidate
-        and the export is inert. This is the mechanism that notices when that
-        stops being true — including if #1175 lands under a different name.
-        Turn it into a plain assertion then, and drop the note's "expected
-        until that switch lands" wording with it.
+        The half that can be checked today is the driver's: it greps the
+        candidate for the same name it exports, so a rename on one side alone
+        makes the grep vacuous. The candidate's half waits on #1175, which is
+        what adds the switch to hack/ci-eval-pr.sh.
+
+        A skip rather than @unittest.expectedFailure, deliberately. An
+        expected failure that starts passing is an unexpectedSuccess, which
+        unittest counts as a failure and exits 1 — so #1175 landing would have
+        reddened main's Python suite, with the failure naming this file rather
+        than the change that caused it.
         """
+        driver = _CI_EVAL_RC.read_text(encoding="utf-8")
+        self.assertIn(
+            _EVAL_TIER_MARKER,
+            driver,
+            "the driver must export the marker it greps the candidate for",
+        )
         evaluator = (_REPO_ROOT / "hack" / "ci-eval-pr.sh").read_text(encoding="utf-8")
-        self.assertIn("EVAL_TIER", evaluator)
+        if _EVAL_TIER_MARKER not in evaluator:
+            self.skipTest(
+                f"{_EVAL_TIER_MARKER} is not on main yet (#1175), so the "
+                "driver's export is inert and its note fires on every "
+                "candidate — the case above covers that state"
+            )
 
     # ─── Reporting ──────────────────────────────────────────────────────────
 

--- a/tests/test_ci_eval_rc.py
+++ b/tests/test_ci_eval_rc.py
@@ -3,11 +3,18 @@
 `hack/ci-eval-rc.sh` runs four steps — resolve the candidate, check it out,
 deploy its published images, evaluate them — and the second one moves the
 ground under the first. Bash reads a script incrementally as it executes, so a
-script that checks out a revision where its own file differs resumes at the
-same byte offset in a different file. The failure is silent: the remaining
-steps disappear and the shell exits 0. `test_bash_self_rewrite_silently_drops_
-steps` demonstrates that on the bare mechanism, and it is the reason the whole
-driver lives inside `main()` and exits rather than returning.
+script that checks out a revision where its own file differs can resume at the
+same byte offset in different content, and when that goes wrong it goes wrong
+silently: a step vanishes and the shell still exits 0. That is why the whole
+driver lives inside `main()`, which bash parses in full before running any of
+it, and exits rather than returning.
+
+Two tests hold that down from opposite ends.
+`test_survives_a_candidate_whose_tree_lacks_the_driver` runs the real script
+through a real checkout that deletes it mid-run, and
+`test_a_wrapped_body_runs_every_step_after_rewriting_its_own_file` pins the
+wrapper property on the bare mechanism. Neither asserts that the *unwrapped*
+form breaks, deliberately — `MainWrapperTestCase` explains why.
 
 Everything else here runs the real script — copied into a throwaway git
 repository with its three siblings stubbed — rather than grepping it, because a
@@ -80,6 +87,7 @@ class RcEvalDriverTestCase(unittest.TestCase):
         deploy_supports_rc: bool = True,
         eval_supports_tier: bool = True,
         eval_exit_code: int = 0,
+        truncate_driver_from_deploy: bool = False,
     ) -> tuple[pathlib.Path, str]:
         """A repository with a candidate commit and a later HEAD to start from.
 
@@ -122,11 +130,21 @@ class RcEvalDriverTestCase(unittest.TestCase):
         # mention it ANYWHERE — including in the trace lines _stub emits,
         # which is why that variant is written out longhand.
         if deploy_supports_rc:
-            deploy_stub = _stub(
-                self.trace,
-                "deploy",
-                body=f'echo "  marker {_DEPLOY_RC_MARKER}" >> "{self.trace}"',
-            )
+            deploy_body = f'echo "  marker {_DEPLOY_RC_MARKER}" >> "{self.trace}"'
+            if truncate_driver_from_deploy:
+                # Truncate the driver IN PLACE, which is the mechanism the
+                # wrapper exists for and the one a checkout does not perform:
+                # git replaces a file by rename, leaving the running shell's
+                # descriptor on the intact original inode, so no checkout can
+                # reproduce this. `: >` keeps the inode and drops it to zero
+                # bytes, so a shell still reading from disk hits EOF at its
+                # offset and the remaining steps silently vanish.
+                #
+                # The path resolves to the same inode the driver is running
+                # from only because the candidate's copy of it is byte-identical
+                # to HEAD's, so the checkout left the file alone.
+                deploy_body += f'\n: > "{hack / "ci-eval-rc.sh"}"'
+            deploy_stub = _stub(self.trace, "deploy", body=deploy_body)
         else:
             deploy_stub = textwrap.dedent(
                 f"""\
@@ -304,13 +322,63 @@ class RcEvalDriverTestCase(unittest.TestCase):
             self.steps(), ["resolve"], "the refusal must land before deploying"
         )
 
-    def test_notes_but_allows_a_candidate_predating_the_tier(self):
-        """A smaller matrix than intended is a note; it is not a wrong verdict."""
+    def test_notes_but_allows_a_candidate_without_the_tier_switch(self):
+        """A smaller matrix than intended is a note; it is not a wrong verdict.
+
+        This is the ordinary case, not a legacy one: the tier switch is not on
+        main, so every candidate reaches here until it lands.
+        """
         root, _ = self.build_repo(eval_supports_tier=False)
         result = self.run_driver(root)
         self.assertEqual(result.returncode, 0, result.stdout)
-        self.assertIn("predates the nightly tier", result.stdout)
+        self.assertIn("carries no EVAL_TIER switch", result.stdout)
+        self.assertIn("presubmit matrix", result.stdout)
         self.assertEqual(self.steps(), ["resolve", "deploy", "eval"])
+
+    def test_finishes_the_run_after_its_own_file_is_emptied_mid_step(self):
+        """The negative control for main(): flatten the wrapper and this fails.
+
+        Every other test here passes against an unwrapped driver, because they
+        all move the file by checkout and a checkout cannot hurt a running
+        shell — git renames, so the descriptor keeps the original inode. This
+        one truncates the live inode from inside the deploy step, which is the
+        hazard the header actually describes. Wrapped, the body is already in
+        memory and the eval still runs; unwrapped, bash reads EOF at its offset
+        and the run ends after deploy having reported nothing and exited 0.
+        """
+        root, _ = self.build_repo(truncate_driver_from_deploy=True)
+        result = self.run_driver(root)
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(
+            self.steps(),
+            ["resolve", "deploy", "eval"],
+            "the eval must run after the driver's own file is emptied",
+        )
+        self.assertTrue(
+            (self.artifacts / "rc-eval-summary.md").is_file(),
+            "a run that loses its tail exits 0 with no summary: the silent failure",
+        )
+
+    # ─── The markers are contracts with real files, not with the stubs ──────
+
+    def test_the_deploy_marker_is_a_string_the_real_ci_deploy_reads(self):
+        """The guard greps for it, so a rename there makes this grep vacuous."""
+        deploy = (_REPO_ROOT / "hack" / "ci-deploy.sh").read_text(encoding="utf-8")
+        self.assertIn(_DEPLOY_RC_MARKER, deploy)
+
+    @unittest.expectedFailure
+    def test_the_tier_marker_is_a_string_the_real_ci_eval_pr_reads(self):
+        """Expected to fail until the EVAL_TIER switch (#1175) lands.
+
+        The driver exports EVAL_TIER and greps the candidate for it, but
+        nothing on main reads it, so today the note fires on every candidate
+        and the export is inert. This is the mechanism that notices when that
+        stops being true — including if #1175 lands under a different name.
+        Turn it into a plain assertion then, and drop the note's "expected
+        until that switch lands" wording with it.
+        """
+        evaluator = (_REPO_ROOT / "hack" / "ci-eval-pr.sh").read_text(encoding="utf-8")
+        self.assertIn("EVAL_TIER", evaluator)
 
     # ─── Reporting ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `hack/ci-eval-rc.sh`, the entrypoint a Prow periodic will call to grade the newest release candidate: it resolves the candidate, checks the tree out at it, deploys its published images, and runs the eval against them, reporting a verdict that gates nothing. The job that calls it does not exist yet and lands later in the lane, so until then the script is dormant — `RC_EVAL_ENABLED` unset means one skip line and exit 0, wherever it runs. The awkward part is step 2: checking out the candidate replaces the tree the script is running from, sometimes deleting the script itself, so the whole body lives inside `main()`, which bash parses into memory before executing and which exits rather than returning.

## Why This Change

Issue #1024 asks for the full eval suite to run against release candidates, reported and non-gating. #1170 taught `ci-deploy.sh` and `ci-eval-pr.sh` how to install and grade a candidate's published images; nothing yet decides *which* candidate or drives the sequence. That is this script. Without it the two halves exist and nothing connects them.

The sequencing needs a driver rather than an addition to `resolve-rc-target.sh`, because whatever performs the checkout has to survive it, and a script cannot reliably survive rewriting its own file mid-run.

## What Changed

- `hack/ci-eval-rc.sh` — the driver. Four steps, dormant by default. Its path is a contract: the periodic invokes it by name. Three verdicts, not two: `GREEN`, `RED`, and `NOT RUN` for a deploy that never got far enough to measure anything. It exits with the failing step's own status, so "non-gating" stays a visible `|| true` in the job config rather than a hidden `exit 0` here.
- `tests/test_ci_eval_rc.py` — 16 tests: thirteen run the real script inside a throwaway git repository with its siblings stubbed, one pins the wrapper property on the bare mechanism, and two assert the guards' marker strings against the real sibling files rather than against the stubs the test itself wrote them into. The second of those two asserts the driver's half of the tier contract unconditionally and skips the candidate's half until #1175 lands.
- `hack/resolve-rc-target.sh` — header comment only. Its explanation of the self-rewrite hazard was wrong about the case it cited, and its worked example was the unsafe shape the paragraph beneath it warned against. Both corrected, pointing at the new driver. See the Self-Review entry.

The only executable change is the new driver, so the only thing that can regress is a lane nothing runs yet.

## Context

- Closes part of #1024. This is PR 2 of that lane; PR 1 was #1170, now merged (`e658b35e`). This branch is rebased onto `main` and depends on nothing unmerged.
- Depends on #1175 to do what it says: the driver exports `EVAL_TIER=nightly`, and nothing on `main` reads that variable yet. Until #1175 lands, every run measures the presubmit matrix and prints a note saying so. `test_the_tier_marker_is_a_string_the_real_ci_eval_pr_reads` skips that half of the contract while it is unmerged and passes silently once it is, in either merge order.
- Still to come in the lane: the dashboard's Releases data, and the `oss-test-infra` periodic itself.
- The lane now has candidates it can measure. Four exist that carry #1170's deploy path — the newest is `rc_2609041034_32c5538` — and the guard correctly refuses everything cut before it. Grading one end to end is what found the bug in the third commit below.

## Testing

- `tests/test_ci_eval_rc.py` — 16 tests, green (`OK (skipped=1)`). The skip is the candidate-side half of the tier contract, which #1175 supplies. Also run with `EVAL_TIER` appended to `hack/ci-eval-pr.sh` to simulate #1175 having merged: `OK`, 16 passed, no skip.
- The four modules covering the touched scripts and their siblings — `test_ci_eval_rc`, `test_resolve_rc_target`, `test_ci_deploy_rc_images`, `test_release_common` — `Ran 96 tests` / `OK (skipped=1)`.
- `tests/` sweep, the Makefile's invocation: `Ran 1179 tests` / `FAILED (failures=2, skipped=17)`. Both failures are in `test_generate_release_sbom.py`, assert Linux-CI swap allocation, and fail on macOS; they come from #1093 and this branch touches neither that test nor the script it exercises.
- `make docs-check` — all five checks pass.
- `bash -n hack/ci-eval-rc.sh` — clean.
- Not run: `shellcheck`, not installed locally. `AGENTS.md` scopes it to the three installer scripts, so `hack/` is unlinted either way.

### Live validation

Exercised on `stalhaali.c.googlers.com` against a clone of `gke-labs/kube-agents` at `main` plus this branch's driver, byte-identical to the file under review (`md5 c5dd3223…`) — real upstream tag graph, real `git checkout`, on Linux rather than the macOS dev box. Every row below is against the branch head as of the driver's last executable change (`9135683d`); earlier rounds against `20c49feb` and `e6aedb9b` were re-run rather than kept. The two commits after it touch a comment block (`6e61c450`) and a test (`9d8ee32e`) respectively — `hack/ci-eval-rc.sh` is byte-identical at the current head — so neither invalidates a row.

| Scenario | Observed |
| --- | --- |
| `RC_EVAL_ENABLED` unset | one skip line, exit 0, `HEAD` unmoved |
| `PULL_NUMBER=1171` | refused, exit 0, `HEAD` unmoved |
| `JOB_TYPE=batch` + `PULL_REFS`, no `PULL_NUMBER` | refused, exit 0, `HEAD` unmoved |
| Dirty working tree | refused before the checkout, naming the modified file, `HEAD` unmoved |
| **Real candidate, real resolver, real `ci-deploy.sh`** | resolved `rc_2609041034_32c5538`; checkout ran and **deleted the running script**; deploy reached its own environment check and exited 1; verdict `NOT RUN`, summary written, restore hint printed, exit 1 |
| Happy path | self-deleted again; deploy and eval both ran, both received `RC_COMMIT_SHA=e13a1700…` and `EVAL_TIER=nightly` with cwd and `HEAD` at the candidate; `GREEN`, exit 0, all three artifacts, summary pointing at `eval-verdict.md` |
| Eval exits non-zero | `RED`, exit 1, all three steps ran, artifacts written — distinct from `NOT RUN` |
| No `JOB_NAME`/`BUILD_ID` | summary written with no `Run` row and no fabricated URL |

The mechanism rather than a coincidence, twice over. **The self-deletion**: `POST-RUN driver in tree: No such file or directory`, on runs that went on to write every artifact. That is the `main()` wrapper surviving a real checkout that really removed the file. **The deploy-failure row**: it is the only one that reached a real `ci-deploy.sh`, which is safe to run on the RC path precisely because that path skips the container build, and it is where the bug in the third commit came from — the previous driver aborted on the spot and wrote nothing.

Both stubbed steps reproduce the real scripts' contracts rather than a convenient version of them, and getting that wrong showed up immediately: a first stub resolver printed its banner on stdout and the driver took the banner as the SHA, which is the real `resolve-rc-target.sh`'s stdout discipline being load-bearing. The eval stub derives `ARTIFACT_DIR="${ARTIFACTS:-/tmp/artifacts}"` the way `ci-eval-pr.sh:1316` does, which is what makes the driver's `verdict_path` and the eval's output the same file.

`PROW_DECK_BUILD_BASE` checked against the live host rather than assumed: `https://oss.gprow.dev/` and the `logs/` path both return HTTP 200.

**What I could not cover, and why.** Nothing here reached a cluster. `hack/ci-deploy.sh:405` is an unguarded `helm upgrade --install` with no dry-run, and the `platform-agent-host` cluster nine other kubeconfig contexts point at is not mine to overwrite; the deploy-failure row stops one step short of it, at the environment check. Past that point the driver's contract with `ci-deploy.sh` and `ci-eval-pr.sh` is the environment it hands them and the status it takes back, and the trace above verifies both.

Cleanup: all work was in `/tmp/rc2` on that host, the scratch clones are removed, and no cluster state was created or modified. The existing `~/kube-agents` checkout was left untouched on its own branch.

## Self-Review

Both required passes ran in **fresh subagent contexts handed only the diff range and nothing else** — neither had written the change or seen the reasoning behind it. Live validation then found one thing neither pass did. Dispositions:

- **A failed deploy wrote no artifact at all.** *Fixed, and found live rather than by either pass.* The adversarial pass checked deploy-succeeds-eval-dies and called it handled; the deploy itself dying was not. `ci-deploy.sh` was invoked bare, so `errexit` took `main()` down before the summary — leaving a Prow run with nothing but a raw log, and making the summary's own "did not reach the verdict step" branch unreachable code. The status is now captured the way the eval's already was, the verdict is `NOT RUN` rather than `RED` (nothing was measured, and `RED` is a judgement on the candidate this run never formed), the summary gets a branch saying so, and the exit status is the deploy's, since `eval_status` is 0 on that path only because the eval never ran. `test_a_failed_deploy_is_reported_and_is_not_a_verdict` pins it, and against the previous driver it reproduces the live run exactly.
- **The tests did not pin the property the design exists for.** *Fixed.* The adversarial pass mechanically unwrapped `main()` and ran the suite: 11 of 12 tests passed against the unwrapped driver, and two docstrings claimed one of them covered the wrapper. The cause is structural — `git checkout` replaces a file by rename, so a running shell keeps its descriptor on the intact original inode, and **no checkout-based test can reproduce the hazard**. I verified this myself before accepting it; my first unwrap attempt failed 11 tests, but that was a broken unwrap (it ate a `local` declaration), not sound tests. `test_finishes_the_run_after_its_own_file_is_emptied_mid_step` now truncates the live inode from inside the deploy step: unwrapped it yields `['resolve','deploy']` and exit 0 — a green run with no eval in it — and wrapped it runs all three. It is the only test in the file that separates them.
- **Trust boundary one condition short of both siblings.** *Fixed.* `PULL_NUMBER` alone let a batch job through — Prow sets `PULL_REFS` and no `PULL_NUMBER` for those — which would have replaced the tree underneath the merge being tested. Now gates on `JOB_TYPE` as well, matching `ci-eval-pr.sh` and `ci-dashboard-refresh.sh`. Verified live.
- **The restore hint printed only on success.** *Fixed.* Every interesting way to strand a detached tree is a failure path. Moved to an `EXIT` trap guarded on whether the checkout happened, and the deploy-failure run above is a live failure path that printed it.
- **`EVAL_TIER` described as a mechanism that exists.** *Fixed.* It appears nowhere in the repository or on `main`; #1175 has not landed. The header framed "no tier switch" as an old-candidate fallback when it is currently the only path. Header, constant comment, and the runtime note now say so. The mechanism that was going to notice when it changed is the subject of the next entry.
- **That mechanism was an `@unittest.expectedFailure`, which would have reddened `main`.** *Fixed in `9d8ee32e`, and found after both passes and after approval.* An expected failure that starts passing is an `unexpectedSuccess`, which `unittest` counts as a failure and exits 1. #1175 adds the exact string this test greps `hack/ci-eval-pr.sh` for, and it is already `approved` + `lgtm` — so whichever of the two merged second would have taken `main`'s Python suite red, with the failure naming this file rather than the change that caused it. Neither pre-PR pass could have caught it: both read this diff, and the defect only exists in relation to another branch. Now a `skipTest` when the marker is absent, plus an unconditional assertion that the driver exports the same name it greps for — the half of the contract that is checkable today, and the half a one-sided rename would break. Verified in both worlds and as a negative control: `OK (skipped=1)` against `main` as it stands, `OK` with `EVAL_TIER` appended to `hack/ci-eval-pr.sh`, and a clean failure when the driver's export is renamed.
- **Module docstring named a deleted test.** *Fixed.* It referenced `test_bash_self_rewrite_silently_drops_steps`, which I removed before the first commit because I could not reproduce its premise. Rewritten to name the tests that exist.
- **Header sold four steps as a whole job.** *Fixed.* Teardown is the job config's, and the leased pool is shared with the presubmit eval, so a periodic that skips it degrades someone else's run. Said so in the header rather than adding a step 5, since the job config is a later PR's.
- **Untracked-file checkout abort had no explanation**, and **`rc_tag` was an unnamed cross-file literal.** *Both fixed.* Widening the dirty-tree pre-check to untracked files would fail runs that are fine (Prow workspaces hold build output), so the explanation is attached to the abort instead.
- **`oss.gprow.dev` unverified.** *Resolved, not a defect.* The adversarial pass had no network and flagged it as an open question; fetched from the remote host, both the host and the `logs/` path return HTTP 200.
- **`hack/resolve-rc-target.sh`'s header overstated the same bash/checkout claim**, and its example snippet — followed literally — produced the unsafe driver this PR works around. *Fixed, in this PR, and it widens the diff into a file nothing else here touches.* Both passes raised it independently. The header said unconditionally that "a script that checks out a different revision of itself is rewriting the bytes the interpreter has not read yet", which is the one case where that does not happen, for the rename reason above; and its three bare top-level statements are the shape the paragraph beneath them warns about. It is in scope because this PR is what makes that header misleading and what supplies the worked example it should cite, and a follow-up editing nothing but a comment block costs a review round for it. Comment-only: the resolver's behaviour and stdout contract are unchanged, and its 96 sibling tests still pass.
- **`docs/testing-map.md` cites `Makefile:129-144` and `:173`, both off by one.** *Not fixed.* Pre-existing, unrelated to this change, and reported per the skill's instruction to flag either way.

Came up clean and worth recording as negative results: nothing here can reach the release pipeline (`scripts/release/` decides from the tag graph and reads no Prow result), so the non-gating requirement in #1024 holds structurally rather than by convention; dormancy is airtight on every path, with only `readonly` assignments between `set -euo pipefail` and `main "$@"`; the baseline store cannot be poisoned, since `ci-eval-pr.sh` independently forces `EVAL_IS_MAIN_RUN=false` on `RC_COMMIT_SHA`; no secrets, IAM, RBAC, or GitHub Actions touched; test placement matches `docs/testing-map.md` and is reached by the `tests/test_*.py` glob in `PYTHON_TEST_DIRS`; no Markdown added, so no documentation-map row is owed.

## Risk & Rollout

Low. Two new files plus a comment block in a third, and the script is inert until a Prow job sets `RC_EVAL_ENABLED` — a job that does not exist yet and arrives in a later PR of this lane. Nothing in the release pipeline reads a Prow result, so this cannot hold up a release, which #1024 requires. Revert is deleting the two new files; the header edit changes no behaviour and can be left or reverted independently.

The one way this lane can cost anyone anything is the shared eval pool: the periodic that eventually calls this must run `hack/ci-teardown.sh` as a separate, unconditional step, or a leased project is left holding a live install and the next lease inherits it (#1006). That is a requirement on the later PR, and the header says so.

---

Generated with the help of Claude Opus 5.
