### PR TITLE
feat(skills): add OpenShift compatibility to manifest generation and storage skills

### DIFF
--- a/agents/platform/skills/gke-manifest-generation/SKILL.md
+++ b/agents/platform/skills/gke-manifest-generation/SKILL.md
@@ -71,6 +71,10 @@ following rules:
     `runAsNonRoot: true`, `runAsUser: 10000`, `runAsGroup: 10000`, `fsGroup:
     10000`). This is strictly enforced on GKE Autopilot and is a critical
     security baseline for GKE Standard.
+    *OpenShift adaptation*: On Red Hat OpenShift, namespaces enforce dynamic UID
+    ranges under the `restricted-v2` SCC. Omit explicit `runAsUser`, `runAsGroup`,
+    and `fsGroup`—specifying only `runAsNonRoot: true`—to allow OpenShift admission
+    to assign valid UIDs, unless the target ServiceAccount has the `nonroot` SCC.
 -   **Minimal Privileges**: Always set `allowPrivilegeEscalation: false` and
     `seccompProfile: {type: RuntimeDefault}`.
 -   **Read-Only Root Filesystem**: Set `readOnlyRootFilesystem: true` to prevent
@@ -118,10 +122,11 @@ following rules:
 -   **Port Naming**: Always assign clear, standard names to service and
     container ports (e.g., `name: http-web` or `name: grpc-api`) to enable
     automatic protocol discovery, tracing, and Web App routing.
--   **Prefer Gateway API**: When exposing APIs externally, prioritize using GKE
-    Gateway API (`Gateway` and `HTTPRoute` resources) over legacy `Ingress`
-    objects to enable advanced L7 routing and security features (e.g., Cloud
-    Armor).
+-   **Prefer Gateway API (GKE) / Routes (OpenShift)**: When exposing APIs externally
+    on GKE, prioritize using GKE Gateway API (`Gateway` and `HTTPRoute` resources)
+    over legacy `Ingress` objects to enable advanced L7 routing and security features
+    (e.g., Cloud Armor). On OpenShift clusters, expose public services via native
+    `Route` (`route.openshift.io/v1`) with edge TLS termination and HTTP redirect.
 
 ### 6. Volume Mounts, StorageClasses & subPath Safety
 
@@ -131,13 +136,15 @@ following rules:
     *Caveat*: Note that containers using `subPath` volume mounts do not receive
     automatic configuration updates if the underlying ConfigMap or Secret is
     modified; pods must be restarted manually to pick up changes.
--   **StorageClass Selection**: Use the correct GKE storage class in
+-   **StorageClass Selection**: Use the correct cluster storage class in
     PersistentVolumeClaims:
-    -   *CSI Driver Clusters (Autopilot & Modern Standard)*: Use `standard-rwo`
+    -   *GKE CSI Driver Clusters (Autopilot & Modern Standard)*: Use `standard-rwo`
         (default balanced PD) or `premium-rwo` (SSD PD).
+    -   *OpenShift on GCE Clusters*: Use `standard-csi` (default balanced PD)
+        or `ssd-csi` (SSD PD) via `pd.csi.storage.gke.io`.
     -   *Legacy Standard Clusters*: Use `standard` (default PD) or `premium`
         (SSD PD) if `standard-rwo`/`premium-rwo` are not configured.
-    -   *Database rule*: Use SSD storage classes (`premium-rwo` or `premium`)
+    -   *Database rule*: Use SSD storage classes (`premium-rwo`, `ssd-csi`, or `premium`)
         only when the prompt explicitly requests high IOPS, low latency, or
         database storage.
 

--- a/agents/platform/skills/gke-storage/SKILL.md
+++ b/agents/platform/skills/gke-storage/SKILL.md
@@ -42,10 +42,18 @@ GKE provides built-in StorageClasses:
 
 StorageClass   | Disk Type             | Use Case
 -------------- | --------------------- | ------------------------------
-`standard-rwo` | `pd-standard`         | Cost-effective, low IOPS
-`premium-rwo`  | `pd-ssd`              | High IOPS, databases
+`standard-rwo` | `pd-standard` (GKE)   | Cost-effective, low IOPS
+`premium-rwo`  | `pd-ssd` (GKE)        | High IOPS, databases
+`standard-csi` | `pd-balanced` (OCP)   | OpenShift on GCE default block storage
+`ssd-csi`      | `pd-ssd` (OCP)        | OpenShift on GCE fast SSD storage
 `standard-rwx` | Filestore (Basic HDD) | Shared NFS
 `premium-rwx`  | Filestore (Basic SSD) | Shared NFS, higher performance
+
+> **Cluster StorageClass Discovery**: To discover the cluster's active default
+> StorageClass dynamically on either GKE or OpenShift:
+> ```bash
+> kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
+> ```
 
 ### Custom StorageClass
 


### PR DESCRIPTION
## Summary
Adds OpenShift workload compatibility instructions to `gke-manifest-generation` and `gke-storage` skills.

## Why This Change
On Red Hat OpenShift:
1. Workload admission enforces dynamic UID ranges under `restricted-v2` SecurityContextConstraints. Manifest generators hardcoding fixed non-root UIDs (e.g. `runAsUser: 10000`) cause admission rejections unless guided to omit fixed UIDs for OpenShift deployments.
2. Ingress on OpenShift clusters defaults to native `Route` objects (`route.openshift.io/v1`) rather than GKE Gateway API or GKE Ingress.
3. Persistent storage on OpenShift on GCE relies on `standard-csi` and `ssd-csi` via `pd.csi.storage.gke.io` rather than GKE's `standard-rwo` / `premium-rwo`.

## What Changed
- `agents/platform/skills/gke-manifest-generation/SKILL.md`:
  - Added OpenShift adaptation guidance: omit `runAsUser`, `runAsGroup`, and `fsGroup` when deploying to OpenShift so SCC admission injects namespace UIDs automatically.
  - Added guidance to author native OpenShift `Route` resources when deploying to OpenShift clusters without Gateway API.
  - Documented OpenShift on GCE StorageClasses (`standard-csi`, `ssd-csi`).
- `agents/platform/skills/gke-storage/SKILL.md`:
  - Added OpenShift on GCE StorageClasses to the storage class mapping table.
  - Added dynamic default StorageClass discovery command (`kubectl get sc -o jsonpath='...'`) to replace hardcoded assumptions.

## Context
Closes #1427. Part of the phased support for Red Hat OpenShift on Google Compute Engine tracked in overarching issue #1374. Part of the phased support for Red Hat OpenShift on Google Compute Engine.
Companion PRs: #1375 (Operator CoreDNS), #1376 (Helm SCC/Route), #1377 (Sandbox oc CLI), #1378 (OpenShift Machine API skill), #1380 (Installer OpenShift support), #1381 (OpenShift SCC skill), #1382 (OpenShift Obtainability skill), #1383 (OpenShift Route skill).

## Testing
- Ran `make prompt-check`:
  ```
  Prompt assets OK: 105 instruction files, 46 skill bundles (cluster 6, platform 40), 17 cron jobs in 2 rosters, all references resolve.
  ```
- Ran `make docs-check`:
  ```
  Checked relative links in 296 Markdown files. All relative links resolve.
  Checking terminology across 296 documentation files... Terminology check passed.
  Documentation map inventory covers all 263 tracked docs (264 counting the map itself), no stale path cells, no re-aligned table rows.
  ```

### Live validation
- **Target Installation:** Red Hat OpenShift / OKD v4.22.x on GCE in `us-central1`, running kube-agents operator and Platform Agent on image tag `main`.
- **Manifest Generation Validation:** Deployed a sample workload (`compliant-workload`) in namespace `default` following the updated manifest guidelines:
  ```
  $ kubectl get pod compliant-workload-77cb66bf8b-2x8pl -n default -o jsonpath='{.spec.securityContext}'
  {"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}
  $ kubectl get pod compliant-workload-77cb66bf8b-2x8pl -n default -o jsonpath='{.metadata.annotations.openshift\.io/scc}'
  restricted-v2
  ```
- **Dynamic StorageClass Discovery Validation:**
  ```
  $ kubectl get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
  standard-csi
  ```
  Verified that persistent volume claims bound to `standard-csi` with provisioner `pd.csi.storage.gke.io`. Test workloads and PVCs were cleaned up after verification.

## Self-Review
- **Adversarial Pass (clean subagent context):**
  - Checked for broken skill reference strings: removed unmerged `openshift-routes-ingress skill` cross-reference that broke `make prompt-check` in automated review.
  - Verified conditional phrasing: ensured OpenShift notes are scoped as conditional adaptations so standard GKE generation remains unaffected.
- **Docs-Drift Pass (clean subagent context):**
  - Confirmed `docs/site/src/content/docs/skills/index.mdx` and docs map require no structural changes as existing skills were updated in-place.
  - Verified that all relative links and terminology pass `make docs-check`.

## Risk & Rollout
Low risk. Documentation and agent skill guidance updates only; no binary, operator runtime, or cluster schema mutations. Revertible by git revert.

---
Generated with the help of Jetski / Gemini.
