### PR TITLE
ci(notify): watch Documentation Checks and Python Unit Tests for a broken main

### DIFF
--- a/.github/workflows/main-broken-notify.yml
+++ b/.github/workflows/main-broken-notify.yml
@@ -14,23 +14,37 @@ name: Notify on Broken Main
 #
 # What may go on the list: a workflow whose green on a push to main is a
 # statement about the tree, not about the push. The script depends on that and
-# cannot check it -- see its docstring. All four below rebuild or re-check
-# everything they cover on every run they start, and `Operator Tests` only
-# starts on a push that touches an operator path.
+# cannot check it -- see its docstring. Every workflow below rebuilds or
+# re-checks everything it covers on every run it starts, and `Operator Tests`
+# only starts on a push that touches an operator path.
+#
+# `Documentation Checks` and `Python Unit Tests` joined the list after both sat
+# red on main for thirteen hours (2026-09-03 20:54Z to 2026-09-04 10:34Z,
+# gke-labs/kube-agents#1223) with sixteen merges landing on top and no
+# `ci:main-broken` issue filed: they became required contexts on 2026-09-02,
+# after this list was written, and nothing revisited it. Each runs its whole
+# suite on every push with no `paths:` filter.
+#
+# `Python Unit Tests` also carries `Run Bench Harness Tests`, which is not a
+# required context, so watching at run level files an issue when only that job
+# is red. That job resolves devops-bench and its dependencies at run time, so a
+# resolver outage during a push run would file an issue naming an innocent
+# commit. Accepted: the alternative is not watching the suite that took
+# thirteen hours to notice. `Validate Repo Structure` is the same shape with
+# both jobs required -- `validate`, and `prompt-assets`, which reports the
+# `Agent instructions cite assets that exist` context.
 #
 # `Prettier Check` is required and deliberately absent. It scopes itself to the
 # files the push changed, so its green says those files are formatted and
 # nothing about the rest of the tree: a bad `docs/a.md` would go red, and the
 # next merge touching only Go would go green and close the issue with an
 # innocent commit named as the fix. Whole-tree prettier is not the fix either --
-# 19 files under `.agents/skills/` have never been formatted, so it would be red
+# files under `.agents/skills/` have never been formatted, so it would be red
 # from the first run. Prettier is also the check least exposed to the stale-base
 # merge this exists to catch: it reads file contents, which a stale merge base
-# does not change. `cla/google` is an external app with no run to watch.
-#
-# `Validate Repo Structure` runs a second, non-required job (`prompt-assets`)
-# alongside the required `validate`. Watching at run level means its failure
-# also files an issue, which is the more useful behaviour, not an oversight.
+# does not change. `cla/google` is an external app with no run to watch, and
+# `Validate Conventional Commit PR Title` runs only on pull requests, so it has
+# no push run to watch either.
 
 on:
   # zizmor: ignore[dangerous-triggers] - workflow_run is only dangerous when it checks
@@ -40,7 +54,9 @@ on:
     workflows:
       - Actionlint
       - Docker Build
+      - Documentation Checks
       - Operator Tests
+      - Python Unit Tests
       - Validate Repo Structure
     types: [completed]
 

--- a/scripts/test_integration_contracts.py
+++ b/scripts/test_integration_contracts.py
@@ -1,6 +1,6 @@
 """Cross-file contract lints: joins that nothing in any language checks.
 
-Three contracts, each of which fails silently today when the two sides drift:
+Four contracts, each of which fails silently today when the two sides drift:
 
 * A verification spec naming a tool that no registry defines can never trip —
   the silent-green shape review found on the first gate branch (a safeguard
@@ -12,6 +12,9 @@ Three contracts, each of which fails silently today when the two sides drift:
   workflows: [...]`) and artifact-name strings; renaming a workflow silently
   disables every consumer, which for the autopush chain means continuous
   deployment stops without a red anywhere.
+* The broken-main notifier watches a fixed roster of push-to-main workflows;
+  a required check dropped from that roster goes red on main without anyone
+  being told, which is how a thirteen-hour red main went unnoticed (#1223).
 """
 
 from __future__ import annotations
@@ -28,6 +31,22 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# The push-to-main workflows `main-broken-notify.yml` must watch: every required
+# push-to-main workflow whose run re-checks everything it covers, so its green on
+# main is a statement about the tree. The header of that workflow says what
+# qualifies and why `Prettier Check` does not. `Documentation Checks` and
+# `Python Unit Tests` are here because they were missing when both went red on
+# main for thirteen hours and nothing paged (gke-labs/kube-agents#1223).
+BROKEN_MAIN_NOTIFIER = "main-broken-notify.yml"
+BROKEN_MAIN_WATCHED_WORKFLOWS = (
+    "Actionlint",
+    "Docker Build",
+    "Documentation Checks",
+    "Operator Tests",
+    "Python Unit Tests",
+    "Validate Repo Structure",
+)
 SCRIPTS_DIR = REPO_ROOT / "agents" / "platform" / "scripts"
 
 
@@ -303,6 +322,27 @@ class WorkflowNameJoinTest(unittest.TestCase):
             broken,
             "workflow_run references that match no workflow name: a rename "
             "has silently disabled these consumers: " + ", ".join(broken),
+        )
+
+    def test_the_broken_main_notifier_watches_every_whole_tree_required_check(self):
+        """A required check missing from the watch list fails silently: main
+        goes red, every open pull request inherits the red, and nobody is told.
+        That is how #1223's thirteen-hour window happened. The test above
+        catches a watched name that stopped matching; this one catches a name
+        dropped from the list in an edit. Neither can tell that a context newly
+        promoted to required was never added: required-ness lives in branch
+        protection, not in the tree, so adding a workflow to this tuple stays a
+        review question whenever one joins the required set."""
+        document = self._workflows()[BROKEN_MAIN_NOTIFIER]
+        triggers = document.get("on") or document.get(True) or {}
+        watched = set((triggers.get("workflow_run") or {}).get("workflows") or [])
+        missing = sorted(set(BROKEN_MAIN_WATCHED_WORKFLOWS) - watched)
+        self.assertEqual(
+            [],
+            missing,
+            f"{BROKEN_MAIN_NOTIFIER} no longer watches these push-to-main "
+            "workflows, so a red on main from any of them files no issue: "
+            + ", ".join(missing),
         )
 
     def test_the_required_python_job_runs_the_suite_in_strict_mode(self):

--- a/scripts/test_notify_broken_main.py
+++ b/scripts/test_notify_broken_main.py
@@ -572,7 +572,7 @@ class ReconcileTest(unittest.TestCase):
         self.assertNotIn("Fixed by", api.actions[0][2], "this run is not the fix and must not claim to be")
 
     def test_another_workflows_issue_is_left_alone(self):
-        """Four workflows are watched and each breaks independently. Closing
+        """Several workflows are watched and each breaks independently. Closing
         another one's issue would hide a real breakage."""
         api = FakeAPI([issue(901, 88, 10)])
         self._reconcile(api, notifier.decide(run(12, "success"), [run(11, "failure")]))


### PR DESCRIPTION
## Summary

`main-broken-notify.yml` opens and maintains a `ci:main-broken` issue when a watched workflow's push-to-main run fails, but its watch list only held the four workflows that were required contexts when it was written. `Documentation Checks` and `Python Unit Tests` became required on 2026-09-02 and were never added. This PR adds them, rewrites the header so its account of the other required contexts is current again, and pins the watch list with a contract test so a name cannot be dropped silently.

## Why This Change

From 2026-09-03 20:54Z to 2026-09-04 10:34Z both workflows were red on `main` (the `AGENTS.md` budget race, then the rc-images test anchor, both recounted in #1223). Sixteen merges landed on a red main and nothing paged; the break was first noticed as unexplained red checks on an unrelated pull request. The notifier would have filed an issue within minutes had either workflow been on its list, as #1115 shows it doing for Operator Tests three days earlier. Without this change the next such break is again found by whoever opens the next PR.

Both workflows qualify under the list's own criterion: each runs its whole suite on every push to main with no `paths:` filter, so a green is a statement about the tree.

## What Changed

- `.github/workflows/main-broken-notify.yml`: `Documentation Checks` and `Python Unit Tests` added to `on.workflow_run.workflows`. Header rewritten: it now says why the two joined, states the bench-tests trade (that job is not a required context and resolves dependencies at run time, so a resolver outage on a push files an issue naming an innocent commit), corrects the claim that `prompt-assets` is non-required (it reports `Agent instructions cite assets that exist`, required since 2026-09-02), and names `Validate Conventional Commit PR Title` as unwatchable because it runs only on pull requests.
- `scripts/test_integration_contracts.py`: a test in `WorkflowNameJoinTest` asserting the notifier watches every name in a module-level roster of the six whole-tree push-to-main workflows. The existing rename guard beside it already covers the other direction. Its docstring says what it cannot catch: a context newly promoted to required that nobody adds.
- `scripts/test_notify_broken_main.py`: one docstring word.

## Context

Refs #1223. This fixes only the notification gap that issue recounts. Its two structural items, moving the presubmit-gate mechanics out of `AGENTS.md` and giving cheap required checks re-test semantics against current `main`, remain open there.

Follow-up not done here: a structural test forcing every whole-tree push-to-main workflow into either the watched roster or an explicit not-watched set with a reason. That would catch the "newly required but never added" case this roster cannot, at the cost of classifying about fourteen workflows.

Generated with the help of Claude Code (Fable 5.1).

## Testing

- `cd scripts && python3 -m unittest test_notify_broken_main test_integration_contracts`: 78 tests pass. In a worktree at the base ref with the new test copied in, the new test fails naming exactly `Documentation Checks, Python Unit Tests`.
- `make docs-check`: clean; the always-loaded instruction files are unchanged at 37.8k chars.
- `prettier@3.9.6 --check` on the changed workflow: clean.
- `actionlint` v1.7.7 on the changed workflow: clean.

### Live validation

Not live-tested against a kube-agents installation: this is a CI workflow with no runtime code path, and a `workflow_run` trigger only fires from the default branch's copy of the file, so the new watches cannot be observed before merge.

What was exercised instead, against the real GitHub run history:

- `python3 scripts/notify_broken_main.py --run-id 33804932275 --dry-run` (the first red `Documentation Checks` push run on main, `5c9f2e5e`, 2026-09-03T20:54:05Z) reports the run as superseded by a later one and does nothing, which is the script's stale-news guard working as designed.
- Replaying the script's own `decide` and `render_body` with the run history truncated to that moment yields a `broken` decision and this issue body, which is what would have been filed at 20:54Z:

```
# 🔴 main is broken: Documentation Checks

🔴 **`Documentation Checks`** is failing on `main`.

| run | commit | author | PR |
| --- | --- | --- | --- |
| 3175 | 5c9f2e5 | bnaylor | #1124 |
```

- After merge, the first push to main will produce a notify run for each new workflow; I will link the first one here.

No API writes were made; the tree and the repository are unchanged by the validation.

## Self-Review

Passes: `review-adversarial` once and `review-docs-drift` twice (the second on the head after fixes), each in a fresh subagent handed only the diff range and the skill, told not to read commit messages or plan files. `make docs-check` ran in the authoring context first and its output was handed on.

Angles the adversarial pass ran: intent derived from the diff versus what the diff does; the script's contract that a green run means the tree is green, checked against both new workflows' triggers, `paths:`, step-level `if:` guards and concurrency keys; the run history behind every figure in the header; red-then-green on the new test in a throwaway worktree; sibling open PRs touching the same files (none) or renaming a watched workflow (none); pinned actions and repository guards (unchanged). Docs-drift checked every factual claim in the header and docstrings against `.github/workflows/*.yml`, `docs/pull-request-workflow.md`, and the live branch-protection API, and searched all Markdown for any description of the notifier or its watch list (none exists, so no doc went stale).

Findings and dispositions:

- Header cited `prompt-assets` as a non-required precedent for watching bench-tests (adversarial MEDIUM CONFIRMED; docs-drift Blocking, same defect). `prompt-assets` reports a required context since 2026-09-02. Fixed: both paragraphs rewritten; the pre-existing stale sentence is gone.
- New test's docstring claimed it catches a name "never added" (adversarial MEDIUM CONFIRMED). It only catches drops. Fixed: docstring narrowed and says why the other case is not derivable offline. The structural alternative is recorded under Context as a follow-up, not done because it grows the change from two names to a classification of about fourteen workflows.
- A bench-tests-only red from a dependency resolver outage would file an issue naming an innocent commit (adversarial LOW PLAUSIBLE; unobserved in 43 push runs). Fixed by stating the trade in the header rather than by changing the watch: the alternative is not watching the suite that took thirteen hours to notice.
- `Validate Conventional Commit PR Title` unexplained among the ten required contexts (docs-drift Advisory). Fixed: one sentence, it has no push run.
- "no issue filed" read as contradicted by the #1223 reference (docs-drift Advisory). Fixed: "no `ci:main-broken` issue filed".
- Hard-coded "six" in the header and a test docstring, and a stale "19 files" count in the Prettier paragraph (docs-drift Advisory). Fixed: counts dropped.
- Module docstring of `test_integration_contracts.py` listed three contracts (docs-drift Advisory, second run). Fixed: fourth added.
- Roster comment said "re-checks the whole tree", imprecise for Operator Tests (docs-drift Advisory, second run). Fixed: "everything it covers".

Not covered by any pass: observing a `workflow_run` firing for the new names before merge; the 2026-09-02 promotion date was checked against the repository's own doc and the notifier's commit history, not GitHub's audit log.

## Risk & Rollout

Low risk: no runtime code paths touched. The new failure mode is the one the header now states, an issue filed for a bench-tests-only red; the notifier closes it on the next green run of the same workflow, so it costs a misleading issue for one merge cycle, not a stuck one. Revert by removing the two names and the roster entries. Nothing has to happen at merge time; the trigger takes effect on the first push to main after it.
