### PR TITLE
docs(install): a GCP project holds one Chat app, and kube-agents takes the slot

### DIFF
--- a/docs/site/src/content/docs/concepts/chatops.md
+++ b/docs/site/src/content/docs/concepts/chatops.md
@@ -17,6 +17,7 @@ Google Chat is the reference channel. Setup is automated by the install: the [`c
 
 - A **Pub/Sub topic** and **subscription** are created in the target GCP project.
 - Your Google Chat app (configured separately in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com)) publishes events to the topic.
+  A GCP project holds only one Chat app, so a project already running one cannot also run this — see [Prerequisites](/kube-agents/install/prerequisites/).
 - The Planning Agent (the pod's `default` Hermes profile) consumes the subscription through Hermes' bundled Google Chat adapter, configured by the `platforms.google_chat` block of [`agents/chat/config.yaml`](https://github.com/gke-labs/kube-agents/blob/main/agents/chat/config.yaml).
 - Environment variables `GOOGLE_CHAT_PROJECT_ID` and `GOOGLE_CHAT_SUBSCRIPTION_NAME` are wired into the pod by the operator.
 

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -83,7 +83,7 @@ On Autopilot you'll additionally need to patch the deployments to append `--lead
 
 ## Chat platform
 
-- **Google Chat** (opt-in, off by default): a GCP project with the Chat API enabled and a Chat app configured to publish events to Pub/Sub. The composition's [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic and subscription (`enable_google_chat = true`, or the installer's `--enable-google-chat`); you configure the Chat app itself in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com).
+- **Google Chat** (opt-in, but the interactive installer pre-selects it): a GCP project with the Chat API enabled and a Chat app configured to publish events to Pub/Sub. The composition's [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic and subscription (`enable_google_chat = true`, or the installer's `--enable-google-chat`); you configure the Chat app itself in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com).
 - **Slack** (opt-in): a Slack workspace where you can install a bot app and generate bot + app tokens. Follow the [Hermes Slack setup guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack). Slack is configured only if you enable it in the installer's chat menu (or set `enable_slack = true` in `terraform.tfvars`).
 
 **A GCP project holds one Chat app.** Google's rule is that "each Google Chat app that you create
@@ -91,10 +91,13 @@ requires its own Google Cloud project with the Chat API enabled" —
 [Configure the Chat API](https://developers.google.com/workspace/chat/configure-chat-api). So a
 project already running a Chat app cannot also run kube-agents' Chat integration.
 
-This only applies if you turn Chat on. It is off by default on every surface
-(`enable_google_chat`, the installer's chat menu, `googleChat.enabled`), and an install that leaves
-it off takes no slot. **Slack is unaffected** — it provisions no GCP resource at all, so a project
-whose Chat slot is already spoken for can still run kube-agents with Slack in it.
+This only applies if Chat is on, and whether it is on by default depends on which front door you
+use. Terraform and Helm both default it off — `enable_google_chat` and the chart's
+`googleChat.enabled` are `false`, so neither takes a slot unless you ask. The interactive installer
+goes the other way: its chat menu pre-selects **Google Chat**, so pressing enter at that prompt
+provisions the Chat backend. Pick "None" or Slack there if you want the project's Chat slot left
+alone. **Slack is unaffected** — it provisions no GCP resource at all, so a project whose Chat slot
+is already spoken for can still run kube-agents with Slack in it.
 
 If you do want Chat and the slot is taken, moving just the Chat backend elsewhere is not available
 through the supported paths: the chart renders the CR's `projectId` from

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -83,24 +83,26 @@ On Autopilot you'll additionally need to patch the deployments to append `--lead
 
 ## Chat platform
 
-- **Google Chat** (default): a GCP project with the Chat API enabled and a Chat app configured to publish events to Pub/Sub. The composition's [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic and subscription (`enable_google_chat = true`, or the installer's `--enable-google-chat`); you configure the Chat app itself in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com).
+- **Google Chat** (opt-in, off by default): a GCP project with the Chat API enabled and a Chat app configured to publish events to Pub/Sub. The composition's [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic and subscription (`enable_google_chat = true`, or the installer's `--enable-google-chat`); you configure the Chat app itself in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com).
 - **Slack** (opt-in): a Slack workspace where you can install a bot app and generate bot + app tokens. Follow the [Hermes Slack setup guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack). Slack is configured only if you enable it in the installer's chat menu (or set `enable_slack = true` in `terraform.tfvars`).
 
-**A GCP project can hold only one Chat app, and kube-agents takes the slot.** The Chat API's
-configuration is scoped to the project, and there is exactly one configuration per project — app
-name, avatar, description and connection settings are all singular. So a project that already runs
-a Chat app cannot also run kube-agents' Chat integration, and a project you install kube-agents
-into gives that slot up for anything else. This is a Google Chat platform limitation rather than a
-kube-agents one; see
-[Configure the Chat API](https://developers.google.com/workspace/chat/configure-chat-api).
+**A GCP project holds one Chat app.** Google's rule is that "each Google Chat app that you create
+requires its own Google Cloud project with the Chat API enabled" —
+[Configure the Chat API](https://developers.google.com/workspace/chat/configure-chat-api). So a
+project already running a Chat app cannot also run kube-agents' Chat integration.
 
-Plan for it before you pick a project, because it is awkward to discover afterwards. Two Chat apps
-means two projects, and the installer does not currently split them: the
-[`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub)
-creates the topic, the subscription and the Workspace Add-ons service identity all under one
-`project_id`, the same one holding the cluster. Pointing kube-agents at a Chat topic in a
-different project is not a supported configuration today. If the project you want the cluster in
-already has a Chat app, either install into a different project or use Slack.
+This only applies if you turn Chat on. It is off by default on every surface
+(`enable_google_chat`, the installer's chat menu, `googleChat.enabled`), and an install that leaves
+it off takes no slot. **Slack is unaffected** — it provisions no GCP resource at all, so a project
+whose Chat slot is already spoken for can still run kube-agents with Slack in it.
+
+If you do want Chat and the slot is taken, moving just the Chat backend elsewhere is not available
+through the supported paths: the chart renders the CR's `projectId` from
+`platformAgent.harness.projectId`, so the installer and the chart always put the Chat topic in the
+cluster's project. Moving the whole install is not a free swap either — the install project is the
+fleet the Platform Agent manages, and it is scoped to that one project, so relocating changes which
+clusters the agent can see. An organisation with clusters in several projects installs kube-agents
+once per project.
 
 ## LLM credentials
 

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -99,10 +99,8 @@ whose Chat slot is already spoken for can still run kube-agents with Slack in it
 If you do want Chat and the slot is taken, moving just the Chat backend elsewhere is not available
 through the supported paths: the chart renders the CR's `projectId` from
 `platformAgent.harness.projectId`, so the installer and the chart always put the Chat topic in the
-cluster's project. Moving the whole install is not a free swap either — the install project is the
-fleet the Platform Agent manages, and it is scoped to that one project, so relocating changes which
-clusters the agent can see. An organisation with clusters in several projects installs kube-agents
-once per project.
+cluster's project. That leaves installing into a project whose Chat slot is free — a choice worth
+weighing against how you want the agent's fleet scoped, not against Chat alone.
 
 ## LLM credentials
 

--- a/docs/site/src/content/docs/install/prerequisites.md
+++ b/docs/site/src/content/docs/install/prerequisites.md
@@ -86,6 +86,22 @@ On Autopilot you'll additionally need to patch the deployments to append `--lead
 - **Google Chat** (default): a GCP project with the Chat API enabled and a Chat app configured to publish events to Pub/Sub. The composition's [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic and subscription (`enable_google_chat = true`, or the installer's `--enable-google-chat`); you configure the Chat app itself in the [Chat API console](https://console.cloud.google.com/apis/api/chat.googleapis.com).
 - **Slack** (opt-in): a Slack workspace where you can install a bot app and generate bot + app tokens. Follow the [Hermes Slack setup guide](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/slack). Slack is configured only if you enable it in the installer's chat menu (or set `enable_slack = true` in `terraform.tfvars`).
 
+**A GCP project can hold only one Chat app, and kube-agents takes the slot.** The Chat API's
+configuration is scoped to the project, and there is exactly one configuration per project — app
+name, avatar, description and connection settings are all singular. So a project that already runs
+a Chat app cannot also run kube-agents' Chat integration, and a project you install kube-agents
+into gives that slot up for anything else. This is a Google Chat platform limitation rather than a
+kube-agents one; see
+[Configure the Chat API](https://developers.google.com/workspace/chat/configure-chat-api).
+
+Plan for it before you pick a project, because it is awkward to discover afterwards. Two Chat apps
+means two projects, and the installer does not currently split them: the
+[`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub)
+creates the topic, the subscription and the Workspace Add-ons service identity all under one
+`project_id`, the same one holding the cluster. Pointing kube-agents at a Chat topic in a
+different project is not a supported configuration today. If the project you want the cluster in
+already has a Chat app, either install into a different project or use Slack.
+
 ## LLM credentials
 
 Pick one at least:


### PR DESCRIPTION
## Summary

Documents a Google Chat platform limitation that constrains which GCP project you can install kube-agents into: **a project holds exactly one Chat app, and kube-agents' Chat integration takes that slot.** Adds two paragraphs to `install/prerequisites.md`.

## Why This Change

Nothing in the tree says this. `docs/designs/spec-chatops-gateway.md:235` gets closest — it lists gchat's standup path as "Cloud project, Chat API config, app published to the workspace" — and stops short of the limitation or what it implies. `install/prerequisites.md`, which is where someone choosing a project actually looks, was silent.

The consequence is concrete and hard to reverse: a project already running a Chat app cannot also run ours, and a project you install into gives up the slot for anything else. Discovering that after choosing a project and running the installer is an expensive way to learn it.

This is **pre-existing and platform-level**. It applies to the legacy Chat integration exactly as much as to the A2A gateway's adapter, so it is not a rider on any feature PR.

## What Changed

`docs/site/src/content/docs/install/prerequisites.md`, in the existing **Chat platform** section, after the Google Chat and Slack bullets:

- The limitation itself, attributed to the platform with a link to [Configure the Chat API](https://developers.google.com/workspace/chat/configure-chat-api), so a reader can tell it is Google's constraint rather than a kube-agents design choice.
- The part that **is** ours: the [`chat-pubsub` module](https://github.com/gke-labs/kube-agents/tree/main/terraform/modules/chat-pubsub) creates the topic, the subscription and the Workspace Add-ons service identity all under one `project_id` — the same one holding the cluster — so pointing kube-agents at a Chat topic in a *different* project is not a supported configuration today.
- The two ways out: install into a different project, or use Slack.

## Context

Surfaced while deciding the live-validation venue for the Google Chat adapter (#1257). That work needed to know whether a second Chat app could be registered in a project we already own; the answer is no, which is what sent the question to a shared project and made the constraint worth writing down for everyone else.

## Testing

Documentation only — no code, no rendered manifests, no behaviour.

- `make docs-check` — terminology check passed; map inventory covers all 260 tracked docs, no stale path cells; context budget unchanged at 0.0k under.
- `prettier@3.9.6 --check` (the CI pin) on the changed file — clean.

Re-run at `e329707c` (the current head) rather than at the commit the numbers above were taken from: `make docs-check` green — 293 files link-checked and all relative links resolve, terminology passed, map inventory covers all 260 tracked docs, budget 0.0k under. `prettier@3.9.6 --check` clean on both changed files.

Every factual claim in the added prose re-verified against the tree at that head, not against the earlier pass's notes:

- Default state per surface: `full-install/variables.tf:255` (`default = false`) and `charts/kube-agents/values.yaml:704` (`enabled: false`) are off. The interactive installer is **on** — see round 2 below. My first pass here checked `install.defaults.env:105`/`installer_common.sh:1320`, which govern the flag and the non-interactive paths, and mistook that for the menu.
- `platform-agent-cr.yaml:183` renders `projectId` from `.Values.platformAgent.harness.projectId` with no override, which is the whole basis for the "not available through the supported paths" sentence.
- Slack provisions no GCP resource: `local.slack_credentials` feeds `local.credentials` into the chart's Kubernetes Secret (`main.tf:111`, `:116`, `:602`), and no `google_*` resource or enabled API is keyed on `enable_slack` — `chat_apis` and `pubsub_apis` are keyed on Chat.
- The Google quotation is verbatim from the linked page, which reads "Each Google Chat app that you create requires its own Google Cloud project with the Chat API enabled." Only the leading capital changed to fit mid-sentence.

### Live validation

Not applicable: this PR changes prose in the install guide and touches no runtime surface.

## Self-Review

**Both required passes ran in fresh `general-purpose` subagent contexts that did not write the change**, each handed only the three-dot range `refs/kube-agents-base/main...HEAD` against a base fetched at the time of the run. They ran *after* this PR was opened, not before — that was the defect [@kube-agents-bot](https://github.com/kube-agents-bot) raised, it was correct, and the findings below are what running them produced. Fixes in `e3ba2fa9`, with one of them revised again in `e329707c` — see finding 4.

**`review-adversarial`** — looked for: every factual claim in the added prose verified against the repository rather than against plausibility, with the "not a supported configuration" sentence named as the most likely to be wrong; whether the remedies offered are genuinely free; whether the prose duplicates or contradicts anything already in the tree.

**`review-docs-drift`** — looked for: contradiction against `spec-chatops-gateway.md`, `concepts/chatops.md`, `quickstart-gke.mdx` and the Chat bullet directly above; whether the prose matches what `chat-pubsub` and `full-install` actually do; the right canonical home; docs-map §5 obligations; terminology; both links.

| # | Pass | Severity | Finding | Disposition |
|---|---|---|---|---|
| 1 | both | **Blocking** | "a project you install kube-agents into gives that slot up" is false — Chat is opt-in and off by default (`install.defaults.env:105`, `full-install/variables.tf:255`, `values.yaml:700`, `chatops.md:8`). The adversarial pass added that the paragraph then **contradicted itself**, offering "or use Slack" as a remedy ten lines later, which only works if an install *can* avoid taking the slot. | Fixed, then corrected again in round 2. The finding was right that a stock Terraform or Helm install takes no slot, but `install.defaults.env:105` was read as covering the installer menu, which it does not. |
| 2 | adversarial | Should-fix | The stated reason was wrong, and disprovable by opening the module the sentence links to: `chat-pubsub` has no relationship to the cluster — `project_id` is a free input, and "the same one holding the cluster" is a property of one *caller*. The real constraint is `platform-agent-cr.yaml:183`, which renders `projectId` from `platformAgent.harness.projectId` with no override. | Fixed. Names the chart. "Not a supported configuration" softened to what the tree shows, since the CRD field is free-form and only the chart and installer pin it. |
| 3 | both | Should-fix | The enumeration of what `chat-pubsub` creates named the Workspace Add-ons identity and omitted the **Chat API** one — whose absence makes Google deliver zero events silently, per the module's own `IMPORTANT` comment and README. | Fixed by **deleting the enumeration**, not completing it: an incomplete list here is worse than none, and the module README owns the complete one. Also retires finding 6. |
| 4 | adversarial | Should-fix | "Install into a different project" was offered as a neutral remedy and is not one — the install project **is** the fleet the Platform Agent manages, scoped to that one project (`kube-agents-iam/main.tf:54-68`, `architecture/02:280`, `architecture/03:114`, `multi-project-scope.md:52`), so relocating trades the collision for a silent scope change. | Fixed twice. `e3ba2fa9` stated the scope consequence; `e329707c` removed the claim instead. It was a supporting claim reached for outside the area this PR verified, and the pass validated it against `architecture/02`, `architecture/03` and `multi-project-scope.md` — all documents. A pass checking prose against prose cannot catch prose going stale. The page now points at fleet scope as a consideration without asserting what the scope rules are. |
| 5 | both | Should-fix | The citation supported the claim only by inversion: Google's page never says one app per project, it says *each app requires its own project*. A reader clicking to verify finds nothing matching the prose. | Fixed. Quotes Google's sentence in its own direction. |
| 6 | both | Nit | Same module link twice, thirteen lines apart, with two different incomplete enumerations (`AGENTS.md:173`, `:197`). | Fixed by finding 3's deletion. |
| 7 | both | Nit | `concepts/chatops.md` gained no pointer, and it is where a reader enabling Chat *after* install lands. | Fixed. One cross-reference line, linking rather than restating. |
| 8 | adversarial | Nit | "a Google Chat platform limitation rather than a kube-agents one" is the "not X, but Y" antithesis `AGENTS.md:210` rules out. | Fixed. Removed. |

**Out of range, fixed anyway:** the Google Chat bullet above the addition was labelled **(default)**, contradicting all four sources in finding 1. Untouched by the original diff, but this PR built a "plan your project around it" argument on top of that label, so leaving it would have left the section incoherent. Now "(opt-in, off by default)".

**Not covered, stated rather than implied:** neither pass rendered the Starlight site (`npm run build` needs a cold `npm ci` for plain prose with no frontmatter change); neither tested a cross-project Chat topic against live GCP, so finding 2's cross-project reasoning comes from the CRD field, the module's free `project_id` and Pub/Sub's IAM model, not from an apply; and the Google platform claim rests on fetching their documentation, not a live console.

### Round 2 — `kube-agents-bot` on `e329707c`

One Medium, and it was correct: **"off by default on every surface" was wrong for the installer's chat menu.** Verified against the source rather than taken on trust, and then proven by execution.

On an interactive install `chat_choice` is deliberately left empty — the guard that sets it to `4` runs only when non-interactive or there is no controlling tty (`install.sh:2461-2474`). `prompt_menu` then computes `default_choice="${!var_name:-1}"` (`install.sh:1347`), and option 1 is "Google Chat (Pub/Sub Event Streaming)", whose arm sets `google_chat_enabled="true"`. Pressing enter at that prompt provisions the Chat backend and takes the project's Chat slot.

Proven by running the shipped function, not by reading it: `prompt_menu` extracted verbatim from `install.sh` and executed returns option 1 for an empty `chat_choice` and option 4 for a preset `chat_choice=4`. The other half — that the interactive path leaves it empty — is the guard above, and the code's own comment says so ("Left unset when there IS someone to ask, so prompt_menu falls back to option 1 for a first install exactly as it used to").

This cuts against round 1's finding 1 rather than merely adding to it. `DEFAULT_GOOGLE_CHAT_ENABLED="false"` is real, but it governs the flag and the non-interactive paths, and both round 1's pass and my own re-verification above read it as covering the menu. The page now splits the answer by front door: Terraform and Helm default off, the interactive installer pre-selects Chat, and it says to pick "None" or Slack at that prompt to leave the slot alone. The bullet's label is now "(opt-in, but the interactive installer pre-selects it)".

Fix in `f14f3bbf`. `make docs-check` and `prettier@3.9.6 --check` green after it.

## Risk & Rollout

No runtime effect. The worst case is that the wording is wrong, which a reader correcting us costs nothing. Reverting is a revert.



