### PR TITLE
ci(risk-classify): key the concurrency group on the pull request head

### DIFF
--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -36,10 +36,11 @@ permissions: {}
 # started first, the edit's run started a second later still carrying the old
 # head, and being newer it cancelled the push's run. The script classifies
 # whatever head the API reports, so the verdict was right either way -- but
-# the cancelled `classify` check run was the only one on the new head, and
-# Tide counts a cancelled check run as failing whether or not the context is
-# required, so the pull request sat unmerged with lgtm and approve. Keyed by
-# head, a run can only supersede runs for its own head.
+# the edit's run put its `classify` check run on the old head, which left the
+# cancelled one as the only `classify` on the new head, and Tide counts a
+# cancelled check run as failing whether or not the context is required, so
+# the pull request sat unmerged with lgtm and approve. Keyed by head, a run
+# can only supersede runs for its own head.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -3,7 +3,8 @@ name: Risk Classification
 # Classifies every pull request's risk tier (low / medium / high) from its
 # diff, against the rules in .github/risk-rules.yml -- a non-blocking signal
 # for reviewers (#818). The verdict lands as a `Risk Classification` check run
-# that always concludes `success`, and a `risk:*` label.
+# that always concludes `success`, and a `risk:*` label. The job's own
+# `classify` check run is the one Tide can trip over; see `concurrency` below.
 #
 # The trigger cannot be `pull_request`: every pull request here comes from a
 # fork, and on a fork `pull_request` hands the workflow a read-only
@@ -39,7 +40,7 @@ permissions: {}
 # the edit's run put its `classify` check run on the old head, which left the
 # cancelled one as the only `classify` on the new head, and Tide counts a
 # cancelled check run as failing whether or not the context is required, so
-# the pull request sat unmerged with lgtm and approve. Keyed by head, a run
+# the pull request sat unmerged with lgtm and approved. Keyed by head, a run
 # can only supersede runs for its own head.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/risk_classify.yml
+++ b/.github/workflows/risk_classify.yml
@@ -27,10 +27,21 @@ on:
 
 permissions: {}
 
-# One run per pull request, newest wins: a push supersedes the classification
-# of the commit it replaced.
+# One run per pull request head, newest wins: a second event for the same
+# head supersedes the run already classifying it.
+#
+# The head SHA is in the group, not just the number, because two events a
+# second apart can start their runs in the other order. On 2026-09-09 a body
+# edit landed two seconds before a push (#1364): the push's `synchronize` run
+# started first, the edit's run started a second later still carrying the old
+# head, and being newer it cancelled the push's run. The script classifies
+# whatever head the API reports, so the verdict was right either way -- but
+# the cancelled `classify` check run was the only one on the new head, and
+# Tide counts a cancelled check run as failing whether or not the context is
+# required, so the pull request sat unmerged with lgtm and approve. Keyed by
+# head, a run can only supersede runs for its own head.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -335,12 +335,12 @@ Those ten are not the whole required set either. Tide also requires every Prow p
 (GoogleCloudPlatform/oss-test-infra#2677), so the behavioural presubmit gates every merge from that
 date. The command below therefore answers part of the question, and the two lists together still do
 not answer all of it: they say which contexts must be _present_ and green, but Tide also refuses any
-posted context that is not green, required or not, unless Prow marks it `optional`, because this
-repository sets no Tide context policy and the default treats a cancelled or failed check run as a
-failing context. A `classify` run cancelled
+posted context that is not green, required or not, unless Prow marks it `optional`: Tide always
+reads a cancelled or failed check run as a failing context, and with no Tide context policy for this
+repository an unknown context is not optional. A `classify` run cancelled
 by a superseding event held #1364 unmerged with `lgtm` and `approved` on it, though `classify` is in
-neither list. `tide`'s own status names the offending context; a `gh run rerun --job` of the
-cancelled job clears it.
+neither list. `tide`'s own status names the offending context; `gh run rerun <run-id> --job <job-id>`
+clears it — by job ID, since `--failed` (below) re-runs failed jobs and a cancelled one is not failed.
 
 ```bash
 gh api repos/gke-labs/kube-agents/branches/main/protection \

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -333,8 +333,13 @@ Those ten are not the whole required set either. Tide also requires every Prow p
 `optional`, and those are configured in `oss-test-infra` rather than in branch protection —
 `pull-kube-agents-smoke-test` dropped its `optional: true` on 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677), so the behavioural presubmit gates every merge from that
-date. The command below therefore answers half the question, and a red check in neither list blocks
-no merge:
+date. The command below therefore answers half the question. It does not answer a third one either:
+the two lists say which contexts must be _present_ and green, but Tide also refuses any context that
+is present and not green, required or not, because this repository sets no Tide context policy and
+the default treats a cancelled or failed check run as a failing context. A `classify` run cancelled
+by a superseding event held #1364 unmerged with `lgtm` and `approved` on it, though `classify` is in
+neither list. `tide`'s own status names the offending context; a `gh run rerun --job` of the
+cancelled job clears it.
 
 ```bash
 gh api repos/gke-labs/kube-agents/branches/main/protection \
@@ -407,8 +412,8 @@ test is a different system and is not watched; the `presubmit-gate` label is tha
 Every open pull request has exactly one party whose move it is, and the commonest way one sits for
 a fortnight is that both sides believe it is the other's. The rule:
 
-**The author owns it while it is blocked on them** — a draft, failing _required_ checks, merge
-conflicts, unresolved review threads, changes requested, or no human reviewer requested yet.
+**The author owns it while it is blocked on them** — a draft, a failing or cancelled check that
+`tide` names, merge conflicts, unresolved review threads, changes requested, or no human reviewer requested yet.
 **Otherwise the requested reviewers own it.** A past reviewer does not: an approval already given
 is not an outstanding obligation. `kube-agents-bot` and other bot reviewers never count either way.
 
@@ -426,9 +431,10 @@ Four states that look like somebody else's problem and are not:
   Clearing the findings and commenting `/review` for a clean pass is what summons one;
   `/request-review` is the override. Answering every bot thread does not summon one by itself, so
   an author who has done everything asked of them can still be sitting with nobody assigned.
-- **A red check that is not required.** It blocks no merge and is not the author's problem — but
-  "required" means both lists above, not branch protection's ten alone, and `tide` is what actually
-  knows. Ask it before treating a failing job as work owed, and before concluding one is not.
+- **A red check that is not required.** It still blocks the merge if it is red on the head: Tide
+  refuses any posted context that is not green, not only the ones on the two lists above, so a
+  cancelled run of a non-required job is the author's problem too. `tide` is what actually knows —
+  ask it before treating a failing job as work owed, and before concluding one is not.
 - **`mergeable: UNKNOWN`.** GitHub computes mergeability lazily and the first query only triggers
   the job, so a conflict reads as conflict-free until you ask twice.
 

--- a/docs/pull-request-workflow.md
+++ b/docs/pull-request-workflow.md
@@ -307,7 +307,7 @@ and retries it every ~85 seconds ahead of everyone else — #608 and #1197 held 
 for an hour on 2026-09-05. `/hold cancel` does not remove this label; resolving the threads does.
 A person who applies the same label by hand keeps it: the workflow removes only what it added.
 `/override <context>`, which only
-a repository admin can use, forces a required check that cannot pass on its own. The forced status
+a repository admin can use, forces a check that cannot pass on its own, required or not. The forced status
 embeds the base SHA at override time, so by itself it would expire on the next merge to `main` and
 Tide would re-run the job — which is how an override came to need repeating whenever `main` moved
 before Tide merged (#1202). The re-pin below carries it across merges the way it carries a green, so
@@ -326,17 +326,18 @@ contexts — `cla/google`, `actionlint`, `build`, `prettier`, `validate`, `Run C
 reviews, because approval is Tide's business rather than GitHub's. A reader who checks the
 repository settings for the review requirement therefore finds nothing and concludes wrongly.
 
-The last four joined the set on 2026-09-02; before that they reported on every pull request without
-gating one.
+The last four joined the set on 2026-09-02; before that, a pull request they had not run on could
+merge without them.
 
 Those ten are not the whole required set either. Tide also requires every Prow presubmit not marked
 `optional`, and those are configured in `oss-test-infra` rather than in branch protection —
 `pull-kube-agents-smoke-test` dropped its `optional: true` on 2026-09-02
 (GoogleCloudPlatform/oss-test-infra#2677), so the behavioural presubmit gates every merge from that
-date. The command below therefore answers half the question. It does not answer a third one either:
-the two lists say which contexts must be _present_ and green, but Tide also refuses any context that
-is present and not green, required or not, because this repository sets no Tide context policy and
-the default treats a cancelled or failed check run as a failing context. A `classify` run cancelled
+date. The command below therefore answers part of the question, and the two lists together still do
+not answer all of it: they say which contexts must be _present_ and green, but Tide also refuses any
+posted context that is not green, required or not, unless Prow marks it `optional`, because this
+repository sets no Tide context policy and the default treats a cancelled or failed check run as a
+failing context. A `classify` run cancelled
 by a superseding event held #1364 unmerged with `lgtm` and `approved` on it, though `classify` is in
 neither list. `tide`'s own status names the offending context; a `gh run rerun --job` of the
 cancelled job clears it.
@@ -413,7 +414,8 @@ Every open pull request has exactly one party whose move it is, and the commones
 a fortnight is that both sides believe it is the other's. The rule:
 
 **The author owns it while it is blocked on them** — a draft, a failing or cancelled check that
-`tide` names, merge conflicts, unresolved review threads, changes requested, or no human reviewer requested yet.
+`tide` names, merge conflicts, unresolved review threads, changes requested, or no human reviewer
+requested yet.
 **Otherwise the requested reviewers own it.** A past reviewer does not: an approval already given
 is not an outstanding obligation. `kube-agents-bot` and other bot reviewers never count either way.
 
@@ -432,8 +434,9 @@ Four states that look like somebody else's problem and are not:
   `/request-review` is the override. Answering every bot thread does not summon one by itself, so
   an author who has done everything asked of them can still be sitting with nobody assigned.
 - **A red check that is not required.** It still blocks the merge if it is red on the head: Tide
-  refuses any posted context that is not green, not only the ones on the two lists above, so a
-  cancelled run of a non-required job is the author's problem too. `tide` is what actually knows —
+  refuses any posted context that is not green unless Prow marks it `optional`, not only the ones on
+  the two lists above, so a cancelled run of a non-required job is the author's problem too. `tide`
+  is what actually knows —
   ask it before treating a failing job as work owed, and before concluding one is not.
 - **`mergeable: UNKNOWN`.** GitHub computes mergeability lazily and the first query only triggers
   the job, so a conflict reads as conflict-free until you ask twice.

--- a/scripts/classify_risk.py
+++ b/scripts/classify_risk.py
@@ -386,6 +386,10 @@ def post_check_run(api, head_sha, result):
     SHA; a fresh POST each time would stack runs, leaving the stale verdict
     ("declares low") standing beside the corrected one with nothing marking
     which is current. So the existing run is PATCHed when there is one --
+    the list-then-write is not atomic, so two runs classifying one head at
+    the same moment (the workflow groups concurrency per head, so an `edited`
+    run for a superseded head and the `synchronize` run for the current one
+    can overlap) may both POST; later runs then PATCH the newest of the pair --
     filtered to the github-actions app AND this script's external_id. The app
     slug alone is not enough: the workflow job's own check run is created by
     the same app on the same SHA, and on a re-classification it is the newest

--- a/tests/test_risk_classify_workflow.py
+++ b/tests/test_risk_classify_workflow.py
@@ -3,7 +3,7 @@
 The classification itself is `scripts/classify_risk.py`, tested beside it.
 What this file pins is the one line of YAML that no other test reaches and
 that GitHub's scheduler, not the script, acts on: the concurrency group. The
-other pull-request workflows here that set one group by pull request number
+other pull-request workflows here that set one key it by pull request number
 alone, so a cleanup that normalises this one to match is the likeliest way
 the #1364 hang comes back -- an `edited` run carrying the previous head cancelling the
 `synchronize` run for the current one, leaving the current head with a

--- a/tests/test_risk_classify_workflow.py
+++ b/tests/test_risk_classify_workflow.py
@@ -1,0 +1,45 @@
+"""Tests for the wiring in .github/workflows/risk_classify.yml.
+
+The classification itself is `scripts/classify_risk.py`, tested beside it.
+What this file pins is the one line of YAML that no other test reaches and
+that GitHub's scheduler, not the script, acts on: the concurrency group. Every
+other pull-request workflow here groups by pull request number alone, so a
+cleanup that normalises this one to match is the likeliest way the #1364 hang
+comes back -- an `edited` run carrying the previous head cancelling the
+`synchronize` run for the current one, leaving the current head with a
+cancelled `classify` check run that Tide reads as failing.
+"""
+
+import pathlib
+import unittest
+
+import yaml
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO_ROOT / ".github" / "workflows" / "risk_classify.yml"
+
+_PR_NUMBER = "${{ github.event.pull_request.number }}"
+_HEAD_SHA = "${{ github.event.pull_request.head.sha }}"
+
+
+def _load():
+    return yaml.safe_load(_WORKFLOW.read_text())
+
+
+class ConcurrencyGroupTest(unittest.TestCase):
+    def setUp(self):
+        self.concurrency = _load()["concurrency"]
+
+    def test_group_is_keyed_on_the_head_sha_as_well_as_the_number(self):
+        """A run may supersede only runs for its own head; the number alone lets a stale-head run cancel the current one."""
+        group = self.concurrency["group"]
+        self.assertIn(_PR_NUMBER, group)
+        self.assertIn(_HEAD_SHA, group)
+
+    def test_newest_run_for_a_head_still_wins(self):
+        """Two events for one head collapse to the newest; per-head keying is not a reason to stop cancelling."""
+        self.assertIs(self.concurrency["cancel-in-progress"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_risk_classify_workflow.py
+++ b/tests/test_risk_classify_workflow.py
@@ -2,10 +2,10 @@
 
 The classification itself is `scripts/classify_risk.py`, tested beside it.
 What this file pins is the one line of YAML that no other test reaches and
-that GitHub's scheduler, not the script, acts on: the concurrency group. Every
-other pull-request workflow here groups by pull request number alone, so a
-cleanup that normalises this one to match is the likeliest way the #1364 hang
-comes back -- an `edited` run carrying the previous head cancelling the
+that GitHub's scheduler, not the script, acts on: the concurrency group. The
+other pull-request workflows here that set one group by pull request number
+alone, so a cleanup that normalises this one to match is the likeliest way
+the #1364 hang comes back -- an `edited` run carrying the previous head cancelling the
 `synchronize` run for the current one, leaving the current head with a
 cancelled `classify` check run that Tide reads as failing.
 """


### PR DESCRIPTION
## Summary

The Risk Classification workflow's concurrency group now carries the pull request head SHA as well as its number, so a run that starts later but was triggered against a superseded head can no longer cancel the run for the current head. On #1364 that cancellation left the current head with a single, cancelled `classify` check run, and Tide held the pull request unmerged with `lgtm` and `approved` on it. The pull request workflow doc, which said a red non-required check blocks no merge, now states what Tide actually does, and a wiring test pins the group key.

## Why This Change

`risk_classify.yml` runs on `pull_request_target` for `synchronize` and `edited` among others, grouped by pull request number with `cancel-in-progress: true`. Two events a second apart can start their runs in the other order. On 2026-09-09 the robot edited #1364's body two seconds before its push landed; the push's run (head `dc7d564`) started at 19:37:52 and the edit's run, still carrying the previous head `bfe1314`, started at 19:37:53 and cancelled it. The script classifies whatever head the API reports, so the verdict was posted on the right head, but the edit's own `classify` job check run went to the old head, leaving the cancelled one as the only `classify` on the new head. Tide reads a cancelled check run as failing, and with no Tide context policy for this repository an unknown context is not optional, so a non-required job's cancelled run blocks the merge. Without the change the same push-then-edit sequence, which the robot performs on every push, can hang any pull request until someone re-runs the job by hand.

## What Changed

- `.github/workflows/risk_classify.yml`: the concurrency group is `<workflow>-<number>-<head.sha>`. Two events for the same head still collapse to the newest; a run can no longer supersede a run for a different head. The comment records the incident, and the header points at the job's own check run as the one Tide can trip over.
- `docs/pull-request-workflow.md`: the merge-gate paragraph, the ownership rule, and the "red check that is not required" bullet now say Tide refuses any posted context that is not green unless Prow marks it optional, with the job-id re-run that clears a cancelled one. The sentence about the four contexts that became required on 2026-09-02 now says what changed that day: their absence started blocking.
- `tests/test_risk_classify_workflow.py`: asserts the group carries both the number and the head SHA and that `cancel-in-progress` stays on. Red against the old group string, green against the new.
- `scripts/classify_risk.py`: the `post_check_run` docstring notes that two runs for one head can now overlap and both create a check run, and that later runs patch the newest.

## Context

The incident is #1364 (`kube-agents-robot`), blocked from 14:49 to 20:35 UTC on 2026-09-10 on `Not mergeable. Job classify has not succeeded.` until the cancelled job was re-run. #1322 hit the same race this morning but the surviving run happened to be for the right head. No open pull request touches the workflow; #1436 edits other passages of the same doc page with no overlapping hunks. The sibling `pull_request` workflows share the out-of-order cancel exposure for two pushes seconds apart but lack the `edited` trigger that makes it likely, so they are left alone.

## Testing

- `pytest tests/test_risk_classify_workflow.py scripts/test_classify_risk.py tests/conformance/test_B_write_path.py scripts/test_integration_contracts.py`: all pass. The new test was also run against a copy of the workflow with the head SHA removed from the group and fails there.
- `actionlint` v1.7.7 on the workflow, `prettier@3.9.6 --check` on the changed YAML and Markdown, `make docs-check`: all clean.

### Live validation

A `pull_request_target` workflow runs the base branch's definition, so the change cannot exercise itself from this pull request. It was exercised on the fork instead: the fork's `main` was fast-forwarded to the first commit of this branch, and a throwaway pull request (bradhoekstra/kube-agents#38) opened against it.

- The `opened` run completed under the new group: `classify` and `Risk Classification` both `success`, `risk:medium` applied.
- The incident sequence, body edit then a push one second later: the edit's run (34527835098, head `0997bfd`) and the push's run (34527838117, head `de612be`) were in progress at the same time and both completed `success`. The new head carries a successful `classify` check run. Under the old group the newer run would have cancelled the older.
- Two body edits back to back on one head: run 34527915591 was cancelled by run 34527917802, and the head keeps a successful `classify`. The newest-wins behaviour per head is intact.

Cleanup: the test pull request is closed with a comment naming the runs, its branch deleted, and the fork's `main` reset to upstream's tip. No kube-agents installation is involved; nothing here reaches a cluster.

## Self-Review

Passes: `review-adversarial` twice and `review-docs-drift` three times, each in a fresh subagent handed the range, the skill path, and the `make docs-check` output, with commit messages and notes withheld. Nothing was reviewed in the context that wrote the change. Re-runs followed each fix round; the last round changed prose only, so the adversarial pass was not re-run against it.

- **Blocking (docs-drift):** `docs/pull-request-workflow.md` said three times that a red check outside the required lists blocks no merge. Fixed: all three passages now state the rule the incident demonstrates.
- **Blocking (docs-drift, second round):** after that rewrite, the sentence saying the four newly required contexts had "reported without gating" contradicted the new paragraph. Fixed.
- **LOW, CONFIRMED (adversarial, test coverage):** nothing pinned the head SHA in the group while other workflows' concurrency blocks have wiring tests. Fixed: the new test, verified red-then-green.
- **LOW, PLAUSIBLE (adversarial, removed serialisation):** two runs classifying one head at the same moment can both create a `Risk Classification` check run because the script lists then writes. Not fixed: both conclude `success`, Tide keeps the best state per name, and the cost is a duplicate on the checks tab. The docstring now records the overlap.
- **LOW, PLAUSIBLE (adversarial, removed serialisation):** the old group also serialised label writes, so a run stalled about a job length between reading the pull request and writing labels could leave two `risk:` labels until the next event. Not fixed: it self-heals on the next push or edit, and `sync_labels` tolerates the 404 or 422 the second writer sees.
- **LOW, PLAUSIBLE (adversarial, prose):** "any non-green context" was broader than Tide's rule, which exempts contexts Prow marks optional. Fixed in both passages.
- **Advisory (docs-drift), fixed:** the comment's "only one on the new head" phrasing; "approve" for "approved"; the override sentence saying "required"; the "half the question" count; the sentence fusing Tide's cancelled-to-failing mapping with the missing context policy; the re-run recipe, now by job id with the reason `--failed` does not reach a cancelled job; the test docstring's grammar and its "every other workflow" overstatement; a header pointer to the job's own check run.
- **Advisory (docs-drift), not fixed:** `docs/testing-map.md`, `AGENTS.md`, and `agents/contributor/AGENTS.md` say "required checks green" as a merge precondition. Those are necessary-not-sufficient summaries that link to the canonical page, and `AGENTS.md` is at its context budget.
- **Could not cover:** the exact gap between the body edit and the push on #1364 is inferred from run creation times, since GitHub exposes no timestamp for body edits. Whether GitHub's checks view collapses two same-name check runs from different suites was not verified.

Generated with the help of Claude (Fable 5.1).

## Risk & Rollout

Low risk. No runtime code path changes; the workflow's permissions, checkout ref, and steps are untouched. The new failure mode is one extra completed run when an edit and a push overlap, which is idempotent on labels and harmless on the check run. Revert is a one-line change to the group key. Nothing has to happen at merge time; the new grouping takes effect for every pull request as soon as it is on `main`, since `pull_request_target` reads the base branch's definition.
