### PR TITLE
feat(a2a): the Hermes bridge, a stand-in executor for platform-addressed tasks

### DIFF
--- a/a2a/cmd/hermes-bridge/main.go
+++ b/a2a/cmd/hermes-bridge/main.go
@@ -1,0 +1,85 @@
+// hermes-bridge consumes tasks addressed to the platform profile and answers
+// them by invoking the hermes CLI, one subprocess per task. It runs as a
+// sidecar in the platform-agent pod. Design: a2a/docs/hermes-bridge.md.
+//
+// PLAYGROUND POSTURE: this deployment exists to prove the A2A fabric shape.
+// Static bus credentials, a shared bus user, and no queue-staleness guard
+// are the playground, not the product - the auth callout, per-identity
+// users, and the stage-3 dispatcher replace them.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	hermesbridge "github.com/gke-labs/kube-agents/a2a/hermes-bridge"
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	url := os.Getenv("NATS_URL")
+	if url == "" {
+		log.Error("NATS_URL is required")
+		os.Exit(2)
+	}
+	cfg := hermesbridge.Config{
+		NATSURL:      url,
+		Profile:      envOr("BRIDGE_PROFILE", "platform"),
+		Concurrency:  envInt(log, "BRIDGE_CONCURRENCY", 2),
+		TaskDeadline: time.Duration(envInt(log, "BRIDGE_TASK_DEADLINE_SECONDS", 7200)) * time.Second,
+		KillGrace:    time.Duration(envInt(log, "BRIDGE_KILL_GRACE_SECONDS", 10)) * time.Second,
+		KVBucket:     envOr("BRIDGE_KV_BUCKET", "runtime-state"),
+		Logger:       log,
+	}
+	if bin := os.Getenv("HERMES_BIN"); bin != "" {
+		cfg.Command = []string{bin, "-p", cfg.Profile, "chat", "-Q", "-q"}
+	}
+	if user := os.Getenv("NATS_USER"); user != "" {
+		cfg.NATSOptions = append(cfg.NATSOptions, nats.UserInfo(user, os.Getenv("NATS_PASSWORD")))
+		// Push delivery answers on inbox subjects, and this user may only
+		// subscribe under its own prefix - the CLI default _INBOX.<nuid>
+		// would be refused and every JS API call would time out.
+		cfg.NATSOptions = append(cfg.NATSOptions, nats.CustomInboxPrefix("_INBOX."+user))
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	b, err := hermesbridge.New(ctx, cfg)
+	if err != nil {
+		log.Error("bridge init failed", "err", err)
+		os.Exit(1)
+	}
+	if err := b.Run(ctx); err != nil {
+		log.Error("bridge exited", "err", err)
+		os.Exit(1)
+	}
+	log.Info("bridge shut down cleanly")
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envInt(log *slog.Logger, key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Error("bad integer env value; using default", "key", key, "value", v, "default", def)
+		return def
+	}
+	return n
+}

--- a/a2a/docs/hermes-bridge.md
+++ b/a2a/docs/hermes-bridge.md
@@ -1,0 +1,164 @@
+# The Hermes bridge
+
+- **Author:** [@bnaylor]
+- **Date:** 2026-08-26
+- **Status:** draft for review
+- **Companions:** the A2A payload spec (task lifecycle, steering), the NATS deployment
+  spec (accounts), the subagent profiles spec (supervision, CAS)
+
+## Purpose
+
+The retargeted first wave routes every gateway task to the addressee `platform`, and
+nothing answers on that subject yet - the worker adapter (W4) fast-follows, and the
+dispatcher is stage 3. The bridge is the stand-in executor: a small Go daemon on
+`a2a/lib` that consumes tasks addressed to `platform`, runs
+`hermes -p platform chat -Q -q <prompt>` per task, and publishes the lifecycle events with
+the output as the `result` artifact. It is scaffolding with a planned demolition date:
+when the dispatcher and worker adapter land, the bridge retires. Nothing here is
+protocol - the wire contract is the payload spec's, unchanged.
+
+## Where it runs
+
+**Sidecar in the platform-agent pod, declared via the CR's `spec.deployment.sidecars`
+field.** The bridge needs two things that only exist in that pod: the `hermes` CLI (it lives in the
+platform-agent image, so the bridge image builds FROM it and adds one static binary) and
+the persona state - `$HERMES_HOME` is the agent's data PVC, RWO, holding the platform
+profile's config, memory, and skills. A separate Deployment would need that PVC mounted
+cross-pod, which RWO only allows with same-node scheduling games. Not worth it for a
+component we intend to delete.
+
+The `sidecars` field takes ordinary `corev1.Container` entries, so the operator renders
+the bridge without any operator code change and reconcile never fights us. The sidecar
+mounts the same data volume, runs as the pod's KSA (model auth via Workload Identity for
+free), and gets `NATS_URL` plus creds from the a2a creds Secret.
+
+Concurrent hermes processes under one `$HERMES_HOME` is the kanban dispatcher's existing
+posture (`deploy/docker/patches/kanban_result_required.py` documents `_default_spawn`
+spawning the same kind of one-shot `hermes chat -q` process), so the bridge inherits a
+known-working concurrency story. Cap is 2, matching the platform profile's `concurrency` in the profiles spec.
+
+## What this deployment method costs
+
+Two properties of riding `spec.deployment.sidecars`, stated here because the operator
+cannot fix either one - gating a user-supplied container means overriding user intent.
+
+**Flipping to `mode: today` with the sidecar still set takes the agent down.** The
+operator copies `spec.deployment.sidecars` into the pod without consulting the mode, so
+the flip removes the NATS Service and leaves the bridge dialling a host that no longer
+resolves. Confirmed live 2026-09-05: the sidecar crash-loops, and because it shares the
+agent's pod the pod never reaches Ready - the whole agent is down, not merely carrying
+an A2A trace. Unset `spec.deployment.sidecars` _before_ flipping to `today`. In any
+flip runbook that step is a blocker, not tidiness.
+
+**The webhook does not screen sidecar env, on purpose.** The `SensitiveEnvVars`
+refusal applies to `spec.deployment.env` only; a sidecar's own `env` is unscreened (the
+webhook validates sidecar `securityContext` and nothing else about it). The bridge
+depends on exactly that gap - its `NATS_URL` and credentials arrive as sidecar env.
+Closing it breaks this deployment method, so it stays open as a stated trade while the
+bridge exists; the bridge's demolition removes the reason.
+
+One provenance note: no build config for the bridge image ships in this repository.
+The image is fork-built for the playground (`FROM` the platform-agent image plus the
+one static binary above) and is not in `images.json` or the release pipeline; it joins
+the release surface at stage-2 graduation or dies before it, whichever the dispatcher
+decides.
+
+## Bus user and grants
+
+The `…in` subject has two reader roles by design - the dispatcher for new tasks, the
+executor for everything after the submission. The bridge is both, collapsed into one
+process: it holds the one durable consumer on `a2a.tasks.platform.*.in` (the dispatcher
+role, `durable: bridge-platform`) and handles follow-ups and cancels for tasks it is
+running (the executor role). That collapse is exactly what makes it a stand-in - when
+the real dispatcher arrives, the roles separate again and the bridge has nothing left to
+do.
+
+On the W6 install the bridge connects as the static `worker` user, whose grants already
+cover it: subscribe `a2a.tasks.>`, publish `a2a.tasks.*.*.events`, plus the JetStream
+tax (`$JS.API.>`, `$JS.ACK.TASKS.>` — ack scoped to the one stream this user consumes
+with explicit ack; unscoped `$JS.ACK.>` is a cross-principal +TERM — `$JS.FC.>`,
+`_INBOX.worker.>`) and `$KV.runtime-state.>`
+for the in-flight registry below. Playground posture - the shared static user is the
+playground, per the deployment spec. The production shape, recorded for when the
+callout arms: a dedicated `bridge` identity with subscribe `a2a.tasks.platform.*.in`,
+publish `a2a.tasks.platform.*.events`, its own inbox prefix, and the KV grant. Nothing
+wider - a bridge that can publish submissions is a bridge that can impersonate the
+gateway.
+
+## Lifecycle, steering, cancel
+
+Per task: `submitted` on accept (before the consumer ack, so a bridge death before the
+ack just redelivers), `working` when the subprocess spawns, the stdout as a `result`
+artifact (chunked if large), one terminal `status-update` with `final: true`. A nonzero
+exit is terminal `failed` with the exit code and a stderr tail in the status message. A
+submission with no text parts is terminal `rejected`. New-task detection is the
+dispatcher's rule: empty `…events` subject means new; anything on `…in` for a task with
+a terminal event is acked with a warning and nothing else.
+
+**Steering:** `hermes chat -Q -q` is one-shot - there is no stdin to inject into. A
+follow-up message to a running task is acked and answered with a non-final status
+echoing the task's current state (`working` once the subprocess spawned, `submitted`
+while still queued) whose message says the input cannot be absorbed mid-run and cancel
+is available.
+Honest, never silent. This does not change task state (payload spec assertion 12).
+
+**Cancel:** SIGTERM to the subprocess's process group, SIGKILL after a grace period,
+then terminal `canceled`. A task racing to completion may land `completed` first - both
+orders are legal and the terminal event wins. A per-task deadline (default 7200s,
+matching the profile's `activeDeadlineSeconds`) takes the same kill path and lands
+`failed`.
+
+## Supervision
+
+The bridge is its own janitor, per the ratified split - every task's supervisor is the
+component that spawned its execution. Two failure classes:
+
+- **The subprocess dies under a live bridge.** The runner sees the exit and publishes
+  terminal `failed` with the evidence. Ordinary executor path, nothing special.
+- **The bridge dies mid-task.** The submission was already acked, so nobody redelivers
+  it, and no terminal event exists. The bridge keeps an in-flight registry in the
+  `runtime-state` KV bucket (key per accepted taskId, written before `submitted`,
+  deleted after the terminal publish). On startup, before consuming, it sweeps: fold
+  each registered task's events, and for any non-final one publish terminal `failed`
+  (`reason: bridge-died-without-terminal-event`).
+
+The sweep's publish is a compare-and-swap per the profiles spec, not a read-then-write:
+expected-last-subject-sequence pinned to the last event the fold saw. A dying
+subprocess's flush racing the sweep wins cleanly, the CAS is rejected, and the sweep
+re-reads instead of double-finalizing. Whichever writer loses lands in the
+warn-and-drop path like any other post-final event.
+
+The sweep assumes incarnations are serial. That assumption is real on this install -
+the kubelet restarts the sidecar container in place, and the operator renders the agent
+Deployment with strategy `Recreate`, so two bridges never run at once. It is an
+assumption, not a mechanism, and it has a named boundary: `Recreate` is the render's
+default only while replicas is 1 - `spec.deployment.availability.replicas` above 1
+switches the strategy to RollingUpdate (`resolveDeploymentReplicasAndStrategy`,
+`manifest_helpers.go`), and an overlapping incarnation could then sweep-fail a task
+its predecessor is still running. Real executor fencing belongs to the stage-3
+dispatcher, not to scaffolding with a demolition date.
+
+Honest gaps, accepted for the playground: no queue-staleness guard (the lib's subscribe
+path doesn't expose server ingest timestamps, and `queueTimeoutSeconds` is the
+dispatcher's job when it exists), no heartbeats on `agents.hb.>`, a submission whose
+events lookup fails transiently is dropped with a log line rather than redelivered (the
+lib acks unconditionally after the handler; a nak path is a lib delta if it ever bites),
+and a terminal publish that fails outright - a bus outage outlasting the finalize
+budget at exactly that moment - leaves the task in the registry for the NEXT
+incarnation's sweep, which may be far away on a healthy sidecar; until then the bridge
+holds the task as done while the stream shows no terminal event, and a later cancel
+cannot unstick it.
+All retire with the bridge. One more: zombie reaping. The operator deliberately leaves
+`ShareProcessNamespace` unset (`platformagent_manifests.go`, the pod-template comment)
+so no container hands its `/proc/<pid>/environ` to its neighbours. The bridge binary is
+therefore PID 1 of its own container, orphans escaping the group kill reparent to it,
+and Go's `cmd.Wait` reaps only direct children - zombies can accumulate until the
+container restarts. Accepted for the playground with the rest; the stage-3 dispatcher
+runs executions as Jobs, where the problem does not exist.
+
+## Definition of done
+
+A task published to `a2a.tasks.platform.<id>.in` on the W6 install returns the platform
+agent's real answer as a `result` artifact. Cancel works. The event sequence passes
+the lifecycle conformance assertions (9, 10, 12, 13, 14, 15, 18), table-driven like the
+`a2a/lib` conformance suite.

--- a/a2a/hermes-bridge/bridge.go
+++ b/a2a/hermes-bridge/bridge.go
@@ -1,0 +1,696 @@
+// Package hermesbridge is the stand-in executor for tasks addressed to the
+// platform profile: it consumes a2a.tasks.{profile}.*.in, runs one
+// `hermes -p {profile} chat -Q -q <prompt>` per task, and publishes the payload
+// spec's lifecycle events with the output as the result artifact. It is
+// scaffolding for the Hermes-first world - when the stage-3 dispatcher and
+// the W4 worker adapter land, the bridge retires. Design:
+// a2a/docs/hermes-bridge.md.
+package hermesbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unicode/utf8"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nuid"
+
+	"github.com/gke-labs/kube-agents/a2a/lib"
+)
+
+const (
+	// taskQueueCapacity bounds the accepted-but-not-started queue; hitting
+	// it on a playground bridge is a fault, not load.
+	taskQueueCapacity = 1024
+	// stderrTailBytes is how much subprocess stderr a failed task's status
+	// message can carry.
+	stderrTailBytes = 2048
+	// finalizePublishTimeout bounds the result+terminal publishes of one
+	// finalize; it must outlast a NATS reconnect, not a task.
+	finalizePublishTimeout = 20 * time.Second
+	// registryClearTimeout bounds the KV delete after a terminal publish.
+	registryClearTimeout = 10 * time.Second
+
+	shutdownReason = "reason: bridge-shutdown - the bridge was terminated while this task was in flight"
+)
+
+// Config wires one bridge. Zero values get playground defaults in Run.
+type Config struct {
+	// NATSURL is the bus address.
+	NATSURL string
+	// Profile is the addressee token the bridge executes for ("platform").
+	Profile string
+	// Command is the invocation prefix; the task prompt is appended as the
+	// final argument. Default: ["hermes", "-p", <profile>, "chat", "-Q", "-q"].
+	Command []string
+	// Concurrency caps simultaneous hermes subprocesses (default 2, the
+	// platform profile's concurrency in the profiles spec).
+	Concurrency int
+	// TaskDeadline is the per-invocation wall-clock ceiling (default 7200s,
+	// matching the platform profile's activeDeadlineSeconds).
+	TaskDeadline time.Duration
+	// KillGrace is SIGTERM-to-SIGKILL grace on cancel/deadline (default 10s).
+	KillGrace time.Duration
+	// KVBucket holds the in-flight registry the sweep reads (default
+	// "runtime-state", the provisioned bucket).
+	KVBucket string
+	// ResultChunkSize bounds one result artifact-update's text part so a
+	// large answer never trips the client-side max-message-size gate
+	// (default 256KiB).
+	ResultChunkSize int
+	// NATSOptions carries credentials etc; applied to both connections.
+	NATSOptions []nats.Option
+	Logger      *slog.Logger
+}
+
+func (c *Config) defaults() {
+	if c.Profile == "" {
+		c.Profile = "platform"
+	}
+	if len(c.Command) == 0 {
+		// -Q is hermes's programmatic mode: no banner, no spinner, no TUI
+		// box around the answer - stdout is the response.
+		c.Command = []string{"hermes", "-p", c.Profile, "chat", "-Q", "-q"}
+	}
+	if c.Concurrency <= 0 {
+		c.Concurrency = 2
+	}
+	if c.TaskDeadline <= 0 {
+		c.TaskDeadline = 7200 * time.Second
+	}
+	if c.KillGrace <= 0 {
+		c.KillGrace = 10 * time.Second
+	}
+	if c.KVBucket == "" {
+		c.KVBucket = "runtime-state"
+	}
+	if c.ResultChunkSize <= 0 {
+		c.ResultChunkSize = 256 * 1024
+	}
+	if c.Logger == nil {
+		c.Logger = slog.Default()
+	}
+}
+
+// runState is a task's position in the bridge, guarded by taskRun.mu.
+type runState int
+
+const (
+	statePending runState = iota // accepted, submitted published, queued
+	stateRunning                 // subprocess spawned
+	stateDone                    // terminal event published
+)
+
+type taskRun struct {
+	origin *lib.Envelope
+	exec   *lib.TaskExecution
+
+	// mu guards state, proc, and killTimers - and is held across the
+	// finalize publish, so a steer refusal can never land after the final
+	// event: whoever holds the lock sees the true state before publishing.
+	mu         sync.Mutex
+	state      runState
+	proc       *exec.Cmd
+	killTimers []*time.Timer
+
+	canceled    atomic.Bool
+	deadlineHit atomic.Bool
+}
+
+// Bridge is one running instance. Two connections by design: the lib client
+// owns the task plane (consume, publish, resilience contract), and a raw
+// jetstream handle owns what the lib doesn't speak yet - the KV in-flight
+// registry and the sweep's CAS publish.
+type Bridge struct {
+	cfg  Config
+	from lib.Party
+
+	c  *lib.Client
+	nc *nats.Conn
+	js jetstream.JetStream
+	kv jetstream.KeyValue
+
+	mu    sync.Mutex
+	tasks map[string]*taskRun
+	queue chan *taskRun
+	wg    sync.WaitGroup
+
+	// closing marks shutdown, so a worker whose subprocess died to the
+	// shutdown SIGKILL reports bridge-shutdown, not a bogus exit code.
+	closing atomic.Bool
+}
+
+// New connects and sweeps but does not consume yet; Run does.
+func New(ctx context.Context, cfg Config) (*Bridge, error) {
+	cfg.defaults()
+	b := &Bridge{
+		cfg: cfg,
+		from: lib.Party{
+			Session:   cfg.Profile + "-bridge",
+			AgentType: "hermes-bridge",
+			Profile:   cfg.Profile,
+		},
+		tasks: make(map[string]*taskRun),
+		queue: make(chan *taskRun, taskQueueCapacity),
+	}
+	var err error
+	b.c, err = lib.Connect(ctx, cfg.NATSURL,
+		lib.WithName(b.from.Session),
+		lib.WithLogger(cfg.Logger),
+		lib.WithNATSOptions(cfg.NATSOptions...))
+	if err != nil {
+		return nil, err
+	}
+	b.nc, err = nats.Connect(cfg.NATSURL, append([]nats.Option{
+		nats.Name(b.from.Session + "-kv"), nats.MaxReconnects(-1),
+	}, cfg.NATSOptions...)...)
+	if err != nil {
+		b.c.Close()
+		return nil, fmt.Errorf("kv connection: %w", err)
+	}
+	b.js, err = jetstream.New(b.nc)
+	if err != nil {
+		b.close()
+		return nil, fmt.Errorf("kv jetstream: %w", err)
+	}
+	b.kv, err = b.js.KeyValue(ctx, cfg.KVBucket)
+	if err != nil {
+		b.close()
+		return nil, fmt.Errorf("kv bucket %s: %w", cfg.KVBucket, err)
+	}
+	return b, nil
+}
+
+func (b *Bridge) close() {
+	b.c.Close()
+	b.nc.Close()
+}
+
+// Run sweeps orphans from a prior incarnation, then consumes the profile's
+// in subjects until ctx is canceled. On shutdown, in-flight tasks get
+// terminal failed (reason: bridge-shutdown) - the eviction path the profiles
+// spec requires of adapters, so a rollout stays distinguishable from a crash.
+func (b *Bridge) Run(ctx context.Context) error {
+	defer b.close()
+	if err := b.sweep(ctx); err != nil {
+		return fmt.Errorf("startup sweep: %w", err)
+	}
+	for i := 0; i < b.cfg.Concurrency; i++ {
+		b.wg.Add(1)
+		go b.worker(ctx)
+	}
+	sub, err := b.c.SubscribeDurable(ctx, lib.SubscribeConfig{
+		Stream:  lib.TasksStream,
+		Subject: fmt.Sprintf("a2a.tasks.%s.*.in", b.cfg.Profile),
+		Durable: "bridge-" + b.cfg.Profile,
+		Session: b.cfg.Profile,
+	}, func(env *lib.Envelope) { b.handle(ctx, env) })
+	if err != nil {
+		return fmt.Errorf("subscribe: %w", err)
+	}
+	b.cfg.Logger.Info("hermes bridge consuming", "profile", b.cfg.Profile)
+	<-ctx.Done()
+	b.closing.Store(true)
+	sub.Stop()
+	// The queue is never closed: Stop does not join an in-flight handler
+	// callback, and a handler mid-accept sending into a closed channel would
+	// panic the whole shutdown. Workers exit on ctx instead; anything still
+	// queued is finalized by shutdownTasks below.
+	b.shutdownTasks()
+	b.wg.Wait()
+	return nil
+}
+
+// shutdownTasks kills running subprocesses and finalizes every task still
+// open. A worker unblocked by the kill may finalize with the real outcome
+// first - finalize is idempotent and whoever wins writes exactly once.
+func (b *Bridge) shutdownTasks() {
+	b.mu.Lock()
+	runs := make([]*taskRun, 0, len(b.tasks))
+	for _, r := range b.tasks {
+		runs = append(runs, r)
+	}
+	b.mu.Unlock()
+	for _, r := range runs {
+		r.mu.Lock()
+		if r.state == stateRunning && r.proc != nil && r.proc.Process != nil {
+			_ = syscall.Kill(-r.proc.Process.Pid, syscall.SIGKILL)
+		}
+		r.mu.Unlock()
+		b.finalize(r, lib.StateFailed, shutdownReason, nil)
+	}
+}
+
+// handle dispatches one envelope from the in subject. Anything it publishes
+// happens before returning, ie before the consumer ack - a bridge death in
+// here just redelivers.
+func (b *Bridge) handle(ctx context.Context, env *lib.Envelope) {
+	switch env.Kind {
+	case lib.KindMessage:
+		b.handleMessage(ctx, env)
+	case lib.KindCancel:
+		b.handleCancel(ctx, env)
+	default:
+		b.cfg.Logger.Warn("unexpected kind on in subject; ignoring",
+			"kind", env.Kind, "task", env.TaskID)
+	}
+}
+
+func (b *Bridge) handleMessage(ctx context.Context, env *lib.Envelope) {
+	b.mu.Lock()
+	run := b.tasks[env.TaskID]
+	b.mu.Unlock()
+	if run != nil {
+		b.refuseSteer(ctx, run, env)
+		return
+	}
+	// Unknown task: the dispatcher rule. Empty events subject means new;
+	// terminal means acked with a warning; non-final events with no local run
+	// is an orphan a follow-up cannot revive.
+	task, err := b.c.TasksGet(ctx, b.cfg.Profile, env.TaskID)
+	switch {
+	case isTaskNotFound(err):
+		b.accept(ctx, env)
+	case err != nil:
+		// The lib acks after this handler returns, so the submission is
+		// dropped, not redelivered - no terminal event will follow. Honest
+		// gap: the lib exposes no nak path yet.
+		b.cfg.Logger.Error("events lookup failed; dropping submission",
+			"task", env.TaskID, "err", err)
+	case task.Final:
+		b.cfg.Logger.Warn("message for a task with a terminal event; ignoring", "task", env.TaskID)
+	default:
+		b.cfg.Logger.Warn("message for an orphaned task this bridge is not running; ignoring",
+			"task", env.TaskID, "state", task.State)
+	}
+}
+
+// accept is the dispatcher half: register in-flight, publish submitted,
+// queue for a worker. KV before submitted, deliberately - a crash between
+// the two leaves a key the sweep deletes harmlessly, where the opposite
+// order leaves a task the sweep cannot see.
+func (b *Bridge) accept(ctx context.Context, env *lib.Envelope) {
+	x, err := b.c.NewTaskExecution(env, b.from, b.cfg.Profile)
+	if err != nil {
+		b.cfg.Logger.Error("rejecting malformed submission", "task", env.TaskID, "err", err)
+		return
+	}
+	run := &taskRun{origin: env, exec: x}
+	if err := b.markInFlight(ctx, env.TaskID); err != nil {
+		b.cfg.Logger.Error("in-flight registry write failed; dropping submission",
+			"task", env.TaskID, "err", err)
+		return
+	}
+	if err := x.PublishStatus(ctx, lib.StateSubmitted, false); err != nil {
+		b.cfg.Logger.Error("submitted publish failed; dropping submission",
+			"task", env.TaskID, "err", err)
+		b.clearInFlight(ctx, env.TaskID)
+		return
+	}
+	b.mu.Lock()
+	b.tasks[env.TaskID] = run
+	b.mu.Unlock()
+	b.cfg.Logger.Info("task accepted", "task", env.TaskID, "correlation", env.CorrelationID, "from", env.From.Session)
+	select {
+	case b.queue <- run:
+	default:
+		// taskQueueCapacity queued tasks on a playground bridge is a fault,
+		// not load.
+		b.finalize(run, lib.StateFailed, "reason: bridge-queue-overflow", nil)
+	}
+}
+
+func (b *Bridge) handleCancel(ctx context.Context, env *lib.Envelope) {
+	b.mu.Lock()
+	run := b.tasks[env.TaskID]
+	b.mu.Unlock()
+	if run == nil {
+		b.cancelOrphan(ctx, env)
+		return
+	}
+	run.canceled.Store(true)
+	run.mu.Lock()
+	pending := run.state == statePending
+	if run.state == stateRunning && run.proc != nil && run.proc.Process != nil {
+		b.killGroup(run, run.proc.Process.Pid)
+	}
+	run.mu.Unlock()
+	if pending {
+		// Not yet spawned: terminal now; the worker skips done runs.
+		b.finalize(run, lib.StateCanceled, "reason: canceled-before-start", nil)
+	}
+	// For a running task the runner publishes terminal canceled on exit.
+}
+
+// cancelOrphan handles cancel for a task the bridge is not running: if its
+// events show it non-final (a prior incarnation died mid-task and the sweep
+// has no key for it), synthesize terminal canceled under CAS. Terminal or
+// absent tasks get a warning and nothing else.
+func (b *Bridge) cancelOrphan(ctx context.Context, env *lib.Envelope) {
+	task, err := b.c.TasksGet(ctx, b.cfg.Profile, env.TaskID)
+	switch {
+	case isTaskNotFound(err):
+		b.cfg.Logger.Warn("cancel for a task with no events; ignoring", "task", env.TaskID)
+	case err != nil:
+		b.cfg.Logger.Error("cancel events lookup failed", "task", env.TaskID, "err", err)
+	case task.Final:
+		b.cfg.Logger.Warn("cancel for a task with a terminal event; ignoring", "task", env.TaskID)
+	default:
+		if err := b.synthesizeTerminal(ctx, env.TaskID, lib.StateCanceled,
+			"reason: canceled-while-orphaned - no live executor held this task"); err != nil {
+			b.cfg.Logger.Error("orphan cancel synthesis failed", "task", env.TaskID, "err", err)
+		}
+	}
+}
+
+// refuseSteer answers a mid-run follow-up honestly: hermes chat -q is
+// one-shot, there is no stdin to inject into. The refusal is a non-final
+// status carrying the task's CURRENT state - a follow-up must not change
+// folded state by itself (assertion 12), so a queued task answers
+// submitted, a spawned one working. Published under run.mu, so it can
+// never land after the final event finalize writes under the same lock.
+func (b *Bridge) refuseSteer(ctx context.Context, run *taskRun, steer *lib.Envelope) {
+	run.mu.Lock()
+	defer run.mu.Unlock()
+	if run.state == stateDone {
+		b.cfg.Logger.Warn("message for a task with a terminal event; ignoring", "task", steer.TaskID)
+		return
+	}
+	state := lib.StateWorking
+	if run.state == statePending {
+		state = lib.StateSubmitted
+	}
+	msg := "steering received but not absorbed: the Hermes CLI runs one-shot and cannot " +
+		"accept mid-run input. The task continues on its original instruction; cancel if that is wrong."
+	if err := b.publishStatusMessage(ctx, run, state, false, msg); err != nil {
+		b.cfg.Logger.Error("steer refusal publish failed", "task", steer.TaskID, "err", err)
+	}
+}
+
+func (b *Bridge) worker(ctx context.Context) {
+	defer b.wg.Done()
+	for {
+		var run *taskRun
+		select {
+		case <-ctx.Done():
+			return
+		case run = <-b.queue:
+		}
+		run.mu.Lock()
+		if run.state != statePending {
+			run.mu.Unlock()
+			continue
+		}
+		run.state = stateRunning
+		run.mu.Unlock()
+		b.runTask(ctx, run)
+	}
+}
+
+func (b *Bridge) runTask(ctx context.Context, run *taskRun) {
+	taskID := run.origin.TaskID
+	prompt, ok := promptFromMessage(run.origin.Payload)
+	if !ok {
+		b.finalize(run, lib.StateRejected,
+			"reason: no-text-parts - the submission message carries nothing the hermes CLI can be asked", nil)
+		return
+	}
+	if err := run.exec.PublishStatus(ctx, lib.StateWorking, false); err != nil {
+		b.cfg.Logger.Error("working publish failed", "task", taskID, "err", err)
+		b.finalize(run, lib.StateFailed, "reason: bus-publish-failed at working", nil)
+		return
+	}
+
+	argv := append(append([]string(nil), b.cfg.Command...), prompt)
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout strings.Builder
+	stderr := newTailBuffer(stderrTailBytes)
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+
+	run.mu.Lock()
+	if run.state != stateRunning {
+		// Shutdown or cancel finalized first.
+		run.mu.Unlock()
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		run.mu.Unlock()
+		b.finalize(run, lib.StateFailed, fmt.Sprintf("reason: spawn-failed - %v", err), nil)
+		return
+	}
+	run.proc = cmd
+	// Cancel may have raced the spawn: its kill saw no process, so re-check
+	// under the same lock its kill path takes.
+	if run.canceled.Load() {
+		b.killGroup(run, cmd.Process.Pid)
+	}
+	run.mu.Unlock()
+
+	deadline := time.AfterFunc(b.cfg.TaskDeadline, func() {
+		run.deadlineHit.Store(true)
+		run.mu.Lock()
+		if run.state == stateRunning && run.proc != nil && run.proc.Process != nil {
+			b.killGroup(run, run.proc.Process.Pid)
+		}
+		run.mu.Unlock()
+	})
+	err := cmd.Wait()
+	deadline.Stop()
+	// The group is gone; stop any armed grace-period SIGKILLs before the
+	// pgid can be recycled onto an innocent process.
+	run.mu.Lock()
+	for _, t := range run.killTimers {
+		t.Stop()
+	}
+	run.killTimers = nil
+	run.mu.Unlock()
+
+	switch {
+	case err == nil:
+		// A canceled task that finished anyway won the race: completed wins,
+		// per the payload spec's cancel mapping.
+		out := stdout.String()
+		b.finalize(run, lib.StateCompleted, "", &out)
+	case run.deadlineHit.Load():
+		b.finalize(run, lib.StateFailed,
+			fmt.Sprintf("reason: deadline-exceeded - killed after %s", b.cfg.TaskDeadline), nil)
+	case run.canceled.Load():
+		b.finalize(run, lib.StateCanceled, "reason: canceled-by-request", nil)
+	case b.closing.Load():
+		// Killed by shutdownTasks; name the real cause, not the exit code.
+		b.finalize(run, lib.StateFailed, shutdownReason, nil)
+	default:
+		b.finalize(run, lib.StateFailed,
+			fmt.Sprintf("reason: hermes-exited-nonzero - %v; stderr tail: %s", err, stderr.String()), nil)
+	}
+}
+
+// finalize is the single writer of a task's terminal event, idempotent: the
+// first caller wins, later callers see stateDone and leave. A non-nil
+// resultOutput publishes the result artifact ahead of the terminal event
+// inside the same critical section, so a racing finalizer cannot slip its
+// final in between. Publishes ride a fresh bounded context, never the
+// caller's - the terminal event must go out even when the caller's context
+// is already canceled, which is exactly what shutdown looks like.
+func (b *Bridge) finalize(run *taskRun, state lib.TaskState, msg string, resultOutput *string) {
+	run.mu.Lock()
+	if run.state == stateDone {
+		run.mu.Unlock()
+		return
+	}
+	run.state = stateDone
+	ctx, cancel := context.WithTimeout(context.Background(), finalizePublishTimeout)
+	if resultOutput != nil {
+		if err := b.publishResult(ctx, run, *resultOutput); err != nil {
+			b.cfg.Logger.Error("result publish failed", "task", run.origin.TaskID, "err", err)
+			state, msg = lib.StateFailed, "reason: bus-publish-failed at result"
+		}
+	}
+	err := b.publishTerminal(ctx, run, state, msg)
+	cancel()
+	run.mu.Unlock()
+	if err != nil {
+		// The task stays in the KV registry, so a restart's sweep writes the
+		// terminal event this publish could not.
+		b.cfg.Logger.Error("terminal publish failed; sweep will finalize",
+			"task", run.origin.TaskID, "state", state, "err", err)
+		return
+	}
+	cctx, ccancel := context.WithTimeout(context.Background(), registryClearTimeout)
+	b.clearInFlight(cctx, run.origin.TaskID)
+	ccancel()
+	b.mu.Lock()
+	delete(b.tasks, run.origin.TaskID)
+	b.mu.Unlock()
+	b.cfg.Logger.Info("task finished", "task", run.origin.TaskID, "state", state)
+}
+
+func (b *Bridge) publishTerminal(ctx context.Context, run *taskRun, state lib.TaskState, msg string) error {
+	if msg == "" {
+		return run.exec.PublishStatus(ctx, state, true)
+	}
+	return b.publishStatusMessage(ctx, run, state, true, msg)
+}
+
+// publishStatusMessage is PublishStatus with a status.message attached -
+// the lib's TaskExecution doesn't carry one, and reasons ride there.
+func (b *Bridge) publishStatusMessage(ctx context.Context, run *taskRun, state lib.TaskState, final bool, text string) error {
+	origin := run.origin
+	payload, err := json.Marshal(lib.StatusUpdate{
+		TaskID:    origin.TaskID,
+		ContextID: origin.ContextID,
+		Status: lib.TaskStatus{
+			State: state,
+			Message: &lib.Message{
+				Role:      "agent",
+				MessageID: "msg-" + nuid.Next(),
+				Parts:     []lib.Part{{Kind: "text", Text: text}},
+				TaskID:    origin.TaskID,
+				ContextID: origin.ContextID,
+			},
+		},
+		Final: final,
+	})
+	if err != nil {
+		return err
+	}
+	env, err := lib.NewStatusUpdateEnvelope(b.from, origin.TaskID, origin.ContextID, origin.CorrelationID, payload)
+	if err != nil {
+		return err
+	}
+	return b.c.Publish(ctx, lib.TaskEventsSubject(b.cfg.Profile, origin.TaskID), env)
+}
+
+// publishResult ships stdout as the result artifact, chunked per A2A rules
+// so one huge answer never trips the max-message-size gate.
+func (b *Bridge) publishResult(ctx context.Context, run *taskRun, output string) error {
+	chunks := chunkString(output, b.cfg.ResultChunkSize)
+	artifactID := "artifact-" + run.origin.TaskID + "-result"
+	for i, chunk := range chunks {
+		payload, err := json.Marshal(lib.ArtifactUpdate{
+			TaskID:    run.origin.TaskID,
+			ContextID: run.origin.ContextID,
+			Artifact: lib.Artifact{
+				ArtifactID: artifactID,
+				Name:       lib.ArtifactResult,
+				Parts:      []lib.Part{{Kind: "text", Text: chunk}},
+			},
+			Append:    i > 0,
+			LastChunk: i == len(chunks)-1,
+		})
+		if err != nil {
+			return err
+		}
+		env, err := lib.NewArtifactUpdateEnvelope(b.from, run.origin.TaskID, run.origin.ContextID, run.origin.CorrelationID, payload)
+		if err != nil {
+			return err
+		}
+		if err := b.c.Publish(ctx, lib.TaskEventsSubject(b.cfg.Profile, run.origin.TaskID), env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// killGroup SIGTERMs the subprocess group and arms a SIGKILL for the grace
+// period. Caller holds run.mu. The timer is remembered so the reaper stops
+// it once the group is gone - an unstopped timer could SIGKILL a recycled
+// pgid belonging to somebody else.
+func (b *Bridge) killGroup(run *taskRun, pid int) {
+	_ = syscall.Kill(-pid, syscall.SIGTERM)
+	t := time.AfterFunc(b.cfg.KillGrace, func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	})
+	run.killTimers = append(run.killTimers, t)
+}
+
+// chunkString splits s into pieces of at most size bytes, never inside a
+// UTF-8 rune - each chunk is JSON-marshaled independently, and a rune split
+// across chunks would be corrupted to U+FFFD on both sides. An empty s is
+// one empty chunk, because a completed task must still carry a result
+// artifact (assertion 18).
+func chunkString(s string, size int) []string {
+	if len(s) <= size {
+		return []string{s}
+	}
+	var out []string
+	for len(s) > size {
+		cut := size
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		if cut == 0 {
+			// No rune boundary inside the window (only possible for
+			// size < utf8.UTFMax with a multi-byte rune first): take the
+			// whole rune rather than loop forever.
+			_, cut = utf8.DecodeRuneInString(s)
+		}
+		out = append(out, s[:cut])
+		s = s[cut:]
+	}
+	return append(out, s)
+}
+
+// promptFromMessage joins the submission message's text parts. ok is false
+// when there is nothing textual to ask.
+func promptFromMessage(payload json.RawMessage) (string, bool) {
+	var m lib.Message
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return "", false
+	}
+	var texts []string
+	for _, p := range m.Parts {
+		if p.Kind == "text" && strings.TrimSpace(p.Text) != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return "", false
+	}
+	return strings.Join(texts, "\n\n"), true
+}
+
+func isTaskNotFound(err error) bool {
+	var a2aErr *lib.A2AError
+	return errors.As(err, &a2aErr) && a2aErr.Code == lib.CodeTaskNotFound
+}
+
+// tailBuffer keeps the last cap bytes written - stderr evidence for the
+// failed reason without holding a runaway stream.
+type tailBuffer struct {
+	mu  sync.Mutex
+	buf []byte
+	cap int
+}
+
+func newTailBuffer(capacity int) *tailBuffer {
+	return &tailBuffer{cap: capacity}
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.buf = append(t.buf, p...)
+	if len(t.buf) > t.cap {
+		t.buf = t.buf[len(t.buf)-t.cap:]
+	}
+	return len(p), nil
+}
+
+func (t *tailBuffer) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return string(t.buf)
+}

--- a/a2a/hermes-bridge/bridge_test.go
+++ b/a2a/hermes-bridge/bridge_test.go
@@ -1,0 +1,766 @@
+package hermesbridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nuid"
+
+	"github.com/gke-labs/kube-agents/a2a/lib"
+)
+
+// ---- harness -------------------------------------------------------------
+
+var testPort atomic.Int32
+
+func init() { testPort.Store(24222) }
+
+func startServer(t *testing.T) (*natsserver.Server, string) {
+	t.Helper()
+	opts := &natsserver.Options{
+		Host:      "127.0.0.1",
+		Port:      int(testPort.Add(1)),
+		JetStream: true,
+		StoreDir:  t.TempDir(),
+		NoLog:     true,
+		NoSigs:    true,
+	}
+	s, err := natsserver.NewServer(opts)
+	if err != nil {
+		t.Fatalf("new server: %v", err)
+	}
+	go s.Start()
+	if !s.ReadyForConnections(10 * time.Second) {
+		t.Fatal("server not ready")
+	}
+	t.Cleanup(s.Shutdown)
+	url := fmt.Sprintf("nats://127.0.0.1:%d", opts.Port)
+
+	nc, err := nats.Connect(url)
+	if err != nil {
+		t.Fatalf("provision connect: %v", err)
+	}
+	defer nc.Close()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatalf("provision jetstream: %v", err)
+	}
+	ctx := testCtx(t)
+	if _, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:      lib.TasksStream,
+		Subjects:  []string{"a2a.tasks.>"},
+		Retention: jetstream.LimitsPolicy,
+		MaxAge:    72 * time.Hour,
+	}); err != nil {
+		t.Fatalf("create TASKS: %v", err)
+	}
+	if _, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "runtime-state"}); err != nil {
+		t.Fatalf("create runtime-state: %v", err)
+	}
+	return s, url
+}
+
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// script writes an executable stub standing in for the hermes CLI. The
+// bridge appends the prompt as the final argument, so stubs see it in "$5"
+// under the default arg shape ["-p", profile, "chat", "-q", prompt] - tests
+// pass Command themselves, so stubs read "$1".
+func script(t *testing.T, body string) []string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hermes-stub")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return []string{path}
+}
+
+// startBridge runs a bridge until test cleanup and waits for its durable
+// consumer, so a submission published right after cannot race the subscribe.
+func startBridge(t *testing.T, url string, command []string) {
+	t.Helper()
+	startBridgeN(t, url, command, 0)
+}
+
+func startBridgeN(t *testing.T, url string, command []string, concurrency int) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	b, err := New(ctx, Config{
+		NATSURL:      url,
+		Command:      command,
+		Concurrency:  concurrency,
+		TaskDeadline: 20 * time.Second,
+		KillGrace:    500 * time.Millisecond,
+	})
+	if err != nil {
+		cancel()
+		t.Fatalf("bridge new: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- b.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Logf("bridge exited: %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("bridge did not shut down")
+		}
+	})
+	waitFor(t, 10*time.Second, "bridge durable consumer", func() bool {
+		nc, err := nats.Connect(url)
+		if err != nil {
+			return false
+		}
+		defer nc.Close()
+		js, err := jetstream.New(nc)
+		if err != nil {
+			return false
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_, err = js.Consumer(ctx, lib.TasksStream, "bridge-platform")
+		return err == nil
+	})
+}
+
+func gatewayClient(t *testing.T, url string) *lib.Client {
+	t.Helper()
+	c, err := lib.Connect(testCtx(t), url, lib.WithName("test-gateway"))
+	if err != nil {
+		t.Fatalf("gateway connect: %v", err)
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+var gatewayParty = lib.Party{Session: "chatops", AgentType: "gateway"}
+
+func messagePayload(t *testing.T, taskID, contextID, text string) json.RawMessage {
+	t.Helper()
+	payload, err := json.Marshal(lib.Message{
+		Role:      "user",
+		MessageID: "msg-" + nuid.Next(),
+		Parts:     []lib.Part{{Kind: "text", Text: text}},
+		TaskID:    taskID,
+		ContextID: contextID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return payload
+}
+
+// submit publishes a task submission addressed to platform and returns its
+// envelope (the ids ride on it).
+func submit(t *testing.T, c *lib.Client, taskID, prompt string) *lib.Envelope {
+	t.Helper()
+	contextID := "ctx-" + taskID
+	corrID := "corr-" + taskID
+	env, err := lib.NewMessageEnvelope(gatewayParty, taskID, contextID, corrID,
+		messagePayload(t, taskID, contextID, prompt), lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatalf("submission envelope: %v", err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", taskID), env); err != nil {
+		t.Fatalf("submission publish: %v", err)
+	}
+	return env
+}
+
+// replayEvents reads the task's events subject in stream order.
+func replayEvents(t *testing.T, url, taskID string) []*lib.Envelope {
+	t.Helper()
+	nc, err := nats.Connect(url)
+	if err != nil {
+		t.Fatalf("replay connect: %v", err)
+	}
+	defer nc.Close()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := testCtx(t)
+	cons, err := js.OrderedConsumer(ctx, lib.TasksStream, jetstream.OrderedConsumerConfig{
+		FilterSubjects: []string{lib.TaskEventsSubject("platform", taskID)},
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// One bounded fetch: repeated fetches on an ordered consumer restart
+	// from sequence 1, and a task's event count is far below the batch.
+	var events []*lib.Envelope
+	msgs, err := cons.FetchNoWait(1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for msg := range msgs.Messages() {
+		env, err := lib.ParseEnvelope(msg.Data())
+		if err != nil {
+			t.Fatalf("unparseable event on the stream: %v", err)
+		}
+		events = append(events, env)
+	}
+	return events
+}
+
+func fold(t *testing.T, c *lib.Client, taskID string) *lib.Task {
+	t.Helper()
+	task, err := c.TasksGet(testCtx(t), "platform", taskID)
+	if err != nil {
+		t.Fatalf("tasks/get %s: %v", taskID, err)
+	}
+	return task
+}
+
+func waitTerminal(t *testing.T, c *lib.Client, taskID string) *lib.Task {
+	t.Helper()
+	var task *lib.Task
+	waitFor(t, 20*time.Second, "terminal event on "+taskID, func() bool {
+		got, err := c.TasksGet(testCtx(t), "platform", taskID)
+		if err != nil {
+			return false
+		}
+		task = got
+		return task.Final
+	})
+	return task
+}
+
+func waitFor(t *testing.T, d time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func statusState(t *testing.T, env *lib.Envelope) (lib.TaskState, bool) {
+	t.Helper()
+	if env.Kind != lib.KindStatusUpdate {
+		t.Fatalf("expected status-update, got %s", env.Kind)
+	}
+	var s lib.StatusUpdate
+	if err := json.Unmarshal(env.Payload, &s); err != nil {
+		t.Fatal(err)
+	}
+	return s.Status.State, s.Final
+}
+
+// ---- lifecycle conformance ------------------------------------------------
+
+// Assertions 9, 10, 14, 15, 18: the happy path produces submitted, working,
+// a result artifact carrying the subprocess output, and exactly one final
+// terminal event, all on the originating message's ids.
+func TestLifecycle_HappyPath(t *testing.T) {
+	_, url := startServer(t)
+	startBridge(t, url, script(t, `echo "the platform answer for $1"`))
+	c := gatewayClient(t, url)
+
+	origin := submit(t, c, "task-happy", "what is the fleet status")
+	task := waitTerminal(t, c, "task-happy")
+
+	if task.State != lib.StateCompleted {
+		t.Fatalf("state = %s, want completed", task.State)
+	}
+	if err := task.ValidateArtifacts(); err != nil {
+		t.Fatalf("assertion 18: %v", err)
+	}
+	result := task.Artifact(lib.ArtifactResult)
+	if result == nil || len(result.Parts) == 0 {
+		t.Fatal("assertion 18: no result artifact")
+	}
+	if got := result.Parts[0].Text; !strings.Contains(got, "the platform answer for what is the fleet status") {
+		t.Fatalf("result = %q, want the stub's stdout", got)
+	}
+
+	events := replayEvents(t, url, "task-happy")
+	if len(events) < 3 {
+		t.Fatalf("want >=3 events, got %d", len(events))
+	}
+	// Assertion 9: first event is submitted.
+	if state, final := statusState(t, events[0]); state != lib.StateSubmitted || final {
+		t.Fatalf("assertion 9: first event %s final=%v, want non-final submitted", state, final)
+	}
+	// Assertion 10: exactly one final, terminal, and it is the last event.
+	finals := 0
+	for _, env := range events {
+		if env.Kind != lib.KindStatusUpdate {
+			continue
+		}
+		var s lib.StatusUpdate
+		if err := json.Unmarshal(env.Payload, &s); err != nil {
+			t.Fatal(err)
+		}
+		if s.Final {
+			finals++
+			if !s.Status.State.Terminal() {
+				t.Fatalf("assertion 10: final event has non-terminal state %s", s.Status.State)
+			}
+		}
+	}
+	if finals != 1 {
+		t.Fatalf("assertion 10: %d final events, want exactly 1", finals)
+	}
+	if state, final := statusState(t, events[len(events)-1]); !final {
+		t.Fatalf("assertion 10: last event %s is not the final one", state)
+	}
+	// Assertions 14, 15: every event carries the originating ids verbatim.
+	for i, env := range events {
+		if env.TaskID != origin.TaskID || env.ContextID != origin.ContextID || env.CorrelationID != origin.CorrelationID {
+			t.Fatalf("assertion 14/15: event %d ids = (%s,%s,%s), want origin's (%s,%s,%s)",
+				i, env.TaskID, env.ContextID, env.CorrelationID,
+				origin.TaskID, origin.ContextID, origin.CorrelationID)
+		}
+	}
+}
+
+// Assertion 12 (steering half): a follow-up during working is answered with
+// a non-final status and does not by itself change task state - the task
+// still completes on its own.
+func TestLifecycle_SteerRefusedHonestly(t *testing.T) {
+	_, url := startServer(t)
+	marker := filepath.Join(t.TempDir(), "started")
+	startBridge(t, url, script(t, fmt.Sprintf(`touch %s
+sleep 2
+echo done-after-steer`, marker)))
+	c := gatewayClient(t, url)
+
+	origin := submit(t, c, "task-steer", "long question")
+	waitFor(t, 10*time.Second, "subprocess start", func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	})
+
+	steer, err := lib.NewFollowUpEnvelope(origin, gatewayParty,
+		messagePayload(t, origin.TaskID, origin.ContextID, "also check the east region"),
+		lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", origin.TaskID), steer); err != nil {
+		t.Fatal(err)
+	}
+
+	// The refusal arrives as a non-final working status with a message.
+	waitFor(t, 10*time.Second, "steer refusal status", func() bool {
+		for _, env := range replayEvents(t, url, origin.TaskID) {
+			if env.Kind != lib.KindStatusUpdate {
+				continue
+			}
+			var s lib.StatusUpdate
+			if json.Unmarshal(env.Payload, &s) != nil {
+				continue
+			}
+			if !s.Final && s.Status.State == lib.StateWorking && s.Status.Message != nil &&
+				strings.Contains(s.Status.Message.Parts[0].Text, "cannot accept mid-run input") {
+				return true
+			}
+		}
+		return false
+	})
+
+	task := waitTerminal(t, c, origin.TaskID)
+	if task.State != lib.StateCompleted {
+		t.Fatalf("state after steer = %s, want completed - a steer must not change state", task.State)
+	}
+	if task.PostFinalDropped != 0 {
+		t.Fatalf("assertion 10: %d events after final", task.PostFinalDropped)
+	}
+}
+
+// Assertion 13: cancel produces terminal canceled, never a silent stop, and
+// the subprocess actually dies.
+func TestLifecycle_Cancel(t *testing.T) {
+	_, url := startServer(t)
+	pidfile := filepath.Join(t.TempDir(), "pid")
+	startBridge(t, url, script(t, fmt.Sprintf(`echo $$ > %s
+sleep 60
+echo never`, pidfile)))
+	c := gatewayClient(t, url)
+
+	origin := submit(t, c, "task-cancel", "run forever")
+	waitFor(t, 10*time.Second, "subprocess start", func() bool {
+		_, err := os.Stat(pidfile)
+		return err == nil
+	})
+
+	cancelEnv, err := lib.NewCancelEnvelope(gatewayParty, origin.TaskID, origin.ContextID, origin.CorrelationID,
+		lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", origin.TaskID), cancelEnv); err != nil {
+		t.Fatal(err)
+	}
+
+	task := waitTerminal(t, c, origin.TaskID)
+	if task.State != lib.StateCanceled {
+		t.Fatalf("state = %s, want canceled", task.State)
+	}
+	raw, err := os.ReadFile(pidfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pid := strings.TrimSpace(string(raw))
+	waitFor(t, 5*time.Second, "subprocess death", func() bool {
+		return !processAlive(pid)
+	})
+}
+
+func processAlive(pidStr string) bool {
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// A nonzero hermes exit is terminal failed carrying the evidence.
+func TestLifecycle_FailedWithEvidence(t *testing.T) {
+	_, url := startServer(t)
+	startBridge(t, url, script(t, `echo "boom: config missing" >&2
+exit 3`))
+	c := gatewayClient(t, url)
+
+	submit(t, c, "task-fail", "doomed")
+	task := waitTerminal(t, c, "task-fail")
+	if task.State != lib.StateFailed {
+		t.Fatalf("state = %s, want failed", task.State)
+	}
+	events := replayEvents(t, url, "task-fail")
+	last := events[len(events)-1]
+	var s lib.StatusUpdate
+	if err := json.Unmarshal(last.Payload, &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.Status.Message == nil || !strings.Contains(s.Status.Message.Parts[0].Text, "boom: config missing") {
+		t.Fatal("failed event does not carry the stderr evidence")
+	}
+	if !strings.Contains(s.Status.Message.Parts[0].Text, "exit status 3") {
+		t.Fatal("failed event does not carry the exit code")
+	}
+}
+
+// A submission with no text parts is terminal rejected - an executor
+// refusing work before starting it.
+func TestLifecycle_RejectedNoTextParts(t *testing.T) {
+	_, url := startServer(t)
+	startBridge(t, url, script(t, `echo unreachable`))
+	c := gatewayClient(t, url)
+
+	taskID := "task-reject"
+	contextID := "ctx-" + taskID
+	payload, err := json.Marshal(lib.Message{
+		Role:      "user",
+		MessageID: "msg-" + nuid.Next(),
+		Parts:     []lib.Part{{Kind: "data", Data: json.RawMessage(`{"structured":"only"}`)}},
+		TaskID:    taskID,
+		ContextID: contextID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := lib.NewMessageEnvelope(gatewayParty, taskID, contextID, "corr-"+taskID, payload,
+		lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", taskID), env); err != nil {
+		t.Fatal(err)
+	}
+	task := waitTerminal(t, c, taskID)
+	if task.State != lib.StateRejected {
+		t.Fatalf("state = %s, want rejected", task.State)
+	}
+}
+
+// In traffic for a task with a terminal event is acked with a warning and
+// produces no events (the dispatcher rule; assertion 10's post-final ban).
+func TestLifecycle_TerminalTaskTrafficIgnored(t *testing.T) {
+	_, url := startServer(t)
+	startBridge(t, url, script(t, `echo quick`))
+	c := gatewayClient(t, url)
+
+	origin := submit(t, c, "task-done", "quick one")
+	waitTerminal(t, c, "task-done")
+	before := len(replayEvents(t, url, "task-done"))
+
+	follow, err := lib.NewFollowUpEnvelope(origin, gatewayParty,
+		messagePayload(t, origin.TaskID, origin.ContextID, "one more thing"),
+		lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", origin.TaskID), follow); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
+	if after := len(replayEvents(t, url, "task-done")); after != before {
+		t.Fatalf("post-terminal follow-up grew events %d -> %d", before, after)
+	}
+}
+
+// Assertion 12 for a QUEUED task: a steer arriving while the run waits for
+// a worker slot answers with the task's actual state (submitted), not
+// working - a follow-up must not change folded state by itself.
+func TestLifecycle_SteerToQueuedTaskAnswersSubmitted(t *testing.T) {
+	_, url := startServer(t)
+	marker := filepath.Join(t.TempDir(), "started")
+	startBridgeN(t, url, script(t, fmt.Sprintf(`touch %s.$1
+sleep 3
+echo done`, marker)), 1)
+	c := gatewayClient(t, url)
+
+	// First task occupies the single worker slot; second stays queued.
+	submit(t, c, "task-slot", "hold-the-slot")
+	waitFor(t, 10*time.Second, "first subprocess start", func() bool {
+		_, err := os.Stat(marker + ".hold-the-slot")
+		return err == nil
+	})
+	queued := submit(t, c, "task-queued", "wait-your-turn")
+	waitFor(t, 10*time.Second, "queued task submitted", func() bool {
+		task, err := c.TasksGet(testCtx(t), "platform", "task-queued")
+		return err == nil && task.State == lib.StateSubmitted
+	})
+
+	steer, err := lib.NewFollowUpEnvelope(queued, gatewayParty,
+		messagePayload(t, queued.TaskID, queued.ContextID, "hurry up"),
+		lib.WithTo(lib.Party{Session: "platform"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Publish(testCtx(t), lib.TaskInSubject("platform", queued.TaskID), steer); err != nil {
+		t.Fatal(err)
+	}
+
+	waitFor(t, 10*time.Second, "steer refusal on queued task", func() bool {
+		for _, env := range replayEvents(t, url, queued.TaskID) {
+			if env.Kind != lib.KindStatusUpdate {
+				continue
+			}
+			var s lib.StatusUpdate
+			if json.Unmarshal(env.Payload, &s) != nil {
+				continue
+			}
+			if s.Status.Message != nil && strings.Contains(s.Status.Message.Parts[0].Text, "cannot accept mid-run input") {
+				if s.Status.State != lib.StateSubmitted {
+					t.Fatalf("refusal state = %s, want submitted for a queued task", s.Status.State)
+				}
+				return true
+			}
+		}
+		return false
+	})
+	task := fold(t, c, queued.TaskID)
+	if task.State != lib.StateSubmitted {
+		t.Fatalf("folded state after steer = %s, want still submitted", task.State)
+	}
+	// Both tasks still finish clean.
+	if got := waitTerminal(t, c, "task-queued"); got.State != lib.StateCompleted {
+		t.Fatalf("queued task ended %s, want completed", got.State)
+	}
+}
+
+// ---- supervision ------------------------------------------------------------
+
+// A task a prior incarnation accepted and never finished gets terminal
+// failed from the startup sweep.
+func TestSweep_OrphanFinalized(t *testing.T) {
+	_, url := startServer(t)
+	c := gatewayClient(t, url)
+
+	// Fabricate the prior incarnation: submission, submitted+working events,
+	// in-flight KV key, no terminal.
+	taskID := "task-orphan"
+	origin := submit(t, c, taskID, "died midway")
+	bridgeParty := lib.Party{Session: "platform-bridge", AgentType: "hermes-bridge", Profile: "platform"}
+	x, err := c.NewTaskExecution(origin, bridgeParty, "platform")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := x.PublishStatus(testCtx(t), lib.StateSubmitted, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := x.PublishStatus(testCtx(t), lib.StateWorking, false); err != nil {
+		t.Fatal(err)
+	}
+	nc, err := nats.Connect(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Close()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kv, err := js.KeyValue(testCtx(t), "runtime-state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kv.Put(testCtx(t), "bridge.platform."+taskID, []byte("platform-bridge")); err != nil {
+		t.Fatal(err)
+	}
+	// Ack the submission the way the dead bridge would have: create its
+	// durable and consume the pending message, so the new bridge is not
+	// simply re-running the task instead of sweeping it.
+	cons, err := js.CreateOrUpdateConsumer(testCtx(t), lib.TasksStream, jetstream.ConsumerConfig{
+		Durable:       "bridge-platform",
+		FilterSubject: "a2a.tasks.platform.*.in",
+		AckPolicy:     jetstream.AckExplicitPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs, err := cons.FetchNoWait(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for msg := range msgs.Messages() {
+		_ = msg.Ack()
+	}
+
+	startBridge(t, url, script(t, `echo unreachable`))
+
+	task := waitTerminal(t, c, taskID)
+	if task.State != lib.StateFailed {
+		t.Fatalf("state = %s, want failed", task.State)
+	}
+	events := replayEvents(t, url, taskID)
+	var s lib.StatusUpdate
+	if err := json.Unmarshal(events[len(events)-1].Payload, &s); err != nil {
+		t.Fatal(err)
+	}
+	if s.Status.Message == nil || !strings.Contains(s.Status.Message.Parts[0].Text, "bridge-died-without-terminal-event") {
+		t.Fatal("sweep terminal does not name its evidence")
+	}
+	waitFor(t, 5*time.Second, "kv key cleared", func() bool {
+		_, err := kv.Get(testCtx(t), "bridge.platform."+taskID)
+		return err != nil
+	})
+}
+
+// The sweep must not double-finalize: a task whose terminal event landed
+// (the flush won the race) is left alone.
+func TestSweep_TerminalTaskLeftAlone(t *testing.T) {
+	_, url := startServer(t)
+	c := gatewayClient(t, url)
+
+	taskID := "task-flushed"
+	origin := submit(t, c, taskID, "flushed on the way down")
+	bridgeParty := lib.Party{Session: "platform-bridge", AgentType: "hermes-bridge", Profile: "platform"}
+	x, err := c.NewTaskExecution(origin, bridgeParty, "platform")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range []struct {
+		state lib.TaskState
+		final bool
+	}{{lib.StateSubmitted, false}, {lib.StateWorking, false}, {lib.StateFailed, true}} {
+		if err := x.PublishStatus(testCtx(t), step.state, step.final); err != nil {
+			t.Fatal(err)
+		}
+	}
+	nc, err := nats.Connect(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nc.Close()
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kv, err := js.KeyValue(testCtx(t), "runtime-state")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kv.Put(testCtx(t), "bridge.platform."+taskID, []byte("platform-bridge")); err != nil {
+		t.Fatal(err)
+	}
+	before := len(replayEvents(t, url, taskID))
+
+	startBridge(t, url, script(t, `echo unreachable`))
+	waitFor(t, 5*time.Second, "kv key cleared", func() bool {
+		_, err := kv.Get(testCtx(t), "bridge.platform."+taskID)
+		return err != nil
+	})
+	if after := len(replayEvents(t, url, taskID)); after != before {
+		t.Fatalf("sweep double-finalized: events %d -> %d", before, after)
+	}
+	task := fold(t, c, taskID)
+	if task.PostFinalDropped != 0 {
+		t.Fatalf("assertion 10: %d events after final", task.PostFinalDropped)
+	}
+}
+
+// ---- chunking ------------------------------------------------------------
+
+// chunkString must never cut inside a UTF-8 rune: each chunk is JSON-
+// marshaled independently, and encoding/json replaces invalid UTF-8 with
+// U+FFFD, so a byte-boundary split corrupts the reassembled artifact.
+func TestChunkString_NeverSplitsARune(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		size int
+	}{
+		{"empty is one empty chunk (assertion 18)", "", 4},
+		{"ascii exact multiple", "abcdefgh", 4},
+		{"multibyte straddles the boundary", "ab日c", 3},
+		{"multibyte everywhere", strings.Repeat("日本語", 100), 7},
+		{"size smaller than one rune", "日", 1},
+		{"emoji at every boundary", strings.Repeat("🙂", 50), 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks := chunkString(tc.in, tc.size)
+			if tc.in == "" && (len(chunks) != 1 || chunks[0] != "") {
+				t.Fatalf("empty input: got %q", chunks)
+			}
+			var rebuilt strings.Builder
+			for i, chunk := range chunks {
+				// The JSON round trip is the corruption mechanism the
+				// publish path applies to each chunk on its own.
+				raw, err := json.Marshal(chunk)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var back string
+				if err := json.Unmarshal(raw, &back); err != nil {
+					t.Fatal(err)
+				}
+				if back != chunk {
+					t.Fatalf("chunk %d corrupted by JSON round trip: %q -> %q", i, chunk, back)
+				}
+				rebuilt.WriteString(back)
+			}
+			if rebuilt.String() != tc.in {
+				t.Fatalf("reassembly mismatch: got %q want %q", rebuilt.String(), tc.in)
+			}
+		})
+	}
+}

--- a/a2a/hermes-bridge/sweep.go
+++ b/a2a/hermes-bridge/sweep.go
@@ -1,0 +1,175 @@
+package hermesbridge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/nats-io/nuid"
+
+	"github.com/gke-labs/kube-agents/a2a/lib"
+)
+
+// synthesizeCASAttempts bounds the horizon-read/fold/CAS-publish loop: each
+// retry means a writer landed after our horizon, and three straight losses
+// on a startup sweep is a fault worth surfacing, not a race worth waiting
+// out.
+const synthesizeCASAttempts = 3
+
+// The in-flight registry: one KV entry per accepted task, written before
+// submitted is published and deleted after the terminal event. The sweep
+// reads it on startup, so a bridge death mid-task costs an honest terminal
+// failed rather than a task that hangs open forever.
+//
+// The sweep assumes incarnations are serial - the kubelet restarts the
+// sidecar container in place, and the operator's agent Deployment is
+// strategy Recreate, so two bridges never run at once. Real fencing for
+// overlapping executors is the stage-3 dispatcher's problem, not scaffolding
+// this component grows.
+
+func (b *Bridge) kvKey(taskID string) string {
+	return "bridge." + b.cfg.Profile + "." + taskID
+}
+
+func (b *Bridge) markInFlight(ctx context.Context, taskID string) error {
+	_, err := b.kv.Put(ctx, b.kvKey(taskID), []byte(b.from.Session))
+	return err
+}
+
+func (b *Bridge) clearInFlight(ctx context.Context, taskID string) {
+	if err := b.kv.Delete(ctx, b.kvKey(taskID)); err != nil {
+		b.cfg.Logger.Warn("in-flight registry delete failed", "task", taskID, "err", err)
+	}
+}
+
+// errTaskStillLive marks a sweep target whose events subject kept moving
+// under the CAS - something is executing it, so the sweep must not finalize
+// it and must not crash the bridge over it. The key stays for a later look.
+var errTaskStillLive = errors.New("task events still advancing; leaving it alone")
+
+// sweep finalizes tasks a prior incarnation accepted and never finished.
+// Runs before the durable consumer starts, so nothing it reads is a task
+// this incarnation is executing.
+func (b *Bridge) sweep(ctx context.Context) error {
+	// Keys (not ListKeys): the lister's channel ends silently on a
+	// disconnect or cancellation, and a truncated listing here reads as "no
+	// orphans" - Keys surfaces the error instead.
+	all, err := b.kv.Keys(ctx)
+	if err != nil && !errors.Is(err, jetstream.ErrNoKeysFound) {
+		return fmt.Errorf("list in-flight keys: %w", err)
+	}
+	prefix := "bridge." + b.cfg.Profile + "."
+	for _, key := range all {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		taskID := strings.TrimPrefix(key, prefix)
+		if err := b.sweepTask(ctx, taskID); err != nil {
+			if errors.Is(err, errTaskStillLive) {
+				b.cfg.Logger.Warn("sweep found a task still emitting events; keeping its key",
+					"task", taskID)
+				continue
+			}
+			return fmt.Errorf("sweep task %s: %w", taskID, err)
+		}
+		if err := b.kv.Delete(ctx, key); err != nil {
+			b.cfg.Logger.Warn("sweep key delete failed", "task", taskID, "err", err)
+		}
+	}
+	return nil
+}
+
+func (b *Bridge) sweepTask(ctx context.Context, taskID string) error {
+	task, err := b.c.TasksGet(ctx, b.cfg.Profile, taskID)
+	switch {
+	case isTaskNotFound(err):
+		// Died between the KV put and the submitted publish: the unacked
+		// submission redelivers, so there is nothing to finalize.
+		return nil
+	case err != nil:
+		return err
+	case task.Final:
+		// Died between the terminal publish and the KV delete.
+		return nil
+	}
+	b.cfg.Logger.Warn("sweeping orphaned task to terminal failed", "task", taskID, "state", task.State)
+	return b.synthesizeTerminal(ctx, taskID,
+		lib.StateFailed, "reason: bridge-died-without-terminal-event")
+}
+
+// synthesizeTerminal writes a terminal event on behalf of a task with no
+// live executor. Compare-and-swap per the profiles spec, not read-then-write
+// - and the expected sequence is read BEFORE the fold, so any event landing
+// after the horizon (a dying process's flush included) fails the CAS and
+// the next iteration's fold sees it. Whichever writer loses lands in the
+// warn-and-drop path like any other post-final event.
+func (b *Bridge) synthesizeTerminal(ctx context.Context, taskID string, state lib.TaskState, reason string) error {
+	subject := lib.TaskEventsSubject(b.cfg.Profile, taskID)
+	stream, err := b.js.Stream(ctx, lib.TasksStream)
+	if err != nil {
+		return err
+	}
+	for attempt := 0; attempt < synthesizeCASAttempts; attempt++ {
+		// Horizon first, fold second: the CAS baseline must never be newer
+		// than what the fold judged non-final.
+		last, err := stream.GetLastMsgForSubject(ctx, subject)
+		if err != nil {
+			if errors.Is(err, jetstream.ErrMsgNotFound) {
+				return nil // no events in the window; nothing to finalize
+			}
+			return fmt.Errorf("last event for %s: %w", taskID, err)
+		}
+		task, err := b.c.TasksGet(ctx, b.cfg.Profile, taskID)
+		if err != nil {
+			if isTaskNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if task.Final {
+			return nil
+		}
+		payload, err := json.Marshal(lib.StatusUpdate{
+			TaskID:    taskID,
+			ContextID: task.ContextID,
+			Status: lib.TaskStatus{
+				State: state,
+				Message: &lib.Message{
+					Role:      "agent",
+					MessageID: "msg-" + nuid.Next(),
+					Parts:     []lib.Part{{Kind: "text", Text: reason}},
+					TaskID:    taskID,
+					ContextID: task.ContextID,
+				},
+			},
+			Final: true,
+		})
+		if err != nil {
+			return err
+		}
+		env, err := lib.NewStatusUpdateEnvelope(b.from, taskID, task.ContextID, task.CorrelationID, payload)
+		if err != nil {
+			return err
+		}
+		data, err := json.Marshal(env)
+		if err != nil {
+			return err
+		}
+		_, err = b.js.Publish(ctx, subject, data,
+			jetstream.WithMsgID(env.EnvelopeID),
+			jetstream.WithExpectLastSequencePerSubject(last.Sequence))
+		if err == nil {
+			return nil
+		}
+		var apiErr *jetstream.APIError
+		if !errors.As(err, &apiErr) || apiErr.ErrorCode != jetstream.JSErrCodeStreamWrongLastSequence {
+			return fmt.Errorf("synthesize terminal for %s: %w", taskID, err)
+		}
+		// Lost the CAS: something wrote after the horizon. Go around - the
+		// next fold sees the write, terminal or not.
+	}
+	return errTaskStillLive
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,6 +49,8 @@ kube-agents/
 │       │                                          report-prioritization SOPs
 │       └── skills/                                SKILL.md bundles + the
 │                                                  gke-compute-classes references
+├── a2a/docs/                                      design notes kept beside the A2A
+│                                                  bus Go module they describe
 ├── bench/                                         devops-bench evaluation harness README
 │                                                  + the task/harness authoring how-to
 ├── charts/                                        canonical Helm charts (kube-agents)
@@ -248,6 +250,7 @@ pull request:
 | `INSTALL.md` | Install guide | Self-contained, executable installation guide: automated GCP/GKE provisioning, manual Kubernetes deployment, local dev, declarative Terraform+Helm install (pointer to its canonical guide), teardown, troubleshooting. Commands only; explanation lives on the site. | Prerequisites, provisioning stages, integrations, teardown | Written to be runnable end-to-end by a human or an AI agent |
 | `AGENTS.md` | Contributor rules | Workspace instructions: repo layout, branching from a freshly fetched `main`, the pre-task scan of open pull requests and issues, skills guidelines, the engineering rules, the canonical-home documentation rules, generated-regions rule, PR hygiene, the live-validation requirement, and the automated pull-request review contract. States the rules; the commands that carry them out live in `docs/pull-request-workflow.md` and the mechanics that are prose in `.agents/rules/`. | Doc ownership table, engineering rules, `make docs-check`, fresh base, duplicate-work scan, Conventional Commits, fork PRs, bot review | AI coding agents and human contributors; owns the doc RULES; loaded into every session, so `make docs-check-context-budget` caps its size |
 | `CLAUDE.md` | Contributor rules | Imports `AGENTS.md` and points to it for commit authorship and PR attribution guidance. | Points to `AGENTS.md` rules | Claude Code sessions |
+| `a2a/docs/hermes-bridge.md` | Feature design | The Hermes bridge, a stand-in executor for `platform`-addressed A2A tasks until the dispatcher and worker adapter land: sidecar placement via `spec.deployment.sidecars`, what that deployment method costs (the mode-flip blocker, the unscreened sidecar env), bus user and grants, task lifecycle, and the startup sweep with CAS finalization. | Sidecar placement, flip blocker, bus grants, sweep, demolition date | Scaffolding design kept beside the `a2a/` module rather than in `docs/designs/` — it is deleted with the bridge when the dispatcher lands |
 | `admin_console/README.md` | Component README | Local setup and operating boundaries for the Kube Agents Console. | Connection, LLM gateway setup, chat, observability, integrations, validation | Console users and contributors |
 | `admin_console/CONNECTION_SECURITY.md` | Security reference | Security contract for the local console's persisted connection lease. | Stored metadata, filesystem controls, identity binding, revalidation, trust boundary | Console users and security reviewers |
 


### PR DESCRIPTION
## Summary

PR 9 of the A2A series. The gateway (#1212) routes every task to the addressee
`platform`, and nothing in-tree answers on that subject yet — the worker adapter
fast-follows and the dispatcher is stage 3. The bridge is the stand-in executor: a
small Go daemon on `a2a/lib` that consumes tasks addressed to `platform`, runs one
`hermes -p platform chat -Q -q <prompt>` subprocess per task, and publishes the
lifecycle events with the output as the `result` artifact. It is scaffolding with a
planned demolition date — when the dispatcher and worker adapter land, the bridge
retires. Nothing here is protocol: the wire contract is `spec-a2a-payloads.md`'s,
unchanged.

## Why This Change

Without an executor on `platform`, a task submitted through the gateway sits
unanswered forever: the fabric proves nothing end-to-end. The bridge closes that loop
now, with the real agent persona answering, without waiting for the dispatcher design
to land.

## What Changed

- `a2a/hermes-bridge/` — the bridge: durable consumer on `a2a.tasks.platform.*.in`,
  lifecycle publishes (`submitted`/`working`/result/terminal), cancel via
  process-group SIGTERM→SIGKILL, per-task deadline, and a startup sweep that
  finalizes tasks a dead incarnation left open, with compare-and-swap publishes so a
  racing writer never double-finalizes.
- `a2a/cmd/hermes-bridge/main.go` — env-configured entrypoint.
- `a2a/docs/hermes-bridge.md` — the design note, including the deployment story
  below.
- One docs-map row in `docs/README.md`.

## The deployment story, honestly

The bridge deploys as a sidecar via `spec.deployment.sidecars`, a user-set CR field
the operator copies without consulting the mode — and should keep copying: gating a
user-supplied container means overriding user intent. Two consequences, both stated
in the design note rather than discovered later:

- **Flipping to `mode: today` with the sidecar still set takes the agent down.**
  Confirmed live 2026-09-05 on a real flip: the sidecar crash-loops against the
  removed NATS Service, and because it shares the agent's pod, the pod never reaches
  Ready. Unset `spec.deployment.sidecars` before flipping. The design note carries
  this as a blocker instruction, not tidiness.
- **The webhook deliberately does not screen sidecar env.** The `SensitiveEnvVars`
  refusal applies to `spec.deployment.env` only; the bridge's `NATS_URL` and
  credentials arrive as sidecar env, so closing that gap breaks this exact
  deployment method. A stated trade while the bridge exists, not an oversight.

The bridge image has no in-repo build config: it is fork-built for the playground
(`FROM` the platform-agent image plus one static binary) and is not in the release
pipeline or `images.json`. It joins the release surface at stage-2 graduation, per
the series plan.

## Context

- Series: PRs 1–8 precede this; #1211 (NATS render) and #1212 (gateway) are merged.
  No open PR or issue touches these paths.
- **Conformance decision (tests/conformance/, per AGENTS.md):** this PR owes no
  assertion. The diff adds no enforcement surface — no operator, webhook, RBAC,
  NetworkPolicy, or manifest change. The one security property it documents (sidecar
  env is unscreened) is a deliberate non-control, and the conformance README's own
  rule is that a test pinning a non-control encodes a gap as an intention (its git
  lease example). The `NATS_*` `SensitiveEnvVars` entries belong to the PR that
  changes the webhook control (PR 6), which owes their decision.

## Testing

- `go build ./...`, `go vet`, `go test ./hermes-bridge/...` green in `a2a/` against
  this base (the suite runs a real embedded JetStream server; ~12s), including the
  new `TestChunkString_NeverSplitsARune` regression test.
- `make docs-check` green (map row and tree entry included); `prettier` 3.9.6 (the
  CI pin) run on both changed Markdown files; `gofmt` clean.

### Live validation

Run 2026-09-05 against the a2a-next-dev install (GKE Autopilot, `mode: next`,
`Ready=True`), under the cluster lease, against the deployed `hermes-bridge`
sidecar in the agent pod. The deployed image was built from the branch tip this
PR was cut from; the only behavioral difference in this PR against that tip is
the `chunkString` rune fix (proven by the new test, which runs against a real
JetStream server) — the cancel, shutdown, and sweep paths differ only by
equal-value constant renames, verified by diff. A small driver published real
envelopes through `a2a/lib` over a port-forward, as the `gateway` user for
submissions and folds and the `worker` user for the orphan plant, with
credentials from the install's creds Secret.

- **Happy path** (`u9-happy-220802`): a submission returned the platform agent's
  real answer — `submitted → working → artifact-update(result) → completed`
  (final), 4 events, `postFinalDropped=0`.
- **Cancel mid-run** (`u9-cancel-220413`): task at `working` with the hermes
  subprocess live; cancel published; terminal
  `canceled` / `reason: canceled-by-request`. 3 events, nothing after final.
- **SIGTERM eviction** (`u9-sigterm-220452`): `kill -TERM 1` in the sidecar
  container with a task at `working`; terminal `failed` /
  `reason: bridge-shutdown - the bridge was terminated while this task was in
  flight`; container restarted by the kubelet and resumed consuming.
- **Sweep after an unclean death** (`u9-orphan-220716`): planted the exact state
  an uncleanly-dead bridge leaves — non-final `submitted`+`working` events from
  the bridge party plus the `bridge.platform.<id>` registry key, no terminal, no
  pending submission — then restarted the container. The startup sweep logged
  `sweeping orphaned task to terminal failed`, published exactly one terminal
  `failed` / `reason: bridge-died-without-terminal-event` (3 events total — the
  CAS did not double-finalize), and deleted the KV key.

What I could not cover, and why: a genuine zero-window SIGKILL of the bridge.
The kernel does not deliver SIGKILL to a container's PID 1 from inside its own
PID namespace, and Autopilot gives no node access; even
`kubectl delete pod --grace-period=0 --force` mid-task left the bridge enough of
a TERM window to publish its eviction terminal cleanly (observed — evidence the
shutdown path is fast, but it exercises the eviction beat, not the sweep). The
planted orphan is byte-equivalent to what the dead bridge leaves, which is
exactly what the sweep folds. Also not covered live: a >256KiB result to
exercise chunking against the install; the suite's new test covers the fix
against a real server.

Cleanup verified before releasing the lease: all five test tasks terminal, no
`bridge.platform.*` registry keys remaining, agent pod 5/5 Running, CR
`mode: next` / `Ready=True` — the baseline the previous lease holder left.

## Self-Review

Both passes ran in fresh subagent contexts handed the diff range and nothing else —
one adversarial, one docs-drift. Merged findings and dispositions:

- **The design note's zombie-reaping claim was false** (docs-drift, Blocking). It
  said the agent pod's shared process namespace makes the pause container reap
  orphans; the operator deliberately leaves `ShareProcessNamespace` unset
  (`platformagent_manifests.go`, pod-template comment). Fixed: the note now states
  the real consequence — orphans reparent to the bridge, which reaps only direct
  children — as an accepted playground gap that vanishes when the dispatcher runs
  executions as Jobs.
- **The worker user's ack grant was overstated in the wider direction** (docs-drift,
  Blocking): doc said `$JS.ACK.>`, the render grants `$JS.ACK.TASKS.>` precisely
  because unscoped ack is a cross-principal +TERM. Fixed, scoping reason included.
- **`chat -q` vs the actual `chat -Q -q`** in the doc and two code comments
  (docs-drift, Blocking). Fixed in all four places.
- **The docs-map tree section lacked the new `a2a/docs/` location** (docs-drift,
  Blocking; `docs-check` guards only the inventory row). Tree entry added.
- Smaller doc-accuracy fixes from the same pass: steering refusal wording now
  matches the code (the code was the correct side, per payload-spec assertion 12);
  the map row notes the doc's location outside `docs/designs/` and why; the
  fork-internal "W1 suite" label replaced; image provenance stated in the note.
- **Reported, deliberately not fixed:** `AGENTS.md`'s `a2a/` bullet under-describes
  the module (pre-existing on base — it already omits the gateway) and the context
  budget has zero headroom, so extending it must displace something; that trade is
  the maintainers', not this PR's. The `spec-chatops-gateway` map row's "operator
  render is not yet in-tree" is stale since #1211, also pre-existing; the map's own
  rule forbids editing rows a PR did not author.

From the adversarial pass (no BLOCKER findings; every operator-facing claim in the
design note verified against source):

- **Result chunking corrupted multi-byte UTF-8** (MEDIUM, confirmed by
  reproduction): chunks were cut on byte boundaries and each chunk is
  JSON-marshaled independently, so a rune straddling a boundary became U+FFFD on
  both sides of the split. Fixed — `chunkString` now backs up to the previous rune
  start — with a regression test that JSON-round-trips every chunk and reasserts
  reassembly. Mutation-checked: reverting the fix turns the test red.
- **A failed terminal publish leaves a task hung until the next restart's sweep,
  and cancel cannot unstick it** (MEDIUM, plausible; trigger is a bus outage
  outlasting the finalize budget at exactly terminal-publish time). Not fixed in
  code: the sweep-on-restart is the designed recovery and a retry loop or periodic
  sweep is dispatcher-grade machinery this scaffolding should not grow. Now stated
  in the design note's honest-gaps paragraph instead of being discoverable only by
  reading `finalize`.
- **The grace-period SIGKILL guard can re-arm a timer after the one-shot cleanup**
  (LOW, plausible): a cancel racing a natural exit in the window between
  `cmd.Wait` returning and `finalize` locking re-arms a timer nothing stops.
  Reported, not fixed: absent pid reuse inside the container's own PID namespace
  within the 10s grace, the stray signal is an ESRCH no-op, and the fix reorders
  locking in the kill path — a change live validation would then have to
  re-exercise. Recorded for the stage-3 fencing owner.
- **Magic constants mid-function** against `.agents/rules/core_engineering.md`
  (LOW): fixed — queue capacity, stderr tail size, both finalize timeouts, and the
  sweep's CAS attempt bound are now named constants at the top of their files.
- **Duplicated `NATS_USER` conditional in main** (LOW): fixed, merged into one.
- **Untested claimed behaviors** (LOW): the chunked-result path is now tested (it
  was load-bearing — the UTF-8 bug lived exactly there). Still untested and known:
  the deadline-exceeded kill, queue-overflow finalize, shutdown eviction, and the
  sweep's CAS-loss loop. The live triple below exercises the eviction and sweep
  paths against a real server.
- The pass also confirmed the zombie-reaping finding independently of the
  docs-drift pass (both converged on the same operator source), and cleared a
  list of suspects for the record: `-Q` is a real hermes flag (verified against
  upstream CLI docs — it implies oneshot exit, which this invocation depends on),
  empty output still satisfies assertion 18, and the unbounded stdout buffer
  degrades to one container OOMKill plus an honest sweep-failed, not data loss.

## Risk & Rollout

Nothing imports the bridge; no operator, webhook, or manifest change; CI builds the
binary but nothing deploys it — it runs only where a user sets
`spec.deployment.sidecars`. Revert is deleting the files. The one operational hazard
this introduces (the mode-flip breakage) exists wherever the sidecar is deployed and
is documented as a blocker instruction in the design note.

Generated with the help of Claude Code.
