### PR TITLE
chore(agents): let Claude Code load .agents/ skills and rules

### DIFF
--- a/.agents/rules/core_engineering.md
+++ b/.agents/rules/core_engineering.md
@@ -1,3 +1,11 @@
+---
+# Claude Code loads this rule only beside files matching `paths`; other tools ignore this block.
+paths:
+  - "**/*.go"
+  - "**/*.py"
+  - "**/*.sh"
+---
+
 # Core engineering rules
 
 Rules for code written in this repository. [`AGENTS.md`](../../AGENTS.md) names this file and is

--- a/.agents/rules/github_actions.md
+++ b/.agents/rules/github_actions.md
@@ -1,3 +1,9 @@
+---
+# Claude Code loads this rule only beside files matching `paths`; other tools ignore this block.
+paths:
+  - ".github/workflows/**"
+---
+
 # GitHub Actions rules
 
 [`AGENTS.md`](../../AGENTS.md) states both rules below under Pull Request Hygiene. This file holds

--- a/.agents/rules/pre_pr_review.md
+++ b/.agents/rules/pre_pr_review.md
@@ -1,3 +1,10 @@
+---
+# Claude Code loads this rule only beside files matching `paths`; other tools ignore this block.
+paths:
+  - ".github/PULL_REQUEST_TEMPLATE.md"
+  - "docs/pull-request-workflow.md"
+---
+
 # Pre-PR review mechanics
 
 [`AGENTS.md`](../../AGENTS.md) owns both rules below — that adversarial self-review and live

--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../.agents/rules

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ terraform.tfvars.json
 build/
 *.tgz
 
-# Per-developer Claude Code state (session settings, local skills). The shared
+# Per-developer Claude Code state (session settings). The shared
 # slash commands in .claude/commands/ and the review skills in .agents/skills/
 # are committed; .claude/settings.json and .claude/settings.local.json stay
 # personal. settings.json is deliberately *not* committed even though the
@@ -65,6 +65,12 @@ build/
 # descends into the directory: a rule that excludes the directory itself can
 # never be undone by a nested .gitignore or a negation, because git does not
 # look inside it.
+#
+# .claude/skills and .claude/rules are symlinks into .agents/, the tool-neutral
+# home Gemini CLI and Codex already read; Claude Code scans only .claude/. No
+# trailing slash on those two negations: git records a symlink as a file.
 .claude/*
 !.claude/commands/
 !.claude/settings.json.example
+!.claude/skills
+!.claude/rules


### PR DESCRIPTION
## Summary

Claude Code scans only `.claude/skills/` and `.claude/rules/`, so those two paths become symlinks into `.agents/`, where Gemini CLI and Codex already read the same files. Each rule file gets a `paths` frontmatter so Claude Code loads it only beside matching files.

Generated with the help of Claude Code (Claude Fable 5.1).

## Why This Change

In a Claude Code session none of the 25 repository skills registered, and the rule files loaded only when the agent followed the "read the file" instruction in `AGENTS.md`. Without the `paths` scoping, all three rules would load in every session, which the `AGENTS.md` split exists to avoid.

## What Changed

- `.claude/skills` and `.claude/rules` symlinks, plus two gitignore negations (no trailing slash: git records a symlink as a file).
- A `paths` frontmatter on the three rule files. Other tools read them as plain Markdown and ignore the block.

## Context

- #1438 adds a rule file without `paths`; once both merge, it loads in every Claude Code session until it gets a block.
- No `GEMINI.md` or `.gemini/settings.json`: a `GEMINI.md` importing `AGENTS.md` makes Gemini builds that already load `AGENTS.md` load it twice, and the setting makes Gemini load `agents/*/AGENTS.md` as context.

## Testing

- `make docs-check`, `make prompt-check`, `prettier --check` on the rule files: clean.

### Live validation

Not against an installation; nothing reaches the operator or agent pod. Claude Code 2.1.267, headless, with an `InstructionsLoaded` hook: only `CLAUDE.md` and `AGENTS.md` loaded at start, and after reading `.github/workflows/prettier.yml` the hook logged `.agents/rules/github_actions.md` with reason `path_glob_match`. Asked to list its skills, the model named ones that exist only under `.agents/skills/`. Gemini CLI 0.59.0-nightly still finds all 25 skills. Not covered: Codex, Windows checkouts.

## Self-Review

`review-adversarial` (twice) and `review-docs-drift` (three times) ran in fresh subagents over a superset of this diff; the kept hunks are unchanged apart from a shorter comment.

- Claude Code skips a symlinked rules directory when launched from a subdirectory (CONFIRMED). Not fixed: that session gets what `main` gives today.
- Checking out the links replaces an ignored personal `.claude/skills/` or `.claude/rules/` directory without warning (CONFIRMED). Not fixed in code; see Risk.
- Nothing fails if a link dangles, and an unscoped rule file loads in every session unchecked (CONFIRMED). An earlier revision extended `check_context_budget.py` for this; dropped to keep the change small, follow-up if wanted.
- The gitignore comment overstated what Gemini and Codex read natively (CONFIRMED). Fixed.
- Docs-drift: nothing against the kept files. Not covered: Codex, Windows, the site build.

## Risk & Rollout

Low, no runtime paths. Personal files under `.claude/skills/` or `.claude/rules/` in a checkout are lost on the next pull unless moved to `~/.claude/` first. Revert by deleting the two links and the three frontmatter blocks.
