### PR TITLE
fix(installer): guard agent GSA identity against accidental replacement

### DIFF
--- a/terraform/examples/full-install/README.md
+++ b/terraform/examples/full-install/README.md
@@ -20,9 +20,10 @@ install without the interview.
 - Optionally (`enable_gke_backup_plan = true`) a scheduled
   [`gke-backup-plan`](../../modules/gke-backup-plan) for the release namespace.
 - The agent's GCP identity ([`kube-agents-iam`](../../modules/kube-agents-iam)
-  module): the `kubeagents-platform-gsa` service account, its read-only
-  project roles, and the Workload Identity binding to the
-  `kubeagents-platform-agent` KSA (see
+  module): a service account (`kubeagents-platform-gsa` by default; a second
+  install in the same project sets `agent_service_account_id` to avoid the
+  name collision), its read-only project roles, and the Workload Identity
+  binding to the `kubeagents-platform-agent` KSA (see
   [IAM roles](#iam-roles-permission_set-and-project_roles) below).
 - Optionally (`enable_google_chat = true`) the Google Chat backend
   ([`chat-pubsub`](../../modules/chat-pubsub) module): Pub/Sub topic,
@@ -130,7 +131,24 @@ plans the whole composition as new and reads as total drift. A gitignored
 `backend_override.tf` points Terraform at
 `gs://<bucket>/<prefix>`, where the prefix defaults to
 `kube-agents/<cluster_name>` (override with `KUBE_AGENTS_STATE_PREFIX`) so two
-installs in one project keep separate state. Versioning is the recovery story:
+installs in one project keep separate state. State is only half of the
+second-install story: set `agent_service_account_id` too, or the installs
+collide on the agent GSA's fixed default name halfway through the second
+install's first apply. Through the installer front doors that means a
+`TF_VAR_agent_service_account_id=...` line in `install.env` - every front
+door sources it with `set -a`, so the line persists and exports on each
+run. Do not rely on a shell `export` instead: it dies with the shell, and
+the next front-door run resolves the variable back to the default name and
+plans the GSA's destroy-and-recreate under `-auto-approve`. And do not
+hand-edit `terraform.tfvars`: install.sh, upgrade.sh and uninstall.sh
+regenerate it on every run, silently dropping the line (Terraform reads
+`TF_VAR_*` only where the file is silent, and on this key it stays silent).
+And a distinct name un-collides creation, not identity: the Workload
+Identity principal names a namespace and KSA project-wide, no cluster, so
+both installs bind the same principal and each agent can mint the other's
+GSA tokens. The `agent_service_account_id` description in `variables.tf`
+carries the limits to read before relying on this. Versioning is the
+recovery story:
 a corrupted or mistakenly-overwritten state file can be rolled back to a prior
 generation by copying it over the live object (`gcloud storage ls -a` lists the
 generations; `gcloud storage restore` is for soft-deleted objects, which is a

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -26,6 +26,10 @@
 #      Reachable on a FIRST install too: configuring the Chat app in the Cloud
 #      console creates the topic before the installer ever runs. `adopt_pubsub`
 #      imports whichever of the two is already there before applying.
+#   6. The agent GSA (account_id) is ForceNew. A lost agent_service_account_id
+#      override in install.env resolves back to the default name and plans a
+#      destructive replacement under -auto-approve. `guard_gsa_identity` refuses
+#      the apply before Terraform runs.
 #
 # Usage:
 #   ./lifecycle.sh apply    [extra terraform args...]
@@ -398,6 +402,42 @@ guard_cluster_ownership() {
   done
 }
 
+# account_id on google_service_account.agent is ForceNew, and the resource
+# carries neither create_before_destroy nor prevent_destroy. If a custom
+# override line in install.env goes missing, the next apply resolves
+# agent_service_account_id back to the module default (kubeagents-platform-gsa)
+# and plans the GSA's destruction and replacement under -auto-approve. If
+# install #1 in the same project already holds the default name, the apply
+# destroys install #2's GSA and then 409s creating the default name, leaving
+# install #2 with no identity.
+guard_gsa_identity() {
+  load_state
+  local addr="module.kube_agents_iam.google_service_account.agent"
+  in_state "$addr" || return 0
+
+  local recorded
+  recorded=$(terraform state show -no-color "$addr" 2>/dev/null |
+    sed -n 's/^ *account_id *= *"\([^"]*\)".*/\1/p' | head -1)
+  [[ -n "$recorded" ]] || return 0
+
+  local desired
+  if ! desired=$(tfvar agent_service_account_id 2>/dev/null); then
+    desired="kubeagents-platform-gsa"
+  fi
+  if [[ "$desired" == "null" || -z "$desired" ]]; then
+    desired="kubeagents-platform-gsa"
+  fi
+
+  if [[ "$recorded" != "$desired" ]]; then
+    warn "agent_service_account_id resolved to '$desired', but this state manages GSA '$recorded' ($addr)."
+    warn "Applying now would plan the service account's DESTRUCTION and recreation under -auto-approve."
+    warn "If this install uses a custom GSA name, preserve it in install.env via:"
+    warn "  TF_VAR_agent_service_account_id=\"$recorded\""
+    warn "or pass it explicitly in terraform.tfvars."
+    exit 1
+  fi
+}
+
 delete_agent_cr() {
   local namespace cluster location project names
   namespace=$(tfvar namespace)
@@ -527,6 +567,10 @@ forget_kms() {
   done
 }
 
+if [[ "${KUBE_AGENTS_SOURCE_ONLY:-false}" == "true" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 case "${1:-}" in
   adopt-kms)
     shift
@@ -560,6 +604,7 @@ case "${1:-}" in
     shift
     ensure_init
     guard_cluster_ownership
+    guard_gsa_identity
     adopt_kms
     adopt_pubsub
     log "terraform apply"

--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -652,7 +652,7 @@ case "${1:-}" in
     # The line range is the header comment above, so it moves whenever that
     # comment grows. It ends at the blank comment line before `set -euo
     # pipefail`.
-    sed -n '2,46p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '2,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit 1
     ;;
 esac

--- a/terraform/examples/full-install/main.tf
+++ b/terraform/examples/full-install/main.tf
@@ -253,10 +253,11 @@ locals {
 module "kube_agents_iam" {
   source = "../../modules/kube-agents-iam"
 
-  project_id      = var.project_id
-  namespace       = var.namespace
-  project_roles   = local.agent_project_roles
-  scoped_clusters = var.scoped_clusters
+  project_id         = var.project_id
+  namespace          = var.namespace
+  project_roles      = local.agent_project_roles
+  scoped_clusters    = var.scoped_clusters
+  service_account_id = var.agent_service_account_id
 
   # module.gke_cluster, and not only the API enablements, because the module's
   # workload_identity binding names the pool as an interpolated string
@@ -638,6 +639,11 @@ resource "helm_release" "kube_agents" {
       org     = local.github_org
       repo    = local.github_repo_name
       appId   = var.github_app_id
+      # The minty rule's only gate on platform-agent-scope is assertion.email
+      # against this value; left unset the chart falls back to the fixed
+      # kubeagents-platform-gsa name, so an install that overrides
+      # agent_service_account_id would annotate one GSA and allowlist another.
+      allowedServiceAccount = module.kube_agents_iam.service_account_email
       kms = {
         keyring = var.github_minter_kms_keyring
         key     = var.github_minter_kms_key

--- a/terraform/examples/full-install/terraform.tfvars.example
+++ b/terraform/examples/full-install/terraform.tfvars.example
@@ -47,6 +47,16 @@ api_server_key = "REPLACE_WITH_A_STRONG_RANDOM_KEY"
 # node pool to provision. enable_gvisor_node_pool must stay false there.
 # agent_runtime_class = "gvisor"
 
+# A second install in this project: the agent GSA's default name is one fixed
+# name per project, so give each install after the first its own. Two caveats:
+# the installer front doors regenerate this file on every run, so through
+# install.sh/upgrade.sh put TF_VAR_agent_service_account_id=... in install.env
+# (sourced and exported by every front door) instead of editing here; and a
+# distinct name un-collides creation, not
+# identity - both installs still bind one Workload Identity principal (see the
+# variable description in variables.tf).
+# agent_service_account_id = "kubeagents-platform-gsa-2"
+
 # Cluster tuning
 # deletion_protection = true
 # release_channel     = "REGULAR"

--- a/terraform/examples/full-install/variables.tf
+++ b/terraform/examples/full-install/variables.tf
@@ -148,6 +148,12 @@ variable "scoped_clusters" {
   default  = []
 }
 
+variable "agent_service_account_id" {
+  description = "IAM service account ID for the agent's GSA. The module default (kubeagents-platform-gsa) is one fixed name per project, so a second install in the same project must set its own — the collision otherwise surfaces as alreadyExists halfway through the second install's first apply. Null selects the module default. Two limits before relying on it: the vertex_ai and github-minter paths create their own fixed-name GSAs this variable does not reach (the minter's authorization rule does track it — the composition passes the resulting email as githubMinter.allowedServiceAccount), and the Workload Identity binding is keyed on namespace/KSA rather than on a cluster, so installs sharing the agent namespace can each mint the other's tokens — a distinct name un-collides creation, not identity."
+  type        = string
+  default     = null
+}
+
 variable "image_tag" {
   description = "Image tag for both the operator and the platform agent. Required because a checkout's Chart.yaml carries an appVersion placeholder that never matches a published image tag, so the chart's tag defaulting cannot work from a checkout. `latest` is fine for evaluation; set an `X.Y.Z` release tag for production."
   type        = string

--- a/terraform/modules/kube-agents-iam/variables.tf
+++ b/terraform/modules/kube-agents-iam/variables.tf
@@ -4,8 +4,9 @@ variable "project_id" {
 }
 
 variable "service_account_id" {
-  description = "IAM Service Account ID for Kube-Agents"
+  description = "IAM Service Account ID for Kube-Agents. Fixed per project, so a second install in the same project must set its own. Passing null selects this default (nullable = false), which lets root modules expose a passthrough variable."
   type        = string
+  nullable    = false
   default     = "kubeagents-platform-gsa"
 
   validation {

--- a/tests/test_lifecycle_script.py
+++ b/tests/test_lifecycle_script.py
@@ -1,0 +1,172 @@
+"""Unit tests for terraform/examples/full-install/lifecycle.sh.
+
+Tests safety guards in lifecycle.sh before terraform apply:
+- guard_gsa_identity: prevents accidental GSA destruction and replace-under-auto-approve
+  when agent_service_account_id override goes missing or changes against existing state.
+- guard_cluster_ownership: prevents cluster destruction when create_cluster is false
+  against a state that manages the cluster.
+"""
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_LIFECYCLE_SH = _REPO_ROOT / "terraform" / "examples" / "full-install" / "lifecycle.sh"
+
+
+class LifecycleScriptGuardTest(unittest.TestCase):
+    def _run_guard(self, func_call, state_list="", state_show="", tfvar_agent_sa="null", tfvar_create_cluster="true"):
+        """Run a lifecycle.sh function against stubbed terraform commands."""
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+
+            # Stub terraform CLI to return configured state list, state show, and console outputs
+            terraform_stub = bin_dir / "terraform"
+            terraform_stub.write_text(f"""#!/usr/bin/env bash
+set -e
+cmd="${{1:-}}"
+if [[ "$cmd" == "state" && "${{2:-}}" == "list" ]]; then
+    cat << 'EOF'
+{state_list}
+EOF
+    exit 0
+elif [[ "$cmd" == "state" && "${{2:-}}" == "show" ]]; then
+    cat << 'EOF'
+{state_show}
+EOF
+    exit 0
+elif [[ "$cmd" == "console" ]]; then
+    read -r expr
+    if [[ "$expr" == *"agent_service_account_id"* ]]; then
+        echo '{tfvar_agent_sa}'
+        exit 0
+    elif [[ "$expr" == *"create_cluster"* ]]; then
+        echo '{tfvar_create_cluster}'
+        exit 0
+    fi
+    echo 'null'
+    exit 0
+fi
+exit 0
+""")
+            terraform_stub.chmod(0o755)
+
+            script = f"""
+KUBE_AGENTS_SOURCE_ONLY=true source "{_LIFECYCLE_SH}"
+{func_call}
+"""
+            env = get_isolated_test_env(bin_dir=str(bin_dir))
+            return subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=str(_REPO_ROOT / "terraform" / "examples" / "full-install"),
+            )
+
+    def test_guard_gsa_identity_no_op_when_gsa_not_in_state(self):
+        """When GSA is not in state (first apply), guard_gsa_identity is a silent no-op."""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list="",
+            tfvar_agent_sa="null",
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stderr, "")
+
+    def test_guard_gsa_identity_passes_when_override_matches_state(self):
+        """When state has an override GSA and the run resolves the same override, apply proceeds."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """# module.kube_agents_iam.google_service_account.agent:
+resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa-2"
+    project      = "test-proj"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa='"kubeagents-platform-gsa-2"',
+        )
+        self.assertEqual(proc.returncode, 0, f"unexpected failure: {proc.stderr}")
+        self.assertEqual(proc.stderr, "")
+
+    def test_guard_gsa_identity_passes_when_default_name_matches_state(self):
+        """When state has the default GSA and variable is unset (null), apply proceeds."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """# module.kube_agents_iam.google_service_account.agent:
+resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa"
+    project      = "test-proj"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa="null",
+        )
+        self.assertEqual(proc.returncode, 0, f"unexpected failure: {proc.stderr}")
+        self.assertEqual(proc.stderr, "")
+
+    def test_guard_gsa_identity_refuses_when_override_lost_and_resolves_to_default(self):
+        """When state has override GSA but variable resolves to default, apply refuses before terraform runs."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """# module.kube_agents_iam.google_service_account.agent:
+resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa-2"
+    project      = "test-proj"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa="null",
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("agent_service_account_id resolved to 'kubeagents-platform-gsa', but this state manages GSA 'kubeagents-platform-gsa-2'", proc.stderr)
+        self.assertIn("Applying now would plan the service account's DESTRUCTION and recreation under -auto-approve.", proc.stderr)
+        self.assertIn('TF_VAR_agent_service_account_id="kubeagents-platform-gsa-2"', proc.stderr)
+
+    def test_guard_gsa_identity_refuses_when_override_differs_from_state(self):
+        """When state has one override GSA and variable resolves to a different override, apply refuses."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """# module.kube_agents_iam.google_service_account.agent:
+resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa-1"
+    project      = "test-proj"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa='"kubeagents-platform-gsa-2"',
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("agent_service_account_id resolved to 'kubeagents-platform-gsa-2', but this state manages GSA 'kubeagents-platform-gsa-1'", proc.stderr)
+        self.assertIn('TF_VAR_agent_service_account_id="kubeagents-platform-gsa-1"', proc.stderr)
+
+    def test_guard_cluster_ownership_refuses_when_create_cluster_false_against_managed_cluster(self):
+        """When create_cluster is false but state manages cluster, apply refuses destruction."""
+        state_list = "module.gke_cluster.google_container_cluster.standard[0]"
+        proc = self._run_guard(
+            "guard_cluster_ownership",
+            state_list=state_list,
+            tfvar_create_cluster='"false"',
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("create_cluster is false, but this state already manages the cluster", proc.stderr)
+        self.assertIn("Applying now would plan the cluster's DESTRUCTION", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Guards the agent's Google Service Account (GSA) against accidental destruction and replacement during `-auto-approve` applies. In `terraform/examples/full-install/lifecycle.sh`, `guard_gsa_identity` compares the `account_id` attribute recorded in Terraform state against the resolved `agent_service_account_id` variable for the run, refusing the apply before any changes are made if a missing `install.env` line or configuration drift would trigger a `ForceNew` destruction. Also declares `agent_service_account_id` in `full-install` root variables, wires it into `module.kube_agents_iam` and `githubMinter.allowedServiceAccount`, and updates `lifecycle.sh`'s usage comment line range.

## Why This Change

`account_id` on `google_service_account.agent` is `ForceNew` (`terraform/modules/kube-agents-iam/main.tf:1-5`), and the resource carries neither `create_before_destroy` nor `prevent_destroy`. When a second install in one project uses a distinct GSA name via `agent_service_account_id`, that override is supplied via `install.env` or `terraform.tfvars`. Because installer front doors (`install.sh`, `upgrade.sh`) regenerate `terraform.tfvars` without this key on each run, a missing `install.env` line causes the variable to resolve back to the default (`kubeagents-platform-gsa`).

Because `install.sh` and `upgrade.sh` apply non-interactively (`-auto-approve -input=false`), Terraform executes the plan without prompt. On a second install where install #1 holds the default GSA name, this destroys install #2's GSA and then fails with 409 attempting to recreate the default name, destroying install #2's identity and invalidating its Workload Identity and minter configurations.

`prevent_destroy` is unsuitable because it fails mid-apply during `uninstall.sh`. `guard_gsa_identity` catches the discrepancy and provides an actionable error message before Terraform runs.

## What Changed

- `terraform/examples/full-install/lifecycle.sh`:
  - Added asymmetry item 6 in header documentation.
  - Implemented `guard_gsa_identity()`:
    - Reads state address `module.kube_agents_iam.google_service_account.agent`. If not in state (e.g. first apply), no-ops cleanly.
    - Reads the `account_id` attribute from state via `terraform state show -no-color`.
    - Resolves `desired` from `tfvar agent_service_account_id` (defaulting `null` to `kubeagents-platform-gsa`).
    - If `recorded != desired`, warns with instructions to set `TF_VAR_agent_service_account_id` in `install.env` and exits `1`.
  - Added `guard_gsa_identity` call to `apply)` subcommand alongside `guard_cluster_ownership`.
  - Updated usage banner `sed` range from `2,46p` to `2,50p` to cover the expanded header without truncating help text.
  - Added `KUBE_AGENTS_SOURCE_ONLY` guard to allow test harnesses to source `lifecycle.sh` functions without executing CLI dispatch.
- `terraform/examples/full-install/variables.tf`:
  - Declared `agent_service_account_id` variable (type string, default `null`) with documentation on multi-install caveats.
- `terraform/examples/full-install/main.tf`:
  - Passed `service_account_id = var.agent_service_account_id` to `module.kube_agents_iam`.
  - Passed `allowedServiceAccount = module.kube_agents_iam.service_account_email` to `helm_release.kube_agents.values.githubMinter`.
- `terraform/modules/kube-agents-iam/variables.tf`:
  - Added `nullable = false` on `service_account_id` so passing `null` selects the module default name.
- `terraform/examples/full-install/README.md` & `terraform.tfvars.example`:
  - Documented `agent_service_account_id` and the `install.env` durable channel for multi-install setups.
- `tests/test_lifecycle_script.py`:
  - Added hermetic unit test suite covering `guard_gsa_identity` matching, mismatch refusals, missing state, and `guard_cluster_ownership`.

## Context

Closes #1303.
Related: #1123, #1239, #1283, #1273, #919.

## Testing

- `python3 -m unittest tests/test_lifecycle_script.py tests/test_reconcile_environment.py`: Passed (56/56 tests pass).
- `python3 -m unittest discover -s tests`: Passed (1,387 tests pass, 3 skipped).
- `cd k8s-operator && go test -count=1 ./...`: Passed (all operator suites pass).
- `make docs-check`: Passed (link checks, terminology, context budgets clean).
- `terraform -chdir=terraform/examples/full-install validate`: Passed.
- `terraform -chdir=terraform/modules/kube-agents-iam validate`: Passed.
- **Sabotage Verification:** Temporarily replaced `if [[ "$recorded" != "$desired" ]]` with `if false; then` in `lifecycle.sh`. `test_lifecycle_script.py` failed both mismatch refusal test cases immediately with `AssertionError: 0 != 1`.

### Live validation

- **Not live-tested against running GKE cluster:** This change modifies installer shell logic and Terraform composition variables prior to cluster provisioning; exercising the destructive GSA replacement path on a live GKE cluster would destroy active service account bindings.
- **Offline Plan & Mechanism Validation:** Verified with OpenTofu `tofu validate` and `tofu init -backend=false` across both `terraform/examples/full-install` and `terraform/modules/kube-agents-iam`. Hermetic subshell execution in `tests/test_lifecycle_script.py` verifies the exact state inspection parsing, variable resolution, and exit/refusal messages.

## Self-Review

Passes: `review-adversarial` and `review-docs-drift`, run in a fresh review session handed the diff range:

- **Undeclared root variable (adversarial, CONFIRMED, FIXED):** `guard_gsa_identity` referenced `tfvar agent_service_account_id` which was pending in #1123 but undeclared on `main`. Fixed by declaring `agent_service_account_id` in `full-install/variables.tf`, wiring it to `module.kube_agents_iam` and `githubMinter.allowedServiceAccount`, and setting `nullable = false` on `kube-agents-iam/variables.tf`.
- **Usage banner sed truncation (docs-drift, CONFIRMED, FIXED):** Asymmetry item 6 grew the header by 4 lines, causing `sed -n '2,46p'` to truncate help output and failing `test_reconcile_environment.py`. Fixed by updating range to `2,50p`.
- **Missing state handling (adversarial, CONFIRMED):** Verified that a first install without GSA in state returns early (`return 0`) without error.

## Risk & Rollout

Low risk. Default configuration remains `kubeagents-platform-gsa`. Prevents destructive replacement on multi-tenant / multi-install projects when environment variables are omitted on rerun.

*Generated with the help of Gemini.*