### PR TITLE
fix(e2e): align test fixtures and pod discovery with shell sandbox architecture (#1265)

### DIFF
--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -119,8 +119,9 @@ dump_prow_artifacts_on_failure() {
     # is visible only in this pod's log -- the gateway just relays the text.
     kubectl logs deployment/litellm -n "${ns}" --tail=1000 > "${artifact_dir}/litellm.log" 2>&1 || true
     # The gateway capture above reads the pod's default container (platform-agent);
-    # a dropped port-forward stream is only visible from the envoy sidecar's side.
-    kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
+    # a dropped port-forward stream is only visible from the auth sidecar's side.
+    kubectl logs deployment/platform-agent-gateway -c agent-api-auth -n "${ns}" --tail=2000 > "${artifact_dir}/agent-api-auth.log" 2>&1 || true
+    kubectl logs deployment/platform-agent-credential-proxy -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
     # Konnectivity/tunnel churn shows up as kube-system events, not in "${ns}".
     kubectl get events -n kube-system --sort-by=.lastTimestamp 2>&1 | tail -100 > "${artifact_dir}/kube-system-events.txt" 2>&1 || true
 

--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -119,9 +119,8 @@ dump_prow_artifacts_on_failure() {
     # is visible only in this pod's log -- the gateway just relays the text.
     kubectl logs deployment/litellm -n "${ns}" --tail=1000 > "${artifact_dir}/litellm.log" 2>&1 || true
     # The gateway capture above reads the pod's default container (platform-agent);
-    # a dropped port-forward stream is only visible from the auth sidecar's side.
-    kubectl logs deployment/platform-agent-gateway -c agent-api-auth -n "${ns}" --tail=2000 > "${artifact_dir}/agent-api-auth.log" 2>&1 || true
-    kubectl logs deployment/platform-agent-credential-proxy -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
+    # a dropped port-forward stream is only visible from the envoy sidecar's side.
+    kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
     # Konnectivity/tunnel churn shows up as kube-system events, not in "${ns}".
     kubectl get events -n kube-system --sort-by=.lastTimestamp 2>&1 | tail -100 > "${artifact_dir}/kube-system-events.txt" 2>&1 || true
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -436,7 +436,7 @@ from exec_tunnel import TunnelConfig, serve_background  # noqa: E402
 # bench/kube_agents_bench/harness.py reads for the same value.
 _AGENT_NAME = os.environ.get("AGENT_SERVICE_NAME", "platform-agent")
 
-_PROXY_CONTAINER = "envoy-credential-proxy"
+_PROXY_CONTAINER = os.environ.get("AGENT_PROXY_CONTAINER", "agent-api-auth")
 _AGENT_CONTAINER = "platform-agent"
 
 # The interpreter the relay runs inside _PROXY_CONTAINER. Named here rather than
@@ -447,8 +447,8 @@ _AGENT_CONTAINER = "platform-agent"
 # with this same path.
 _PROXY_PYTHON = "/opt/hermes/.venv/bin/python3"
 
-# The credential-proxy sidecar's authenticated listener, and the Service's
-# targetPort for `api`.
+# The credential-proxy / agent-api-auth sidecar's authenticated listener, and
+# the Service's targetPort for `api`.
 _PROXY_API_PORT = 8643
 _HERMES_API_PORT = 8642
 
@@ -595,6 +595,46 @@ def _gateway_pod_selector(namespace: str, note: Callable[[str], None]) -> str:
     return ",".join(f"{key}={value}" for key, value in sorted(selector.items()))
 
 
+def _resolve_gateway_proxy_container(
+    namespace: str, selector: str, note: Callable[[str], None]
+) -> str:
+    """Resolves the container in the gateway pod listening on _PROXY_API_PORT.
+
+    In PR #913+ the gateway pod runs the native sidecar `agent-api-auth`.
+    For legacy single-pod deployments, it was `envoy-credential-proxy`.
+    """
+    configured = os.environ.get("AGENT_PROXY_CONTAINER")
+    if configured:
+        return configured
+    try:
+        res = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "-l",
+                selector,
+                "--field-selector=status.phase=Running",
+                "-o",
+                "jsonpath={.items[0].spec.initContainers[*].name} {.items[0].spec.containers[*].name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if res.returncode == 0 and res.stdout.strip():
+            containers = res.stdout.strip().split()
+            if "agent-api-auth" in containers:
+                return "agent-api-auth"
+            if "envoy-credential-proxy" in containers:
+                return "envoy-credential-proxy"
+    except Exception as exc:  # noqa: BLE001
+        note(f"failed to detect proxy container in {selector}: {exc}")
+    return _PROXY_CONTAINER
+
+
 def _diagnose_hermes(namespace: str) -> str:
     """Separates "the agent is down" from "the credential proxy is broken".
 
@@ -689,8 +729,11 @@ def port_forward_agent(
     selector = _gateway_pod_selector(
         agent_namespace, lambda message: diary.append(f"  {message}")
     )
+    proxy_container = _resolve_gateway_proxy_container(
+        agent_namespace, selector, lambda message: diary.append(f"  {message}")
+    )
     target = (
-        f"exec relay -> {_PROXY_CONTAINER}:{_PROXY_API_PORT} "
+        f"exec relay -> {proxy_container}:{_PROXY_API_PORT} "
         f"in a pod matching {selector}"
     )
 
@@ -700,7 +743,7 @@ def port_forward_agent(
             TunnelConfig(
                 namespace=agent_namespace,
                 selector=selector,
-                container=_PROXY_CONTAINER,
+                container=proxy_container,
                 remote_port=_PROXY_API_PORT,
                 python=_PROXY_PYTHON,
                 ready_timeout=budget,

--- a/tests/e2e/test_agent_fleet_audit.py
+++ b/tests/e2e/test_agent_fleet_audit.py
@@ -188,7 +188,7 @@ if full_name.lower() != '{github_repo}'.lower():
 print(f"Successfully authenticated and queried repository: {{full_name}}")
 """
 
-    cmd = [
+    base_exec = [
         "kubectl",
         "exec",
         "-n",
@@ -197,10 +197,12 @@ print(f"Successfully authenticated and queried repository: {{full_name}}")
         "-c",
         container_name,
         "--",
-        "python3",
-        "-c",
-        script,
     ]
+    if container_name == "shell":
+        cmd = base_exec + ["runuser", "-u", "agent", "--", "python3", "-c", script]
+    else:
+        cmd = base_exec + ["python3", "-c", script]
+
     try:
         proc_start = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
         assert proc_start.returncode == 0, (

--- a/tests/e2e/test_agent_fleet_audit.py
+++ b/tests/e2e/test_agent_fleet_audit.py
@@ -46,14 +46,13 @@ def test_github_token_minting_and_connectivity(
     if not gke_cluster_name or not github_repo:
         pytest.fail("GKE cluster name and GITHUB_REPO are required for live GitHub connectivity probe.")
 
-    # Find running platform-agent pod with availability wait
+    # 1. Wait for running shell sandbox pod (StatefulSet app=<name>-shell, container: shell)
     deadline = time.time() + _POD_WAIT_TIMEOUT_SECONDS
     pod_name = ""
     container_name = "shell"
     agent_name = os.environ.get("AGENT_SERVICE_NAME", "platform-agent")
 
     while time.time() < deadline:
-        # 1. Shell sandbox pod (StatefulSet app=<name>-shell, container: shell)
         proc_pod = subprocess.run(
             [
                 "kubectl",
@@ -74,38 +73,11 @@ def test_github_token_minting_and_connectivity(
             pod_name = proc_pod.stdout.strip()
             container_name = "shell"
             break
+        time.sleep(_POD_POLL_INTERVAL_SECONDS)
 
-        # 2. Search for any pod running the 'shell' container
-        proc_all = subprocess.run(
-            [
-                "kubectl",
-                "get",
-                "pods",
-                "-n",
-                agent_namespace,
-                "--field-selector=status.phase=Running",
-                "-o",
-                "json",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if proc_all.returncode == 0 and proc_all.stdout.strip():
-            try:
-                items = json.loads(proc_all.stdout).get("items", [])
-                for item in items:
-                    c_names = [c.get("name") for c in item.get("spec", {}).get("containers", [])]
-                    if "shell" in c_names:
-                        pod_name = item.get("metadata", {}).get("name", "")
-                        container_name = "shell"
-                        break
-            except Exception:
-                pass
-        if pod_name:
-            break
-
-        # 3. Fallback for legacy single-pod layout: gateway pod with container platform-agent
-        proc_pod = subprocess.run(
+    # 2. Fallback for legacy single-pod layout: gateway pod with container platform-agent
+    if not pod_name:
+        proc_gw = subprocess.run(
             [
                 "kubectl",
                 "get",
@@ -121,40 +93,13 @@ def test_github_token_minting_and_connectivity(
             capture_output=True,
             text=True,
         )
-        if proc_pod.returncode == 0 and proc_pod.stdout.strip():
-            pod_name = proc_pod.stdout.strip()
+        if proc_gw.returncode == 0 and proc_gw.stdout.strip():
+            pod_name = proc_gw.stdout.strip()
             container_name = "platform-agent"
-            break
-
-        # Fallback to checking any running pod in agent namespace with 'agent' or 'gateway' in name
-        proc_pod_all = subprocess.run(
-            [
-                "kubectl",
-                "get",
-                "pod",
-                "-n",
-                agent_namespace,
-                "--field-selector=status.phase=Running",
-                "-o",
-                "jsonpath={.items[*].metadata.name}",
-            ],
-            capture_output=True,
-            text=True,
-        )
-        if proc_pod_all.returncode == 0 and proc_pod_all.stdout.strip():
-            candidate_pods = [
-                p for p in proc_pod_all.stdout.split()
-                if ("agent" in p or "gateway" in p) and not any(k in p for k in ("minter", "minty", "operator", "hindsight"))
-            ]
-            if candidate_pods:
-                pod_name = candidate_pods[0]
-                container_name = "platform-agent"
-                break
-        time.sleep(_POD_POLL_INTERVAL_SECONDS)
 
     if not pod_name:
         pytest.fail(
-            f"No running agent shell or gateway pod found in namespace '{agent_namespace}' within {_POD_WAIT_TIMEOUT_SECONDS}s."
+            f"No running agent shell or legacy gateway pod found in namespace '{agent_namespace}' within {_POD_WAIT_TIMEOUT_SECONDS}s."
         )
 
     # Refresh credentials via broker and query repository via read-only GET API

--- a/tests/e2e/test_agent_fleet_audit.py
+++ b/tests/e2e/test_agent_fleet_audit.py
@@ -49,7 +49,11 @@ def test_github_token_minting_and_connectivity(
     # Find running platform-agent pod with availability wait
     deadline = time.time() + _POD_WAIT_TIMEOUT_SECONDS
     pod_name = ""
+    container_name = "shell"
+    agent_name = os.environ.get("AGENT_SERVICE_NAME", "platform-agent")
+
     while time.time() < deadline:
+        # 1. Shell sandbox pod (StatefulSet app=<name>-shell, container: shell)
         proc_pod = subprocess.run(
             [
                 "kubectl",
@@ -58,7 +62,7 @@ def test_github_token_minting_and_connectivity(
                 "-n",
                 agent_namespace,
                 "-l",
-                "kubeagents.x-k8s.io/has-credential-proxy=true",
+                f"app={agent_name}-shell",
                 "--field-selector=status.phase=Running",
                 "-o",
                 "jsonpath={.items[0].metadata.name}",
@@ -68,7 +72,39 @@ def test_github_token_minting_and_connectivity(
         )
         if proc_pod.returncode == 0 and proc_pod.stdout.strip():
             pod_name = proc_pod.stdout.strip()
+            container_name = "shell"
             break
+
+        # 2. Search for any pod running the 'shell' container
+        proc_all = subprocess.run(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                agent_namespace,
+                "--field-selector=status.phase=Running",
+                "-o",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if proc_all.returncode == 0 and proc_all.stdout.strip():
+            try:
+                items = json.loads(proc_all.stdout).get("items", [])
+                for item in items:
+                    c_names = [c.get("name") for c in item.get("spec", {}).get("containers", [])]
+                    if "shell" in c_names:
+                        pod_name = item.get("metadata", {}).get("name", "")
+                        container_name = "shell"
+                        break
+            except Exception:
+                pass
+        if pod_name:
+            break
+
+        # 3. Fallback for legacy single-pod layout: gateway pod with container platform-agent
         proc_pod = subprocess.run(
             [
                 "kubectl",
@@ -77,7 +113,7 @@ def test_github_token_minting_and_connectivity(
                 "-n",
                 agent_namespace,
                 "-l",
-                "app=platform-agent-gateway",
+                f"app={agent_name}-gateway",
                 "--field-selector=status.phase=Running",
                 "-o",
                 "jsonpath={.items[0].metadata.name}",
@@ -87,7 +123,9 @@ def test_github_token_minting_and_connectivity(
         )
         if proc_pod.returncode == 0 and proc_pod.stdout.strip():
             pod_name = proc_pod.stdout.strip()
+            container_name = "platform-agent"
             break
+
         # Fallback to checking any running pod in agent namespace with 'agent' or 'gateway' in name
         proc_pod_all = subprocess.run(
             [
@@ -110,11 +148,14 @@ def test_github_token_minting_and_connectivity(
             ]
             if candidate_pods:
                 pod_name = candidate_pods[0]
+                container_name = "platform-agent"
                 break
         time.sleep(_POD_POLL_INTERVAL_SECONDS)
 
     if not pod_name:
-        pytest.fail(f"No running platform-agent-gateway pod found in namespace '{agent_namespace}' within {_POD_WAIT_TIMEOUT_SECONDS}s.")
+        pytest.fail(
+            f"No running agent shell or gateway pod found in namespace '{agent_namespace}' within {_POD_WAIT_TIMEOUT_SECONDS}s."
+        )
 
     # Refresh credentials via broker and query repository via read-only GET API
     script = f"""
@@ -132,6 +173,7 @@ if p_refresh.returncode == 0 and p_refresh.stdout.strip():
 # 2. Execute read-only GitHub API verification via Envoy proxy from workspace root
 env = os.environ.copy()
 env['PWD'] = '/opt/data'
+env['PATH'] = '/opt/credential-proxy/bin:' + env.get('PATH', '')
 cmd_gh = ['gh', 'api', f'repos/{github_repo}', '--jq', '.full_name']
 res_gh = subprocess.run(cmd_gh, cwd='/opt/data', env=env, capture_output=True, text=True)
 if res_gh.returncode != 0:
@@ -153,7 +195,7 @@ print(f"Successfully authenticated and queried repository: {{full_name}}")
         agent_namespace,
         pod_name,
         "-c",
-        "platform-agent",
+        container_name,
         "--",
         "python3",
         "-c",


### PR DESCRIPTION
## Summary

Aligns E2E test fixtures and live probe execution with the pod split introduced in #913 (where the single agent pod was separated into gateway, credential-proxy broker, and shell sandbox). Fixes regressions in the blocking `rc` test suite that were preventing Nightly release promotion.

## Why This Change

PR #913 ("feat(operator)!: run the agent shell in a sandbox pod") split the monolithic agent workload into three distinct pods:
1. `platform-agent-gateway` (running container `platform-agent` and native sidecar `agent-api-auth`)
2. `platform-agent-credential-proxy` (running `envoy-credential-proxy`)
3. `platform-agent-shell-0` (StatefulSet pod running container `shell` with `/opt/data` and credential proxy CLI shims)

The E2E `rc` suite (`test_agent_api_health.py` and `test_agent_fleet_audit.py`) was failing because:
- `port_forward_agent` tried to exec into `envoy-credential-proxy` inside `platform-agent-gateway` where it no longer exists.
- `test_github_token_minting_and_connectivity` selected `platform-agent-credential-proxy` via `kubeagents.x-k8s.io/has-credential-proxy=true` and tried to exec into `platform-agent`, failing because that container does not exist there. Furthermore, `gh` and `/opt/data` live exclusively in the sandbox pod.

Because `nightly-pipeline.yml` enforces `rc` as a blocking promotion gate, all nightly runs and staging promotions were blocked.

## What Changed

- **`tests/e2e/conftest.py`**:
  - Default `_PROXY_CONTAINER` to `"agent-api-auth"` with dynamic fallback via `_resolve_gateway_proxy_container` to `"envoy-credential-proxy"` on older single-pod layouts.
- **`tests/e2e/test_agent_fleet_audit.py`**:
  - Update `test_github_token_minting_and_connectivity` to target the shell sandbox pod (`app=<name>-shell`, container `shell`) with a dedicated 120s availability wait loop.
  - Drop privileges to unprivileged `agent` user (uid 1000) via `runuser -u agent` when execing inside the sandbox shell container, avoiding running agent-writable scripts with root privileges.
  - Prepend `/opt/credential-proxy/bin` to `PATH` for `gh`.
  - Retain fallback to legacy gateway pod only after sandbox wait expires.

*(Note: Diagnostic failure artifact collection in `hack/ci-env.sh` was split out into a separate PR to decouple Prow CI script reviews from E2E release test fixtures).*

## Context

- Fixes #1265
- Regressed from #913

## Testing

- Python syntax and compile validation: `python3 -m py_compile tests/e2e/test_agent_fleet_audit.py` passed.
- Unit tests: `pytest scripts/test_ci_connectivity_retry.py` passed (5/5).
- CI workflow linters and checks passing on GitHub Actions.

### Live validation

Executed against the live `platform-agent-host` cluster in `kube-agents-nightly` (`us-central1`, preserved from failed nightly run #34128024494):
- Full `rc` suite passed 20/20 (9 skipped):
  - `test_agent_api_health.py::test_platform_agent_api_health_ping` PASSED (exec relay via `agent-api-auth:8643`).
  - `test_agent_fleet_audit.py::test_github_token_minting_and_connectivity` PASSED (exec under `agent` user in `platform-agent-shell-0` via `runuser -u agent`).
  - All audit report and stockout scenarios passed.
- Also tested against single-pod cluster to verify backward-compatible gateway fallback.

## Self-Review

Passes conducted:
- **Security & Privilege Analysis**: Verified that `kubectl exec` into the sandbox `shell` container runs as root by default. Added `runuser -u agent` to drop privileges to `agent` (uid 1000) so agent-writable scripts under `/opt` are never executed as root.
- **Race Condition / Timeout Analysis**: Addressed review feedback where gateway fallback could pre-empt the sandbox wait loop; separated sandbox wait into a dedicated 120s polling loop before falling back.
- **Scope Scrutiny**: Removed unscoped namespace pod scans that could inadvertently select foreign agent pods in shared namespaces. Reverted `hack/ci-env.sh` so Prow infrastructure scripts are reviewed in a standalone PR.

## Risk & Rollout

Low risk: changes are limited to E2E test fixtures and test assertions. No production operator or runtime container logic is modified.
