### PR TITLE
fix(ci): make each WIF credential the active account so gsutil is not anonymous

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -147,9 +147,13 @@ jobs:
       # an anonymous caller (401 on the bucket, 40 failed ticks on
       # 2026-09-10). `gcloud auth login --cred-file` is what setup-gcloud
       # would have done, and it makes the credential the active account for
-      # gcloud, gsutil and `gcloud auth print-access-token` alike.
+      # gcloud, gsutil and `gcloud auth print-access-token` alike. Moving
+      # setup-gcloud below this auth step would fix only this half; the
+      # publisher half below needs the same login (or a second SDK download),
+      # so one mechanism serves both. An empty path would send gcloud to the
+      # interactive browser flow and hang the job, hence the `:?` guard.
       - name: Make the Prow-archive reader credential active for gsutil
-        run: gcloud auth login --cred-file="$GOOGLE_GHA_CREDS_PATH" --quiet
+        run: gcloud auth login --cred-file="${GOOGLE_GHA_CREDS_PATH:?the auth step exported no credential file}" --quiet
 
       - name: Collect (incremental, onto the published data.json)
         id: collect
@@ -194,16 +198,10 @@ jobs:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.CI_HEALTH_SA }}
 
-      # setup-gcloud registers a credential only if one exists when it runs,
-      # and it runs before either auth step. gcloud honours the credential
-      # file the auth step exports through an environment variable; gsutil
-      # does not, and without this login every gsutil call in the job ran as
-      # an anonymous caller (401 on the bucket, 40 failed ticks on
-      # 2026-09-10). `gcloud auth login --cred-file` is what setup-gcloud
-      # would have done, and it makes the credential the active account for
-      # gcloud, gsutil and `gcloud auth print-access-token` alike.
+      # Same as the reader's login above: make this credential the active
+      # account for gsutil (and the Chat token mint) too.
       - name: Make the publisher credential active for gsutil
-        run: gcloud auth login --cred-file="$GOOGLE_GHA_CREDS_PATH" --quiet
+        run: gcloud auth login --cred-file="${GOOGLE_GHA_CREDS_PATH:?the auth step exported no credential file}" --quiet
 
       - name: Render and publish the dashboard
         if: steps.collect.outcome == 'success'

--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -140,6 +140,17 @@ jobs:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.COLLECT_SA }}
 
+      # setup-gcloud registers a credential only if one exists when it runs,
+      # and it runs before either auth step. gcloud honours the credential
+      # file the auth step exports through an environment variable; gsutil
+      # does not, and without this login every gsutil call in the job ran as
+      # an anonymous caller (401 on the bucket, 40 failed ticks on
+      # 2026-09-10). `gcloud auth login --cred-file` is what setup-gcloud
+      # would have done, and it makes the credential the active account for
+      # gcloud, gsutil and `gcloud auth print-access-token` alike.
+      - name: Make the Prow-archive reader credential active for gsutil
+        run: gcloud auth login --cred-file="$GOOGLE_GHA_CREDS_PATH" --quiet
+
       - name: Collect (incremental, onto the published data.json)
         id: collect
         continue-on-error: true
@@ -182,6 +193,17 @@ jobs:
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.CI_HEALTH_SA }}
+
+      # setup-gcloud registers a credential only if one exists when it runs,
+      # and it runs before either auth step. gcloud honours the credential
+      # file the auth step exports through an environment variable; gsutil
+      # does not, and without this login every gsutil call in the job ran as
+      # an anonymous caller (401 on the bucket, 40 failed ticks on
+      # 2026-09-10). `gcloud auth login --cred-file` is what setup-gcloud
+      # would have done, and it makes the credential the active account for
+      # gcloud, gsutil and `gcloud auth print-access-token` alike.
+      - name: Make the publisher credential active for gsutil
+        run: gcloud auth login --cred-file="$GOOGLE_GHA_CREDS_PATH" --quiet
 
       - name: Render and publish the dashboard
         if: steps.collect.outcome == 'success'


### PR DESCRIPTION
## Summary

Every scheduled tick of the CI health workflow has failed since #1305 merged, before it could adjudicate the gate or post to Chat, because gsutil inside the job runs as an anonymous caller. This PR adds one `gcloud auth login --cred-file` step after each of the workflow's two authentication steps, which makes each Workload Identity credential the active account for gsutil as well as gcloud. It is the same command `setup-gcloud` runs itself when it is placed after the auth step.

## Why This Change

40 consecutive runs of `ci-health.yml` (2026-09-09 22:36Z onward) died at the first `gsutil cp` with:

```
ServiceException: 401 Anonymous caller does not have storage.objects.get access to ... kube-agents-dashboards/objects/evals/data.json
```

`setup-gcloud` runs before either `google-github-actions/auth` step and registers a credential only if `GOOGLE_GHA_CREDS_PATH` exists when it runs, so it registered nothing. The auth step exports the credential through `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE`, which gcloud honours and gsutil does not (the auth action's README says so: "The `gsutil` command will not use the credentials exported by this GitHub Action"). Both identities hit the same wall. The collect step's failure was hidden by its `continue-on-error`, which is why the runs showed the later fetch step as the first red. Without this, the dashboard never refreshes, `health.json` is never written, and the Chat channel stays silent.

## What Changed

- `.github/workflows/ci-health.yml`: after each auth step, `gcloud auth login --cred-file="${GOOGLE_GHA_CREDS_PATH:?...}" --quiet`. Running it a second time flips the active account to the publisher, which is what the render, upload, Chat-token and post steps need. The `:?` guard fails the step if the auth action exported no path, because an empty `--cred-file` sends gcloud to the interactive browser flow and would hang the job to its timeout.
- The comment on the first login explains the failure and why `setup-gcloud` is not simply moved: that would fix only the reader half, and the publisher half needs the same login or a second SDK download.

## Context

- #1305 shipped the workflow; the PR body listed "the second auth step re-pointing gsutil" as one of three things that could not be exercised before merge. This is that one failing.
- Follow-ups #1400 does not touch: the other two unverified steps (Chat token mint under WIF, archive listing within the collect timeout) are exercised by the first green tick after this merges.
- The pending bot follow-ups branch (`feat/ci-health-followups`) carries the same step order and merges main after this lands.

## Testing

```
$ npx prettier@3.9.6 --check .github/workflows/ci-health.yml
Checking formatting...
All matched files use Prettier code style!

$ python3 -c 'import yaml; d=yaml.safe_load(open(".github/workflows/ci-health.yml")); print(len(d["jobs"]["refresh-and-adjudicate"]["steps"]), "steps")'
17 steps

$ zizmor --offline .github/workflows/ci-health.yml
4 findings (3 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
```

The zizmor medium is the pre-existing `artipacked` note on the checkout step; identical output on `origin/main`'s copy of the file. `actionlint` is not installed locally; CI runs it.

```
$ gcloud auth login --help | grep -A2 -- --cred-file
    --cred-file flag must be specified with the path to the workload identity
    credential configuration file ... Login with workload and workforce identity
    federation is also supported in both gsutil and bq.
```

### Live validation

Not live-tested: the job no-ops on any ref but `main` (`github.ref == 'refs/heads/main'` guard), so the workflow cannot run from this branch. The first scheduled tick after merge is the test; expected outcome is a green run, a fresh `data.json` and `health.json` in the bucket, and a Chat post if the gate is not GREEN at that moment. I will watch that tick and report on this PR.

Locally reproduced the failure mode the guard prevents: `gcloud auth login --cred-file="" --quiet` in a throwaway `CLOUDSDK_CONFIG` opens the OAuth browser flow and blocks; a missing file path fails cleanly with `Failed to load YAML ... exit 1`.

## Self-Review

Adversarial and docs-drift passes ran in a fresh subagent context handed the diff range only.

- **Fixed:** empty `$GOOGLE_GHA_CREDS_PATH` would fall through to the interactive login and hang the job rather than fail (gcloud's `if args.cred_file:` treats empty as absent). Now `${GOOGLE_GHA_CREDS_PATH:?}`.
- **Fixed:** the 8-line comment was duplicated verbatim on both logins; the second now says it mirrors the first.
- **Fixed:** the comment gave the diagnosis but not why `setup-gcloud` isn't moved; one sentence added.
- **Confirmed, no change:** `--cred-file` accepts the external_account JSON the auth action writes (gcloud help; `setup-gcloud`'s own `authenticateGcloudSDK` is `gcloud --quiet auth login --force --cred-file <path>`). The second login switches gsutil to the publisher because the gsutil wrapper reads `core/account` and points `BOTO_PATH` at that account's legacy credentials; the wrapper never reads the override variable, which is exactly why it was anonymous. The override variable still wins for gcloud and points at the same account as the active one in each half, so there is no split. `--quiet` answers the only prompt on this path; `--force` is irrelevant here. The auth action's cleanup post-step removes only the second credential file, as on main; the login's copy in the gcloud config dir is on an ephemeral runner.
- **Docs-drift:** neither the workflow header nor `docs/ci-health.md` states the auth order or claims gsutil is covered by the auth action; nothing to update.
- **Not verified:** actual execution on a runner (see Live validation).

## Risk & Rollout

Low. Workflow-only, no runtime code paths, and the job is already failing on every tick, so the worst case is that it keeps failing with a different message. Revert is a one-file revert. Nothing has to happen at merge time; the next scheduled tick picks it up within 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
