### PR TITLE
docs(designs): name the trust-domain assumption a declared scope rests on

### DIFF
--- a/docs/designs/multi-project-scope.md
+++ b/docs/designs/multi-project-scope.md
@@ -448,6 +448,31 @@ one cluster regardless of how wide discovery is. Until then the design recommend
 `folders` for a fleet an operator would be comfortable reading with one account, and documents
 `organizations` as available but wide.
 
+### A scope is one trust domain, by operator assertion
+
+The widening above is about what a credential may read. The scope change also decides what
+happens to what it has read, and the design's answer is that declaring a scope is the
+operator asserting these projects may share findings.
+
+Cross-project reach is not itself new: the broker never pinned a project (§2), the
+`manage-cluster` skill takes `--project` today (§7), and §5's own snapshot example carries
+a profile in another project. What the stock IAM grant did was make an operator arrange
+each one deliberately. A scope makes reading across projects the supported default, and
+the aggregation stage is where that lands — the sweep fans out per cluster, so each Cluster
+Agent's context holds one, but the roll-up in the Platform Agent holds all of them and
+nothing there keeps them apart. For the case this document motivates, one organisation and
+several of its own projects, that is what the operator wants. For a scope drawn across
+projects whose findings should not meet, it is not.
+
+The check is one sentence: _every project in this scope may see every other project's
+findings._ An install that cannot say yes wants two Platform Agents with disjoint scopes,
+which is where §11's cardinality question also points — though disjointness is a
+declaration too, and nothing prevents two installs from declaring overlapping scopes.
+
+Nothing in `spec.scope` verifies any of this. The platform enforces the scope; the trust
+boundary is the operator's claim that the scope is drawn where the trust is. Where those
+diverge, the divergence is silent.
+
 ## 10. Implementation order
 
 Each step is shippable alone and live-testable on a shared install by granting its service account


### PR DESCRIPTION
## Summary

One subsection at the end of §9 of `multi-project-scope.md`, naming an assumption the design rests on and giving it a stated default: a declared scope is one trust domain, by operator assertion.  §9 already covers what a credential may *read* once a scope widens; this covers what happens to what it has read, which the document leaves implicit.  No design change is proposed and nothing about the scope model moves.

## Why This Change

Once one Platform Agent reads across a declared scope, the aggregation stage holds every project in it.  The sweep fans out per cluster, so each Cluster Agent's context holds one cluster — but the roll-up in the Platform Agent holds all of them, and nothing there keeps them apart.  For the case the document motivates, one organisation and several of its own projects, that is exactly what the operator wants and no further control is needed.  For a scope drawn across projects whose findings should not meet, it isn't, and nothing in the document tells a reader which case they are in.

Stating the assumption is what lets the second case be detected.  The default proposed is the one the design already behaves as if it holds: declaring the scope *is* the operator asserting these projects may share findings.

Raised as a comment on #1215 before it merged, then as #1235.  Sending the paragraph rather than the request, since it is a sentence rather than a redesign — happy for it to be reworded or rejected outright.

## What Changed

- `docs/designs/multi-project-scope.md`: one `###` subsection at the end of §9.

Kept at `###` rather than promoted to `## 10.` deliberately: renumbering would break the in-document `§11` references (including this text's own) and the §-numbered cross-references in `docs/README.md`, and would collide with #1229, which is open against this file.

## Context

- #1215 — the design this amends, merged 2026-09-03.
- #1235 — the question this answers; closes with it.
- #1229 — also open against this file, at `:63-67`.  No textual overlap with this hunk.
- Not included, and deliberately: the other ask from the #1215 comment, that this document and `spec-subagent-profiles.md` name each other explicitly.  That is a change to two documents and should be its own PR or ride whichever one is next edited.

## Testing

- `make docs-check` green (links, terminology, map inventory over 254 tracked docs, generated regions, context budget).
- `prettier` 3.9.6 clean on the changed file.
- No map row added: the row for this file already exists and does not enumerate subsections, and re-aligning that table is forbidden.

### Live validation

Not live-tested: docs-only, no code path reaches a running installation.  The behavioural claim in the text — that the sweep fans out per cluster and mixes at the roll-up — is read from `agents/chat/scripts/bootstrap_scan_gate.py` (`_task_body()`, "Step 2 — fan out"; the degraded solo path at `:112-121`) and `agents/platform/governance/inventory.md:60-75`, not observed on a cluster.

## Self-Review

Both required passes run in one fresh subagent context handed the diff range and the repo skills, not the conversation that wrote the text.  Seven findings, all confirmed, six fixed and one deliberately not.

- **Fixed, and it was the important one:** the first draft claimed "before, an agent could not reach a second project."  That is false and this document contradicts it three times — §2 ("It does not pin a project.  Only IAM stops a cross-project call"), §5's snapshot example carrying a profile in another project, and §7's note that `manage-cluster` takes `--project` today.  Verified against source as well (`manage-cluster/SKILL.md:27`; `common_types.go` documents `scopedServiceAccounts[].projectId` as needing not to be the agent's project).  Single-project was the stock Terraform grant, not an impossibility.  Rewritten to say so, which strengthens the point rather than weakening it: mixing is already reachable on hand-onboarded installs.
- **Fixed:** the draft opened by denying a weakening and then described one, inside the section that is otherwise candid about the widening.  Removed.
- **Fixed:** it said §11's cardinality question "arrives at" two agents with disjoint scopes; §11 raises it and leaves it open.  Corrected, and the text now adds that disjointness is itself only a declaration — nothing prevents two installs declaring overlapping scopes, which is the same hole the paragraph's own closing line is about.
- **Fixed:** the mechanism was stated as a single reasoning context reading across the scope.  The sweep actually fans out per cluster; mixing happens at the roll-up and in the degraded solo path.  Naming the aggregation stage is both correct and a stronger sentence.
- **Fixed:** roughly 40% shorter.  One paragraph argued for its own existence rather than stating a fact; one restated the first.
- **Fixed:** "it is worth being plain about the difference" — the one preamble construction in the file, against the write-it-straight rule.
- **Not fixed, with reason:** the `###` level, per What Changed above.

Worth passing on separately rather than adding to the text, since it cites unmerged work: #861 keys findings on `(check, cluster, namespace, object)` with no project field, and §3 of this document notes cluster names are unique only within a project and location.  Under a multi-project scope, two clusters named `prod` in different projects collide into one row.  That is the same concern as a data-model bug rather than a reasoning-context argument, and it is worth a comment on #861.


## Risk & Rollout

Low risk, no runtime code paths touched: one subsection added to a design document, no code, no manifests, no generated regions.  Nothing to roll out and nothing to happen at merge time; revert is a revert.

The one non-zero risk is editorial rather than operational — this is text on someone else's merged design of record, and if the stated default is wrong the document now asserts it with authority.  That is why it is a default with a named assertion rather than a mechanism, why it says plainly that nothing verifies it, and why the wording is offered rather than argued for.  Reword or close it; nothing depends on this landing.
