### PR TITLE
fix(installer): treat empty state instances as unmanaged cluster and adopt GSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage-go.xml
 *.tfvars
 !*.tfvars.example
 terraform.tfvars.json
+.adopted_resources
 
 # Terraform override files are environment-local by convention: lifecycle.sh
 # writes (and normally removes) providers_lifecycle_override.tf mid-import,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,7 +160,7 @@ and GitHub minter workloads).
 - **Canonical guide (self-contained):** [`terraform/examples/full-install/README.md`](terraform/examples/full-install/README.md)
 - Drive it through [`lifecycle.sh`](terraform/examples/full-install/lifecycle.sh) rather than bare
   `terraform` commands: `apply` adopts the Cloud KMS resources GCP refuses to delete and any Pub/Sub
-  topic or subscription that already exists, `destroy` handles the four teardown asymmetries a bare
+  topic or subscription that already exists, `destroy` handles the teardown asymmetries a bare
   `terraform destroy` trips over, and `plan` reports what an apply would change while creating
   nothing.
 - The composition installs `cert-manager` automatically (`enable_cert_manager`, default true), so
@@ -620,11 +620,12 @@ cd terraform/examples/full-install
 KUBE_AGENTS_STATE_BUCKET=auto ./lifecycle.sh destroy
 ```
 
-`destroy` handles the four asymmetries a bare `terraform destroy` trips over: it deletes the
+`destroy` handles the teardown asymmetries a bare `terraform destroy` trips over: it deletes the
 PlatformAgent CR up front (force-clearing a wedged finalizer), purges the backups a BackupPlan
-still owns, clears the cluster's deletion protection, and forgets the undeletable Cloud KMS
-resources from state so their key versions are never scheduled for destruction — the next
-`lifecycle.sh apply` adopts them back automatically.
+still owns, clears the cluster's deletion protection, forgets adopted pre-existing service accounts
+from state so their identities are preserved in GCP, and forgets the undeletable Cloud KMS resources
+from state so their key versions are never scheduled for destruction — the next `lifecycle.sh apply`
+adopts them back automatically.
 
 With **no Terraform state** (none in the GCS bucket, none locally), `uninstall.sh` says so and
 stops with exit **3**, touching nothing. Either nothing is installed against those coordinates,

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,9 @@
 
 set -Eeuo pipefail
 
+readonly CMEK_RETRY_ATTEMPTS=6
+readonly CMEK_RETRY_DELAY_SECONDS=5
+
 # ─── ANSI Colors & Terminal Responsive Helpers ─────────────────────────────────
 # A function because scripts/installer/common.sh defines the same variables
 # unconditionally: sourcing it would re-enable colour under NO_COLOR or in a pipe,
@@ -1627,11 +1630,13 @@ ensure_existing_cluster_cmek() {
   print_info "Enabling CMEK database encryption on existing cluster '$cluster_name' (key: $key_resource)..."
   gcloud services enable cloudkms.googleapis.com --project="$project_id"
   if ! gcloud kms keyrings describe "$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
-    retry 6 5 gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null || true
+    retry "$CMEK_RETRY_ATTEMPTS" "$CMEK_RETRY_DELAY_SECONDS" \
+      gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null || true
   fi
   if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
-    retry 6 5 gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
-      --purpose="encryption" --project="$project_id" 2>/dev/null || true
+    retry "$CMEK_RETRY_ATTEMPTS" "$CMEK_RETRY_DELAY_SECONDS" \
+      gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
+        --purpose="encryption" --project="$project_id" 2>/dev/null || true
   fi
   if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
     print_error "Failed to create or verify Cloud KMS key: $key_resource"

--- a/install.sh
+++ b/install.sh
@@ -1627,25 +1627,11 @@ ensure_existing_cluster_cmek() {
   print_info "Enabling CMEK database encryption on existing cluster '$cluster_name' (key: $key_resource)..."
   gcloud services enable cloudkms.googleapis.com --project="$project_id"
   if ! gcloud kms keyrings describe "$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
-    local kr_attempt=0
-    while [ "$kr_attempt" -lt 5 ]; do
-      if gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null; then
-        break
-      fi
-      kr_attempt=$((kr_attempt + 1))
-      sleep 2
-    done
+    retry 6 5 gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null || true
   fi
   if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
-    local k_attempt=0
-    while [ "$k_attempt" -lt 5 ]; do
-      if gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
-        --purpose="encryption" --project="$project_id" 2>/dev/null; then
-        break
-      fi
-      k_attempt=$((k_attempt + 1))
-      sleep 2
-    done
+    retry 6 5 gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
+      --purpose="encryption" --project="$project_id" 2>/dev/null || true
   fi
   if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
     print_error "Failed to create or verify Cloud KMS key: $key_resource"

--- a/install.sh
+++ b/install.sh
@@ -1626,9 +1626,31 @@ ensure_existing_cluster_cmek() {
   local key_resource="projects/${project_id}/locations/${kms_location}/keyRings/${keyring}/cryptoKeys/${key}"
   print_info "Enabling CMEK database encryption on existing cluster '$cluster_name' (key: $key_resource)..."
   gcloud services enable cloudkms.googleapis.com --project="$project_id"
-  gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null || true
-  gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
-    --purpose="encryption" --project="$project_id" 2>/dev/null || true
+  if ! gcloud kms keyrings describe "$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
+    local kr_attempt=0
+    while [ "$kr_attempt" -lt 5 ]; do
+      if gcloud kms keyrings create "$keyring" --location="$kms_location" --project="$project_id" 2>/dev/null; then
+        break
+      fi
+      kr_attempt=$((kr_attempt + 1))
+      sleep 2
+    done
+  fi
+  if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
+    local k_attempt=0
+    while [ "$k_attempt" -lt 5 ]; do
+      if gcloud kms keys create "$key" --keyring="$keyring" --location="$kms_location" \
+        --purpose="encryption" --project="$project_id" 2>/dev/null; then
+        break
+      fi
+      k_attempt=$((k_attempt + 1))
+      sleep 2
+    done
+  fi
+  if ! gcloud kms keys describe "$key" --keyring="$keyring" --location="$kms_location" --project="$project_id" >/dev/null 2>&1; then
+    print_error "Failed to create or verify Cloud KMS key: $key_resource"
+    return 1
+  fi
   local project_number service_agent
   project_number=$(gcloud projects describe "$project_id" --format="value(projectNumber)")
   service_agent="service-${project_number}@container-engine-robot.iam.gserviceaccount.com"

--- a/scripts/installer/installer_common.sh
+++ b/scripts/installer/installer_common.sh
@@ -642,7 +642,9 @@ try:
 except Exception:
     sys.exit(1)
 managed = any(
-    r.get("type") == "google_container_cluster" and r.get("mode") == "managed"
+    r.get("type") == "google_container_cluster"
+    and r.get("mode") == "managed"
+    and len(r.get("instances", [1])) > 0
     for r in doc.get("resources", [])
 )
 sys.exit(0 if managed else 1)

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -519,13 +519,15 @@ What each one does that raw Terraform cannot:
 | A `BackupPlan` cannot be deleted while it owns backups                   | `tf-destroy` purges the plan's backups first                                                                                                 |
 | `deletion_protection = true` cannot be overridden by a destroy alone     | `tf-destroy` applies it as `false`, then destroys                                                                                            |
 | A Pub/Sub topic or subscription that already exists makes the create 409 | `tf-apply` imports it first (`adopt_pubsub`), so a topic created in the Cloud console while wiring up Google Chat does not block the install |
+| Applying against an existing cluster would destroy residual cluster KMS | `tf-apply` removes unmanaged cluster KMS from state first (`forget_unmanaged_cluster_kms`) and restores scheduled versions |
+| Pre-existing service accounts make the create 409 | `tf-apply` imports them (`adopt_kms`); `tf-destroy` forgets adopted accounts so pre-existing identities are preserved in GCP |
 
 The chart also carries a `pre-delete` hook that removes the CR and waits for
 its finalizer, so a plain `helm uninstall` is safe on its own; `tf-destroy`
 does it up front anyway, which turns the hook into a no-op. Disable it with
 `platformAgent.cleanupHook.enabled=false`.
 
-Running `terraform destroy` directly still works, but you own the four steps
+Running `terraform destroy` directly still works, but you own the steps
 above yourself — starting with `kubectl delete platformagent <name> -n
 kubeagents-system --wait` while the operator is still running, and setting
 `deletion_protection = false` and applying before the cluster can be removed.

--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -519,8 +519,8 @@ What each one does that raw Terraform cannot:
 | A `BackupPlan` cannot be deleted while it owns backups                   | `tf-destroy` purges the plan's backups first                                                                                                 |
 | `deletion_protection = true` cannot be overridden by a destroy alone     | `tf-destroy` applies it as `false`, then destroys                                                                                            |
 | A Pub/Sub topic or subscription that already exists makes the create 409 | `tf-apply` imports it first (`adopt_pubsub`), so a topic created in the Cloud console while wiring up Google Chat does not block the install |
-| Applying against an existing cluster would destroy residual cluster KMS | `tf-apply` removes unmanaged cluster KMS from state first (`forget_unmanaged_cluster_kms`) and restores scheduled versions |
-| Pre-existing service accounts make the create 409 | `tf-apply` imports them (`adopt_kms`); `tf-destroy` forgets adopted accounts so pre-existing identities are preserved in GCP |
+| Applying against an existing cluster would destroy residual cluster KMS  | `tf-apply` removes unmanaged cluster KMS from state first (`forget_unmanaged_cluster_kms`) and restores scheduled versions                   |
+| Pre-existing service accounts make the create 409                        | `tf-apply` imports them (`adopt_kms`); `tf-destroy` forgets adopted accounts so pre-existing identities are preserved in GCP                 |
 
 The chart also carries a `pre-delete` hook that removes the CR and waits for
 its finalizer, so a plain `helm uninstall` is safe on its own; `tf-destroy`

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -543,10 +543,43 @@ forget_kms() {
   done
 }
 
+# When create_cluster = false, the gke-cluster module manages no cluster KMS
+# resources (local.manage_kms = false), giving them count = 0. If a prior
+# attempt created the KMS key and keyring before failing, or if an apply was
+# interrupted, those resources remain in state. Applying with create_cluster=false
+# would therefore plan their destruction, scheduling the key versions for
+# destruction in Cloud KMS and corrupting the live cluster's etcd encryption.
+# Forgetting these keeps them untouched in GCP, and restore_key_versions recovers
+# any version already pending destruction.
+forget_unmanaged_cluster_kms() {
+  [[ "$(tfvar create_cluster)" == "false" ]] || return 0
+  load_state
+  local address
+  for address in \
+    "module.gke_cluster.google_kms_crypto_key.gke_key[0]" \
+    "module.gke_cluster.google_kms_key_ring.gke_keyring[0]" \
+    "module.gke_cluster.google_kms_crypto_key_iam_member.gke_kms_binding[0]" \
+    "module.gke_cluster.google_project_service_identity.gke_service_agent[0]"; do
+    in_state "$address" || continue
+    log "forgetting $address (create_cluster=false; kept in GCP so apply does not destroy it)"
+    terraform state rm "$address" >/dev/null 2>&1 ||
+      warn "could not forget $address; its key versions may be scheduled for destruction"
+  done
+
+  local project location keyring key id
+  project=$(tfvar project_id)
+  location=$(sed -E 's/-[a-z]$//' <<<"$(tfvar location)")
+  keyring=$(tfvar kms_keyring_name)
+  key=$(tfvar kms_key_name)
+  id="projects/$project/locations/$location/keyRings/$keyring/cryptoKeys/$key"
+  restore_key_versions "$id" "$location" "$project"
+}
+
 case "${1:-}" in
   adopt-kms)
     shift
     ensure_init
+    forget_unmanaged_cluster_kms
     adopt_kms
     ;;
   plan)
@@ -576,6 +609,7 @@ case "${1:-}" in
     shift
     ensure_init
     guard_cluster_ownership
+    forget_unmanaged_cluster_kms
     adopt_kms
     adopt_pubsub
     log "terraform apply"

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -260,6 +260,11 @@ adopt_kms() {
     )
   fi
 
+  local agent_gsa="kubeagents-platform-gsa"
+  targets+=(
+    "module.kube_agents_iam.google_service_account.agent	service_account	projects/$project/serviceAccounts/$agent_gsa@$project.iam.gserviceaccount.com"
+  )
+
   # Skipping both halves — cluster KMS (create_cluster or database encryption
   # off) and the minter — leaves targets empty, and macOS's bash 3.2 treats an
   # empty array expansion as unbound under `set -u`. The ${arr[@]+...} form
@@ -284,6 +289,8 @@ adopt_kms() {
       pubsub_sub)   gcloud pubsub subscriptions describe "${id##*/}" \
                       --project "$project" >/dev/null 2>&1 || continue ;;
       logging_sink) gcloud logging sinks describe "${id##*/}" \
+                      --project "$project" >/dev/null 2>&1 || continue ;;
+      service_account) gcloud iam service-accounts describe "$id" \
                       --project "$project" >/dev/null 2>&1 || continue ;;
     esac
 

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -236,12 +236,14 @@ adopt_kms() {
   fi
 
   if [[ "$(tfvar enable_github_minter)" == "true" ]]; then
-    local minter_keyring minter_key
+    local minter_keyring minter_key minter_gsa
     minter_keyring=$(tfvar github_minter_kms_keyring)
     minter_key=$(tfvar github_minter_kms_key)
+    minter_gsa="kubeagents-github-minter-gsa"
     targets+=(
       "module.github_minter[0].google_kms_key_ring.minter	keyring	projects/$project/locations/$location/keyRings/$minter_keyring"
       "module.github_minter[0].google_kms_crypto_key.minter	key	projects/$project/locations/$location/keyRings/$minter_keyring/cryptoKeys/$minter_key"
+      "module.github_minter[0].google_service_account.minter	service_account	projects/$project/serviceAccounts/$minter_gsa@$project.iam.gserviceaccount.com"
     )
   fi
 
@@ -257,6 +259,13 @@ adopt_kms() {
       "google_pubsub_topic.stockout_alerts[0]	pubsub_topic	projects/$project/topics/$stockout_topic"
       "google_pubsub_subscription.stockout_alerts[0]	pubsub_sub	projects/$project/subscriptions/$stockout_sub"
       "google_logging_project_sink.stockout_alerts[0]	logging_sink	projects/$project/sinks/$stockout_sink"
+    )
+  fi
+
+  if [[ "$(tfvar model_provider)" == "vertex_ai" ]]; then
+    local litellm_gsa="kubeagents-litellm-gsa"
+    targets+=(
+      "module.litellm_vertex_iam[0].google_service_account.agent	service_account	projects/$project/serviceAccounts/$litellm_gsa@$project.iam.gserviceaccount.com"
     )
   fi
 
@@ -290,7 +299,7 @@ adopt_kms() {
                       --project "$project" >/dev/null 2>&1 || continue ;;
       logging_sink) gcloud logging sinks describe "${id##*/}" \
                       --project "$project" >/dev/null 2>&1 || continue ;;
-      service_account) gcloud iam service-accounts describe "$id" \
+      service_account) gcloud iam service-accounts describe "${id##*/}" \
                       --project "$project" >/dev/null 2>&1 || continue ;;
     esac
 

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -26,6 +26,14 @@
 #      Reachable on a FIRST install too: configuring the Chat app in the Cloud
 #      console creates the topic before the installer ever runs. `adopt_pubsub`
 #      imports whichever of the two is already there before applying.
+#   6. When applying against an unmanaged cluster (create_cluster = false),
+#      residual cluster KMS resources left in state from an earlier attempt
+#      would be destroyed (count = 0). `forget_unmanaged_cluster_kms` removes
+#      them from state before apply and restores any scheduled key versions.
+#   7. Pre-existing Google Service Accounts (platform agent, token minter,
+#      litellm) make the create 409. `adopt_kms` imports them if already
+#      present, and `destroy` forgets only adopted accounts so pre-existing SAs
+#      are not deleted from GCP.
 #
 # Usage:
 #   ./lifecycle.sh apply    [extra terraform args...]
@@ -63,6 +71,10 @@ warn() { printf '\033[1;33m warn\033[0m %s\n' "$*" >&2; }
 # project do not collide. Without the variable nothing here runs and local
 # state behaves exactly as before.
 BACKEND_OVERRIDE_FILE="backend_override.tf"
+readonly DEFAULT_AGENT_GSA_NAME="kubeagents-platform-gsa"
+readonly DEFAULT_MINTER_GSA_NAME="kubeagents-github-minter-gsa"
+readonly DEFAULT_LITELLM_GSA_NAME="kubeagents-litellm-gsa"
+readonly ADOPTED_RESOURCES_FILE=".adopted_resources"
 
 #
 # One argument, "readonly", suppresses the bucket creation for `plan`. A plan
@@ -151,6 +163,17 @@ tfvar() {
   printf '%s\n' "$out" | tail -1 | tr -d '"'
 }
 
+# Reads an optional input variable. If undeclared in configuration or null,
+# outputs the provided default value without failing.
+tfvar_or_default() {
+  local var_name="$1" default_val="$2" out
+  if out=$(echo "var.$var_name" | terraform console 2>/dev/null) && [[ -n "$out" && "$out" != "null" ]]; then
+    printf '%s\n' "$out" | tail -1 | tr -d '"'
+  else
+    printf '%s\n' "$default_val"
+  fi
+}
+
 # The state list is read once and matched in memory. Piping it straight into
 # `grep -q` looks equivalent but is not: grep exits at the first match, terraform
 # dies of SIGPIPE, and `set -o pipefail` reports the whole pipeline as failed — so
@@ -212,6 +235,66 @@ restore_key_versions() {
   done <<<"$versions"
 }
 
+# Returns the GCS URI for .adopted_resources if remote state is enabled.
+get_adopted_resources_gcs_uri() {
+  [[ -n "${KUBE_AGENTS_STATE_BUCKET:-}" ]] || return 1
+  local project bucket prefix
+  project=$(tfvar project_id)
+  bucket="$KUBE_AGENTS_STATE_BUCKET"
+  [[ "$bucket" == "auto" ]] && bucket="${project}-kube-agents-tfstate"
+  prefix="${KUBE_AGENTS_STATE_PREFIX:-kube-agents/$(tfvar cluster_name)}"
+  printf 'gs://%s/%s/%s\n' "$bucket" "$prefix" "$ADOPTED_RESOURCES_FILE"
+}
+
+# Loads .adopted_resources from GCS if absent locally and remote state is active.
+load_adopted_resources() {
+  local gcs_uri
+  if [[ ! -f "$ADOPTED_RESOURCES_FILE" ]] && gcs_uri=$(get_adopted_resources_gcs_uri 2>/dev/null); then
+    gcloud storage cp "$gcs_uri" "$ADOPTED_RESOURCES_FILE" >/dev/null 2>&1 || true
+  fi
+}
+
+# Records an adopted resource address into .adopted_resources and syncs to GCS.
+record_adopted() {
+  local address="$1"
+  load_adopted_resources
+  if [[ -f "$ADOPTED_RESOURCES_FILE" ]]; then
+    if ! grep -Fxq "$address" "$ADOPTED_RESOURCES_FILE"; then
+      printf '%s\n' "$address" >>"$ADOPTED_RESOURCES_FILE"
+    fi
+  else
+    printf '%s\n' "$address" >"$ADOPTED_RESOURCES_FILE"
+  fi
+
+  local gcs_uri
+  if gcs_uri=$(get_adopted_resources_gcs_uri 2>/dev/null); then
+    gcloud storage cp "$ADOPTED_RESOURCES_FILE" "$gcs_uri" >/dev/null 2>&1 || true
+  fi
+}
+
+# Forgets only those service accounts that were adopted into state from outside,
+# so destroying the composition does not delete pre-existing service accounts.
+# Resources created by Terraform itself are not in .adopted_resources and are
+# destroyed normally by `terraform destroy`.
+forget_adopted_service_accounts() {
+  load_adopted_resources
+  [[ -f "$ADOPTED_RESOURCES_FILE" ]] || return 0
+  load_state
+  local address
+  while read -r address; do
+    [[ -n "$address" ]] || continue
+    in_state "$address" || continue
+    log "forgetting adopted service account $address (pre-existed; kept in GCP so destroy does not delete it)"
+    terraform state rm "$address" >/dev/null 2>&1 ||
+      warn "could not forget adopted service account $address"
+  done <"$ADOPTED_RESOURCES_FILE"
+  rm -f "$ADOPTED_RESOURCES_FILE"
+  local gcs_uri
+  if gcs_uri=$(get_adopted_resources_gcs_uri 2>/dev/null); then
+    gcloud storage rm "$gcs_uri" >/dev/null 2>&1 || true
+  fi
+}
+
 adopt_kms() {
   local project location keyring key
   load_state
@@ -239,7 +322,7 @@ adopt_kms() {
     local minter_keyring minter_key minter_gsa
     minter_keyring=$(tfvar github_minter_kms_keyring)
     minter_key=$(tfvar github_minter_kms_key)
-    minter_gsa="kubeagents-github-minter-gsa"
+    minter_gsa="$DEFAULT_MINTER_GSA_NAME"
     targets+=(
       "module.github_minter[0].google_kms_key_ring.minter	keyring	projects/$project/locations/$location/keyRings/$minter_keyring"
       "module.github_minter[0].google_kms_crypto_key.minter	key	projects/$project/locations/$location/keyRings/$minter_keyring/cryptoKeys/$minter_key"
@@ -263,13 +346,14 @@ adopt_kms() {
   fi
 
   if [[ "$(tfvar model_provider)" == "vertex_ai" ]]; then
-    local litellm_gsa="kubeagents-litellm-gsa"
+    local litellm_gsa="$DEFAULT_LITELLM_GSA_NAME"
     targets+=(
       "module.litellm_vertex_iam[0].google_service_account.agent	service_account	projects/$project/serviceAccounts/$litellm_gsa@$project.iam.gserviceaccount.com"
     )
   fi
 
-  local agent_gsa="kubeagents-platform-gsa"
+  local agent_gsa
+  agent_gsa=$(tfvar_or_default agent_service_account_id "$DEFAULT_AGENT_GSA_NAME")
   targets+=(
     "module.kube_agents_iam.google_service_account.agent	service_account	projects/$project/serviceAccounts/$agent_gsa@$project.iam.gserviceaccount.com"
   )
@@ -309,6 +393,8 @@ adopt_kms() {
       adopted=$((adopted + 1))
       if [[ "$kind" == "key" ]]; then
         restore_key_versions "$id" "$location" "$project"
+      elif [[ "$kind" == "service_account" ]]; then
+        record_adopted "$address"
       fi
     else
       warn "could not import $address ($id); the apply will fail with a 409"
@@ -646,6 +732,7 @@ case "${1:-}" in
     purge_backups
     disable_deletion_protection
     forget_kms
+    forget_adopted_service_accounts
     log "terraform destroy"
     # deletion_protection is passed again because destroy re-evaluates the config,
     # and the variable's default would otherwise reinstate the guard.
@@ -657,7 +744,7 @@ case "${1:-}" in
     # The line range is the header comment above, so it moves whenever that
     # comment grows. It ends at the blank comment line before `set -euo
     # pipefail`.
-    sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,54p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 1
     ;;
 esac

--- a/tests/test_installer_common.py
+++ b/tests/test_installer_common.py
@@ -136,6 +136,18 @@ class InstallerCommonTest(unittest.TestCase):
         )
         self.assertIn("rc=1", proc.stdout, proc.stderr)
 
+    def test_empty_instances_managed_entry_is_not_ours(self):
+        # When a resource block exists in state with instances=[] (e.g. count=0),
+        # it has no live instances and must not be treated as managed.
+        empty_managed = _state_doc(
+            [{"mode": "managed", "type": "google_container_cluster", "name": "autopilot", "instances": []}]
+        )
+        proc = self._run(
+            'tf_state_has_cluster; echo "rc=$?"',
+            gcloud_stdout=empty_managed,
+        )
+        self.assertIn("rc=1", proc.stdout, proc.stderr)
+
     def test_unparseable_state_fails_safe(self):
         proc = self._run(
             'tf_state_has_cluster; echo "rc=$?"',

--- a/tests/test_reconcile_environment.py
+++ b/tests/test_reconcile_environment.py
@@ -189,6 +189,24 @@ class LifecyclePlanTest(unittest.TestCase):
                                  re.MULTILINE | re.DOTALL).group(1)
         self.assertIn("adopt_pubsub", apply_branch)
 
+    def test_apply_forgets_unmanaged_cluster_kms_before_adopting(self):
+        """Residual cluster KMS must be dropped from state before adopting or applying."""
+        apply_branch = re.search(r"^  apply\)$(.*?)^  destroy\)$", self.text,
+                                 re.MULTILINE | re.DOTALL).group(1)
+        forget_pos = apply_branch.index("forget_unmanaged_cluster_kms")
+        adopt_pos = apply_branch.index("adopt_kms")
+        self.assertLess(forget_pos, adopt_pos)
+
+    def test_adopt_kms_describes_service_account_by_email_or_id(self):
+        """The service account describe command strips the projects/... prefix to pass the email/id."""
+        self.assertIn('service_account) gcloud iam service-accounts describe "${id##*/}"', self.text)
+
+    def test_destroy_forgets_adopted_service_accounts(self):
+        """Pre-existing SAs adopted into state must be forgotten before terraform destroy."""
+        destroy_branch = re.search(r"^  destroy\)$(.*?)^  \*\)$", self.text,
+                                   re.MULTILINE | re.DOTALL).group(1)
+        self.assertIn("forget_adopted_service_accounts", destroy_branch)
+
     def test_the_usage_range_still_covers_the_whole_header(self):
         """The fallback branch prints a fixed line range, so a longer header truncates it."""
         printed = re.search(r"sed -n '2,(\d+)p'", self.text)


### PR DESCRIPTION
## Summary

When installing `kube-agents` onto an existing cluster, `install.sh` queries the remote Terraform state to decide whether Terraform created the cluster (`create_cluster = true`) or should adopt an external one (`create_cluster = false`). If an interrupted or dry-run apply left a managed resource record in state with an empty instances array (`"instances": []`), the installer previously concluded Terraform owned the cluster, setting `create_cluster = true` and failing with a 409 conflict. Additionally, if the Google Service Accounts (`kubeagents-platform-gsa`, `kubeagents-github-minter-gsa`, or `kubeagents-litellm-gsa`) already existed in the project, Terraform failed with a 409 conflict during apply. Furthermore, when `create_cluster` flips to `false` on a state that retained cluster KMS resources from an interrupted run, Terraform would plan their destruction. This PR fixes the cluster ownership probe, ensures unmanaged cluster KMS is forgotten rather than destroyed, adds retries for CMEK key creation during API propagation, and adds pre-existing service accounts to adoption in `lifecycle.sh`.

## Why This Change

1. Installing `kube-agents` onto an existing cluster that had an interrupted prior attempt caused `create_cluster = true` and 409 cluster creation failures.
2. Pre-existing Google Service Accounts failed during `terraform apply` with 409 creation conflicts.
3. Flipping `create_cluster` to `false` when cluster KMS resources were in state took them from `count = 1` to `count = 0`, causing Terraform to plan their destruction and schedule Cloud KMS key versions for destruction, breaking the live cluster's etcd database encryption.
4. Enabling `cloudkms.googleapis.com` in `ensure_existing_cluster_cmek` races with immediate keyring/key creation before API activation propagates.

## What Changed

- `scripts/installer/installer_common.sh`: Updated `tf_state_has_cluster` to require `len(r.get("instances", [1])) > 0` before treating a managed cluster record as managing a live cluster.
- `terraform/examples/full-install/lifecycle.sh`:
  - Added `forget_unmanaged_cluster_kms()` to forget cluster KMS resources (`gke_key[0]`, `gke_keyring[0]`, `gke_kms_binding[0]`, `gke_service_agent[0]`) from state via `terraform state rm` and restore any `DESTROY_SCHEDULED` key versions before apply when `create_cluster = false`.
  - Added `module.kube_agents_iam.google_service_account.agent`, `module.github_minter[0].google_service_account.minter`, and `module.litellm_vertex_iam[0].google_service_account.agent` to `adopt_kms()` targets so pre-existing service accounts are adopted rather than failing with 409 creation conflicts.
  - Added `forget_adopted_service_accounts()` to forget adopted pre-existing service accounts on `destroy` via `.adopted_resources` tracking (persisted to GCS state bucket) so they are kept in GCP.
  - Fixed `gcloud iam service-accounts describe` lookup to pass `${id##*/}` (the email address) instead of the full resource path.
- `install.sh`:
  - Added retry loop and validation in `ensure_existing_cluster_cmek` to handle `cloudkms.googleapis.com` API enablement propagation before creating the keyring and key.
  - Declared `CMEK_RETRY_ATTEMPTS` and `CMEK_RETRY_DELAY_SECONDS` at top of file, replacing bare literals per engineering rules.
- `INSTALL.md`: Updated teardown asymmetries descriptions (L163, L623-628) to include preserving adopted pre-existing service accounts during destroy.
- `terraform/examples/full-install/README.md`: Documented service account adoption and teardown asymmetry handling.
- `tests/test_installer_common.py`: Added unit test `test_empty_instances_managed_entry_is_not_ours`.

## Context

Observed during installation and testing on existing GKE clusters in multi-cluster environments (`standard-agent-test` and `autopilot-cluster-1`).

## Testing

- `python3 -m unittest tests/test_installer_common.py`: All 66 tests passing, including `test_empty_instances_managed_entry_is_not_ours`.
- `make docs-check`: Passed with zero warnings or errors.
- Prettier on `INSTALL.md` & `README.md`: Formatting verified.

### Live validation

Exercised against two distinct live environments:

1. **GKE Standard (`standard-agent-test` in `sergiuspiridon-gkedemos`, `us-east4-a`)**:
   - Prior interrupted apply left an empty managed entry in GCS state, causing `install.sh` to generate `create_cluster = true` and 409 on cluster creation. Pre-existing `kubeagents-platform-gsa` and `kubeagents-github-minter-gsa` caused 409 conflicts during apply.
   - Result: `install.sh` detected no live instances, setting `create_cluster = false`. `lifecycle.sh adopt-kms` cleanly adopted pre-existing GSAs via `${id##*/}`. Apply succeeded.

2. **GKE Autopilot (`autopilot-cluster-1` in `quick-test-508010`, `us-central1`)**:
   - Installed onto pre-existing Autopilot cluster with CMEK database encryption (`k8s-secret-encryption-key` in `platform-agent-keyring`).
   - Prior failed run had initialized KMS resources in state. On retry with `create_cluster = false`, `forget_unmanaged_cluster_kms` successfully removed the unmanaged cluster KMS addresses from state via `terraform state rm`, preventing key version destruction. Verified key version 1 remained in `ENABLED` state in Cloud KMS.
   - `adopt_kms` successfully verified and adopted pre-existing `kubeagents-platform-gsa` and `kubeagents-github-minter-gsa` via `${id##*/}` without 409 conflicts.
   - End-to-end install succeeded (`/tmp/kube-agents-install-report.json`: `status: SUCCESS`).
   - Workload verification in `kubeagents-system`:
     - `github-token-minter`: 2/2 Running
     - `kube-agents-controller-manager`: 1/1 Running
     - `litellm`: 2/2 Running
     - `platform-agent-credential-proxy`: 1/1 Running
     - `platform-agent-gateway`: 3/3 Running
     - `platform-agent-shell-0`: 1/1 Running
     - `PlatformAgent` CR: Phase `Ready` (`Gateway, shell sandbox and credential broker are all ready`).

- **Coverage limits & Cleanup**:
  - What was NOT covered: Did not exercise multi-project scoped cluster service account pools (`scoped_clusters`), as the live test environment uses standard single-cluster identity.
  - Artifact cleanup: Temporary provider overrides (`providers_lifecycle_override.tf`) were cleaned up via the trap; test state remains isolated to the designated test project.

## Self-Review

Passes were run in separate clean subagent contexts handed only the branch diff against `upstream/main`:

- **Adversarial review** (clean subagent context):
  - *Finding*: `gcloud iam service-accounts describe` was passed full resource ID `$id` rather than account email `${id##*/}`, causing HTTP 404 and silent skip. *Disposition*: Fixed by stripping prefix with `${id##*/}`.
  - *Finding*: `create_cluster` flipping to `false` causes Terraform to plan destruction of residual cluster KMS keys (`google_kms_crypto_key.gke_key[0]`). *Disposition*: Fixed by adding `forget_unmanaged_cluster_kms` to remove unmanaged cluster KMS from state before apply and call `restore_key_versions`.
  - *Finding*: `cloudkms.googleapis.com` enablement propagation race in `ensure_existing_cluster_cmek`. *Disposition*: Fixed by adding retry loop to keyring and key creation.
  - *Finding*: `retry 6 5` in `ensure_existing_cluster_cmek` hardcoded retry count and delay literals. *Disposition*: Fixed by declaring `CMEK_RETRY_ATTEMPTS` and `CMEK_RETRY_DELAY_SECONDS` at the top of `install.sh`.
  - *Finding*: `module.github_minter[0].google_service_account.minter` and Vertex LiteLLM GSA were omitted from targets. *Disposition*: Fixed by adding both to adoption targets.
  - *Finding*: Missing `instances` key in older state formats. *Disposition*: Handled safely using `r.get("instances", [1])`.
- **Docs-drift review** (clean subagent context):
  - *Finding*: `INSTALL.md` still stated destroy handles "four asymmetries" / "four teardown asymmetries", omitting adopted service account forgetting. *Disposition*: Fixed by updating `INSTALL.md` (L163, L623-628) to describe teardown asymmetries including preserving adopted pre-existing service accounts in GCP.
  - *Finding*: Checked `scripts/installer/README.md` and site docs for references to cluster ownership probing and GSA adoption. *Disposition*: No drift; internal state reconciliation mechanism changes do not alter documented user-facing CLI flags or configuration parameters. `make docs-check` passes cleanly.

## Risk & Rollout

Low risk. Only affects installer tfvars generation when probing GCS state and pre-apply adoption/forgetting. Protects existing cluster CMEK encryption keys from unintended destruction. Does not alter runtime agent or operator code paths.
