### PR TITLE
feat(sandbox): add OpenShift oc CLI to credential proxy allowlist and sandbox shims

### DIFF
--- a/agents/platform/scripts/command_policy.py
+++ b/agents/platform/scripts/command_policy.py
@@ -58,9 +58,9 @@ class Decision:
 
 _ALLOWED = Decision(allowed=True, rule_id="", message="")
 
-# Only these two reach a cluster or a cloud project. Everything else the proxy
+# Only these reach a cluster or a cloud project. Everything else the proxy
 # executes is governed elsewhere.
-_GOVERNED_TOOLS = frozenset({"kubectl", "gcloud"})
+_GOVERNED_TOOLS = frozenset({"kubectl", "gcloud", "oc"})
 
 # Verb sequences that only read. Tuples rather than bare strings so a verb whose
 # effect depends on its subcommand can say which subcommand it meant: `rollout
@@ -90,9 +90,12 @@ KUBECTL_READ_VERBS: frozenset[tuple[str, ...]] = frozenset(
         ("explain",),
         ("get",),
         ("logs",),
+        ("project",),
+        ("status",),
         ("top",),
         ("version",),
         ("wait",),
+        ("whoami",),
         ("auth", "can-i"),
         ("auth", "whoami"),
         ("config", "current-context"),
@@ -818,7 +821,7 @@ def evaluate(argv: list[str]) -> Decision:
             offending_flag=impersonation_flag,
         )
 
-    if argv[0] == "kubectl":
+    if argv[0] in ("kubectl", "oc"):
         # Ordered before the identity check, the same way gcloud checks
         # --flags-file before _GCLOUD_IDENTITY_FLAGS: the refusal a caller sees
         # should name the file-of-flags problem rather than the identity one it

--- a/agents/platform/scripts/credential_proxy.py
+++ b/agents/platform/scripts/credential_proxy.py
@@ -1952,7 +1952,7 @@ def content_workspace_enabled() -> bool:
 
 
 class CommandExecutor:
-    ALLOWED_EXECUTABLES = ("gcloud", "kubectl", "gh", "git")
+    ALLOWED_EXECUTABLES = ("gcloud", "kubectl", "oc", "gh", "git")
 
     def __init__(
         self,
@@ -2258,7 +2258,7 @@ class CommandExecutor:
         # requests still resolve a named kubeconfig the way they did before
         # the pool existed -- regenerated on the ambient identity, never
         # selected on.
-        scoped = executable == "kubectl"
+        scoped = executable in ("kubectl", "oc")
         command, flag_kubeconfig = self._reroute_kubeconfig_flags(command, scoped=scoped)
         if flag_kubeconfig is not None:
             # The flag beats the environment, because that is the precedence
@@ -2279,7 +2279,7 @@ class CommandExecutor:
             )
         elif kubeconfig_context:
             kubeconfig_path = self._resolve_kubeconfig(kubeconfig_context, scoped=scoped)
-        elif self.scoped_pool is not None and executable == "kubectl":
+        elif self.scoped_pool is not None and executable in ("kubectl", "oc"):
             # `KUBECONFIG` is in the base environment, so this branch is not
             # "no cluster" — it is "the sidecar's default cluster", and it has to
             # go through selection like any other.

--- a/agents/platform/scripts/credential_proxy_client.py
+++ b/agents/platform/scripts/credential_proxy_client.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-SUPPORTED_EXECUTABLES = ("kubectl", "gcloud", "gh", "git")
+SUPPORTED_EXECUTABLES = ("kubectl", "oc", "gcloud", "gh", "git")
 
 # How long to wait to reach the broker. Bounds the connect only — see
 # BrokerConnection.
@@ -122,7 +122,7 @@ def authorization_headers() -> dict[str, str]:
 # resolving it for them buys nothing and costs plenty — an unreadable kubeconfig
 # is a hard failure, which would turn a stray KUBECONFIG into a refused `gh pr
 # create`.
-KUBECONFIG_AWARE = frozenset({"kubectl", "gcloud"})
+KUBECONFIG_AWARE = frozenset({"kubectl", "gcloud", "oc"})
 
 # Flags whose value may be `-`, meaning "read the document from stdin". This is
 # the whole list the shipped skills use: kubectl's `-f`/`--filename` and

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1779,6 +1779,9 @@ RUN curl -sSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dear
     curl -fL -o /tmp/gh.deb "https://github.com/cli/cli/releases/download/v2.92.0/gh_2.92.0_linux_${ARCH}.deb" && \
     dpkg -i /tmp/gh.deb && \
     rm -f /tmp/gh.deb && \
+    OC_ARCH=$([ "$ARCH" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
+    curl -fL "https://mirror.openshift.com/pub/openshift-v4/${OC_ARCH}/clients/ocp/stable/openshift-client-linux.tar.gz" | tar -xz -C /usr/local/bin oc && \
+    chmod 0755 /usr/local/bin/oc && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /etc/envoy
 

--- a/deploy/sandbox/Dockerfile
+++ b/deploy/sandbox/Dockerfile
@@ -355,10 +355,10 @@ RUN find /opt/defaults -name '__pycache__' -type d -prune -exec rm -rf {} + && \
 # the build PATH — profile.d puts it there at login — so `command -v` here can
 # only be finding a native binary.
 RUN mkdir -p /opt/credential-proxy/bin && \
-    for binary in gcloud kubectl gh git; do \
+    for binary in gcloud kubectl oc gh git; do \
         ln -s /usr/local/bin/credential-proxy-exec "/opt/credential-proxy/bin/${binary}"; \
     done && \
-    for binary in gcloud kubectl gh git; do \
+    for binary in gcloud kubectl oc gh git; do \
         if command -v "${binary}" >/dev/null 2>&1; then \
             echo "unexpected credential-aware CLI in the sandbox image: ${binary}" >&2; \
             exit 1; \

--- a/docs/credential-isolation-design.md
+++ b/docs/credential-isolation-design.md
@@ -26,7 +26,7 @@ The **gateway Pod** holds the harness and nothing credentialed:
    internal key. It holds no credential path.
 
 The **shell sandbox Pod**, `<agent>-shell`, runs `sshd`, the agent's own tools, a
-durable `/opt/data`, and the shims that stand in for `gcloud`, `kubectl`, `gh`, and
+durable `/opt/data`, and the shims that stand in for `gcloud`, `kubectl`, `oc`, `gh`, and
 `git`. This is the Pod that executes anything the model wrote. Its ServiceAccount
 carries no `iam.gke.io/gcp-service-account` annotation, so the metadata server hands it
 an unbound principal that IAM grants nothing.
@@ -151,7 +151,7 @@ records the principal; nothing reads it yet.
 
 - PlatformAgent only.
 - Credentials managed by the operator.
-- CLI forwarding for `gcloud`, `kubectl`, `gh`, and `git`.
+- CLI forwarding for `gcloud`, `kubectl`, `oc`, `gh`, and `git`.
 - Slack and Google Chat credentialed relays.
 - PlatformAgent API bearer-key termination in the `agent-api-auth` sidecar.
 - GitHub installation tokens minted through Minty.
@@ -290,7 +290,7 @@ proxy. The credential runtime directly executes the corresponding real CLI and
 returns output and exit status. It never evaluates an agent-supplied shell
 command.
 
-Only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy also rejects
+Only `gcloud`, `kubectl`, `oc`, `gh`, and `git` are accepted. The proxy also rejects
 known credential-disclosure, credential-replacement, and self-modification
 operations, and the GitHub **write** path: merging a pull request
 (`github.merge`), approving a review (`github.assent`), mutating through the

--- a/docs/designs/multi-forge-support.md
+++ b/docs/designs/multi-forge-support.md
@@ -209,7 +209,7 @@ to the agent.
 Five things name GitHub: three inside the broker, the minting pipeline behind it, and the network
 policy that lets the pod out at all.
 
-**The executable allowlist.** `ALLOWED_EXECUTABLES` is `("gcloud", "kubectl", "gh", "git")`, a class
+**The executable allowlist.** `ALLOWED_EXECUTABLES` is `("gcloud", "kubectl", "oc", "gh", "git")`, a class
 attribute of `CommandExecutor` read from three places — and `credential_proxy_client.py` carries the
 same set again as `SUPPORTED_EXECUTABLES`, so the step is two files, not one. GitLab has `glab`, so
 a GitLab install wants that entry and a GitHub install must not have it — an allowlist that is the

--- a/docs/security-requirements.md
+++ b/docs/security-requirements.md
@@ -81,7 +81,7 @@ See [Google Chat Session Metadata Data Flow](designs/gchat-session-metadata-data
 - Provider access uses workload identity or short-lived credentials rather than static keys in the sandbox.
 - GitHub access uses short-lived, repository-scoped installation tokens.
 - Chat and source-control credentials remain behind explicitly configured relay or command interfaces.
-- The current command proxy supports `gcloud`, `kubectl`, `gh`, and `git`. Additional CLIs require explicit proxy support.
+- The current command proxy supports `gcloud`, `kubectl`, `oc`, `gh`, and `git`. Additional CLIs require explicit proxy support.
 - A configuration file the sandbox supplies to a credentialed command selects a target; it does not supply content. The proxy must not run a credentialed command against a document the sandbox authored, because such a document can direct execution, redirect the minted token, or name a file to disclose — none of which the argument-vector deny policy can see. Kubeconfigs are regenerated in the broker for this reason.
 
 The sandbox and the credential runtime must not share a process namespace, and must not run as the

--- a/docs/site/src/content/docs/reference/credential-isolation.md
+++ b/docs/site/src/content/docs/reference/credential-isolation.md
@@ -104,7 +104,7 @@ Pod-wide `automountServiceAccountToken` is `false` everywhere. The broker's proj
 
 ## Request paths
 
-- **CLI commands** — only `gcloud`, `kubectl`, `gh`, and `git` are accepted. The proxy rejects known credential-disclosure, credential-replacement, and self-modification operations, and the GitHub write path (see below); interactive TTY programs, unbounded streaming, sandbox-only file paths, and background processes fail closed.
+- **CLI commands** — only `gcloud`, `kubectl`, `oc`, `gh`, and `git` are accepted. The proxy rejects known credential-disclosure, credential-replacement, and self-modification operations, and the GitHub write path (see below); interactive TTY programs, unbounded streaming, sandbox-only file paths, and background processes fail closed.
 - **Chat** — Slack and Google Chat adapters send credential-free payloads to Envoy; the credential runtime owns the platform tokens and performs the external API calls, enforcing user allowlists and payload limits.
 - **PlatformAgent API** — the Service targets port 8643 on `agent-api-auth` in the gateway Pod, which validates the external bearer key and forwards to the agent API on loopback (port 8642) with a non-secret sentinel. The real key never reaches `platform-agent`.
 - **GitHub** — the broker obtains a Google OIDC identity token and calls [Minty](/kube-agents/deploy/token-minter/), which brokers a repository-scoped GitHub App installation token with a maximum one-hour lifetime. The App's private key stays in Cloud KMS.

--- a/k8s-operator/internal/controller/platformagent_manifests.go
+++ b/k8s-operator/internal/controller/platformagent_manifests.go
@@ -180,7 +180,7 @@ const credentialProxyPolicyJSON = `{
     {"id":"gcp.access-token-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+print-(?:access|identity)-token\\b"},
     {"id":"gcp.config-helper-disclosure","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+config-helper\\b"},
     {"id":"github.token-disclosure","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+token\\b|\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+status\\b(?:\\s+\\S+)*?\\s+(?:--show-token|-t)\\b"},
-    {"id":"kubernetes.token-disclosure","pattern":"\\bkubectl\\b(?:\\s+\\S+)*?\\s+create\\b(?:\\s+\\S+)*?\\s+token\\b|\\bkubectl\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+view\\b(?:\\s+\\S+)*?\\s+--raw\\b"},
+    {"id":"kubernetes.token-disclosure","pattern":"\\b(?:kubectl|oc)\\b(?:\\s+\\S+)*?\\s+create\\b(?:\\s+\\S+)*?\\s+token\\b|\\b(?:kubectl|oc)\\b(?:\\s+\\S+)*?\\s+config\\b(?:\\s+\\S+)*?\\s+view\\b(?:\\s+\\S+)*?\\s+--raw\\b"},
     {"id":"git.credential-disclosure","pattern":"\\bgit\\b(?:\\s+\\S+)*?\\s+credential\\b(?:\\s+\\S+)*?\\s+fill\\b"},
     {"id":"gcp.credential-replacement","pattern":"\\bgcloud\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|activate-service-account)\\b"},
     {"id":"github.credential-replacement","pattern":"\\bgh\\b(?:\\s+\\S+)*?\\s+auth\\b(?:\\s+\\S+)*?\\s+(?:login|refresh|switch|logout)\\b"},

--- a/tests/test_shipped_command_policy.py
+++ b/tests/test_shipped_command_policy.py
@@ -258,6 +258,8 @@ class ShippedPolicyTest(unittest.TestCase):
             (["gcloud", "config", "config-helper"], "gcp.config-helper-disclosure"),
             (["kubectl", "config", "view", "--raw"], "kubernetes.token-disclosure"),
             (["kubectl", "create", "token", "default"], "kubernetes.token-disclosure"),
+            (["oc", "config", "view", "--raw"], "kubernetes.token-disclosure"),
+            (["oc", "create", "token", "default"], "kubernetes.token-disclosure"),
             (["git", "credential", "fill"], "git.credential-disclosure"),
             (["gcloud", "auth", "login"], "gcp.credential-replacement"),
             (
@@ -291,6 +293,10 @@ class ShippedPolicyTest(unittest.TestCase):
             ["gh", "api", "repos/o/r/pulls/1/comments"],
             ["gh", "auth", "status"],
             ["kubectl", "get", "pods"],
+            ["oc", "get", "pods"],
+            ["oc", "project"],
+            ["oc", "whoami"],
+            ["oc", "status"],
         ):
             with self.subTest(argv=argv):
                 self.assertAllowed(argv)
@@ -590,6 +596,25 @@ class TheRulesReadCommandsNotProse(ShippedPolicyTest):
                 "--body", body]
         self.assertIsNone(self.policy.blocked_by(argv))
 
+    def test_oc_command_policy_governance(self):
+        """Verifies that oc is governed by command_policy.evaluate just like kubectl."""
+        import command_policy
+
+        # Read verbs allowed
+        self.assertTrue(command_policy.evaluate(["oc", "get", "pods"]).allowed)
+        self.assertTrue(command_policy.evaluate(["oc", "project"]).allowed)
+        self.assertTrue(command_policy.evaluate(["oc", "whoami"]).allowed)
+        self.assertTrue(command_policy.evaluate(["oc", "status"]).allowed)
+
+        # Mutating verbs blocked as read-only violations
+        self.assertFalse(command_policy.evaluate(["oc", "apply", "-f", "pod.yaml"]).allowed)
+        self.assertFalse(command_policy.evaluate(["oc", "delete", "pod", "test"]).allowed)
+        self.assertFalse(command_policy.evaluate(["oc", "create", "route", "edge"]).allowed)
+
+        # Impersonation flags blocked
+        self.assertFalse(command_policy.evaluate(["oc", "get", "pods", "--as=system:admin"]).allowed)
+
 
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
## Summary

Adds the OpenShift CLI (`oc`) to the credential-proxy broker allowlist, sandbox environment shims, and command policy governance.

## Context

Closes #1422. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine (Phase 3).

## Problem

When running on OpenShift, administrative tasks, routes, OAuth tokens, and OpenShift-specific CRDs (MachineSets, ClusterOperators, Projects) are typically inspected using `oc`.
The kube-agents credential proxy broker enforces a strict executable allowlist (`ALLOWED_EXECUTABLES` and `SUPPORTED_EXECUTABLES`). Without adding `oc`, attempts by agent skills or bash sandboxes to invoke `oc` via `credential-proxy-exec` are rejected by the broker.
Furthermore, simply adding `oc` to the allowlist without command policy governance would bypass read-only enforcement, permit credential-disclosure commands (`oc config view --raw`, `oc create token`), bypass scoped credential routing, and fail with a 500 error if `oc` is missing from the proxy-tools container image.

## Solution

1. **Broker & Client Allowlist:** Added `"oc"` to `CommandExecutor.ALLOWED_EXECUTABLES` and `credential_proxy_client.SUPPORTED_EXECUTABLES`.
2. **Command Policy Governance:**
   - Added `"oc"` to `_GOVERNED_TOOLS` in `agents/platform/scripts/command_policy.py`.
   - Included `"oc"` alongside `"kubectl"` for read-only verb enforcement, argument routing, and impersonation-flag refusals.
   - Added OpenShift inspection verbs (`project`, `whoami`, `status`) to `KUBECTL_READ_VERBS`.
3. **Token Disclosure Protection:** Updated `kubernetes.token-disclosure` regex in `k8s-operator/internal/controller/platformagent_manifests.go` to match `\b(?:kubectl|oc)\b`.
4. **Scoped Credential Routing:** Updated `scoped` flag check and `KUBECONFIG_AWARE` set to include `oc` in `agents/platform/scripts/credential_proxy.py` and `credential_proxy_client.py`.
5. **Container Image Delivery:** Added `oc` installation to the `proxy-tools` stage in `deploy/docker/Dockerfile` from `mirror.openshift.com`.
6. **Documentation & Unit Tests:** Updated security and design docs, and added unit tests in `tests/test_shipped_command_policy.py`.

## Testing

- Ran command policy test suite: `python3 -m unittest tests/test_shipped_command_policy.py` (39/39 PASS).
- Ran conformance test suites: `python3 -m unittest tests.conformance.test_A_authority tests.conformance.test_B_write_path tests.conformance.test_C_enforcement tests.conformance.test_D15_parser_differentials tests.conformance.test_D_accountability tests.conformance.test_harness_selfcheck` (93/93 PASS).
- `make docs-check`: PASS.

### Live validation

Verified in the sandbox container on OpenShift that `oc get nodes` and `oc project` route through the credential proxy successfully. Verified that token disclosure commands (`oc config view --raw` and `oc create token`) and mutating operations (`oc delete pod test`) are rejected with `RuleViolationError`.

## Self-Review

- Finding (Adversarial): Allowing `oc` in `ALLOWED_EXECUTABLES` without adding it to `_GOVERNED_TOOLS` would allow mutating commands. Disposition: Fixed. Added to `_GOVERNED_TOOLS`, `KUBECTL_READ_VERBS`, and added unit test coverage in `tests/test_shipped_command_policy.py`.
- Finding (Adversarial): Token disclosure regex in `credentialProxyPolicyJSON` did not match `oc`. Disposition: Fixed. Updated pattern to `\b(?:kubectl|oc)\b` in `platformagent_manifests.go` and verified in unit tests.
- Finding (Adversarial): `oc` was not installed in `deploy/docker/Dockerfile` (`proxy-tools`), resulting in broker 500 errors. Disposition: Fixed. Added curl and tar extraction of `oc` binary into `/usr/local/bin` in the `proxy-tools` stage.
- Finding (Docs drift): `credential-isolation.md`, `security-requirements.md`, and `multi-forge-support.md` still quoted the old four-CLI tuple. Disposition: Fixed. Updated all documentation references.

## Risk & Rollout

Low risk. Only takes effect when `oc` is invoked. Read-only policy blocks all mutating verbs just like `kubectl`. Revertible by reverting this commit.

