### PR TITLE
test(operator): cap the kanban board at one worker to confirm the fan-out deadlock

### DIFF
--- a/agents/chat/config.yaml
+++ b/agents/chat/config.yaml
@@ -205,7 +205,7 @@ kanban:
   # operator writes into profile-default.overlay.yaml and the entrypoint merges
   # over this key at startup — so keep this value in step with
   # defaultKanbanMaxInProgress in platformagent_manifests.go.
-  max_in_progress: 2
+  max_in_progress: 1
 
 # Denylist applied last for every platform key — the authoritative guarantee that
 # the front door cannot touch the system. Everything except the delegation

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -691,7 +691,7 @@ const clusterProfileClassKey = "profileclass-cluster" + profileOverlaySuffix
 // can be compared against it, and so the two files can be kept in step. The one place it
 // IS rendered is frontDoorKanban, where there is no image copy to defer to: the platform
 // profile's config declares no `kanban` key at all.
-const defaultKanbanMaxInProgress = 2
+const defaultKanbanMaxInProgress = 1
 
 // defaultProfileLimits, platformProfileLimits and clusterProfileLimits read
 // spec.harness.tuning, tolerating every level being nil.


### PR DESCRIPTION
> **Not for merge.** This branch is an experiment. It exists to make the deadlock in #1252
> reproducible on demand, and it will be closed once the presubmit reports.

## Context

#1252 records that `pull-kube-agents-smoke-test` began timing out at the 360-minute ceiling
after 2026-09-04, and identifies a mechanism: `b90acf76` (#1174) changed the fan-out pattern in
`agents/platform/SOUL.md` so that a worker **keeps its own card open and polls** its children
instead of completing and being re-spawned on a fan-in card. A worker holds its dispatch slot
for as long as it runs, and the board allows two, so two waiting parents can hold both slots
while their children sit in `ready` with nothing able to dispatch them.

That mechanism has never been observed. It is a deduction from three sources:

- `k8s-operator/internal/controller/platformagent_manifests.go:732` — "under
  `kanban.max_in_progress` a single long-running worker blocks every other profile"
- `docs/site/src/content/docs/operator/platformagent-crd.md:237` — "a long-running worker holds
  its slot for the whole task"
- `agents/platform/SOUL.md` — "keep your own card open and wait for them there", polling with
  `sleep 60`

It also no longer reproduces on its own. Over 18 post-Vertex builds (972 repetitions) the hang
rate is 1.9%, against 12.0% during the affected window on a comparably quiet fleet. Every recent
build ran with at most 5 concurrent builds; the affected window had 19–20. So the condition that
made it fatal has not recurred, and waiting for it to recur is not a plan.

## What this changes

Two numbers, from 2 to 1:

- `agents/chat/config.yaml:208` — `max_in_progress`
- `k8s-operator/internal/controller/platformagent_manifests.go:694` —
  `defaultKanbanMaxInProgress`

Both, because `TestChatConfigCapsTheBoardAndWakesOnFailuresOnly` requires them to be the same
number, and because the two cover different paths: the constant is what `frontDoorKanban`
renders onto the platform profile the dispatcher reads, and the config file is what caps an
install running the image without the operator. The eval install sets no
`spec.harness.tuning.maxInProgress`, so it takes the default.

## Why one slot settles it

With one slot, a fan-out deadlocks on its own — no second concurrent fan-out required, and no
busy fleet required. The parent holds the only slot; the child cannot be dispatched until the
parent gives up. That makes the result independent of how fast the model is, which matters
because the move to Vertex AI (#1193) shortened every card and is a plausible reason the failure
stopped being fatal. Speed changes how long a wedge lasts. It does not change whether one
happens.

## What the result has to look like

**If the mechanism is real:** cases that fan out hang at close to 100%, not marginally more. The
signature to look for is cards left in `ready` that no worker ever claimed, and
`delegated tasks did not finish within 2700s` in `results.json`'s `errors`.

**If it is not:** the hang rate stays near the 1.9% baseline and the suite merely runs slower.

Slower runs alone prove nothing — halving the slots halves the parallelism, so some slowdown is
expected either way. The `ready`-never-claimed signature is what distinguishes a wedge from
ordinary queueing.

The control needs no second run: `main` at two slots is 1.9% hangs over 972 repetitions.

## Expect this presubmit to be red

That is the point of the branch. A red here is not a regression in the diff and should not be
treated as one. The run also holds an evals pool project for its duration (recent builds median
139 minutes), so this is one run, not a series.

## Testing

- **Live validation:** the presubmit run on this PR *is* the live validation — it is the
  experiment. Result will be recorded on #1252.
- `go build` / `go test` were not run locally: there is no Go toolchain on this machine. CI runs
  both. The only Go change is a constant, and the one test that pins it
  (`platformagent_manifests_test.go:4552`) asserts equality with `agents/chat/config.yaml`, which
  this branch keeps.
- The pre-PR adversarial and docs-drift passes were not run. The branch is a two-line experiment
  that will not be merged; running them would be spend against a diff nobody will review.

Generated with the help of Claude Opus 5.
