### PR TITLE
fix(installer): suppress duplicate error banner and misleading tee failure

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1696,18 +1696,38 @@ tf_compose_dir() {
   echo "${1}/terraform/examples/full-install"
 }
 
+# Evaluates PIPESTATUS after a pipeline guarded with `|| ps=("${PIPESTATUS[@]}")`.
+# Dispatches to on_error with the primary command name instead of the trailing tee.
+handle_pipeline_status() {
+  local primary_cmd="$1"
+  local log_file="$2"
+  local rc_primary="${3:-0}"
+  local rc_tee="${4:-0}"
+
+  if [ "$rc_primary" -ne 0 ]; then
+    on_error "$rc_primary" "$LINENO" "$primary_cmd"
+  elif [ "$rc_tee" -ne 0 ]; then
+    on_error "$rc_tee" "$LINENO" "tee \"$log_file\""
+  fi
+}
+
 # Runs lifecycle.sh apply against the generated terraform.tfvars. Reads the
 # install coordinates from the environment (load install.env first).
 run_lifecycle_apply() {
   local repo_dir="$1"
   local log_file="$2"
+  local -a ps=()
   (
     cd "$(tf_compose_dir "$repo_dir")"
     export KUBE_AGENTS_STATE_BUCKET="${KUBE_AGENTS_STATE_BUCKET:-$DEFAULT_KUBE_AGENTS_STATE_BUCKET}"
     export KUBE_AGENTS_STATE_PREFIX
     KUBE_AGENTS_STATE_PREFIX="$(tf_state_prefix)"
     ./lifecycle.sh apply -auto-approve -input=false
-  ) 2>&1 | tee "$log_file"
+  ) 2>&1 | tee "$log_file" || ps=("${PIPESTATUS[@]}")
+
+  # ${ps[@]+"${ps[@]}"}: empty on a clean apply, and macOS's bash 3.2 treats an
+  # empty array expansion as unbound under `set -u`.
+  handle_pipeline_status "./lifecycle.sh apply -auto-approve -input=false" "$log_file" ${ps[@]+"${ps[@]}"}
 }
 
 # CMEK on a pre-existing cluster is the one create-path behaviour Terraform

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -2493,5 +2493,79 @@ KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
             self.assertIn("Tool 'gke-gcloud-auth-plugin' is still missing", proc.stderr + proc.stdout)
 
 
+class RunLifecycleApplyTrapTest(unittest.TestCase):
+    """Verifies that run_lifecycle_apply does not trigger duplicate ERR traps or
+    misleading 'tee' error banners when lifecycle.sh fails (#1298)."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self._tmp_path = pathlib.Path(tmp.name)
+        self._empty_install_env = self._tmp_path / "install.env"
+        self._empty_install_env.write_text("")
+
+    def _run_func(self, func_call, cwd=None):
+        setup = f"""
+source "{_INSTALLER_COMMON}"
+KUBE_AGENTS_SOURCE_ONLY=true source "{_INSTALL_SH}"
+{func_call}
+"""
+        overrides = {
+            "KUBE_AGENTS_INSTALL_ENV": str(self._empty_install_env),
+            "KUBE_AGENTS_INSTALL_REPORT_FILE": str(self._tmp_path / "report.json"),
+        }
+        full_env = get_isolated_test_env(overrides=overrides)
+        return subprocess.run(
+            ["bash", "-c", setup],
+            capture_output=True,
+            text=True,
+            env=full_env,
+            cwd=str(cwd or _REPO_ROOT),
+        )
+
+    def test_failed_apply_reports_only_command_and_not_tee(self):
+        repo_dir = self._tmp_path / "mock-repo"
+        compose_dir = repo_dir / "terraform" / "examples" / "full-install"
+        compose_dir.mkdir(parents=True)
+        lifecycle_sh = compose_dir / "lifecycle.sh"
+        lifecycle_sh.write_text("#!/bin/bash\necho 'Terraform error' >&2\nexit 1\n")
+        lifecycle_sh.chmod(0o755)
+
+        log_file = self._tmp_path / "provision.log"
+        proc = self._run_func(f'run_lifecycle_apply "{repo_dir}" "{log_file}"')
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Error encountered at line", proc.stderr)
+        self.assertIn("./lifecycle.sh apply -auto-approve -input=false", proc.stderr)
+        self.assertNotIn('tee "$log_file"', proc.stderr)
+        self.assertNotIn("tee ", proc.stderr)
+
+    def test_successful_apply_writes_log_file_and_succeeds(self):
+        repo_dir = self._tmp_path / "mock-repo"
+        compose_dir = repo_dir / "terraform" / "examples" / "full-install"
+        compose_dir.mkdir(parents=True)
+        lifecycle_sh = compose_dir / "lifecycle.sh"
+        lifecycle_sh.write_text("#!/bin/bash\necho 'Apply complete'\nexit 0\n")
+        lifecycle_sh.chmod(0o755)
+
+        log_file = self._tmp_path / "provision.log"
+        proc = self._run_func(f'run_lifecycle_apply "{repo_dir}" "{log_file}"')
+
+        self.assertEqual(proc.returncode, 0, f"Stderr: {proc.stderr}")
+        self.assertTrue(log_file.exists())
+        self.assertIn("Apply complete", log_file.read_text())
+
+    def test_pipeline_status_handles_empty_array_safely_under_set_u(self):
+        source = _INSTALL_SH.read_text()
+        self.assertIn(
+            'handle_pipeline_status "./lifecycle.sh apply -auto-approve -input=false" "$log_file" ${ps[@]+"${ps[@]}"}',
+            source,
+        )
+        self.assertNotIn(
+            'handle_pipeline_status "./lifecycle.sh apply -auto-approve -input=false" "$log_file" "${ps[@]}"',
+            source,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Prevents `install.sh` from firing duplicate error banners and emitting a bogus `tee "$log_file"` failure message when Terraform provisioning fails during an installation. The pipeline is guarded to capture `PIPESTATUS` directly and dispatch errors via a dedicated helper function, ensuring only the real failing command is reported to the user and recorded in the machine-readable install report.

## Why This Change

Under `set -Eeuo pipefail`, when `lifecycle.sh apply` fails inside the subshell of `run_lifecycle_apply`, the inherited `ERR` trap fires inside the subshell to report the command. Because `pipefail` makes the entire pipeline exit non-zero, the parent shell's `ERR` trap immediately fired a second time, with `$BASH_COMMAND` pointing to the pipeline's trailing element (`tee "$log_file"`). This produced two red error banners, actively misdirected users and debuggers into thinking `tee` failed, and caused `/tmp/kube-agents-install-report.json` to be written twice.

## What Changed

- **`install.sh`**: Added `handle_pipeline_status()` to evaluate `${PIPESTATUS[@]}` after a guarded pipeline and trigger `on_error` with the primary command name if the subshell failed (or blame `tee` only if `tee` itself genuinely failed). Updated `run_lifecycle_apply()` to guard the `( ... ) 2>&1 | tee "$log_file"` pipeline with `|| ps=("${PIPESTATUS[@]}")` and pass the exit statuses safely using `${ps[@]+"${ps[@]}"}`.
- **`tests/test_install_script.py`**: Added `RunLifecycleApplyTrapTest` to verify that failed apply commands report `./lifecycle.sh apply ...` without mentioning `tee`, that successful applies continue to populate the provisioning log properly, and that array expansion remains safe under `set -u`.

## Context

Closes #1298

## Testing

- `python3 -m unittest tests.test_install_script.RunLifecycleApplyTrapTest` (passed: 3/3 tests)
- `python3 -m unittest tests/test_installer_common.py` (passed: 65/65 tests)
- `make docs-check` (passed: all doc map references, relative links, and terminology checks)

### Live validation

Exercised against a mock failing `lifecycle.sh apply` and verified through non-interactive `install.sh` execution:
1. Triggered a simulated apply failure during `install.sh` execution.
2. Verified that exactly one red error banner is printed identifying `./lifecycle.sh apply -auto-approve -input=false` at the relevant line with exit code 1.
3. Confirmed that no secondary banner mentioning `tee "$log_file"` appears.
4. Verified that full provisioning logs are preserved in `/tmp/kube-agents-provision-*.log` and `/tmp/kube-agents-install-report.json` contains a single `FAILED` status record.
5. Verified the happy path: successful applies stream output to the terminal, record complete logs in the log file, and exit with status 0 without error banners.
6. A live multi-resource Terraform failure against a running cloud cluster was not triggered to avoid unnecessary cloud resource creation and billing churn; mocking `lifecycle.sh apply` directly exercises the exact subshell, pipeline, and trap mechanisms touched by this change.
7. Confirmed that all temporary verification logs and `/tmp/kube-agents-install-report.json` files generated during testing were cleaned up.

## Self-Review

Both passes ran in a clean subagent context handed the diff range:

- **Adversarial Pass**: Looked for pipeline status capture edge cases, subshell environment leakage (`cd`/`export` remaining scoped to the pipeline subshell), and Bash 3.2 compatibility under `set -u`.
  - *Finding*: Initial draft expanded `"${ps[@]}"` directly, which on Bash 3.2 under `set -u` aborts on the success path with an `unbound variable` error when `ps` is empty.
  - *Disposition*: Fixed by using the repository's standard `${ps[@]+"${ps[@]}"}` idiom and reading positional parameters `${3:-0}` / `${4:-0}` directly in `handle_pipeline_status()`.
- **Docs Drift Pass**: Checked whether installer documentation or the documentation map required updates.
  - *Finding*: No user-facing documentation or doc map entries were affected by internal error-trap refactoring.

## Risk & Rollout

Low risk. Confined entirely to error handling around the `run_lifecycle_apply` pipeline in `install.sh`. Does not touch runtime agent code, Kubernetes manifests, or Helm charts.

---
*Generated with the help of Jetski.*