### PR TITLE
fix(a2a): release a conversation whose task never produced a first event

### DIFF
--- a/a2a/gateway/config.go
+++ b/a2a/gateway/config.go
@@ -37,6 +37,10 @@ const defaultTaskDeadline = 30 * time.Minute
 // the horizon rationale.
 const defaultAskTTL = 24 * time.Hour
 
+// defaultFirstEventGrace is what FirstEventGrace means when unset; the
+// field's comment carries the sizing rationale.
+const defaultFirstEventGrace = 10 * time.Minute
+
 // Config is the gateway's runtime configuration. The env contract matches
 // what the W6 operator renders onto the a2a-gateway Deployment; everything
 // else has playground defaults.
@@ -110,6 +114,27 @@ type Config struct {
 	// retention erodes exactly that claim; lowering it only trims how long
 	// a status card can echo the ask.
 	AskTTL time.Duration
+
+	// FirstEventGrace bounds how long an active task with NOTHING on its
+	// events subject may hold a conversation's serialization
+	// (A2A_FIRST_EVENT_GRACE). Every other bound assumes a pod: the adapter's
+	// deadline runs from task start inside the worker, the pod deadline from
+	// pod start, and Sweep watches pod phases — so a task whose executor
+	// never came up (a spawn that never happened, a bus that dropped between
+	// the two publishes, a gateway restart mid-turn) has no events for the
+	// heal in handleInbound to see a terminal in, and the record steers every
+	// later message into it. Past this grace the heal treats "no events" as
+	// "never started" and releases the serialization; the task itself is
+	// left to the supervisor paths, which only ever act on evidence. Unset
+	// means 10 minutes: the spec's cold start is 5-10s and the pod deadline's
+	// pre-start budget (podDeadlineGrace, the image pull before the process
+	// starts) is 10 minutes, so a task still legitimately pre-first-event at
+	// this age is a pod that will not be coming up. Lowering it risks
+	// releasing a slow-starting worker's task out from under it — the next
+	// turn then starts a second task while the first may still emit;
+	// raising it is how long a user waits before the conversation answers
+	// again.
+	FirstEventGrace time.Duration
 
 	// OwnerDeployment names the gateway's own Deployment
 	// (A2A_OWNER_DEPLOYMENT; the operator renders its own render's name).
@@ -212,6 +237,16 @@ func FromEnv() (*Config, error) {
 		return nil, fmt.Errorf("A2A_ASK_TTL %q is under the 1m floor; it would erase the ask from status cards while the task runs", askTTL)
 	}
 	cfg.AskTTL = at
+
+	grace := envOr("A2A_FIRST_EVENT_GRACE", defaultFirstEventGrace.String())
+	fg, err := time.ParseDuration(grace)
+	if err != nil {
+		return nil, fmt.Errorf("A2A_FIRST_EVENT_GRACE %q: %w", grace, err)
+	}
+	if fg < time.Minute {
+		return nil, fmt.Errorf("A2A_FIRST_EVENT_GRACE %q is under the 1m floor; it would release a task still cold-starting", grace)
+	}
+	cfg.FirstEventGrace = fg
 
 	cfg.OwnerDeployment = os.Getenv("A2A_OWNER_DEPLOYMENT")
 

--- a/a2a/gateway/config.go
+++ b/a2a/gateway/config.go
@@ -124,8 +124,8 @@ type Config struct {
 	// the two publishes, a gateway restart mid-turn) has no events for the
 	// heal in handleInbound to see a terminal in, and the record steers every
 	// later message into it. Past this grace the heal treats "no events" as
-	// "never started" and releases the serialization; the task itself is
-	// left to the supervisor paths, which only ever act on evidence. Unset
+	// "never started" and releases the serialization; it publishes no
+	// terminal for the task, because age alone is not evidence. Unset
 	// means 10 minutes: the spec's cold start is 5-10s and the pod deadline's
 	// pre-start budget (podDeadlineGrace, the image pull before the process
 	// starts) is 10 minutes, so a task still legitimately pre-first-event at
@@ -133,7 +133,7 @@ type Config struct {
 	// releasing a slow-starting worker's task out from under it — the next
 	// turn then starts a second task while the first may still emit;
 	// raising it is how long a user waits before the conversation answers
-	// again.
+	// again. Values under 1m are refused at boot.
 	FirstEventGrace time.Duration
 
 	// OwnerDeployment names the gateway's own Deployment

--- a/a2a/gateway/config_test.go
+++ b/a2a/gateway/config_test.go
@@ -25,6 +25,7 @@ func setBaseEnv(t *testing.T) {
 	t.Setenv("A2A_ATTRIBUTION_SALT", "")
 	t.Setenv("A2A_TASK_DEADLINE_SECONDS", "")
 	t.Setenv("A2A_ASK_TTL", "")
+	t.Setenv("A2A_FIRST_EVENT_GRACE", "")
 	t.Setenv("A2A_OWNER_DEPLOYMENT", "")
 	t.Setenv("A2A_MAX_SESSIONS", "")
 	t.Setenv("A2A_IDLE_TTL", "")
@@ -282,6 +283,37 @@ func TestFromEnvAskTTL(t *testing.T) {
 		t.Setenv("A2A_ASK_TTL", bad)
 		if _, err := FromEnv(); err == nil {
 			t.Fatalf("A2A_ASK_TTL=%q accepted", bad)
+		}
+	}
+}
+
+// TestFromEnvFirstEventGrace: the bound on a task with no events at all —
+// absent means 10m (the pod deadline's pre-start budget), and a sub-minute
+// value refuses at boot.
+func TestFromEnvFirstEventGrace(t *testing.T) {
+	setBaseEnv(t)
+
+	cfg, err := FromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.FirstEventGrace != 10*time.Minute {
+		t.Fatalf("default FirstEventGrace = %v, want 10m", cfg.FirstEventGrace)
+	}
+
+	t.Setenv("A2A_FIRST_EVENT_GRACE", "3m")
+	cfg, err = FromEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.FirstEventGrace != 3*time.Minute {
+		t.Fatalf("FirstEventGrace = %v, want 3m", cfg.FirstEventGrace)
+	}
+
+	for _, bad := range []string{"30s", "junk"} {
+		t.Setenv("A2A_FIRST_EVENT_GRACE", bad)
+		if _, err := FromEnv(); err == nil {
+			t.Fatalf("A2A_FIRST_EVENT_GRACE=%q accepted", bad)
 		}
 	}
 }

--- a/a2a/gateway/gateway.go
+++ b/a2a/gateway/gateway.go
@@ -23,6 +23,11 @@ const turnTimeout = 60 * time.Second
 // Options.RelayDurable for the one caller that may not share it.
 const relayDurable = "gateway-relay"
 
+// neverStartedNotice is what the conversation sees when the heal releases a
+// task that produced no first event inside FirstEventGrace: the task id,
+// the grace, and what happens to the message that triggered it.
+const neverStartedNotice = "⚠️ task `%s` never started — nothing on its event stream after %s — so this conversation is released and this message is handled as a new turn"
+
 // Hex-suffix widths for the ids the gateway mints. Context and correlation
 // ids are wider than task and message ids: they outlive one task and join
 // records across surfaces, so a collision costs more.
@@ -128,6 +133,9 @@ func New(o Options) (*Gateway, error) {
 	}
 	if o.Config.AskTTL <= 0 {
 		o.Config.AskTTL = defaultAskTTL
+	}
+	if o.Config.FirstEventGrace <= 0 {
+		o.Config.FirstEventGrace = defaultFirstEventGrace
 	}
 	g := &Gateway{
 		cfg:          o.Config,
@@ -264,10 +272,32 @@ func (g *Gateway) handleInbound(msg InboundMessage) {
 	// card rather than clearing silently — the same deterministic template
 	// the status ask uses. In the relay-lag case this duplicates the
 	// rolling-line edit that follows; redundant beats swallowed.
+	//
+	// The other stale shape has no terminal to find: a task with NO events
+	// at all (TasksGet answers TaskNotFound) because its executor never
+	// came up — nothing for the fold to see, nothing for Sweep to watch,
+	// and reap never clears ActiveTask. Past FirstEventGrace that is a
+	// task that never started, and the serialization is released the same
+	// way, with a plain line instead of a status card (there is no status
+	// to replay). Only TaskNotFound qualifies: a transport failure cannot
+	// rule out events, so it heals nothing, as everywhere else the
+	// supervisor paths consult the stream. The task's own closure is not
+	// this branch's — the spawn-failure and Sweep paths publish terminals
+	// on evidence, and a heal on age alone could race a first event that
+	// is merely late.
 	if active := rec.ActiveTask; active != nil && !active.Detached {
-		if task, err := g.client.TasksGet(ctx, rec.Addressee, active.TaskID); err == nil && task.Final {
+		task, err := g.client.TasksGet(ctx, rec.Addressee, active.TaskID)
+		switch {
+		case err == nil && task.Final:
 			g.log.Info("healing stale active task", "taskId", active.TaskID, "state", task.State)
 			g.post(rec.Key, formatTaskStatus(task, active.Ask, active.SubmittedAt))
+			rec.ActiveTask = nil
+		case isTaskNotFound(err) && !active.SubmittedAt.IsZero() &&
+			time.Since(active.SubmittedAt) > g.cfg.FirstEventGrace:
+			g.log.Info("healing an active task that never produced a first event",
+				"conversation", rec.Key, "taskId", active.TaskID, "addressee", rec.Addressee,
+				"age", time.Since(active.SubmittedAt).Round(time.Second), "grace", g.cfg.FirstEventGrace)
+			g.post(rec.Key, fmt.Sprintf(neverStartedNotice, active.TaskID, g.cfg.FirstEventGrace))
 			rec.ActiveTask = nil
 		}
 	}
@@ -297,6 +327,12 @@ func (g *Gateway) handleInbound(msg InboundMessage) {
 			g.post(rec.Key, "🤷 nothing is running")
 		}
 	case active != nil && !active.Detached:
+		// The one routing decision with no other log line: a new task logs
+		// "ingress", a heal logs itself, but a steer used to be silent, and
+		// a conversation wedged on a stale record was undiagnosable from
+		// the gateway's logs (#1318).
+		g.log.Info("routing as steer", "conversation", msg.Conversation, "taskId", active.TaskID,
+			"addressee", rec.Addressee, "taskAge", time.Since(active.SubmittedAt).Round(time.Second))
 		g.steerTask(ctx, rec, msg, authority)
 	default:
 		if rest, ok := isDelegate(msg.Text); ok && g.spawner != nil {

--- a/a2a/gateway/gateway.go
+++ b/a2a/gateway/gateway.go
@@ -25,8 +25,9 @@ const relayDurable = "gateway-relay"
 
 // neverStartedNotice is what the conversation sees when the heal releases a
 // task that produced no first event inside FirstEventGrace: the task id,
-// the grace, and what happens to the message that triggered it.
-const neverStartedNotice = "⚠️ task `%s` never started — nothing on its event stream after %s — so this conversation is released and this message is handled as a new turn"
+// the grace, and what happens to the message that triggered it. It states
+// the evidence (nothing on the stream in that long), not the inference.
+const neverStartedNotice = "⚠️ task `%s` has produced nothing on its event stream in %s, so this conversation is released and this message is handled as a new turn"
 
 // Hex-suffix widths for the ids the gateway mints. Context and correlation
 // ids are wider than task and message ids: they outlive one task and join
@@ -281,24 +282,38 @@ func (g *Gateway) handleInbound(msg InboundMessage) {
 	// way, with a plain line instead of a status card (there is no status
 	// to replay). Only TaskNotFound qualifies: a transport failure cannot
 	// rule out events, so it heals nothing, as everywhere else the
-	// supervisor paths consult the stream. The task's own closure is not
-	// this branch's — the spawn-failure and Sweep paths publish terminals
-	// on evidence, and a heal on age alone could race a first event that
-	// is merely late.
+	// supervisor paths consult the stream. No terminal is published here:
+	// age alone is not evidence, a first event that is merely late could
+	// still arrive, and no supervisor path ever sees a task with no pod —
+	// so a task released here ages out with the stream's retention, the
+	// residue Session lifecycle names. The task index stays, as in the
+	// terminal case, so a late start still renders; its key is retired
+	// only if the task ever terminates.
 	if active := rec.ActiveTask; active != nil && !active.Detached {
 		task, err := g.client.TasksGet(ctx, rec.Addressee, active.TaskID)
+		healed := false
 		switch {
 		case err == nil && task.Final:
 			g.log.Info("healing stale active task", "taskId", active.TaskID, "state", task.State)
 			g.post(rec.Key, formatTaskStatus(task, active.Ask, active.SubmittedAt))
-			rec.ActiveTask = nil
+			healed = true
 		case isTaskNotFound(err) && !active.SubmittedAt.IsZero() &&
 			time.Since(active.SubmittedAt) > g.cfg.FirstEventGrace:
-			g.log.Info("healing an active task that never produced a first event",
+			g.log.Info("healing an active task with no first event inside the grace",
 				"conversation", rec.Key, "taskId", active.TaskID, "addressee", rec.Addressee,
 				"age", time.Since(active.SubmittedAt).Round(time.Second), "grace", g.cfg.FirstEventGrace)
 			g.post(rec.Key, fmt.Sprintf(neverStartedNotice, active.TaskID, g.cfg.FirstEventGrace))
+			healed = true
+		}
+		if healed {
 			rec.ActiveTask = nil
+			// Write the release now, not at the end of the turn: a turn that
+			// returns early — a cap refusal, on exactly the Delegate that
+			// follows a wedge — would otherwise announce a release it never
+			// wrote and announce it again on the next turn.
+			if err := withRetry(kvRetryAttempts, func() error { return g.reg.Put(ctx, rec) }); err != nil {
+				g.log.Error("healed record write failed", "conversation", rec.Key, "err", err)
+			}
 		}
 	}
 

--- a/a2a/gateway/gateway_test.go
+++ b/a2a/gateway/gateway_test.go
@@ -670,6 +670,95 @@ func TestStaleActiveTaskHealsInsteadOfSteering(t *testing.T) {
 	})
 }
 
+// seedTasklessDelegate writes the record #1318 observed: a Delegate whose
+// task is on the serialization record but produced NOTHING on its events
+// subject — no pod (PodName empty), no terminal for the heal to find, and
+// not even a `submitted` for Sweep or the relay to act on. Nothing is
+// published to the stream here on purpose; a task with events would pass
+// the old heal whether or not the no-events case is handled.
+func seedTasklessDelegate(t *testing.T, r *rig, conv string, age time.Duration) *SessionRecord {
+	t.Helper()
+	rec := &SessionRecord{
+		Key: conv, ContextID: "ctx-taskless", Kind: "group", LastActivity: time.Now().UTC(),
+		BusSession: "chat-otter-dead", Addressee: "chat-otter-dead",
+		ActiveTask: &ActiveTask{TaskID: "task-never", CorrelationID: "corr-never",
+			Ask: "write a haiku", SubmittedAt: time.Now().Add(-age)},
+		Tasks: []TaskRef{{ID: "task-never", Addressee: "chat-otter-dead"}},
+	}
+	if err := r.g.reg.Put(context.Background(), rec); err != nil {
+		t.Fatal(err)
+	}
+	return rec
+}
+
+// TestTasklessActiveTaskPastGraceHealsIntoNewDelegation (#1318): an active
+// task older than FirstEventGrace with no events at all must release the
+// conversation — the next "Delegate:" is a NEW delegation (fresh task, fresh
+// session, a spawn), not a steer into the task that never started, and the
+// conversation is told why.
+func TestTasklessActiveTaskPastGraceHealsIntoNewDelegation(t *testing.T) {
+	r, spawn := startRigWithSpawner(t)
+	conv := "discord:g1/thread-taskless-old"
+	seedTasklessDelegate(t, r, conv, defaultFirstEventGrace+time.Minute)
+
+	r.adapter.inbox <- InboundMessage{Conversation: conv, Kind: "group",
+		AuthorID: "1001", MessageID: "t-1", Text: "Delegate: write a haiku about otters"}
+	waitFor(t, "a fresh delegation spawned", func() bool { return len(spawn.calls()) == 1 })
+	call := spawn.calls()[0]
+	if call.TaskID == "task-never" || call.Session == "chat-otter-dead" {
+		t.Fatalf("delegation reused the dead task or session: %+v", call)
+	}
+	if steers := inSubjectEnvelopes(t, r.url, "chat-otter-dead"); len(steers) != 0 {
+		t.Fatalf("the message was steered into the task that never started: %+v", steers)
+	}
+	var told bool
+	for _, p := range r.adapter.postTexts() {
+		if strings.Contains(p, "task-never") && strings.Contains(p, "never started") {
+			told = true
+		}
+	}
+	if !told {
+		t.Fatalf("the conversation was not told the task never started: %q", r.adapter.postTexts())
+	}
+	rec, err := r.g.reg.Get(context.Background(), conv)
+	if err != nil || rec == nil || rec.ActiveTask == nil || rec.ActiveTask.TaskID != call.TaskID {
+		t.Fatalf("record does not serialize on the new task: %+v (err=%v)", rec, err)
+	}
+}
+
+// TestTasklessActiveTaskInsideGraceStillSteers: the same record younger than
+// the grace is a task that may simply not have started yet — a cold pod, a
+// slow pull — and clearing it would start a second task under the first.
+// The message steers, as before, and nothing is released.
+func TestTasklessActiveTaskInsideGraceStillSteers(t *testing.T) {
+	r, spawn := startRigWithSpawner(t)
+	conv := "discord:g1/thread-taskless-young"
+	seedTasklessDelegate(t, r, conv, time.Minute)
+
+	r.adapter.inbox <- InboundMessage{Conversation: conv, Kind: "group",
+		AuthorID: "1001", MessageID: "t-2", Text: "make it about otters"}
+	waitFor(t, "steer published to the pending task", func() bool {
+		for _, e := range inSubjectEnvelopes(t, r.url, "chat-otter-dead") {
+			if e.Kind == lib.KindMessage && e.TaskID == "task-never" {
+				return true
+			}
+		}
+		return false
+	})
+	if got := len(spawn.calls()); got != 0 {
+		t.Fatalf("a task inside the grace was released: %d spawns", got)
+	}
+	for _, p := range r.adapter.postTexts() {
+		if strings.Contains(p, "never started") {
+			t.Fatalf("released a task still inside the grace: %q", p)
+		}
+	}
+	rec, err := r.g.reg.Get(context.Background(), conv)
+	if err != nil || rec == nil || rec.ActiveTask == nil || rec.ActiveTask.TaskID != "task-never" {
+		t.Fatalf("record no longer serializes on the pending task: %+v (err=%v)", rec, err)
+	}
+}
+
 func TestLongFailureReasonIsChunkedUnderTheCap(t *testing.T) {
 	r := startRig(t)
 	conv := "discord:g1/thread8"

--- a/a2a/gateway/gateway_test.go
+++ b/a2a/gateway/gateway_test.go
@@ -679,7 +679,7 @@ func TestStaleActiveTaskHealsInsteadOfSteering(t *testing.T) {
 func seedTasklessDelegate(t *testing.T, r *rig, conv string, age time.Duration) *SessionRecord {
 	t.Helper()
 	rec := &SessionRecord{
-		Key: conv, ContextID: "ctx-taskless", Kind: "group", LastActivity: time.Now().UTC(),
+		Key: conv, ContextID: "ctx-taskless-" + randHex(4), Kind: "group", LastActivity: time.Now().UTC(),
 		BusSession: "chat-otter-dead", Addressee: "chat-otter-dead",
 		ActiveTask: &ActiveTask{TaskID: "task-never", CorrelationID: "corr-never",
 			Ask: "write a haiku", SubmittedAt: time.Now().Add(-age)},
@@ -713,12 +713,12 @@ func TestTasklessActiveTaskPastGraceHealsIntoNewDelegation(t *testing.T) {
 	}
 	var told bool
 	for _, p := range r.adapter.postTexts() {
-		if strings.Contains(p, "task-never") && strings.Contains(p, "never started") {
+		if strings.Contains(p, "task-never") && strings.Contains(p, "produced nothing") {
 			told = true
 		}
 	}
 	if !told {
-		t.Fatalf("the conversation was not told the task never started: %q", r.adapter.postTexts())
+		t.Fatalf("the conversation was not told the task produced nothing: %q", r.adapter.postTexts())
 	}
 	rec, err := r.g.reg.Get(context.Background(), conv)
 	if err != nil || rec == nil || rec.ActiveTask == nil || rec.ActiveTask.TaskID != call.TaskID {
@@ -729,33 +729,70 @@ func TestTasklessActiveTaskPastGraceHealsIntoNewDelegation(t *testing.T) {
 // TestTasklessActiveTaskInsideGraceStillSteers: the same record younger than
 // the grace is a task that may simply not have started yet — a cold pod, a
 // slow pull — and clearing it would start a second task under the first.
-// The message steers, as before, and nothing is released.
+// The message steers, as before, and nothing is released. A record with no
+// SubmittedAt at all has no age to judge and is left alone the same way.
 func TestTasklessActiveTaskInsideGraceStillSteers(t *testing.T) {
 	r, spawn := startRigWithSpawner(t)
-	conv := "discord:g1/thread-taskless-young"
-	seedTasklessDelegate(t, r, conv, time.Minute)
+	for name, age := range map[string]time.Duration{"discord:g1/thread-taskless-young": time.Minute, "discord:g1/thread-taskless-unaged": 0} {
+		conv := name
+		rec := seedTasklessDelegate(t, r, conv, age)
+		if age == 0 {
+			rec.ActiveTask.SubmittedAt = time.Time{}
+			if err := r.g.reg.Put(context.Background(), rec); err != nil {
+				t.Fatal(err)
+			}
+		}
+		r.adapter.inbox <- InboundMessage{Conversation: conv, Kind: "group",
+			AuthorID: "1001", MessageID: "t-" + conv, Text: "make it about otters"}
+		waitFor(t, "steer published to the pending task for "+conv, func() bool {
+			for _, e := range inSubjectEnvelopes(t, r.url, "chat-otter-dead") {
+				if e.Kind == lib.KindMessage && e.TaskID == "task-never" && e.ContextID == rec.ContextID {
+					return true
+				}
+			}
+			return false
+		})
+		if got := len(spawn.calls()); got != 0 {
+			t.Fatalf("%s: a task inside the grace was released: %d spawns", conv, got)
+		}
+		for _, p := range r.adapter.postTexts() {
+			if strings.Contains(p, "produced nothing") {
+				t.Fatalf("%s: released a task still inside the grace: %q", conv, p)
+			}
+		}
+		got, err := r.g.reg.Get(context.Background(), conv)
+		if err != nil || got == nil || got.ActiveTask == nil || got.ActiveTask.TaskID != "task-never" {
+			t.Fatalf("%s: record no longer serializes on the pending task: %+v (err=%v)", conv, got, err)
+		}
+	}
+}
+
+// TestTasklessHealPersistsAcrossCapRefusal: the release is written when the
+// heal fires, not at the end of the turn — a Delegate refused at the session
+// cap returns before the end-of-turn write, and the conversation must not be
+// told it is released while the record still says otherwise.
+func TestTasklessHealPersistsAcrossCapRefusal(t *testing.T) {
+	r, spawn := startRigWithSpawnerCap(t, "platform", 1)
+	spawn.setLive(1)
+	conv := "discord:g1/thread-taskless-cap"
+	seedTasklessDelegate(t, r, conv, defaultFirstEventGrace+time.Minute)
 
 	r.adapter.inbox <- InboundMessage{Conversation: conv, Kind: "group",
-		AuthorID: "1001", MessageID: "t-2", Text: "make it about otters"}
-	waitFor(t, "steer published to the pending task", func() bool {
-		for _, e := range inSubjectEnvelopes(t, r.url, "chat-otter-dead") {
-			if e.Kind == lib.KindMessage && e.TaskID == "task-never" {
+		AuthorID: "1001", MessageID: "t-3", Text: "Delegate: write a haiku about otters"}
+	waitFor(t, "cap refusal posted", func() bool {
+		for _, p := range r.adapter.postTexts() {
+			if strings.Contains(p, "cap 1") {
 				return true
 			}
 		}
 		return false
 	})
-	if got := len(spawn.calls()); got != 0 {
-		t.Fatalf("a task inside the grace was released: %d spawns", got)
-	}
-	for _, p := range r.adapter.postTexts() {
-		if strings.Contains(p, "never started") {
-			t.Fatalf("released a task still inside the grace: %q", p)
-		}
-	}
 	rec, err := r.g.reg.Get(context.Background(), conv)
-	if err != nil || rec == nil || rec.ActiveTask == nil || rec.ActiveTask.TaskID != "task-never" {
-		t.Fatalf("record no longer serializes on the pending task: %+v (err=%v)", rec, err)
+	if err != nil || rec == nil {
+		t.Fatal(err)
+	}
+	if rec.ActiveTask != nil {
+		t.Fatalf("release announced but not written: %+v", rec.ActiveTask)
 	}
 }
 

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -235,6 +235,11 @@ limit, and the `ask` copy outlives the stream copy its justification rests on. T
 same missing field closes both, and until it does the gateway owes the record an
 independent bound (a bucket TTL, or clearing an active task whose pod no longer
 exists) rather than a justification that assumes a terminal that may not come. The
+no-events case has that bound: an active task with nothing on its events subject past
+the first-event grace (`A2A_FIRST_EVENT_GRACE`, 10 minutes by default) is released from
+the serialization at the conversation's next turn, with one line in the conversation
+saying so; the task's own terminal stays with the spawn-failure and Sweep paths, which
+publish on evidence. The
 terminal event this chain guarantees is also what deletes the active-task record (and
 the `ask` copy riding it). A detached task is the exception on both counts: it does
 not exempt the session, so reap may delete a pod whose harness is still working, and

--- a/docs/designs/spec-chatops-gateway.md
+++ b/docs/designs/spec-chatops-gateway.md
@@ -142,8 +142,10 @@ claims during a `working` task is a steer, per the 8/24 decision above.
 **Gateway-authored posts (amended 8/31).** Step 4's relay - events in, chat out - is
 not the whole output story: the gateway authors a small set of posts of its own. The
 placeholder that opens a task ("submitted…", which becomes the rolling line the relay
-edits), the status card, the steer acknowledgement, and failure notices (a submission
-or steer that never reached the bus). All are deterministic templates over facts the
+edits), the status card, the steer acknowledgement, the release line for a task that
+produced no first event inside the grace (its id and the grace; Session lifecycle
+below), and failure notices (a submission or steer that never reached the bus). All
+are deterministic templates over facts the
 gateway itself owns - its own publishes, its own registry, stream replay - which is
 what keeps them inside the no-model rule. They also say only what the gateway knows:
 the steer acknowledgement reports that the steer is on the stream, and what it says
@@ -225,23 +227,22 @@ from the idle TTL. The exemption is safe because the pod's end has owners. The s
 worker's adapter enforces a task deadline (30 minutes default, config-backed): at the
 deadline it kills the harness process group and publishes the terminal event itself,
 and a pod that dies wedged reaches a terminal phase where Sweep takes over. The
-spawner owes the pod-level `activeDeadlineSeconds` mirroring that deadline - the
-adapter's contract is written assuming it - so a wedged adapter also lands in Sweep's
-domain instead of holding its bus credential indefinitely; until that field ships, a
-wedged adapter is the one unowned end, named here rather than papered over. It costs
-two things, not one: the held bus credential, and the content posture below - with no
-terminal event the active-task record is never deleted, `session-state` has no age
-limit, and the `ask` copy outlives the stream copy its justification rests on. The
-same missing field closes both, and until it does the gateway owes the record an
-independent bound (a bucket TTL, or clearing an active task whose pod no longer
-exists) rather than a justification that assumes a terminal that may not come. The
-no-events case has that bound: an active task with nothing on its events subject past
-the first-event grace (`A2A_FIRST_EVENT_GRACE`, 10 minutes by default) is released from
-the serialization at the conversation's next turn, with one line in the conversation
-saying so; the task's own terminal stays with the spawn-failure and Sweep paths, which
-publish on evidence. The
-terminal event this chain guarantees is also what deletes the active-task record (and
-the `ask` copy riding it). A detached task is the exception on both counts: it does
+spawner sets the pod-level `activeDeadlineSeconds` above that deadline (the adapter's
+deadline plus a fixed grace for the image pull), so a wedged adapter also lands in
+Sweep's domain instead of holding its bus credential indefinitely. Two ends still have
+no terminal to wait for, and the record carries an independent bound for each rather
+than a justification that assumes a terminal that may not come. The `ask` copy is
+cleared by the reap scan once it is older than `A2A_ASK_TTL` (24 hours by default,
+under the stream's retention, which is what the content posture below needs). A task
+with nothing on its events subject at all - no pod, or a pod that never ran - is
+released from the serialization at the conversation's next turn once it is older than
+the first-event grace (`A2A_FIRST_EVENT_GRACE`, 10 minutes by default), with one line
+in the conversation saying so. That release publishes no terminal: age alone is not
+evidence, a first event that is merely late could still arrive, and no supervisor path
+ever sees a task with no pod, so its submission ages out with the stream's retention -
+named here rather than papered over. Otherwise the terminal event this chain
+guarantees is what deletes the active-task record (and the `ask` copy riding it). A
+detached task is the exception on both counts: it does
 not exempt the session, so reap may delete a pod whose harness is still working, and
 the supervisor rule below is what keeps that from being a silent stop.
 
@@ -356,15 +357,16 @@ spec calls W a tenancy decision. What the rule forbids is identifiers that carry
 content; the payload spec's opaque-token rule is the same rule seen from the other
 side. Within that posture, the gateway may hold a bounded copy of the active task's ask
 in the session KV - truncated, one revision, deleted with the active-task record at the
-terminal event - for status rendering. The copy adds no new audience (the gateway is
+terminal event or when the gateway releases the record (Session lifecycle) - for
+status rendering. The copy adds no new audience (the gateway is
 the bucket's only reader and writer, by grant - see the deployment spec's note on the
 one residual write route) and has a shorter horizon than the stream copy it
 duplicates. What would breach the posture is content anywhere with a wider audience or
 a longer life than the stream already grants it - which makes the horizon a condition
 on the copy, not a property of it. The horizon holds only where a terminal event is
-guaranteed, so the one case Session lifecycle names as unowned (a wedged adapter,
-until the pod-level deadline ships) is a case where this justification does not hold
-and the record needs the independent bound named there.
+guaranteed, so the ends Session lifecycle names as having none are cases where this
+justification does not hold on its own, and the `ask` TTL and first-event grace named
+there are what carry it.
 
 - `requester.principal` is the pseudonymized identity in _our_ trust domain; the gateway
   resolves it to the RBAC string at the boundary that needs one. `subject` is the


### PR DESCRIPTION
## Summary

A conversation whose task never produced a single event could never take another task. The heal in `handleInbound` releases a stale `ActiveTask` only when `TasksGet` returns a final task; a task with zero events answers `TaskNotFound`, so the heal never fired, reap skips records with no pod and never clears `ActiveTask` anyway, and every deadline assumes a pod. This change lets the heal treat `TaskNotFound` as "never started" once the task is older than a first-event grace (`A2A_FIRST_EVENT_GRACE`, default 10m), tells the conversation in one line, and routes the message that triggered it as a new turn. The steer route also gets one INFO log line, so the wedge is visible in the gateway log next time.

## Why This Change

#1318, observed on `a2a-next-dev` 2026-09-08: after a `Delegate:` that produced nothing, every later message in that Discord thread was steered into the dead task and new delegations were ignored, for hours, across gateway restarts (the record is in the `session-state` KV bucket). A new thread worked immediately, which is also why it can sit unnoticed. Without this, the only recovery is the user knowing to start a new conversation.

## What Changed

- `a2a/gateway/gateway.go`: the heal branch now switches on the `TasksGet` result. `err == nil && task.Final` behaves as before (status card, clear). `isTaskNotFound(err)` with `SubmittedAt` older than `FirstEventGrace` logs at INFO, posts `neverStartedNotice` ("task `<id>` has produced nothing on its event stream in 10m0s, so this conversation is released and this message is handled as a new turn"), and clears `ActiveTask`. Any other error heals nothing, as before: a transport failure cannot rule out events. Either heal now writes the record when it fires rather than at the end of the turn, because a turn can return early (a cap refusal, on exactly the `Delegate:` that follows a wedge) and would otherwise announce a release it never wrote. The branch publishes no terminal for the task: age alone is not evidence and a first event that is merely late could still arrive. The task index stays, as in the terminal case, so a late start still renders.
- `a2a/gateway/gateway.go`: the steer case logs `routing as steer` (conversation, taskId, addressee, task age). A new task already logs `ingress` and a heal logs itself; the steer was the one routing decision with no line, and the issue's diagnosis cost an hour for that reason.
- `a2a/gateway/config.go`: `FirstEventGrace` beside `AskTTL`, read from `A2A_FIRST_EVENT_GRACE` with the same 1m floor the sibling knobs have; `New()` defaults it for embedders that build `Config` directly. Default 10m: the spec's cold start is 5-10s and the pod deadline's pre-start budget (`podDeadlineGrace`, image pull before the process starts) is 10m, so a task still pre-first-event at that age is one whose pod is not coming.
- `docs/designs/spec-chatops-gateway.md`: one sentence in Session lifecycle where the spec already said the record "owes an independent bound", naming this one for the no-events case.

## Context

Closes #1318. Fix follows the second comment on the issue (the heal is the gap, not reap). No open PR touches the heal, `reap.go`, or this config; `gh pr list --search` on `ActiveTask`, `TaskNotFound`, `gateway heal`, `1318` returned nothing relevant. Unmerged A2A stacks (#1258 worker, #1319 auth callout, #1248/#1257 adapters) do not touch `handleInbound`'s heal or `config.go`'s duration knobs.

Not done here, on purpose: a supervisor-published `failed` terminal for the task (the issue's first "what a fix has to decide" bullet). That is the composing first-event deadline the issue's second comment describes; this heal is the backstop that works without it. What that leaves, named in the spec rather than papered over: a zero-event task with no pod is an end no supervisor path closes (spawn-failure publishes at spawn time, Sweep only sees pods), so its submission and its task-index key stay until the stream's retention ages the subject out; one small key per released task, bounded per incident.

## Testing

- `cd a2a && go vet ./... && go test -race ./...`: green on the branch (`ok .../a2a/gateway 22.2s`, all packages).
- New `TestTasklessActiveTaskPastGraceHealsIntoNewDelegation` seeds the record the issue observed (`ActiveTask` set, `PodName` empty, `SubmittedAt` past the grace, nothing published on the task's events subject) with the spawner armed, sends `Delegate: …`, and asserts a spawn with a fresh task and session, no envelope on the dead task's `in` subject, the notice in the conversation, and the record now serializing on the new task. On `upstream/main` (source edits stashed, constant inlined, at this branch's first commit) it fails: `timed out waiting for a fresh delegation spawned`, i.e. the message was steered. The adversarial-pass subagent reproduced the same red/green independently in a scratch copy.
- New `TestTasklessActiveTaskInsideGraceStillSteers`: the same record one minute old, and one with no `SubmittedAt` at all, are steered into (`task-never` envelope on its `in` subject), no spawn, no notice, record untouched. Passes on both.
- New `TestTasklessHealPersistsAcrossCapRefusal`: at the session cap, the refused `Delegate:` still leaves the release written in KV.
- New `TestFromEnvFirstEventGrace`: default 10m, override, sub-minute and junk refused at boot.
- `make docs-check` clean; `prettier --check` (3.9.6, the pinned version) clean on the spec.
- Drift check against `upstream/main`: 0 commits behind, no overlapping files.

### Live validation

Not live-tested. The only `spec.mode: next` install (`a2a-next-dev`) carries another session's stacked build and is read-only for this work; a shipped gateway image would mean rolling its Deployment. Observed there read-only on 2026-09-10 (gateway image `gateway:a2-20260908-162517`): the gateway log since its last restart is two INFO lines (boot, Discord connect) in ~70 minutes, which is the "nothing to diagnose from" half of the issue and what the new steer line addresses; no session pods exist; the gateway's env carries no `A2A_ASK_TTL` / `A2A_IDLE_TTL`, so `A2A_FIRST_EVENT_GRACE` has the same env-only-with-default shape as its siblings and needs no operator change. The `session-state` record was not read: the only nats CLI on the install is the finished provision Job's image, and the alternatives were a pod mutation or borrowing the gateway credential through the callout another session is validating. The mechanism proof is the regression pair above against an embedded JetStream server, with the test failing on `upstream/main` and passing on the branch.

## Self-Review

Both passes ran in fresh `general-purpose` subagents handed only the worktree path, the diff range `upstream/main...HEAD`, and the skill file; neither saw the plan, the issue thread, or this body.

Adversarial pass (`.agents/skills/review-adversarial/SKILL.md`), four LOW findings, no higher:

- Confirmed: the release was announced before it was persisted; a cap-refused `Delegate:` returns before the end-of-turn write, so the record kept the dead task and the notice would repeat. Fixed: the heal writes the record when it fires; `TestTasklessHealPersistsAcrossCapRefusal` covers it.
- Confirmed: the notice said "never started", an inference the gateway cannot make (the submission is durable and the index is kept so a late start renders). Fixed: the notice and the log line state the evidence.
- Confirmed: the spec sentence I added named the spawn-failure and Sweep paths as the task's supervisor, and neither can reach a task with no pod. Fixed in the spec (below).
- Plausible: the task's routing state (`taskSessions`, `relays`, the KV task index) is never retired for a task that never terminates. Not changed: it is kept so a first event that is merely late still renders, and the relay's `active.TaskID == taskID` guard keeps a late terminal from clobbering the successor; the cost is one small key per released task. Bounding the index in general is the same question for a detached task that never terminates and is not this change's to settle; the comment names it.
- Also raised: `ensureSessionPod`'s residue comment ("the user's stop detaches it and retirement completes the cancel") describes a path that was already unreachable for a pod-less task before this change (retirement runs only behind `PodName != ""`). Not changed: rewriting it belongs with the first-event deadline the issue defers, which is the real supervisor for pod-less tasks.
- Untested angles it named: a transport error past the grace must not heal. Judged by reading, not by test: `isTaskNotFound` is `errors.As` on the lib's `A2AError` and the `switch` falls through on anything else, the same rule Sweep and `closeDetachedBeforeDelete` use; the package fakes the bus with an embedded server, not a client, so injecting a transport failure through `handleInbound` has no seam. Zero `SubmittedAt` and heal-then-cap-refusal are now covered.
- Clean: detached tasks and `!task.Final` excluded by the guard; config plumbing mirrors `AskTTL` (default in `New`, parse and floor in `FromEnv`, `setBaseEnv` reset); constants at top of file; the steer log reads only record fields; sibling A2A PRs touch `config.go`/`gateway.go` but not the heal block or `setBaseEnv`'s body.

Docs-drift pass (`.agents/skills/review-docs-drift/SKILL.md`), no Blocking:

- Should fix: the spec's gateway-authored posts enumeration (the no-model rule's list of what the gateway may say on its own) lacked the new line. Fixed.
- Should fix: the Reap paragraph my sentence sat in still said the pod-level `activeDeadlineSeconds` had not shipped and never mentioned `AskTTL`, so the new sentence rested on a false premise. Fixed: the paragraph's tail is in the present tense (pod deadline shipped, `AskTTL` bound, first-event grace), the zero-event task is named as an end no supervisor closes, and the content-posture paragraph's matching "until the pod-level deadline ships" is reconciled.
- Nit: content-posture "deleted with the active-task record at the terminal event" was incomplete. Amended to "or when the gateway releases the record".
- Nit: the `FirstEventGrace` field comment omitted the 1m boot floor. Fixed.
- Nit: `registry.go`'s `ActiveTask` comment enumerates the ask copy's horizons without the heal. Not changed: that comment argues why the copy is permitted (a horizon no longer than the stream's), and a release that shortens the horizon is inside that argument; the existing terminal heal already cleared it the same way.
- Should fix, pre-existing: the `docs/README.md` map row for the spec says "the operator render is not yet in-tree", which it is. Not changed here: this branch does not touch the map and a row edit is its own one-line change; flagged for a separate fix.
- Clean: no README, INSTALL, site page, chart, or CRD text enumerates the gateway's duration env vars (only `A2A_MAX_SESSIONS` is documented); `make docs-check` and the pinned prettier pass; no generated region or map structure is affected.

## Risk & Rollout

Runtime change is confined to the heal branch of `handleInbound` (one extra KV write when a heal fires) and one log line; the reap and sweep loops are untouched. New failure mode: a worker that legitimately takes more than 10 minutes to publish its first event has its conversation released at the user's next message, and that message starts a second task while the first may still run (its events still relay through the task index). The default is sized above the existing pre-start budget to keep that rare, and `A2A_FIRST_EVENT_GRACE` raises it per install. Revert is a plain revert; no data migration, no CRD or chart change. The env var is optional, so existing Deployments pick up the default on the next gateway image roll.

Generated with the help of Claude (Claude Code).
