### PR TITLE
ci(tide): keep a pull request with unresolved review threads out of the merge pool

### DIFF
--- a/.github/workflows/hold-unresolved-threads.yml
+++ b/.github/workflows/hold-unresolved-threads.yml
@@ -1,0 +1,85 @@
+name: Hold Unresolved Threads
+
+# Keep a pull request with unresolved review threads out of Tide's merge pool.
+#
+# `main` requires every conversation resolved before a merge, and Tide does
+# not read that rule: it picks the lowest-numbered `lgtm`+`approved` pull
+# request, GitHub refuses the merge, and Tide retries the same one every ~85
+# seconds while every other pull request in the pool waits behind it. #608
+# and #1197 held the queue that way for an hour on 2026-09-05.
+#
+# `scripts/hold_unresolved_threads.py` mirrors thread state onto the bare
+# `do-not-merge` label, which Tide's query for this repository excludes and no
+# Prow plugin writes: on while any thread is unresolved (with one comment
+# saying so), off once they all are -- unless a person applied it, in which
+# case it is theirs. The script's docstring is the reference.
+#
+# Two triggers. The schedule is the guarantee: thread resolution fires
+# `pull_request_review_thread`, but from a fork -- where every pull request
+# here comes from -- that event hands the workflow a read-only token, so it
+# cannot be the mechanism. The `labeled` fast path closes the window that
+# matters most: the moment `lgtm` or `approved` lands is the moment Tide would
+# otherwise start retrying, and `pull_request_target` carries a write token
+# whatever the head's origin. Nothing from the pull request is checked out or
+# read as code on either path.
+on:
+  schedule:
+    - cron: "*/5 * * * *" # SWEEP_MINUTES in the script quotes this to the author
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log what would change and change nothing
+        type: boolean
+        default: false
+  # zizmor: ignore[dangerous-triggers] - the job checks out the default
+  # branch only (the script) and reads pull-request state through the API;
+  # no pull-request content reaches the write token's context.
+  pull_request_target:
+    types: [labeled]
+    branches: [main]
+
+permissions: {}
+
+# Sweeps reconcile the same state; two at once would race each other's reads.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Mirror unresolved threads onto the do-not-merge label
+    # The repository guard is required of any credentialed workflow that
+    # starts on its own (AGENTS.md, Pull Request Hygiene). The label filter
+    # keeps every other label event -- size, risk, lgtm removed -- off a
+    # runner; the schedule covers anything it misses.
+    if: >-
+      github.repository == 'gke-labs/kube-agents' &&
+      (github.event_name != 'pull_request_target' ||
+        github.event.label.name == 'lgtm' ||
+        github.event.label.name == 'approved')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # check out the default branch: the script
+      pull-requests: write # add and remove the label, post the comment
+      issues: write # create the label the first time
+    steps:
+      # The default branch, never a pull request head: this job holds a
+      # writable token and must not run code from a fork. `ref:` is explicit
+      # because on `pull_request_target` the fallback is the pull request's
+      # base branch.
+      - name: Checkout the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      # The runner's own python3; the script is stdlib-only. Every sweep is
+      # the same whole-repository reconcile, whichever trigger started it, so
+      # the event carries nothing the script needs.
+      - name: Sweep the merge pool
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then set -- --dry-run; fi
+          python3 scripts/hold_unresolved_threads.py "$@"

--- a/.github/workflows/hold-unresolved-threads.yml
+++ b/.github/workflows/hold-unresolved-threads.yml
@@ -25,6 +25,7 @@ name: Hold Unresolved Threads
 on:
   schedule:
     - cron: "*/5 * * * *" # SWEEP_MINUTES in the script quotes this to the author
+  #checkov:skip=CKV_GHA_7:One boolean, dry-run, which decides whether the sweep writes; nothing is built and no input reaches a shell
   workflow_dispatch:
     inputs:
       dry_run:

--- a/docs/README.md
+++ b/docs/README.md
@@ -179,6 +179,7 @@ identifier appears, add its source here.
 | Admission webhook server port (`--webhook-port` default) | `DefaultPort` in `k8s-operator/internal/webhook/platformagent_webhook.go` |
 | Live-test lease: ConfigMap name, TTL, install-configuration keys read, which commands count as mutations | `scripts/live_test_lease.py` |
 | PR evidence screenshots: publish branch, file-name provenance, caption format | `scripts/pr_evidence_screenshot.sh` |
+| Unresolved-thread hold: the label, the pool condition, the sweep interval, the ownership rule | `scripts/hold_unresolved_threads.py` and `.github/workflows/hold-unresolved-threads.yml` |
 | Context budget for the always-loaded agent instruction files (`AGENTS.md`, `CLAUDE.md`) | `BUDGET` in `scripts/check_context_budget.py` |
 | Who may set the `approved` label on a change | `OWNERS`, `k8s-operator/OWNERS`, and `OWNERS_ALIASES` |
 | Which labels Tide merges on, and which Prow presubmits gate | `prow/oss/config.yaml` and `prow/prowjobs/gke-labs/kube-agents/` in `GoogleCloudPlatform/oss-test-infra` — not a file in this repository |

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -211,7 +211,10 @@ gh api repos/gke-labs/kube-agents/pulls/<number>/comments/<comment-id>/replies \
 ## Resolving conversations
 
 Reply first — `AGENTS.md` says why — naming what changed and the commit that changed it. Then
-resolve:
+resolve. A pull request carrying both `lgtm` and `approved` with a thread still open also carries
+the `do-not-merge` label,
+applied by a workflow so that Tide does not spend the queue retrying a merge GitHub will refuse;
+resolving the last thread is what removes it ([how a change merges](#how-a-change-merges)).
 
 ```bash
 # Every unresolved thread, with both ids you need: resolveReviewThread takes the
@@ -294,7 +297,15 @@ Prow's jobs, not the GitHub Actions checks, so a pull request can look fully gre
 waiting on it.
 
 `/hold` parks an otherwise-mergeable pull request without withdrawing anything else, and
-`/hold cancel` releases it — #1045 held that way for a smoke test. `/override <context>`, which only
+`/hold cancel` releases it — #1045 held that way for a smoke test. The bare `do-not-merge` label is
+a different thing: [`hold-unresolved-threads.yml`](../.github/workflows/hold-unresolved-threads.yml)
+puts it on any pull request in the pool whose review threads are not all resolved, and takes it off
+at the next five-minute sweep after the last resolution. Tide does not read the
+conversation-resolution rule, so without the label it picks such a pull request, fails the merge,
+and retries it every ~85 seconds ahead of everyone else — #608 and #1197 held the queue that way
+for an hour on 2026-09-05. `/hold cancel` does not remove this label; resolving the threads does.
+A person who applies the same label by hand keeps it: the workflow removes only what it added.
+`/override <context>`, which only
 a repository admin can use, forces a required check that cannot pass on its own — and expires: the
 forced status embeds the base SHA at override time, so the next merge to `main` invalidates it,
 Tide re-runs the job, and the override has to be repeated if `main` moves before Tide merges
@@ -357,7 +368,7 @@ on the querying user. #1065 read `BLOCKED` while carrying both labels and while 
 merge attempt that failed — an unresolved review thread, most often — is retried every ~85
 seconds and recorded only in the `err` field of
 [tide-history](https://oss.gprow.dev/tide-history); #1122 sat approved for 5h46m and 231
-attempts that way.
+attempts that way — the case the `do-not-merge` label above now keeps out of the pool.
 
 ```bash
 # Why Tide has not merged it: its own reason first, then the labels it wants.

--- a/scripts/github_api.py
+++ b/scripts/github_api.py
@@ -2,7 +2,9 @@
 
 Combines bounded retries on transient errors (5xx, 429, secondary rate limit 403)
 with automatic list endpoint pagination (`get_all`), so callers neither drop
-writes on transient blips nor silently truncate multi-page lists.
+writes on transient blips nor silently truncate multi-page lists. `graphql()`
+goes through the same retries and raises on an `errors` body, so a partial
+answer is never mistaken for a whole one.
 """
 
 from __future__ import annotations
@@ -16,6 +18,7 @@ import urllib.request
 
 API_ROOT = "https://api.github.com"
 API_VERSION = "2022-11-28"
+GRAPHQL_PATH = "/graphql"
 DEFAULT_USER_AGENT = "kube-agents-scripts"
 
 REQUEST_ATTEMPTS = 3
@@ -138,3 +141,16 @@ class GitHubAPI:
 
     def delete(self, path: str, tolerate=()):
         return self.request("DELETE", path, tolerate=tolerate)
+
+    def graphql(self, query: str, variables=None):
+        """One GraphQL call. Errors in the body are raised, not returned.
+
+        GraphQL answers 200 to a query that failed and puts the failure under
+        `errors`, so a caller reading `data` alone would take a partial answer
+        for a whole one.
+        """
+        result = self.post(GRAPHQL_PATH, {"query": query, "variables": variables or {}})
+        errors = (result or {}).get("errors")
+        if errors:
+            raise RuntimeError(f"GraphQL: {errors}")
+        return result["data"]

--- a/scripts/hold_unresolved_threads.py
+++ b/scripts/hold_unresolved_threads.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Keep a pull request with unresolved review threads out of Tide's merge pool.
+
+`main` requires every review conversation resolved before a merge, and Tide
+does not read that rule. A pull request carrying `lgtm` and `approved` is in
+its pool whatever its threads say; Tide picks the lowest-numbered one, GitHub
+refuses the merge ("Repository rule violations found"), and Tide retries the
+same pull request every ~85 seconds -- ahead of every other pull request in
+the pool, which wait behind it. #608 and #1197 held the whole queue that way
+for an hour on 2026-09-05 until an admin `/hold`ed them by hand; #1122 sat
+5h46m and 231 attempts the same way (#1202).
+
+Tide's query for this repository excludes four labels. `do-not-merge` -- the
+bare one, not `do-not-merge/hold` -- is the one no Prow plugin writes, so this
+script owns it. Each sweep lists the open pull requests carrying both pool
+labels and puts `do-not-merge` on any whose review threads are not all
+resolved, with one comment saying why; and takes it off any pull request whose
+threads are now all resolved -- but only when the label's most recent
+application was its own, so a label a person put there by hand stays until
+that person removes it. Resolving the threads is the only exit: `/hold cancel`
+does not touch this label, which is the point.
+
+The pool is listed from the pulls endpoint, not search: the workflow's fast
+path runs the moment `lgtm` lands, and the search index that would list the
+label is eventually consistent, so a search-based sweep could miss the pull
+request the event was about. Thread state is GraphQL because REST has no
+notion of a resolved thread. Who applied the label is read from the issue
+timeline rather than remembered anywhere: a sweep that crashed after labelling
+leaves nothing behind for the next one to need.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from github_api import GitHubAPI, log  # noqa: E402
+
+#: Excluded by Tide's query for this repository (`prow/oss/config.yaml` in oss-test-infra) and
+#: written by no Prow plugin, which is what lets this script own it outright.
+LABEL = "do-not-merge"
+LABEL_COLOR = "b60205"
+LABEL_DESCRIPTION = "Review threads are unresolved; removed automatically once they all are"
+#: Tide's pool wants both. A pull request without them is not one Tide will try to merge.
+POOL_LABELS = frozenset({"lgtm", "approved"})
+#: The login a GITHUB_TOKEN acts as; a `labeled` event by anyone else is a person's decision.
+BOT_LOGIN = "github-actions[bot]"
+#: Opens the explanatory comment. A pull request that already carries one gets no second: a
+#: label removed by hand while threads stay open is re-applied every sweep, and the comment
+#: would otherwise be re-posted with it.
+COMMENT_MARKER = "<!-- hold-unresolved-threads -->"
+#: GraphQL's per-page ceiling; the thread query pages past it.
+PAGE = 100
+USER_AGENT = "kube-agents-hold-unresolved-threads"
+TIMELINE_LABELED = "labeled"
+#: Interval `.github/workflows/hold-unresolved-threads.yml` sweeps on, quoted in the comment.
+SWEEP_MINUTES = 5
+ACTION_ADD = "add"
+ACTION_REMOVE = "remove"
+
+THREADS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: %d, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { isResolved }
+      }
+    }
+  }
+}
+""" % PAGE
+
+COMMENT = f"""{COMMENT_MARKER}
+Tide would try to merge this pull request and fail: **{{count}} review thread{{plural}} unresolved**, \
+and `main` requires every conversation resolved before a merge. Tide retries a failed merge every \
+~85 seconds ahead of every other pull request in the pool, so the `{LABEL}` label keeps this one out \
+of the pool until the threads are resolved.
+
+Reply to each thread naming what changed, then resolve it \
+([`docs/pull-request-workflow.md`, "Resolving conversations"](https://github.com/{{repo}}/blob/main/docs/pull-request-workflow.md#resolving-conversations)). \
+The label comes off by itself at the next sweep (every {SWEEP_MINUTES} minutes) after the last one; `/hold cancel` does not remove it."""
+
+
+def open_pulls(api):
+    """Every open pull request: number, draft flag, label names. Consistent, unlike search."""
+    pulls = {}
+    for pull in api.get_all(f"/repos/{api.repo}/pulls?state=open"):
+        pulls[pull["number"]] = {
+            "number": pull["number"],
+            "draft": bool(pull.get("draft")),
+            "labels": {label["name"] for label in pull.get("labels") or []},
+        }
+    return pulls
+
+
+def concerns_us(pull):
+    """In the pool, or carrying our label: the two populations a sweep reconciles."""
+    return (POOL_LABELS <= pull["labels"] and not pull["draft"]) or LABEL in pull["labels"]
+
+
+def unresolved_threads(api, number):
+    """How many review threads on the pull request are not resolved, every page counted."""
+    owner, name = api.repo.split("/", 1)
+    count = 0
+    after = None
+    while True:
+        threads = api.graphql(
+            THREADS_QUERY, {"owner": owner, "name": name, "number": number, "after": after}
+        )["repository"]["pullRequest"]["reviewThreads"]
+        count += sum(1 for thread in threads["nodes"] if not thread["isResolved"])
+        if not threads["pageInfo"]["hasNextPage"]:
+            return count
+        after = threads["pageInfo"]["endCursor"]
+
+
+def label_is_ours(api, number):
+    """Whether the most recent application of LABEL on the pull request was this script's.
+
+    The timeline is the record: the last `labeled` event for the label names
+    who did it. A person's label is theirs to remove; a label with no event at
+    all (an API gap) is treated the same way, because removing a label nobody
+    is known to have applied is the wrong side to err on.
+    """
+    actor = None
+    for event in api.get_all(f"/repos/{api.repo}/issues/{number}/timeline"):
+        if event.get("event") == TIMELINE_LABELED and (event.get("label") or {}).get("name") == LABEL:
+            actor = (event.get("actor") or {}).get("login")
+    return actor == BOT_LOGIN
+
+
+def already_explained(api, number):
+    """Whether a comment carrying COMMENT_MARKER is already on the pull request."""
+    return any(
+        (comment.get("body") or "").startswith(COMMENT_MARKER)
+        for comment in api.get_all(f"/repos/{api.repo}/issues/{number}/comments")
+    )
+
+
+def decide(pull, unresolved):
+    """(ACTION_ADD | ACTION_REMOVE | None, reason) for one pull request, from what a sweep read.
+
+    Pure so the tests can drive it. The ownership check for ACTION_REMOVE is
+    the caller's: it costs a timeline read this function should not force on
+    every pull request.
+    """
+    labelled = LABEL in pull["labels"]
+    in_pool = POOL_LABELS <= pull["labels"] and not pull["draft"]
+    if unresolved and in_pool and not labelled:
+        return ACTION_ADD, f"{unresolved} unresolved thread(s) and in the pool"
+    if unresolved and labelled:
+        return None, f"{unresolved} unresolved thread(s); already labelled"
+    if unresolved:
+        return None, f"{unresolved} unresolved thread(s) but not in the pool; nothing to keep out"
+    if labelled:
+        return ACTION_REMOVE, "every thread resolved"
+    return None, "every thread resolved; not labelled"
+
+
+def ensure_label(api, dry_run=False):
+    """Create LABEL if the repository lacks it. 422 is 'already exists'."""
+    if dry_run:
+        return
+    api.post(
+        f"/repos/{api.repo}/labels",
+        {"name": LABEL, "color": LABEL_COLOR, "description": LABEL_DESCRIPTION},
+        tolerate=(422,),
+    )
+
+
+def sweep(api, dry_run=False):
+    """Reconcile every pull request in the pool or carrying LABEL. Returns (log lines, failures)."""
+    lines = []
+    failures = 0
+    pulls = {number: pull for number, pull in open_pulls(api).items() if concerns_us(pull)}
+    ensure_label(api, dry_run=dry_run)
+    for number in sorted(pulls):
+        pull = pulls[number]
+        try:
+            unresolved = unresolved_threads(api, number)
+            action, reason = decide(pull, unresolved)
+            if action == ACTION_REMOVE and not label_is_ours(api, number):
+                action, reason = None, "every thread resolved, but the label was applied by a person; leaving it"
+            if action == ACTION_ADD and not dry_run:
+                api.post(f"/repos/{api.repo}/issues/{number}/labels", {"labels": [LABEL]})
+                if already_explained(api, number):
+                    reason += "; the comment is already there"
+                else:
+                    api.post(
+                        f"/repos/{api.repo}/issues/{number}/comments",
+                        {"body": COMMENT.format(count=unresolved, plural="s are" if unresolved != 1 else " is", repo=api.repo)},
+                    )
+            elif action == ACTION_REMOVE and not dry_run:
+                api.delete(f"/repos/{api.repo}/issues/{number}/labels/{LABEL}", tolerate=(404,))
+            verb = {ACTION_ADD: "labelled", ACTION_REMOVE: "unlabelled", None: "left alone"}[action]
+            if action and dry_run:
+                verb = f"would be {verb}"
+            line = f"#{number}: {verb}: {reason}"
+        except Exception as error:  # one pull request must not stop the sweep
+            failures += 1
+            line = f"#{number}: failed: {error}"
+        log(line)
+        lines.append(line)
+    return lines, failures
+
+
+def _parse_args(argv):
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/name")
+    parser.add_argument("--dry-run", action="store_true", help="log what would change, change nothing")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = _parse_args(argv)
+    token = os.environ.get("GITHUB_TOKEN")
+    if not args.repo or not token:
+        print("GITHUB_REPOSITORY (or --repo) and GITHUB_TOKEN are required", file=sys.stderr)
+        return 2
+    api = GitHubAPI(args.repo, token, user_agent=USER_AGENT)
+    _, failures = sweep(api, dry_run=args.dry_run)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_github_api.py
+++ b/scripts/test_github_api.py
@@ -150,6 +150,18 @@ class GitHubAPITest(unittest.TestCase):
         self.assertIsNone(delete_res)
         self.assertEqual(calls[1].get_method(), "DELETE")
 
+    def test_graphql_returns_data(self):
+        api, calls = self._api([{"data": {"viewer": {"login": "x"}}}])
+        self.assertEqual(api.graphql("query { viewer { login } }", {"a": 1}), {"viewer": {"login": "x"}})
+        self.assertEqual(calls[0].full_url, "https://api.github.com/graphql")
+        self.assertEqual(json.loads(calls[0].data)["variables"], {"a": 1})
+
+    def test_graphql_raises_on_an_errors_body(self):
+        """GraphQL answers 200 to a failed query; the failure is in the body, not the status."""
+        api, _ = self._api([{"data": None, "errors": [{"message": "Could not resolve to a PullRequest"}]}])
+        with self.assertRaises(RuntimeError):
+            api.graphql("query { nothing }")
+
     def test_url_error_is_retried(self):
         url_error = urllib.error.URLError("Connection refused")
         api, calls = self._api([url_error, {"status": "ok"}])

--- a/scripts/test_hold_unresolved_threads.py
+++ b/scripts/test_hold_unresolved_threads.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Tests for hold_unresolved_threads.py -- the label that keeps an unmergeable PR out of Tide's pool.
+
+Run: cd scripts && python3 -m unittest test_hold_unresolved_threads
+
+Both wrong answers are quiet. A pull request that should have been labelled
+sits in the pool and Tide retries it every 85 seconds ahead of everyone else;
+a label that should have been left alone -- a person's, or one on a pull
+request whose threads are still open -- disappears and the merge Tide then
+attempts is the one the label existed to prevent. So each side of `decide`
+gets a case, and the ownership check is driven with the timeline shapes the
+API actually returns.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import hold_unresolved_threads as hold
+
+REPO = "gke-labs/kube-agents"
+POOL = {"lgtm", "approved", "size/L"}
+
+
+def pull(number, labels=POOL, draft=False):
+    return {"number": number, "draft": draft, "labels": set(labels)}
+
+
+class FakeAPI:
+    """Just enough of `GitHubAPI` for the functions that call it."""
+
+    def __init__(self, pulls=(), threads=None, timelines=None, comments=None):
+        self.repo = REPO
+        self.pulls = list(pulls)
+        self.threads = threads or {}  # number -> list of pages, each a list of isResolved flags
+        self.timelines = timelines or {}
+        self.comments = comments or {}
+        self.posts = []
+        self.deletes = []
+
+    def graphql(self, query, variables):
+        pages = self.threads.get(variables["number"], [[]])
+        index = int(variables["after"] or 0)
+        page = pages[index]
+        more = index + 1 < len(pages)
+        return {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": more, "endCursor": str(index + 1) if more else None},
+                        "nodes": [{"isResolved": flag} for flag in page],
+                    }
+                }
+            }
+        }
+
+    def get_all(self, path):
+        if path.endswith("/pulls?state=open"):
+            return [
+                {"number": p["number"], "draft": p["draft"], "labels": [{"name": n} for n in p["labels"]]}
+                for p in self.pulls
+            ]
+        number = int(path.rsplit("/issues/", 1)[1].split("/")[0])
+        if path.endswith("/timeline"):
+            return self.timelines.get(number, [])
+        if path.endswith("/comments"):
+            return [{"body": body} for body in self.comments.get(number, [])]
+        raise AssertionError(path)
+
+    def post(self, path, payload, tolerate=()):
+        self.posts.append((path, payload))
+
+    def delete(self, path, tolerate=()):
+        self.deletes.append(path)
+
+
+def labeled(by, name=hold.LABEL):
+    return {"event": "labeled", "label": {"name": name}, "actor": {"login": by}}
+
+
+class DecideTest(unittest.TestCase):
+    def test_unresolved_threads_in_the_pool_get_the_label(self):
+        self.assertEqual(hold.decide(pull(1), 3)[0], hold.ACTION_ADD)
+
+    def test_unresolved_threads_already_labelled_are_left_alone(self):
+        self.assertIsNone(hold.decide(pull(1, POOL | {hold.LABEL}), 3)[0])
+
+    def test_a_draft_is_not_in_the_pool(self):
+        self.assertIsNone(hold.decide(pull(1, draft=True), 3)[0])
+
+    def test_without_both_pool_labels_there_is_nothing_to_keep_out(self):
+        self.assertIsNone(hold.decide(pull(1, {"approved"}), 3)[0])
+
+    def test_all_resolved_and_labelled_is_removed(self):
+        self.assertEqual(hold.decide(pull(1, POOL | {hold.LABEL}), 0)[0], hold.ACTION_REMOVE)
+
+    def test_the_label_comes_off_even_after_the_pool_labels_went(self):
+        """A push stripped `lgtm`; the label must not outlive the threads it was for."""
+        self.assertEqual(hold.decide(pull(1, {hold.LABEL}), 0)[0], hold.ACTION_REMOVE)
+
+    def test_all_resolved_and_unlabelled_is_nothing(self):
+        self.assertIsNone(hold.decide(pull(1), 0)[0])
+
+
+class SelectionTest(unittest.TestCase):
+    def test_only_the_pool_and_the_labelled_are_read(self):
+        """Every other open pull request costs a thread query it does not need."""
+        api = FakeAPI(pulls=[pull(1, {"lgtm"}), pull(2), pull(3, {hold.LABEL}), pull(4, POOL, draft=True)])
+        chosen = sorted(n for n, p in hold.open_pulls(api).items() if hold.concerns_us(p))
+        self.assertEqual(chosen, [2, 3])
+
+
+class OwnershipTest(unittest.TestCase):
+    def test_the_last_application_decides(self):
+        api = FakeAPI(timelines={1: [labeled("someone"), labeled(hold.BOT_LOGIN)]})
+        self.assertTrue(hold.label_is_ours(api, 1))
+        api = FakeAPI(timelines={1: [labeled(hold.BOT_LOGIN), labeled("someone")]})
+        self.assertFalse(hold.label_is_ours(api, 1))
+
+    def test_other_labels_do_not_count(self):
+        api = FakeAPI(timelines={1: [labeled(hold.BOT_LOGIN, "risk:low")]})
+        self.assertFalse(hold.label_is_ours(api, 1))
+
+    def test_no_event_at_all_is_not_ours(self):
+        self.assertFalse(hold.label_is_ours(FakeAPI(), 1))
+
+
+class ThreadCountTest(unittest.TestCase):
+    def test_every_page_is_counted(self):
+        api = FakeAPI(threads={1: [[True] * 3, [True, False], [False]]})
+        self.assertEqual(hold.unresolved_threads(api, 1), 2)
+
+
+class SweepTest(unittest.TestCase):
+    def test_labels_and_comments_once(self):
+        api = FakeAPI(pulls=[pull(7)], threads={7: [[False, True]]})
+        lines, failures = hold.sweep(api)
+        self.assertEqual(failures, 0)
+        paths = [path for path, _ in api.posts]
+        self.assertIn(f"/repos/{REPO}/issues/7/labels", paths)
+        self.assertIn(f"/repos/{REPO}/issues/7/comments", paths)
+        comment = next(payload for path, payload in api.posts if path.endswith("/comments"))["body"]
+        self.assertTrue(comment.startswith(hold.COMMENT_MARKER))
+        self.assertIn("1 review thread is unresolved", comment)
+        self.assertIn("#7: labelled", lines[0])
+
+    def test_a_relabel_does_not_repeat_the_comment(self):
+        """Someone removed the label by hand with threads still open: label back, comment not."""
+        api = FakeAPI(pulls=[pull(7)], threads={7: [[False]]}, comments={7: [hold.COMMENT_MARKER + "\nearlier"]})
+        lines, _ = hold.sweep(api)
+        paths = [path for path, _ in api.posts]
+        self.assertIn(f"/repos/{REPO}/issues/7/labels", paths)
+        self.assertNotIn(f"/repos/{REPO}/issues/7/comments", paths)
+        self.assertIn("comment is already there", lines[0])
+
+    def test_the_label_is_created_before_it_is_applied(self):
+        api = FakeAPI(pulls=[pull(7)], threads={7: [[False]]})
+        hold.sweep(api)
+        self.assertEqual(api.posts[0][0], f"/repos/{REPO}/labels")
+        self.assertEqual(api.posts[0][1]["name"], hold.LABEL)
+
+    def test_removes_its_own_label_once_resolved(self):
+        api = FakeAPI(
+            pulls=[pull(7, POOL | {hold.LABEL})],
+            threads={7: [[True, True]]},
+            timelines={7: [labeled(hold.BOT_LOGIN)]},
+        )
+        hold.sweep(api)
+        self.assertEqual(api.deletes, [f"/repos/{REPO}/issues/7/labels/{hold.LABEL}"])
+
+    def test_leaves_a_persons_label_alone(self):
+        api = FakeAPI(
+            pulls=[pull(7, POOL | {hold.LABEL})],
+            threads={7: [[True]]},
+            timelines={7: [labeled("a-maintainer")]},
+        )
+        lines, _ = hold.sweep(api)
+        self.assertEqual(api.deletes, [])
+        self.assertIn("applied by a person", lines[0])
+
+    def test_dry_run_writes_nothing(self):
+        api = FakeAPI(
+            pulls=[pull(7), pull(8, POOL | {hold.LABEL})],
+            threads={7: [[False]], 8: [[True]]},
+            timelines={8: [labeled(hold.BOT_LOGIN)]},
+        )
+        lines, _ = hold.sweep(api, dry_run=True)
+        self.assertEqual(api.posts, [])
+        self.assertEqual(api.deletes, [])
+        self.assertIn("#7: would be labelled", lines[0])
+        self.assertIn("#8: would be unlabelled", lines[1])
+
+    def test_one_failure_does_not_stop_the_sweep(self):
+        api = FakeAPI(pulls=[pull(7), pull(8)], threads={8: [[False]]})
+        original = api.graphql
+
+        def graphql(query, variables):
+            if variables["number"] == 7:
+                raise RuntimeError("boom")
+            return original(query, variables)
+
+        api.graphql = graphql
+        lines, failures = hold.sweep(api)
+        self.assertEqual(failures, 1)
+        self.assertIn("#7: failed", lines[0])
+        self.assertIn("#8: labelled", lines[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/conformance/test_B_write_path.py
+++ b/tests/conformance/test_B_write_path.py
@@ -338,6 +338,11 @@ class B2AssentIsHumanOrPolicy(unittest.TestCase):
         - risk_classify: `pull_request_target` with `permissions: {}` at the
           top, the grant job-scoped, checkout pinned to the default branch,
           and its one write is swapping the `risk:*` label.
+        - hold-unresolved-threads: `schedule` plus `pull_request_target:
+          labeled`, `permissions: {}` at the top, the grant job-scoped,
+          checkout pinned to the default branch, and its writes are the
+          `do-not-merge` label and one comment on pull requests with
+          unresolved review threads. It withholds a merge; it cannot grant one.
 
         The list is an allowlist of holders, not of intents: the permission is
         a capability, and this asserts membership rather than absence so a
@@ -360,6 +365,7 @@ class B2AssentIsHumanOrPolicy(unittest.TestCase):
                 "auto-assign-milestone.yml",
                 "auto_request_review.yml",
                 "coverage-comment.yml",
+                "hold-unresolved-threads.yml",
                 "risk_classify.yml",
             ],
             sorted(set(holders)),


### PR DESCRIPTION
## Summary

A scheduled workflow puts the bare `do-not-merge` label on any `lgtm`+`approved` pull request whose review threads are not all resolved, and takes it off at the next five-minute sweep after the last resolution. Tide's query for this repository already excludes that label and no Prow plugin writes it, so the workflow can own it outright. The label carries one comment telling the author why it is there and that resolving the threads is what removes it.

## Why This Change

`main` requires every review conversation resolved before a merge, and Tide does not read that rule. It picks the lowest-numbered pull request in its pool, GitHub refuses the merge with a repository-rule violation, and Tide retries the same pull request every ~85 seconds while every other pull request in the pool waits behind it. On 2026-09-05 the batch `[608, 1197]` failed that way from 10:59 to 11:57 until an admin held both by hand; #1122 sat 5h46m and 231 attempts the same way (#1202). Nothing in the repository prevented it, and the pull requests that were actually ready merged only after someone noticed.

## What Changed

- `.github/workflows/hold-unresolved-threads.yml`: every five minutes, and on the `lgtm`/`approved` label events through `pull_request_target`, runs the sweep with a write token. The schedule is the guarantee: thread resolution fires `pull_request_review_thread`, but from a fork that event carries a read-only token. Checks out the default branch only.
- `scripts/hold_unresolved_threads.py`: lists open pull requests through the pulls endpoint (strongly consistent, unlike search, which lags the label event the fast path reacts to), keeps the non-draft ones carrying both pool labels plus any carrying `do-not-merge`, counts unresolved threads through GraphQL (paged), adds the label with one marked comment, and removes it only when the issue timeline shows the label's most recent application was the workflow's own. A person's hand-applied label stays. `/hold cancel` does not touch it.
- `scripts/github_api.py`: a `graphql()` call, because REST has no notion of a resolved thread. Raises on an `errors` body rather than returning partial data.
- `docs/pull-request-workflow.md`: "How a change merges" explains the label next to `/hold`; "Resolving conversations" points at it; the `mergeStateStatus` paragraph's #1122 example now names this as the case the label keeps out. `docs/README.md` gains one identifier-sources row.

## Context

No open issue or pull request covers this. It follows the queue drain on 2026-09-05 (#1175 through #1240 merged serially by hand); #1202 documents the earlier #1122 stall. `pull_request_target` follows the pattern `risk_classify.yml` already uses, with the same zizmor annotation and default-branch checkout.

## Testing

- `cd scripts && python3 -m pytest -q`: 1026 passed, including 19 new tests in `test_hold_unresolved_threads.py` (each branch of `decide`, which open pull requests are read at all, timeline ownership by last event, thread paging, label created before use, one comment per hold and none on a relabel, dry run writes nothing, one failure does not stop the sweep) and two in `test_github_api.py` for `graphql()` (data returned; a 200 with an `errors` body raises).
- `actionlint` clean on the workflow; `prettier@3.9.6 --check` clean on the workflow and the doc; `make docs-check` clean (AGENTS.md at 0.0k under budget, unchanged by this PR).
- `tests/conformance/test_B_write_path.py` (17 passed, 3 xfailed): the new workflow is on B2's allowlist of `pull-requests: write` holders, with the reasoning in the docstring. Checkov's `CKV_GHA_7` on the `dry_run` dispatch input is skipped with a reason, the form every other dispatchable workflow here uses; the first CI run red on both before this.

### Live validation

Not a cluster change, so the live surface is GitHub itself.

Read path, against gke-labs/kube-agents with a dry run at 2026-09-06 ~00:20 UTC (`python3 scripts/hold_unresolved_threads.py --repo gke-labs/kube-agents --dry-run`):

```
#608: would be labelled: 4 unresolved thread(s) and in the pool
#965: left alone: every thread resolved; not labelled
#1150: would be labelled: 1 unresolved thread(s) and in the pool
#1186: left alone: every thread resolved; not labelled
#1199: left alone: every thread resolved; not labelled
#1200: left alone: every thread resolved; not labelled
```

#608 is exactly the pull request that jammed the queue the day before. Nothing was written to this repository.

Write path, on a throwaway pull request in my fork (bradhoekstra/kube-agents#25, since closed and its branch deleted) labelled `lgtm`+`approved` with one review thread on its diff, running the real script with my token:

1. Run 1: `#25: labelled: 1 unresolved thread(s) and in the pool` → labels `lgtm,approved,do-not-merge`, one comment carrying the marker.
2. Run 2, nothing changed: `left alone: 1 unresolved thread(s); already labelled` → still exactly one marked comment.
3. Thread resolved through `resolveReviewThread`, run 3: `left alone: every thread resolved, but the label was applied by a person; leaving it` — correct, because my token (not `github-actions[bot]`) had applied it.
4. Run 4 with `BOT_LOGIN` set to my login in-process, to stand in for the workflow's token: `unlabelled: every thread resolved` → label gone.

Repeated on a second throwaway (bradhoekstra/kube-agents#26, also closed) after the review-driven changes below: run 1 labelled and commented; the label was then removed by hand with the thread still open and run 2 re-applied it without a second comment (one marker comment on the pull request afterwards). The dry run above was re-run after switching the listing from search to the pulls endpoint and selected the same pull requests.

Not covered: the workflow itself has not run under `schedule` or `pull_request_target` yet, because both are guarded to gke-labs/kube-agents; the first scheduled run after merge is the proof, and `workflow_dispatch` with `dry_run` can be run before that. The bare `do-not-merge` label does not exist in this repository yet; the script creates it on first run.

## Self-Review

Both passes ran in fresh subagents handed the diff range and the skill path only, told to derive intent from the diff and not to read commit messages. Neither had a cluster or dispatch rights.

- **MEDIUM, PLAUSIBLE (adversarial).** The `labeled` fast path listed the pool through GitHub search, which is eventually consistent, so the sweep that runs seconds after `lgtm` lands could miss the very pull request the event was about and leave it to the next schedule tick. Fixed: the pool is now read from `GET /pulls?state=open` and filtered in Python; the search queries and their paging are gone. Confirmed by the live dry run selecting the same pull requests.
- **LOW, CONFIRMED (adversarial).** `"add"`/`"remove"` were bare strings compared in six places (no-magic-constants). Fixed: `ACTION_ADD`/`ACTION_REMOVE`.
- **LOW, CONFIRMED (adversarial).** `COMMENT_MARKER` claimed a later sweep could find it, but nothing read it, and a label removed by hand while threads stayed open would get a fresh comment every five minutes. Fixed: an add checks for an existing marker comment first and posts none if one is there; tested, and exercised live on the second fork fixture.
- **LOW, CONFIRMED (adversarial; also docs-drift advisory 1).** "Within five minutes" promised more than a `*/5` schedule guarantees. Fixed in the doc and in the comment text: "at the next five-minute sweep".
- **LOW, CONFIRMED (adversarial).** `graphql()` had no test for the contract it exists for. Fixed: two tests in `test_github_api.py`.
- **Advisory (docs-drift).** "An approved pull request" was looser than the code's `lgtm`+`approved`, non-draft condition — reworded. The new paragraph repeated the #1122 figure the same page already states — dropped, and the existing #1122 sentence now points at the label. `docs/README.md`'s identifier-sources table gained a row for the label, interval, and ownership rule. `github_api.py`'s module docstring now names `graphql()` and its raise-on-`errors` contract.
- **Advisory (docs-drift), not fixed here.** `docs/testing-map.md:11` cites the `PYTHON_TEST_DIRS` globs at a `Makefile` line range that has drifted (now 151-166). Pre-existing and outside this diff; noted for a follow-up.
- **Adversarial angles with nothing found:** `ref: default_branch` is empty on `schedule` and falls back to `github.ref`, the default branch, as `risk_classify.yml` relies on; `pull_request_target` safety (default-branch checkout, `persist-credentials: false`, no pull-request content in `run:`); label writes with `GITHUB_TOKEN` do not re-trigger the workflow, so no loop; concurrency group serialises sweeps; `label_is_ours` errs toward leaving a label on; `pin_smoke_status.py` already treats any `do-not-merge*` label as out of the pool, so the two sweeps agree. Docs-drift verified the four-label exclusion list against `prow/oss/config.yaml` in oss-test-infra and that no Prow plugin writes the bare label.
- **Not covered by either pass:** the workflow has not run under `schedule` or `pull_request_target` (both guarded to gke-labs/kube-agents); no red-then-green, since this is new behaviour rather than a fix.

## Risk & Rollout

The workflow writes labels and one comment; it runs no pull-request code and never merges anything. The failure modes are a label applied to a pull request that is in fact mergeable, which the sweep removes within five minutes once the threads read resolved and Tide would have refused anyway, and a person's `do-not-merge` removed by mistake, which the timeline check prevents and a test covers. Revert by deleting the workflow; any label it left is removed by hand. Nothing has to happen at merge time; the label is created on the first sweep. Merging this does not need a Prow config change: the label is already in Tide's exclusion list for this repository.

Generated with the help of Claude Code.

