### PR TITLE
fix(ci): align prow failure artifact collection with shell sandbox architecture (#1265)

### DIFF
--- a/hack/ci-env.sh
+++ b/hack/ci-env.sh
@@ -119,8 +119,9 @@ dump_prow_artifacts_on_failure() {
     # is visible only in this pod's log -- the gateway just relays the text.
     kubectl logs deployment/litellm -n "${ns}" --tail=1000 > "${artifact_dir}/litellm.log" 2>&1 || true
     # The gateway capture above reads the pod's default container (platform-agent);
-    # a dropped port-forward stream is only visible from the envoy sidecar's side.
-    kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
+    # a dropped port-forward stream is only visible from the auth sidecar's side.
+    kubectl logs deployment/platform-agent-gateway -c agent-api-auth -n "${ns}" --tail=2000 > "${artifact_dir}/agent-api-auth.log" 2>&1 || true
+    kubectl logs deployment/platform-agent-credential-proxy -c envoy-credential-proxy -n "${ns}" --tail=2000 > "${artifact_dir}/envoy-credential-proxy.log" 2>&1 || true
     # Konnectivity/tunnel churn shows up as kube-system events, not in "${ns}".
     kubectl get events -n kube-system --sort-by=.lastTimestamp 2>&1 | tail -100 > "${artifact_dir}/kube-system-events.txt" 2>&1 || true
 


### PR DESCRIPTION
## Summary

Updates the Prow CI post-failure artifact dumper (`dump_prow_artifacts_on_failure` in `hack/ci-env.sh`) to collect logs from the separated gateway and credential-proxy deployments introduced in #913.

## Why This Change

PR #913 ("feat(operator)!: run the agent shell in a sandbox pod") split the agent workload into distinct deployments:
- `platform-agent-gateway` (which replaced the `envoy-credential-proxy` container with `agent-api-auth`)
- `platform-agent-credential-proxy` (which now hosts `envoy-credential-proxy`)

When Prow evaluation runs (`hack/ci-eval-pr.sh`, `hack/ci-deploy.sh`) fail, `dump_prow_artifacts_on_failure()` previously attempted:
`kubectl logs deployment/platform-agent-gateway -c envoy-credential-proxy -n "${ns}" ...`
which failed with `error: container envoy-credential-proxy is not valid for deployment platform-agent-gateway`, preventing credential proxy logs from being captured.

This change is separated from E2E PR #1266 so Prow test-infra maintainers can review it independently without coupling to release E2E test gate changes.

## What Changed

- **`hack/ci-env.sh`**:
  - Dump `agent-api-auth.log` from `deployment/platform-agent-gateway -c agent-api-auth`.
  - Dump `envoy-credential-proxy.log` from `deployment/platform-agent-credential-proxy -c envoy-credential-proxy`.

## Context

- Ref: #1265
- Regressed from #913
- Companion to E2E PR #1266

## Testing

- `bash -n hack/ci-env.sh` passed.
- Unit tests: `pytest scripts/test_ci_connectivity_retry.py` passed (5/5).

### Live validation

Not live-tested on GKE cluster because this function executes strictly in Prow CI artifact dump traps on container failure; syntax and container name alignments verified against operator pod specs rendered in #913.

## Self-Review

Passes conducted:
- Verified container and deployment names against current operator deployment definitions (`platform-agent-gateway` with `agent-api-auth`, and `platform-agent-credential-proxy` with `envoy-credential-proxy`).
- Verified zero impact on runtime production workloads (only diagnostic logging in CI script).

## Risk & Rollout

Low risk: changes are limited to `dump_prow_artifacts_on_failure()` diagnostic logging in Prow CI scripts. No production code or deployment templates modified.
