### PR TITLE
fix(ci): pass KUBE_AGENTS_KUBECTL_TIMEOUT from environment (#1465)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -174,6 +174,10 @@ jobs:
       - name: Refuse while somebody is live-testing
         if: inputs.github_environment == 'autopush' || inputs.github_environment == 'staging'
         env:
+          # Configured in GitHub Environment Variables (vars.KUBE_AGENTS_KUBECTL_TIMEOUT).
+          # Overrides the default 8s kubectl timeout in live_test_lease.py to accommodate
+          # cold runner gke-gcloud-auth-plugin WIF token exchange and TLS handshake to GKE (#1465).
+          KUBE_AGENTS_KUBECTL_TIMEOUT: ${{ vars.KUBE_AGENTS_KUBECTL_TIMEOUT }}
           TARGET: ${{ inputs.github_environment }}
           GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
           GCP_REGION: ${{ vars.GCP_REGION }}

--- a/.github/workflows/reconcile-environment.yml
+++ b/.github/workflows/reconcile-environment.yml
@@ -159,6 +159,10 @@ jobs:
         id: reconcile
         env:
           CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
+          # Configured in GitHub Environment Variables (vars.KUBE_AGENTS_KUBECTL_TIMEOUT).
+          # Overrides the default 8s kubectl timeout in live_test_lease.py to accommodate
+          # cold runner gke-gcloud-auth-plugin WIF token exchange and TLS handshake to GKE (#1465).
+          KUBE_AGENTS_KUBECTL_TIMEOUT: ${{ vars.KUBE_AGENTS_KUBECTL_TIMEOUT }}
           RECONCILE_MODE: ${{ inputs.mode }}
           GITHUB_ENVIRONMENT: ${{ inputs.github_environment }}
           IMAGE_TAG: ${{ inputs.image_tag }}

--- a/scripts/live_test_lease.py
+++ b/scripts/live_test_lease.py
@@ -67,8 +67,38 @@ DEFAULT_TTL_MIN = 60
 # to stay well inside the `timeout` set in .claude/settings.json. The hook makes
 # at most three of these in a row (read the lease, then renew: read again and
 # replace) plus one context probe, which is cached per classification because a
-# compound line would otherwise pay for one probe per segment.
 KUBECTL_TIMEOUT = 8
+
+
+def _get_kubectl_timeout() -> int:
+    """Resolves the kubectl execution timeout in seconds.
+
+    Reads KUBE_AGENTS_KUBECTL_TIMEOUT from the environment if set, otherwise
+    defaults to KUBECTL_TIMEOUT (8s).
+
+    Why this variable exists:
+    On cold GitHub Actions runners, the first kubectl command must cold-start
+    gke-gcloud-auth-plugin, exchange tokens with Google STS / IAM via Workload
+    Identity Federation (WIF), and perform TLS handshakes to GKE API endpoints
+    over the public internet. Under cloud latency jitter this takes ~8-9s,
+    exceeding the 8s hook budget and causing spurious acquire/status timeouts
+    (exit code 124) during reconcile and deploy CI jobs (#1465).
+
+    Where it is configured:
+    In GitHub Repository Settings under Environments (e.g. `autopush`, `staging`)
+    as `vars.KUBE_AGENTS_KUBECTL_TIMEOUT` (typically set to 15s), passed into CI
+    workflow steps via `env: KUBE_AGENTS_KUBECTL_TIMEOUT: ${{ vars.KUBE_AGENTS_KUBECTL_TIMEOUT }}`.
+    Can also be exported locally in shell environments to override the timeout.
+    """
+    raw = os.environ.get("KUBE_AGENTS_KUBECTL_TIMEOUT")
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    return KUBECTL_TIMEOUT
 
 # SessionEnd `reason` values that do not end the session. Claude Code fires the
 # event for `/clear` and `/resume` too, on a process that carries on with the
@@ -586,13 +616,14 @@ def kubectl(install, args, stdin=None):
     kenv = dict(os.environ)
     if install.kubeconfig:
         kenv["KUBECONFIG"] = install.kubeconfig
+    timeout = _get_kubectl_timeout()
     try:
         proc = subprocess.run(
             cmd, input=stdin, capture_output=True, text=True,
-            timeout=KUBECTL_TIMEOUT, env=kenv,
+            timeout=timeout, env=kenv,
         )
     except subprocess.TimeoutExpired:
-        return 124, "", "kubectl timed out after %ds" % KUBECTL_TIMEOUT
+        return 124, "", "kubectl timed out after %ds" % timeout
     except FileNotFoundError:
         return 127, "", "kubectl not found on PATH"
     return proc.returncode, proc.stdout, proc.stderr

--- a/scripts/test_live_test_lease.py
+++ b/scripts/test_live_test_lease.py
@@ -1762,5 +1762,36 @@ def _fake_kubectl(data, rv="1"):
     return mock.Mock(side_effect=call)
 
 
+class KubectlTimeoutConfigurationTest(unittest.TestCase):
+    """Tests the resolution of kubectl timeout, including CI environment overrides."""
+
+    def test_default_timeout_is_eight_seconds(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertEqual(lease._get_kubectl_timeout(), 8)
+
+    def test_env_override_sets_custom_timeout(self):
+        with mock.patch.dict(os.environ, {"KUBE_AGENTS_KUBECTL_TIMEOUT": "30"}, clear=True):
+            self.assertEqual(lease._get_kubectl_timeout(), 30)
+
+    def test_invalid_env_override_falls_back_to_default(self):
+        for invalid in ("", "invalid", "-5", "0"):
+            with self.subTest(invalid=invalid):
+                with mock.patch.dict(os.environ, {"KUBE_AGENTS_KUBECTL_TIMEOUT": invalid}, clear=True):
+                    self.assertEqual(lease._get_kubectl_timeout(), 8)
+
+    def test_kubectl_uses_configured_timeout(self):
+        install = lease.Install(
+            name="test",
+            context="test-ctx",
+            namespace="kubeagents-system",
+        )
+        with mock.patch.dict(os.environ, {"KUBE_AGENTS_KUBECTL_TIMEOUT": "45"}, clear=True), \
+             mock.patch.object(lease.subprocess, "run") as run_mock:
+            run_mock.return_value = mock.Mock(returncode=0, stdout="ok", stderr="")
+            rc, out, err = lease.kubectl(install, ["version"])
+            self.assertEqual(rc, 0)
+            self.assertEqual(run_mock.call_args.kwargs.get("timeout"), 45)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Allow configuring the `kubectl` timeout in `scripts/live_test_lease.py` via the `KUBE_AGENTS_KUBECTL_TIMEOUT` environment variable (falling back to 8 seconds if unset), and pass `${{ vars.KUBE_AGENTS_KUBECTL_TIMEOUT }}` from GitHub Environment variables in `reconcile-environment.yml` and `deploy-environment.yml` to prevent spurious timeouts on cold CI runners.

## Why This Change

On cold GitHub Actions runners (`ubuntu-latest`), initial `kubectl` executions against GKE must cold-start `gke-gcloud-auth-plugin`, perform Workload Identity Federation (WIF) token exchanges with Google STS and IAM, and establish TLS sessions to GKE control planes over the public internet. This sequence typically takes ~8.2s under cloud latency variations. Because `scripts/live_test_lease.py` had a rigid `KUBECTL_TIMEOUT = 8` tuned for local interactive Claude Code PreToolUse hook latency, `subprocess.run` raised `subprocess.TimeoutExpired` (exit code 124) when reading or acquiring the lease during scheduled reconcile and deploy runs on `autopush` (#1465). The safety guard in `reconcile_environment.sh` aborted execution with:
> `Could not determine whether 'autopush' is in use, so this reconcile stopped rather than assuming either answer.`
blocking automated reconciles.

## What Changed

- `scripts/live_test_lease.py`: Added `_get_kubectl_timeout()` to inspect `os.environ.get("KUBE_AGENTS_KUBECTL_TIMEOUT")` and parse positive integers, while preserving the default `8s` (`KUBECTL_TIMEOUT`) when unset. Documented the rationale and configuration location in the function docstring.
- `.github/workflows/reconcile-environment.yml` & `.github/workflows/deploy-environment.yml`: Passed `KUBE_AGENTS_KUBECTL_TIMEOUT: ${{ vars.KUBE_AGENTS_KUBECTL_TIMEOUT }}` in the steps that interact with the GKE cluster.
- `scripts/test_live_test_lease.py`: Added `KubectlTimeoutConfigurationTest` covering default resolution (8s), valid environment override, invalid/non-positive fallback, and subprocess timeout propagation.
- Configured `KUBE_AGENTS_KUBECTL_TIMEOUT = 15` in `autopush` and `staging` GitHub Environment variables.

## Context

- Fixes #1465.
- Failed deploy runs: https://github.com/gke-labs/kube-agents/actions/runs/34584225071/job/103214701950 and job/103220051709.

## Testing

- `PYTHONPATH=scripts python3 -m unittest scripts/test_live_test_lease.py` (143 tests passed, including all 4 timeout tests).
- `python3 -m unittest tests/test_reconcile_environment.py` (54 tests passed).
- `npx prettier --check .github/workflows/reconcile-environment.yml .github/workflows/deploy-environment.yml` (all files formatted).
- `bash -n scripts/release/reconcile_environment.sh` (syntax OK).

### Live validation

Not live-tested on a live cluster: this change modifies CI workflow environment variable wiring and a client-side subprocess timeout fallback in lease acquisition. The mechanism was validated via unit tests mocking environment variables and `subprocess.run(timeout=...)`. Verified via `gh variable list` that `KUBE_AGENTS_KUBECTL_TIMEOUT` is set to `15` in both `autopush` and `staging` environments in `gke-labs/kube-agents`.

## Self-Review

- **Adversarial pass**:
  - Checked for empty/unset `vars.KUBE_AGENTS_KUBECTL_TIMEOUT`: When undefined or empty string `""`, `_get_kubectl_timeout()` safely ignores it and falls back to 8s without raising `ValueError`.
  - Checked for invalid values (e.g. whitespace, non-integers, negative numbers, zero): Added unit tests verifying `""`, `"invalid"`, `"-5"`, and `"0"` all fall back cleanly to 8s.
  - Checked local Claude Code hook latency: Local runs without `KUBE_AGENTS_KUBECTL_TIMEOUT` retain the exact 8s budget so interactive hook timeouts are not compromised.
  - Checked subprocess inheritance: Verified that `reconcile-environment.yml` exports the variable to `reconcile_environment.sh`, which in turn passes it down to child Python processes without needing repeated exports in bash.
- **Docs & comments pass**: Added explanatory comments in `reconcile-environment.yml`, `deploy-environment.yml`, and `live_test_lease.py` referencing #1465.

## Risk & Rollout

Low risk. Unset environments continue to use the existing 8s default. In environments with `KUBE_AGENTS_KUBECTL_TIMEOUT` configured, `kubectl` calls inside lease acquisition can take up to the configured limit before timing out, eliminating spurious CI failures on cold runner starts. Revertible by removing the environment variable in GitHub Settings or reverting the commit.
