### PR TITLE
fix(release): schedule weekly GA release for Friday morning overnight

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -9,7 +9,7 @@ name: "Release: Scheduler"
 # work is required, quietly recording skips to Job Summary when no candidate
 # exists or when no commits have merged since the last release.
 #
-# Every Thursday, the scheduler ships whatever has merged since the last GA release.
+# Every Friday, the scheduler ships whatever has merged since the last GA release.
 # In pre-1.0 initial development (0.y.z), breaking changes bump minor under SemVer 2.0
 # Clause 4 and release unattended. Once 1.0.0 has been cut, resolve_scheduled_release.sh
 # halts on major breaking changes with exit 1 and an error annotation, turning this scheduler
@@ -20,9 +20,9 @@ permissions:
 
 on:
   schedule:
-    - cron: "17 5 * * 4"
+    - cron: "17 5 * * 5"
   # Dispatchable so the evaluation can be exercised by hand without waiting for
-  # Thursday 05:17 UTC. It takes no inputs: the whole job is "work out whether
+  # Friday 05:17 UTC. It takes no inputs: the whole job is "work out whether
   # there is anything to release", and a manual run that overrode that would be
   # testing something else. To force a specific release through, dispatch
   # release-publish.yml directly with schedule_gate=bypass.

--- a/docs/site/src/content/docs/deploy/release-versioning.md
+++ b/docs/site/src/content/docs/deploy/release-versioning.md
@@ -33,14 +33,14 @@ also a hand-pushable redeploy trigger.
 The RC pipeline, the nightly staging promotion, and the GA release all run on schedules,
 with manual dispatches available for overrides and off-schedule releases.
 
-| Step                        | When it runs                                                                                                    | Workflow                                                                                                                          |
-| :-------------------------- | :-------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
-| RC selection and validation | Every three hours, at 17 minutes past. Dispatches nothing when the newest candidate has already been tried.     | `rc-scheduler.yml` starts `rc-release-pipeline.yml`, which pushes the `rc_*` and `rc_*_validated` tags.                           |
-| Staging promotion           | Daily at 02:17 UTC, against the newest validated candidate. One already promoted is re-tested, not re-tagged.   | `nightly-scheduler.yml` starts `nightly-pipeline.yml`, which pushes the `staging_<ts>_<sha>` tag when the full E2E matrix passes. |
-| GA release                  | Weekly on Thursdays at 05:17 UTC, or when a maintainer dispatches it; `release-publish.yml` has no `schedule:`. | `release-scheduler.yml` starts `release-publish.yml` with `schedule_gate=evaluate` when an eligible staging candidate is found.   |
+| Step                        | When it runs                                                                                                  | Workflow                                                                                                                          |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------- |
+| RC selection and validation | Every three hours, at 17 minutes past. Dispatches nothing when the newest candidate has already been tried.   | `rc-scheduler.yml` starts `rc-release-pipeline.yml`, which pushes the `rc_*` and `rc_*_validated` tags.                           |
+| Staging promotion           | Daily at 02:17 UTC, against the newest validated candidate. One already promoted is re-tested, not re-tagged. | `nightly-scheduler.yml` starts `nightly-pipeline.yml`, which pushes the `staging_<ts>_<sha>` tag when the full E2E matrix passes. |
+| GA release                  | Weekly on Fridays at 05:17 UTC, or when a maintainer dispatches it; `release-publish.yml` has no `schedule:`. | `release-scheduler.yml` starts `release-publish.yml` with `schedule_gate=evaluate` when an eligible staging candidate is found.   |
 
 Scheduled runs start when GitHub's scheduler picks them up, so the minute is a floor, not a
-promise. A scheduled GA release ships unattended on Thursdays if a new staging-promoted
+promise. A scheduled GA release ships unattended on Fridays if a new staging-promoted
 candidate exists, or maintainers may dispatch the workflow by hand. The gate that decides whether
 a dispatch publishes, and how the schedulers pick a candidate, are described in
 [`scripts/release/README.md`](https://github.com/gke-labs/kube-agents/tree/main/scripts/release),
@@ -121,7 +121,7 @@ gh workflow run release-publish.yml --repo gke-labs/kube-agents \
   -f explicit_release_version="1.0.0"
 ```
 
-Scheduled releases are automated weekly on Thursdays at 05:17 UTC via
+Scheduled releases are automated weekly on Fridays at 05:17 UTC via
 `.github/workflows/release-scheduler.yml` using the decoupled trigger pattern.
 The publishing workflow itself (`release-publish.yml`) has no `schedule:` and is dispatch-only:
 when the scheduler finds an eligible staging-promoted candidate, it dispatches the workflow with

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -84,7 +84,7 @@ The end-to-end pipeline (`.github/workflows/rc-release-pipeline.yml`) is dispatc
   - Automatically resolves the latest validated candidate (`rc_*_validated`) using `resolve_promotion_candidate.sh`.
   - **Redundant Run Skipping**: If no eligible validated candidate exists, the scheduler dispatches nothing and records the reason in its job summary via `record_nightly_scheduler_skip.sh`.
   - Dispatches `nightly-pipeline.yml` using `dispatch_nightly_pipeline.sh` with the default `GITHUB_TOKEN` and `actions: write`.
-- **Weekly GA Scheduled Cadence (`release-scheduler.yml`, weekly on Thursdays at `17 5 * * 4`, best-effort)**:
+- **Weekly GA Scheduled Cadence (`release-scheduler.yml`, weekly on Fridays at `17 5 * * 5`, best-effort)**:
   - Automatically resolves whether an eligible candidate exists using `resolve_scheduled_release.sh` (requiring a valid `staging_<ts>_<sha>` tag and unreleased commits since the last GA tag, while halting on major breaking changes on stable `>= 1.0.0` releases).
   - **Redundant Run Skipping**: If no eligible candidate exists or no new commits have merged, the scheduler dispatches nothing and records why in its job summary via `record_release_scheduler_skip.sh`.
   - Dispatches `release-publish.yml` using `dispatch_release_pipeline.sh` (`-f schedule_gate=evaluate`) with the default `GITHUB_TOKEN` and `actions: write`.
@@ -302,7 +302,7 @@ reason is strictly the emergency override for hotfixes rather than a way to cut 
 ### Scheduled execution & testing the gate
 
 **Scheduled execution is owned by `.github/workflows/release-scheduler.yml` via the decoupled
-trigger pattern (`cron: "17 5 * * 4"`), while `release-publish.yml` remains dispatch-only.** The gate
+trigger pattern (`cron: "17 5 * * 5"`), while `release-publish.yml` remains dispatch-only.** The gate
 reads the staging tag produced nightly by `nightly-pipeline.yml` (dispatched by `nightly-scheduler.yml`).
 The activation ladder progresses in order:
 
@@ -327,15 +327,15 @@ The activation ladder progresses in order:
    bump minor under SemVer 2.0 Clause 4 (`0.4.0 -> 0.5.0`) and release unattended.
 
 4. **Automate on weekly schedule via dedicated scheduler.** Automated execution is owned by
-   `.github/workflows/release-scheduler.yml` via the decoupled trigger pattern (`cron: "17 5 * * 4"`).
-   Thursday leaves a working day to react to a bad release, which Friday does not. 05:17 UTC is meant
+   `.github/workflows/release-scheduler.yml` via the decoupled trigger pattern (`cron: "17 5 * * 5"`).
+   The schedule runs overnight from Thursday into Friday at 05:17 UTC, which is meant
    to sit after the nightly pipeline has finished, but that is an estimate rather than a measured
    margin — its 02:17 start gives three hours for a run that budgets 60 minutes on the deploy plus
    `timeout_minutes: 120` on the matrix. Being wrong about it costs latency and never correctness,
    because the gate is a poll: a candidate promoted later is simply picked up the following week.
    Pick a later slot if the two turn out to overlap.
 
-Two things to know about a weekly cadence, neither of them a reason to change it. A Thursday that
+Two things to know about a weekly cadence, neither of them a reason to change it. A Friday that
 produces nothing costs a full week, because there is no rate limiter inside the resolver to buy the
 week back — the cron is the cadence, which is what keeps wall-clock arithmetic out of the decision
 entirely. Against the staging gate that is a real risk rather than a rarity: a release needs a

--- a/tests/test_release_publish_workflow.py
+++ b/tests/test_release_publish_workflow.py
@@ -19,7 +19,7 @@ Three expressions carry it, and each fails quietly if it is dropped:
     publish job, and the release goes out at a commit nothing gated.
 
 The cron trigger is decoupled: release-publish.yml is strictly dispatch-only so that quiet
-ticks with nothing to release produce no workflow run at all. The weekly cron ("17 5 * * 4")
+ticks with nothing to release produce no workflow run at all. The weekly cron ("17 5 * * 5")
 lives on .github/workflows/release-scheduler.yml, which evaluates candidate eligibility
 and dispatches release-publish.yml only when work is required.
 """

--- a/tests/test_release_scheduler_wiring.py
+++ b/tests/test_release_scheduler_wiring.py
@@ -2,11 +2,11 @@
 
 Following the decoupled trigger pattern established by rc-scheduler.yml and
 nightly-scheduler.yml, release-scheduler.yml holds the cron trigger
-("17 5 * * 4") so that quiet ticks with nothing to release produce no
+("17 5 * * 5") so that quiet ticks with nothing to release produce no
 pipeline run at all.
 
 These tests pin the structural invariants:
-- The scheduler holds the cron ("17 5 * * 4"), and release-publish.yml does not.
+- The scheduler holds the cron ("17 5 * * 5"), and release-publish.yml does not.
 - The scheduler evaluates candidates via resolve_scheduled_release.sh.
 - Dispatch is strictly gated on steps.resolve.outputs.should_release == 'true'.
 - Skips are recorded via record_release_scheduler_skip.sh on should_release != 'true'.
@@ -22,7 +22,7 @@ _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
 _SCHEDULER = "release-scheduler.yml"
 _PIPELINE = "release-publish.yml"
-_RELEASE_CRON = "17 5 * * 4"
+_RELEASE_CRON = "17 5 * * 5"
 
 _DISPATCH_SCRIPT_NAME = "dispatch_release_pipeline.sh"
 _DISPATCH_SCRIPT = (


### PR DESCRIPTION
## Summary

Moves the weekly GA release scheduler cron from Thursday morning (`17 5 * * 4`) to Friday morning (`17 5 * * 5`) at 05:17 UTC. This ensures that the scheduler executes overnight from Thursday into Friday, after the Friday 02:17 UTC nightly promotion pipeline finishes validating and promoting commits merged throughout Thursday.

## Why This Change

Under the previous schedule (`17 5 * * 4`), the release scheduler ran early Thursday morning (Wednesday night into Thursday). Merges completed during Thursday's working hours were missed by the weekly cadence and had to wait until the following week. Aligning the schedule with Friday 05:17 UTC ensures that Thursday's work merges are tested overnight by `nightly-pipeline.yml` (02:17 UTC) and eligible for weekly GA release without human intervention.

## What Changed

- `.github/workflows/release-scheduler.yml`: Updated `schedule.cron` to `"17 5 * * 5"` and updated comments reflecting Friday 05:17 UTC execution.
- `tests/test_release_scheduler_wiring.py`: Updated `_RELEASE_CRON` constant and docstrings to `"17 5 * * 5"`.
- `tests/test_release_publish_workflow.py`: Updated schedule docstring to reference `"17 5 * * 5"`.
- `scripts/release/README.md`: Updated weekly GA release cadence sections and timing descriptions to Friday at 05:17 UTC.
- `docs/site/src/content/docs/deploy/release-versioning.md`: Updated release cadence table and descriptive paragraphs to Fridays at 05:17 UTC.

## Context

Follow-up to #1325 (*feat(release): automate weekly GA release dispatch via scheduled workflow*).

## Testing

- `python3 -m unittest tests/test_release_scheduler_wiring.py tests/test_release_publish_workflow.py` (32 tests passed).
- `python3 -m unittest tests/test_release_scheduler_wiring.py tests/test_release_publish_workflow.py tests/test_dispatch_release_pipeline.py tests/test_resolve_scheduled_release.py tests/test_calculate_next_version.py tests/test_decide_release_gate.py tests/test_release_common.py` (172 tests passed).
- `make docs-check`: all markdown links, design-doc citations, terminology, and doc map inventory verified clean.
- `npx prettier --check`: formatting verified on all modified markdown and YAML files.

### Live validation

Not live-tested on a running cluster: this change modifies only GitHub Actions workflow schedule expressions, release documentation, and unit tests pinning structural workflow invariants. No operator runtime code or Kubernetes deployment manifests are touched.

## Self-Review

- Adversarial check (authoring session, diff inspection): Verified that changing day-of-week to `5` preserves the decoupled trigger pattern, retains `release-publish.yml` as strictly dispatch-only without accidental schedule triggers, and provides a 3-hour buffer after the 02:17 UTC nightly promotion pipeline.
- Docs drift check (authoring session, full-tree sweep): Ran `git grep -i "thursday"` and `git grep "17 5"` across the entire repository to ensure all references to the scheduled release day and cron expression were consistently updated without orphaned mentions.

## Risk & Rollout

Low risk. Only touches the release scheduler cron schedule expression, release documentation, and unit test assertions. Can be reverted cleanly with no data loss or schema migrations.