### PR TITLE
fix(docs): replace two dead design-doc citations and check code-cited doc paths

### DIFF
--- a/.agents/skills/review-docs-drift/SKILL.md
+++ b/.agents/skills/review-docs-drift/SKILL.md
@@ -70,7 +70,7 @@ For every doc the PR adds or edits:
 
 ## 5. Run the mechanical gates
 
-- `make docs-check` at the PR's HEAD — generated tables current, relative links resolve (targets must be git-tracked), terminology matches source, map inventory current and its tables un-re-aligned, `AGENTS.md` plus `CLAUDE.md` inside their context budget.
+- `make docs-check` at the PR's HEAD — generated tables current, relative links resolve (targets must be git-tracked, and so must a `docs/designs/…` or `docs/architecture/…` path cited from code), terminology matches source, map inventory current and its tables un-re-aligned, `AGENTS.md` plus `CLAUDE.md` inside their context budget.
 - If the PR touched a generated-table source: run `make docs-generate` and confirm `git status` is clean afterwards (a dirty tree means the PR forgot to commit regenerated tables).
 - `npx prettier --check` on changed `.md`/`.json`/`.yaml` files (note: the generated `skills/index.mdx` is intentionally prettier-exempt).
 - If site pages changed: `cd docs/site && npm run build`.

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Generated tables are current
         run: make docs-check-generated
 
-      # Relative links must resolve. Catches paths broken by moved files.
+      # Relative links, and design-doc paths cited from code, must resolve.
+      # Catches paths broken by moved files and citations of unmerged docs.
       - name: Relative links resolve
         run: make docs-check-links
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Relative links, and design-doc paths cited from code, must resolve.
       # Catches paths broken by moved files and citations of unmerged docs.
-      - name: Relative links resolve
+      - name: Links and cited design docs resolve
         run: make docs-check-links
 
       # Identifiers must match the source of truth (service accounts,

--- a/agents/platform/scripts/cluster_agent_profile.py
+++ b/agents/platform/scripts/cluster_agent_profile.py
@@ -111,9 +111,10 @@ def _inject_cluster_identity(home: Path, project: str, cluster: str, location: s
 
     Records the target project/cluster/location as structured identity metadata — robust
     vs the sanitized/hashed profile name. (Re-dumping drops the template's comments in this
-    per-profile copy, which is fine.) Kept intentionally after the fleet-handover retirement:
-    it is cheap identity metadata and is what a restored `write_handover` producer would read
-    (see docs/designs/fleet-handover-retirement.md).
+    per-profile copy, which is fine.) The stamp is load-bearing: `read_cluster_identity` below
+    is how cluster_agent_reconcile.py matches a profile to its live cluster, and a profile
+    without it is skipped — neither matched nor pruned. It is also what the proposed handover
+    producer would read (docs/designs/agent-communication.md, design of record, not implemented).
     """
     import yaml  # lazy: only needed on the scaffold path, keeps the module importable without pyyaml
 

--- a/agents/platform/scripts/cluster_agent_reconcile.py
+++ b/agents/platform/scripts/cluster_agent_reconcile.py
@@ -29,9 +29,12 @@
 #     included on any `custom` set that names an admin role. RECONCILE_EXCLUDE is the opt-out,
 #     and the security reference is the canonical statement.
 #
-# It runs as a `no_agent` cron job on the profile the gateway actually ticks (the `default`/chat
-# profile — see docs/designs/fleet-handover-retirement.md §4). Scripts and the profiles PVC are
-# shared pod-wide, so it operates on every profile regardless of which profile ticks it. It is
+# It runs as a `no_agent` cron job on the `default`/chat profile's roster
+# (agents/chat/defaults/cron/jobs.json), not the Platform Agent's: it belongs to no one profile,
+# and that store is the one the gateway's own ticker thread ticks directly. Scripts and the
+# profiles PVC are shared pod-wide, so it operates on every profile regardless of which profile
+# ticks it — see "This roster is not inert" and "Never put an id on both rosters" in
+# agents/platform/cron/README.md for the ticking model and why the id lives on one roster. It is
 # resilient (always exit 0 on the cron path) and posts a summary to every configured chat
 # platform only when it created or pruned. `--require-create-pass` opts out of that for a caller
 # that has to know whether the roster is actually reconciled; the bootstrap scan gate is the only

--- a/deploy/sandbox/Dockerfile
+++ b/deploy/sandbox/Dockerfile
@@ -1,6 +1,6 @@
 # The agent shell sandbox: the container the agent's terminal, file and
 # code-execution tools actually run in, reached over SSH from the agent pod.
-# See docs/designs/agent-shell-sandbox.md for why the shell moved out of the
+# See docs/designs/agent-shell-sandboxing.md for why the shell moved out of the
 # agent container at all.
 #
 # Two things this image is deliberately not:

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,8 +109,8 @@ CI enforcement: `make docs-check` runs the same checks as
   document deleted from inside a collapsed family row's glob (see section 5).
 - `docs-check-links` — `scripts/check_docs_links.py`; relative links must
   resolve to **git-tracked** targets, and a `docs/designs/…` or
-  `docs/architecture/…` path cited from a `.py`, `.go` or `.sh` file must be
-  one too.
+  `docs/architecture/…` path cited from a code or configuration file (Python,
+  Go, shell, Dockerfiles, YAML, Terraform, TypeScript) must be one too.
 - `docs-check-terminology` — `hack/check-docs-terminology.sh`; identifiers in
   prose must match their source (service-account names, versions, the
   fleet-audit finding-id pattern and rendering caps, …), and a quoted cron

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,9 @@ CI enforcement: `make docs-check` runs the same checks as
   generated region or file no longer matches its source. This is what catches a
   document deleted from inside a collapsed family row's glob (see section 5).
 - `docs-check-links` — `scripts/check_docs_links.py`; relative links must
-  resolve to **git-tracked** targets.
+  resolve to **git-tracked** targets, and a `docs/designs/…` or
+  `docs/architecture/…` path cited from a `.py`, `.go` or `.sh` file must be
+  one too.
 - `docs-check-terminology` — `hack/check-docs-terminology.sh`; identifiers in
   prose must match their source (service-account names, versions, the
   fleet-audit finding-id pattern and rendering caps, …), and a quoted cron

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -17,14 +17,16 @@ Scope is deliberately narrow and offline:
   build in ``docs-build.yml``;
 * anchors are stripped before resolution, and a bare ``#anchor`` is skipped;
 * a ``docs/designs/...`` or ``docs/architecture/...`` path written inside a
-  ``.py``, ``.go`` or ``.sh`` file is resolved from the repository root and
-  must be git-tracked too. Header comments cite design documents as the
-  reasoning behind the code, and a citation of a document that was never
-  merged reads the same as a real one (#992). Nothing else in code is
-  inspected. A test fixture that needs a fake document path cites something
-  like ``docs/x.md``, outside the two directories, as the existing ones do,
-  or assembles the path from parts at runtime the way this script's own
-  tests do; a literal in a tracked ``.py`` is a citation like any other.
+  code or configuration file (the ``CODE_GLOBS`` below: Python, Go, shell,
+  Dockerfiles, YAML, Terraform, TypeScript) is resolved from the repository
+  root and must be git-tracked too. Comments cite design documents as the
+  reasoning behind what they sit above, and a citation of a document that
+  was never merged reads the same as a real one (#992). No other path in
+  those files is inspected. A test fixture that needs a fake document path
+  cites something like ``docs/x.md``, outside the two directories, as the
+  existing ones do, or assembles the path from parts at runtime the way
+  this script's own tests do; a literal in a tracked file is a citation
+  like any other.
 
 Standard library only, so it runs in CI and in a bare clone.
 
@@ -44,7 +46,13 @@ from urllib.parse import unquote
 REPO = Path(__file__).resolve().parent.parent
 
 MARKDOWN_GLOBS = ("*.md", "*.mdx")
-CODE_GLOBS = ("*.py", "*.go", "*.sh")
+# Where a design document gets cited as the reasoning behind something: code,
+# shell, container builds, Helm and cron configuration, Terraform, the A2A web
+# client. Selected by name pattern because `git ls-files` takes one; the
+# citation pattern below is conservative enough that any text file could be
+# scanned, so widen this rather than exempt when a new kind of file starts
+# citing designs.
+CODE_GLOBS = ("*.py", "*.go", "*.sh", "*Dockerfile*", "*.yaml", "*.yml", "*.tf", "*.ts")
 # The docs site's dependency tree carries its own Markdown and scripts.
 VENDORED_DIR = "node_modules"
 

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -15,7 +15,16 @@ Scope is deliberately narrow and offline:
 * site-absolute routes (``/kube-agents/...``) are Starlight routes rather than
   paths on disk, so they are skipped -- broken ones surface as a failed site
   build in ``docs-build.yml``;
-* anchors are stripped before resolution, and a bare ``#anchor`` is skipped.
+* anchors are stripped before resolution, and a bare ``#anchor`` is skipped;
+* a ``docs/designs/...`` or ``docs/architecture/...`` path written inside a
+  ``.py``, ``.go`` or ``.sh`` file is resolved from the repository root and
+  must be git-tracked too. Header comments cite design documents as the
+  reasoning behind the code, and a citation of a document that was never
+  merged reads the same as a real one (#992). Nothing else in code is
+  inspected. A test fixture that needs a fake document path cites something
+  like ``docs/x.md``, outside the two directories, as the existing ones do,
+  or assembles the path from parts at runtime the way this script's own
+  tests do; a literal in a tracked ``.py`` is a citation like any other.
 
 Standard library only, so it runs in CI and in a bare clone.
 
@@ -33,6 +42,11 @@ from pathlib import Path
 from urllib.parse import unquote
 
 REPO = Path(__file__).resolve().parent.parent
+
+MARKDOWN_GLOBS = ("*.md", "*.mdx")
+CODE_GLOBS = ("*.py", "*.go", "*.sh")
+# The docs site's dependency tree carries its own Markdown and scripts.
+VENDORED_DIR = "node_modules"
 
 # [text](target) but not ![image](target) handled separately; both are checked.
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(\s*([^)\s]+)(?:\s+\"[^\"]*\")?\s*\)")
@@ -65,6 +79,13 @@ FENCE_RE = re.compile(r"^\s*(```|~~~)")
 # report keep meaning what they say.
 INLINE_CODE_RE = re.compile(r"(?<!`)(`+)(?!`).+?(?<!`)\1(?!`)")
 
+# A design or architecture document named from code. The match ends at `.md`,
+# so a trailing `)`, `.`, `,`, `:12`, `#anchor`, a closing backtick or a
+# following ` §4` is never part of the path, and the lookahead keeps `.mdx`
+# from matching as `.md`. A glob (`*.md`) or an f-string (`{name}.md`) contains
+# a character outside the class and is skipped, which is the safe direction.
+CITATION_RE = re.compile(r"docs/(?:designs|architecture)/[A-Za-z0-9_./-]+?\.md(?![A-Za-z0-9_])")
+
 
 def tracked_paths() -> set[Path]:
     out = subprocess.run(
@@ -77,15 +98,23 @@ def tracked_paths() -> set[Path]:
     return {(REPO / p).resolve() for p in out if p and (REPO / p).is_file()}
 
 
-def tracked_markdown() -> list[Path]:
+def tracked_files(patterns: tuple[str, ...]) -> list[Path]:
     out = subprocess.run(
-        ["git", "ls-files", "-z", "*.md", "*.mdx"],
+        ["git", "ls-files", "-z", *patterns],
         cwd=REPO,
         capture_output=True,
         text=True,
         check=True,
     ).stdout.split("\0")
-    return [REPO / p for p in out if p and "node_modules" not in p and (REPO / p).is_file()]
+    return [REPO / p for p in out if p and VENDORED_DIR not in p and (REPO / p).is_file()]
+
+
+def tracked_markdown() -> list[Path]:
+    return tracked_files(MARKDOWN_GLOBS)
+
+
+def tracked_code() -> list[Path]:
+    return tracked_files(CODE_GLOBS)
 
 
 def strip_code_fences(text: str) -> list[tuple[int, str]]:
@@ -131,6 +160,24 @@ def check_file(path: Path, tracked: set[Path]) -> list[str]:
     return problems
 
 
+def check_code_file(path: Path, tracked: set[Path]) -> list[str]:
+    """Report every design-document path cited in a code file that is not tracked.
+
+    Citations are repository-root paths by convention, so nothing is resolved
+    relative to the citing file. Code fences and inline code are not stripped
+    here: in a comment, backticks are how a path is quoted, not a sign that it
+    is a specimen.
+    """
+    problems: list[str] = []
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        for m in CITATION_RE.finditer(line):
+            cited = m.group(0)
+            if (REPO / cited).resolve() not in tracked:
+                rel = path.relative_to(REPO)
+                problems.append(f"{rel}:{lineno}: broken citation -> {cited}")
+    return problems
+
+
 def main() -> int:
     files = tracked_markdown()
     if not files:
@@ -142,13 +189,20 @@ def main() -> int:
     for f in files:
         problems.extend(check_file(f, tracked))
 
-    print(f"Checked relative links in {len(files)} Markdown files.")
+    code = tracked_code()
+    for f in code:
+        problems.extend(check_code_file(f, tracked))
+
+    print(
+        f"Checked relative links in {len(files)} Markdown files "
+        f"and design-doc citations in {len(code)} code files."
+    )
     if problems:
-        print(f"\n{len(problems)} broken link(s):\n", file=sys.stderr)
+        print(f"\n{len(problems)} broken link(s) or citation(s):\n", file=sys.stderr)
         for p in problems:
             print(f"    {p}", file=sys.stderr)
         return 1
-    print("All relative links resolve.")
+    print("All relative links and design-doc citations resolve.")
     return 0
 
 

--- a/scripts/test_check_docs_links.py
+++ b/scripts/test_check_docs_links.py
@@ -7,10 +7,12 @@ The synthetic ones build a miniature git repository in a temporary directory
 and point the checker at it. They prove each rule *fires*: a lint nobody has
 watched fail is a lint nobody knows is wired up.
 
-The rest run against the real repository. They pin the two things that would
-silently turn the code-citation scan into a no-op -- a glob that stops matching
-the files it exists for, and the tree growing a dangling citation -- because a
-lint that stops reporting anything looks exactly like a clean repository.
+The rest run against the real repository. They do not re-run the lint over the
+tree -- `make docs-check-links` already does that in CI, and a second copy of
+its verdict would only make one dangling citation red two jobs. They pin what
+would silently turn the scan into a no-op: a glob that stops matching the
+files it exists for, and this module growing a literal it would then report.
+A lint that stops reporting anything looks exactly like a clean repository.
 
 Every design-document path a fixture cites is assembled from DESIGNS and
 ARCHITECTURE at runtime. This file is itself a tracked ``.py``, so a literal
@@ -43,10 +45,15 @@ MISSING = DESIGNS + "missing.md"
 ON_DISK_ONLY = DESIGNS + "on_disk_only.md"
 MISSING_PLAIN = "docs/missing.md"  # outside the scanned directories: a Markdown-link fixture only
 
-# The two files #992 was filed against; the scan has to keep reaching them.
-ISSUE_992_FILES = (
+# Files the scan has to keep reaching: the two #992 was filed against, and one
+# of each other kind CODE_GLOBS names, each of which cites a design document.
+MUST_REACH = (
     "agents/platform/scripts/cluster_agent_reconcile.py",
     "agents/platform/scripts/cluster_agent_profile.py",
+    "deploy/sandbox/Dockerfile",
+    "a2a/cmd/gateway/main.go",
+    "charts/kube-agents/values.yaml",
+    "hack/ci-eval-pr.sh",
 )
 
 TOOL_LINES = (
@@ -157,14 +164,9 @@ class CitationPatternTest(unittest.TestCase):
 
 
 class RealRepoTest(unittest.TestCase):
-    def test_no_code_file_cites_a_missing_design_document(self) -> None:
-        tracked = cdl.tracked_paths()
-        problems = [p for f in cdl.tracked_code() for p in cdl.check_code_file(f, tracked)]
-        self.assertEqual(problems, [])
-
-    def test_the_scan_reaches_the_files_from_issue_992(self) -> None:
+    def test_the_scan_reaches_the_files_it_exists_for(self) -> None:
         code = {p.relative_to(REPO).as_posix() for p in cdl.tracked_code()}
-        for rel in ISSUE_992_FILES:
+        for rel in MUST_REACH:
             with self.subTest(file=rel):
                 self.assertIn(rel, code)
 

--- a/scripts/test_check_docs_links.py
+++ b/scripts/test_check_docs_links.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for check_docs_links.py.
+
+Two kinds of test here, and the split is deliberate.
+
+The synthetic ones build a miniature git repository in a temporary directory
+and point the checker at it. They prove each rule *fires*: a lint nobody has
+watched fail is a lint nobody knows is wired up.
+
+The rest run against the real repository. They pin the two things that would
+silently turn the code-citation scan into a no-op -- a glob that stops matching
+the files it exists for, and the tree growing a dangling citation -- because a
+lint that stops reporting anything looks exactly like a clean repository.
+
+Every design-document path a fixture cites is assembled from DESIGNS and
+ARCHITECTURE at runtime. This file is itself a tracked ``.py``, so a literal
+``docs/designs/<name>.md`` written here would be scanned and reported as a
+broken citation of a document that exists only in a temporary directory.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+import check_docs_links as cdl
+
+REPO = Path(__file__).resolve().parents[1]
+
+# Directory prefixes the scan is anchored on, kept apart from the file names so
+# no line of this module is itself a citation (see the module docstring).
+DESIGNS = "docs/designs/"
+ARCHITECTURE = "docs/architecture/"
+
+PRESENT = DESIGNS + "present.md"
+MISSING = DESIGNS + "missing.md"
+ON_DISK_ONLY = DESIGNS + "on_disk_only.md"
+MISSING_PLAIN = "docs/missing.md"  # outside the scanned directories: a Markdown-link fixture only
+
+# The two files #992 was filed against; the scan has to keep reaching them.
+ISSUE_992_FILES = (
+    "agents/platform/scripts/cluster_agent_reconcile.py",
+    "agents/platform/scripts/cluster_agent_profile.py",
+)
+
+TOOL_LINES = (
+    "# tool.py",
+    f"# see {PRESENT} §4).",
+    f"# see {MISSING}",
+    f'print("`{ON_DISK_ONLY}`")',
+    f"# {PRESENT}#section, {PRESENT}:12",
+)
+README_LINES = (
+    "# fixture",
+    f"[ok]({PRESENT})",
+    f"[bad]({MISSING_PLAIN})",
+)
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@unittest.skipUnless(shutil.which("git"), "the checker shells out to git")
+class SyntheticRepoTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        # Resolved, because tracked_paths() resolves and /tmp may be a symlink.
+        self.root = Path(self._tmp.name).resolve()
+        _git(self.root, "init", "-q")
+        _write(self.root, PRESENT, "# present\n")
+        _write(self.root, ON_DISK_ONLY, "# not added\n")
+        self.readme = _write(self.root, "README.md", "\n".join(README_LINES) + "\n")
+        self.tool = _write(self.root, "tool.py", "\n".join(TOOL_LINES) + "\n")
+        _git(self.root, "add", PRESENT, "README.md", "tool.py")
+        patcher = mock.patch.object(cdl, "REPO", self.root)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_reports_a_dangling_citation_with_its_line(self) -> None:
+        problems = cdl.check_code_file(self.tool, cdl.tracked_paths())
+        self.assertEqual(
+            problems,
+            [
+                f"tool.py:3: broken citation -> {MISSING}",
+                f"tool.py:4: broken citation -> {ON_DISK_ONLY}",
+            ],
+        )
+
+    def test_trailing_punctuation_anchor_and_line_ref_are_not_the_path(self) -> None:
+        problems = cdl.check_code_file(self.tool, cdl.tracked_paths())
+        self.assertFalse([p for p in problems if ":2:" in p or ":5:" in p], problems)
+
+    def test_markdown_links_are_still_checked(self) -> None:
+        problems = cdl.check_file(self.readme, cdl.tracked_paths())
+        self.assertEqual(problems, [f"README.md:3: broken link -> {MISSING_PLAIN}"])
+
+    def test_main_reports_both_kinds_and_exits_one(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = cdl.main()
+        self.assertEqual(rc, 1)
+        # README.md plus the present design doc are the tracked Markdown; tool.py is the code.
+        self.assertIn("2 Markdown files and design-doc citations in 1 code files", out.getvalue())
+        self.assertEqual(err.getvalue().count("broken link ->"), 1)
+        self.assertEqual(err.getvalue().count("broken citation ->"), 2)
+
+    def test_main_is_clean_once_every_citation_is_tracked(self) -> None:
+        _write(self.root, MISSING, "# now present\n")
+        _write(self.root, MISSING_PLAIN, "# now present\n")
+        _git(self.root, "add", MISSING, ON_DISK_ONLY, MISSING_PLAIN)
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+            rc = cdl.main()
+        self.assertEqual(rc, 0, out.getvalue())
+        self.assertIn("All relative links and design-doc citations resolve.", out.getvalue())
+
+
+class CitationPatternTest(unittest.TestCase):
+    def test_mdx_glob_and_placeholder_do_not_match(self) -> None:
+        for text in (
+            DESIGNS + "page.mdx",
+            DESIGNS + "*.md",
+            DESIGNS + "{name}.md",
+            "docs/site/src/content/docs/deploy/x.md",
+        ):
+            with self.subTest(text=text):
+                self.assertIsNone(cdl.CITATION_RE.search(text))
+
+    def test_dotted_name_and_both_directories_match_whole(self) -> None:
+        dotted = DESIGNS + "a.b.md"
+        security = ARCHITECTURE + "03-security-model.md"
+        memory = DESIGNS + "memory.md"
+        for text, expected in (
+            (f"see {dotted}.", dotted),
+            (f"({security}#x)", security),
+            (f"`{memory}`", memory),
+        ):
+            with self.subTest(text=text):
+                m = cdl.CITATION_RE.search(text)
+                self.assertIsNotNone(m)
+                self.assertEqual(m.group(0), expected)
+
+
+class RealRepoTest(unittest.TestCase):
+    def test_no_code_file_cites_a_missing_design_document(self) -> None:
+        tracked = cdl.tracked_paths()
+        problems = [p for f in cdl.tracked_code() for p in cdl.check_code_file(f, tracked)]
+        self.assertEqual(problems, [])
+
+    def test_the_scan_reaches_the_files_from_issue_992(self) -> None:
+        code = {p.relative_to(REPO).as_posix() for p in cdl.tracked_code()}
+        for rel in ISSUE_992_FILES:
+            with self.subTest(file=rel):
+                self.assertIn(rel, code)
+
+    def test_this_module_contains_no_literal_citation(self) -> None:
+        """The guard behind the module docstring: a literal here would fail docs-check."""
+        problems = cdl.check_code_file(Path(__file__).resolve(), cdl.tracked_paths())
+        self.assertEqual(problems, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two Cluster Agent scripts cited `docs/designs/fleet-handover-retirement.md`, a document that never reached `main`. This replaces both citations with the rationale they stood in for, pointing at documents that exist, and extends `docs-check-links` so a `docs/designs/…` or `docs/architecture/…` path cited from a code or configuration file must be git-tracked, the same rule Markdown links already follow. The wider scan found one more citation of the same class, a one-letter typo in `deploy/sandbox/Dockerfile`, fixed here.

## Why This Change

The document was real: dc3e4913 on the old `feat/mvp` branch added it, and PR #441 squashed the scripts onto `main` without it, so the citations were dangling from the day they landed. Both sit in header comments that carry the reasoning behind the code, and a reader who follows either pointer finds nothing and cannot tell whether the design moved or was never written. Nothing caught it because `scripts/check_docs_links.py` walked Markdown only. On `main` today the scan reaches 1112 files that cite design and architecture documents; the two from #992 and the Dockerfile typo were the only broken ones, so the class is real and small.

## What Changed

- `agents/platform/scripts/cluster_agent_reconcile.py`: the comment now says why the job sits on the chat profile's roster (that store is the one the gateway's ticker thread ticks; an id lives on one roster) and cites `agents/platform/cron/README.md`.
- `agents/platform/scripts/cluster_agent_profile.py`: the `_inject_cluster_identity` docstring now says what the stamp does today. `read_cluster_identity` is how the reconciler matches a profile to its cluster, and a profile without it is skipped, neither matched nor pruned. The handover producer is cited from `docs/designs/agent-communication.md`, the design of record.
- `scripts/check_docs_links.py`: a second walk over tracked Python, Go, shell, Dockerfile, YAML, Terraform and TypeScript files, matching `docs/(designs|architecture)/<name>.md` tokens and resolving them from the repository root against the git-tracked set. Reported as `broken citation ->` to tell it apart from a Markdown link. The summary line counts both walks; one exit code. The citation pattern ends at `.md`, so trailing punctuation, `§4`, `:12` and `#anchor` never join the path, and globs or placeholders never match.
- `deploy/sandbox/Dockerfile:3`: `agent-shell-sandbox.md` was `agent-shell-sandboxing.md`, the document line 209 of the same file cites correctly.
- `scripts/test_check_docs_links.py` (new, the module had no tests): a synthetic git repository proving each rule fires, including tracked-not-on-disk; the pattern's edge cases; and two real-repo pins: the scan reaches one file of each kind it exists for, and this module carries no literal citation of its own. Every fixture path is assembled from parts at runtime, because a literal in a tracked file is a citation like any other.
- `docs/README.md` check list, the workflow step's name and comment, and the docs-drift skill's one-line description of `docs-check`. AGENTS.md is untouched: it sits at 0.0k under its context budget.

## Context

Closes #992. Filed from a docs-drift pass on #989; #991, the other finding from that pass on the same file, was fixed by #871. Merge-order note: #1253 cites `docs/designs/version-control-support.md`, which #1246 adds; after this merges, #1253's `docs-check` reds until #1246 lands or #1253 rebases onto it. Out of scope and noted for whoever wants them: `k8s-operator/cmd/k8s-event-watcher/types.go:20` cites `docs/k8s-event-agent-design.md`, which also never existed but is outside the two directories this scan covers; `docs/designs/*.yaml` citations; the conformance tests' deliberate cross-branch reference.

Generated with the help of Claude Code (Fable 5.1).

## Testing

- `make docs-check`: all five checks pass on the head. The links line now reads `Checked relative links in 298 Markdown files and design-doc citations in 1112 code files.`
- Negative checks, two. With the original dead citation put back into `cluster_agent_reconcile.py`, `make docs-check-links` exits 1 with exactly one finding, `agents/platform/scripts/cluster_agent_reconcile.py:36: broken citation -> docs/designs/fleet-handover-retirement.md`; reverted. And widening the file globs before fixing the Dockerfile produced exactly one finding across 1112 files, `deploy/sandbox/Dockerfile:3: broken citation -> docs/designs/agent-shell-sandbox.md`, so the wider set adds no false positives on today's tree.
- `cd scripts && python3 -m unittest discover -s . -p 'test_*.py'`: 1387 tests pass, 19 skipped as before, on the first commit; the new module is 9 tests on the head and passes.
- `prettier@3.9.6 --check` on the changed Markdown and YAML: clean. `python3 -m py_compile` on both edited scripts: clean.
- The context budget is at 0.0k headroom; AGENTS.md is untouched by this change.

### Live validation

Not live-tested against an installation: nothing here reaches one. The two agent-script edits are comments, inert in the image; the checker runs only in CI and `make docs-check`; the rest is its tests and two lines of docs. What stands in for it is the negative check above, which reproduced the exact failure #992 reports through the new scan and showed it reporting nothing else across the tree.

## Self-Review

Passes run: `review-adversarial` and `review-docs-drift`, each in a fresh subagent handed only the diff range, the skill path and the gate results, told to derive intent from the diff and not read commit messages. Both ran once, on the first commit (ec518bb0). The second commit (b8e81224) applies their findings and was not re-reviewed by a fresh context; it is small and listed below so a reviewer can look there first: the wider file globs, the Dockerfile typo, the test module's real-repo pins, and three lines of docs.

Adversarial angles run: intent versus diff, error paths and edge cases of the pattern, altitude of the file selection, redundancy, test coverage, security (nothing applicable), and open-PR interaction. Docs-drift checked every new sentence against source (the reconciler's create and prune passes, the cron README's headings and ticking model, the handover design's banner and §2), every place in the tree that describes `docs-check-links`, test placement against "Where Tests Go", and the map instruments.

Fixed:

- MEDIUM, CONFIRMED by both passes: the scan's file list was three extensions, and a third dangling citation of the same class sat in `deploy/sandbox/Dockerfile`, which the scan never opened. The globs now cover Dockerfiles, YAML, Terraform and TypeScript too; the Dockerfile line is corrected; the docstring's "nothing else in code is inspected" now describes the globs.
- LOW, CONFIRMED: a real-repo test re-ran the lint over the whole tree, so one dangling citation would have redded two CI jobs. Removed; the real-repo pins are now the glob reach and the module's own literal-free state.
- Docs-drift, Advisory: the workflow step was still named "Relative links resolve"; renamed. The docs-drift skill's line describing `docs-check` said links only; extended by one clause.

Deliberately not fixed:

- Merge order with #1253 (adversarial, LOW, CONFIRMED). That PR's code cites `docs/designs/version-control-support.md`, which only #1246 adds, so once this merges #1253 fails `docs-check` until #1246 lands or #1253 rebases onto it. That is the check working as intended; noted in Context so nobody is surprised.
- `docs/testing-map.md:11` cites Makefile line numbers for `PYTHON_TEST_DIRS` that have drifted. Pre-existing, the Makefile is not in this diff.
- AGENTS.md's summary of `make docs-check` still says "relative links resolve". Still true, and the file has no context-budget headroom; `docs/README.md` is the enumerated home and is updated.

Not covered: no pass ran `make test-python` in full or observed the checker in CI; both were handed the local results. Nothing here reaches a running installation.

## Risk & Rollout

No runtime path changes. The new scan can fail `docs-check` on a future pull request that cites a design document from code before the document is tracked, which is the intended behaviour; the fix is to track the document or cite one that exists. A test fixture that needs a fake design path assembles it from parts, as the new test module does and its docstring explains. Revert is one commit.
