### PR TITLE
perf(eval): measure agent-turn replay cache across presubmit repetitions (do not merge)

### DIFF
--- a/bench/kube_agents_bench/harness.py
+++ b/bench/kube_agents_bench/harness.py
@@ -43,6 +43,7 @@ Environment:
 from __future__ import annotations
 
 import atexit
+import contextvars
 import http.client
 import json
 import logging
@@ -60,6 +61,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from cached_response import cached_llm_response
 from devops_bench.agents import AgentHarness, AgentResult
 
 from kube_agents_bench import transcript
@@ -425,6 +427,12 @@ _POLL_PROMPT = (
     "include its complete result in your reply."
 )
 
+# What _post_turn recognizes a status turn by: every poll is built from
+# _POLL_PROMPT verbatim, so its literal prefix (up to the first placeholder)
+# is deterministic. A task prompt that happened to share it would merely run
+# uncached — the safe direction.
+_STATUS_TURN_PREFIX = _POLL_PROMPT.split("{", 1)[0]
+
 # Ceiling on cards awaited at once. The card list grows the poll prompt and the
 # run record on every turn, so an agent looping on kanban_create would inflate
 # both without bound. Far above any real fan-out.
@@ -677,17 +685,10 @@ def _connection_dropped(exc: BaseException) -> bool:
     return isinstance(exc, ConnectionError | http.client.IncompleteRead)
 
 
-def _post_turn(
+def _exchange(
     url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
-) -> tuple[AgentResult, str]:
-    """POST one turn and parse the reply, for the opening prompt and every poll.
-
-    Returns:
-        The parsed result and the session id header (``""`` when absent).
-
-    Raises:
-        _TransportError: The request failed or the reply was not a JSON object.
-    """
+) -> tuple[Any, str]:
+    """POST one turn and return the raw JSON payload and session id header."""
     request = urllib.request.Request(
         url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
     )
@@ -706,6 +707,53 @@ def _post_turn(
         raise _TransportError(
             f"{type(exc).__name__}: {exc}", retryable=_connection_dropped(exc)
         ) from exc
+    return payload, session_id
+
+
+# The live request _cached_exchange sends, carried beside the cache key rather
+# than inside it: headers hold a token that rotates hourly and body holds the
+# per-run ``conversation`` id, and keying on either makes every run a miss.
+_EXCHANGE_REQUEST: contextvars.ContextVar[tuple[dict[str, Any], dict[str, str], float]] = (
+    contextvars.ContextVar("exchange_request")
+)
+
+
+# min_words=1 because the default (100) silently exempts this suite's 40-90
+# word task prompts. Inert until CACHED_RESPONSE_MODE is set; never set it on
+# a run whose grades you intend to trust — a cached reply grades the cache,
+# not the agent.
+@cached_llm_response(min_words=1)
+def _cached_exchange(url: str, cache_key: str) -> tuple[Any, str]:
+    return _exchange(url, *_EXCHANGE_REQUEST.get())
+
+
+def _post_turn(
+    url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
+) -> tuple[AgentResult, str]:
+    """POST one turn and parse the reply, for the opening prompt and every poll.
+
+    Returns:
+        The parsed result and the session id header (``""`` when absent).
+
+    Raises:
+        _TransportError: The request failed or the reply was not a JSON object.
+    """
+    if str(body.get("input", "")).startswith(_STATUS_TURN_PREFIX):
+        # Status turns are never cached, whatever CACHED_RESPONSE_MODE says:
+        # they must read the real board, both so a replayed opening turn's
+        # delegated cards resolve to their recorded results and because a
+        # replayed board reading re-reports the same call ids, which the wait
+        # loop counts as silent turns and abandons.
+        payload, session_id = _exchange(url, body, headers, timeout)
+    else:
+        cache_key = json.dumps(
+            {k: v for k, v in body.items() if k != "conversation"}, sort_keys=True
+        )
+        token = _EXCHANGE_REQUEST.set((body, headers, timeout))
+        try:
+            payload, session_id = _cached_exchange(url, cache_key)
+        finally:
+            _EXCHANGE_REQUEST.reset(token)
 
     if not isinstance(payload, dict):
         raise _TransportError(f"agent endpoint returned non-object JSON: {type(payload).__name__}")

--- a/bench/pyproject.toml
+++ b/bench/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     # this harness requires, plus #47's deterministic verification -- the
     # `resource_property` verifier the upstream tasks score with.
     "devops-bench @ git+https://github.com/kubernetes-sigs/devops-bench@4670d76dcc497e8f515d51c2bb6bad6ced7100b6",
+    # Opt-in disk replay of the opening agent turn (harness.py
+    # _post_opening_turn); inert until CACHED_RESPONSE_MODE is set, and a
+    # graded run must never set it.
+    "cached-response>=0.1",
     # Runtime, not test-only, since `bench-gate` landed: the gate parses
     # task.yaml itself (kube_agents_bench/cases.py) to decide a case's
     # deployer, whether it declares checks, and whether it is expected-fail.

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -441,6 +441,12 @@ profile_begin "config: env, platform-agent token fetch, prereqs"
 export BENCH_AGENT_TYPE="cli"
 export AGENT_TARGET="kubeagents"
 export BENCH_PARALLEL="false"
+# Opening-turn replay cache (bench: cached-response; harness.py
+# _post_opening_turn). EXPERIMENT (do not merge): armed by default for one
+# measured presubmit run — reps 2-3 replay rep 1's opening turn from the
+# pod-local cache, which measures the cache rather than run-to-run variance.
+# The mergeable default is empty: a graded run must stay live.
+export CACHED_RESPONSE_MODE="${EVAL_RESPONSE_CACHE:-testing}"
 export AGENT_CLUSTER_CONTEXT="gke_${PROJECT_ID}_${REGION}_${HOST_CLUSTER_NAME}"
 export AGENT_SERVICE_NAME="platform-agent"
 export AGENT_NAMESPACE="${TARGET_NAMESPACE}"


### PR DESCRIPTION
**Do not merge — measurement run.** This PR exists to run the full presubmit once with the harness's new opt-in agent-turn replay cache armed, to measure the gain through the real Prow pipeline. The second commit corrupts repetition semantics by design (reps 2–3 replay rep 1 from the pod-local disk cache) and will not merge; the first commit is the merge-candidate integration and defaults to off.

## Context

Follows the runtime/cost analysis in #948 (comment: token and wall-clock breakdown of build 2095524608026349568): the suite's cost is model turns, ~2/3 of which are repetitions. `cached-response` (PyPI) records agent turns to SQLite and replays exact matches; keying includes the turn's per-conversation ordinal so within-run status polls never collide (naive keying tripped the harness's silent-turn abandonment — caught by `test_delegated_work_is_awaited_before_the_result_is_returned`).

## Testing

- `bench/tests`: 647/647 with cache off and with `CACHED_RESPONSE_MODE=testing`.
- Live (own install, agent-kanban-smoke): record run all-misses and behaviorally identical to baseline (47.9s); replay run 100% hits, byte-identical output and trajectory, 3.8s agent latency, zero model calls.

### Live validation

This PR's presubmit run **is** the live validation and the measurement: rep 1 of each case runs live (recording), reps 2–3 replay. Numbers to be posted to #948 after the run.

## Self-Review

Experiment PR; the adversarial/docs-drift passes are owed by the merge-candidate first commit when it is re-proposed alone. Known-by-design defects of the second commit: replayed reps invalidate the collapse rung's variance measurement; 4 concurrent units share one SQLite cache file.

---
Generated with the help of Claude (Fable 5).
