### PR TITLE
test(release): make the mock helm read --password-stdin so the login pipeline cannot take SIGPIPE

### DIFF
--- a/tests/test_publish_helm_chart.py
+++ b/tests/test_publish_helm_chart.py
@@ -399,6 +399,38 @@ class PublishHelmChartScriptTest(unittest.TestCase):
         finally:
             temp_dir.cleanup()
 
+    def test_mock_helm_registry_login_reads_the_password_from_stdin(self):
+        """The mock must consume --password-stdin the way real helm does.
+
+        publish_helm_chart.sh runs `printf token | helm registry login
+        --password-stdin` under `set -o pipefail`. A mock that exits without
+        reading stdin races the writer: when helm wins, printf takes SIGPIPE and
+        the pipeline reports failure. That was an intermittent CI red in the
+        CI-mode tests above. The sleep makes the race deterministic -- helm has
+        certainly exited before the write unless it is waiting on stdin.
+        """
+        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        try:
+            bin_dir = pathlib.Path(temp_dir.name) / "bin"
+            helm_path, _ = create_mock_helm_binary(bin_dir)
+            proc = subprocess.run(
+                [
+                    "bash",
+                    "-o",
+                    "pipefail",
+                    "-c",
+                    '(sleep 0.5; printf "%s" "$1") | "$2" registry login ghcr.io -u user --password-stdin',
+                    "_",
+                    MOCK_GH_TOKEN,
+                    str(helm_path),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+        finally:
+            temp_dir.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testing/release.py
+++ b/tests/testing/release.py
@@ -267,7 +267,7 @@ exit 1
 
 
 def create_mock_helm_binary(bin_dir, log_file=None, fail_lint=False, fail_package=False, fail_push=False):
-    """Creates a mock helm CLI supporting lint, package, and push commands."""
+    """Creates a mock helm CLI supporting lint, package, push, and registry login commands."""
     bin_path = pathlib.Path(bin_dir)
     bin_path.mkdir(parents=True, exist_ok=True)
     helm_path = bin_path / "helm"
@@ -279,6 +279,18 @@ def create_mock_helm_binary(bin_dir, log_file=None, fail_lint=False, fail_packag
 
     content = f"""#!/bin/sh
 echo "mock helm: $@" >> "{log_path}"
+if [ "$1" = "registry" ] && [ "$2" = "login" ]; then
+  # The real helm reads the password from stdin when --password-stdin is
+  # given. A mock that exits without reading it races the writer: under
+  # `set -o pipefail`, a `printf token | helm registry login` whose helm exits
+  # first kills printf with SIGPIPE and the pipeline reports failure.
+  for arg in "$@"; do
+    if [ "$arg" = "--password-stdin" ]; then
+      cat >/dev/null
+    fi
+  done
+  exit 0
+fi
 if [ "$1" = "lint" ]; then
   {lint_exit}
 fi


### PR DESCRIPTION
## Summary

The Python Unit Tests check has been going red intermittently on pull requests whose diff never touched Python, and a re-run fixed it each time. Every such failure was one of the CI-mode tests in `tests/test_publish_helm_chart.py`, failing on the registry login step with "Failed to authenticate to ghcr.io with Helm!". The cause is the mock `helm` the release tests install, not the script: the script pipes the token into `helm registry login --password-stdin` under `set -o pipefail`, and the mock exited without reading stdin. Whenever the mock won the race against `printf`, `printf` died with SIGPIPE, the pipeline returned 141, and the script took its error branch. This PR makes the mock consume stdin the way real helm does and adds a test that pins that.

## Why This Change

Three re-runs of the check in two days (the dependabot bumps in #1321 and the gomod group PR on 2026-09-08 among them) were this flake, and each cost a maintainer a re-run and a wait. Reproduced locally: with the old mock, about one login pipeline in twenty fails under the load the concurrent Makefile sweep produces; with the new mock, zero in 2,400. Without this change the check keeps redding at random on unrelated pull requests.

## What Changed

- `tests/testing/release.py`: `create_mock_helm_binary` now handles `registry login`, draining stdin when `--password-stdin` is among the arguments, and exits 0. Every other subcommand behaves as before.
- `tests/test_publish_helm_chart.py`: a new test runs the exact pipeline shape the script uses under `bash -o pipefail`, with the writer sleeping before it writes so the mock has certainly exited unless it is waiting on stdin. Against the old mock it fails deterministically with exit 141; against the new one it passes.

`scripts/release/publish_helm_chart.sh` is unchanged. Its pipeline is correct against real helm, which reads stdin to EOF, and if real helm ever exits early on bad arguments `pipefail` surfaces helm's own status, so the error branch still fires for the right reason.

## Context

No open issue or pull request tracks this flake. The failed attempts that show the signature: run 34297433610 attempts 1 and 2, run 34233173585 attempt 1, and run 34291985406. The other recent reds on this check named tests the respective diffs had changed and were not this.

## Testing

- `tests/test_publish_helm_chart.py`: 19 tests, OK. Thirty concurrent invocations of the file with the fix, all OK.
- The new test against the pre-change mock: `AssertionError: 141 != 0`, so it is red-then-green.
- Standalone reproduction of the race under load: 6 parallel loops of 400 login pipelines each. Old mock: 17 to 37 failures per loop. New mock: 0 in every loop.
- `tests/` directory under `unittest discover` as the Makefile sweep runs it: the only failures are the six in `test_package_release_bundle.py`, which fail identically on unchanged `main` because this machine lacks the `zip` binary and do not reach the helm mock.
- `make docs-check`: passes.

### Live validation

Not live-tested. The change touches only a test fixture and a test; nothing in it reaches an installation. The behaviour it corrects is exercised by the Python Unit Tests check on this pull request.

## Self-Review

Both passes ran in fresh subagent contexts handed only the diff range, the skill path, and the `make docs-check` result, with instructions not to read the commit message or scratch notes.

- **review-adversarial (subagent): no findings.** Looked for: blocking `cat` with no EOF (refuted: every caller feeds a pipe that closes, as real helm requires too), the `sleep` making the new test flaky (refuted: it can only false-green on a machine where `sh` startup exceeds 500 ms, never false-red), whether the fix belongs in the script instead (refuted: the script is correct against real helm), other stdin-fed mock invocations needing the same treatment (none: this is the only `--password-stdin` pipeline under `scripts/release/` and `scripts/installer/`), the second consumer of the helm mock (`test_package_release_bundle.py` never calls `registry login`), no-magic-constants and Conventional Commits conventions, and open PRs touching these files (none). It independently reproduced 141 at base and 0 at HEAD.
- **review-docs-drift (subagent): no Blocking, one Advisory.** The mock's docstring still listed "lint, package, and push". Fixed in this commit. No document names the mock, the test, or the login mechanism; the docs that describe `publish_helm_chart.sh` describe behaviour this PR does not change.
- **Not covered:** `test_package_release_bundle.py` could not run to green locally (no `zip`); its use of the mock was verified by reading. Neither pass read CI history; I did that separately and the run IDs are in Context.

## Risk & Rollout

Low risk, no runtime code paths touched. The only new failure mode is a mock `helm registry login --password-stdin` that blocks if a caller feeds it an unclosed stdin, which no caller does and which real helm would also do. Revert is a plain revert of the commit.

Generated with the help of Claude Code (Fable 5.1).
