### PR TITLE
ci(smoke-test-sticky): re-pin an admin /override the way a green is re-pinned

### DIFF
--- a/.github/workflows/smoke-test-sticky.yml
+++ b/.github/workflows/smoke-test-sticky.yml
@@ -8,7 +8,8 @@ name: Smoke Test Sticky Status
 # the 1.5-3.5h job runs again for a pull request whose head has not changed
 # (#1179, #1202). `scripts/pin_smoke_status.py` re-pins that suffix to the new
 # head of `main` -- for every open pull request on each push to `main`, and for
-# one commit when its green arrives after `main` has already moved -- so a pull
+# one commit when its green arrives after `main` has already moved (or with no
+# base at all, as the override plugin's own status does) -- so a pull
 # request green at its own head merges without a fresh-base retest. What that
 # gives up is testing the combination with the `main` it lands on before the
 # merge; until a scheduled eval run on `main` exists, a bad combination is
@@ -20,8 +21,13 @@ name: Smoke Test Sticky Status
 # What it does NOT change: a push creates a new head with no status, so the
 # job runs as before; `/test pull-kube-agents-smoke-test` on the same head
 # posts `pending`, which is newer and wins (`/retest` does not -- it reruns
-# only failed contexts); a red is never touched, and neither is an admin
-# `/override`.
+# only failed contexts); a red is never touched.
+#
+# An admin `/override` is re-pinned like a green -- crier stamps the same
+# `BaseSHA:` suffix on it -- so a plain `/override` holds for the head it was
+# given until a push whenever the sweep wins the race below; when it loses,
+# the overridden job reruns, reds, and the override has to be repeated.
+# Upstream's `/override-sticky` has no race, and this Prow does not have it.
 #
 # It races Tide's sync loop: a sync that sees the stale statuses before the
 # sweep has re-pinned them starts the retest, and crier's `pending` then wins.
@@ -49,16 +55,15 @@ jobs:
     name: Pin green smoke-test statuses to the head of main
     # The repository guard is required of any credentialed workflow that starts
     # on its own (AGENTS.md, Pull Request Hygiene). A push to main always
-    # sweeps; a status event qualifies only when it is the smoke test, green,
-    # and not an admin override -- the script checks the same things again and
-    # is the reference, this expression is what keeps the other statuses off a
-    # runner.
+    # sweeps; a status event qualifies only when it is the smoke test and green
+    # -- an admin override included -- the script checks the same things again
+    # and is the reference, this expression is what keeps the other statuses
+    # off a runner.
     if: >-
       github.repository == 'gke-labs/kube-agents' &&
       (github.event_name == 'push' ||
         (github.event.context == 'pull-kube-agents-smoke-test' &&
-          github.event.state == 'success' &&
-          !startsWith(github.event.description, 'Overridden by')))
+          github.event.state == 'success'))
     runs-on: ubuntu-latest
     permissions:
       contents: read # check out the default branch: the script

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -307,15 +307,17 @@ and retries it every ~85 seconds ahead of everyone else — #608 and #1197 held 
 for an hour on 2026-09-05. `/hold cancel` does not remove this label; resolving the threads does.
 A person who applies the same label by hand keeps it: the workflow removes only what it added.
 `/override <context>`, which only
-a repository admin can use, forces a required check that cannot pass on its own — and expires: the
-forced status embeds the base SHA at override time, so the next merge to `main` invalidates it,
-Tide re-runs the job, and the override has to be repeated if `main` moves before Tide merges
-(#1202).
-Prow's `/override-sticky` would write the `[prow:skip-retest]` sentinel instead, which Tide accepts
-regardless of base — but it is not in the Prow build this repository merges through: the
+a repository admin can use, forces a required check that cannot pass on its own. The forced status
+embeds the base SHA at override time, so by itself it would expire on the next merge to `main` and
+Tide would re-run the job — which is how an override came to need repeating whenever `main` moved
+before Tide merged (#1202). The re-pin below carries it across merges the way it carries a green, so
+an override usually holds for the head it was given until a push — subject to the same race with
+Tide's sync, and a lost race costs more here, because the retest is of a check that cannot pass: it
+comes back red and the override has to be given again. Prow's `/override-sticky` would do this
+without the race, with the `[prow:skip-retest]` sentinel Tide accepts regardless of base — but it is
+not in the Prow build this repository merges through: the
 [plugin help](https://oss.gprow.dev/command-help?repo=gke-labs%2Fkube-agents) lists only
-`/override`, and the command is silently ignored. A green run of the job is a different matter,
-below.
+`/override`, and the command is silently ignored.
 
 **Branch protection is not the gate and reads as though there is none.** `main` requires ten
 contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run Controller Tests`,
@@ -353,7 +355,8 @@ starts the retest as before (a batch, when two or more qualify), crier's `pendin
 newer status, and the sweep leaves it alone. A push still starts a fresh run;
 `/test pull-kube-agents-smoke-test` on the same head posts `pending`, which wins until that run
 reports (`/retest` does not, because it reruns only failed contexts); a red is never touched, and
-neither is an admin `/override`. What this trades away is testing the combination with the `main`
+an admin `/override` is carried the same way as a green, because crier stamps the same `BaseSHA:`
+suffix on it. What this trades away is testing the combination with the `main`
 it lands on before the merge; until a scheduled eval run on `main` exists, a bad combination is
 found by the next smoke run that actually starts after it — a push or `/test` on whichever pull
 request that is, whose author then sees a red that is not theirs. Prow's own form of this — a `[prow:skip-retest]` sentinel

--- a/scripts/pin_smoke_status.py
+++ b/scripts/pin_smoke_status.py
@@ -29,13 +29,25 @@ is sometimes lost. Two merges seconds apart start two sweeps with no ordering
 between them, so a pin is always made to the head of `main` as read just
 before the write, never to the head the run started with.
 
-What it will not do: touch a status that is not `success`, touch an admin
-`/override`, pin a pull request that does not target `main` (Tide keys the
-base SHA on the pull request's own base branch), or overwrite a newer status
-on the same context. Deciding and writing are separate calls, and a throttled
-call retries with a delay of seconds to a minute, so the status is read a
-second time immediately before the write and the write is dropped if a newer
-one has landed. What stays open is the POST itself. One pull request failing
+An admin `/override` is pinned the same way as a green. The plugin on this
+Prow build posts a bare `Overridden by <user>`, and crier posts a second
+status with the same `BaseSHA:` suffix a green carries when it reports the
+success ProwJob the plugin creates; whichever is the latest, Tide reads it the
+way it reads a green, and so does this (a bare one has no base, which is a
+stale one). So a plain `/override` holds for the head it was given until a
+push whenever the sweep wins the race above, instead of having to be repeated
+after every merge to `main` (#1202). A lost race costs an override more than
+it costs a green: the retest is of a job that was overridden because it cannot
+pass, so it comes back red and the override has to be given again. Upstream's
+`/override-sticky` sentinel has no race, which is one more reason to switch.
+
+What it will not do: touch a status that is not `success`, pin a pull request
+that does not target `main` (Tide keys the base SHA on the pull request's own
+base branch), or overwrite a newer status on the same context. Deciding and
+writing are separate calls, and a throttled call retries with a delay of
+seconds to a minute, so the status is read a second time immediately before
+the write and the write is dropped if a newer one has landed. What stays open
+is the POST itself. One pull request failing
 -- a head force-pushed away mid-sweep, a call out of retries -- is logged and
 the sweep goes on, because every pull request after it would otherwise wait
 for the next merge; the failure still sets the exit status.
@@ -56,8 +68,6 @@ from github_api import GitHubAPI, log  # noqa: E402
 CONTEXT = "pull-kube-agents-smoke-test"
 #: `contextDescriptionBaseSHADelimiter` in kubernetes-sigs/prow, pkg/config/config.go.
 BASE_SHA_DELIMITER = " BaseSHA:"
-#: What the override plugin writes; its statuses are an admin's decision, not ours.
-OVERRIDE_PREFIX = "Overridden by"
 #: Left in the human-readable part so the description does not claim a run it did not have.
 PIN_NOTE = "(base pinned to main by smoke-test-sticky)"
 #: GitHub rejects a longer status description; Prow's `contextDescriptionMaxLen` agrees.
@@ -107,10 +117,7 @@ def skip_reason(status, main_sha):
         return f"no {CONTEXT} status on the commit"
     if status.get("state") != SUCCESS:
         return f"state is {status.get('state')!r}, not {SUCCESS}"
-    description = status.get("description") or ""
-    if description.startswith(OVERRIDE_PREFIX):
-        return "an admin override, which is not ours to extend"
-    _, base_sha = split_description(description)
+    _, base_sha = split_description(status.get("description") or "")
     if base_sha == main_sha:
         return "already pinned to the head of main"
     return None

--- a/scripts/test_pin_smoke_status.py
+++ b/scripts/test_pin_smoke_status.py
@@ -5,9 +5,9 @@ Run: cd scripts && python3 -m unittest test_pin_smoke_status
 
 Every wrong answer here fails green: a status that should have been pinned is
 left stale and Tide quietly re-runs a 1.5-3.5h job; a status that should have
-been left alone -- a red, an override, a newer `pending` -- is overwritten with
-a success. So the guards get one test each, and the description builder is
-driven with what crier actually writes, U+2001 padding included.
+been left alone -- a red, a newer `pending` -- is overwritten with a success.
+So the guards get one test each, and the description builder is driven with
+what crier and the override plugin actually write, U+2001 padding included.
 """
 
 import sys
@@ -25,6 +25,10 @@ MAIN = "a" * 40
 OLD = "b" * 40
 HEAD = "c" * 40
 CRIER = "Job succeeded." + " " * 20 + "BaseSHA:" + OLD
+#: The shape `/override` left on #1177's head: crier's report of the plugin's success ProwJob, padded like a green.
+OVERRIDE = "Overridden by bradhoekstra" + " " * 17 + "BaseSHA:" + OLD
+#: The plugin's own status on the same head, posted the same second, with no base at all.
+BARE_OVERRIDE = "Overridden by bradhoekstra"
 URL = "https://oss.gprow.dev/view/gs/kube-agents-prow/pr-logs/pull/gke-labs_kube-agents/1/pull-kube-agents-smoke-test/1"
 
 
@@ -105,6 +109,12 @@ class DescriptionTest(unittest.TestCase):
     def test_a_malformed_base_is_not_mistaken_for_one(self):
         self.assertIsNone(pin.split_description("Job succeeded. BaseSHA:ABC")[1])
 
+    def test_an_override_keeps_its_prefix_where_the_override_plugin_looks_for_it(self):
+        """`/override-cancel` finds its own statuses by the "Overridden by" text; a reader does too."""
+        got = pin.pinned_description(OVERRIDE, MAIN)
+        self.assertEqual(got, f"Overridden by bradhoekstra {pin.PIN_NOTE} BaseSHA:{MAIN}")
+        self.assertEqual(pin.split_description(got), ("Overridden by bradhoekstra", MAIN))
+
 
 class GuardTest(unittest.TestCase):
     def test_a_stale_green_is_pinned(self):
@@ -117,8 +127,11 @@ class GuardTest(unittest.TestCase):
         for state in ("pending", "failure", "error"):
             self.assertIn(state, pin.skip_reason(status(state=state), MAIN))
 
-    def test_an_admin_override_is_left_alone(self):
-        self.assertIn("override", pin.skip_reason(status(description="Overridden by someone BaseSHA:" + OLD), MAIN))
+    def test_a_stale_admin_override_is_pinned_like_a_green(self):
+        """The override plugin writes the same suffix crier does, and it expired the same way (#1202)."""
+        self.assertIsNone(pin.skip_reason(status(description=OVERRIDE), MAIN))
+        self.assertIsNone(pin.skip_reason(status(description=BARE_OVERRIDE), MAIN))
+        self.assertIn("already pinned", pin.skip_reason(status(description=f"Overridden by someone BaseSHA:{MAIN}"), MAIN))
 
     def test_a_commit_with_no_smoke_status_is_left_alone(self):
         self.assertIn("no pull-kube-agents-smoke-test status", pin.skip_reason(None, MAIN))

--- a/tests/test_smoke_test_sticky_workflow.py
+++ b/tests/test_smoke_test_sticky_workflow.py
@@ -53,11 +53,13 @@ class SmokeTestStickyWorkflowTest(unittest.TestCase):
     def test_the_job_carries_the_fork_guard(self):
         self.assertIn(_FORK_GUARD, self.condition)
 
-    def test_a_status_event_must_be_a_green_smoke_test_and_not_an_override(self):
+    def test_a_status_event_must_be_a_green_smoke_test_an_admin_override_included(self):
         self.assertIn(f"github.event.context == '{_CONTEXT}'", self.condition)
         self.assertIn("github.event.state == 'success'", self.condition)
-        self.assertIn("!startsWith(github.event.description, 'Overridden by')", self.condition)
         self.assertIn("github.event_name == 'push' ||", self.condition)
+        # An override is re-pinned like a green, so nothing may keep it off the runner.
+        self.assertNotIn("Overridden", self.condition)
+        self.assertNotIn("description", self.condition)
 
     def test_the_token_can_write_statuses_and_read_the_checkout_and_nothing_else(self):
         self.assertEqual(self.workflow["permissions"], {})


### PR DESCRIPTION
## Summary

`smoke-test-sticky.yml` now re-pins an admin `/override` on `pull-kube-agents-smoke-test` to the head of `main` the same way it re-pins a green run. Until now the workflow's job-level `if:` and `scripts/pin_smoke_status.py` both skipped any status whose description began `Overridden by`, so a plain `/override` embedded the base SHA of the moment and expired on the next merge to `main`. With this change an override holds for the head it was given until a push, whenever the sweep wins its race with Tide's sync, which is what upstream's `/override-sticky` promises and the Prow this repository merges through does not have.

## Why This Change

An `/override` is only given for a red the eval crew classified as not the pull request's, and that classification does not change when `main` moves. Yet every merge invalidated it: Tide re-ran a job that had been overridden because it cannot pass, it came back red, and an admin had to override again. #1177, #1190 and #1191 each needed two overrides on 2026-09-03 for that reason (#1202). The override plugin's `/override-sticky` would fix it but is not deployed on oss.gprow.dev, whose plugin help lists only `/override`.

## What Changed

- The workflow's job-level `if:` no longer excludes statuses whose description starts with `Overridden by`; a green smoke status of any description reaches the runner.
- `skip_reason()` in `scripts/pin_smoke_status.py` drops the override guard and the `OVERRIDE_PREFIX` constant. A stale override is pinned; one already at the head of `main` is left alone; the plugin's own suffix-less `Overridden by <user>` status has no base and is pinned too.
- The tests that pinned the carve-out now pin its absence, with the description shape `/override` actually left on #1177's head (U+2001 padding and `BaseSHA:` suffix), and a check that the `Overridden by` prefix survives the pin where `/override-cancel` looks for it.
- `docs/pull-request-workflow.md` "How a change merges", the workflow header and the script docstring say an override is carried across merges, subject to the same race as a green, and what a lost race costs.

## Context

Part of #1202 (merge throughput under the gate). Follows #1220, which introduced the re-pin and left overrides alone on purpose. No open pull request touches these files.

## Testing

- `cd scripts && python3 -m unittest test_pin_smoke_status`: 36 passed. The new `test_a_stale_admin_override_is_pinned_like_a_green` fails against the pre-change script and passes on the branch.
- `python3 -m unittest tests.test_smoke_test_sticky_workflow`: 9 passed, including the negative assertion that nothing in the `if:` reads the description.
- `make docs-check`: clean. `prettier@3.9.6 --check` on the changed Markdown and YAML: clean. `actionlint` 1.7.7 with shellcheck on the workflow: clean.

### Live validation

Not live-tested against a running kube-agents installation: the change is a GitHub Actions workflow and its script, which touch no cluster. What was exercised against the real repository, read-only:

- The new code was run against the real override status on #1177's merged head `20e90cbe` (the `/override` from 2026-09-03 13:12Z, `Overridden by bradhoekstra` + 17×U+2001 + `BaseSHA:b0a4d7d1`). `skip_reason` returned `None` where `main` had returned "an admin override, which is not ours to extend", and `pin_head(..., dry_run=True)` produced:

  ```
  20e90cbe: pinned to fb6f281e: Overridden by bradhoekstra (base pinned to main by smoke-test-sticky) BaseSHA:fb6f281e7fd408cc39213668d2febb82fb2e1877
  ```

- `python3 scripts/pin_smoke_status.py --repo gke-labs/kube-agents sweep --dry-run` on the live repository: every open pull request either has no smoke status, a failure, or is already pinned to the head of `main`. No open pull request carries an override today, so no status was changed and the sweep was a no-op in dry-run.

Not covered: no override has yet been re-pinned by this code on a live pull request, so Tide crediting a re-pinned override is inferred rather than observed. The code path is identical to the green re-pin Tide was seen to credit on 2026-09-04 (#1174 merged on a re-pinned status with no retest ProwJob), and Tide's `prowJobsFromContexts` reads only the state and the `BaseSHA:` suffix, never the description text. The first admin `/override` after this merges is the observation; the workflow run's log will show the pin.

## Self-Review

Passes run: `review-adversarial` once and `review-docs-drift` three times (once per prose revision), each in a fresh subagent handed the diff range and the skill path, told not to read commit messages, and forbidden from editing. `make docs-check` ran in the main loop before each round.

- **LOW, CONFIRMED (adversarial, angles H/I), also Advisory (docs-drift round 1). Fixed.** The new prose said an override "holds until a push" unconditionally and equated it with `/override-sticky`. The re-pin is a race with Tide's once-a-minute sync, and a lost race costs an override more than a green: the retest is of a job that cannot pass, so it reds and the admin overrides again. All three passages now say "whenever the sweep wins the race", state the lost-race cost, and say the sentinel has no race.
- **Blocking (docs-drift round 2). Rejected, with a fix to the test fixture comment.** It said the override plugin, not crier, writes the `BaseSHA:` suffix, citing upstream `main`. On the deployed build, `/override` leaves two statuses in the same second on #1177's head: a bare `Overridden by bradhoekstra` with the job URL (the plugin's own `CreateStatus`, which predates upstream's `ContextDescriptionWithBaseSha` call there) and a suffixed one with the comment URL (crier reporting the synthetic success ProwJob, whose URL is the comment). The prose keeps crier. The fixture comment had this backwards and was corrected; a test for the bare status was added. Round 3 re-verified against the live statuses and agreed.
- **Advisory (docs-drift round 2). Fixed.** "The race below" in the docstring pointed the wrong way; the workflow header listed the new behaviour under "What it does NOT change"; "verbatim" on the fixture overstated it (the live description has an ASCII space before `BaseSHA:` that `split_description` collapses).
- **Advisory (docs-drift round 3). Fixed.** The header's "when its green arrives after `main` has already moved" now notes that the plugin's bare status, having no base, is pinned regardless.
- **Advisory (docs-drift round 3). Not changed.** The doc and header say "crier stamps the suffix" without the two-status detail; the script docstring carries that detail and is the canonical description of the mechanism.
- Adversarial angles that found nothing: A (line-by-line, including long-username truncation dropping the note whole), B (the removed guard is the intent; tests assert the inverse), C (no dangling references; `description` absent from the `if:`), D (removing `github.event.description` from the expression reduces exposure; token scope unchanged), E/F/G (code got smaller), H no-magic-constants (only a removal), I (every hunk serves the intent), J (no overlapping open pull request).
- Not covered by any pass: the workflow was not executed live; the deployed Prow's plugin help was read from `plugin-help.js` (lists `/override` only) but the hook's version is not exposed.

Generated with the help of Claude Code (Claude Fable 5.1).

## Risk & Rollout

Blast radius is one status context on open pull requests against `main`. The new failure mode is the one intended: an admin's override now outlives merges to `main` for the head it was given, so an override given for a transient infra red persists until the author pushes, even if the red would have cleared on its own. That is the semantics upstream chose for `/override-sticky`, and `/override` was already reserved for reds classified as not the pull request's. A red, a pending, and a newer status on the context are still never touched. Revert by reverting the commit; the next sweep leaves overrides alone again and already-pinned ones expire at the next merge as before. Nothing has to happen at merge time.
