### PR TITLE
fix(build): parameterize a2a gateway base images and tie to a2a/go.mod (#1330)

### DIFF
--- a/a2a/Dockerfile.gateway
+++ b/a2a/Dockerfile.gateway
@@ -10,7 +10,21 @@
 # Build from the a2a/ module root:
 #   docker build -f Dockerfile.gateway -t <registry>/gateway:<tag> .
 
-FROM golang:1.27 AS build
+# Bases come from images.json, the repo's image inventory, spelled the way
+# k8s-operator/Dockerfile spells them so `make mirror-images` and the pinning
+# there cover this build too. Note the distroless repository: images.json pins
+# gcr.io/distroless/static, not static-debian12, which is a different
+# repository and therefore a different pin.
+ARG GOLANG_IMAGE=golang
+ARG GOLANG_VERSION=1.27-alpine
+ARG DISTROLESS_IMAGE=gcr.io/distroless/static
+ARG DISTROLESS_VERSION=nonroot
+
+FROM ${GOLANG_IMAGE}:${GOLANG_VERSION} AS build
+# Refuse to download a toolchain the pin above does not name: without this, a
+# substituted GOLANG_IMAGE older than a2a/go.mod's `go` directive silently
+# fetches a newer one instead of failing the build (#1138).
+ENV GOTOOLCHAIN=local
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -18,7 +32,7 @@ COPY . .
 RUN CGO_ENABLED=0 go build -trimpath -o /out/gateway ./cmd/gateway
 
 # Distroless nonroot matches the Deployment's runAsNonRoot/runAsUser posture.
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM ${DISTROLESS_IMAGE}:${DISTROLESS_VERSION}
 COPY --from=build /out/gateway /gateway
 USER nonroot
 ENTRYPOINT ["/gateway"]

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -74,7 +74,6 @@ Needed only to rebuild the images above from source, not to run an install. Each
 | `golang` | `docker.io/library/golang` | `1.27-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile, k8s-operator/Dockerfile and a2a/Dockerfile.gateway builder stages. |
 | `python` | `docker.io/library/python` | `3.14-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile and deploy/sandbox/Dockerfile. |
 | `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile and a2a/Dockerfile.gateway runtime stages. |
-| `node` | `docker.io/library/node` | `22-slim` | `NODE_IMAGE` | a2a/Dockerfile.worker runtime stage. |
 | `busybox` | `docker.io/library/busybox` | `musl@sha256:32b5cdad7cce41dfd53d0ae06baebcf8357a147ee7694dc706911c373bc30c37` | — | agentplugins/*/Dockerfile base images. |
 
 <!-- prettier-ignore-end -->

--- a/docs/site/src/content/docs/deploy/docker-images.md
+++ b/docs/site/src/content/docs/deploy/docker-images.md
@@ -71,9 +71,10 @@ Needed only to rebuild the images above from source, not to run an install. Each
 | ----- | ------------------ | --- | -------- | --------- |
 | `hermes-agent` | `docker.io/nousresearch/hermes-agent` | `HERMES_AGENT_TAG` in [`tags.env`](https://github.com/gke-labs/kube-agents/blob/main/tags.env) | `HERMES_AGENT_IMAGE` | deploy/docker/Dockerfile (agent-base stage). |
 | `envoy` | `docker.io/envoyproxy/envoy` | `v1.39.1` | `ENVOY_IMAGE` | deploy/docker/Dockerfile (envoy-bin stage). |
-| `golang` | `docker.io/library/golang` | `1.27-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages. |
+| `golang` | `docker.io/library/golang` | `1.27-alpine` | `GOLANG_IMAGE` | deploy/docker/Dockerfile, k8s-operator/Dockerfile and a2a/Dockerfile.gateway builder stages. |
 | `python` | `docker.io/library/python` | `3.14-slim` | `PYTHON_IMAGE` | examples/inference-replay/replay-proxy/Dockerfile and deploy/sandbox/Dockerfile. |
-| `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile runtime stage. |
+| `distroless-static` | `gcr.io/distroless/static` | `nonroot` | `DISTROLESS_IMAGE` | k8s-operator/Dockerfile and a2a/Dockerfile.gateway runtime stages. |
+| `node` | `docker.io/library/node` | `22-slim` | `NODE_IMAGE` | a2a/Dockerfile.worker runtime stage. |
 | `busybox` | `docker.io/library/busybox` | `musl@sha256:32b5cdad7cce41dfd53d0ae06baebcf8357a147ee7694dc706911c373bc30c37` | — | agentplugins/*/Dockerfile base images. |
 
 <!-- prettier-ignore-end -->

--- a/hack/check-image-inventory.sh
+++ b/hack/check-image-inventory.sh
@@ -112,16 +112,6 @@ check_base_image python deploy/sandbox/Dockerfile PYTHON_IMAGE PYTHON_VERSION
 check_base_image golang a2a/Dockerfile.gateway GOLANG_IMAGE GOLANG_VERSION
 check_base_image distroless-static a2a/Dockerfile.gateway DISTROLESS_IMAGE DISTROLESS_VERSION
 
-if [ -f a2a/Dockerfile.authcallout ]; then
-  check_base_image golang a2a/Dockerfile.authcallout GOLANG_IMAGE GOLANG_VERSION
-  check_base_image distroless-static a2a/Dockerfile.authcallout DISTROLESS_IMAGE DISTROLESS_VERSION
-fi
-
-if [ -f a2a/Dockerfile.worker ]; then
-  check_base_image golang a2a/Dockerfile.worker GOLANG_IMAGE GOLANG_VERSION
-  check_base_image node a2a/Dockerfile.worker NODE_IMAGE NODE_VERSION
-fi
-
 # The Go builder and k8s-operator/go.mod's `go` directive must name the same
 # major.minor: a builder behind the directive fails the image build (the
 # official golang image sets GOTOOLCHAIN=local, and the Dockerfiles repeat it so
@@ -171,14 +161,6 @@ check_go_directive() {
 check_go_directive deploy/docker/Dockerfile GOLANG_VERSION
 check_go_directive k8s-operator/Dockerfile GOLANG_VERSION
 check_go_directive a2a/Dockerfile.gateway GOLANG_VERSION a2a/go.mod
-
-if [ -f a2a/Dockerfile.authcallout ]; then
-  check_go_directive a2a/Dockerfile.authcallout GOLANG_VERSION a2a/go.mod
-fi
-
-if [ -f a2a/Dockerfile.worker ]; then
-  check_go_directive a2a/Dockerfile.worker GOLANG_VERSION a2a/go.mod
-fi
 
 # hermes-agent is the one base image whose tag lives outside the Dockerfile —
 # the release workflows read tags.env — so the inventory points at that file

--- a/hack/check-image-inventory.sh
+++ b/hack/check-image-inventory.sh
@@ -109,6 +109,18 @@ check_base_image golang k8s-operator/Dockerfile GOLANG_IMAGE GOLANG_VERSION
 check_base_image distroless-static k8s-operator/Dockerfile DISTROLESS_IMAGE DISTROLESS_VERSION
 check_base_image python examples/inference-replay/replay-proxy/Dockerfile PYTHON_IMAGE PYTHON_VERSION
 check_base_image python deploy/sandbox/Dockerfile PYTHON_IMAGE PYTHON_VERSION
+check_base_image golang a2a/Dockerfile.gateway GOLANG_IMAGE GOLANG_VERSION
+check_base_image distroless-static a2a/Dockerfile.gateway DISTROLESS_IMAGE DISTROLESS_VERSION
+
+if [ -f a2a/Dockerfile.authcallout ]; then
+  check_base_image golang a2a/Dockerfile.authcallout GOLANG_IMAGE GOLANG_VERSION
+  check_base_image distroless-static a2a/Dockerfile.authcallout DISTROLESS_IMAGE DISTROLESS_VERSION
+fi
+
+if [ -f a2a/Dockerfile.worker ]; then
+  check_base_image golang a2a/Dockerfile.worker GOLANG_IMAGE GOLANG_VERSION
+  check_base_image node a2a/Dockerfile.worker NODE_IMAGE NODE_VERSION
+fi
 
 # The Go builder and k8s-operator/go.mod's `go` directive must name the same
 # major.minor: a builder behind the directive fails the image build (the
@@ -124,36 +136,49 @@ check_base_image python deploy/sandbox/Dockerfile PYTHON_IMAGE PYTHON_VERSION
 # first RUN: it is the only guard left once a mirror has frozen the patch, and
 # nothing else would notice a reshuffle moving it out of that stage or below the
 # `go build` it has to precede.
+# The third argument is the module whose `go` directive the builder is tied to.
+# It defaults to the operator's because that was the only Go image here for a
+# long time; a2a/ is a second module with its own go.mod, and pinning its
+# builder against the operator's directive would pass while the two drift.
 check_go_directive() {
-  local dockerfile=$1 version_arg=$2
+  local dockerfile=$1 version_arg=$2 go_mod=${3:-$GO_MOD}
   local builder_tag directive builder_ver builder_mm directive_mm
   awk -v img="\${$GOLANG_IMAGE_ARG}" '/^FROM / { in_stage = index($0, img) > 0; next } /^RUN / { in_stage = 0 } in_stage' "$dockerfile" |
     grep -qx "$GOTOOLCHAIN_PIN" ||
     fail "$dockerfile: no line exactly '$GOTOOLCHAIN_PIN' between the FROM \${$GOLANG_IMAGE_ARG} line and that stage's first RUN, so a substituted $GOLANG_IMAGE_ARG without that default downloads a toolchain the pin does not name instead of failing."
   builder_tag="$(arg_default "$dockerfile" "$version_arg")"
-  directive="$(sed -n 's/^go[[:space:]][[:space:]]*\([0-9][0-9A-Za-z.]*\).*$/\1/p' "$GO_MOD" | head -n1)"
+  directive="$(sed -n 's/^go[[:space:]][[:space:]]*\([0-9][0-9A-Za-z.]*\).*$/\1/p' "$go_mod" | head -n1)"
   [ -n "$directive" ] || {
-    fail "$GO_MOD has no 'go' directive, so nothing pins the toolchain the operator builds with."
+    fail "$go_mod has no 'go' directive, so nothing pins the toolchain that module builds with."
     return
   }
   builder_ver="$(sed -n 's/^\([0-9][0-9A-Za-z.]*\).*$/\1/p' <<<"$builder_tag")"
   builder_mm="$(sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' <<<"$builder_ver")"
   directive_mm="$(sed -n 's/^\([0-9][0-9]*\.[0-9][0-9]*\).*$/\1/p' <<<"$directive")"
   [ -n "$builder_mm" ] || {
-    fail "$dockerfile: ARG $version_arg defaults to '${builder_tag:-<unset>}', which does not name a Go major.minor, so nothing ties the builder to the 'go $directive' directive in $GO_MOD."
+    fail "$dockerfile: ARG $version_arg defaults to '${builder_tag:-<unset>}', which does not name a Go major.minor, so nothing ties the builder to the 'go $directive' directive in $go_mod."
     return
   }
   [ "$builder_mm" = "$directive_mm" ] || {
-    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_mm), but $GO_MOD says 'go $directive' (Go $directive_mm). Move both together: a go.mod ahead of the builder fails the image build, a builder ahead of go.mod ships a compiler the directive does not name."
+    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_mm), but $go_mod says 'go $directive' (Go $directive_mm). Move both together: a go.mod ahead of the builder fails the image build, a builder ahead of go.mod ships a compiler the directive does not name."
     return
   }
   [ "$builder_ver" = "$builder_mm" ] ||
     [ "$(printf '%s\n%s\n' "$directive" "$builder_ver" | sort -V | head -n1)" = "$directive" ] ||
-    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_ver), below the 'go $directive' floor in $GO_MOD, so the image build fails under $GOTOOLCHAIN_PIN."
+    fail "$dockerfile: ARG $version_arg defaults to '$builder_tag' (Go $builder_ver), below the 'go $directive' floor in $go_mod, so the image build fails under $GOTOOLCHAIN_PIN."
 }
 
 check_go_directive deploy/docker/Dockerfile GOLANG_VERSION
 check_go_directive k8s-operator/Dockerfile GOLANG_VERSION
+check_go_directive a2a/Dockerfile.gateway GOLANG_VERSION a2a/go.mod
+
+if [ -f a2a/Dockerfile.authcallout ]; then
+  check_go_directive a2a/Dockerfile.authcallout GOLANG_VERSION a2a/go.mod
+fi
+
+if [ -f a2a/Dockerfile.worker ]; then
+  check_go_directive a2a/Dockerfile.worker GOLANG_VERSION a2a/go.mod
+fi
 
 # hermes-agent is the one base image whose tag lives outside the Dockerfile —
 # the release workflows read tags.env — so the inventory points at that file

--- a/images.json
+++ b/images.json
@@ -203,15 +203,6 @@
       "description": "Runtime base for the operator image."
     },
     {
-      "name": "node",
-      "origin": "build-time",
-      "repository": "docker.io/library/node",
-      "tag": "22-slim",
-      "buildArg": "NODE_IMAGE",
-      "pulledBy": "a2a/Dockerfile.worker runtime stage.",
-      "description": "Runtime base for the A2A session worker image."
-    },
-    {
       "name": "busybox",
       "origin": "build-time",
       "repository": "docker.io/library/busybox",

--- a/images.json
+++ b/images.json
@@ -181,7 +181,7 @@
       "repository": "docker.io/library/golang",
       "tag": "1.27-alpine",
       "buildArg": "GOLANG_IMAGE",
-      "pulledBy": "deploy/docker/Dockerfile and k8s-operator/Dockerfile builder stages.",
+      "pulledBy": "deploy/docker/Dockerfile, k8s-operator/Dockerfile and a2a/Dockerfile.gateway builder stages.",
       "description": "Go toolchain for the operator and k8s-event-watcher builds."
     },
     {
@@ -199,8 +199,17 @@
       "repository": "gcr.io/distroless/static",
       "tag": "nonroot",
       "buildArg": "DISTROLESS_IMAGE",
-      "pulledBy": "k8s-operator/Dockerfile runtime stage.",
+      "pulledBy": "k8s-operator/Dockerfile and a2a/Dockerfile.gateway runtime stages.",
       "description": "Runtime base for the operator image."
+    },
+    {
+      "name": "node",
+      "origin": "build-time",
+      "repository": "docker.io/library/node",
+      "tag": "22-slim",
+      "buildArg": "NODE_IMAGE",
+      "pulledBy": "a2a/Dockerfile.worker runtime stage.",
+      "description": "Runtime base for the A2A session worker image."
     },
     {
       "name": "busybox",

--- a/tests/test_check_image_inventory_go_directive.py
+++ b/tests/test_check_image_inventory_go_directive.py
@@ -26,6 +26,7 @@ _LIFTED_FUNCTIONS = ("fail", "arg_default", "check_go_directive")
 _CALL_SITES = (
     "check_go_directive deploy/docker/Dockerfile GOLANG_VERSION",
     "check_go_directive k8s-operator/Dockerfile GOLANG_VERSION",
+    "check_go_directive a2a/Dockerfile.gateway GOLANG_VERSION a2a/go.mod",
 )
 
 # What the check requires of the builder stage besides the ARG default, and
@@ -152,10 +153,30 @@ class CheckGoDirectiveTest(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_script_calls_the_check_for_both_dockerfiles(self):
+    def test_script_calls_the_check_for_dockerfiles(self):
         text = _SCRIPT.read_text()
         for call in _CALL_SITES:
             self.assertIn(call, text)
+
+    def test_custom_go_mod_path_respected(self):
+        text = _SCRIPT.read_text()
+        functions = "".join(_lift(name, text) for name in _LIFTED_FUNCTIONS)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = pathlib.Path(tmp)
+            (root / "custom.mod").write_text("module example.com/y\n\ngo 1.27.0\n")
+            (root / "go.mod").write_text("module example.com/x\n\ngo 1.28.0\n")
+            (root / "Dockerfile").write_text(_dockerfile("1.27-alpine"))
+            script = (
+                "set -u\nstatus=0\nGO_MOD=go.mod\nGOLANG_IMAGE_ARG=GOLANG_IMAGE\n"
+                f"GOTOOLCHAIN_PIN='{_TOOLCHAIN_PIN}'\n"
+                + functions
+                + "check_go_directive Dockerfile GOLANG_VERSION custom.mod\nexit $status\n"
+            )
+            result = subprocess.run(
+                ["bash", "-c", script], cwd=root, capture_output=True, text=True, check=False
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stderr, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Parameterizes base images in `a2a/Dockerfile.gateway`, updates `images.json` inventory annotations, and enforces base-image pinning and toolchain consistency for `a2a` in `hack/check-image-inventory.sh` and `tests/test_check_image_inventory_go_directive.py`.

## Why This Change

1. `a2a/Dockerfile.gateway` hardcoded `FROM golang:1.27 AS build` and `FROM gcr.io/distroless/static-debian12:nonroot`, bypassing `images.json` pinning and `make mirror-images`.
2. Using `static-debian12` introduced an unpinned second repository instead of the repository-standard `gcr.io/distroless/static:nonroot`.
3. Without `ENV GOTOOLCHAIN=local`, building `a2a/Dockerfile.gateway` was vulnerable to the #1138 silent toolchain swap under base image substitution.
4. `hack/check-image-inventory.sh` had no checks for `a2a/Dockerfile.gateway` base images, and `check_go_directive` assumed a single global `k8s-operator/go.mod` path rather than supporting module-specific `go.mod` directives for multi-module subdirectories (`a2a/go.mod`).

## What Changed

- **`a2a/Dockerfile.gateway`**:
  - Added `ARG GOLANG_IMAGE=golang`, `ARG GOLANG_VERSION=1.27-alpine`, `ARG DISTROLESS_IMAGE=gcr.io/distroless/static`, and `ARG DISTROLESS_VERSION=nonroot` with defaults matching `images.json`.
  - Added `ENV GOTOOLCHAIN=local` to the Go builder stage immediately after `FROM`.
  - Moved the runtime stage from `gcr.io/distroless/static-debian12:nonroot` to `${DISTROLESS_IMAGE}:${DISTROLESS_VERSION}` (`gcr.io/distroless/static:nonroot`).
- **`images.json`**:
  - Updated `pulledBy` fields for `golang` and `distroless-static` to include `a2a/Dockerfile.gateway`.
- **`hack/check-image-inventory.sh`**:
  - Added `check_base_image` calls for `a2a/Dockerfile.gateway` against `golang` and `distroless-static`.
  - Generalized `check_go_directive` to accept an optional third argument for the module-specific `go.mod` path (`local go_mod=${3:-$GO_MOD}`).
  - Added `check_go_directive a2a/Dockerfile.gateway GOLANG_VERSION a2a/go.mod`.
- **`docs/site/src/content/docs/deploy/docker-images.md`**:
  - Regenerated via `make docs-generate` to reflect the updated `pulledBy` consumers for `golang` and `distroless-static`.
- **`tests/test_check_image_inventory_go_directive.py`**:
  - Added `check_go_directive a2a/Dockerfile.gateway GOLANG_VERSION a2a/go.mod` to `_CALL_SITES`.
  - Added `test_custom_go_mod_path_respected` verifying that a custom `go.mod` path is respected and checked by `check_go_directive`.

## Context

- Addresses #1330.
- Note on `Dockerfile.worker` and `node`: issue #1330 also referenced `Dockerfile.worker` and `node:22-slim`. Because `a2a/Dockerfile.worker` is introduced in pending PR #1258 rather than present on `main`, inventory entries and checks for `node` and `Dockerfile.worker` belong in #1258 when that file lands, avoiding speculative unverified inventory entries.

## Testing

- `./hack/check-image-inventory.sh`:
  ```
  Image inventory check passed: images.json matches every pin, the Go builder pin matches k8s-operator/go.mod, and the chart mirrors cleanly.
  ```
- `make docs-check`:
  ```
  Checked relative links in 295 Markdown files.
  All relative links resolve.
  Checking terminology across 295 documentation files...
  Terminology check passed.
  Documentation map inventory covers all 262 tracked docs (263 counting the map itself), no stale path cells, no re-aligned table rows (32 root-level dot-directory tooling files exempt).
  Always-loaded instruction files total 38.0k chars (AGENTS.md 37.8k, CLAUDE.md 0.2k), 0.0k under the 38,000-char budget.
  ```
- `python3 -m unittest tests/test_check_image_inventory_go_directive.py`:
  ```
  Ran 10 tests in 0.428s
  OK
  ```
- `python3 -m unittest discover -s tests`:
  ```
  Ran 1461 tests in 89.998s
  OK (skipped=3)
  ```
- `cd a2a && go test -count=1 ./...`:
  ```
  ok  	github.com/gke-labs/kube-agents/a2a/cmd/a2a	0.007s
  ok  	github.com/gke-labs/kube-agents/a2a/gateway	18.540s
  ok  	github.com/gke-labs/kube-agents/a2a/hermes-bridge	10.634s
  ok  	github.com/gke-labs/kube-agents/a2a/lib	3.197s
  ok  	github.com/gke-labs/kube-agents/a2a/profiles	0.009s
  ```
- `cd k8s-operator && go test -count=1 ./...`:
  ```
  ok  	github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1	0.072s
  ok  	github.com/gke-labs/kube-agents/k8s-operator/cmd/k8s-event-watcher	0.055s
  ok  	github.com/gke-labs/kube-agents/k8s-operator/internal/controller	7.030s
  ok  	github.com/gke-labs/kube-agents/k8s-operator/internal/testing	0.478s
  ok  	github.com/gke-labs/kube-agents/k8s-operator/internal/webhook	0.212s
  ```

### Live validation

Not live-tested against a live Kubernetes cluster because this change modifies only build-time image inventory metadata, Dockerfile ARG parameterization, documentation, and local inventory validation scripts; no Kubernetes CRDs, controllers, runtime manifests, or cluster-deployed workloads are changed.

Verification was conducted via test doubles and sabotage verification:
- **Sabotage Test 1 (Omitted ARGs)**: Reverting `a2a/Dockerfile.gateway` to hardcoded base images causes `make images-check` to fail immediately on missing ARG defaults.
- **Sabotage Test 2 (Missing GOTOOLCHAIN=local)**: Removing `ENV GOTOOLCHAIN=local` causes `make images-check` to fail with `no line exactly 'ENV GOTOOLCHAIN=local'`.
- **Sabotage Test 3 (Custom go.mod drift)**: Verified in `test_custom_go_mod_path_respected` that `check_go_directive` enforces the version floor of the specified `go.mod` (`custom.mod`) rather than only `k8s-operator/go.mod`.

## Self-Review

Pre-PR review was conducted via an isolated subagent context (`deleg_627eb0fc`) handed only the diff range `upstream/main...HEAD`.

- **Adversarial Pass**:
  - *Looked for*: Speculative or dead inventory entries, missing ARG declarations, `ENV GOTOOLCHAIN` placement, base image drift between `images.json` and Dockerfiles, and edge cases in `check_go_directive`'s path handling.
  - *Found*: Confirmed that removing speculative `node` inventory entries and `Dockerfile.worker`/`Dockerfile.authcallout` conditional blocks leaves clean, non-dead validation on tree-present files. Confirmed `ENV GOTOOLCHAIN=local` is strictly positioned between `FROM` and first `RUN` stage. Noted informational descriptions in `images.json` omit mentioning gateway, which is non-functional.
  - *Disposition*: All invariants passed.
- **Docs-Drift Pass**:
  - *Looked for*: Stale generated documentation tables in `docs/site/src/content/docs/deploy/docker-images.md`, documentation map consistency across tracked docs, and instruction character budget constraints.
  - *Found*: `docs/site/src/content/docs/deploy/docker-images.md` was regenerated to match `images.json` `pulledBy` fields. `python3 scripts/check_docs_map.py` verified all 262 tracked docs are covered with 0 drift.
  - *Disposition*: Clean pass.

## Risk & Rollout

- **Risk**: Very low. `a2a/Dockerfile.gateway` switches runtime base from `gcr.io/distroless/static-debian12:nonroot` to `gcr.io/distroless/static:nonroot`, which is identical for statically-compiled Go binaries (both are nonroot uid 65532 distroless static environments) while eliminating repository fragmentation.
- **Rollout**: Included in subsequent A2A gateway container builds. Reverting is reverting the commit.

Closes #1330

*Generated with the help of Gemini.*