### PR TITLE
fix(e2e): skip stockout test when plugin absent and not required, fail when expected

### DIFF
--- a/docs/designs/e2e-testing-harness.md
+++ b/docs/designs/e2e-testing-harness.md
@@ -147,7 +147,8 @@ make test-e2e
 The stockout suite waits for its AgentPlugin to reach Ready, for the gateway to finish
 rolling, and for the plugin's `SKILL.md` to be readable inside the surviving pod before
 the first scenario runs. A failure in any of those ends the module naming what was wrong
-rather than letting each scenario spend its watch timeout. The plugin is installed only
-when its custom resource is absent, so the suite needs the permissions that
-[`agentplugins/README.md`](../../agentplugins/README.md#installing) lists only on a
-cluster that has never had it.
+rather than letting each scenario spend its watch timeout. The suite does not install the
+plugin out of band or mutate cluster state: if the AgentPlugin CRD or custom resource is
+absent, the suite skips cleanly on optional environments and fails when expected
+(`ENABLE_STOCKOUT_INVESTIGATOR=true` or gating E2E suites), requiring the plugin to be
+pre-provisioned via Helm or Terraform.

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -59,6 +59,17 @@ _GENERATION_STABLE_SECONDS = 20
 # roll on a warm node rather than a boot from nothing.
 _ROLLOUT_TIMEOUT_SECONDS = 300
 _PLUGIN_READY_TIMEOUT_SECONDS = 300
+# How long an AgentPlugin must continuously report Degraded before treating it as a
+# permanent failure rather than a transient condition.
+#
+# The operator updates plugin.Status.ObservedGeneration = plugin.Generation on every pass
+# before evaluating readiness (platformagent_controller.go:3004), and maps live container
+# states such as ErrImagePull, ImagePullBackOff, or staging crashes directly into
+# Degraded (platformagent_controller.go:3076-3119). During gateway rollouts or under
+# registry throttling (e.g. HTTP 429), kubelet retries pulling the image automatically.
+# Requiring the Degraded state to persist prevents failing on transient retry windows while
+# still failing fast on broken specs or unpullable images well short of the 300s ceiling.
+_DEGRADED_PERSISTENCE_SECONDS = 30
 # Polled rather than read once, because rollout-complete does not always mean the entrypoint
 # has finished linking plugins.
 #
@@ -281,10 +292,16 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
     platformagent_controller.go:485 and the workload at :514 inside one reconcile, so
     waiting here first means the rollout wait that follows is looking at a workload the
     operator has already written, not one it is about to.
+
+    Requires a Degraded observation to persist for _DEGRADED_PERSISTENCE_SECONDS before
+    treating it as a terminal failure. The operator stamps observedGeneration = generation
+    on every pass before evaluating readiness, and maps transient container states like
+    ErrImagePull (which kubelet retries) straight into Degraded.
     """
     window, bound = _remaining(budget_deadline, _PLUGIN_READY_TIMEOUT_SECONDS)
     deadline = time.time() + window
     detail = "the AgentPlugin was never read"
+    degraded_first_seen: Optional[float] = None
     while True:
         res = _kubectl("get", "agentplugins", _PLUGIN_NAME, "-n", namespace, "-o", "json")
         if res.returncode == 0:
@@ -304,20 +321,28 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
                 if phase == "Ready" and observed == generation:
                     return obj
                 if phase == "Degraded" and observed == generation:
-                    conditions = status.get("conditions", [])
-                    reason = ""
-                    message = ""
-                    for cond in conditions:
-                        if cond.get("status") == "False" or cond.get("reason"):
-                            reason = cond.get("reason", "")
-                            message = cond.get("message", "")
-                            break
-                    pytest.fail(
-                        f"AgentPlugin '{_PLUGIN_NAME}' in '{namespace}' installation failed: "
-                        f"phase is 'Degraded' (reason: {reason or 'Unknown'}): {message or detail}"
-                    )
+                    now = time.time()
+                    if degraded_first_seen is None:
+                        degraded_first_seen = now
+                    elif now - degraded_first_seen >= _DEGRADED_PERSISTENCE_SECONDS:
+                        conditions = status.get("conditions", [])
+                        reason = ""
+                        message = ""
+                        for cond in conditions:
+                            if cond.get("status") == "False" or cond.get("reason"):
+                                reason = cond.get("reason", "")
+                                message = cond.get("message", "")
+                                break
+                        pytest.fail(
+                            f"AgentPlugin '{_PLUGIN_NAME}' in '{namespace}' installation failed: "
+                            f"phase has remained 'Degraded' for {int(now - degraded_first_seen)}s "
+                            f"(reason: {reason or 'Unknown'}): {message or detail}"
+                        )
+                else:
+                    degraded_first_seen = None
         else:
             detail = res.stderr.strip() or f"kubectl exited {res.returncode}"
+            degraded_first_seen = None
         if time.time() >= deadline:
             break
         time.sleep(5)

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -158,6 +158,17 @@ def _kubectl(
         )
 
 
+def _is_resource_not_found(res: subprocess.CompletedProcess) -> bool:
+    """Reports whether kubectl failed specifically because the resource does not exist.
+
+    Distinguishes genuine resource absence (NotFound / not found) from transport,
+    connection, authentication, or context errors (e.g. connection refused, dial tcp,
+    unauthorized, or no context set).
+    """
+    err = (res.stderr + " " + res.stdout).lower()
+    return "notfound" in err or "not found" in err
+
+
 def _remaining(deadline: float, cap: int) -> Tuple[int, str]:
     """How long a wait gets, and which of the two ceilings decided it.
 
@@ -578,8 +589,10 @@ def _verify_skill_mounted(
         # Conclusive: the exec ran, repeatedly, and the file is not there.
         pytest.fail(
             f"The stockout plugin's skill is not mounted in {absent_in}: {skill_path} does not "
-            f"exist, {window}s ({bound}) after the gateway rolled out. The AgentPlugin is present, "
-            f"but image volume mounting or staging failed to link the skill into profile '{target_profile or 'default'}'."
+            f"exist, {window}s ({bound}) after the gateway rolled out. The AgentPlugin "
+            f"reconciled, so the alerts these tests publish would be investigated by nobody. "
+            f"Either the plugin image did not reach the '{target_profile or 'default'}' profile, "
+            "or the spec the operator reconciled is not the one this candidate installs."
         )
     # Inconclusive rather than a verdict on the plugin: no pod resolved, or every exec
     # failed. Saying which, and which ceiling ran out, keeps this from reading as an
@@ -759,6 +772,11 @@ def ensure_stockout_plugin_installed(
     # 1. The CRD is the prerequisite for plugins. If absent, plugins are not installed on the cluster.
     check_crd = _kubectl("get", "crd", _CRD_NAME, fail_on_timeout=True)
     if check_crd.returncode != 0:
+        if not _is_resource_not_found(check_crd):
+            pytest.fail(
+                f"Failed to reach cluster when checking for CRD '{_CRD_NAME}': "
+                f"{check_crd.stderr.strip() or f'kubectl exited {check_crd.returncode}'}"
+            )
         if expected:
             pytest.fail(
                 f"AgentPlugin CRD '{_CRD_NAME}' was expected on this environment, but is missing from cluster."
@@ -773,6 +791,11 @@ def ensure_stockout_plugin_installed(
         "get", "agentplugins", _PLUGIN_NAME, "-n", agent_namespace, fail_on_timeout=True
     )
     if check_plugin.returncode != 0:
+        if not _is_resource_not_found(check_plugin):
+            pytest.fail(
+                f"Failed to reach cluster when checking for AgentPlugin '{_PLUGIN_NAME}' in '{agent_namespace}': "
+                f"{check_plugin.stderr.strip() or f'kubectl exited {check_plugin.returncode}'}"
+            )
         if expected:
             pytest.fail(
                 f"Stockout investigator was expected on this environment (ENABLE_STOCKOUT_INVESTIGATOR=true), "

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -72,10 +72,10 @@ _PLUGIN_READY_TIMEOUT_SECONDS = 300
 # before evaluating readiness (platformagent_controller.go:3004), and maps live container
 # states such as ErrImagePull, ImagePullBackOff, or staging crashes directly into
 # Degraded (platformagent_controller.go:3076-3119). During gateway rollouts or under
-# registry throttling (e.g. HTTP 429), kubelet retries pulling the image automatically.
-# Requiring the Degraded state to persist prevents failing on transient retry windows while
-# still failing fast on broken specs or unpullable images well short of the 300s ceiling.
-_DEGRADED_PERSISTENCE_SECONDS = 30
+# registry throttling (e.g. HTTP 429), kubelet retries pulling the image on an exponential
+# backoff (10s -> 20s -> 40s...). A 120s window allows several backoff cycles while still
+# failing fast on permanently broken specs or missing images well short of the 300s ceiling.
+_DEGRADED_PERSISTENCE_SECONDS = 120
 # Polled rather than read once, because rollout-complete does not always mean the entrypoint
 # has finished linking plugins.
 #

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -25,6 +25,7 @@ _PLUGIN_SKILL_NAME = "gke-stockout-investigator"
 # the live CR: the fixture has to name the same agent install.sh will, and install.sh
 # takes it from AGENT_REF or this default without consulting the cluster.
 _DEFAULT_AGENT_REF = "platform-agent"
+_CRD_NAME = "agentplugins.kubeagents.x-k8s.io"
 
 # Everything this fixture does has to finish inside the E2E job's `timeout-minutes`
 # (.github/workflows/e2e-run.yml, whose default is what the RC pipeline gets), which also
@@ -306,6 +307,19 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
                 observed = status.get("observedGeneration")
                 if phase == "Ready" and observed == generation:
                     return obj
+                if phase == "Degraded" and observed == generation:
+                    conditions = status.get("conditions", [])
+                    reason = ""
+                    message = ""
+                    for cond in conditions:
+                        if cond.get("reason"):
+                            reason = cond.get("reason", "")
+                            message = cond.get("message", "")
+                            break
+                    pytest.fail(
+                        f"AgentPlugin '{_PLUGIN_NAME}' in '{namespace}' installation failed: "
+                        f"phase is 'Degraded' (reason: {reason or 'Unknown'}): {message or detail}"
+                    )
                 detail = (
                     f"phase={phase!r}, observedGeneration={observed}, generation={generation}"
                 )
@@ -540,10 +554,8 @@ def _verify_skill_mounted(
         # Conclusive: the exec ran, repeatedly, and the file is not there.
         pytest.fail(
             f"The stockout plugin's skill is not mounted in {absent_in}: {skill_path} does not "
-            f"exist, {window}s ({bound}) after the gateway rolled out. The AgentPlugin "
-            f"reconciled, so the alerts these tests publish would be investigated by nobody. "
-            f"Either the plugin image did not reach the '{target_profile or 'default'}' profile, "
-            "or the spec the operator reconciled is not the one this candidate installs."
+            f"exist, {window}s ({bound}) after the gateway rolled out. The AgentPlugin is present, "
+            f"but image volume mounting or staging failed to link the skill into profile '{target_profile or 'default'}'."
         )
     # Inconclusive rather than a verdict on the plugin: no pod resolved, or every exec
     # failed. Saying which, and which ceiling ran out, keeps this from reading as an
@@ -699,32 +711,13 @@ def ensure_stockout_plugin_installed(
     gcp_region: str,
     agent_namespace: str,
 ) -> None:
-    """Waits for the deployed stockout plugin to settle, then refuses to run on a broken one.
+    """Waits for the deployed stockout plugin to settle, or skips if not installed.
 
-    Installs the plugin only when the AgentPlugin CR is absent, which is what this fixture
-    has always done. What it adds is the waiting: step 2 of the RC pipeline provisions the
-    environment immediately before this module runs, so the gateway may still be rolling
-    when the first scenario starts, and the plugin's skill is linked by the entrypoint of
-    whichever pod wins. Probing before that settles reads the outgoing pod.
-
-    That is not a hypothetical. Run 32866087154 reported `SKILL.md not found under the
-    platform profile's plugins directory` and every selected scenario then burned its full
-    360s watch to report "Platform Agent never started investigation"; run 32953137904, on
-    the same cluster, found the skill present. The difference between them is which pod the
-    preflight caught, and this fixture is what removes that from the result.
-
-    Three waits, in this order: the AgentPlugin's status catches up to its spec, the gateway
-    finishes rolling, and the plugin's SKILL.md is readable inside the pod that survived.
-    Any of them failing ends the module naming what was wrong, in place of ten minutes of
-    watch timeouts that name nothing.
-
-    Deliberately not a reinstall. Running `install.sh` every session would repair an
-    AgentPlugin whose rendered spec has drifted from this candidate's, but it repairs
-    nothing in the common case — an unchanged plugin source tree renders a byte-identical
-    CR — while adding unconditional writes to the RC's critical path, including four
-    `add-iam-policy-binding` calls that read-modify-write the *project* IAM policy. An IAM
-    race unrelated to the candidate would then block the release. Drift is worth detecting;
-    the checks below do that and say so, rather than papering over it with a write.
+    Skips the suite if the AgentPlugin CRD or the stockout plugin CR is absent from the
+    cluster, avoiding out-of-band cluster mutations or IAM writes. When the plugin is
+    installed, refuses to run on a broken one, distinguishing between operator
+    reconciliation failures, imageVolume mounting/staging failures, entrypoint linker
+    failures, and missing skill files.
 
     `SKIP_STOCKOUT=1` skips the whole thing, tests included.
     """
@@ -734,9 +727,42 @@ def ensure_stockout_plugin_installed(
     if not gcp_project_id or not gke_cluster_name:
         pytest.fail("GCP_PROJECT_ID and GKE_CLUSTER_NAME are required for stockout E2E tests.")
 
+    expected = (
+        os.environ.get("ENABLE_STOCKOUT_INVESTIGATOR", "").lower() == "true"
+        or os.environ.get("E2E_SUITE") in ("rc", "nightly", "stockout-full", "investigations")
+    )
+
+    # 1. The CRD is the prerequisite for plugins. If absent, plugins are not installed on the cluster.
+    check_crd = _kubectl("get", "crd", _CRD_NAME, fail_on_timeout=True)
+    if check_crd.returncode != 0:
+        if expected:
+            pytest.fail(
+                f"AgentPlugin CRD '{_CRD_NAME}' was expected on this environment, but is missing from cluster."
+            )
+        pytest.skip(
+            f"AgentPlugin CRD '{_CRD_NAME}' not found on cluster; "
+            "stockout investigator is not installed."
+        )
+
+    # 2. Check if the stockout AgentPlugin is installed.
+    check_plugin = _kubectl(
+        "get", "agentplugins", _PLUGIN_NAME, "-n", agent_namespace, fail_on_timeout=True
+    )
+    if check_plugin.returncode != 0:
+        if expected:
+            pytest.fail(
+                f"Stockout investigator was expected on this environment (ENABLE_STOCKOUT_INVESTIGATOR=true), "
+                f"but AgentPlugin '{_PLUGIN_NAME}' is not installed in namespace '{agent_namespace}'."
+            )
+        pytest.skip(
+            f"Stockout investigator plugin '{_PLUGIN_NAME}' is not installed in namespace "
+            f"'{agent_namespace}'. Enable it via Helm (plugins.stockoutInvestigator.enabled=true) "
+            "or Terraform (enable_stockout_investigator=true) to run this suite."
+        )
+
     budget_deadline = time.time() + _FIXTURE_BUDGET_SECONDS
 
-    # 1. Ensure the Pub/Sub topic exists.
+    # 3. Ensure the Pub/Sub topic exists (only reached when plugin is installed).
     topic = os.environ.get("STOCKOUT_TOPIC", "gke-stockout-alerts-topic")
     check_topic = subprocess.run(
         ["gcloud", "pubsub", "topics", "describe", topic, f"--project={gcp_project_id}"],
@@ -748,69 +774,7 @@ def ensure_stockout_plugin_installed(
             capture_output=True,
         )
 
-    # 2. The CRD is the one prerequisite install.sh does not own: the kube-agents Helm
-    # chart installs it, and helm would otherwise fail on an unknown kind.
-    check_crd = _kubectl("get", "crd", "agentplugins.kubeagents.x-k8s.io", fail_on_timeout=True)
-    if check_crd.returncode != 0:
-        pytest.fail(
-            "AgentPlugin CRD 'agentplugins.kubeagents.x-k8s.io' not found on cluster; "
-            "it is managed and installed by the kube-agents Helm chart."
-        )
-
-    # AGENT_REF and KUBECTL_CONTEXT are pinned rather than inherited, so the agent and
-    # cluster this fixture inspects cannot be different ones from those install.sh would
-    # write to. install.sh falls back to `kubectl config current-context`, which is
-    # whatever the last `get-credentials` in this process left behind.
     agent_ref = os.environ.get("AGENT_REF") or _DEFAULT_AGENT_REF
-    kube_context = os.environ.get("KUBECTL_CONTEXT") or ""
-    if not kube_context:
-        ctx_res = _kubectl("config", "current-context", fail_on_timeout=True)
-        kube_context = ctx_res.stdout.strip() if ctx_res.returncode == 0 else ""
-        if not kube_context:
-            pytest.fail(
-                "No kubectl context is set and KUBECTL_CONTEXT is unset, so there is no cluster "
-                "to verify the stockout plugin against."
-            )
-
-    # 3. Install only when the plugin is genuinely absent.
-    check_plugin = _kubectl(
-        "get", "agentplugins", _PLUGIN_NAME, "-n", agent_namespace, fail_on_timeout=True
-    )
-    if check_plugin.returncode != 0:
-        if not _INSTALL_SCRIPT.is_file():
-            pytest.fail(f"Stockout investigator install script missing at '{_INSTALL_SCRIPT}'.")
-        install_env = {
-            **os.environ,
-            "GCP_PROJECT_ID": gcp_project_id,
-            "TARGET_CLUSTER_NAME": gke_cluster_name,
-            "TARGET_CLUSTER_LOCATION": gcp_region,
-            "HERMES_NAMESPACE": agent_namespace,
-            "AGENT_REF": agent_ref,
-            "KUBECTL_CONTEXT": kube_context,
-        }
-        install_timeout, install_bound = _remaining(budget_deadline, _INSTALL_TIMEOUT_SECONDS)
-        try:
-            proc = subprocess.run(
-                [str(_INSTALL_SCRIPT)],
-                capture_output=True,
-                text=True,
-                env=install_env,
-                timeout=install_timeout,
-            )
-        except subprocess.TimeoutExpired as exc:
-            pytest.fail(
-                f"Stockout investigator install.sh did not finish within {install_timeout}s "
-                f"({install_bound}):\n"
-                f"STDOUT:\n{_as_text(exc.stdout)}\nSTDERR:\n{_as_text(exc.stderr)}"
-            )
-        if proc.returncode != 0:
-            pytest.fail(
-                f"Stockout investigator install.sh failed with exit code {proc.returncode}:\n"
-                f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
-            )
-        # Printed on success too. It names the image tag and says whether the build was
-        # skipped, which is the only record of what the tests below ran against.
-        print(proc.stdout)
 
     # 4. Plugin status first, rollout second. See _wait_for_plugin_ready for why the other
     # order lets a slow reconcile pass a check against the outgoing pod.
@@ -861,7 +825,19 @@ def test_stockout_ingress_alert_smoke(
         timeout=5,
     )
     if res_plugin.returncode != 0:
-        pytest.fail("gkestockoutinvestigator AgentPlugin is not active in cluster; ingress smoke test failed.")
+        expected = (
+            os.environ.get("ENABLE_STOCKOUT_INVESTIGATOR", "").lower() == "true"
+            or os.environ.get("E2E_SUITE") in ("rc", "nightly", "stockout-full", "investigations")
+        )
+        if expected:
+            pytest.fail(
+                f"gkestockoutinvestigator AgentPlugin was expected on this environment, but is not active "
+                f"in namespace '{agent_namespace}'."
+            )
+        pytest.skip(
+            f"gkestockoutinvestigator AgentPlugin is not installed in namespace '{agent_namespace}'; "
+            "skipping ingress smoke test."
+        )
 
     agent_ref = os.environ.get("AGENT_REF") or _DEFAULT_AGENT_REF
     ready_pod = _wait_for_agent_available(agent_ref, agent_namespace)

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -26,6 +26,12 @@ _PLUGIN_SKILL_NAME = "gke-stockout-investigator"
 _DEFAULT_AGENT_REF = "platform-agent"
 _CRD_NAME = "agentplugins.kubeagents.x-k8s.io"
 
+# Suites in tests/e2e/e2e_config.yaml that run this test file. When E2E_SUITE matches
+# any of these, the stockout plugin is required to be provisioned, and its absence fails
+# the run (pytest.fail) rather than skipping it.
+# Enforced by test_suites_running_stockout_match_expected_suites_tuple in tests/test_stockout_fixture_helpers.py.
+_EXPECTED_E2E_SUITES = ("rc", "nightly", "stockout-full", "investigations")
+
 # Everything this fixture does has to finish inside the E2E job's `timeout-minutes`
 # (.github/workflows/e2e-run.yml, whose default is what the RC pipeline gets), which also
 # has to cover runner setup, the other e2e modules, and scenario 04's own 360s watch. A wait that outlives the job
@@ -747,7 +753,7 @@ def ensure_stockout_plugin_installed(
 
     expected = (
         os.environ.get("ENABLE_STOCKOUT_INVESTIGATOR", "").lower() == "true"
-        or os.environ.get("E2E_SUITE") in ("rc", "nightly", "stockout-full", "investigations")
+        or os.environ.get("E2E_SUITE") in _EXPECTED_E2E_SUITES
     )
 
     # 1. The CRD is the prerequisite for plugins. If absent, plugins are not installed on the cluster.

--- a/tests/e2e/test_stockout_investigation.py
+++ b/tests/e2e/test_stockout_investigation.py
@@ -13,7 +13,6 @@ import pytest
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 _PLUGIN_DIR = _REPO_ROOT / "agentplugins" / "gke-stockout-investigator"
 _SCENARIOS_DIR = _PLUGIN_DIR / "scenarios"
-_INSTALL_SCRIPT = _PLUGIN_DIR / "install.sh"
 _CLEAN_KANBAN_SCRIPT = _SCENARIOS_DIR / "lib" / "clean_stale_kanban_tasks.py"
 
 # AgentPlugin object name, Helm release, and Hermes plugin module — one identifier, fixed
@@ -40,12 +39,6 @@ _CRD_NAME = "agentplugins.kubeagents.x-k8s.io"
 # minutes. Sum of the individual caps exceeds it deliberately — each is the honest
 # ceiling for its own step, and the budget is what binds when several go long at once.
 _FIXTURE_BUDGET_SECONDS = 600
-# Only reachable when the AgentPlugin is absent, which on the RC means the environment was
-# never provisioned rather than that the plugin drifted. Bounded because install.sh builds
-# and pushes an image on that path: before this, a hung gcloud or docker burned the whole
-# job timeout with no output. The fixture budget above binds first, and that is the
-# intended ceiling — a plugin missing outright is a finding, not something to wait out.
-_INSTALL_TIMEOUT_SECONDS = 600
 # How long the gateway's generation has to hold still before its spec counts as settled.
 #
 # Step 2 provisions the environment immediately before this suite runs, and a `helm
@@ -305,6 +298,9 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
                 status = obj.get("status", {})
                 phase = status.get("phase")
                 observed = status.get("observedGeneration")
+                detail = (
+                    f"phase={phase!r}, observedGeneration={observed}, generation={generation}"
+                )
                 if phase == "Ready" and observed == generation:
                     return obj
                 if phase == "Degraded" and observed == generation:
@@ -312,7 +308,7 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
                     reason = ""
                     message = ""
                     for cond in conditions:
-                        if cond.get("reason"):
+                        if cond.get("status") == "False" or cond.get("reason"):
                             reason = cond.get("reason", "")
                             message = cond.get("message", "")
                             break
@@ -320,9 +316,6 @@ def _wait_for_plugin_ready(namespace: str, budget_deadline: float) -> Dict[str, 
                         f"AgentPlugin '{_PLUGIN_NAME}' in '{namespace}' installation failed: "
                         f"phase is 'Degraded' (reason: {reason or 'Unknown'}): {message or detail}"
                     )
-                detail = (
-                    f"phase={phase!r}, observedGeneration={observed}, generation={generation}"
-                )
         else:
             detail = res.stderr.strip() or f"kubectl exited {res.returncode}"
         if time.time() >= deadline:
@@ -816,28 +809,6 @@ def test_stockout_ingress_alert_smoke(
         pytest.fail(f"Stockout verify script missing at '{verify_script}'.")
     if not gcp_project_id or not gke_cluster_name:
         pytest.fail("GCP_PROJECT_ID and GKE_CLUSTER_NAME are required for stockout smoke test.")
-
-    # Check if the stockout plugin is active in the cluster
-    res_plugin = subprocess.run(
-        ["kubectl", "get", "agentplugins", "gkestockoutinvestigator", "-n", agent_namespace],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
-    if res_plugin.returncode != 0:
-        expected = (
-            os.environ.get("ENABLE_STOCKOUT_INVESTIGATOR", "").lower() == "true"
-            or os.environ.get("E2E_SUITE") in ("rc", "nightly", "stockout-full", "investigations")
-        )
-        if expected:
-            pytest.fail(
-                f"gkestockoutinvestigator AgentPlugin was expected on this environment, but is not active "
-                f"in namespace '{agent_namespace}'."
-            )
-        pytest.skip(
-            f"gkestockoutinvestigator AgentPlugin is not installed in namespace '{agent_namespace}'; "
-            "skipping ingress smoke test."
-        )
 
     agent_ref = os.environ.get("AGENT_REF") or _DEFAULT_AGENT_REF
     ready_pod = _wait_for_agent_available(agent_ref, agent_namespace)

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -38,6 +38,7 @@ _FIXTURE = _ROOT / "tests" / "e2e" / "test_stockout_investigation.py"
 _CLEAN_SCRIPT = _ROOT / "agentplugins" / "gke-stockout-investigator" / "scenarios" / "lib" / "clean_stale_kanban_tasks.py"
 _UPGRADE_SCRIPT = _ROOT / "upgrade.sh"
 _E2E_RUN_WORKFLOW = _ROOT / ".github" / "workflows" / "e2e-run.yml"
+_E2E_CONFIG = _ROOT / "tests" / "e2e" / "e2e_config.yaml"
 
 
 def _load_clean_script_module():
@@ -783,6 +784,37 @@ class EnsurePluginInstalledTest(unittest.TestCase):
             sof.ensure_stockout_plugin_installed(
                 "proj", "cluster", "us-central1", "kubeagents-system"
             )
+
+    def test_suites_running_stockout_match_expected_suites_tuple(self):
+        doc = yaml.safe_load(_E2E_CONFIG.read_text())
+        fixture_rel = "tests/e2e/test_stockout_investigation.py"
+        suites_with_stockout = {
+            suite["name"]
+            for suite in doc.get("suites", [])
+            if fixture_rel in suite.get("tests", [])
+        }
+        self.assertEqual(
+            suites_with_stockout,
+            set(sof._EXPECTED_E2E_SUITES),
+            f"Suites in {_E2E_CONFIG} listing {fixture_rel} must match "
+            f"test_stockout_investigation._EXPECTED_E2E_SUITES exactly.",
+        )
+
+    def test_fails_when_plugin_cr_is_absent_and_suite_is_gating(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=0)
+            if "agentplugins" in args:
+                return _completed(returncode=1, stderr="NotFound")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl), \
+                mock.patch.dict(sof.os.environ, {"E2E_SUITE": "rc", "ENABLE_STOCKOUT_INVESTIGATOR": ""}):
+            with self.assertRaises(_StubFail) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("was expected on this environment", str(caught.exception))
 
 
 class PluginReadyStatusTest(unittest.TestCase):

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -477,7 +477,7 @@ class BudgetTest(unittest.TestCase):
         )
 
     def test_every_wait_is_capped_by_the_budget(self):
-        for name in ("_INSTALL_TIMEOUT_SECONDS", "_ROLLOUT_TIMEOUT_SECONDS",
+        for name in ("_ROLLOUT_TIMEOUT_SECONDS",
                      "_PLUGIN_READY_TIMEOUT_SECONDS", "_SKILL_MOUNT_TIMEOUT_SECONDS",
                      "_GENERATION_STABLE_SECONDS", "_AGENT_AVAILABILITY_TIMEOUT_SECONDS"):
             with self.subTest(constant=name):
@@ -768,6 +768,21 @@ class EnsurePluginInstalledTest(unittest.TestCase):
                 )
         self.assertIn("was expected on this environment", str(caught.exception))
         self.assertIn("ENABLE_STOCKOUT_INVESTIGATOR=true", str(caught.exception))
+
+    def test_proceeds_when_present(self):
+        def fake_kubectl(*args, **kwargs):
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl), \
+                mock.patch("subprocess.run", return_value=_completed(returncode=0)), \
+                mock.patch.object(sof, "_wait_for_plugin_ready", return_value={"spec": {"targetProfile": "platform"}}), \
+                mock.patch.object(sof, "_wait_for_gateway_rollout", return_value=("deployment/platform-agent-gateway", "settled")), \
+                mock.patch.object(sof, "_verify_skill_mounted", return_value="pod-gateway-xyz"), \
+                mock.patch.object(sof, "_clean_stale_kanban_tasks"):
+            # Proceeds cleanly through setup without skipping or failing
+            sof.ensure_stockout_plugin_installed(
+                "proj", "cluster", "us-central1", "kubeagents-system"
+            )
 
 
 class PluginReadyStatusTest(unittest.TestCase):

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -480,7 +480,8 @@ class BudgetTest(unittest.TestCase):
     def test_every_wait_is_capped_by_the_budget(self):
         for name in ("_ROLLOUT_TIMEOUT_SECONDS",
                      "_PLUGIN_READY_TIMEOUT_SECONDS", "_SKILL_MOUNT_TIMEOUT_SECONDS",
-                     "_GENERATION_STABLE_SECONDS", "_AGENT_AVAILABILITY_TIMEOUT_SECONDS"):
+                     "_GENERATION_STABLE_SECONDS", "_AGENT_AVAILABILITY_TIMEOUT_SECONDS",
+                     "_DEGRADED_PERSISTENCE_SECONDS"):
             with self.subTest(constant=name):
                 self.assertLessEqual(getattr(sof, name), sof._FIXTURE_BUDGET_SECONDS)
 
@@ -907,10 +908,10 @@ class PluginReadyStatusTest(unittest.TestCase):
                 mock.patch.object(sof.time, "time", side_effect=clock.time), \
                 mock.patch.object(sof.time, "sleep", side_effect=clock.sleep):
             with self.assertRaises(_StubFail) as caught:
-                sof._wait_for_plugin_ready("ns", clock.cur + 120.0)
+                sof._wait_for_plugin_ready("ns", clock.cur + 300.0)
         msg = str(caught.exception)
         self.assertIn("installation failed", msg)
-        self.assertIn("phase has remained 'Degraded'", msg)
+        self.assertIn("phase has remained 'Degraded' for 120s", msg)
         self.assertIn("ImagePullFailed", msg)
         self.assertIn("Failed to pull image xyz", msg)
 

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -54,6 +54,14 @@ class _StubFailure(Exception):
     """What the stubbed pytest.fail and pytest.skip raise."""
 
 
+class _StubSkip(_StubFailure):
+    """Raised when pytest.skip is called."""
+
+
+class _StubFail(_StubFailure):
+    """Raised when pytest.fail is called."""
+
+
 def _pytest_stub() -> types.ModuleType:
     """A stand-in for pytest, which no unit-test job installs.
 
@@ -74,10 +82,10 @@ def _pytest_stub() -> types.ModuleType:
     stub.mark = mark
 
     def _fail(msg="", pytrace=True):
-        raise _StubFailure(msg)
+        raise _StubFail(msg)
 
     def _skip(msg="", **kwargs):
-        raise _StubFailure(msg)
+        raise _StubSkip(msg)
 
     stub.fail = _fail
     stub.skip = _skip
@@ -709,6 +717,90 @@ class CleanStaleTasksScriptTest(unittest.TestCase):
 
         self.assertEqual(count, 1)
         self.assertTrue(any("warning" in str(call) for call in fake_stderr.call_args_list))
+
+
+class EnsurePluginInstalledTest(unittest.TestCase):
+    """Verifies that ensure_stockout_plugin_installed skips when absent and proceeds when present."""
+
+    def test_skips_when_crd_is_absent(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=1, stderr="crd not found")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl):
+            with self.assertRaises(_StubSkip) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("AgentPlugin CRD", str(caught.exception))
+        self.assertIn("not found on cluster", str(caught.exception))
+
+    def test_skips_when_plugin_cr_is_absent(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=0)
+            if "agentplugins" in args:
+                return _completed(returncode=1, stderr="NotFound")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl):
+            with self.assertRaises(_StubSkip) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("is not installed", str(caught.exception))
+        self.assertIn("gkestockoutinvestigator", str(caught.exception))
+
+    def test_fails_when_plugin_cr_is_absent_and_expected(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=0)
+            if "agentplugins" in args:
+                return _completed(returncode=1, stderr="NotFound")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl), \
+                mock.patch.dict(sof.os.environ, {"ENABLE_STOCKOUT_INVESTIGATOR": "true"}):
+            with self.assertRaises(_StubFail) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("was expected on this environment", str(caught.exception))
+        self.assertIn("ENABLE_STOCKOUT_INVESTIGATOR=true", str(caught.exception))
+
+
+class PluginReadyStatusTest(unittest.TestCase):
+    """Verifies that _wait_for_plugin_ready returns Ready object or fails immediately on Degraded."""
+
+    def test_ready_plugin_returns_object(self):
+        obj = {
+            "metadata": {"generation": 3},
+            "status": {"phase": "Ready", "observedGeneration": 3},
+        }
+        with mock.patch.object(sof, "_kubectl", return_value=_completed(stdout=json.dumps(obj))):
+            res = sof._wait_for_plugin_ready("ns", time.time() + 60)
+        self.assertEqual(res["status"]["phase"], "Ready")
+
+    def test_degraded_plugin_fails_immediately_with_reason(self):
+        obj = {
+            "metadata": {"generation": 2},
+            "status": {
+                "phase": "Degraded",
+                "observedGeneration": 2,
+                "conditions": [
+                    {"type": "Ready", "status": "False", "reason": "ImagePullFailed", "message": "Failed to pull image xyz"}
+                ],
+            },
+        }
+        with mock.patch.object(sof, "_kubectl", return_value=_completed(stdout=json.dumps(obj))):
+            with self.assertRaises(_StubFail) as caught:
+                sof._wait_for_plugin_ready("ns", time.time() + 60)
+        msg = str(caught.exception)
+        self.assertIn("installation failed", msg)
+        self.assertIn("phase is 'Degraded'", msg)
+        self.assertIn("ImagePullFailed", msg)
+        self.assertIn("Failed to pull image xyz", msg)
 
 
 if __name__ == "__main__":

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -786,7 +786,7 @@ class EnsurePluginInstalledTest(unittest.TestCase):
 
 
 class PluginReadyStatusTest(unittest.TestCase):
-    """Verifies that _wait_for_plugin_ready returns Ready object or fails immediately on Degraded."""
+    """Verifies that _wait_for_plugin_ready tolerates transient Degraded and fails on persistent Degraded."""
 
     def test_ready_plugin_returns_object(self):
         obj = {
@@ -797,7 +797,30 @@ class PluginReadyStatusTest(unittest.TestCase):
             res = sof._wait_for_plugin_ready("ns", time.time() + 60)
         self.assertEqual(res["status"]["phase"], "Ready")
 
-    def test_degraded_plugin_fails_immediately_with_reason(self):
+    def test_transient_degraded_recovers_to_ready_without_failing(self):
+        degraded_obj = {
+            "metadata": {"generation": 2},
+            "status": {
+                "phase": "Degraded",
+                "observedGeneration": 2,
+                "conditions": [
+                    {"type": "Ready", "status": "False", "reason": "ImagePullFailed", "message": "Failed to pull image xyz"}
+                ],
+            },
+        }
+        ready_obj = {
+            "metadata": {"generation": 2},
+            "status": {"phase": "Ready", "observedGeneration": 2},
+        }
+        # First poll sees transient Degraded (e.g. 429 during pull); second poll sees Ready.
+        with mock.patch.object(sof, "_kubectl", side_effect=[
+            _completed(stdout=json.dumps(degraded_obj)),
+            _completed(stdout=json.dumps(ready_obj)),
+        ]), mock.patch.object(sof.time, "sleep"):
+            res = sof._wait_for_plugin_ready("ns", time.time() + 60)
+        self.assertEqual(res["status"]["phase"], "Ready")
+
+    def test_persistent_degraded_fails_with_reason_after_persistence_window(self):
         obj = {
             "metadata": {"generation": 2},
             "status": {
@@ -808,12 +831,24 @@ class PluginReadyStatusTest(unittest.TestCase):
                 ],
             },
         }
-        with mock.patch.object(sof, "_kubectl", return_value=_completed(stdout=json.dumps(obj))):
+
+        class _MockClock:
+            def __init__(self, start: float = 100.0):
+                self.cur = start
+            def time(self) -> float:
+                return self.cur
+            def sleep(self, seconds: float) -> None:
+                self.cur += seconds
+
+        clock = _MockClock(start=100.0)
+        with mock.patch.object(sof, "_kubectl", return_value=_completed(stdout=json.dumps(obj))), \
+                mock.patch.object(sof.time, "time", side_effect=clock.time), \
+                mock.patch.object(sof.time, "sleep", side_effect=clock.sleep):
             with self.assertRaises(_StubFail) as caught:
-                sof._wait_for_plugin_ready("ns", time.time() + 60)
+                sof._wait_for_plugin_ready("ns", clock.cur + 120.0)
         msg = str(caught.exception)
         self.assertIn("installation failed", msg)
-        self.assertIn("phase is 'Degraded'", msg)
+        self.assertIn("phase has remained 'Degraded'", msg)
         self.assertIn("ImagePullFailed", msg)
         self.assertIn("Failed to pull image xyz", msg)
 

--- a/tests/test_stockout_fixture_helpers.py
+++ b/tests/test_stockout_fixture_helpers.py
@@ -816,6 +816,36 @@ class EnsurePluginInstalledTest(unittest.TestCase):
                 )
         self.assertIn("was expected on this environment", str(caught.exception))
 
+    def test_fails_when_crd_check_encounters_transport_error(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=1, stderr="dial tcp 127.0.0.1:8080: connect: connection refused")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl):
+            with self.assertRaises(_StubFail) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("Failed to reach cluster", str(caught.exception))
+        self.assertIn("connection refused", str(caught.exception))
+
+    def test_fails_when_plugin_check_encounters_transport_error(self):
+        def fake_kubectl(*args, **kwargs):
+            if "crd" in args:
+                return _completed(returncode=0)
+            if "agentplugins" in args:
+                return _completed(returncode=1, stderr="Unable to connect to the server: net/http: TLS handshake timeout")
+            return _completed(returncode=0)
+
+        with mock.patch.object(sof, "_kubectl", side_effect=fake_kubectl):
+            with self.assertRaises(_StubFail) as caught:
+                sof.ensure_stockout_plugin_installed(
+                    "proj", "cluster", "us-central1", "kubeagents-system"
+                )
+        self.assertIn("Failed to reach cluster", str(caught.exception))
+        self.assertIn("TLS handshake timeout", str(caught.exception))
+
 
 class PluginReadyStatusTest(unittest.TestCase):
     """Verifies that _wait_for_plugin_ready tolerates transient Degraded and fails on persistent Degraded."""


### PR DESCRIPTION
## Summary

Refactors the GKE Stockout Investigator E2E test fixture (`tests/e2e/test_stockout_investigation.py`) to stop mutating cluster state and project IAM out of band during test execution. If the `AgentPlugin` custom resource or CRD is absent on a cluster where stockout investigation is optional, the test suite skips cleanly. When stockout is expected (`ENABLE_STOCKOUT_INVESTIGATOR=true` or in gating suites `rc`, `nightly`, `stockout-full`, `investigations`), missing plugin prerequisites fail fast (`pytest.fail`) so CI catches deployment regressions. Transport errors (connection refused, unauthorized) are explicitly distinguished from resource absence and fail fast. Additionally, persistent degraded plugin conditions report their root failure reason after a 120s grace window (allowing kubelet exponential pull backoffs to recover) rather than burning the full 300s timeout, and `docs/designs/e2e-testing-harness.md` is updated to document the passive verification contract.

## Why This Change

Tests should be passive observers and verifiers of system state, never mutating their runtime environment out of band. Previously, when the plugin was absent from the cluster, `ensure_stockout_plugin_installed` imperatively ran `agentplugins/gke-stockout-investigator/install.sh`, which executed `add-iam-policy-binding` against the GCP project and applied ad-hoc manifests during test setup (#1042). This created several failure modes:
1. **Unwanted environment mutation:** Ad-hoc test runs on clusters without stockout attempted full installations and project-level IAM modifications instead of skipping optional coverage.
2. **Project IAM race conditions:** Concurrently running suites or releases competed on read-modify-write IAM calls at test time, risking transient 409 conflicts.
3. **Gateway rollout race condition:** Installing the plugin during fixture execution raced the operator's re-template of `platform-agent-gateway`, leading to watch timeouts or probes running against outgoing pods without mounted volumes.
4. **False green risk if merely skipped:** If the fixture unconditionally skipped on missing plugins without checking expectations, deployment failures in gating pipelines (`rc`, `nightly`) would silently report green.

Removing dynamic installation and enforcing explicit skip-vs-fail expectations ensures the test suite validates what was provisioned without mutating the cluster.

## What Changed

- **Removed out-of-band installation:** Removed execution of `install.sh` and dead constants (`_INSTALL_SCRIPT`, `_INSTALL_TIMEOUT_SECONDS`) from `tests/e2e/test_stockout_investigation.py`.
- **Enforced expectation-aware skips and failures:** In `ensure_stockout_plugin_installed`, checked if stockout is expected via `ENABLE_STOCKOUT_INVESTIGATOR=true` or `E2E_SUITE in _EXPECTED_E2E_SUITES`. Fails with `pytest.fail` if the CRD or `AgentPlugin/gkestockoutinvestigator` is missing when expected; skips with `pytest.skip` otherwise.
- **Distinguished cluster transport errors from resource absence:** Added `_is_resource_not_found` helper to verify that kubectl errors indicate `NotFound` before treating them as absence. Transport errors (connection refused, bad context, unauthorized) call `pytest.fail` immediately rather than misreporting the plugin as uninstalled.
- **Enforced E2E suite configuration parity:** Added `_EXPECTED_E2E_SUITES = ("rc", "nightly", "stockout-full", "investigations")` to `test_stockout_investigation.py`, and added a unit test in `test_stockout_fixture_helpers.py` parsing `tests/e2e/e2e_config.yaml` to ensure any suite listing this file is kept in sync.
- **Degraded persistence grace window:** In `_wait_for_plugin_ready`, required `status.phase == "Degraded"` (with `observedGeneration == generation`) to persist across `_DEGRADED_PERSISTENCE_SECONDS` (120s) before failing. This accommodates transient `ErrImagePull`, `ImagePullBackOff` exponential retry intervals (10s -> 20s -> 40s...), and registry throttling (HTTP 429), while still failing fast on broken specs or permanently unpullable images well short of `_PLUGIN_READY_TIMEOUT_SECONDS` (300s).
- **Removed redundant in-test check:** Removed redundant in-test `kubectl get agentplugins` call with brittle 5s timeout from `test_stockout_ingress_alert_smoke` because the module fixture already validates the CR.
- **Preserved two-branch skill failure hypotheses:** Restored the two-branch failure message in `_verify_skill_mounted` acknowledging both profile delivery and spec drift hypotheses.
- **Updated documentation:** Updated `docs/designs/e2e-testing-harness.md` to document that the suite passively verifies pre-provisioned plugins rather than installing them out of band.
- **Added unit test coverage:** Added unit tests in `tests/test_stockout_fixture_helpers.py` covering absent CRD skip, absent plugin skip, absent plugin failure when expected, gating suite failure, transport error handling, suite config parity assertion, budget cap verification, successful proceed when present, transient Degraded recovery, and persistent Degraded failure after the persistence window.

## Context

Closes #1042

## Testing

- `PYTHONPATH=tests python3 -m unittest tests/test_stockout_fixture_helpers.py` (63 unit tests passed in 0.06s).
- `make docs-check` passed cleanly (link resolution, terminology, documentation map coverage, and context budget 38.0k).

### Live validation

Live execution in target environments was verified by inspecting current CI runs of the RC pipeline ([run 34477874812 / job 102881511252](https://github.com/gke-labs/kube-agents/actions/runs/34477874812/job/102881511252)) and Nightly pipeline ([run 34430055779 / job 102729030088](https://github.com/gke-labs/kube-agents/actions/runs/34430055779/job/102729030088)).

In both runs:
- Step 2 (`deploy-environment`) configures `ENABLE_STOCKOUT_INVESTIGATOR=true`, which causes Terraform to provision the GCP Pub/Sub topics, subscriptions, and logging sinks, while Helm applies `plugins.stockoutInvestigator.enabled=true`, rendering the `AgentPlugin` CR directly into the cluster.
- In Step 3 (`run-e2e`), the raw test logs show `tests/e2e/test_stockout_investigation.py` immediately verified the existing CR:
  ```
  tests/e2e/test_stockout_investigation.py::test_stockout_ingress_alert_smoke deployment/platform-agent-gateway: generation settled at 1
  stockout plugin verified in platform-agent-gateway-89f5fbd66-9mpdz; the tests below run against it
  PASSED
  ```
  Neither run executed `install.sh` or relied on in-test mutation; the tests validated the declaratively provisioned infrastructure.

### Self-Review

Ran adversarial and docs-drift reviews in clean, isolated subagent contexts (`5acd9759-34d9-4aa9-ac2c-7a6de5555996` and `50ec62b0-abdf-4b9a-9e70-8f7df90ad2ee`) against `upstream/main...HEAD`, followed by review feedback integration:

- **Review findings & dispositions:**
  - *Finding 1 (High - Degraded Settlement & Kubelet Backoff):* Failing immediately on `phase == "Degraded"` fails on transient retryable conditions. A 30s window was too short because kubelet exponential backoff on `ImagePullBackOff` doubles intervals (10s -> 20s -> 40s...). **Fixed:** Raised `_DEGRADED_PERSISTENCE_SECONDS` to 120s, allowing multiple backoff cycles to resolve while still failing fast on permanently broken specs. Added unit tests for transient recovery vs. persistent failure.
  - *Finding 2 (Medium - Suite List Synchronization):* `ensure_stockout_plugin_installed` duplicated the suite list from `tests/e2e/e2e_config.yaml` without enforcement, risking false greens if a suite was added or renamed. **Fixed:** Declared `_EXPECTED_E2E_SUITES` constant and added `test_suites_running_stockout_match_expected_suites_tuple` in `tests/test_stockout_fixture_helpers.py` parsing `e2e_config.yaml` to ensure exact parity.
  - *Finding 3 (Medium - Transport Error vs. Absence):* A non-zero kubectl exit was treated as absence even on transport/connection errors (e.g. connection refused). **Fixed:** Added `_is_resource_not_found` helper to verify `NotFound` before skipping; transport errors fail fast with connection details. Added unit tests for both CRD and plugin transport error cases.
  - *Finding 4 (Medium - Skill Mount Message Hypotheses):* Wording narrowed the failure to image volume mount when operator spec drift is also a valid hypothesis. **Fixed:** Restored the original two-branch wording in `_verify_skill_mounted`.
  - *Finding 5 (Medium - Test Adequacy):* `EnsurePluginInstalledTest` docstring claimed to test both absent and present paths, but lacked `test_proceeds_when_present`. **Fixed:** Added `test_proceeds_when_present` verifying clean pass-through when all prerequisites exist.
  - *Finding 6 (Medium - Brittle Timeout & Redundancy):* `test_stockout_ingress_alert_smoke` performed a redundant in-test `kubectl get` with a hardcoded string and 5s timeout. **Fixed:** Removed the redundant in-test query as `ensure_stockout_plugin_installed` already validates plugin presence.
  - *Finding 7 (Low - Dead Code):* `_INSTALL_SCRIPT` and `_INSTALL_TIMEOUT_SECONDS` were unused after removing installation logic. **Fixed:** Removed unused constants and budget test references.
  - *Finding 8 (Low - Error Handling):* In `_wait_for_plugin_ready`, `detail` was assigned after the degraded check, risking an empty fallback message. **Fixed:** Assigned `detail` before the degraded check.
  - *Finding 9 (Low - Condition Parsing):* Condition loop selected the first condition regardless of status. **Fixed:** Condition filtering prioritizes `status == "False"` conditions.
  - *Finding 10 (Blocking - Doc Drift):* `docs/designs/e2e-testing-harness.md:150-153` stated that the suite installs the plugin out of band when absent. **Fixed:** Updated the documentation to describe the expectation-aware skip-vs-fail behavior and requirement for pre-provisioned infrastructure via Helm or Terraform.

## Risk & Rollout

Low risk. Touches only the E2E test fixture and test documentation. No runtime operator code, agent binaries, or Helm chart defaults are modified. Can be reverted cleanly with `git revert` if needed.
