### PR TITLE
fix(ci): grant workflows write permission to release bot token

### DIFF
--- a/.github/workflows/nightly-pipeline.yml
+++ b/.github/workflows/nightly-pipeline.yml
@@ -183,6 +183,7 @@ jobs:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
 
       - name: Checkout repository
         if: needs.step-1-resolve-candidate.outputs.skip_promotion != 'true'

--- a/.github/workflows/rc-create-tag.yml
+++ b/.github/workflows/rc-create-tag.yml
@@ -61,6 +61,7 @@ jobs:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/rc-tag-validated.yml
+++ b/.github/workflows/rc-tag-validated.yml
@@ -37,6 +37,7 @@ jobs:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -135,6 +135,7 @@ jobs:
           app-id: ${{ vars.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/tests/test_nightly_pipeline_wiring.py
+++ b/tests/test_nightly_pipeline_wiring.py
@@ -114,6 +114,7 @@ class NightlyPipelineWiringTest(unittest.TestCase):
         self.assertIn("RELEASE_BOT_APP_ID", token_step["with"]["app-id"])
         self.assertIn("RELEASE_BOT_APP_PRIVATE_KEY", token_step["with"]["private-key"])
         self.assertEqual(token_step["with"].get("permission-contents"), "write")
+        self.assertEqual(token_step["with"].get("permission-workflows"), "write")
         checkout = next(
             step
             for step in steps
@@ -315,6 +316,34 @@ class DockerPublishGhcrWiringTest(unittest.TestCase):
         self.assertIn("publish-operator", self.jobs)
         self.assertIn("publish-agents", self.jobs)
         self.assertFalse((_WORKFLOWS / "docker-publish-k8s-operator.yml").exists())
+
+
+class ReleaseBotTokenWiringTest(unittest.TestCase):
+    """Every workflow that mints a token for RELEASE_BOT_APP_ID must request both
+    contents: write (for creating refs/tags) and workflows: write (to prevent GH013
+    rejections when the tagged commit has workflow diffs relative to main)."""
+
+    def test_every_release_bot_token_mint_requests_workflows_write(self):
+        workflows = [
+            "nightly-pipeline.yml",
+            "release-publish.yml",
+            "rc-create-tag.yml",
+            "rc-tag-validated.yml",
+        ]
+        for name in workflows:
+            with self.subTest(workflow=name):
+                doc = _doc(_WORKFLOWS / name)
+                token_steps = [
+                    step
+                    for job in (doc.get("jobs") or {}).values()
+                    for step in (job.get("steps") or [])
+                    if str(step.get("uses", "")).startswith("actions/create-github-app-token@")
+                    and "RELEASE_BOT_APP_ID" in str(step.get("with", {}).get("app-id", ""))
+                ]
+                self.assertTrue(token_steps, f"expected at least one release bot token step in {name}")
+                for step in token_steps:
+                    self.assertEqual(step["with"].get("permission-contents"), "write")
+                    self.assertEqual(step["with"].get("permission-workflows"), "write")
 
 
 if __name__ == "__main__":

--- a/tests/test_release_publish_workflow.py
+++ b/tests/test_release_publish_workflow.py
@@ -185,6 +185,7 @@ class ReleasePublishWorkflowTest(unittest.TestCase):
         self.assertIn("RELEASE_BOT_APP_ID", token_step["with"]["app-id"])
         self.assertIn("RELEASE_BOT_APP_PRIVATE_KEY", token_step["with"]["private-key"])
         self.assertEqual(token_step["with"].get("permission-contents"), "write")
+        self.assertEqual(token_step["with"].get("permission-workflows"), "write")
         checkout = next(
             step
             for step in steps


### PR DESCRIPTION
## Summary

Grants `permission-workflows: write` to the `kube-agents-release-bot` token minted across nightly, release candidate, and release publication workflows. This allows the bot to push git tags (`staging_*`, `rc_*`, `v*`) on commits where `.github/workflows/` differs from `main` without triggering GitHub platform rule violations (`GH013`).

## Why This Change

GitHub's server-side pre-receive hook (`rule_source: workflow_updates`) validates ref creations and updates (including tags). When a tag is pushed pointing to a commit where files in `.github/workflows/` differ from the default branch (`main`), GitHub considers the ref creation as introducing or altering workflow definitions and requires `workflows: write` permission.

Without this permission, tag pushes fail with:
`remote: - refusing to allow a GitHub App to create or update workflow ... without workflows permission`
`remote: error: GH013: Repository rule violations found for refs/tags/...`

In the nightly pipeline, whenever a PR touching `.github/workflows/*` merges to `main` between candidate validation and staging promotion (~1.5–3 hours), Step 4 fails while promoting the candidate to staging. The same failure mode affects RC tagging and GA release publication if the target commit contains workflow diffs against `main`.

## What Changed

- Added `permission-workflows: write` to `actions/create-github-app-token` in:
  - `.github/workflows/nightly-pipeline.yml`
  - `.github/workflows/rc-create-tag.yml`
  - `.github/workflows/rc-tag-validated.yml`
  - `.github/workflows/release-publish.yml`
- Updated unit test assertions in `tests/test_nightly_pipeline_wiring.py` and `tests/test_release_publish_workflow.py`.
- Added `ReleaseBotTokenWiringTest` in `tests/test_nightly_pipeline_wiring.py` asserting that all workflows minting `RELEASE_BOT_APP_ID` request both `permission-contents: write` and `permission-workflows: write`.

## Context

Fixes #1463

## Testing

- Ran pipeline wiring test suites:
  `python3 -m unittest tests/test_nightly_pipeline_wiring.py tests/test_release_publish_workflow.py` (43 passed)
- Ran regression and conformance suites:
  `python3 -m unittest tests/conformance/test_B_write_path.py tests/test_workflow_script_invocation.py tests/test_tag_commit.py` (all passed)
- Verified YAML style formatting:
  `npx prettier --check .github/workflows/nightly-pipeline.yml .github/workflows/rc-create-tag.yml .github/workflows/rc-tag-validated.yml .github/workflows/release-publish.yml`
  Output: `All matched files use Prettier code style!`

### Live validation

Not live-tested: This change modifies GitHub Actions workflow token permissions and pipeline unit tests; it does not touch Kubernetes runtime components, CRDs, or running cluster workloads. The required GitHub App organization permissions update (#1463) has been completed and verified.

## Self-Review

- Passes executed:
  - `review-adversarial` executed in an isolated subagent context (`self/subagent`).
  - `review-docs-drift` executed in an isolated subagent context (`self/subagent`).
- Adversarial evaluation:
  - Evaluated whether granting `workflows: write` to the release bot token expands the attack surface. In `nightly-pipeline.yml` and `release-publish.yml`, the jobs are explicitly repository-gated (`if: github.repository == 'gke-labs/kube-agents'`).
  - In `rc-create-tag.yml` and `rc-tag-validated.yml`, the workflows are `workflow_dispatch` and `workflow_call` workflows exempt from direct job guards per `.agents/rules/github_actions.md`: their caller in scheduled execution (`rc-release-pipeline.yml`) is repository-gated, and forks lack `RELEASE_BOT_APP_PRIVATE_KEY` so installation tokens cannot be minted in forks.
  - The token is minted strictly from protected App credentials (`RELEASE_BOT_APP_ID`), scoped to tag operations, and never exported to external or untrusted steps.
- Docs drift evaluation:
  - Checked whether documentation or README references token permissions; `scripts/release/README.md` notes that the bot token pushes staging/release tags without specifying an exhaustive permission subset. No documentation drift detected.

## Risk & Rollout

- **Merge-time prerequisite**: ✅ **COMPLETED**. The GitHub App `kube-agents-release-bot` permissions have been updated to grant `Workflows: Read and write`, and the organization permissions update has been accepted by a `gke-labs` admin. The PR is ready to be merged.
- **Blast radius**: Low risk. Touches only CI workflow token permission requests on tag creation steps and associated pipeline unit tests. Does not touch operator runtime, CRDs, or cluster configurations.
- **Rollback**: Reversible by reverting the PR commit.
