### PR TITLE
fix(tests): call lift_function instead of undefined _lift in test_custom_go_mod_path_respected

### DIFF
--- a/tests/test_check_image_inventory_go_directive.py
+++ b/tests/test_check_image_inventory_go_directive.py
@@ -158,7 +158,7 @@ class CheckGoDirectiveTest(unittest.TestCase):
 
     def test_custom_go_mod_path_respected(self):
         text = _SCRIPT.read_text()
-        functions = "".join(_lift(name, text) for name in _LIFTED_FUNCTIONS)
+        functions = "".join(lift_function(name, text, _SCRIPT) for name in _LIFTED_FUNCTIONS)
         with tempfile.TemporaryDirectory() as tmp:
             root = pathlib.Path(tmp)
             (root / "custom.mod").write_text("module example.com/y\n\ngo 1.27.0\n")


### PR DESCRIPTION
## Summary
Fixes an undefined function reference in `tests/test_check_image_inventory_go_directive.py` by calling `lift_function(name, text, _SCRIPT)` instead of the removed `_lift` helper.

## Why This Change
Commit 35d45b4c refactored test function extraction helpers into `tests/_lift_shell.py` (`lift_function`) and updated `test_builder_tag_against_directive`, but `test_custom_go_mod_path_respected` retained a call to `_lift`. On Python 3.12/3.13 runners, running `python3 -m unittest tests/test_check_image_inventory_go_directive.py` raises `NameError: name '_lift' is not defined`, failing CI `Python Unit Tests`.

## What Changed
- `tests/test_check_image_inventory_go_directive.py`: Updates `test_custom_go_mod_path_respected` to call `lift_function(name, text, _SCRIPT)` consistently with line 73.

## Context
Related to #1317 and #1330.

## Testing
- Ran `python3 -m unittest tests/test_check_image_inventory_go_directive.py`:
  ```
  Ran 10 tests in 0.657s
  OK
  ```
- Ran `make docs-check`:
  ```
  Checked relative links in 298 Markdown files. All relative links resolve.
  Terminology check passed.
  ```

### Live validation
Not live-tested: test suite bugfix that does not touch runtime controller, harness, or container images.

## Self-Review
- **Adversarial Pass:** Verified that `lift_function` is already imported from `_lift_shell` at the top of the file and its signature `(name, text, source)` matches `lift_function(name, text, _SCRIPT)`.
- **Docs-Drift Pass:** No doc changes required.

## Risk & Rollout
Zero risk. Test-only change. Revertible by git revert.

---
Generated with the help of Jetski / Gemini.
