### PR TITLE
fix(e2e): raise generation wait timeout and fail on timeout in agentplugins e2e test

### DIFF
--- a/tests/e2e/operator/agentplugins_e2e_test.py
+++ b/tests/e2e/operator/agentplugins_e2e_test.py
@@ -122,6 +122,7 @@ ROLLOUT_RETRY_INTERVAL_SEC: int = 3
 API_POLL_INTERVAL_SEC: int = 2
 MIN_ROLLOUT_TIMEOUT_SEC: int = 5
 DEFAULT_GENERATION_TIMEOUT_SEC: int = 180
+CRD_MISSING_LOG_POLL_TIMEOUT_SEC: int = 30
 GATEWAY_DEPLOYMENT: str = "platform-agent-gateway"
 # AgentPlugin names are restricted to ^[a-z][a-z0-9]*$ by the CRD: the name doubles as
 # the plugin directory and the module identifier Hermes imports.
@@ -1166,14 +1167,11 @@ def step12_verify_missing_crd_decoupled_dependency_safeguard() -> None:
         log("Deleting AgentPlugin CRD from cluster...")
         run_kubectl(["delete", "crd", "agentplugins.kubeagents.x-k8s.io"], check=True)
 
-        gen_before = get_deployment_generation(GATEWAY_DEPLOYMENT)
         trigger_val = str(int(time.time()))
         run_kubectl([
             "annotate", "platformagent", "platform-agent", "-n", NAMESPACE,
             f"e2e.test/crd-missing-trigger={trigger_val}", "--overwrite"
         ])
-
-        wait_deployment_generation_change(GATEWAY_DEPLOYMENT, min_gen=gen_before + 1)
         wait_deployment_rollout(GATEWAY_DEPLOYMENT)
 
         op_image = get_kubectl_output([
@@ -1181,10 +1179,18 @@ def step12_verify_missing_crd_decoupled_dependency_safeguard() -> None:
             "-o", "jsonpath={.spec.template.spec.containers[?(@.name==\"manager\")].image}"
         ])
         op_pod = poll_operator_pod(expected_image=op_image, timeout_sec=OPERATOR_PROBE_TIMEOUT_SEC)
-        crd_missing_logged = (
-            check_operator_error_log("the server could not find the requested resource") or
-            check_operator_error_log("AgentPlugin CRD is not installed on cluster")
-        )
+
+        crd_missing_logged = False
+        start_time = time.time()
+        while time.time() - start_time < CRD_MISSING_LOG_POLL_TIMEOUT_SEC:
+            if (
+                check_operator_error_log("the server could not find the requested resource") or
+                check_operator_error_log("AgentPlugin CRD is not installed on cluster")
+            ):
+                crd_missing_logged = True
+                break
+            time.sleep(1)
+
         assert crd_missing_logged, "Expected operator to log missing CRD reflector warning or info message"
         log("Verified operator logged missing CRD reflector message while PlatformAgent reconciliation succeeded.")
 

--- a/tests/e2e/operator/agentplugins_e2e_test.py
+++ b/tests/e2e/operator/agentplugins_e2e_test.py
@@ -121,6 +121,7 @@ DEFAULT_ROLLOUT_TIMEOUT_SEC: int = 900
 ROLLOUT_RETRY_INTERVAL_SEC: int = 3
 API_POLL_INTERVAL_SEC: int = 2
 MIN_ROLLOUT_TIMEOUT_SEC: int = 5
+DEFAULT_GENERATION_TIMEOUT_SEC: int = 180
 GATEWAY_DEPLOYMENT: str = "platform-agent-gateway"
 # AgentPlugin names are restricted to ^[a-z][a-z0-9]*$ by the CRD: the name doubles as
 # the plugin directory and the module identifier Hermes imports.
@@ -444,8 +445,15 @@ def get_latest_pod_template_hash(deployment_name: str) -> str:
     return lines[-1] if lines else ""
 
 
-def wait_deployment_generation_change(deployment_name: str, min_gen: int, timeout_sec: int = 20) -> None:
-    """Wait for operator reconciliation to update deployment metadata.generation."""
+def wait_deployment_generation_change(
+    deployment_name: str, min_gen: int, timeout_sec: int = DEFAULT_GENERATION_TIMEOUT_SEC
+) -> None:
+    """Wait for operator reconciliation to update deployment metadata.generation.
+
+    Raises TimeoutError if the deployment generation does not reach min_gen within
+    timeout_sec, preventing subsequent rollout and spec checks from validating a stale
+    revision.
+    """
     end_time = time.time() + timeout_sec
     while time.time() < end_time:
         try:
@@ -456,7 +464,9 @@ def wait_deployment_generation_change(deployment_name: str, min_gen: int, timeou
         except (subprocess.CalledProcessError, ValueError):
             pass
         time.sleep(1)
-    log(f"Warning: Deployment '{deployment_name}' generation did not reach {min_gen} within {timeout_sec}s")
+    raise TimeoutError(
+        f"Deployment '{deployment_name}' generation did not reach {min_gen} within {timeout_sec}s"
+    )
 
 
 def poll_running_pod_name(label_selector: str, pod_template_hash: str | None = None, timeout_sec: int = 30) -> str:

--- a/tests/test_agentplugins_e2e_helpers.py
+++ b/tests/test_agentplugins_e2e_helpers.py
@@ -111,6 +111,36 @@ class AgentPluginsE2EHelpersTest(unittest.TestCase):
             with self.assertRaises(TimeoutError):
                 e2e.wait_deployment_rollout("nonexistent-deployment", timeout="5s")
 
+    def test_wait_deployment_generation_change_succeeds_when_min_gen_reached(self):
+        """When current generation reaches or exceeds min_gen, return cleanly."""
+        with patch.object(e2e, "get_deployment_generation", return_value=3):
+            e2e.wait_deployment_generation_change("platform-agent-gateway", min_gen=2, timeout_sec=5)
+
+    def test_wait_deployment_generation_change_retries_and_succeeds(self):
+        """Retries through transient errors and lower generations until min_gen is reached."""
+        generations = [1, subprocess.CalledProcessError(1, ["cmd"]), 2]
+
+        def mock_get_generation(deployment_name):
+            val = generations.pop(0)
+            if isinstance(val, Exception):
+                raise val
+            return val
+
+        with patch.object(e2e, "get_deployment_generation", side_effect=mock_get_generation), \
+             patch("time.sleep", return_value=None):
+            e2e.wait_deployment_generation_change("platform-agent-gateway", min_gen=2, timeout_sec=10)
+
+        self.assertEqual(len(generations), 0)
+
+    def test_wait_deployment_generation_change_raises_timeout_error(self):
+        """When generation never reaches min_gen, raise TimeoutError."""
+        with patch.object(e2e, "get_deployment_generation", return_value=1), \
+             patch("time.sleep", return_value=None):
+            with self.assertRaises(TimeoutError) as ctx:
+                e2e.wait_deployment_generation_change("platform-agent-gateway", min_gen=2, timeout_sec=0)
+            self.assertIn("generation did not reach 2", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_agentplugins_e2e_helpers.py
+++ b/tests/test_agentplugins_e2e_helpers.py
@@ -133,12 +133,14 @@ class AgentPluginsE2EHelpersTest(unittest.TestCase):
         self.assertEqual(len(generations), 0)
 
     def test_wait_deployment_generation_change_raises_timeout_error(self):
-        """When generation never reaches min_gen, raise TimeoutError."""
-        with patch.object(e2e, "get_deployment_generation", return_value=1), \
+        """When generation never reaches min_gen, poll until timeout and raise TimeoutError."""
+        with patch.object(e2e, "get_deployment_generation", return_value=1) as mock_get_gen, \
+             patch("time.time", side_effect=[100.0, 100.0, 103.0]), \
              patch("time.sleep", return_value=None):
             with self.assertRaises(TimeoutError) as ctx:
-                e2e.wait_deployment_generation_change("platform-agent-gateway", min_gen=2, timeout_sec=0)
+                e2e.wait_deployment_generation_change("platform-agent-gateway", min_gen=2, timeout_sec=2)
             self.assertIn("generation did not reach 2", str(ctx.exception))
+            mock_get_gen.assert_called_once_with("platform-agent-gateway")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the intermittent test failure in `tests/e2e/operator/agentplugins_e2e_test.py` where `wait_deployment_generation_change` silently timed out after 20 seconds on GKE Autopilot clusters, allowing downstream checks to evaluate a stale Deployment generation before the operator reconciled the test's `AgentPlugin` custom resource. The timeout is raised to 180 seconds to match the suite's operator settle bounds and now raises `TimeoutError` on expiration instead of returning `None`, while Step 12 replaces an unneeded Deployment generation wait with a poll loop against operator logs.

## Why This Change

In nightly CI on GKE Autopilot (run [34430055779](https://github.com/gke-labs/kube-agents/actions/runs/34430055779/job/102729030088)), `agentplugins_e2e_test.py` failed at step 4 with `AssertionError: Expected imagePullPolicy Always, got ''`. When `PlatformAgent` reconciles on GKE Autopilot, full reconciliation across discovery, RBAC, PVC, and workload patching often exceeds 20 seconds. Because `wait_deployment_generation_change` only emitted a warning on timeout and returned `None`, `wait_deployment_rollout` immediately observed the already-available generation 1 deployment and passed. The test then asserted against the un-reconciled generation 1 deployment spec where the plugin volume was absent, resulting in an empty string and failing the assertion. Without this fix, E2E tests against Autopilot clusters intermittently fail due to this race condition.

## What Changed

- Declared `DEFAULT_GENERATION_TIMEOUT_SEC = 180` and `CRD_MISSING_LOG_POLL_TIMEOUT_SEC = 30` in `tests/e2e/operator/agentplugins_e2e_test.py`.
- Updated `wait_deployment_generation_change` to use `DEFAULT_GENERATION_TIMEOUT_SEC` by default and to raise `TimeoutError` when the target generation is not reached within the timeout.
- In `step12_verify_missing_crd_decoupled_dependency_safeguard`, replaced the call to `wait_deployment_generation_change` (annotating `PlatformAgent` does not change the gateway deployment generation) with a poll loop checking operator logs for missing CRD reflector warnings within `CRD_MISSING_LOG_POLL_TIMEOUT_SEC`.
- Added unit test coverage in `tests/test_agentplugins_e2e_helpers.py` verifying that `wait_deployment_generation_change` returns when the generation reaches `min_gen`, retries across lower generations, and raises `TimeoutError` on timeout.

## Context

- Closes failure observed in GitHub Actions run [34430055779/job/102729030088](https://github.com/gke-labs/kube-agents/actions/runs/34430055779/job/102729030088).
- Builds upon changes in PR #1289.

## Testing

- `python3 -m unittest tests/test_agentplugins_e2e_helpers.py`: 11 tests passed in 5.0s.
- `PYTHONPATH=. bench/.venv/bin/pytest -v tests/test_agentplugins_e2e_helpers.py`: 11 tests passed in 5.4s.
- `make docs-check`: Passed cleanly (links, terminology, map coverage, context budget 38.0k chars).

### Live validation

Exercised against running cluster `gke_quick-test-508010_us-central1_autopilot-cluster-1` (GKE Autopilot 1.35.7-gke.1218000) using operator image `us-central1-docker.pkg.dev/quick-test-508010/e2e-plugins/k8s-operator:v20260909-130001` in namespace `kubeagents-system`:

1. Executed E2E test via:
   ```bash
   KUBE_CONTEXT=gke_quick-test-508010_us-central1_autopilot-cluster-1 \
   NAMESPACE=kubeagents-system \
   REGISTRY=us-central1-docker.pkg.dev/quick-test-508010/e2e-plugins \
   IMAGE_BUILDER=crane \
   CRANE_BIN=/usr/local/google/home/sergiuspiridon/.local/bin/crane \
   REBUILD_OPERATOR=false \
   TEST_DESTRUCTIVE_CRD=false \
   python3 tests/e2e/operator/agentplugins_e2e_test.py
   ```
2. Observed Step 4:
   ```text
   [2026-09-10 11:13:45] [E2E-TEST] Deploying targeted AgentPlugin custom resource 'e2eexampleplugin'...
   agentplugin.kubeagents.x-k8s.io/e2eexampleplugin created
   [2026-09-10 11:13:48] [E2E-TEST] Waiting for operator reconciliation and PlatformAgent deployment update...
   [2026-09-10 11:13:49] [E2E-TEST] Deployment 'platform-agent-gateway' generation updated to 50 (>= 50)
   deployment "platform-agent-gateway" successfully rolled out
   [2026-09-10 11:14:27] [E2E-TEST] Verified plugin volume imagePullPolicy on deployment: Always
   [2026-09-10 11:14:27] [E2E-TEST] STEP 4 SUCCESS: AgentPlugin opt-in targeting, imagePullPolicy, and CR deployment verified.
   ```
3. Observed Steps 1, 3, 5–8, 9, 10, 11, and 13 passed cleanly. All test resources (`e2eexampleplugin`, `e2euntargetedplugin`, `e2ebadimageplugin`, `sessionstore`) were deleted during test execution.

## Self-Review

Conducted independent clean-context adversarial review and documentation drift review against diff range `upstream/main...HEAD`:

- **Docs-Drift Review** (clean subagent context):
  - Checked `docs/README.md`, `tests/e2e/README.md`, `scripts/release/README.md`, `docs/designs/e2e-testing-harness.md`, and `docs/testing-map.md`.
  - Findings: None. Test constants and internal test helper functions do not modify documented public APIs or procedures.
- **Adversarial Review** (clean subagent context):
  - Finding 1 (HIGH, CONFIRMED): In Step 12, annotating `PlatformAgent` does not modify the Gateway Deployment spec, so `wait_deployment_generation_change` would deterministically raise `TimeoutError` when timeout is enforced.
    - *Disposition*: Fixed in commit `5ebcaaf8`. Removed the generation change wait in Step 12 and replaced with a poll loop checking operator logs for missing CRD reflector messages within `CRD_MISSING_LOG_POLL_TIMEOUT_SEC = 30`.
  - Finding 2 (MEDIUM, CONFIRMED): `test_wait_deployment_generation_change_raises_timeout_error` called the helper with `timeout_sec=0`, which bypassed the polling loop entirely.
    - *Disposition*: Fixed in commit `5ebcaaf8`. Used `patch("time.time", side_effect=[100.0, 100.0, 103.0])` with `timeout_sec=2` and asserted `mock_get_gen.assert_called_once_with("platform-agent-gateway")` to verify the loop ran and inspected deployment generation.

## Risk & Rollout

Low risk. Changes are confined to the test harness in `tests/e2e/operator/agentplugins_e2e_test.py` and unit test helper verification in `tests/test_agentplugins_e2e_helpers.py`. No runtime controller or agent production code paths are touched. Revert by reverting the commit.

Generated with the help of Antigravity.
