### PR TITLE
ci(validate): run lifecycle.sh's tfvar helper against a real terraform console

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -432,10 +432,14 @@ jobs:
             exit 1
           fi
 
+      # terraform_wrapper: false for the same reason deploy-environment.yml
+      # gives: the tfvar check below captures `terraform console` stdout
+      # through lifecycle.sh, and the wrapper re-prints it.
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_version: "1.15.8"
+          terraform_wrapper: false
 
       - name: Enable Terraform plugin cache
         # Terraform does not tilde-expand TF_PLUGIN_CACHE_DIR, so the path
@@ -459,3 +463,11 @@ jobs:
               (cd "$dir" && terraform init -backend=false && terraform validate)
             fi
           done
+
+      # lifecycle.sh reads its inputs out of `terraform console`, whose output
+      # shapes the unit tests can only stub. #1309's stub answered `null` where
+      # the binary answers `tostring(null)`, every autopush deploy failed, and
+      # #1350 fixed it post-merge. This is where the helper meets the real
+      # binary before merge; it reuses the composition the loop above initialised.
+      - name: Check lifecycle.sh reads terraform console correctly
+        run: make tfvar-check

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BASE_IMAGE_ARGS := $(foreach v,$(BASE_IMAGE_VARS),$(if $($(v)),--build-arg $(v)=
 SANDBOX_IMAGE_VARS := PYTHON_IMAGE
 SANDBOX_IMAGE_ARGS := $(foreach v,$(SANDBOX_IMAGE_VARS),$(if $($(v)),--build-arg $(v)=$($(v))))
 
-.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-build-sandbox docker-smoke-sandbox docker-push docker-push-agents docker-push-credential-proxy docker-push-sandbox dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps test-bench test-bench-deps bench-case-check e2e-tests e2e-test-deps test-e2e test-e2e-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map docs-check-context-budget chart-sync chart-check iac-parity-check tf-apply tf-destroy coverage coverage-check test-integration conformance
+.PHONY: default help docker-build docker-build-agents docker-build-credential-proxy docker-build-sandbox docker-smoke-sandbox docker-push docker-push-agents docker-push-credential-proxy docker-push-sandbox dev-rebuild-agent mirror-images images-check status prettier-check prettier-write test-python test-python-deps test-bench test-bench-deps bench-case-check e2e-tests e2e-test-deps test-e2e test-e2e-deps validate prompt-check docs-generate docs-check docs-check-generated docs-check-links docs-check-terminology docs-check-map docs-check-context-budget chart-sync chart-check iac-parity-check tfvar-check tf-apply tf-destroy coverage coverage-check test-integration conformance
 
 # The agent images this repository builds -- one per `--target` stage in
 # deploy/docker/Dockerfile, which is not the same thing as one per directory
@@ -569,6 +569,12 @@ iac-parity-check: ## Verify DNS egress rule parity across static NetworkPolicy c
 		exit 1; \
 	}
 	@python3 scripts/check_iac_parity.py
+
+# The unit tests stub `terraform`, so only this puts lifecycle.sh's tfvar()
+# in front of the real binary (#1309 shipped against a stub that answered `null`
+# where Terraform answers `tostring(null)`; #1350 has the story).
+tfvar-check: ## Run lifecycle.sh's tfvar() against a real terraform console for every variable it reads and fail on any unnormalised shape (CI runs this).
+	@./hack/check-tfvar-console.sh
 
 tf-apply: ## Apply terraform/examples/full-install, adopting KMS resources a previous destroy left behind.
 	@./terraform/examples/full-install/lifecycle.sh apply $(ARGS)

--- a/hack/check-tfvar-console.sh
+++ b/hack/check-tfvar-console.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Runs lifecycle.sh's tfvar() against a real `terraform console` for every
+# variable the script reads, and fails if any of them comes back in a shape the
+# helper did not normalise.
+#
+# The unit tests in tests/test_lifecycle_script.py stub `terraform`, so they
+# check what the script does with an answer, never what the binary actually
+# answers. #1309's stub said `null` for an unset nullable string; Terraform
+# says `tostring(null)`. The GSA guard read that as a custom name, refused
+# every apply whose tfvars left the default in place, and the autopush deploy
+# was the first thing to run the real binary -- four and a half hours after
+# merge (#1350). validate.yml already installs Terraform and initialises the
+# composition; this is the step that puts the helper in front of it.
+#
+# The sweep is read out of the source rather than listed here: every variable
+# named literally at a tfvar call site in lifecycle.sh, plus every string
+# variable variables.tf declares with `default = null`. The second set is what
+# makes a call that passes the name in a shell variable -- `$(tfvar "$name")`
+# -- safe to leave unread: a string with a non-null default cannot come back
+# as anything but a plain value, so the nullable strings are the only ones that
+# can leak whichever way they are read. A nullable bool or list read through
+# tfvar is the bound: the helper does not normalise those shapes today, and
+# nothing reads one. The variables without a default are given placeholders so
+# their answer is a value rather than `(known after apply)`.
+#
+# Run via `make tfvar-check`; CI runs it in validate.yml. `--list` prints the
+# variables the sweep would evaluate and exits, without touching terraform.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+readonly COMPOSITION=terraform/examples/full-install
+readonly LIFECYCLE=lifecycle.sh
+readonly VARIABLES_TF=variables.tf
+# A Terraform identifier: letters, digits, underscores and hyphens.
+readonly TFVAR_CALL_PATTERN='\$\(tfvar [A-Za-z0-9_-]+'
+readonly REPORT_NAME_WIDTH=32
+# Shapes `terraform console` prints for anything that is not a plain value:
+# `tostring(null)`, `tobool(null)`, `tolist(null) /* of string */`,
+# `(known after apply)`, `(sensitive value)`, and for a populated list or map
+# the closing `])` or `}` that tfvar's `tail -1` would keep. Every one of them
+# carries a bracket or the word `null`, and no variable lifecycle.sh reads
+# legitimately does.
+readonly LEAK_PATTERN='null|[][(){}]'
+readonly LIST_FLAG=--list
+readonly PLACEHOLDER_PROJECT=tfvar-check-project
+readonly PLACEHOLDER_CLUSTER=tfvar-check-cluster
+readonly PLACEHOLDER_LOCATION=us-central1
+readonly PLACEHOLDER_API_SERVER_KEY=tfvar-check-key
+
+cd "$COMPOSITION"
+
+# The lifecycle script's `set -euo pipefail` and its `cd` to its own directory
+# both come along with the source; the composition directory is that directory.
+# lifecycle.sh is linted on its own; following it here would lint it twice.
+# shellcheck disable=SC1090,SC1091
+KUBE_AGENTS_SOURCE_ONLY=true source "./$LIFECYCLE"
+
+literal_callers() { grep -oE "$TFVAR_CALL_PATTERN" "$LIFECYCLE" | awk '{print $2}'; }
+nullable_strings() {
+  awk '
+    /^variable "/ { name = $2; gsub(/"/, "", name); is_string = 0; is_null = 0 }
+    /^[ \t]*type[ \t]*=[ \t]*string[ \t]*$/ { is_string = 1 }
+    /^[ \t]*default[ \t]*=[ \t]*null[ \t]*$/ { is_null = 1 }
+    /^}/ { if (name != "" && is_string && is_null) print name; name = "" }
+  ' "$VARIABLES_TF"
+}
+variables=()
+while IFS= read -r name; do variables+=("$name"); done < <({ literal_callers; nullable_strings; } | sort -u)
+if [[ $(literal_callers | wc -l) -eq 0 ]]; then
+  echo "ERROR: found no tfvar callers in $COMPOSITION/$LIFECYCLE; the pattern is stale." >&2
+  exit 1
+fi
+if [[ "${1:-}" == "$LIST_FLAG" ]]; then
+  printf '%s\n' "${variables[@]}"
+  exit 0
+fi
+
+command -v terraform >/dev/null 2>&1 || {
+  echo "ERROR: terraform is required to check the tfvar helper." >&2
+  exit 1
+}
+
+export TF_VAR_project_id=$PLACEHOLDER_PROJECT
+export TF_VAR_cluster_name=$PLACEHOLDER_CLUSTER
+export TF_VAR_location=$PLACEHOLDER_LOCATION
+export TF_VAR_api_server_key=$PLACEHOLDER_API_SERVER_KEY
+
+# -backend=false: console evaluates variables from configuration and tfvars
+# alone, so on a fresh checkout -- CI's case -- no state and no credentials are
+# needed. A checkout that lifecycle.sh has already initialised against a remote
+# backend keeps that backend, and console then opens it. A no-op when
+# validate.yml's own init has already run.
+terraform init -backend=false -input=false >/dev/null
+
+status=0
+for name in "${variables[@]}"; do
+  # tfvar exits the shell on a console failure; the subshell keeps that to one
+  # variable so the rest still report.
+  if ! value=$(tfvar "$name"); then
+    echo "ERROR: tfvar $name: terraform console could not evaluate it." >&2
+    status=1
+    continue
+  fi
+  if grep -qE "$LEAK_PATTERN" <<<"$value"; then
+    echo "ERROR: tfvar $name returned raw console output '$value'; tfvar() must normalise this shape." >&2
+    status=1
+    continue
+  fi
+  printf "%-${REPORT_NAME_WIDTH}s -> %s\n" "$name" "${value:-<empty>}"
+done
+
+if [[ $status -ne 0 ]]; then
+  echo "ERROR: lifecycle.sh's tfvar() leaked terraform console syntax for at least one variable (see above)." >&2
+fi
+exit "$status"

--- a/tests/test_check_tfvar_console.py
+++ b/tests/test_check_tfvar_console.py
@@ -1,0 +1,135 @@
+"""Unit tests for hack/check-tfvar-console.sh.
+
+The script exists because the lifecycle.sh unit tests stub `terraform` and so
+never see what the binary really prints (#1309 shipped against a stub that
+answered `null` where Terraform answers `tostring(null)`; #1350 fixed it after
+the autopush deploy failed). These tests stub `terraform` too -- deliberately:
+they check that the script recognises a leaked console shape and reports which
+variable leaked it, not what Terraform prints. validate.yml runs the script
+against the real binary; that run is the check, this is the check's own test.
+"""
+
+import pathlib
+import re
+import subprocess
+import tempfile
+import unittest
+
+from tests.testing.common import get_isolated_test_env
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "hack" / "check-tfvar-console.sh"
+
+# What the stub answers for any variable the test does not single out.
+_PLAIN_ANSWER = '"plain-value"'
+
+
+class CheckTfvarConsoleTest(unittest.TestCase):
+    def _run(self, answers=None, console_exit=0):
+        """Run the script with a stub `terraform` whose console answers per variable.
+
+        `answers` maps a variable name to the line the stub prints for it; every
+        other variable gets a plain quoted string, which is what Terraform prints
+        for a string variable with a value.
+        """
+        answers = answers or {}
+        cases = "\n".join(
+            f'        *"{name}"*) echo \'{line}\' ;;' for name, line in answers.items()
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            bin_dir = pathlib.Path(tmp) / "bin"
+            bin_dir.mkdir()
+            stub = bin_dir / "terraform"
+            stub.write_text(f"""#!/usr/bin/env bash
+case "${{1:-}}" in
+  init) exit 0 ;;
+  console)
+    read -r expr
+    case "$expr" in
+{cases}
+        *) echo '{_PLAIN_ANSWER}' ;;
+    esac
+    exit {console_exit} ;;
+  *) echo "unexpected terraform invocation: $*" >&2; exit 1 ;;
+esac
+""")
+            stub.chmod(0o755)
+            env = get_isolated_test_env(bin_dir=str(bin_dir))
+            return subprocess.run(
+                ["bash", str(_SCRIPT)],
+                capture_output=True,
+                text=True,
+                env=env,
+                cwd=str(_REPO_ROOT),
+            )
+
+    def test_plain_values_pass_and_every_caller_is_swept(self):
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # The sweep is read out of the source. The GSA guard calls
+        # `$(tfvar agent_service_account_id 2>/dev/null)`, so a pattern anchored
+        # on a closing paren would skip precisely the variable that regressed;
+        # it is also the one string variables.tf declares with `default = null`,
+        # so it reaches the sweep by both routes.
+        self.assertIn("agent_service_account_id", result.stdout)
+        self.assertIn("project_id", result.stdout)
+
+    def test_the_shapes_tfvar_normalises_pass_as_empty(self):
+        """`tostring(null)` is the shape #1309 missed and #1350 taught tfvar() to
+        read as unset; the check sees the helper's answer, so both pass empty.
+        Against the helper as #1309 left it, this case fails with the message
+        the test below asserts."""
+        for shape in ("tostring(null)", "null"):
+            with self.subTest(shape=shape):
+                result = self._run(answers={"agent_service_account_id": shape})
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertRegex(result.stdout, r"agent_service_account_id\s+-> <empty>")
+
+    def test_the_shapes_tfvar_does_not_normalise_fail_and_name_the_variable(self):
+        """A typed null of another type, a typed null list, and an unresolved
+        required variable: what the next nullable variable a caller reads could
+        come back as."""
+        for shape in ("tobool(null)", "tolist(null) /* of string */", "(known after apply)"):
+            with self.subTest(shape=shape):
+                result = self._run(answers={"namespace": shape})
+                self.assertEqual(result.returncode, 1, result.stdout)
+                self.assertIn(f"tfvar namespace returned raw console output '{shape}'", result.stderr)
+
+    def test_the_sweep_includes_every_nullable_string_in_variables_tf(self):
+        """The second route into the sweep. Its only member today is also a
+        literal caller, so the sweep's output cannot show whether the route
+        works; the list mode can. The expected set is parsed here with a
+        different tool than the script's awk, so a formatting change in
+        variables.tf that one of them misses fails rather than agrees."""
+        variables_tf = (_REPO_ROOT / "terraform" / "examples" / "full-install" / "variables.tf").read_text()
+        blocks = re.findall(r'^variable "([^"]+)" \{(.*?)^\}', variables_tf, re.M | re.S)
+        expected = {
+            name for name, body in blocks
+            if re.search(r"^\s*type\s*=\s*string\s*$", body, re.M)
+            and re.search(r"^\s*default\s*=\s*null\s*$", body, re.M)
+        }
+        self.assertIn("agent_service_account_id", expected)
+        result = subprocess.run(
+            ["bash", str(_SCRIPT), "--list"],
+            capture_output=True, text=True, cwd=str(_REPO_ROOT),
+            env=get_isolated_test_env(),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        listed = set(result.stdout.split())
+        self.assertTrue(expected <= listed, f"nullable strings missing from the sweep: {expected - listed}")
+        self.assertIn("project_id", listed)
+
+    def test_a_populated_list_shape_fails(self):
+        """tfvar keeps the last line of a multi-line console value, so a
+        populated list reaches the check as `])`."""
+        result = self._run(answers={"namespace": "])"})
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("tfvar namespace returned raw console output '])'", result.stderr)
+
+    def test_a_failing_console_fails_the_check_for_that_variable(self):
+        result = self._run(console_exit=1)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("terraform console could not evaluate it", result.stderr)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a CI step that runs `lifecycle.sh`'s `tfvar()` helper against a real `terraform console` for every variable the script reads, and fails when an answer still carries console syntax. This is the check that would have stopped #1309 before merge: its unit tests stubbed `terraform` to answer `null` where the binary answers `tostring(null)`, and the first real run was the post-merge autopush deploy, four and a half hours later (#1350).

## Why This Change

`tests/test_lifecycle_script.py` stubs `terraform`, so it checks what the script does with an answer and never what the binary actually answers. Nothing pre-merge put `tfvar()` in front of a real `terraform console`, and `validate.yml` already installs Terraform 1.15.8 and initialises the composition with `-backend=false`, which is all `console` needs to evaluate a variable. Without this step the next unnormalised console shape ships the same way: #1327 adds two more `default = null` strings and a `$(tfvar "$variable")` call form, and Terraform also prints `tobool(null)`, `tolist(null) /* of string */` and `(known after apply)` for shapes the helper does not normalise today.

## What Changed

- `hack/check-tfvar-console.sh` sources `lifecycle.sh` under `KUBE_AGENTS_SOURCE_ONLY`, sweeps every variable named literally at a `tfvar` call site plus every string variable `variables.tf` declares with `default = null`, gives the four no-default variables placeholders, runs `terraform init -backend=false`, evaluates each through `tfvar()`, and fails on any answer containing `null` or a bracket. `--list` prints the sweep without touching terraform.
- `Makefile` gains `tfvar-check`, and `validate.yml` runs it after the `terraform validate` loop that already initialises the composition, with `terraform_wrapper: false` on the setup step for the reason `deploy-environment.yml` already gives.
- `tests/test_check_tfvar_console.py` stubs `terraform` to test the check's own detection: plain values pass, the shapes the helper normalises pass as empty, the shapes it does not normalise fail naming the variable, a populated-list tail fails, a failing console fails, and the nullable-string route of the sweep matches an independent parse of `variables.tf`.

## Context

- Follow-up to #1350, which fixed the regression #1309 introduced. Neither is reopened; this prevents the class.
- #1327 (mplakhtiy) touches `lifecycle.sh` and `variables.tf` but not `tfvar()` or `validate.yml`. Run against its hunks, the sweep tolerates its `$(tfvar "$variable")` loop and picks up its two new nullable strings through the `variables.tf` route. Merge order does not matter.
- Pre-existing, not fixed here: `docs/testing-map.md` cites the `PYTHON_TEST_DIRS` line range as 129 to 144; it is 151 to 166 on `main` today. Separate one-liner.

Generated with the help of Claude Fable 5.1.

## Testing

- `python3 -m unittest tests.test_check_tfvar_console`: 6 tests pass. `tests.test_lifecycle_script` still passes.
- `make tfvar-check` against real Terraform 1.15.8 in the composition: exit 0, 19 variables, about 70 seconds.
- Run against `lifecycle.sh` as #1309 left it (`d1344901^`), swapped in temporarily and restored:

  ```text
  ERROR: tfvar agent_service_account_id returned raw console output 'tostring(null)'; tfvar() must normalise this shape.
  ERROR: lifecycle.sh's tfvar() leaked terraform console syntax for at least one variable (see above).
  exit=1
  ```

- `shellcheck hack/check-tfvar-console.sh` clean, `prettier --check` clean on `validate.yml`, `make docs-check` clean.

### Live validation

Not live-tested against a running kube-agents installation: the change is a CI check and touches no deployed artefact. The mechanism was exercised against the real binary instead, red on #1309's head and green on `main` as shown above, and the `validate` job on this pull request is the first run on a GitHub runner. It reuses the initialised composition, so the plugin-cache hit or miss is what that run will show that the local run cannot.

## Self-Review

Passes run: `review-adversarial` twice and `review-docs-drift` once, each in a fresh subagent handed the diff range and its skill file and told not to read commit messages. The second adversarial pass ran because the sweep logic changed after the first read it. Both adversarial passes ran the check against the real binary, the unit tests and shellcheck, probed `terraform console` directly for every shape the comments name and for a credential-less environment, verified the pre-#1350 helper from git history, and read #1327's hunks. The docs-drift pass classified all four paths against the documentation map and verified the workflow and script comments against `lifecycle.sh`, `variables.tf` and `deploy-environment.yml`. The last five fixes below were applied by the authoring context after the second pass and not re-reviewed in a fresh one; they are each a few lines and their tests are named. Not covered by any pass: a GitHub Actions run of the step itself, and the full `make test-python` sweep.

- LOW, PLAUSIBLE, adversarial: the sweep matched only literal `$(tfvar name)` calls and `[a-z_]` names, so #1327's `$(tfvar "$variable")` loop would be unswept. Fixed: the sweep also takes every `default = null` string from `variables.tf`, which is the only shape that can leak whichever way it is read; identifier characters widened. A first fix that refused indirect calls was dropped because it would have gone red on #1327 the day this merged.
- LOW, CONFIRMED, adversarial: unnamed column width in the `printf`. Fixed, `REPORT_NAME_WIDTH`; test uses a regex.
- LOW, PLAUSIBLE, adversarial: a populated list or map reaches `tfvar()` as `])` or `}` through its `tail -1`, which `null|\(` missed. Fixed: the leak pattern rejects any bracket; test added.
- LOW, CONFIRMED, adversarial: the nullable-string route had no test that failed if the awk stopped matching. Fixed: `--list` mode plus a test comparing it with an independent parse of `variables.tf`.
- LOW, CONFIRMED, adversarial: `tfvar-check` missing from `.PHONY`. Fixed.
- LOW, PLAUSIBLE, adversarial: `mapfile` needs bash 4, and no other script here uses it. Fixed with a `read` loop.
- LOW, PLAUSIBLE, adversarial: the "no credentials needed" comment holds only on a checkout whose composition is on local state. Fixed: the comment now says so; CI is always that case.
- Advisory, docs-drift: test docstring said "see the PR" with no number. Fixed by dropping the clause.
- Advisory, docs-drift, pre-existing: `docs/testing-map.md` Makefile line range is stale on `main`. Not fixed here; unrelated to this change and listed under Context.
- Advisory, docs-drift: no doc points at the new step. No change: `make help` prints it, and no doc enumerates the sibling `terraform validate` step either.
- Not a finding, recorded: the bound. A nullable bool or list read through `tfvar()` is not normalised today and nothing reads one; the check would fail loudly on one, not pass it.

## Risk & Rollout

Adds about 70 seconds to the `validate` job and no runtime code path. A false positive fails `validate` on the pull request that introduces it, with the variable and raw value named. Revert by removing the step; nothing happens at merge time.
