### PR TITLE
fix(scripts): register the redactor in sys.modules while loading it

### DIFF
--- a/scripts/test_task_registration.py
+++ b/scripts/test_task_registration.py
@@ -881,12 +881,14 @@ class TestTheSanitizer(unittest.TestCase):
         # The loader runs the redactor outside the import system, which is
         # cheap until the file pairs a dataclass with `from __future__ import
         # annotations`. Every annotation is a string then, and dataclasses
-        # resolves an unqualified one through sys.modules[cls.__module__] --
-        # unguarded, so a module never registered there dies on None, inside
-        # dataclasses and nowhere near the shapes this scan wants.
-        # gke-labs/kube-agents#1364 added RedactionRule and reded every test in
-        # this file. Both halves matter, so both are here; a fixture of our own
-        # keeps this a test of the loader after the redactor's contents move on.
+        # probes an unqualified one for KW_ONLY through
+        # sys.modules[cls.__module__] -- unguarded, so a module never
+        # registered there dies on None, inside dataclasses and nowhere near
+        # the shapes this scan wants. gke-labs/kube-agents#1364 added
+        # RedactionRule and reded every test in this file. Both halves matter,
+        # so both are here; a fixture of our own keeps this a test of the
+        # loader after the redactor's contents move on.
+        self.addCleanup(sys.modules.pop, validator.REDACTOR_MODULE_NAME, None)
         source = textwrap.dedent(
             '''
             from __future__ import annotations
@@ -912,8 +914,14 @@ class TestTheSanitizer(unittest.TestCase):
                     self.assertEqual(
                         set(validator.credential_patterns()), {"a token"}
                     )
-        # ..and the loader leaves the import system as it found it.
-        self.assertNotIn(validator.REDACTOR_MODULE_NAME, sys.modules)
+            # ..and it is still registered afterwards, the way the gateway's
+            # loader in charts/kube-agents/files/litellm_redaction_callback.py
+            # leaves it. Asserting the name is *absent* would be no test at
+            # all -- that passes on the broken version too, which never
+            # registers anything.
+            loaded = sys.modules.get(validator.REDACTOR_MODULE_NAME)
+            self.assertIsNotNone(loaded)
+            self.assertEqual(pathlib.Path(loaded.__file__), path)
 
     def test_main_exits_non_zero_on_a_sanitization_finding(self):
         # main() scans the named case's directory, so a scratch draft is

--- a/scripts/test_task_registration.py
+++ b/scripts/test_task_registration.py
@@ -42,6 +42,7 @@ import pathlib
 import re
 import sys
 import tempfile
+import textwrap
 import unittest
 import unittest.mock
 
@@ -875,6 +876,44 @@ class TestTheSanitizer(unittest.TestCase):
         ):
             with self.assertRaises(validator.CaseError):
                 validator.credential_patterns()
+
+    def test_the_redactor_loads_even_though_it_defines_a_dataclass(self):
+        # The loader runs the redactor outside the import system, which is
+        # cheap until the file pairs a dataclass with `from __future__ import
+        # annotations`. Every annotation is a string then, and dataclasses
+        # resolves an unqualified one through sys.modules[cls.__module__] --
+        # unguarded, so a module never registered there dies on None, inside
+        # dataclasses and nowhere near the shapes this scan wants.
+        # gke-labs/kube-agents#1364 added RedactionRule and reded every test in
+        # this file. Both halves matter, so both are here; a fixture of our own
+        # keeps this a test of the loader after the redactor's contents move on.
+        source = textwrap.dedent(
+            '''
+            from __future__ import annotations
+
+            import re
+            from dataclasses import dataclass
+
+            @dataclass(frozen=True)
+            class Rule:
+                name: str
+
+            class AuditRedactor:
+                A_TOKEN = re.compile(r"tok-[0-9]+")
+            '''
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "redactor.py"
+            path.write_text(source, encoding="utf-8")
+            with unittest.mock.patch.object(validator, "REDACTOR_FILE", path):
+                with unittest.mock.patch.dict(
+                    validator.CREDENTIAL_SHAPES, {"A_TOKEN": "a token"}, clear=True
+                ):
+                    self.assertEqual(
+                        set(validator.credential_patterns()), {"a token"}
+                    )
+        # ..and the loader leaves the import system as it found it.
+        self.assertNotIn(validator.REDACTOR_MODULE_NAME, sys.modules)
 
     def test_main_exits_non_zero_on_a_sanitization_finding(self):
         # main() scans the named case's directory, so a scratch draft is

--- a/scripts/validate_bench_cases.py
+++ b/scripts/validate_bench_cases.py
@@ -703,24 +703,28 @@ def credential_patterns() -> dict[str, re.Pattern[str]]:
     if spec is None or spec.loader is None:
         raise CaseError(f"{REDACTOR_FILE}: could not be loaded")
     module = importlib.util.module_from_spec(spec)
-    # Registered for the duration of the exec, then taken back out. A module
-    # object on its own is not enough once the file defines a dataclass. The
-    # redactor carries `from __future__ import annotations`, so every field
-    # annotation reaches dataclasses as a string, and an unqualified one like
-    # `name: str` is resolved through sys.modules[cls.__module__].__dict__ --
-    # unguarded, so a module that was never registered there raises
-    # AttributeError on None (dataclasses._is_type). The failure surfaces
-    # inside dataclasses, nowhere near this loader.
+    # Registered before the exec, the way the import system would, and left
+    # there. A module object on its own stopped being enough once the redactor
+    # gained a dataclass: the file carries `from __future__ import annotations`,
+    # so every field annotation reaches dataclasses as a string, and an
+    # unqualified one like `name: str` gets probed for KW_ONLY through
+    # sys.modules[cls.__module__].__dict__ -- unguarded, so a module absent
+    # from sys.modules dies there on None (dataclasses._is_type). The failure
+    # lands inside dataclasses, nowhere near this loader.
     #
-    # Taking it back out afterwards keeps the "loaded, not imported" property
-    # the docstring claims. Nothing below reads the module through sys.modules.
+    # Same shape as _load_redactor in charts/kube-agents/files/
+    # litellm_redaction_callback.py, which loads this same redactor at the
+    # gateway and hit this first; one convention between the two loaders is
+    # worth more than a marginally tidier sys.modules here. Leaving it
+    # registered also keeps the module usable afterwards -- unregistering it
+    # would leave an object whose own annotations no longer resolve, which
+    # breaks at a distance rather than here. REDACTOR_MODULE_NAME is ours
+    # alone (see its definition), so this displaces nothing.
     sys.modules[REDACTOR_MODULE_NAME] = module
     try:
         spec.loader.exec_module(module)
     except Exception as exc:  # any import failure is the finding, whatever its class
         raise CaseError(f"{REDACTOR_FILE}: could not be imported: {exc}") from exc
-    finally:
-        sys.modules.pop(REDACTOR_MODULE_NAME, None)
     redactor = getattr(module, REDACTOR_CLASS, None)
     patterns: dict[str, re.Pattern[str]] = {}
     for attribute, label in CREDENTIAL_SHAPES.items():

--- a/scripts/validate_bench_cases.py
+++ b/scripts/validate_bench_cases.py
@@ -703,10 +703,24 @@ def credential_patterns() -> dict[str, re.Pattern[str]]:
     if spec is None or spec.loader is None:
         raise CaseError(f"{REDACTOR_FILE}: could not be loaded")
     module = importlib.util.module_from_spec(spec)
+    # Registered for the duration of the exec, then taken back out. A module
+    # object on its own is not enough once the file defines a dataclass. The
+    # redactor carries `from __future__ import annotations`, so every field
+    # annotation reaches dataclasses as a string, and an unqualified one like
+    # `name: str` is resolved through sys.modules[cls.__module__].__dict__ --
+    # unguarded, so a module that was never registered there raises
+    # AttributeError on None (dataclasses._is_type). The failure surfaces
+    # inside dataclasses, nowhere near this loader.
+    #
+    # Taking it back out afterwards keeps the "loaded, not imported" property
+    # the docstring claims. Nothing below reads the module through sys.modules.
+    sys.modules[REDACTOR_MODULE_NAME] = module
     try:
         spec.loader.exec_module(module)
     except Exception as exc:  # any import failure is the finding, whatever its class
         raise CaseError(f"{REDACTOR_FILE}: could not be imported: {exc}") from exc
+    finally:
+        sys.modules.pop(REDACTOR_MODULE_NAME, None)
     redactor = getattr(module, REDACTOR_CLASS, None)
     patterns: dict[str, re.Pattern[str]] = {}
     for attribute, label in CREDENTIAL_SHAPES.items():


### PR DESCRIPTION
## Summary

`Python Unit Tests` has been red on every `main` commit since #1364 landed.  `scripts/validate_bench_cases.py` loads the audit redactor by path without registering it in `sys.modules`, which was fine until #1364 gave that file a dataclass.  This registers it, matching the loader the chart already ships.

## Why This Change

`main` is red and stays red until this lands.  Every PR's `Python Unit Tests` inherits the failure, so it is not just cosmetic -- it hides real regressions in anything that touches `scripts/`.

The break is not in #1364.  `credential_patterns()` runs the redactor through `importlib.util.module_from_spec` + `exec_module` without putting it in `sys.modules`, on the theory that loading a file is cheaper than importing a package.  That works right up until the file defines a dataclass.

`agents/chat/defaults/plugins/common/redactor.py` carries `from __future__ import annotations` (line 32), so every field annotation arrives at `dataclasses` as a string.  For an unqualified one like `name: str`, `dataclasses._is_type` probes whether it denotes `KW_ONLY` or `ClassVar` by way of `sys.modules.get(cls.__module__).__dict__` -- unguarded, so a module that was never registered gets `None` and the whole thing dies with `AttributeError: 'NoneType' object has no attribute '__dict__'`.  #1364 added `RedactionRule` with exactly that shape.

Both halves are needed to trigger it.  A qualified annotation like `pattern: "re.Pattern[str]"` takes a different, guarded branch and is harmless, which is why the file's other fields were fine.  The failure surfaces inside `dataclasses`, nowhere near the loader, which is what made it look like a #1364 bug.

## What Changed

- `scripts/validate_bench_cases.py`: register the module under `REDACTOR_MODULE_NAME` before `exec_module`, and leave it there.
- `scripts/test_task_registration.py`: a regression test that builds its own minimal fixture with both halves (`from __future__ import annotations` + an unqualified dataclass field), so it stays a test of the loader after the real redactor's contents move on.

Second commit (60a6ac6e) is the self-review follow-up.  The first version popped the module back out afterwards; that turned out to be worse in three ways, see Self-Review below.

## Context

Bisected to a3fe6f48 (#1364), which merged at 01:48:17Z.  `9fb840e5` at 01:48:07Z was the last green, and #1364's own merge run was already red.  Reproduced against a pristine `origin/main` worktree before touching anything, so this is not an artefact of a local branch.

`charts/kube-agents/files/litellm_redaction_callback.py::_load_redactor` loads this same `redactor.py` at the gateway and hit this first -- it registers before the exec and does not pop.  This change makes the two loaders agree.  Worth knowing if a third one ever shows up: loading a file that defines a dataclass by path means registering it, full stop.

## Testing

- `python3 -m unittest discover -p 'test_*.py'` under `scripts/`: **1416 tests OK** (1 skipped).
- `make bench-case-check`: **33 bench cases OK**.
- Regression test verified in both directions.  Against `origin/main`'s loader it fails with the exact production error (`could not be imported: 'NoneType' object has no attribute '__dict__'`); with the fix it passes.
- Ran the loader against Python **3.12.8, 3.13.7 and 3.14.2** -- unregistered raises, registered loads, behaviour identical on all three.  CI pins `.python-version` to 3.12 and the agent-plugin workflows use `.agent-python-version` 3.13, so both are covered.
- `git status` clean, `make docs-check` exit 0.

## Live validation

**Not live-tested.**  This is a test-infrastructure fix in `scripts/` -- `validate_bench_cases.py` runs in CI and from `make bench-case-check`, and never reaches a running installation.  There is nothing on the dev cluster to point it at.  The equivalent of a live run here is executing the real validator against the real redactor, which is what `make bench-case-check` does, and it is in Testing above.

## Self-Review

Two passes, both run in **fresh general-purpose subagent contexts** that did not write the change -- each was handed the diff range and nothing else.

**Docs-drift pass.  Zero findings.**  Looked for docs asserting the old "loaded, not imported" property or describing the validator's contract.  Searched `validate_bench_cases`, `credential_patterns`, `bench-case-check`, `REDACTOR_MODULE_NAME`, `REDACTOR_FILE`, `REDACTOR_CLASS`, `CREDENTIAL_SHAPES`, `sanitization_findings`, `AuditRedactor`, `test_task_registration`, `RedactionRule`, `sys.modules`, `spec_from_file_location`.  Read `AGENTS.md:53-54`, `docs/designs/bench-case-format.md:291-341,357`, `bench/CONTRIBUTING.md:58-70`, `bench/CUSTOM-TASKS.md:238-250`, `docs/testing-map.md:96-102`, `docs/README.md:334,439`, `tests/conformance/README.md:161-162`.  All unaffected -- the docstring's "loaded from the file rather than imported as a package" claim is about `sys.path` and package semantics, not `sys.modules`, and is still true.

**Adversarial pass.  Nine checks, four findings, three fixed and one accepted.**

- **MEDIUM, fixed in 60a6ac6e** -- the unconditional `sys.modules.pop` destroyed a pre-existing entry instead of restoring it.  Confirmed by execution, not just by reading.
- **MEDIUM, fixed in 60a6ac6e** -- diverged from `_load_redactor` in the chart, which already solves this identically and leaves the module registered.  I verified this one against the file myself rather than taking the pass's word for it.  Two loaders of the same redactor with two conventions, and mine was the riskier.  Now they match, which retires the first finding too.
- **LOW, fixed in 60a6ac6e** -- the test's closing assertion was vacuous.  `assertNotIn(REDACTOR_MODULE_NAME, sys.modules)` passes identically on unfixed `main`, where nothing is ever registered.  It now asserts the module is present and is the one that was loaded, and it fails on `main` with the original `AttributeError`.
- **NIT, fixed in 60a6ac6e** -- "resolved through `sys.modules`" in both comments.  `dataclasses` is not resolving the annotation, it is probing whether it denotes `KW_ONLY`/`ClassVar`.  The wrong word points a reader at a different and wrong fix.
- Clean: the test genuinely reproduces the bug (verified by execution both ways); no state leakage between tests; the stdlib claim in the comments is accurate against `dataclasses._is_type` source; no 3.12-vs-3.14 divergence; `CaseError` wrapping is correct.

Nothing was left deliberately unfixed.

Worth flagging for the reviewer since it is a judgement call rather than a defect: I chose "register and leave it" over "save and restore" because it matches the chart loader.  Save/restore would keep `sys.modules` marginally tidier, at the cost of two loaders of one file disagreeing, and of handing back a module whose own dataclass annotations no longer resolve.

## Risk & Rollout

Low.  The change is three lines in a CI-only script plus a test.  `REDACTOR_MODULE_NAME` (`kube_agents_audit_redactor`) is ours alone and matches no package, so registering it displaces nothing -- the comment at its definition claimed as much already, and this makes the claim load-bearing.

Rollback is a revert; it puts `main`'s Python job back to red but breaks nothing else.  No runtime, chart, or operator surface is touched.
