### PR TITLE
feat(skills): add OpenShift SecurityContextConstraints skill

### DIFF
--- a/agents/platform/skills/openshift-security-scc/SKILL.md
+++ b/agents/platform/skills/openshift-security-scc/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: openshift-security-scc
+metadata:
+  category: Security
+description: >-
+  Audits, inspects, and manages OpenShift SecurityContextConstraints (SCCs),
+  ServiceAccount security permissions, and pod admission security contexts. Use
+  when troubleshooting pod admission failures on OpenShift (e.g., unable to
+  validate against any security context constraint), configuring non-root or
+  arbitrary UID execution, granting SCCs to ServiceAccounts (nonroot, anyuid,
+  privileged), or inspecting namespace UID ranges. Don't use for standard GCP IAM
+  roles or cluster-wide network policies.
+---
+
+# OpenShift SecurityContextConstraints (SCC) Skill
+
+This skill provides workflows for auditing, configuring, and troubleshooting
+SecurityContextConstraints (SCCs) on Red Hat OpenShift clusters.
+
+OpenShift uses SCCs to govern what actions pods can perform and what system
+resources they can access, acting as an admission controller comparable to
+Kubernetes Pod Security Standards but with granular per-ServiceAccount bindings.
+
+## Critical Rules
+
+- **READ-ONLY DIAGNOSTICS & PRIVILEGE ELEVATION:** The Platform Agent operates with read-only cluster visibility. When an admission rejection is diagnosed, recommend the minimal-privilege SCC grant (`nonroot` over `anyuid`, `anyuid` over `privileged`). Present SCC grants as declarative RoleBinding manifests or propose the `oc adm policy` command via `submit-suggestion` for explicit operator approval.
+- **CLI COMPATIBILITY:** Namespace UID annotations, pod events, and admitted pod annotations are queryable via both `kubectl` and `oc`.
+- **DYNAMIC UID INJECTION:** Always recommend omitting explicit `runAsUser` and `fsGroup` fields from manifests when deploying to OpenShift, allowing the admission controller to dynamically assign UIDs from the namespace's allocated range.
+
+## Core Concepts & Standard SCCs
+
+Every pod admitted to OpenShift is matched against an available SCC:
+
+| SCC Name | Description | Default Use Case |
+| :--- | :--- | :--- |
+| `restricted-v2` | Default for user workloads. Disallows root (`runAsUser: MustRunAsRange`), drops all capabilities, requires dynamic namespace UID. | Production non-root microservices |
+| `nonroot` | Allows any non-root UID (e.g. fixed UID `10000`, `1000`), requires `runAsNonRoot: true`. | Third-party container images with baked unprivileged UIDs |
+| `anyuid` | Allows arbitrary UIDs including root (`runAsUser: 0`), but restricts host access and privileges. | Workloads requiring root startup or legacy containers |
+| `hostmount-anyuid` | Allows host volume mounts and arbitrary UIDs. | Logging agents, local storage operators |
+| `privileged` | Unrestricted execution (root, host network, host PID, host IPC, all capabilities). | Storage drivers, CNI daemons, virtualization |
+
+---
+
+## Workflows
+
+### 1. Diagnose Pod Admission SCC Failures
+
+When a pod or deployment is rejected during admission:
+
+```bash
+# Check deployment / replicaset events for admission denial
+oc get events -n {namespace} --field-selector reason=FailedCreate --sort-by='.metadata.creationTimestamp'
+
+# Check the namespace's allocated UID range
+oc get ns {namespace} -o jsonpath='{.metadata.annotations.openshift\.io/sa\.scc\.uid-range}{"\n"}'
+```
+
+Common admission error:
+`pods "app-xyz" is forbidden: unable to validate against any security context constraint: [provider "restricted-v2": ... runAsUser: Invalid value: 10000: is not an allowed group]`
+
+**Diagnosis:**
+The container specifies a fixed UID (e.g. `runAsUser: 10000`), but the namespace enforces `restricted-v2` with an auto-allocated high UID range (e.g. `1000670000/10000`).
+
+---
+
+### 2. Grant an SCC to a Workload ServiceAccount
+
+To permit a workload to run with a specific security posture without modifying cluster-wide defaults:
+
+```bash
+# Permitting baked unprivileged UIDs (e.g. UID 10000 or 1000)
+oc adm policy add-scc-to-user nonroot -z {serviceaccount_name} -n {namespace}
+
+# Permitting root execution (e.g. runAsUser: 0)
+oc adm policy add-scc-to-user anyuid -z {serviceaccount_name} -n {namespace}
+
+# Permitting privileged execution (e.g. daemonsets requiring host access)
+oc adm policy add-scc-to-user privileged -z {serviceaccount_name} -n {namespace}
+```
+
+*Verification:*
+```bash
+# Verify the role binding was created
+oc get rolebindings -n {namespace} -o wide | grep scc
+
+# Force pod restart to trigger new admission review
+oc rollout restart deployment/{deployment_name} -n {namespace}
+```
+
+---
+
+### 3. Verify Active SCC on Running Pods
+
+To determine which SCC admitted a running pod:
+
+```bash
+oc get pod {pod_name} -n {namespace} -o jsonpath='{.metadata.annotations.openshift\.io/scc}{"\n"}'
+```
+
+---
+
+### 4. Authoring OpenShift-Compliant Workload Security Contexts
+
+To design manifests that pass default `restricted-v2` admission without requiring custom SCC grants:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: compliant-workload
+  namespace: {namespace}
+spec:
+  replicas: 1
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: app
+          image: {image}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+```
+
+> **Note:** Omit `runAsUser`, `runAsGroup`, and `fsGroup` from the YAML to allow OpenShift's admission controller to dynamically assign valid UIDs within the namespace's allocated range.

--- a/docs/family-roster.txt
+++ b/docs/family-roster.txt
@@ -93,6 +93,7 @@ agents/platform/skills/*/SKILL.md
   agents/platform/skills/inspect-repository/SKILL.md
   agents/platform/skills/kube-agents-observability/SKILL.md
   agents/platform/skills/manage-cluster/SKILL.md
+  agents/platform/skills/openshift-security-scc/SKILL.md
   agents/platform/skills/pr-conversation/SKILL.md
   agents/platform/skills/submit-suggestion/SKILL.md
   agents/platform/skills/workload-rebalancing/SKILL.md

--- a/docs/site/src/content/docs/skills/index.mdx
+++ b/docs/site/src/content/docs/skills/index.mdx
@@ -104,6 +104,12 @@ Generated from the `name` and `description` frontmatter of every `agents/platfor
 | [`inspect-repository`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/inspect-repository/SKILL.md) | Read and analyze the source of any GitHub repository — public or one this install has a token for — without a local checkout. Clones broker-side and pulls file content back; use it to answer questions about code, not to change it. |
 | [`pr-conversation`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/pr-conversation/SKILL.md) | Answer a reviewer who addressed you on one of your own pull requests — read the thread, answer or amend the branch, and reply in the thread. |
 
+### Other
+
+| Skill | Description |
+| ----- | ----------- |
+| [`openshift-security-scc`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/openshift-security-scc/SKILL.md) | Audits, inspects, and manages OpenShift SecurityContextConstraints (SCCs), ServiceAccount security permissions, and pod admission security contexts. Use when troubleshooting pod admission failures on OpenShift (e.g., unable to validate against any security context constraint), configuring non-root or arbitrary UID execution, granting SCCs to ServiceAccounts (nonroot, anyuid, privileged), or inspecting namespace UID ranges. Don't use for standard GCP IAM roles or cluster-wide network policies. |
+
 ### Cluster Agent (per-cluster runtime)
 
 | Skill | Description |


### PR DESCRIPTION
## Summary
Adds an OpenShift SecurityContextConstraints management skill (`openshift-security-scc`) for the Platform Agent.

## Why This Change
On Red Hat OpenShift:
1. Pod admission is controlled by SecurityContextConstraints (SCCs). Workloads running under default `restricted-v2` SCC fail admission if they specify root UIDs (`runAsUser: 0`) or fixed UIDs outside the namespace allocated UID range (`openshift.io/sa.scc.uid-range`).
2. Agents operating on OpenShift clusters require operational runbooks and skills to diagnose admission denials (`FailedCreate` events), understand dynamic namespace UID allocation, and recommend appropriate SCC policy bindings (`nonroot`, `anyuid`).
3. Privilege elevation (binding SCCs) must follow strict operator review boundaries.

## What Changed
- `agents/platform/skills/openshift-security-scc/SKILL.md`: New skill for auditing, inspecting, and managing OpenShift SCCs (`restricted-v2`, `nonroot`, `anyuid`, `privileged`).
  - Covers troubleshooting admission rejections and dynamic namespace UID ranges.
  - Formulates commands with `kubectl` / `oc` compatibility.
  - Enforces read-only diagnostics and operator confirmation via `submit-suggestion` or declarative RBAC for privilege escalation.
- `docs/site/src/content/docs/skills/index.mdx` & `docs/family-roster.txt`: Updated generated skill catalog and family roster via `make docs-generate`.

## Context
Closes #1425. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine.
Companion PRs: #1375 (Operator CoreDNS), #1376 (Helm SCC/Route), #1377 (Sandbox oc CLI), #1378 (OpenShift Machine API skill), #1380 (Installer OpenShift support), #1382 (OpenShift Obtainability skill), #1383 (OpenShift Route skill), #1384 (Manifest & storage compatibility).

## Testing
- Ran `make prompt-check`:
  ```
  Prompt assets OK: 106 instruction files, 47 skill bundles (cluster 6, platform 41), 17 cron jobs in 2 rosters, all references resolve.
  ```
- Ran `make docs-check`:
  ```
  Checked relative links in 297 Markdown files. All relative links resolve.
  Checking terminology across 297 documentation files... Terminology check passed.
  Documentation map inventory covers all 264 tracked docs (265 counting the map itself), no stale path cells, no re-aligned table rows.
  ```

### Live validation
- **Target Installation:** Red Hat OpenShift / OKD v1.35.5 running on GCE in `us-central1` (project `gca-gke-2025`), running platform agent `platform-agent-gateway-6f4974576d-rq7ll` in `kubeagents-system`.
- **Fault Injection (SCC Rejection):**
  Deployed workload `secure-data-processor` requesting `runAsUser: 0` in namespace `scc-test-workload`:
  ```
  $ oc get rs -n scc-test-workload
  NAME                               DESIRED   CURRENT   READY   AGE
  secure-data-processor-7dcfc6b5cb   1         0         0       3s

  $ oc get events -n scc-test-workload --sort-by='.metadata.creationTimestamp'
  Warning  FailedCreate  replicaset/secure-data-processor-7dcfc6b5cb
    Error creating: pods "secure-data-processor-7dcfc6b5cb-" is forbidden: unable to validate against any security context constraint:
    [provider "restricted-v2": .containers[0].runAsUser: Invalid value: 0: must be in the ranges: [1000790000, 1000799999],
     provider restricted-v3: .containers[0].runAsUser: Invalid value: 0: must be in the ranges: [1000, 65534]]
  ```
- **Autonomous Agent Diagnosis:**
  Dispatched task `t_f49cac7a` to the platform agent:
  ```
  [hermes-otel] Registered 13 hooks
    ┊ 📋 preparing kanban_show…
    ┊ 📚 preparing skill_view… openshift-security-scc
    ┊ 💻 $ oc get events -n scc-test-workload --field-selector reason=FailedCreate --sort-by='.metadata.creationTimestamp'

  ╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮
  Diagnosis
  - Offending Field: .containers[0].runAsUser: 0
  - Blocking SCCs: restricted-v2 and restricted-v3
  - Evidence: The replicaset event shows pods "secure-data-processor-7dcfc6b5cb-" is forbidden:
    unable to validate against any security context constraint.

  Recommended Fix
  Grant the anyuid SCC to the ServiceAccount used by the secure-data-processor deployment:
    oc adm policy add-scc-to-user anyuid -z default -n scc-test-workload

  After applying the SCC, the deployment should be rolled out again to trigger a new admission review:
    oc rollout restart deployment/secure-data-processor -n scc-test-workload
  ╰──────────────────────────────────────────────────────────────────────────────╯
  ```
- **Remediation Result:**
  Applied the exact remediation commands recommended by the agent:
  ```
  $ oc adm policy add-scc-to-user anyuid -z default -n scc-test-workload
  clusterrole.rbac.authorization.k8s.io/system:openshift:scc:anyuid added: "default"

  $ oc rollout restart deployment/secure-data-processor -n scc-test-workload
  deployment.apps/secure-data-processor restarted

  $ oc get pods -n scc-test-workload
  NAME                                    READY   STATUS    RESTARTS   AGE
  secure-data-processor-66cfb8464-bnw4p   1/1     Running   0          4s
  ```
  Workload admitted successfully and reached `1/1 Running`.

## Self-Review
- **Adversarial Pass (clean subagent context):**
  - Verified that granting SCC policies cannot be executed directly unattended. Explicitly updated runbook rules to require operator confirmation via `submit-suggestion` or declarative RBAC before running `oc adm policy add-scc-to-user`.
  - Confirmed CLI agnosticism across all inspection commands.
- **Docs-Drift Pass (clean subagent context):**
  - Regenerated `docs/family-roster.txt` and verified `make docs-check` passes with zero stale files.

## Risk & Rollout
Low risk. Documentation and agent skill guidance updates only; no binary or cluster runtime mutations. Revertible by git revert.

---
Generated with the help of Jetski / Gemini.
