### PR TITLE
feat(skills): add OpenShift Route ingress skill

### DIFF
--- a/agents/platform/skills/openshift-routes-ingress/SKILL.md
+++ b/agents/platform/skills/openshift-routes-ingress/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: openshift-routes-ingress
+metadata:
+  category: Networking
+description: >-
+  Configures and troubleshoots OpenShift native Routes (route.openshift.io/v1),
+  HAProxy edge ingress, TLS termination (edge, passthrough, re-encrypt), and
+  service exposing. Use when exposing services externally on OpenShift,
+  configuring HTTP-to-HTTPS redirects, setting custom hostnames, resolving
+  router 503 "Application is not available" errors, or configuring OpenShift
+  Service Serving Certificates. Don't use for GKE Gateway API, GKE Ingress, or
+  Cloud Armor policies.
+---
+
+# OpenShift Routes & Ingress Skill
+
+This skill provides workflows for exposing services on Red Hat OpenShift using
+native OpenShift `Route` resources (`route.openshift.io/v1`), configured with
+OpenShift's default HAProxy Ingress Controller (`router-default`).
+
+On OpenShift, Routes are the standard, lightweight alternative to Kubernetes
+Ingress and GKE Gateway API, providing automated DNS resolution, TLS
+termination, and traffic routing.
+
+## Critical Rules
+
+- **READ-ONLY DIAGNOSTICS & GITOPS MUTATIONS:** The Platform Agent operates with read-only cluster visibility. Do not run direct mutating commands (`oc create route`, `oc annotate service`) unattended. Propose all Route manifests and Service annotations as declarative GitOps pull requests or present them via `submit-suggestion` for operator confirmation.
+- **CLI COMPATIBILITY:** Route resources (`route.openshift.io/v1`) are standard Custom Resources. All inspection commands run identically via `oc` or `kubectl` (e.g. `kubectl get routes.route.openshift.io -n {namespace}`).
+- **DEFAULT ROUTE HOSTING:** When `spec.host` is omitted, OpenShift automatically assigns `<route_name>-<namespace>.apps.<domain>`. Do not hardcode domain names unless explicitly requested.
+
+## TLS Termination Modes
+
+| Mode | Termination Point | Backend Communication | Typical Use Case |
+| :--- | :--- | :--- | :--- |
+| `edge` | HAProxy Router | Plain HTTP | Standard web apps, APIs, microservices |
+| `passthrough` | Target Pod | Direct HTTPS/TLS (end-to-end) | Workloads with dedicated certificates or mTLS |
+| `reencrypt` | HAProxy Router & Target Pod | HTTPS to Router, re-encrypted HTTPS to Pod | Zero-trust internal networks |
+
+---
+
+## Workflows
+
+### 1. Expose a Service via Edge Route (Recommended Default)
+
+Exposes an internal Service over HTTPS, terminating TLS at the router using the cluster's default wildcard certificate (`*.apps.<domain>`), and redirecting plain HTTP to HTTPS:
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {route_name}
+  namespace: {namespace}
+spec:
+  to:
+    kind: Service
+    name: {service_name}
+    weight: 100
+  port:
+    targetPort: {service_port_name_or_number}
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+```
+
+---
+
+### 2. Configure Service Serving Certificates (Internal TLS)
+
+OpenShift provides an internal Service CA that automatically generates certificates for cluster services:
+
+1. Propose annotating the Service in the GitOps manifest:
+   ```yaml
+   metadata:
+     annotations:
+       service.beta.openshift.io/serving-cert-secret-name: {secret_name}
+   ```
+2. Mount `{secret_name}` into the application pod for TLS listening (contains `tls.crt` and `tls.key`).
+3. Create a `reencrypt` Route so HAProxy verifies the internal cert:
+   ```yaml
+   apiVersion: route.openshift.io/v1
+   kind: Route
+   metadata:
+     name: {route_name}
+     namespace: {namespace}
+   spec:
+     to:
+       kind: Service
+       name: {service_name}
+     port:
+       targetPort: https
+     tls:
+       termination: reencrypt
+       insecureEdgeTerminationPolicy: Redirect
+   ```
+
+---
+
+### 3. Expose via Passthrough Route (mTLS / End-to-End Encryption)
+
+Sends encrypted traffic directly to the backend pod without HAProxy decrypting:
+
+```yaml
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {route_name}
+  namespace: {namespace}
+spec:
+  to:
+    kind: Service
+    name: {service_name}
+  port:
+    targetPort: {https_port}
+  tls:
+    termination: passthrough
+```
+
+---
+
+### 4. Troubleshoot Route Issues (503 "Application is not available")
+
+When curl or a browser returns:
+`503 Service Unavailable: Application is not available`
+
+**Step 1: Check Route Host & DNS Resolution**
+```bash
+# Retrieve the assigned canonical hostname
+HOST=$(kubectl get routes.route.openshift.io {route_name} -n {namespace} -o jsonpath='{.spec.host}' 2>/dev/null || oc get route {route_name} -n {namespace} -o jsonpath='{.spec.host}')
+echo "Route Host: $HOST"
+
+# Verify DNS resolution matches the ingress router IP
+dig +short "$HOST"
+```
+
+**Step 2: Inspect Service Endpoints**
+HAProxy returns 503 if the backend Service has 0 healthy endpoints:
+```bash
+kubectl get endpoints {service_name} -n {namespace}
+```
+If endpoints list is `<none>`, inspect backend pod readiness probes and labels:
+```bash
+kubectl get pods -n {namespace} -l {selector}
+```
+
+**Step 3: Check Ingress Controller Status**
+```bash
+kubectl get ingresscontroller.operator.openshift.io default -n openshift-ingress-operator
+kubectl get pods -n openshift-ingress
+```

--- a/docs/family-roster.txt
+++ b/docs/family-roster.txt
@@ -93,6 +93,7 @@ agents/platform/skills/*/SKILL.md
   agents/platform/skills/inspect-repository/SKILL.md
   agents/platform/skills/kube-agents-observability/SKILL.md
   agents/platform/skills/manage-cluster/SKILL.md
+  agents/platform/skills/openshift-routes-ingress/SKILL.md
   agents/platform/skills/pr-conversation/SKILL.md
   agents/platform/skills/submit-suggestion/SKILL.md
   agents/platform/skills/workload-rebalancing/SKILL.md

--- a/docs/site/src/content/docs/skills/index.mdx
+++ b/docs/site/src/content/docs/skills/index.mdx
@@ -104,6 +104,12 @@ Generated from the `name` and `description` frontmatter of every `agents/platfor
 | [`inspect-repository`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/inspect-repository/SKILL.md) | Read and analyze the source of any GitHub repository — public or one this install has a token for — without a local checkout. Clones broker-side and pulls file content back; use it to answer questions about code, not to change it. |
 | [`pr-conversation`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/pr-conversation/SKILL.md) | Answer a reviewer who addressed you on one of your own pull requests — read the thread, answer or amend the branch, and reply in the thread. |
 
+### Other
+
+| Skill | Description |
+| ----- | ----------- |
+| [`openshift-routes-ingress`](https://github.com/gke-labs/kube-agents/blob/main/agents/platform/skills/openshift-routes-ingress/SKILL.md) | Configures and troubleshoots OpenShift native Routes (route.openshift.io/v1), HAProxy edge ingress, TLS termination (edge, passthrough, re-encrypt), and service exposing. Use when exposing services externally on OpenShift, configuring HTTP-to-HTTPS redirects, setting custom hostnames, resolving router 503 "Application is not available" errors, or configuring OpenShift Service Serving Certificates. Don't use for GKE Gateway API, GKE Ingress, or Cloud Armor policies. |
+
 ### Cluster Agent (per-cluster runtime)
 
 | Skill | Description |


### PR DESCRIPTION
## Summary
Adds an OpenShift native Route ingress and traffic routing skill (`openshift-routes-ingress`) for the Platform Agent.

## Why This Change
On Red Hat OpenShift:
1. Ingress and external service exposure rely on native OpenShift `Route` resources (`route.openshift.io/v1`) driven by the cluster HAProxy ingress controller, rather than GKE Gateway API or GKE Ingress.
2. Agents operating on OpenShift need operational skills to author `Route` manifests, configure TLS termination modes (`edge`, `passthrough`, `reencrypt`), configure Service Serving Certificates, and diagnose HAProxy 503 "Application is not available" errors.
3. Declarative GitOps workflows are preferred over live imperatively generated routes.

## What Changed
- `agents/platform/skills/openshift-routes-ingress/SKILL.md`: New skill covering OpenShift Route authoring, TLS termination modes, OpenShift Service Serving Certificates, and 503 troubleshooting.
  - Enforces read-only cluster visibility and declarative GitOps pull requests for route creation.
  - Formulates commands with `kubectl` / `oc` compatibility.
- `docs/site/src/content/docs/skills/index.mdx` & `docs/family-roster.txt`: Updated generated skill catalog and family roster via `make docs-generate`.

## Context
Closes #1426. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine.
Companion PRs: #1375 (Operator CoreDNS), #1376 (Helm SCC/Route), #1377 (Sandbox oc CLI), #1378 (OpenShift Machine API skill), #1380 (Installer OpenShift support), #1381 (OpenShift SCC skill), #1382 (OpenShift Obtainability skill), #1384 (Manifest & storage compatibility).

## Testing
- Ran `make prompt-check`:
  ```
  Prompt assets OK: 106 instruction files, 47 skill bundles (cluster 6, platform 41), 17 cron jobs in 2 rosters, all references resolve.
  ```
- Ran `make docs-check`:
  ```
  Checked relative links in 297 Markdown files. All relative links resolve.
  Checking terminology across 297 documentation files... Terminology check passed.
  Documentation map inventory covers all 264 tracked docs (265 counting the map itself), no stale path cells, no re-aligned table rows.
  ```

### Live validation
- **Target Installation:** Red Hat OpenShift / OKD v1.35.5 running on GCE in `us-central1` (project `gca-gke-2025`), running platform agent `platform-agent-gateway-6f4974576d-rq7ll` in `kubeagents-system`.
- **Fault Injection (Route TargetPort Mismatch):**
  Deployed Service `web-service` on port 8080 and misconfigured Route `web-route` with `targetPort: 9090` in namespace `route-ingress-test`:
  ```
  $ oc get route web-route -n route-ingress-test
  NAME        HOST/PORT                                                SERVICES      PORT   TERMINATION
  web-route   web-route-route-ingress-test.apps.okd.gca-gke-2025.net   web-service   9090
  ```
- **Autonomous Agent Diagnosis:**
  Dispatched task `t_29a326cd` to the platform agent:
  ```
  [hermes-otel] Registered 13 hooks
    ┊ 📋 preparing kanban_show…
    ┊ 📚 preparing skill_view… openshift-routes-ingress
    ┊ 💻 $ oc get endpoints web-service -n route-ingress-test
    ┊ 💻 $ HOST=$(oc get route web-route -n route-ingress-test -o jsonpath='{.spec.host}')
    ┊ 💻 $ oc get ingresscontroller default -n openshift-ingress-operator
    ┊ 💻 $ oc get pods -n openshift-ingress
    ┊ 💻 $ oc get route web-route -n route-ingress-test -o yaml
    ┊ 💻 $ oc get service web-service -n route-ingress-test -o yaml

  ╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮
  The OpenShift Route web-route in namespace route-ingress-test is failing because of a port mismatch
  between the Route's targetPort and the web-service's actual listening port.

  What's wrong:
  Route-Service Port Mismatch — The web-route is configured to send traffic to targetPort: 9090,
  but the web-service is listening on port 8080.

  Why:
  * Route Configuration: spec.port.targetPort: 9090.
  * Service Configuration: spec.ports[0].port: 8080 and spec.ports[0].targetPort: 8080.
  * Endpoints Verification: oc get endpoints web-service shows active endpoints on 10.131.0.22:8080.

  What to do:
  Patch the web-route to update its spec.port.targetPort to 8080 to match the web-service exposed port:
    oc patch route web-route -n route-ingress-test -p '{"spec":{"port":{"targetPort":8080}}}' --type=merge
  ╰──────────────────────────────────────────────────────────────────────────────╯
  ```
- **Remediation Result:**
  Applied the recommended patch:
  ```
  $ oc patch route web-route -n route-ingress-test -p '{"spec":{"port":{"targetPort":8080}}}' --type=merge
  route.route.openshift.io/web-route patched

  $ oc get route web-route -n route-ingress-test
  NAME        HOST/PORT                                                SERVICES      PORT   TERMINATION
  web-route   web-route-route-ingress-test.apps.okd.gca-gke-2025.net   web-service   8080
  ```
  Route traffic path restored and pointing directly to live endpoint `8080`.

## Self-Review
- **Adversarial Pass (clean subagent context):**
  - Verified default wildcard domain omission so agents do not invent arbitrary hostnames.
  - Required declarative Route manifests instead of direct `oc create route` commands.
- **Docs-Drift Pass (clean subagent context):**
  - Regenerated `docs/family-roster.txt` and `docs/site/src/content/docs/skills/index.mdx` with `make docs-generate`.
  - Confirmed `make docs-check` passes with zero stale targets.

## Risk & Rollout
Low risk. Documentation and agent skill guidance updates only; no binary or cluster runtime mutations. Revertible by git revert.

---
Generated with the help of Jetski / Gemini.
