### PR TITLE
fix(installer): normalize typed null in lifecycle tfvar to fix autopush deploy

### DIFF
--- a/terraform/examples/full-install/lifecycle.sh
+++ b/terraform/examples/full-install/lifecycle.sh
@@ -145,14 +145,23 @@ ensure_init() {
 # failing console left an empty value, `set -e` killed the script on the
 # assignment, and the run ended with no output whatsoever — which is exactly what
 # an uninitialised module did before ensure_init existed.
+# A variable nobody set and whose default is null -- agent_service_account_id
+# in a hand-written tfvars -- prints as `tostring(null)` (a typed null; older
+# releases print `null`). Callers want "unset", not that spelling: read as a
+# name, it made guard_gsa_identity refuse every apply whose tfvars left the
+# variable alone, which is what broke the autopush deploys after #1309.
 tfvar() {
-  local out
+  local out value
   if ! out=$(echo "var.$1" | terraform console 2>&1); then
     printf '%s\n' "$out" >&2
     warn "could not evaluate var.$1 (see the terraform error above)"
     exit 1
   fi
-  printf '%s\n' "$out" | tail -1 | tr -d '"'
+  value=$(printf '%s\n' "$out" | tail -1 | tr -d '"')
+  case "$value" in
+    null | "tostring(null)") value="" ;;
+  esac
+  printf '%s\n' "$value"
 }
 
 # The state list is read once and matched in memory. Piping it straight into
@@ -424,7 +433,7 @@ guard_gsa_identity() {
   if ! desired=$(tfvar agent_service_account_id 2>/dev/null); then
     desired="kubeagents-platform-gsa"
   fi
-  if [[ "$desired" == "null" || -z "$desired" ]]; then
+  if [[ "$desired" == "null" || "$desired" == "tostring(null)" || -z "$desired" ]]; then
     desired="kubeagents-platform-gsa"
   fi
 

--- a/tests/test_lifecycle_script.py
+++ b/tests/test_lifecycle_script.py
@@ -116,6 +116,62 @@ resource "google_service_account" "agent" {
         self.assertEqual(proc.returncode, 0, f"unexpected failure: {proc.stderr}")
         self.assertEqual(proc.stderr, "")
 
+    def test_guard_gsa_identity_reads_a_typed_null_as_the_default(self):
+        """terraform console prints an unset nullable variable as tostring(null).
+        Read as a name, it disagreed with every state and refused every apply
+        whose tfvars left the variable alone -- the autopush deploys after #1309."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """# module.kube_agents_iam.google_service_account.agent:
+resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa"
+    project      = "test-proj"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa="tostring(null)",
+        )
+        self.assertEqual(proc.returncode, 0, f"unexpected failure: {proc.stderr}")
+        self.assertEqual(proc.stderr, "")
+
+    def test_a_typed_null_still_refuses_a_lost_override(self):
+        """When state has an override GSA but variable resolves to a typed null,
+        the fallback default name still disagrees with state and refuses destruction."""
+        state_list = "module.kube_agents_iam.google_service_account.agent"
+        state_show = """resource "google_service_account" "agent" {
+    account_id   = "kubeagents-platform-gsa-2"
+}
+"""
+        proc = self._run_guard(
+            "guard_gsa_identity",
+            state_list=state_list,
+            state_show=state_show,
+            tfvar_agent_sa="tostring(null)",
+        )
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("agent_service_account_id resolved to 'kubeagents-platform-gsa', but this state manages GSA 'kubeagents-platform-gsa-2'", proc.stderr)
+        self.assertIn("Applying now would plan the service account's DESTRUCTION and recreation under -auto-approve.", proc.stderr)
+
+    def test_tfvar_reads_a_typed_null_as_empty(self):
+        """tfvar should normalize typed nulls (tostring(null)) to empty string."""
+        proc = self._run_guard(
+            'printf "[%s]" "$(tfvar agent_service_account_id)"',
+            tfvar_agent_sa="tostring(null)",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout, "[]")
+
+    def test_tfvar_reads_bare_null_as_empty(self):
+        """tfvar should normalize bare null to empty string."""
+        proc = self._run_guard(
+            'printf "[%s]" "$(tfvar agent_service_account_id)"',
+            tfvar_agent_sa="null",
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout, "[]")
+
     def test_guard_gsa_identity_refuses_when_override_lost_and_resolves_to_default(self):
         """When state has override GSA but variable resolves to default, apply refuses before terraform runs."""
         state_list = "module.kube_agents_iam.google_service_account.agent"


### PR DESCRIPTION
## Summary

Fixes a direct regression introduced in #1309 by normalizing Terraform console's `tostring(null)` and `null` evaluations to empty strings in `lifecycle.sh`'s `tfvar()` helper and adding defensive handling for `tostring(null)` in `guard_gsa_identity`. When `agent_service_account_id` is left at its default (`null`) in `variables.tf`, real Terraform evaluates `var.agent_service_account_id` to the typed null `tostring(null)`. `guard_gsa_identity` previously treated this string literally, concluded that the desired GSA differed from the state-managed GSA (`kubeagents-platform-gsa`), and refused `lifecycle.sh apply` under `-auto-approve`.

## Why This Change

Addresses an immediate blocker on the continuous deployment pipeline observed in autopush run [34369450176](https://github.com/gke-labs/kube-agents/actions/runs/34369450176).

### Regression Mechanism (#1309)
PR #1309 added `guard_gsa_identity` to prevent accidental GSA destruction when custom overrides are lost. However, unit tests in #1309 mocked `terraform console` as returning the bare string `"null"`. In reality, Terraform console outputs typed nulls: for `type = string` with `default = null`, Terraform console outputs `tostring(null)`.

Because `tfvar()` returned `tostring(null)` unchanged, `guard_gsa_identity`:
1. Checked `[[ "$desired" == "null" || -z "$desired" ]]`, which evaluated to `false` because `$desired` was the non-empty string `"tostring(null)"`.
2. Compared `$recorded` (`"kubeagents-platform-gsa"`) with `$desired` (`"tostring(null)"`).
3. Concluded they mismatched and aborted with:
   ```text
   warn agent_service_account_id resolved to 'tostring(null)', but this state manages GSA 'kubeagents-platform-gsa' (module.kube_agents_iam.google_service_account.agent).
   warn Applying now would plan the service account's DESTRUCTION and recreation under -auto-approve.
   ✗ Upgrade error encountered at line 473 (exit code 1): ./lifecycle.sh "$@"
   ```
This broke every automated upgrade / deploy run on standard installs whose `terraform.tfvars` leaves `agent_service_account_id` at the default.

This change extracts the focused hotfix out of in-progress PR #1327 so continuous deployment is unblocked immediately while broader installer refactoring in #1327 continues review.

## What Changed

- **`terraform/examples/full-install/lifecycle.sh`**:
  - In `tfvar()`, normalized `null` and `tostring(null)` outputs from `terraform console` to empty string `""` so callers expecting unset variables correctly receive an empty string.
  - In `guard_gsa_identity()`, added defensive handling for `"$desired" == "tostring(null)"` alongside `null` and `-z "$desired"` when defaulting to `kubeagents-platform-gsa`.
- **`tests/test_lifecycle_script.py`**:
  - Added unit test `test_guard_gsa_identity_reads_a_typed_null_as_the_default` asserting that a typed null (`tostring(null)`) successfully falls back to the default GSA name when state holds the default.
  - Added unit test `test_a_typed_null_still_refuses_a_lost_override` ensuring that a typed null still refuses apply if state managed a custom override GSA.
  - Added unit tests `test_tfvar_reads_a_typed_null_as_empty` and `test_tfvar_reads_bare_null_as_empty`.

## Context

- Direct fix for regression introduced in #1309.
- Fixes failed autopush CI run: https://github.com/gke-labs/kube-agents/actions/runs/34369450176.
- Extracted minimal fix from draft/in-progress PR #1327.

## Testing

- `python3 -m unittest -v tests/test_lifecycle_script.py`: 10/10 tests passed in 0.376s
- `python3 -m unittest discover -s tests -p "test_*.py"`: 1472 tests passed (3 skipped) in 345.898s
- `make docs-check`: checked relative links across 295 Markdown files, terminology check passed, documentation map inventory verified (PASS)

### Live validation

Empirically validated against a live production GKE installation and real Terraform state:
- **Target environment**: Project `eleontev-kube-agents`, cluster `platform-agent-host` (`us-central1`).
- **Target state backend**: `gs://eleontev-kube-agents-kube-agents-tfstate/kube-agents/platform-agent-host/default.tfstate`.
- **State contents verified**:
  - `module.kube_agents_iam.google_service_account.agent` exists.
  - State attributes: `account_id = "kubeagents-platform-gsa"`, `email = "kubeagents-platform-gsa@eleontev-kube-agents.iam.gserviceaccount.com"`.
- **Pre-fix verification (`upstream/main` HEAD)**:
  Executing `guard_gsa_identity` directly against the live state:
  ```text
  warn agent_service_account_id resolved to 'tostring(null)', but this state manages GSA 'kubeagents-platform-gsa' (module.kube_agents_iam.google_service_account.agent).
  warn Applying now would plan the service account's DESTRUCTION and recreation under -auto-approve.
  warn If this install uses a custom GSA name, preserve it in install.env via:
  warn   TF_VAR_agent_service_account_id="kubeagents-platform-gsa"
  warn or pass it explicitly in terraform.tfvars.
  Exit code: 1
  ```
- **Post-fix verification (this branch)**:
  Executing patched `guard_gsa_identity` against the same live state:
  ```text
  Acquiring state lock. This may take a few moments...
  GUARD_GSA_IDENTITY SUCCESS
  Exit code: 0
  ```
- **What could NOT be covered**:
  - Full mutation via `terraform apply` (intentionally not executed to avoid unnecessary remote resource mutation on a running cluster; `guard_gsa_identity` runs immediately prior to `terraform apply` and was the sole failing check in CI).
  - The lost-override refusal against live production state (as the state manages the default GSA `kubeagents-platform-gsa`).
- **Artifact and lock cleanup**:
  - Confirmed the state lock and all temporary staging files were released immediately following the check, leaving zero residual locks or modified state files.

## Self-Review

Conducted two hostile pre-merge review passes using isolated subagents handed only the diff range against `upstream/main`:

- **Pass 1: Adversarial Code Reviewer (isolated subagent context)**:
  - *Context*: Fresh subagent context evaluating full git diff against `upstream/main`.
  - *Angles evaluated*:
    - Audited all 18 callers of `tfvar()` across `lifecycle.sh` (`project_id`, `cluster_name`, `location`, `create_cluster`, `enable_database_encryption`, `kms_keyring_name`, `kms_key_name`, `enable_github_minter`, `github_minter_kms_keyring`, `github_minter_kms_key`, `enable_stockout_investigator`, `stockout_pubsub_topic`, `stockout_pubsub_subscription`, `stockout_pubsub_sink`, `enable_google_chat`, `chat_topic_name`, `chat_subscription_name`, `namespace`). Confirmed that mapping `null` and `tostring(null)` to empty string resolves rather than causes bugs (notably `stockout_pubsub_topic` which checks `[[ -n "$stockout_topic" ]]` and previously treated `"tostring(null)"` as truthy).
    - Verified other Terraform console typed nulls (`tonumber(null)`, `tobool(null)`) and confirmed all nullable variables in `variables.tf` are strings.
    - False positives/negatives in `guard_gsa_identity`: Confirmed that custom override loss (`kubeagents-platform-gsa-2` in state with default null in tfvars) still reliably refuses apply with exit code 1.
    - Test hermeticity & leak prevention: Verified `tests/test_lifecycle_script.py` uses sanitized environment via `get_isolated_test_env` and cleans up temporary directories using `tempfile.TemporaryDirectory()`.
  - *Findings & Disposition*: None (Verdict: CLEAN).

- **Pass 2: Docs Drift Reviewer (isolated subagent context)**:
  - *Context*: Fresh subagent context evaluating full git diff against `upstream/main`.
  - *Angles evaluated*:
    - Line range preservation: Checked `lifecycle.sh` lines 1–50 and confirmed header comments were untouched, preserving line numbering for `sed -n '2,50p'` help text on line 664.
    - Documentation consistency: Audited `terraform/examples/full-install/README.md`, `scripts/installer/README.md`, and `docs/site/src/content/docs/deploy/environment-reconcile.md`. Confirmed that documented GSA fallback semantics match code behavior.
    - Docs validation: Ran `make docs-check` across all 295 documentation files.
  - *Findings & Disposition*: None (Verdict: CLEAN).

## Risk & Rollout

Low risk — targeted fix to the Terraform console parser helper in `lifecycle.sh`. Rollout takes effect immediately upon merge for all automated deploy and upgrade workflows.
