### PR TITLE
feat(operator): publish observedGeneration on PlatformAgent status and its conditions

### DIFF
--- a/charts/kube-agents/crds/kubeagents.x-k8s.io_platformagents.yaml
+++ b/charts/kube-agents/crds/kubeagents.x-k8s.io_platformagents.yaml
@@ -10571,6 +10571,12 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                observedGeneration:
+                  description:
+                    ObservedGeneration is the .metadata.generation the status
+                    was last computed from.
+                  format: int64
+                  type: integer
                 phase:
                   description:
                     Phase is the overall state (Pending, Provisioning, Ready,

--- a/docs/site/src/content/docs/operator/platformagent-crd.md
+++ b/docs/site/src/content/docs/operator/platformagent-crd.md
@@ -493,24 +493,25 @@ See [`k8s-operator/api/v1alpha1/platformagent_types.go`](https://github.com/gke-
 
 The operator writes observed state to the `status` subresource:
 
-| Field                                  | Type     | Purpose                                                                                             |
-| -------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
-| `phase`                                | string   | Overall state (`Pending`, `Provisioning`, `Ready`, `Degraded`, `Failed`).                           |
-| `address`                              | string   | Fully qualified domain name (FQDN) of the agent service.                                            |
-| `lastReconcileTime`                    | time     | Timestamp of the last status update.                                                                |
-| `conditions`                           | list     | Standard `metav1.Condition` observations, keyed by `type`.                                          |
-| `deploymentStatus.name`                | string   | Name of the underlying Deployment.                                                                  |
-| `deploymentStatus.readyReplicas`       | int32    | Number of fully ready replicas.                                                                     |
-| `serviceStatus.endpoint`               | string   | Primary URL/IP (with protocol and port) to reach the agent.                                         |
-| `storageStatus.bound`                  | bool     | Whether the primary PVC has been provisioned.                                                       |
-| `telemetry.otlpEndpoint`               | string   | The OTLP collector the agent was wired to.                                                          |
-| `telemetry.otlpEndpointSource`         | string   | Which rung answered: `DeploymentEnv`, `Spec`, `OperatorEnv`, `Discovered`, `None`, or `Default`.    |
-| `networkPolicy.generated`              | bool     | Whether the operator-managed NetworkPolicy is active. `false` when disabled, or not yet reconciled. |
-| `networkPolicy.dnsClusterIPs`          | []string | The DNS ClusterIPs written into rule 1.                                                             |
-| `networkPolicy.dnsClusterIPsSource`    | string   | Which rung answered: `Annotation`, `Spec`, `OperatorEnv`, `Discovered`, or `Default`.               |
-| `networkPolicy.metadataDaemonIP`       | string   | The post-NAT daemon IP in rule 3, empty when suppressed.                                            |
-| `networkPolicy.metadataDaemonPort`     | int32    | The post-NAT daemon port in rule 3, resolved from live DaemonSet or default (`988`).                |
-| `networkPolicy.metadataDaemonIPSource` | string   | Which rung answered: `Annotation`, `Spec`, `OperatorEnv`, `Discovered`, `Default`, or `Suppressed`. |
+| Field                                  | Type     | Purpose                                                                                                                                         |
+| -------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `phase`                                | string   | Overall state (`Pending`, `Provisioning`, `Ready`, `Degraded`, `Failed`).                                                                       |
+| `observedGeneration`                   | int64    | The `metadata.generation` the status was last computed from. Behind `metadata.generation` from a spec edit until the reconcile that follows it. |
+| `address`                              | string   | Fully qualified domain name (FQDN) of the agent service.                                                                                        |
+| `lastReconcileTime`                    | time     | Timestamp of the last status update.                                                                                                            |
+| `conditions`                           | list     | Standard `metav1.Condition` observations, keyed by `type`.                                                                                      |
+| `deploymentStatus.name`                | string   | Name of the underlying Deployment.                                                                                                              |
+| `deploymentStatus.readyReplicas`       | int32    | Number of fully ready replicas.                                                                                                                 |
+| `serviceStatus.endpoint`               | string   | Primary URL/IP (with protocol and port) to reach the agent.                                                                                     |
+| `storageStatus.bound`                  | bool     | Whether the primary PVC has been provisioned.                                                                                                   |
+| `telemetry.otlpEndpoint`               | string   | The OTLP collector the agent was wired to.                                                                                                      |
+| `telemetry.otlpEndpointSource`         | string   | Which rung answered: `DeploymentEnv`, `Spec`, `OperatorEnv`, `Discovered`, `None`, or `Default`.                                                |
+| `networkPolicy.generated`              | bool     | Whether the operator-managed NetworkPolicy is active. `false` when disabled, or not yet reconciled.                                             |
+| `networkPolicy.dnsClusterIPs`          | []string | The DNS ClusterIPs written into rule 1.                                                                                                         |
+| `networkPolicy.dnsClusterIPsSource`    | string   | Which rung answered: `Annotation`, `Spec`, `OperatorEnv`, `Discovered`, or `Default`.                                                           |
+| `networkPolicy.metadataDaemonIP`       | string   | The post-NAT daemon IP in rule 3, empty when suppressed.                                                                                        |
+| `networkPolicy.metadataDaemonPort`     | int32    | The post-NAT daemon port in rule 3, resolved from live DaemonSet or default (`988`).                                                            |
+| `networkPolicy.metadataDaemonIPSource` | string   | Which rung answered: `Annotation`, `Spec`, `OperatorEnv`, `Discovered`, `Default`, or `Suppressed`.                                             |
 
 Three condition types appear in `conditions`, and only the first is always present:
 
@@ -529,10 +530,35 @@ state — it is a decision somebody made, and `phase` stays `Ready`.
 $ kubectl describe platformagent platform-agent -n kubeagents-system
 ...
   Conditions:
-    Type:     EventWatcher
-    Status:   False
-    Reason:   DisabledBySpec
-    Message:  Cluster event ingestion is disabled by spec.harness.eventWatcher.enabled=false. …
+    Type:                 EventWatcher
+    Status:               False
+    Observed Generation:  3
+    Reason:               DisabledBySpec
+    Message:              Cluster event ingestion is disabled by spec.harness.eventWatcher.enabled=false. …
+```
+
+### Telling a current status from a stale one
+
+`status.observedGeneration` is the `metadata.generation` the status was last computed from, and the
+`Ready` condition, with any `Degraded` or `EventWatcher` condition written in the same pass, carries
+it in its own `observedGeneration`. `Degraded`/`RBACIncomplete` is the exception: it is written when
+the set of denied permissions changes and left in place otherwise, so its `observedGeneration` is
+the generation at which that set last changed. A spec edit bumps `metadata.generation` at admission
+and leaves both behind until the next reconcile, so a `Ready` condition whose `observedGeneration`
+is below `metadata.generation` describes the previous spec, and `kubectl wait --for=condition=Ready`
+on its own can return on it. The field says the operator has processed that generation; it does not
+say the rollout it triggered has finished. `Ready` is still derived from replica counts, and during
+a rollout the replica satisfying it can be the previous one. `Ready` is a claim about three
+workloads (the gateway, the shell sandbox and the credential broker), so to gate on a change, wait
+for the generation to be observed, then for the rollout of each workload, then for the condition:
+
+```bash
+gen=$(kubectl get platformagent platform-agent -n kubeagents-system -o jsonpath='{.metadata.generation}')
+kubectl wait platformagent/platform-agent -n kubeagents-system --for=jsonpath='{.status.observedGeneration}'="$gen"
+kubectl rollout status deployment/platform-agent-gateway -n kubeagents-system
+kubectl rollout status statefulset/platform-agent-shell -n kubeagents-system
+kubectl rollout status deployment/platform-agent-credential-proxy -n kubeagents-system
+kubectl wait platformagent/platform-agent -n kubeagents-system --for=condition=Ready
 ```
 
 ## How config reaches each profile

--- a/k8s-operator/api/v1alpha1/common_types.go
+++ b/k8s-operator/api/v1alpha1/common_types.go
@@ -1194,6 +1194,10 @@ type AgentStatus struct {
 	// +optional
 	Phase string `json:"phase,omitempty"`
 
+	// ObservedGeneration is the .metadata.generation the status was last computed from.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Address is the fully qualified domain name (FQDN) of the agent service.
 	// +optional
 	Address string `json:"address,omitempty"`

--- a/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
+++ b/k8s-operator/config/crd/bases/kubeagents.x-k8s.io_platformagents.yaml
@@ -10571,6 +10571,12 @@ spec:
                       format: int32
                       type: integer
                   type: object
+                observedGeneration:
+                  description:
+                    ObservedGeneration is the .metadata.generation the status
+                    was last computed from.
+                  format: int64
+                  type: integer
                 phase:
                   description:
                     Phase is the overall state (Pending, Provisioning, Ready,

--- a/k8s-operator/internal/controller/platformagent_controller.go
+++ b/k8s-operator/internal/controller/platformagent_controller.go
@@ -2314,7 +2314,16 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 	degradedUnchanged := (degradedStatus == metav1.ConditionFalse && existingDegradedCond == nil) || rbacDegradedPreserved ||
 		(degradedStatus == metav1.ConditionTrue && existingDegradedCond != nil && existingDegradedCond.Status == metav1.ConditionTrue && existingDegradedCond.Reason == degradedReason && existingDegradedCond.Message == condMsg)
 
-	// Check if anything actually changed
+	// Check if anything actually changed. The generation is in the list so that
+	// a spec edit which changes nothing derived here still gets one write:
+	// without it the status would keep describing the previous generation and
+	// a reader could not tell that the operator had seen the new one (#534).
+	// The witness is the Ready condition's observedGeneration rather than the
+	// top-level field, deliberately: the two are written together, but a CRD
+	// that predates status.observedGeneration prunes the top-level copy on
+	// every write while the condition's has always been in the schema. Keyed
+	// on the pruned copy, an operator rolled ahead of its CRD would write on
+	// every pass, and each write wakes the next through the unfiltered watch.
 	if agent.Status.Phase == newPhase &&
 		agent.Status.DeploymentStatus.Name == newDeploymentStatusName &&
 		agent.Status.DeploymentStatus.ReadyReplicas == newDeploymentStatusReadyReplicas &&
@@ -2326,12 +2335,14 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 		networkPolicyStatusUnchanged(agent.Status.NetworkPolicy, netpolProfile) &&
 		degradedUnchanged &&
 		eventWatcherUnchanged &&
-		existingCond != nil && existingCond.Status == condStatus && existingCond.Reason == condReason && existingCond.Message == condMsg {
+		existingCond != nil && existingCond.Status == condStatus && existingCond.Reason == condReason && existingCond.Message == condMsg &&
+		existingCond.ObservedGeneration == agent.Generation {
 		return newPhase, nil
 	}
 
 	// Apply updates
 	agent.Status.Phase = newPhase
+	agent.Status.ObservedGeneration = agent.Generation
 	agent.Status.DeploymentStatus.Name = newDeploymentStatusName
 	agent.Status.DeploymentStatus.ReadyReplicas = newDeploymentStatusReadyReplicas
 	agent.Status.StorageStatus.Bound = newStorageStatusBound
@@ -2354,6 +2365,7 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 		Status:             condStatus,
 		Reason:             condReason,
 		Message:            condMsg,
+		ObservedGeneration: agent.Generation,
 		LastTransitionTime: now,
 	}
 	meta.SetStatusCondition(&agent.Status.Conditions, condition)
@@ -2364,6 +2376,7 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 			Status:             metav1.ConditionTrue,
 			Reason:             degradedReason,
 			Message:            condMsg,
+			ObservedGeneration: agent.Generation,
 			LastTransitionTime: now,
 		}
 		meta.SetStatusCondition(&agent.Status.Conditions, degradedCond)
@@ -2382,6 +2395,7 @@ func (r *PlatformAgentReconciler) updateStatusReady(ctx context.Context, agent *
 			Status:             metav1.ConditionFalse,
 			Reason:             eventWatcherDisabledReason,
 			Message:            eventWatcherDisabledMessage,
+			ObservedGeneration: agent.Generation,
 			LastTransitionTime: now,
 		})
 	}
@@ -2600,6 +2614,7 @@ func requestedRuntimeClasses(agent *agentv1alpha1.PlatformAgent) []string {
 
 func (r *PlatformAgentReconciler) updateStatusDegraded(ctx context.Context, agent *agentv1alpha1.PlatformAgent, reason, message string) error {
 	agent.Status.Phase = "Degraded"
+	agent.Status.ObservedGeneration = agent.Generation
 	now := metav1.Now()
 	agent.Status.LastReconcileTime = &now
 
@@ -2608,6 +2623,7 @@ func (r *PlatformAgentReconciler) updateStatusDegraded(ctx context.Context, agen
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
 		Message:            message,
+		ObservedGeneration: agent.Generation,
 		LastTransitionTime: now,
 	}
 	meta.SetStatusCondition(&agent.Status.Conditions, condition)

--- a/k8s-operator/internal/controller/platformagent_observed_generation_envtest_test.go
+++ b/k8s-operator/internal/controller/platformagent_observed_generation_envtest_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+const (
+	// envtestAssetsEnvVar is the variable setup-envtest exports and envtest reads.
+	// `make -C k8s-operator test` sets it; a bare `go test` does not, and without
+	// it there is no API server to start.
+	envtestAssetsEnvVar = "KUBEBUILDER_ASSETS"
+	// envtestCRDDir is the operator's CRDs, relative to this package, so the API
+	// server under test serves the schema the branch generated rather than one
+	// hand-written for the test.
+	envtestCRDDir = "../../config/crd/bases"
+	// envtestNamespace and envtestAgentName are the CR under test.
+	envtestNamespace = "observed-gen"
+	envtestAgentName = "test-agent"
+	// envtestSpecEditAnnotation is the pod annotation the test adds to move
+	// metadata.generation. A metadata annotation would not: only spec edits bump it.
+	envtestSpecEditAnnotation = "observed-gen.test/edit"
+	// The CRD requires spec.harness, and the credential proxy bootstrap wants
+	// the full project/location/cluster triple; none of it is contacted here.
+	envtestHarnessProject  = "envtest-project"
+	envtestHarnessLocation = "envtest-location"
+	envtestHarnessCluster  = "envtest-cluster"
+)
+
+// startEnvtest boots an API server carrying the operator's CRDs and hands back
+// a direct, uncached client to it. Skips — loudly, naming the variable — when
+// the binaries are not configured, because envtest cannot start without them
+// and a silent skip here would leave this file looking like coverage it is not.
+func startEnvtest(t *testing.T) (client.Client, *runtime.Scheme) {
+	t.Helper()
+	if os.Getenv(envtestAssetsEnvVar) == "" {
+		t.Skipf("%s is unset: run through `make -C k8s-operator test`, or export it from `bin/setup-envtest use -p path`", envtestAssetsEnvVar)
+	}
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{envtestCRDDir},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := env.Start()
+	if err != nil {
+		t.Fatalf("envtest start: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := env.Stop(); err != nil {
+			t.Errorf("envtest stop: %v", err)
+		}
+	})
+	scheme := setupScheme()
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("envtest client: %v", err)
+	}
+	return cl, scheme
+}
+
+// TestObservedGenerationFollowsMetadataGenerationEnvtest is the fix against a
+// real API server, which is the only place metadata.generation is assigned:
+// create a PlatformAgent, reconcile, edit the spec, reconcile again, and read
+// status.observedGeneration and the Ready condition's observedGeneration
+// tracking metadata.generation at each step. Between the edit and the second
+// reconcile the status is stale, and the field says so — that gap is what a
+// caller gating on the CR could not see before (#534).
+//
+// No Deployment controller runs under envtest, so the phase stays Provisioning
+// throughout; the claim under test is the generation bookkeeping, not readiness.
+func TestObservedGenerationFollowsMetadataGenerationEnvtest(t *testing.T) {
+	cl, scheme := startEnvtest(t)
+	ctx := context.Background()
+
+	if err := cl.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: envtestNamespace}}); err != nil {
+		t.Fatalf("creating namespace: %v", err)
+	}
+	agent := &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: envtestAgentName, Namespace: envtestNamespace},
+		Spec: agentv1alpha1.PlatformAgentSpec{
+			Harness: &agentv1alpha1.HarnessSpec{
+				ProjectID:   envtestHarnessProject,
+				Location:    envtestHarnessLocation,
+				ClusterName: envtestHarnessCluster,
+			},
+		},
+	}
+	if err := cl.Create(ctx, agent); err != nil {
+		t.Fatalf("creating PlatformAgent: %v", err)
+	}
+	// Without the sandbox keypair the reconcile parks on Degraded/ShellSandboxKeysMissing
+	// before reaching updateStatusReady; the fixture Secret lets it get there.
+	if err := cl.Create(ctx, shellSandboxKeysSecret(agent)); err != nil {
+		t.Fatalf("creating sandbox keys Secret: %v", err)
+	}
+
+	r := &PlatformAgentReconciler{Client: cl, APIReader: cl, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(agent)}
+	reconcile := func(pass string) {
+		t.Helper()
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("Reconcile (%s) failed: %v", pass, err)
+		}
+	}
+	fetch := func() *agentv1alpha1.PlatformAgent {
+		t.Helper()
+		got := &agentv1alpha1.PlatformAgent{}
+		if err := cl.Get(ctx, req.NamespacedName, got); err != nil {
+			t.Fatalf("reading the PlatformAgent back: %v", err)
+		}
+		return got
+	}
+	readyGeneration := func(pa *agentv1alpha1.PlatformAgent) int64 {
+		t.Helper()
+		cond := meta.FindStatusCondition(pa.Status.Conditions, "Ready")
+		if cond == nil {
+			t.Fatalf("no Ready condition on the PlatformAgent at generation %d", pa.Generation)
+		}
+		return cond.ObservedGeneration
+	}
+
+	// The first pass adds the finalizer and returns; the second is the real one.
+	reconcile("finalizer")
+	reconcile("first full pass")
+
+	first := fetch()
+	if first.Generation != 1 {
+		t.Fatalf("metadata.generation = %d after create, want 1", first.Generation)
+	}
+	if got := first.Status.ObservedGeneration; got != first.Generation {
+		t.Errorf("status.observedGeneration = %d after the first reconcile, want %d", got, first.Generation)
+	}
+	if got := readyGeneration(first); got != first.Generation {
+		t.Errorf("Ready condition observedGeneration = %d after the first reconcile, want %d", got, first.Generation)
+	}
+	t.Logf("after first reconcile: generation=%d status.observedGeneration=%d phase=%s ready.observedGeneration=%d",
+		first.Generation, first.Status.ObservedGeneration, first.Status.Phase, readyGeneration(first))
+
+	// A spec edit that changes nothing the status derives from, so the only
+	// thing the next write can be about is the generation.
+	first.Spec.Deployment = &agentv1alpha1.DeploymentSpec{
+		PodAnnotations: map[string]string{envtestSpecEditAnnotation: "1"},
+	}
+	if err := cl.Update(ctx, first); err != nil {
+		t.Fatalf("editing the spec: %v", err)
+	}
+
+	edited := fetch()
+	if edited.Generation != 2 {
+		t.Fatalf("metadata.generation = %d after a spec edit, want 2", edited.Generation)
+	}
+	// Honest staleness: the operator has not run, and the status says which
+	// generation it still describes.
+	if got := edited.Status.ObservedGeneration; got != 1 {
+		t.Errorf("status.observedGeneration = %d before the reconcile that follows the edit, want 1 (the status has not been recomputed)", got)
+	}
+	if got := readyGeneration(edited); got != 1 {
+		t.Errorf("Ready condition observedGeneration = %d before the reconcile that follows the edit, want 1", got)
+	}
+	t.Logf("after spec edit, before reconcile: generation=%d status.observedGeneration=%d ready.observedGeneration=%d",
+		edited.Generation, edited.Status.ObservedGeneration, readyGeneration(edited))
+
+	reconcile("after spec edit")
+
+	final := fetch()
+	if got := final.Status.ObservedGeneration; got != final.Generation {
+		t.Errorf("status.observedGeneration = %d after reconciling generation %d, want %d", got, final.Generation, final.Generation)
+	}
+	if got := readyGeneration(final); got != final.Generation {
+		t.Errorf("Ready condition observedGeneration = %d after reconciling generation %d, want %d", got, final.Generation, final.Generation)
+	}
+	if final.Status.Phase != first.Status.Phase {
+		t.Errorf("phase moved from %q to %q across an edit that changed nothing the status derives from", first.Status.Phase, final.Status.Phase)
+	}
+	t.Logf("after second reconcile: generation=%d status.observedGeneration=%d phase=%s ready.observedGeneration=%d",
+		final.Generation, final.Status.ObservedGeneration, final.Status.Phase, readyGeneration(final))
+}

--- a/k8s-operator/internal/controller/platformagent_observed_generation_test.go
+++ b/k8s-operator/internal/controller/platformagent_observed_generation_test.go
@@ -1,0 +1,319 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	agentv1alpha1 "github.com/gke-labs/kube-agents/k8s-operator/api/v1alpha1"
+)
+
+// What status.observedGeneration has to mean on a PlatformAgent (#534). Before
+// it existed, Ready=True on a CR whose spec had just changed described the
+// previous generation and nothing on the object said so. These tests pin the
+// two halves of the fix: every status write records the generation it was
+// computed from, on the status and on the conditions, and a generation bump
+// that changes nothing else still gets a write.
+//
+// The fake client does not maintain metadata.generation, so the tests set it
+// by hand. The envtest case in platformagent_observed_generation_envtest_test.go
+// is where a real API server assigns it.
+
+// observedGenerationAgent is the CR under test, already at the generation the
+// API server would have assigned after generation-1 spec edits.
+func observedGenerationAgent(generation int64) *agentv1alpha1.PlatformAgent {
+	return &agentv1alpha1.PlatformAgent{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns", Generation: generation},
+	}
+}
+
+// statusWriteCounter wraps the SSA interceptors with a count of status
+// subresource writes, so a test can say which passes wrote and which did not.
+type statusWriteCounter struct{ writes int }
+
+func (c *statusWriteCounter) interceptors() interceptor.Funcs {
+	funcs := fakeServerSideApplyInterceptors()
+	funcs.SubResourceUpdate = func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+		c.writes++
+		return cl.SubResource(subResourceName).Update(ctx, obj, opts...)
+	}
+	return funcs
+}
+
+// observedGenerationReconciler holds the agent and all three workloads ready,
+// so the status under test is Ready and the only thing varying is the generation.
+func observedGenerationReconciler(agent *agentv1alpha1.PlatformAgent, counter *statusWriteCounter) *PlatformAgentReconciler {
+	scheme := setupScheme()
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent, readyGateway(agent), shellSandbox(agent, 1), credentialBroker(agent, 1)).
+		WithStatusSubresource(agent).
+		WithInterceptorFuncs(counter.interceptors()).
+		Build()
+	return &PlatformAgentReconciler{Client: cl, APIReader: cl, Scheme: scheme}
+}
+
+func settleReady(t *testing.T, r *PlatformAgentReconciler, agent *agentv1alpha1.PlatformAgent) string {
+	t.Helper()
+	ctx := context.Background()
+	phase, err := r.updateStatusReady(ctx, agent, "", otlpSourceNone, r.resolveNetpolProfile(ctx, agent))
+	if err != nil {
+		t.Fatalf("updateStatusReady failed: %v", err)
+	}
+	return phase
+}
+
+// readyConditionGeneration is the condition's own observedGeneration, which is
+// what a `kubectl wait`-style caller reads to tell a stale Ready from a current one.
+func readyConditionGeneration(t *testing.T, agent *agentv1alpha1.PlatformAgent) int64 {
+	t.Helper()
+	cond := meta.FindStatusCondition(agent.Status.Conditions, "Ready")
+	if cond == nil {
+		t.Fatal("no Ready condition was written")
+	}
+	return cond.ObservedGeneration
+}
+
+// TestReadyStatusRecordsTheGenerationItWasComputedFrom is the field itself: a
+// Ready status names the generation it describes, on the status and on the
+// condition, and the persisted object agrees with the in-memory one.
+func TestReadyStatusRecordsTheGenerationItWasComputedFrom(t *testing.T) {
+	agent := observedGenerationAgent(3)
+	r := observedGenerationReconciler(agent, &statusWriteCounter{})
+
+	if phase := settleReady(t, r, agent); phase != "Ready" {
+		t.Fatalf("got phase %q, want Ready: every workload has a ready replica", phase)
+	}
+	if got := agent.Status.ObservedGeneration; got != 3 {
+		t.Errorf("status.observedGeneration = %d, want 3", got)
+	}
+	if got := readyConditionGeneration(t, agent); got != 3 {
+		t.Errorf("Ready condition observedGeneration = %d, want 3", got)
+	}
+
+	stored := &agentv1alpha1.PlatformAgent{}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(agent), stored); err != nil {
+		t.Fatalf("reading the agent back: %v", err)
+	}
+	if got := stored.Status.ObservedGeneration; got != 3 {
+		t.Errorf("persisted status.observedGeneration = %d, want 3", got)
+	}
+	if got := readyConditionGeneration(t, stored); got != 3 {
+		t.Errorf("persisted Ready condition observedGeneration = %d, want 3", got)
+	}
+}
+
+// TestAGenerationBumpAloneWritesStatus is the equality half. Nothing the status
+// derives from changes between the passes — same workloads, same phase, same
+// message — so the only reason the third pass writes is that the generation
+// moved. Without that write the status would keep claiming generation 1 forever
+// and the field would be decoration.
+func TestAGenerationBumpAloneWritesStatus(t *testing.T) {
+	agent := observedGenerationAgent(1)
+	counter := &statusWriteCounter{}
+	r := observedGenerationReconciler(agent, counter)
+
+	settleReady(t, r, agent)
+	if counter.writes != 1 {
+		t.Fatalf("first pass made %d status writes, want 1", counter.writes)
+	}
+	settleReady(t, r, agent)
+	if counter.writes != 1 {
+		t.Fatalf("an unchanged pass made a status write (%d total); the equality check is broken", counter.writes)
+	}
+
+	// The fake client does not manage metadata.generation and copies the stored
+	// object's metadata back over the in-memory one on every status write, so
+	// the bump has to be stored as well as set, as a real spec edit would be.
+	agent.Generation = 2
+	if err := r.Update(context.Background(), agent); err != nil {
+		t.Fatalf("storing the generation bump: %v", err)
+	}
+	if agent.Generation != 2 {
+		t.Fatalf("the fake client rewrote metadata.generation to %d; the fixture needs another way to bump it", agent.Generation)
+	}
+	settleReady(t, r, agent)
+	if counter.writes != 2 {
+		t.Fatalf("a generation bump made %d status writes in total, want 2: the bump alone must write", counter.writes)
+	}
+	if got := agent.Status.ObservedGeneration; got != 2 {
+		t.Errorf("status.observedGeneration = %d after the bump, want 2", got)
+	}
+	if got := readyConditionGeneration(t, agent); got != 2 {
+		t.Errorf("Ready condition observedGeneration = %d after the bump, want 2", got)
+	}
+
+	settleReady(t, r, agent)
+	if counter.writes != 2 {
+		t.Errorf("the pass after the bump wrote again (%d total); the new generation should now read as unchanged", counter.writes)
+	}
+}
+
+// TestDegradedStatusRecordsTheGenerationItWasComputedFrom covers the other
+// writer. A refusal is as much a verdict on a generation as Ready is, and a
+// caller waiting on the condition needs to know which spec was refused.
+func TestDegradedStatusRecordsTheGenerationItWasComputedFrom(t *testing.T) {
+	agent := observedGenerationAgent(5)
+	r := observedGenerationReconciler(agent, &statusWriteCounter{})
+
+	if err := r.updateStatusDegraded(context.Background(), agent, reasonRuntimeClassNotFound, "RuntimeClass 'gvisor' is not configured in this cluster"); err != nil {
+		t.Fatalf("updateStatusDegraded failed: %v", err)
+	}
+	if agent.Status.Phase != "Degraded" {
+		t.Errorf("got phase %q, want Degraded", agent.Status.Phase)
+	}
+	if got := agent.Status.ObservedGeneration; got != 5 {
+		t.Errorf("status.observedGeneration = %d, want 5", got)
+	}
+	if got := readyConditionGeneration(t, agent); got != 5 {
+		t.Errorf("Ready condition observedGeneration = %d, want 5", got)
+	}
+}
+
+// TestRBACSkewConditionCarriesTheGenerationButDoesNotClaimIt: reportRBACSkew
+// writes status before the spec has been acted on, so it stamps its own
+// condition and leaves status.observedGeneration alone. Claiming the generation
+// there would let a reconcile that errors out afterwards leave a status that
+// says "generation N seen" beside a Ready condition computed from N-1 — the
+// exact stale success the field exists to expose.
+func TestRBACSkewConditionCarriesTheGenerationButDoesNotClaimIt(t *testing.T) {
+	agent := observedGenerationAgent(4)
+	r := observedGenerationReconciler(agent, &statusWriteCounter{})
+	authorizer := &fakeAuthorizer{deny: denyPDBPatch}
+	r.RBAC = NewRBACChecker(authorizer.reviews())
+	ctx := context.Background()
+	if _, err := r.RBAC.Probe(ctx); err != nil {
+		t.Fatalf("boot probe: %v", err)
+	}
+
+	degraded, err := r.reportRBACSkew(ctx, agent)
+	if err != nil {
+		t.Fatalf("reportRBACSkew failed: %v", err)
+	}
+	if !degraded {
+		t.Fatal("reportRBACSkew reported no denial against an authorizer that denies")
+	}
+	cond := meta.FindStatusCondition(agent.Status.Conditions, degradedConditionType)
+	if cond == nil {
+		t.Fatal("no Degraded condition was written")
+	}
+	if got := cond.ObservedGeneration; got != 4 {
+		t.Errorf("Degraded condition observedGeneration = %d, want 4", got)
+	}
+	if got := agent.Status.ObservedGeneration; got != 0 {
+		t.Errorf("status.observedGeneration = %d after an RBAC-only write, want 0: the phase was not recomputed", got)
+	}
+}
+
+// TestAPrunedObservedGenerationDoesNotWriteEveryPass is the operator-ahead-of-
+// its-CRD case. A CRD that predates status.observedGeneration prunes the
+// top-level field on every write, so if the equality check were keyed on it
+// the operator would see 0 != generation on every pass and write again, each
+// write waking the next reconcile. The Ready condition's observedGeneration
+// has always been in the schema, so it is the witness; the pruning is
+// simulated by dropping the top-level field before the fake persists it.
+func TestAPrunedObservedGenerationDoesNotWriteEveryPass(t *testing.T) {
+	agent := observedGenerationAgent(1)
+	counter := &statusWriteCounter{}
+	funcs := counter.interceptors()
+	persist := funcs.SubResourceUpdate
+	funcs.SubResourceUpdate = func(ctx context.Context, cl client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+		if pa, ok := obj.(*agentv1alpha1.PlatformAgent); ok {
+			pa.Status.ObservedGeneration = 0
+		}
+		return persist(ctx, cl, subResourceName, obj, opts...)
+	}
+	scheme := setupScheme()
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(agent, readyGateway(agent), shellSandbox(agent, 1), credentialBroker(agent, 1)).
+		WithStatusSubresource(agent).
+		WithInterceptorFuncs(funcs).
+		Build()
+	r := &PlatformAgentReconciler{Client: cl, APIReader: cl, Scheme: scheme}
+
+	settleReady(t, r, agent)
+	if agent.Status.ObservedGeneration != 0 {
+		t.Fatalf("the fixture did not prune status.observedGeneration (got %d); the test is not exercising the skew", agent.Status.ObservedGeneration)
+	}
+	if got := readyConditionGeneration(t, agent); got != 1 {
+		t.Fatalf("Ready condition observedGeneration = %d under pruning, want 1: the condition's copy is the witness", got)
+	}
+	settleReady(t, r, agent)
+	settleReady(t, r, agent)
+	if counter.writes != 1 {
+		t.Errorf("%d status writes across three unchanged passes under a pruning CRD, want 1: this is the write-every-pass loop", counter.writes)
+	}
+
+	agent.Generation = 2
+	if err := r.Update(context.Background(), agent); err != nil {
+		t.Fatalf("storing the generation bump: %v", err)
+	}
+	settleReady(t, r, agent)
+	settleReady(t, r, agent)
+	if counter.writes != 2 {
+		t.Errorf("%d status writes after a generation bump under a pruning CRD, want 2: one for the bump, then quiet", counter.writes)
+	}
+}
+
+// TestEventWatcherConditionCarriesTheGeneration: the emergency-stop condition
+// is written in the same pass as Ready and must name the same generation, or
+// the doc's claim about the conditions written alongside Ready is false.
+func TestEventWatcherConditionCarriesTheGeneration(t *testing.T) {
+	agent := observedGenerationAgent(6)
+	agent.Spec.Harness = &agentv1alpha1.HarnessSpec{EventWatcher: &agentv1alpha1.EventWatcherSpec{Enabled: ptr.To(false)}}
+	r := observedGenerationReconciler(agent, &statusWriteCounter{})
+
+	settleReady(t, r, agent)
+	cond := meta.FindStatusCondition(agent.Status.Conditions, eventWatcherConditionType)
+	if cond == nil {
+		t.Fatal("no EventWatcher condition was written with the watcher disabled")
+	}
+	if got := cond.ObservedGeneration; got != 6 {
+		t.Errorf("EventWatcher condition observedGeneration = %d, want 6", got)
+	}
+}
+
+// TestDegradedGitRepoConditionCarriesTheGeneration covers the Degraded
+// condition updateStatusReady itself writes, as distinct from the RBAC one.
+func TestDegradedGitRepoConditionCarriesTheGeneration(t *testing.T) {
+	agent := observedGenerationAgent(7)
+	agent.Spec.Integration = &agentv1alpha1.PlatformAgentIntegrationSpec{IntegrationSpec: agentv1alpha1.IntegrationSpec{GitHub: &agentv1alpha1.GitHubSpec{Org: "-invalid-org-"}}}
+	r := observedGenerationReconciler(agent, &statusWriteCounter{})
+
+	if phase := settleReady(t, r, agent); phase != "Degraded" {
+		t.Fatalf("got phase %q with an invalid org, want Degraded", phase)
+	}
+	cond := meta.FindStatusCondition(agent.Status.Conditions, degradedConditionType)
+	if cond == nil {
+		t.Fatal("no Degraded condition was written for the invalid org")
+	}
+	if cond.Reason != conditionReasonInvalidGitRepoURL {
+		t.Fatalf("Degraded reason = %q, want %q", cond.Reason, conditionReasonInvalidGitRepoURL)
+	}
+	if got := cond.ObservedGeneration; got != 7 {
+		t.Errorf("Degraded condition observedGeneration = %d, want 7", got)
+	}
+}

--- a/k8s-operator/internal/controller/rbac_selfcheck.go
+++ b/k8s-operator/internal/controller/rbac_selfcheck.go
@@ -375,6 +375,7 @@ func (r *PlatformAgentReconciler) reportRBACSkew(ctx context.Context, agent *age
 		Status:             metav1.ConditionTrue,
 		Reason:             reasonRBACIncomplete,
 		Message:            message,
+		ObservedGeneration: agent.Generation,
 		LastTransitionTime: metav1.Now(),
 	})
 	return true, r.Status().Update(ctx, agent)


### PR DESCRIPTION
## Summary

`PlatformAgent.status` now carries `observedGeneration`, the `metadata.generation` the status was last computed from, and every condition the operator writes on the agent (`Ready`, `Degraded`, `EventWatcher`, and the RBAC self-check's `Degraded/RBACIncomplete`) carries the same value in its own `observedGeneration`. A spec edit that changes nothing else the status derives from still produces one status write, so the field moves whenever the operator has processed a new generation. `AgentPluginStatus` already worked this way; the agent side was the omission #534 describes. The Ready derivation itself is unchanged; making it rollout-aware is described under Context as follow-up, with the reasoning.

## Why This Change

`Ready=True` on a PlatformAgent means "some replica is ready right now". After `kubectl apply` of a changed spec, the previous Pod keeps satisfying that until the Recreate rollout takes it down, so `kubectl wait --for=condition=Ready` returns on the old status and has verified nothing, and nothing on the object lets a caller tell. #533 worked around it in a shell script by waiting on the gateway Deployment's rollout plus a bounded wait for the operator to bump the Deployment generation first. With this change the CR says which generation its status describes, on the status and on the conditions, which is what the API conventions specify and what the AgentPlugin path already publishes.

## What Changed

- `k8s-operator/api/v1alpha1/common_types.go`: `AgentStatus.ObservedGeneration int64`, same doc comment as the plugin field. CRD and deepcopy regenerated; chart copy synced (`make chart-check` clean).
- `platformagent_controller.go` `updateStatusReady`: sets `status.observedGeneration` from `metadata.generation`; stamps `observedGeneration` on the `Ready`, `Degraded` and `EventWatcher` conditions it writes; the "anything changed" check now includes the generation, so a bump alone writes once and the pass after it is quiet again. The witness in that check is the `Ready` condition's `observedGeneration`, not the top-level field: the two are written together, but a CRD that predates the field prunes the top-level copy on every write while the condition's has always been in the schema, and keyed on the pruned copy an operator rolled ahead of its CRD would write on every pass (each write waking the next reconcile through the unfiltered watch).
- `platformagent_controller.go` `updateStatusDegraded`: same for the refusal path (`RuntimeClassNotFound`, `ShellSandboxKeysMissing`, `ModeNotRecognized`, ...), which always writes.
- `rbac_selfcheck.go` `reportRBACSkew`: stamps its `Degraded/RBACIncomplete` condition but does not set the top-level field. That pass runs before the spec has been acted on; claiming the generation there would let a reconcile that errors out afterwards leave "generation N seen" beside a Ready condition computed from N-1, which is the stale success the field exists to expose.
- `docs/site/src/content/docs/operator/platformagent-crd.md`: the field in the status table, and a short section on telling a current status from a stale one, with a wait recipe (`--for=jsonpath='{.status.observedGeneration}'=<gen>`, then `rollout status` on the gateway, then `--for=condition=Ready`). The section says plainly that the field means "the operator processed this generation", not "the rollout finished".
- Tests: `platformagent_observed_generation_test.go` (fake client) and `platformagent_observed_generation_envtest_test.go`, the operator's first envtest case (see Testing).

## Context

Closes #534. Related: #533 (merged; the `rollout status` heuristic this field lets a caller drop the bounded-wait half of), #1042 (the stockout E2E fixture's rollout wait, which reads the AgentPlugin's `observedGeneration`; not touched here). No open PR touches `AgentStatus`, `updateStatusReady`, `updateStatusDegraded` or `reportRBACSkew` (`gh pr list --search` on each; the only hits were PRs whose bodies mention "observedGeneration" for unrelated resources).

**Generation-aware Ready, deliberately not done here.** The issue's optional item was to publish `Ready=True` only once the running workload corresponds to the observed generation, using the `kubectl rollout status` predicate on the gateway Deployment. I evaluated it and left Ready alone, for three reasons that make it not a contained change to the derivation:

1. `updateStatusReady` reads the gateway Deployment through the manager's cached client in the same reconcile that just server-side-applied it. The cache can still hold the previous generation, fully rolled out, so `status.observedGeneration == metadata.generation && updatedReplicas == replicas && readyReplicas > 0` can be satisfied by the old object and the operator would publish `Ready=True` stamped with the *new* generation, a stronger false claim than today's. Closing that needs the applied Deployment's generation carried from `applyManaged` into the status pass, or a live read, which changes the apply path rather than the Ready derivation.
2. The gateway can be a StatefulSet (`useStatefulSet`), whose rollout predicate is `currentRevision == updateRevision`, and Ready is a claim about three workloads since the split, so the shell StatefulSet and the credential broker need the same treatment for Ready to mean "this generation". Every existing readiness fixture builds those workloads with only `ReadyReplicas` set, so the gate touches all of them.
3. Under the Recreate single-replica default the window the gate would close is between the CR update and the Deployment controller scaling the old ReplicaSet to zero, after which `readyReplicas` is 0 and Ready already flips. That window is the cache lag in (1), so the gate as specified does not remove it.

With the field published, a caller can do the correct thing today with the three-step recipe in the doc, and a follow-up can make Ready carry that meaning once the Deployment generation is threaded through from the apply.

## Testing

- `make -C k8s-operator test` green (manifests, generate, fmt, vet, envtest setup, `go test ./...`, python tests). `make chart-check`, `make docs-check`, pinned `prettier --check` (3.9.6) on the changed `.md`/`.yaml`: all clean.
- Unit tests (fake client), all fail on `upstream/main`'s controller and pass here:
  - `TestReadyStatusRecordsTheGenerationItWasComputedFrom`: Ready status and condition at generation 3 both record 3, in memory and as persisted.
  - `TestAGenerationBumpAloneWritesStatus`: counts status-subresource writes through an interceptor. Pass 1 writes; an unchanged pass 2 does not; a generation bump with nothing else changed writes once; the pass after it is quiet.
  - `TestDegradedStatusRecordsTheGenerationItWasComputedFrom`: the refusal path at generation 5.
  - `TestRBACSkewConditionCarriesTheGenerationButDoesNotClaimIt`: the RBAC condition at generation 4 carries 4 and the top-level field stays 0.
  - `TestAPrunedObservedGenerationDoesNotWriteEveryPass`: an interceptor drops the top-level field before the fake persists it (the old-CRD skew). Three unchanged passes make one write; a generation bump makes one more, then quiet. With the equality keyed on the top-level field instead, the same test reports 3 writes across the unchanged passes.
  - `TestEventWatcherConditionCarriesTheGeneration`, `TestDegradedGitRepoConditionCarriesTheGeneration`: the two other conditions `updateStatusReady` writes carry the generation (added after the adversarial pass found them unpinned).
- envtest, `TestObservedGenerationFollowsMetadataGenerationEnvtest` (the operator had none before; `envtest.Environment` loads `config/crd/bases`, so the API server serves the schema this branch generated). It creates a PlatformAgent and the sandbox keys Secret, runs `Reconcile` (finalizer pass, then the full pass), edits `spec.deployment.podAnnotations`, and reconciles again. Confirmed it RUNS with `KUBEBUILDER_ASSETS` set (7s), and skips with a message naming the variable when unset:

  ```text
  after first reconcile:              generation=1 status.observedGeneration=1 phase=Provisioning ready.observedGeneration=1
  after spec edit, before reconcile:  generation=2 status.observedGeneration=1 ready.observedGeneration=1
  after second reconcile:             generation=2 status.observedGeneration=2 phase=Provisioning ready.observedGeneration=2
  ```

  The middle line is the stale gap a caller could not see before. With the controller change reverted (API field and tests kept), the same case reads `observedGeneration=0` at every step and fails.

### Live validation

`gke_bnaylor-kagents-dev_us-east4_bnaylor-ka-test`, ns `kubeagents-system`, a default-mode install running operator `k8s-operator:dev-pr724b` (weeks behind main; single pre-split gateway Deployment, no sandbox keys Secret). Lease claimed first; operator Deployment, CRD and namespace inventory snapshotted before any change.

1. Applied the regenerated CRD server-side; rolled the operator to `k8s-operator:observed-gen-20260910-001330` built from this branch on Cloud Build. Pod Running, `RBAC self-check passed`.
2. Within 60s the CR read `generation=57 observedGeneration=57 phase=Degraded`, `Ready=False reason=ShellSandboxKeysMissing observedGeneration=57`. Degraded is the install drift (main's operator wants the sandbox keypair this install never had); it is the `updateStatusDegraded` path, and it carries the field.
3. Benign spec edit: `spec.mode: today` (resolves identically to absent; the gateway Deployment generation did not move across either edit). `patch` returned with `generation=58 observedGeneration=58 ready.observedGeneration=58` already settled.
4. Revert (`remove /spec/mode`): immediately after, `generation=59 observedGeneration=58 ready.observedGeneration=58`, the stale gap captured live; settled to `59 59 59` on the next poll.
5. Restore: operator image back to `dev-pr724b`, CRD spec replaced from the snapshot (`observedGeneration` occurrences back to the snapshot's 3), inventory diff 0 new / 0 missing objects, gateway rolled back to its original three containers and `1/1`, CR `phase=Ready Ready=True/Reconciled`, `status.observedGeneration` absent again under the old operator. Lease released.

Operator log during the run: two `Reconciler error: Operation cannot be fulfilled on platformagents...` lines, the optimistic-lock conflict between a status write and the finalizer/spec update, self-resolving; the old operator logged one of the same after the rollback. No other errors. Not covered live: the `Ready=True` path with the field (the install cannot reach Ready under main's operator without the sandbox Secret and image pins); that path is the envtest and unit coverage above.

## Self-Review

Both passes ran in fresh `general-purpose` subagents handed only the worktree path, the range `upstream/main...HEAD`, and the skill file (`.agents/skills/review-adversarial/SKILL.md`, `.agents/skills/review-docs-drift/SKILL.md`); neither had this session's reasoning. The adversarial pass built, vetted, ran the controller package with envtest assets, and reverse-applied the controller hunks on a copy to confirm the five original tests go red without the fix. Findings, merged:

- **Docs prose claimed every condition carries the generation (both passes; docs-drift Blocking, adversarial MEDIUM).** Confirmed: `Degraded/RBACIncomplete` is written when the denied set changes and left in place otherwise (`rbac_selfcheck.go`), and `updateStatusReady` preserves it. **Fixed**: the section now names `Ready` plus the `Degraded`/`EventWatcher` written in the same pass, and states the `RBACIncomplete` exception with the adversarial pass's correction (its generation is the one at which the denied set last changed, not first reported).
- **Wait recipe gated on the gateway rollout only (both passes; Should fix / MEDIUM).** Confirmed: Ready is a claim about three workloads. **Fixed**: the recipe waits on `deployment/platform-agent-gateway`, `statefulset/platform-agent-shell` and `deployment/platform-agent-credential-proxy` (names checked against `shellSandboxName` and `credentialBrokerName`), and the prose says why.
- **`kubectl describe` sample above the section lacked `Observed Generation` (docs-drift Nit).** **Fixed** in the sample.
- **`Degraded` (gitRepo) and `EventWatcher` condition stamps had no test (adversarial LOW).** Confirmed. **Fixed**: two cases added; the suite would have stayed green with either stamp removed before.
- **`updateStatusDegraded` writes on every pass into an unfiltered watch, so a CR parked on a refusal reconciles about once a second (adversarial MEDIUM, pre-existing, plausible from source, not observed).** **Not fixed here**: this diff adds one assignment inside that already-unconditional write and neither introduces nor worsens the loop; the fix is the equality gate `updateStatusReady` has, which is its own change with its own test. Filed as #1392.
- **Recipe uses `deployment/platform-agent-gateway`, wrong for the StatefulSet gateway mode (docs-drift Nit, suspicion).** **Not fixed**: the page documents no StatefulSet mode at all; the caveat belongs with the follow-up that documents that mode, not in a recipe for the default.
- **Advisory (docs-drift): no map row for CRD status identifiers; AgentPlugin page could cross-link.** Not done; neither is owed by this change and both widen scope.
- **Sibling #1159 (adversarial, not a finding)** rewrites the gitRepo block directly above this diff's first hunk; non-overlapping, auto-mergeable. Whichever lands second should re-run `TestReadyStatusRecordsTheGenerationItWasComputedFrom`.

Looked for and found nothing (both passes): removed behaviour or weakened CI; RBAC/NetworkPolicy/credential impact (one extra status write per spec edit and one per CR at operator upgrade); the concurrent-edit race (the status write carries the resourceVersion and 409s); `omitempty` on an `int64` whose real values start at 1; generated-artefact drift (both CRD copies byte-identical, deepcopy unchanged for a scalar, `AgentStatus` embedded only by PlatformAgent); new literals in non-test code; PR-status prose or generated-region edits in docs; other in-repo prose or scripts that gate on PlatformAgent `Ready` after a spec edit (none do; the stockout E2E gates on the AgentPlugin's field). The adversarial pass rated the top-level-vs-condition witness as unable to diverge; that holds only while the CRD keeps the field, which is the skew the pruning test now covers (added after the pass, in this session's context, and noted as such).

## Risk & Rollout

Additive optional status field plus condition stamps; no rendered object changes. New behaviour: one status write per generation bump that previously wrote nothing, and that write wakes one more reconcile through the PlatformAgent watch, after which the pass is quiet (tested). An old operator against the new CRD simply never sets the field. A new operator against an old CRD (an image rolled without `upgrade.sh`'s CRD apply) has the API server prune the top-level field on every write; the equality check therefore keys on the Ready condition's `observedGeneration`, which every CRD version already schemas, so that skew costs one write per generation rather than a write per pass. Revert is a straight revert of the commit; nothing has to happen at merge time. The doc's wait recipe uses `kubectl wait --for=jsonpath`, available since kubectl 1.23.

Generated with the help of Claude (Claude Code).

