### PR TITLE
feat(operator): add OpenShift cluster DNS discovery and egress policy support

### DIFF
--- a/k8s-operator/internal/controller/netpolprofile.go
+++ b/k8s-operator/internal/controller/netpolprofile.go
@@ -52,6 +52,13 @@ const (
 	metadataDaemonPortName    = "metadata-server"
 	metadataDaemonDefaultPort int32 = 988
 
+	// openShiftDNSNamespace and openShiftDNSServiceName locate the OpenShift CoreDNS Service
+	// when kube-system/kube-dns is absent.
+	openShiftDNSNamespace         = "openshift-dns"
+	openShiftDNSServiceName       = "dns-default"
+	openShiftDNSDaemonSetLabelKey = "dns.operator.openshift.io/daemonset-dns"
+	openShiftDNSDaemonSetLabelVal = "default"
+
 	// Source constants reporting how the network policy values were chosen.
 	netpolSourceSpec        = "Spec"
 	netpolSourceAnnotation  = "Annotation"
@@ -159,7 +166,7 @@ func (r *PlatformAgentReconciler) resolveNetpolProfile(ctx context.Context, agen
 	// 4a. In-cluster discovery from OpenShift openshift-dns/dns-default Service
 	if len(p.DNSClusterIPs) == 0 {
 		var ocpSvc corev1.Service
-		if err := r.Get(ctx, types.NamespacedName{Namespace: "openshift-dns", Name: "dns-default"}, &ocpSvc); err == nil {
+		if err := r.Get(ctx, types.NamespacedName{Namespace: openShiftDNSNamespace, Name: openShiftDNSServiceName}, &ocpSvc); err == nil {
 			var discovered []string
 			if len(ocpSvc.Spec.ClusterIPs) > 0 {
 				for _, ip := range ocpSvc.Spec.ClusterIPs {

--- a/k8s-operator/internal/controller/netpolprofile.go
+++ b/k8s-operator/internal/controller/netpolprofile.go
@@ -156,6 +156,35 @@ func (r *PlatformAgentReconciler) resolveNetpolProfile(ctx context.Context, agen
 		}
 	}
 
+	// 4a. In-cluster discovery from OpenShift openshift-dns/dns-default Service
+	if len(p.DNSClusterIPs) == 0 {
+		var ocpSvc corev1.Service
+		if err := r.Get(ctx, types.NamespacedName{Namespace: "openshift-dns", Name: "dns-default"}, &ocpSvc); err == nil {
+			var discovered []string
+			if len(ocpSvc.Spec.ClusterIPs) > 0 {
+				for _, ip := range ocpSvc.Spec.ClusterIPs {
+					trimmed := strings.TrimSpace(ip)
+					if trimmed != "" && trimmed != "None" && net.ParseIP(trimmed) != nil {
+						discovered = append(discovered, trimmed)
+					}
+				}
+			} else if ip := strings.TrimSpace(ocpSvc.Spec.ClusterIP); ip != "" && ip != "None" && net.ParseIP(ip) != nil {
+				discovered = append(discovered, ip)
+			}
+
+			if len(discovered) > 0 {
+				p.DNSClusterIPs = discovered
+				p.DNSSource = netpolSourceDiscovered
+			}
+		} else if !apierrors.IsNotFound(err) {
+			log.Info("Failed to discover OpenShift dns-default ClusterIP", "error", err)
+			if agent != nil && agent.Status.NetworkPolicy.DNSClusterIPsSource == netpolSourceDiscovered && len(agent.Status.NetworkPolicy.DNSClusterIPs) > 0 {
+				p.DNSClusterIPs = append([]string(nil), agent.Status.NetworkPolicy.DNSClusterIPs...)
+				p.DNSSource = netpolSourceDiscovered
+			}
+		}
+	}
+
 	// 5. Documented fallback default
 	if len(p.DNSClusterIPs) == 0 {
 		p.DNSClusterIPs = []string{defaultDNSClusterIP}

--- a/k8s-operator/internal/controller/netpolprofile_test.go
+++ b/k8s-operator/internal/controller/netpolprofile_test.go
@@ -118,6 +118,28 @@ func TestResolveNetpolProfile(t *testing.T) {
 		}
 	})
 
+	t.Run("DiscoveryOpenShiftDNS", func(t *testing.T) {
+		t.Parallel()
+		scheme := setupScheme()
+		ocpDNSSvc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "openshift-dns", Name: "dns-default"},
+			Spec:       corev1.ServiceSpec{ClusterIP: "172.30.0.10"},
+		}
+		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ocpDNSSvc).Build()
+		r := &PlatformAgentReconciler{Client: client, Scheme: scheme}
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "default"},
+		}
+
+		profile := r.resolveNetpolProfile(context.Background(), agent)
+		if !reflect.DeepEqual(profile.DNSClusterIPs, []string{"172.30.0.10"}) {
+			t.Errorf("got DNSClusterIPs %v, want [172.30.0.10]", profile.DNSClusterIPs)
+		}
+		if profile.DNSSource != netpolSourceDiscovered {
+			t.Errorf("got DNSSource %q, want %q", profile.DNSSource, netpolSourceDiscovered)
+		}
+	})
+
 	// The three subtests below hold the anti-flap arm of the discovery rung: a Get that
 	// fails with anything other than NotFound must not drop the agent back to
 	// defaultDNSClusterIP. On a cluster whose kube-dns sits outside the classic Service

--- a/k8s-operator/internal/controller/netpolprofile_test.go
+++ b/k8s-operator/internal/controller/netpolprofile_test.go
@@ -140,6 +140,31 @@ func TestResolveNetpolProfile(t *testing.T) {
 		}
 	})
 
+	t.Run("DiscoveryOpenShiftDNS_TransientError_PreservesDiscoveredStatus", func(t *testing.T) {
+		t.Parallel()
+		scheme := setupScheme()
+		client := fake.NewClientBuilder().WithScheme(scheme).
+			WithInterceptorFuncs(openShiftDNSGetFails()).Build()
+		r := &PlatformAgentReconciler{Client: client, Scheme: scheme}
+		agent := &agentv1alpha1.PlatformAgent{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "default"},
+			Status: agentv1alpha1.AgentStatus{
+				NetworkPolicy: agentv1alpha1.NetworkPolicyStatus{
+					DNSClusterIPs:       []string{"172.30.0.10"},
+					DNSClusterIPsSource: netpolSourceDiscovered,
+				},
+			},
+		}
+
+		profile := r.resolveNetpolProfile(context.Background(), agent)
+		if !reflect.DeepEqual(profile.DNSClusterIPs, []string{"172.30.0.10"}) {
+			t.Errorf("got DNSClusterIPs %v, want [172.30.0.10]", profile.DNSClusterIPs)
+		}
+		if profile.DNSSource != netpolSourceDiscovered {
+			t.Errorf("got DNSSource %q, want %q", profile.DNSSource, netpolSourceDiscovered)
+		}
+	})
+
 	// The three subtests below hold the anti-flap arm of the discovery rung: a Get that
 	// fails with anything other than NotFound must not drop the agent back to
 	// defaultDNSClusterIP. On a cluster whose kube-dns sits outside the classic Service
@@ -927,3 +952,17 @@ func metadataDaemonGetFails() interceptor.Funcs {
 		},
 	}
 }
+
+// openShiftDNSGetFails makes the openshift-dns/dns-default read return ServiceUnavailable --
+// a transient API error rather than a NotFound, testing anti-flap logic for OpenShift DNS.
+func openShiftDNSGetFails() interceptor.Funcs {
+	return interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if key.Namespace == openShiftDNSNamespace && key.Name == openShiftDNSServiceName {
+				return apierrors.NewServiceUnavailable("apiserver is shutting down")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}
+}
+

--- a/k8s-operator/internal/controller/platformagent_egress_policy.go
+++ b/k8s-operator/internal/controller/platformagent_egress_policy.go
@@ -285,6 +285,7 @@ func buildAgentEgressNetworkPolicy(agent *agentv1alpha1.PlatformAgent, dnsCluste
 	dnsPeers := []networkingv1.NetworkPolicyPeer{
 		namespacedPodPeer("kube-system", map[string]string{"k8s-app": "kube-dns"}),
 		namespacedPodPeer("kube-system", map[string]string{"k8s-app": "node-local-dns"}),
+		namespacedPodPeer("openshift-dns", map[string]string{"dns.operator.openshift.io/daemonset-dns": "default"}),
 		{IPBlock: &networkingv1.IPBlock{CIDR: nodeLocalDNSCacheIP}},
 		{IPBlock: &networkingv1.IPBlock{CIDR: metadataResolverCIDR}},
 	}

--- a/k8s-operator/internal/controller/platformagent_egress_policy.go
+++ b/k8s-operator/internal/controller/platformagent_egress_policy.go
@@ -285,7 +285,7 @@ func buildAgentEgressNetworkPolicy(agent *agentv1alpha1.PlatformAgent, dnsCluste
 	dnsPeers := []networkingv1.NetworkPolicyPeer{
 		namespacedPodPeer("kube-system", map[string]string{"k8s-app": "kube-dns"}),
 		namespacedPodPeer("kube-system", map[string]string{"k8s-app": "node-local-dns"}),
-		namespacedPodPeer("openshift-dns", map[string]string{"dns.operator.openshift.io/daemonset-dns": "default"}),
+		namespacedPodPeer(openShiftDNSNamespace, map[string]string{openShiftDNSDaemonSetLabelKey: openShiftDNSDaemonSetLabelVal}),
 		{IPBlock: &networkingv1.IPBlock{CIDR: nodeLocalDNSCacheIP}},
 		{IPBlock: &networkingv1.IPBlock{CIDR: metadataResolverCIDR}},
 	}

--- a/k8s-operator/internal/controller/platformagent_egress_policy_test.go
+++ b/k8s-operator/internal/controller/platformagent_egress_policy_test.go
@@ -384,6 +384,10 @@ func TestTheAllowlistCoversWhatTheAgentCannotRunWithout(t *testing.T) {
 			why: "every other destination is reached by name; without DNS the allowlist is a total block",
 		},
 		{
+			name: "openshift-dns", ns: "openshift-dns", labels: map[string]string{"dns.operator.openshift.io/daemonset-dns": "default"}, port: 53,
+			why: "OpenShift CoreDNS daemonset in openshift-dns resolves names on OpenShift clusters",
+		},
+		{
 			name: "the credential broker", ns: agent.Namespace,
 			labels: map[string]string{"app": credentialBrokerName(agent)}, port: credentialProxyPort,
 			why: "CREDENTIAL_PROXY_URL, GOOGLE_CHAT_RELAY_URL and SLACK_RELAY_URL all address it (credentialProxyBaseURL)",

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -4526,6 +4526,18 @@ func clusterDNSPeers(dnsIPs []string) []networkingv1.NetworkPolicyPeer {
 			},
 		},
 		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": openShiftDNSNamespace,
+				},
+			},
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					openShiftDNSDaemonSetLabelKey: openShiftDNSDaemonSetLabelVal,
+				},
+			},
+		},
+		{
 			IPBlock: &networkingv1.IPBlock{
 				CIDR: nodeLocalDNSCacheIP,
 			},


### PR DESCRIPTION
## Summary

Enables the `k8s-operator` to discover cluster DNS on Red Hat OpenShift clusters and permits DNS resolution traffic across all operator-managed NetworkPolicies (gateway, shell sandbox, and egress allowlist).

## Why This Change

On standard GKE clusters, CoreDNS runs in `kube-system/kube-dns`. On Red Hat OpenShift, cluster DNS is managed by the OpenShift DNS Operator, which exposes the `dns-default` Service in the `openshift-dns` namespace and runs CoreDNS daemonsets with label `dns.operator.openshift.io/daemonset-dns: default`. Without this change, deploying `kube-agents` on OpenShift falls back to the static default DNS IP, and default-deny egress NetworkPolicies (`clusterDNSPeers` in gateway and shell sandbox, plus egress allowlist) drop all DNS traffic under OVN-Kubernetes, rendering the agent, shell sandbox, and credential proxy unable to resolve cluster services or external endpoints.

## What Changed

- `k8s-operator/internal/controller/netpolprofile.go`: Added named constants (`openShiftDNSNamespace`, `openShiftDNSServiceName`, `openShiftDNSDaemonSetLabelKey`, `openShiftDNSDaemonSetLabelVal`) and in-cluster discovery probe for `openshift-dns/dns-default` when `kube-system/kube-dns` is absent, including anti-flap protection preserving status on transient errors.
- `k8s-operator/internal/controller/platformagent_manifests.go`: Added OpenShift DNS peers to `clusterDNSPeers` helper so both the gateway NetworkPolicy (`buildNetworkPolicy`) and shell sandbox NetworkPolicy (`buildShellSandboxNetworkPolicy`) permit egress to `openshift-dns` CoreDNS pods.
- `k8s-operator/internal/controller/platformagent_egress_policy.go`: Added OpenShift DNS pod peer to `buildAgentEgressNetworkPolicy` allowlist.
- `k8s-operator/internal/controller/netpolprofile_test.go`: Added unit tests `TestResolveNetpolProfile/DiscoveryOpenShiftDNS` (happy path discovery) and `DiscoveryOpenShiftDNS_TransientError_PreservesDiscoveredStatus` (anti-flap validation via `openShiftDNSGetFails` interceptor).
- `k8s-operator/internal/controller/platformagent_egress_policy_test.go`: Updated allowlist verification tests to cover `openshift-dns`.

## Context

Closes #1420. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine (Phase 1).

## Testing

- Unit tests:
  `cd k8s-operator && go test -v ./internal/controller -run "TestResolveNetpolProfile|TestTheRenderedPolicy"` (all 26 subtests PASS).

### Live validation

Validated against a live Red Hat OpenShift 4.22 / OKD cluster running on Google Compute Engine (`v1.35.5`, CentOS Stream CoreOS 10 kernel 6.12, OVN-Kubernetes):
1. Verified in-cluster discovery of `openshift-dns/dns-default` Service ClusterIP (`172.30.0.10`).
2. Verified `clusterDNSPeers` renders the `openshift-dns` namespace and pod selector into the shell sandbox and gateway NetworkPolicies.
3. Verified name resolution from the shell sandbox (`platform-agent-shell-0`) and gateway pod to cluster services (`litellm.kubeagents-system.svc.cluster.local`) and external endpoints over OVN-Kubernetes.

## Self-Review

- Adversarial review (clean context): Checked whether default-deny rules in `clusterDNSPeers` were missing OpenShift DNS pod peers in addition to `buildAgentEgressNetworkPolicy`. Identified that gateway and shell sandbox policies both rely on `clusterDNSPeers`; updated `clusterDNSPeers` so both policies permit OpenShift DNS.
- Coding standards (AGENTS.md): Eliminated string literals in favour of declared top-of-file constants (`openShiftDNSNamespace`, `openShiftDNSServiceName`, `openShiftDNSDaemonSetLabelKey`, `openShiftDNSDaemonSetLabelVal`).
- Verified anti-flap behavior: Added explicit `DiscoveryOpenShiftDNS_TransientError_PreservesDiscoveredStatus` test with `openShiftDNSGetFails` interceptor to confirm transient API errors preserve previously discovered status.
- Docs-drift: Verified DNS discovery order matches operator documentation.

## Risk & Rollout

Low risk. Only introduces an additional fallback discovery branch and adds an additional allowed DNS pod peer in the NetworkPolicy; existing GKE deployments are unaffected. Revertible by reverting this commit.

