### PR TITLE
feat(helm): add OpenShift SecurityContextConstraints and Route templates

### DIFF
--- a/charts/kube-agents/templates/openshift-route-netpol.yaml
+++ b/charts/kube-agents/templates/openshift-route-netpol.yaml
@@ -1,0 +1,29 @@
+{{- $openshift := .Values.openshift | default dict }}
+{{- $route := $openshift.route | default dict }}
+{{- if and $openshift.enabled $route.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-ingress-router
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "kube-agents.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ default "platform-agent" .Values.platformAgent.name }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+      ports:
+        - protocol: TCP
+          port: 8642
+        - protocol: TCP
+          port: 8643
+        - protocol: TCP
+          port: 9119
+{{- end }}

--- a/charts/kube-agents/templates/openshift-route-netpol.yaml
+++ b/charts/kube-agents/templates/openshift-route-netpol.yaml
@@ -5,13 +5,14 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: {{ .Release.Name }}-ingress-router
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
     {{- include "kube-agents.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ default "platform-agent" .Values.platformAgent.name }}
+      app: {{ default "platform-agent" .Values.platformAgent.name }}-gateway
   policyTypes:
     - Ingress
   ingress:

--- a/charts/kube-agents/templates/openshift-scc.yaml
+++ b/charts/kube-agents/templates/openshift-scc.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
     {{- include "kube-agents.labels" . | nindent 4 }}
+priority: 10
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/charts/kube-agents/templates/openshift-scc.yaml
+++ b/charts/kube-agents/templates/openshift-scc.yaml
@@ -1,0 +1,40 @@
+{{- $openshift := .Values.openshift | default dict }}
+{{- $scc := $openshift.scc | default dict }}
+{{- if and $openshift.enabled $scc.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ .Release.Name }}-scc
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "kube-agents.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+readOnlyRootFilesystem: false
+runAsUser:
+  type: MustRunAsRange
+  uidRangeMin: 1000
+  uidRangeMax: 65535
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - min: 1000
+      max: 65535
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ default "kubeagents-platform-agent" .Values.platformAgent.security.serviceAccountName }}
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ default "platform-agent" .Values.platformAgent.name }}-shell
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-controller-manager
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-cr-cleanup
+{{- end }}

--- a/charts/kube-agents/templates/openshift-scc.yaml
+++ b/charts/kube-agents/templates/openshift-scc.yaml
@@ -18,16 +18,11 @@ allowedCapabilities: []
 defaultAddCapabilities: []
 readOnlyRootFilesystem: false
 runAsUser:
-  type: MustRunAsRange
-  uidRangeMin: 1000
-  uidRangeMax: 65535
+  type: RunAsAny
 seLinuxContext:
   type: MustRunAs
 fsGroup:
-  type: MustRunAs
-  ranges:
-    - min: 1000
-      max: 65535
+  type: RunAsAny
 supplementalGroups:
   type: RunAsAny
 seccompProfiles:

--- a/charts/kube-agents/templates/route.yaml
+++ b/charts/kube-agents/templates/route.yaml
@@ -1,0 +1,26 @@
+{{- $openshift := .Values.openshift | default dict }}
+{{- $route := $openshift.route | default dict }}
+{{- if and $openshift.enabled $route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ .Release.Name }}-gateway
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    {{- include "kube-agents.labels" . | nindent 4 }}
+spec:
+  {{- if $route.host }}
+  host: {{ $route.host | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ default "platform-agent" .Values.platformAgent.name }}
+    weight: 100
+  port:
+    targetPort: {{ default "api" $route.targetPort }}
+  {{- if $route.tls }}
+  tls:
+    termination: {{ default "edge" $route.tls.termination }}
+    insecureEdgeTerminationPolicy: Redirect
+  {{- end }}
+{{- end }}

--- a/charts/kube-agents/templates/route.yaml
+++ b/charts/kube-agents/templates/route.yaml
@@ -5,6 +5,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ .Release.Name }}-gateway
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Chart.Name }}
     {{- include "kube-agents.labels" . | nindent 4 }}

--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -806,6 +806,8 @@ openshift:
   route:
     enabled: false
     host: ""
+    # Backend service port to target (defaults to api / 8642).
+    targetPort: api
     tls:
       termination: edge
 

--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -794,3 +794,18 @@ plugins:
       sink: gke-stockout-alerts-sink
       thresholdCount: 1
       thresholdWindowSeconds: 300
+
+# OpenShift on GCE compatibility settings.
+openshift:
+  # Enable OpenShift-specific resources and configurations (e.g. SCC, Route).
+  enabled: false
+  # SecurityContextConstraints (SCC) configuration.
+  scc:
+    create: true
+  # OpenShift Route configuration for external access.
+  route:
+    enabled: false
+    host: ""
+    tls:
+      termination: edge
+

--- a/charts/kube-agents/values.yaml
+++ b/charts/kube-agents/values.yaml
@@ -810,4 +810,3 @@ openshift:
     targetPort: api
     tls:
       termination: edge
-


### PR DESCRIPTION
## Summary
Adds optional OpenShift `SecurityContextConstraints` (SCC), native `Route` templates, and companion router `NetworkPolicy` to the `kube-agents` Helm chart.

## Why This Change
On Red Hat OpenShift:
1. Default `restricted-v2` SCC enforces namespace-allocated UID ranges and rejects pods specifying fixed unprivileged UIDs (e.g., `runAsUser: 10000` or `65532`) without explicit SCC bindings. Furthermore, the shell sandbox (`platform-agent-shell-0`) requires root at entrypoint to chown mounted data volumes before privilege-separating to `agent`. A custom SCC must specify `priority: 10` (matching built-in `anyuid`) so OpenShift evaluates it ahead of `restricted-v2` for unconstrained pods.
2. Ingress and web traffic routing rely on native OpenShift `Route` resources (`route.openshift.io/v1`) driven by HAProxy in `openshift-ingress`, rather than GKE Gateway API or GKE Ingress.
3. The operator's default NetworkPolicy restricts ingress to same-namespace pods, dropping traffic from the OpenShift HAProxy router without a companion ingress rule targeting `app: <agent>-gateway`.
4. Templates must support zero-downtime upgrades and `helm upgrade --reuse-values` without failing on missing keys from earlier chart versions.

## What Changed
- `charts/kube-agents/templates/openshift-scc.yaml`:
  - Added SecurityContextConstraints template granting required capabilities, `priority: 10`, `runAsUser: type: RunAsAny`, and `fsGroup: type: RunAsAny` to accommodate the shell sandbox entrypoint.
  - Added `seccompProfiles: [runtime/default]` to admit pods specifying `RuntimeDefault`.
  - Added `{{ .Release.Name }}-cr-cleanup` ServiceAccount to `users` to ensure Helm pre-delete cleanup hooks admit cleanly.
  - Guarded `.Values.openshift` with `| default dict` to protect `helm upgrade --reuse-values` from nil pointer evaluations.
- `charts/kube-agents/templates/route.yaml`:
  - Added native OpenShift `Route` template targeting the operator-created `platform-agent` Service on port `api` (8642) in namespace `{{ .Release.Namespace }}`.
  - Guarded `.Values.openshift` with `| default dict`.
- `charts/kube-agents/templates/openshift-route-netpol.yaml`:
  - Added companion NetworkPolicy admitting ingress from OpenShift router pods (`network.openshift.io/policy-group: ingress`) to ports 8642, 8643, and 9119 with podSelector `app: {{ default "platform-agent" .Values.platformAgent.name }}-gateway` in namespace `{{ .Release.Namespace }}`.
- `charts/kube-agents/values.yaml`: Added `openshift` configuration block (defaulting to `enabled: false`), including `scc.create`, `route.enabled`, `route.host`, `route.targetPort`, and `route.tls.termination` with inline documentation comments.

## Context
Closes #1421. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine.
Companion PRs: #1375 (Operator CoreDNS), #1377 (Sandbox oc CLI), #1378 (OpenShift Machine API skill), #1380 (Installer OpenShift support), #1381 (OpenShift SCC skill), #1382 (OpenShift Obtainability skill), #1383 (OpenShift Route skill), #1384 (Manifest & storage compatibility).

## Testing
- Tested `helm template` with OpenShift enabled:
  ```bash
  $ helm template kube-agents ./charts/kube-agents --namespace kubeagents-system \
      --set platformAgent.harness.clusterName=okd-8w9p8 \
      --set platformAgent.harness.location=us-central1 \
      --set platformAgent.harness.projectId=gca-gke-2025 \
      --set openshift.enabled=true \
      --set openshift.route.enabled=true \
      --show-only templates/openshift-scc.yaml \
      --show-only templates/route.yaml \
      --show-only templates/openshift-route-netpol.yaml
  ```
  Rendered output successfully synthesized:
  - `SecurityContextConstraints` (`kube-agents-scc`) with `priority: 10`, `RunAsAny`, and `runtime/default`
  - `Route` (`kube-agents-gateway` -> `platform-agent:api`) in namespace `kubeagents-system`
  - `NetworkPolicy` (`kube-agents-ingress-router` selecting `app: platform-agent-gateway` and admitting router ingress)
- Tested `helm upgrade --reuse-values` compatibility (rendering against values omitting `.Values.openshift`): passed with exit code 0.
- Ran `make docs-check`: verified documentation links, terminology, and context budget pass cleanly.

### Live validation
- **Target Installation:** Red Hat OpenShift / OKD v1.35.5 (Kubernetes v1.35.5) on Google Compute Engine in `us-central1` (project `gca-gke-2025`, context `admin`), operator image `us-docker.pkg.dev/gca-gke-2025/kube-agents/operator:v0.1.0`.
- **SCC Validation:**
  Applied rendered `kube-agents-scc` and verified `priority: 10`:
  ```
  $ oc get scc kube-agents-scc -o jsonpath='{.priority}'
  10
  $ oc get pods -n kubeagents-system
  NAME                                                  READY   STATUS    RESTARTS   AGE
  litellm-7977f4d656-pvfh8                              1/1     Running   0          110m
  litellm-7977f4d656-wl2kk                              1/1     Running   0          110m
  platform-agent-credential-proxy-bb4c55c98-vk52z       1/1     Running   0          103m
  platform-agent-gateway-6f4974576d-rq7ll               4/4     Running   0          119m
  platform-agent-shell-0                                1/1     Running   0          121m
  ```
- **NetworkPolicy & Route Validation:**
  Applied rendered Route `kube-agents-gateway` and companion NetworkPolicy `kube-agents-ingress-router` in `kubeagents-system`:
  ```
  $ oc get route kube-agents-gateway -n kubeagents-system
  NAME                  HOST/PORT                                                         PATH   SERVICES         PORT   TERMINATION     WILDCARD
  kube-agents-gateway   kube-agents-gateway-kubeagents-system.apps.okd.gca-gke-2025.net          platform-agent   api    edge/Redirect   None

  $ oc get netpol kube-agents-ingress-router -n kubeagents-system
  NAME                         POD-SELECTOR                 AGE
  kube-agents-ingress-router   app=platform-agent-gateway   4s

  $ curl -k -s -i https://kube-agents-gateway-kubeagents-system.apps.okd.gca-gke-2025.net/v1/models
  HTTP/1.1 401 Unauthorized
  server: BaseHTTP/0.6 Python/3.13.5
  date: Thu, 10 Sep 2026 03:50:40 GMT
  content-type: text/html;charset=utf-8
  content-length: 346
  ```
- **Cleanup:**
  Live validation Route and NetworkPolicy verified in namespace `kubeagents-system`; transient testing artifacts in default namespace removed.

## Self-Review
- **Adversarial Pass (clean subagent context):**
  - Updated `openshift-scc.yaml` to include `priority: 10` so OpenShift evaluates it ahead of `restricted-v2` for unconstrained pods (ensuring the shell sandbox entrypoint runs as root without falling victim to `restricted-v2` mutation).
  - Aligned `openshift-route-netpol.yaml` podSelector to `app: {{ default "platform-agent" .Values.platformAgent.name }}-gateway`, exactly matching the operator's gateway pod label.
  - Added explicit `namespace: {{ .Release.Namespace }}` to both `route.yaml` and `openshift-route-netpol.yaml` metadata blocks to prevent cluster-default namespace leakage.
  - Added `| default dict` guards across all OpenShift templates to ensure clean `helm upgrade --reuse-values` execution.
- **Docs-Drift Pass (clean subagent context):**
  - Confirmed `values.yaml` comments document all new OpenShift parameters including `targetPort`.
  - Ran `make docs-check`: all links, terminology, and context budget passed.

## Risk & Rollout
Low risk. OpenShift templates are disabled by default (`openshift.enabled: false`). GKE deployments remain completely unchanged. Safe for rollout across existing clusters.

---
Generated with the help of Jetski / Gemini.

