### PR TITLE
fix(dashboard): pages render from inlined data and use absolute links, so they work on storage.cloud.google.com

### DIFF
--- a/.github/workflows/ci-health.yml
+++ b/.github/workflows/ci-health.yml
@@ -326,7 +326,10 @@ jobs:
           [ -f work/health.json ] && render_args+=(--health work/health.json)
           [ -f work/health-history.jsonl ] && render_args+=(--health-history work/health-history.jsonl)
           [ -f work/health-history.jsonl ] || echo "::warning::no health-history.jsonl this tick; the Brief renders the current verdict only"
-          python3 scripts/eval_dashboard/render.py --data work/data.json --out-dir work/site "${render_args[@]}"
+          # --public-url (bare) emits <base href> for the published site,
+          # post_health.DASHBOARD_URL's directory, so the pages' links
+          # resolve there whatever URL the console login lands on.
+          python3 scripts/eval_dashboard/render.py --data work/data.json --out-dir work/site "${render_args[@]}" --public-url
           python3 scripts/eval_dashboard/publish.py --out-dir work/site --target "$DASHBOARD_BUCKET/"
 
       - name: Fetch the webhook URL (optional alternative to the Chat API)

--- a/hack/ci-dashboard-refresh.sh
+++ b/hack/ci-dashboard-refresh.sh
@@ -214,9 +214,11 @@ if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
   render_args=()
   [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
   [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
-  # --public-url (bare): <base href> for the published site, so the pages
-  # link to post_health.DASHBOARD_URL'"'"'s host wherever the browser landed.
-  python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}" --public-url
+  # A bucket target is the published site: --public-url (bare) emits
+  # <base href> for post_health.DASHBOARD_URL'"'"'s host, so the pages link
+  # there wherever the browser landed. A local directory keeps relative links.
+  case "$3" in gs://*) render_args+=(--public-url) ;; esac
+  python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}"
   python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
 ' _ "${DASH_SRC}" "${WORK}" "${EVAL_DASHBOARD_TARGET}" "${EVAL_DASHBOARD_PR_GLOB}" \
   "${EVAL_DASHBOARD_SINCE_DAYS}" "${EVAL_DASHBOARD_FROM_DIR:-}" \

--- a/hack/ci-dashboard-refresh.sh
+++ b/hack/ci-dashboard-refresh.sh
@@ -214,7 +214,9 @@ if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
   render_args=()
   [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
   [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
-  python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}"
+  # --public-url (bare): <base href> for the published site, so the pages
+  # link to post_health.DASHBOARD_URL'"'"'s host wherever the browser landed.
+  python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}" --public-url
   python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
 ' _ "${DASH_SRC}" "${WORK}" "${EVAL_DASHBOARD_TARGET}" "${EVAL_DASHBOARD_PR_GLOB}" \
   "${EVAL_DASHBOARD_SINCE_DAYS}" "${EVAL_DASHBOARD_FROM_DIR:-}" \

--- a/scripts/eval_dashboard/SCHEMA.md
+++ b/scripts/eval_dashboard/SCHEMA.md
@@ -317,8 +317,9 @@ first two is America/Toronto ("ET"), formatted in the browser with
 
 The Brief and the PR view render in the browser from `brief.json` (below),
 which `render.py` inlines into each page as
-`<script type="application/json" id="inline-brief">` (the health verdict
-beside it as `inline-health`), so a page needs no request beyond itself;
+`<script type="application/json" id="inline-brief">` (the verdict it read,
+the same document as `brief.health`, again as `inline-health`), so a page
+needs no request beyond itself;
 the poll of the published `brief.json` and `health.json` every 60 seconds
 is a best-effort refresh on top, and the legacy page polls `data.json` the
 same way. That matters on `storage.cloud.google.com`, which answers an XHR

--- a/scripts/eval_dashboard/SCHEMA.md
+++ b/scripts/eval_dashboard/SCHEMA.md
@@ -315,10 +315,25 @@ first two is America/Toronto ("ET"), formatted in the browser with
 | `run.html`    | **The PR view**, `run.html?build=<prow build id>`: one run, each failed gate case tagged `failing on N other PRs` / `only your PR` / `quota storm` / `unexplained` with its check reason, 30-day pass rate, transcript link and a one-line Do; a "what to do" box. |
 | `legacy.html` | The two-band page (agent trend, gate matrix, Pareto, evidence table).                                                                                                                                                                                              |
 
-The Brief and the PR view render in the browser from `brief.json` (below)
-and refetch it and `health.json` every 60 seconds. `classify.py` is the one
-place the "is this red mine?" rule lives; the pages read its answer through
-`brief.json`, and anything else that answers the question imports it.
+The Brief and the PR view render in the browser from `brief.json` (below),
+which `render.py` inlines into each page as
+`<script type="application/json" id="inline-brief">` (the health verdict
+beside it as `inline-health`), so a page needs no request beyond itself;
+the poll of the published `brief.json` and `health.json` every 60 seconds
+is a best-effort refresh on top, and the legacy page polls `data.json` the
+same way. That matters on `storage.cloud.google.com`, which answers an XHR
+with a login redirect: the pages still render whole there. The header
+badge says `updated <time> · Nm ago`, plus `· regenerated every 15 min`
+while no poll has succeeded (the workflow republishes every page on that
+cron, so that is how old the inlined copy can be); `STALE` is prepended
+only when the data's `generated_at` is older than its `stale_after_s`.
+`render.py --public-url [BASE]` emits `<base href>` so every relative link
+resolves to the published site wherever the browser landed after the
+login redirect; the bare flag means `post_health.DASHBOARD_URL`'s
+directory, and without the flag links stay relative for a local render.
+`classify.py` is the one place the "is this red mine?" rule lives; the
+pages read its answer through `brief.json`, and anything else that answers
+the question imports it.
 
 ### URL contract
 

--- a/scripts/eval_dashboard/publish.py
+++ b/scripts/eval_dashboard/publish.py
@@ -10,10 +10,10 @@ A ``gs://`` target shells out to gsutil; anything else is a local directory
 copy (which is also what the tests exercise -- nothing in the test suite
 touches a bucket).
 
-Every object is uploaded with ``Cache-Control: no-cache``. The page refetches
-``data.json`` every 60 seconds, and GCS's default public-object caching
-(3600s) would quietly turn that into an hour-stale dashboard; ``no-cache``
-makes each poll revalidate instead.
+Every object is uploaded with ``Cache-Control: no-cache``. The pages poll
+``brief.json``, ``health.json`` and ``data.json`` every 60 seconds, and GCS's
+default public-object caching (3600s) would quietly turn that into an
+hour-stale dashboard; ``no-cache`` makes each poll revalidate instead.
 """
 
 from __future__ import annotations

--- a/scripts/eval_dashboard/render.py
+++ b/scripts/eval_dashboard/render.py
@@ -22,9 +22,17 @@ writes three pages and two data files into ``out/``:
   classification, the current health verdict, the incident history and the
   recent merges. ``data.json`` is copied verbatim beside it.
 
-The Brief and the PR view are rendered in the browser from ``brief.json``
-(``template/page.html.tmpl`` + ``template/pages.js``); every time they show
-is America/Toronto, formatted there. The optional inputs are
+The Brief and the PR view are rendered in the browser
+(``template/page.html.tmpl`` + ``template/pages.js``) from the brief.json
+document inlined into each page as ``<script type="application/json"
+id="inline-brief">`` (health.json beside it as ``inline-health``), so a
+page needs no request beyond itself; the 60-second poll of the published
+``brief.json`` is a best-effort refresh on top, and a host that answers an
+XHR with a login redirect (storage.cloud.google.com does) just leaves the
+inlined data on screen. ``--public-url`` adds ``<base href>`` so every
+relative link resolves to the published site wherever the browser landed
+after that redirect. Every time they show is America/Toronto, formatted
+there. The optional inputs are
 ``health.json`` (the CI health adjudicator's verdict, published beside
 data.json; nothing here writes it) and ``health-history.jsonl`` (one
 health.json document per line plus a ``tick`` stamp); without them the
@@ -92,10 +100,11 @@ import sys
 import yaml
 
 try:
-    from . import classify
+    from . import classify, post_health
 except ImportError:  # run as a script: python3 scripts/eval_dashboard/render.py
     sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
     import classify
+    import post_health
 
 HERE = pathlib.Path(__file__).resolve().parent
 TEMPLATE = HERE / "template" / "index.html.tmpl"
@@ -115,6 +124,15 @@ BRIEF_JSON = "brief.json"
 # writes both (health-history.jsonl is appended one line per tick).
 HEALTH_FILE = "health.json"
 HEALTH_HISTORY_FILE = "health-history.jsonl"
+# The ids of the <script type="application/json"> elements each page
+# carries its data in; pages.js and the legacy script boot from them, so the
+# page renders whole without a single fetch (module docstring).
+INLINE_BRIEF_ID = "inline-brief"
+INLINE_HEALTH_ID = "inline-health"
+# Where the pages are published: the directory of the index.html URL the
+# Chat messages and the gate comment link to, so `--public-url` with no
+# value names the same host they do (one source, post_health.py).
+PUBLISHED_SITE = post_health.DASHBOARD_URL.rsplit("/", 1)[0]
 # The three states health.json can carry. The pages announce a state with
 # a glyph and the word, never with colour alone.
 HEALTH_STATES = ("GREEN", "DEGRADED", "OUTAGE")
@@ -886,19 +904,22 @@ def brief_document(data: dict, health: dict | None, history: list[dict] | None, 
     }
 
 
-def render_new_page(page: str, brief: dict, data: dict) -> str:
+def render_new_page(page: str, brief: dict, data: dict, public_url: str | None = None) -> str:
     """The Brief (``page`` = "brief") or the PR view ("run") from the shared
-    template, with brief.json and pages.js inlined."""
+    template, with brief.json (and the health verdict, when there is one)
+    inlined as JSON data elements and pages.js after them."""
     template = PAGE_TEMPLATE.read_text()
-    script = PAGES_JS.read_text()
     values = {
         "__TITLE__": "kube-agents · smoke gate brief" if page == "brief" else "kube-agents · smoke run",
         "__PAGE__": page,
         "__NAV_BRIEF__": 'class="on"' if page == "brief" else "",
         "__NAV_RUN__": 'class="on"' if page == "run" else "",
+        "__BASE__": base_html(public_url),
+        "__INLINE_BRIEF__": inline_json_html(INLINE_BRIEF_ID, brief),
+        "__INLINE_HEALTH__": inline_json_html(INLINE_HEALTH_ID, brief["health"]) if brief.get("health") else "",
         "__META__": meta_html(data),
         "__FRESHNESS__": freshness_html(data),
-        "__PAGES_JS__": script.replace("__BRIEF_JSON__", bootstrap_json(brief)),
+        "__PAGES_JS__": PAGES_JS.read_text(),
     }
     for token in values:
         if token not in template:
@@ -1571,9 +1592,26 @@ def bootstrap_json(value) -> str:
     return json.dumps(value, separators=(",", ":")).replace("<", "\\u003c")
 
 
-def render_page(data: dict, notes: dict, events: dict) -> str:
+def inline_json_html(element_id: str, value) -> str:
+    """A data element a page reads with JSON.parse on boot. bootstrap_json
+    keeps every '<' out of it, so no data string can close the element."""
+    return f'<script type="application/json" id="{element_id}">{bootstrap_json(value)}</script>'
+
+
+def base_html(public_url: str | None) -> str:
+    """``<base href>`` for the published site, so every relative link on the
+    page (nav, footer, run.html?build=, the incident deep links) resolves
+    there whatever URL the browser is showing; nothing when no public URL
+    is known, which keeps a file:// render browsable."""
+    if not public_url:
+        return ""
+    return f'<base href="{esc(public_url.rstrip("/") + "/")}">'
+
+
+def render_page(data: dict, notes: dict, events: dict, public_url: str | None = None) -> str:
     page = TEMPLATE.read_text()
     values = {
+        "__BASE__": base_html(public_url),
         "__META__": meta_html(data),
         "__FRESHNESS__": freshness_html(data),
         "__APP__": app_html(data, notes, events),
@@ -1629,6 +1667,14 @@ def main(argv: list[str] | None = None) -> int:
         default=str(classify.REPO_ROOT),
         help="checkout whose git log lists the merges to main (a shallow checkout omits the block)",
     )
+    parser.add_argument(
+        "--public-url",
+        nargs="?",
+        const=PUBLISHED_SITE,
+        default=None,
+        metavar="BASE",
+        help=f"emit <base href> so every link resolves to this site; the bare flag means the published dashboard ({PUBLISHED_SITE}); default: none, links stay relative",
+    )
     args = parser.parse_args(argv)
 
     data = load_data(pathlib.Path(args.data))
@@ -1641,9 +1687,9 @@ def main(argv: list[str] | None = None) -> int:
 
     out_dir = pathlib.Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / BRIEF_PAGE).write_text(render_new_page("brief", brief, data))
-    (out_dir / RUN_PAGE).write_text(render_new_page("run", brief, data))
-    (out_dir / LEGACY_PAGE).write_text(render_page(data, notes, events))
+    (out_dir / BRIEF_PAGE).write_text(render_new_page("brief", brief, data, args.public_url))
+    (out_dir / RUN_PAGE).write_text(render_new_page("run", brief, data, args.public_url))
+    (out_dir / LEGACY_PAGE).write_text(render_page(data, notes, events, args.public_url))
     (out_dir / BRIEF_JSON).write_text(json.dumps(brief, separators=(",", ":")))
     # health.json and health-history.jsonl are deliberately not copied into
     # the out-dir: the adjudicator owns those objects, and republishing a

--- a/scripts/eval_dashboard/render.py
+++ b/scripts/eval_dashboard/render.py
@@ -4,7 +4,8 @@
 Usage::
 
     python3 scripts/eval_dashboard/render.py --data data.json --out-dir out/ \\
-        [--health health.json] [--health-history health-history.jsonl]
+        [--health health.json] [--health-history health-history.jsonl] \\
+        [--public-url [BASE]]
 
 writes three pages and two data files into ``out/``:
 
@@ -25,9 +26,9 @@ writes three pages and two data files into ``out/``:
 The Brief and the PR view are rendered in the browser
 (``template/page.html.tmpl`` + ``template/pages.js``) from the brief.json
 document inlined into each page as ``<script type="application/json"
-id="inline-brief">`` (health.json beside it as ``inline-health``), so a
+id="inline-brief">`` (the verdict it read again as ``inline-health``), so a
 page needs no request beyond itself; the 60-second poll of the published
-``brief.json`` is a best-effort refresh on top, and a host that answers an
+``brief.json`` and ``health.json`` is a best-effort refresh on top, and a host that answers an
 XHR with a login redirect (storage.cloud.google.com does) just leaves the
 inlined data on screen. ``--public-url`` adds ``<base href>`` so every
 relative link resolves to the published site wherever the browser landed
@@ -130,8 +131,9 @@ HEALTH_HISTORY_FILE = "health-history.jsonl"
 INLINE_BRIEF_ID = "inline-brief"
 INLINE_HEALTH_ID = "inline-health"
 # Where the pages are published: the directory of the index.html URL the
-# Chat messages and the gate comment link to, so `--public-url` with no
-# value names the same host they do (one source, post_health.py).
+# Chat messages (post_health.py) and the gate comment (gate_comment.py's
+# DASHBOARD_ROOT) already link to, so `--public-url` with no value names
+# the host they do rather than a second copy of it.
 PUBLISHED_SITE = post_health.DASHBOARD_URL.rsplit("/", 1)[0]
 # The three states health.json can carry. The pages announce a state with
 # a glyph and the word, never with colour alone.
@@ -1673,7 +1675,7 @@ def main(argv: list[str] | None = None) -> int:
         const=PUBLISHED_SITE,
         default=None,
         metavar="BASE",
-        help=f"emit <base href> so every link resolves to this site; the bare flag means the published dashboard ({PUBLISHED_SITE}); default: none, links stay relative",
+        help=f"emit <base href> so every link resolves to this site; the bare flag means the published dashboard ({PUBLISHED_SITE}); default (or an empty value): none, links stay relative",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/eval_dashboard/template/index.html.tmpl
+++ b/scripts/eval_dashboard/template/index.html.tmpl
@@ -175,8 +175,8 @@ __BASE__
   <span class="brand"><span class="logo">ka</span>evals</span>
   <nav class="nav">
     <a href="index.html">Brief</a>
-    <a class="on" href="#agent">The agent</a><a href="#gate">The gate</a>
-    <a href="#nightly">Evidence</a><a href="#release">Releases</a>
+    <a class="on" href="legacy.html#agent">The agent</a><a href="legacy.html#gate">The gate</a>
+    <a href="legacy.html#nightly">Evidence</a><a href="legacy.html#release">Releases</a>
   </nav>
   <span class="meta"><span id="headmeta">__META__</span> · <span id="freshness" class="fresh">__FRESHNESS__</span></span>
 </div></div>

--- a/scripts/eval_dashboard/template/index.html.tmpl
+++ b/scripts/eval_dashboard/template/index.html.tmpl
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+__BASE__
 <title>kube-agents · evaluation dashboard</title>
 <style>
   .viz-root {
@@ -59,7 +60,7 @@
   .nav a.on { color:var(--text-primary); border-bottom-color:var(--accent); }
   .top .meta { margin-left:auto; font-size:12px; color:var(--text-muted); font-weight:500; }
   .fresh { font-weight:650; white-space:nowrap; }
-  /* Staleness is announced with a text label (STALE / UNREACHABLE), never
+  /* Staleness is announced with a text label (STALE), never
      with color alone; the amber chrome is reinforcement. */
   .fresh.stale { background:var(--hl-soft); border:1px solid var(--hl);
     border-radius:6px; padding:2px 8px; color:var(--text-primary); font-weight:750; }
@@ -201,12 +202,18 @@ document.addEventListener("mousemove",e=>{
  * function names, same order); render.py owns the golden tests, this owns
  * the screen a viewer actually watches. Change them together.
  *
- * States:
- *  - fresh:       "updated HH:MM UTC · Nm ago"
- *  - stale:       generated_at older than data.json's stale_after_s
- *                 (default 7200s) -> amber badge labelled STALE
- *  - unreachable: a poll failed -> amber badge labelled UNREACHABLE, and
- *                 the last successfully rendered data stays on screen
+ * The poll is a best-effort refresh, not what the page depends on: the
+ * whole page is republished every DASH.republishMinutes by the workflow,
+ * so a host that will not answer an XHR (storage.cloud.google.com answers
+ * one with a login redirect) still shows a page at most that old.
+ *
+ * Badge states:
+ *  - polled:   "updated HH:MM UTC · Nm ago" -- a poll has succeeded
+ *  - baked:    the same plus "· regenerated every 15 min" -- no poll has
+ *              succeeded (yet, or at all), so the page is as fresh as its
+ *              last publish
+ *  - stale:    generated_at older than data.json's stale_after_s (default
+ *              7200s), from either source -> amber badge labelled STALE
  */
 "use strict";
 
@@ -217,6 +224,8 @@ const DASH = {
   refreshMs: 60000,
   freshnessTickMs: 30000,
   staleDefaultS: 7200,
+  // The ci-health workflow's cron: how old the baked copy can be at most.
+  republishMinutes: 15,
   screeningWindow: 20,
   repResults: ["pass", "fail", "infra"],
   matrixRuns: 30,
@@ -250,7 +259,9 @@ const DASH = {
 };
 
 let current = DASH.bootstrap;
-let unreachable = false;
+// True once a data.json poll has succeeded; until then (a file:// preview,
+// a host that redirects XHRs) the page is as fresh as its last publish.
+let live = false;
 
 const esc = (value) => String(value)
   .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
@@ -966,11 +977,9 @@ function renderFreshness() {
   const hhmm = generated != null ? new Date(generated).toISOString().slice(11, 16) : "—";
   const ageMin = generated != null ? Math.max(0, Math.round((Date.now() - generated) / 60000)) : null;
   let text = `updated ${hhmm} UTC` + (ageMin != null ? ` · ${ageMin}m ago` : "");
-  let stale = false;
-  if (unreachable) { text = `UNREACHABLE · ${text}`; stale = true; }
-  else if (generated != null && Date.now() - generated > staleAfterMs) {
-    text = `STALE · ${text}`; stale = true;
-  }
+  if (!live) text += ` · regenerated every ${DASH.republishMinutes} min`;
+  const stale = generated != null && Date.now() - generated > staleAfterMs;
+  if (stale) text = `STALE · ${text}`;
   el.textContent = text;
   el.className = stale ? "fresh stale" : "fresh";
 }
@@ -986,22 +995,21 @@ async function refresh() {
     const response = await fetch("data.json", { cache: "no-store" });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     current = await response.json();
-    unreachable = false;
+    live = true;
     renderAll();
   } catch (err) {
-    // Keep the last rendered data on screen; only the badge changes.
-    unreachable = true;
+    // Keep the last rendered data on screen; the badge says the page is
+    // as fresh as its last publish.
+    live = false;
     renderFreshness();
   }
 }
 
 renderAll();
-if (location.protocol !== "file:") {
-  // A file:// preview of a rendered out-dir cannot fetch; it stays a static
-  // render of the baked data instead of pretending the feed is down.
-  refresh();
-  setInterval(refresh, DASH.refreshMs);
-}
+// Polling is attempted everywhere, a file:// preview included: a failed
+// poll costs nothing but the "regenerated every N min" suffix.
+refresh();
+setInterval(refresh, DASH.refreshMs);
 setInterval(renderFreshness, DASH.freshnessTickMs);
 </script>
 </body>

--- a/scripts/eval_dashboard/template/page.html.tmpl
+++ b/scripts/eval_dashboard/template/page.html.tmpl
@@ -3,7 +3,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+__BASE__
 <title>__TITLE__</title>
+<!-- The page's data, inlined by render.py: pages.js boots from these two
+     elements, so the page renders whole with no request beyond itself; the
+     poll of the published brief.json is a best-effort refresh on top. -->
+__INLINE_BRIEF__
+__INLINE_HEALTH__
 <style>
   /* The same visual tokens as legacy.html (index.html.tmpl); the two page
      kinds this template renders -- the Brief and the PR view -- share them
@@ -176,7 +182,7 @@
   <span class="meta"><span id="headmeta">__META__</span> · <span id="freshness" class="fresh">__FRESHNESS__</span></span>
 </div></div>
 
-<div class="wrap"><div id="app"><noscript>This page renders in the browser from <code>brief.json</code>; the <a href="legacy.html">legacy view</a> is the server-rendered table.</noscript></div></div>
+<div class="wrap"><div id="app"><noscript>This page renders in the browser from the data inlined in it; the <a href="legacy.html">legacy view</a> is the server-rendered table.</noscript></div></div>
 
 <script>
 __PAGES_JS__

--- a/scripts/eval_dashboard/template/pages.js
+++ b/scripts/eval_dashboard/template/pages.js
@@ -3,8 +3,9 @@
  * render.py inlines it into both pages after two JSON data elements
  * (PAGE.inlineBrief and PAGE.inlineHealth): brief.json -- the per-run
  * classification classify.py produced, the current health verdict, the
- * health history and the recent merges -- and health.json when there is
- * one. Each page renders itself from those in the browser. There is no
+ * health history and the recent merges -- and, when there is a verdict,
+ * that verdict again under its own id (the same normalized document as
+ * brief.health). Each page renders itself from those in the browser. There is no
  * server-side HTML for these two pages:
  * everything a reader sees is computed here from the inlined copy, with no
  * request beyond the page itself.
@@ -74,7 +75,11 @@ function inlineJson(id) {
   try { return JSON.parse(el.textContent); } catch (err) { return null; }
 }
 
-let brief = inlineJson(PAGE.inlineBrief) || {};
+let brief = inlineJson(PAGE.inlineBrief);
+// No usable data element (a truncated upload, a hand-edited page): say so
+// rather than render an empty dashboard that reads as "nothing happened".
+let briefLoaded = brief != null && typeof brief === "object";
+brief = briefLoaded ? brief : {};
 let health = normalizeHealth(inlineJson(PAGE.inlineHealth) ?? brief.health);
 // True once a brief.json poll has succeeded; until then (a file:// preview,
 // a host that redirects XHRs) the page is as fresh as its last publish.
@@ -745,6 +750,7 @@ function renderAll() {
   const app = document.getElementById("app");
   const page = document.body.dataset.page;
   try {
+    if (!briefLoaded) throw new Error(`the page's data element (#${PAGE.inlineBrief}) is missing or unreadable`);
     app.innerHTML = page === "run" ? runHtml(link) : briefHtml(link);
   } catch (err) {
     app.innerHTML = `<div class="sec head"><h1>This page could not render.</h1><div class="lede">${esc(String(err && err.message || err))}. <a href="legacy.html">Legacy view →</a></div></div>`;
@@ -770,9 +776,11 @@ async function refresh() {
     const next = await fetchJson(PAGE.briefFile);
     if (next && typeof next === "object" && Array.isArray(next.runs)) {
       brief = next;
+      briefLoaded = true;
       health = normalizeHealth(next.health) ?? health;
+      // Only a payload the page took counts as a successful poll.
+      live = true;
     }
-    live = true;
   } catch (err) {
     // The inlined data stays on screen; the badge says the page is as
     // fresh as its last publish.

--- a/scripts/eval_dashboard/template/pages.js
+++ b/scripts/eval_dashboard/template/pages.js
@@ -1,11 +1,21 @@
 /* The Brief (index.html) and the PR view (run.html) share this script.
  *
- * render.py inlines it into both pages together with brief.json -- the
- * per-run classification classify.py produced, the current health verdict,
- * the health history and the recent merges -- and each page renders itself
- * from that document in the browser. There is no server-side HTML for these
- * two pages: everything a reader sees is computed here from the baked copy,
- * then again from a fresh brief.json and health.json every PAGE.refreshMs.
+ * render.py inlines it into both pages after two JSON data elements
+ * (PAGE.inlineBrief and PAGE.inlineHealth): brief.json -- the per-run
+ * classification classify.py produced, the current health verdict, the
+ * health history and the recent merges -- and health.json when there is
+ * one. Each page renders itself from those in the browser. There is no
+ * server-side HTML for these two pages:
+ * everything a reader sees is computed here from the inlined copy, with no
+ * request beyond the page itself.
+ *
+ * The poll of the published brief.json and health.json every PAGE.refreshMs
+ * is a best-effort refresh on top, not what the page depends on: the whole
+ * page is republished every PAGE.republishMinutes by the workflow, so a
+ * host that will not answer an XHR (storage.cloud.google.com answers one
+ * with a login redirect) still shows a page at most that old. A poll that
+ * fails leaves the inlined data on screen and the badge saying so; only
+ * data older than its own stale_after_s reads STALE.
  *
  * Every time a reader sees is America/Toronto ("ET"), formatted with
  * Intl.DateTimeFormat. URL parameters stay ISO 8601 UTC:
@@ -15,8 +25,12 @@
 "use strict";
 
 const PAGE = {
-  brief: __BRIEF_JSON__,
+  // The ids of the data elements render.py inlines (its INLINE_*_ID).
+  inlineBrief: "inline-brief",
+  inlineHealth: "inline-health",
   refreshMs: 60000,
+  // The ci-health workflow's cron: how old the inlined copy can be at most.
+  republishMinutes: 15,
   tz: "America/Toronto",
   tzLabel: "ET",
   // Dates inside this many days of "now" read as a weekday ("Sun 7:30 AM ET");
@@ -54,9 +68,17 @@ const PAGE = {
   healthFile: "health.json",
 };
 
-let brief = PAGE.brief || {};
-let health = normalizeHealth(brief.health);
-let unreachable = false;
+function inlineJson(id) {
+  const el = document.getElementById(id);
+  if (!el) return null;
+  try { return JSON.parse(el.textContent); } catch (err) { return null; }
+}
+
+let brief = inlineJson(PAGE.inlineBrief) || {};
+let health = normalizeHealth(inlineJson(PAGE.inlineHealth) ?? brief.health);
+// True once a brief.json poll has succeeded; until then (a file:// preview,
+// a host that redirects XHRs) the page is as fresh as its last publish.
+let live = false;
 
 const esc = (value) => String(value)
   .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
@@ -711,9 +733,9 @@ function renderFreshness() {
   const staleAfterMs = 1000 * (typeof brief.stale_after_s === "number" ? brief.stale_after_s : 7200);
   const ageMin = generated != null ? Math.max(0, Math.round((Date.now() - generated) / 60000)) : null;
   let text = `updated ${generated != null ? et(generated, Date.now()) : "—"}${ageMin != null ? ` · ${ageMin}m ago` : ""}`;
-  let stale = false;
-  if (unreachable) { text = `UNREACHABLE · ${text}`; stale = true; }
-  else if (generated != null && Date.now() - generated > staleAfterMs) { text = `STALE · ${text}`; stale = true; }
+  if (!live) text += ` · regenerated every ${PAGE.republishMinutes} min`;
+  const stale = generated != null && Date.now() - generated > staleAfterMs;
+  if (stale) text = `STALE · ${text}`;
   el.textContent = text;
   el.className = stale ? "fresh stale" : "fresh";
 }
@@ -750,23 +772,25 @@ async function refresh() {
       brief = next;
       health = normalizeHealth(next.health) ?? health;
     }
-    unreachable = false;
+    live = true;
   } catch (err) {
-    unreachable = true;
+    // The inlined data stays on screen; the badge says the page is as
+    // fresh as its last publish.
+    live = false;
   }
   try {
     const fresh = normalizeHealth(await fetchJson(PAGE.healthFile));
     if (fresh) health = fresh;
   } catch (err) {
-    // health.json is optional; the baked verdict (or none) stays.
+    // health.json is optional; the inlined verdict (or none) stays.
   }
   renderAll();
 }
 
 renderAll();
-if (location.protocol !== "file:") {
-  refresh();
-  setInterval(refresh, PAGE.refreshMs);
-}
+// Polling is attempted everywhere, a file:// preview included: a failed
+// poll costs nothing but the "regenerated every N min" suffix.
+refresh();
+setInterval(refresh, PAGE.refreshMs);
 window.addEventListener("hashchange", renderAll);
 setInterval(renderFreshness, 30000);

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -1021,15 +1021,20 @@ class LiveReadSideTest(unittest.TestCase):
         self.assertIn("staleDefaultS: 7200", self.html)
         self.assertIn('"stale_after_s":600', self.html)
 
-    def test_stale_and_unreachable_states_carry_text_labels(self):
+    def test_stale_state_carries_a_text_label_and_a_failed_poll_is_not_an_alarm(self):
         # A template-contract tripwire, deliberately: the baked page cannot
-        # reach these states server-side (they exist only after a poll), so
-        # this pins the *shipped script* -- the amber badge must always
+        # reach the stale state server-side (it exists only against a clock),
+        # so this pins the *shipped script* -- the amber badge must always
         # carry a written label, never color alone -- scoped to the script
-        # source so it fails if the labels leave the template.
+        # source so it fails if the label leaves the template. A failed poll
+        # is not a state of its own: the page is republished every 15
+        # minutes, so the badge says that and stays un-amber (the published
+        # host answers every XHR with a login redirect).
         js = script_source(self.html)
         self.assertIn("`STALE · ${text}`", js)
-        self.assertIn("`UNREACHABLE · ${text}`", js)
+        self.assertNotIn("UNREACHABLE", js)
+        self.assertIn("regenerated every ${DASH.republishMinutes} min", js)
+        self.assertIn("republishMinutes: 15", js)
         self.assertIn(".fresh.stale", self.html)
 
     def test_notes_travel_with_the_bootstrap(self):

--- a/scripts/test_eval_dashboard.py
+++ b/scripts/test_eval_dashboard.py
@@ -1066,7 +1066,7 @@ class LiveReadSideTest(unittest.TestCase):
         # bare Date.parse reads one as local time, so the mirror appends
         # "Z" -- otherwise every day bucket and week window would shift
         # for a viewer outside UTC. Contract tripwire on the shipped
-        # script, like the STALE/UNREACHABLE labels.
+        # script, like the STALE label.
         self.assertIn('text += "Z"', script_source(self.html))
 
 

--- a/scripts/test_eval_dashboard_pages.py
+++ b/scripts/test_eval_dashboard_pages.py
@@ -112,19 +112,51 @@ def strict_date_parse_page(page: pathlib.Path) -> pathlib.Path:
     return copy
 
 
-def dom_text(page: pathlib.Path, query: str = "", fragment: str = "") -> str:
-    """The page's #app innerHTML after the script ran, via headless Chrome."""
+def dom_html(page: pathlib.Path, query: str = "", fragment: str = "") -> str:
+    """The whole document after the script ran, via headless Chrome. From
+    file:// every fetch fails, which is the condition a host that answers
+    an XHR with a login redirect puts the pages in."""
     url = page.as_uri() + (f"?{query}" if query else "") + fragment
     result = subprocess.run(
         [chrome(), "--headless", "--disable-gpu", "--no-sandbox", "--virtual-time-budget=3000", "--dump-dom", url],
         capture_output=True, text=True, timeout=90, check=False,
     )
-    html = result.stdout
+    return result.stdout
+
+
+def dom_text(page: pathlib.Path, query: str = "", fragment: str = "") -> str:
+    """The page's #app innerHTML after the script ran."""
+    html = dom_html(page, query, fragment)
     start = html.find('<div id="app">')
     # Slice up to the page's own inline script (its first comment line), not
     # the first <script> tag: an injected tag inside #app must stay visible.
     end = html.find("<script>\n/* The Brief", start)
     return html[start:end]
+
+
+def freshness_badge(html: str) -> tuple[str, str]:
+    """(class, text) of the header's freshness badge in a rendered document."""
+    match = re.search(r'<span id="freshness" class="([^"]*)">([^<]*)</span>', html)
+    assert match, "no freshness badge in the document"
+    return match.group(1), match.group(2)
+
+
+def clock_page(page: pathlib.Path, now_iso: str) -> pathlib.Path:
+    """A copy of the rendered page whose wall clock is pinned to
+    ``now_iso``, so the badge's age and staleness are the test's, not the
+    day the suite happens to run."""
+    ms = int(render.iso_ms(now_iso))
+    shim = f"<script>Date.now = () => {ms};</script>"
+    copy = page.with_name(page.stem + "-clock" + page.suffix)
+    copy.write_text(page.read_text().replace("<head>", "<head>" + shim, 1))
+    return copy
+
+
+def inline_blob(html: str, element_id: str):
+    """The parsed JSON of a page's ``<script type="application/json">``
+    data element, or None when the page carries none by that id."""
+    match = re.search(rf'<script type="application/json" id="{element_id}">(.*?)</script>', html, re.DOTALL)
+    return json.loads(match.group(1)) if match else None
 
 
 class HealthInputsTest(unittest.TestCase):
@@ -301,16 +333,65 @@ class RenderedFilesTest(unittest.TestCase):
             self.assertIn('data-page="brief"', index)
             self.assertIn('timeZone: PAGE.tz', index.replace("Object.assign({ timeZone: PAGE.tz }", "timeZone: PAGE.tz"))
             self.assertIn('tz: "America/Toronto"', index)
-            self.assertIn("brief:", index)
             self.assertIn("\\u003c", render.bootstrap_json({"x": "<script>"}))
-            self.assertNotIn("__BRIEF_JSON__", index)
             self.assertNotIn("__PAGES_JS__", index)
+            self.assertNotIn("__INLINE_", index)
+            self.assertNotIn("__BASE__", index)
             run_page = (out / "run.html").read_text()
             self.assertIn('data-page="run"', run_page)
             legacy = (out / "legacy.html").read_text()
             self.assertIn('href="index.html">Brief</a>', legacy)
             self.assertIn('id="agent"', legacy)
+            self.assertNotIn("__BASE__", legacy)
             self.assertFalse((out / "health.json").exists(), "the adjudicator owns health.json")
+
+    def test_each_page_carries_its_data_inline(self):
+        # The pages must render with no request beyond themselves (the
+        # published host answers an XHR with a login redirect), so brief.json
+        # and the verdict travel inside each page as JSON data elements.
+        data = load_fixture()
+        data["generated_at"] = NOW
+        with tempfile.TemporaryDirectory() as tmp:
+            out = render_to(tmp, data, health=health_doc())
+            brief = json.loads((out / "brief.json").read_text())
+            for name in ("index.html", "run.html"):
+                page = (out / name).read_text()
+                head = page.split("<body", 1)[0]
+                self.assertEqual(inline_blob(head, render.INLINE_BRIEF_ID), brief, f"{name}: the inline brief is brief.json")
+                self.assertEqual(inline_blob(head, render.INLINE_HEALTH_ID), brief["health"], f"{name}: the inline verdict")
+                self.assertEqual(page.count('id="inline-brief">'), 1, f"{name}: one copy of the document, not two")
+                raw = re.search(r'id="inline-brief">(.*?)</script>', head, re.DOTALL).group(1)
+                self.assertNotIn("<", raw, f"{name}: no '<' inside the data element, so no string in it can close it")
+            self.assertIn('inlineBrief: "inline-brief"', page, "pages.js reads the id render.py writes")
+            self.assertIn('inlineHealth: "inline-health"', page)
+            self.assertNotIn("brief: ", page.split("const PAGE = {")[1].split("};")[0], "brief.json is no longer a JS literal inside pages.js")
+            # No verdict: the health element is absent and the page still parses its brief.
+            out = render_to(pathlib.Path(tmp) / "nohealth", data)
+            page = (out / "index.html").read_text()
+            self.assertIsNone(inline_blob(page, render.INLINE_HEALTH_ID))
+            self.assertIsNone(inline_blob(page, render.INLINE_BRIEF_ID)["health"])
+
+    def test_base_href_only_with_a_public_url(self):
+        data = load_fixture()
+        data["generated_at"] = NOW
+        with tempfile.TemporaryDirectory() as tmp:
+            out = render_to(tmp, data)
+            for name in ("index.html", "run.html", "legacy.html"):
+                self.assertNotIn("<base", (out / name).read_text(), f"{name}: a local render keeps relative links")
+            out = render_to(pathlib.Path(tmp) / "pub", data, extra_args=["--public-url", "https://example.test/evals"])
+            for name in ("index.html", "run.html", "legacy.html"):
+                page = (out / name).read_text()
+                self.assertEqual(page.count("<base "), 1, name)
+                self.assertIn('<base href="https://example.test/evals/">', page.split("<body", 1)[0], f"{name}: in <head>, with the trailing slash")
+            # A trailing slash on the flag is not doubled.
+            out = render_to(pathlib.Path(tmp) / "slash", data, extra_args=["--public-url", "https://example.test/evals/"])
+            self.assertIn('<base href="https://example.test/evals/">', (out / "index.html").read_text())
+            # The bare flag names the published dashboard, post_health's URL.
+            out = render_to(pathlib.Path(tmp) / "bare", data, extra_args=["--public-url"])
+            self.assertIn('<base href="https://storage.cloud.google.com/kube-agents-dashboards/evals/">', (out / "index.html").read_text())
+            self.assertEqual(render.PUBLISHED_SITE + "/index.html", render.post_health.DASHBOARD_URL)
+        self.assertEqual(render.base_html(None), "")
+        self.assertEqual(render.base_html('https://h/"><script>'), '<base href="https://h/&quot;&gt;&lt;script&gt;/">')
 
     def test_hostile_data_never_escapes_the_script_block(self):
         data = load_fixture()
@@ -572,6 +653,42 @@ class BrowserTest(unittest.TestCase):
         self.assertIn(f"No run with that id in the last {render.RUN_VIEW_DAYS} days.", app)
         app = dom_text(self.run_page)
         self.assertIn("Which run?", app)
+
+    def test_pages_render_whole_when_every_fetch_fails(self):
+        # From file:// every fetch fails, as it does on storage.cloud.google.com
+        # (an XHR there is answered with a login redirect). The pages must
+        # render fully from their inlined data, the badge must not call the
+        # feed unreachable, and it must say how old the page can be instead.
+        # The clock is pinned to the data's generated_at so the badge is fresh.
+        for name, query, expect in (
+            ("index.html", "", "3 gate cases fail on every PR"),
+            ("index.html", "", "Runs in this window"),
+            ("run.html", "build=2097282860221206528", "3 of 10 gate cases failed. None of them look like your PR."),
+        ):
+            page = clock_page(self.out / name, NOW)
+            html = dom_html(page, query=query)
+            app = html[html.find('<div id="app">'):html.find("<script>\n/* The Brief")]
+            self.assertIn(expect, app, f"{name}?{query}")
+            self.assertNotIn("could not render", app, name)
+            cls, text = freshness_badge(html)
+            self.assertEqual(cls, "fresh", f"{name}: not amber")
+            self.assertNotIn("UNREACHABLE", text, name)
+            self.assertNotIn("STALE", text, name)
+            self.assertEqual(text, "updated Tue 10:30 AM ET · 0m ago · regenerated every 15 min", name)
+        # The legacy page's content is baked; its badge follows the same rule.
+        cls, text = freshness_badge(dom_html(clock_page(self.out / "legacy.html", NOW)))
+        self.assertEqual((cls, text), ("fresh", "updated 14:30 UTC · 0m ago · regenerated every 15 min"))
+
+    def test_old_inline_data_still_reads_stale(self):
+        # Not calling a failed poll UNREACHABLE must not hide real staleness:
+        # inlined data older than its stale_after_s (7200 s default) is STALE.
+        three_hours_on = "2026-09-08T17:30:00+00:00"
+        for name in ("index.html", "run.html", "legacy.html"):
+            cls, text = freshness_badge(dom_html(clock_page(self.out / name, three_hours_on)))
+            self.assertEqual(cls, "fresh stale", name)
+            self.assertTrue(text.startswith("STALE · updated "), f"{name}: {text}")
+            self.assertIn("180m ago · regenerated every 15 min", text, name)
+            self.assertNotIn("UNREACHABLE", text, name)
 
 
 if __name__ == "__main__":

--- a/scripts/test_eval_dashboard_pages.py
+++ b/scripts/test_eval_dashboard_pages.py
@@ -383,6 +383,9 @@ class RenderedFilesTest(unittest.TestCase):
                 page = (out / name).read_text()
                 self.assertEqual(page.count("<base "), 1, name)
                 self.assertIn('<base href="https://example.test/evals/">', page.split("<body", 1)[0], f"{name}: in <head>, with the trailing slash")
+                # Under <base>, a bare "#agent" resolves to the site root, not
+                # this page: every in-page link must carry its file name.
+                self.assertNotIn('href="#', page, f"{name}: no fragment-only link")
             # A trailing slash on the flag is not doubled.
             out = render_to(pathlib.Path(tmp) / "slash", data, extra_args=["--public-url", "https://example.test/evals/"])
             self.assertIn('<base href="https://example.test/evals/">', (out / "index.html").read_text())
@@ -676,8 +679,21 @@ class BrowserTest(unittest.TestCase):
             self.assertNotIn("STALE", text, name)
             self.assertEqual(text, "updated Tue 10:30 AM ET · 0m ago · regenerated every 15 min", name)
         # The legacy page's content is baked; its badge follows the same rule.
-        cls, text = freshness_badge(dom_html(clock_page(self.out / "legacy.html", NOW)))
-        self.assertEqual((cls, text), ("fresh", "updated 14:30 UTC · 0m ago · regenerated every 15 min"))
+        html = dom_html(clock_page(self.out / "legacy.html", NOW))
+        self.assertIn("Is the agent getting better or worse?", html[html.find('<div id="app">'):])
+        self.assertEqual(freshness_badge(html), ("fresh", "updated 14:30 UTC · 0m ago · regenerated every 15 min"))
+
+    def test_a_page_without_its_data_element_says_so(self):
+        # A truncated upload must not read as a quiet, empty dashboard.
+        for name, query in (("index.html", ""), ("run.html", "build=2097282860221206528")):
+            page = self.out / name
+            copy = page.with_name(page.stem + "-nodata" + page.suffix)
+            copy.write_text(re.sub(r'<script type="application/json" id="inline-brief">.*?</script>', "", page.read_text(), count=1, flags=re.DOTALL))
+            app = dom_text(copy, query=query)
+            self.assertIn("This page could not render.", app, name)
+            self.assertIn("inline-brief", app, name)
+            self.assertNotIn("No gate verdict is published", app, name)
+            self.assertNotIn("No run with that id", app, name)
 
     def test_old_inline_data_still_reads_stale(self):
         # Not calling a failed poll UNREACHABLE must not hide real staleness:


### PR DESCRIPTION
## Summary

The published eval dashboard is opened through the console URL, `https://storage.cloud.google.com/kube-agents-dashboards/evals/index.html`. That host answers an XHR for a sibling object with a `302` to `accounts.google.com`, and the redirect chain is cross-origin, so every `fetch()` the pages make fails there: the Brief showed an amber `UNREACHABLE · updated Fri 9:59 AM ET · 13m ago` badge on every load, and the nav links misbehaved after the login redirect. This PR makes the three pages work with zero successful fetches: they boot from JSON data elements inlined into the page, a failed poll is no longer an alarm state, and `render.py --public-url` emits `<base href>` so every link resolves to the published site wherever the browser landed.

## Why This Change

Everyone who clicks the dashboard link lands on `storage.cloud.google.com`; the bucket is internal-only with no other public host. Without this change the Brief always reads as unreachable and the "Numbers" / "PR view" / "Legacy view" links are unreliable there, so the dashboard is effectively broken for its readers. The pages are republished every 15 minutes by the `ci-health` workflow, which means the 60-second in-page poll was only ever a nicety; the page itself is the freshness mechanism.

## What Changed

- `render.py` inlines `brief.json` into `index.html` and `run.html` as `<script type="application/json" id="inline-brief">` (and the verdict it read as `inline-health`); `pages.js` boots from those. On `main` the brief was already inlined as a JS literal inside `pages.js`, so "renders with no request" already held; this moves the data to a data element and is a small refactor riding along with the two behaviour changes below.
- Badge: a failed poll keeps the inlined data and reads `updated <ET time> · Nm ago · regenerated every 15 min` in the normal (non-amber) style; there is no `UNREACHABLE` state any more. `STALE` is unchanged: shown, amber, whenever the data's `generated_at` is older than its `stale_after_s`. The legacy page's `data.json` poll follows the same rule. Polling is now attempted from `file://` too, so a local render exercises exactly the failing-fetch path the published host produces.
- `render.py --public-url [BASE]` emits `<base href="<BASE>/">` in all three pages. The bare flag derives the site from `post_health.DASHBOARD_URL`'s directory (the URL the Chat messages and the gate comment already link to); without the flag links stay relative, so local renders and tests are unchanged. The `ci-health` workflow passes the bare flag; `hack/ci-dashboard-refresh.sh` passes it only for a `gs://` target. The legacy page's in-page nav links now carry `legacy.html#…` because under `<base>` a bare `#agent` would resolve to the site root.
- A page whose `inline-brief` element is missing or unreadable now says "This page could not render" instead of drawing an empty dashboard.
- `SCHEMA.md` "The rendered pages": how pages get their data, what the badge means, the flag.

## Context

- Related tracker: #1022 (dashboard live at a URL).
- #1446 (open, same author) touches five of the same files; the only textual overlap is `render.py`'s import block and the `SCHEMA.md` "rendered pages" paragraph. Merge-conflict warning, not a conflict of intent; the workflow and hack-script hunks do not overlap.
- Verified with `curl`: unauthenticated `GET` of `index.html` and `brief.json` on `storage.cloud.google.com` both return `302 → accounts.google.com/ServiceLogin`, and the host ignores a bearer token (cookie session only), so the hosted behaviour cannot be exercised from a shell.

## Testing

- `cd scripts && python3 -m unittest discover -s . -p 'test_eval_dashboard*.py'` → 333 tests, OK (2 skipped: node-less parity harness and one Chrome-less guard that is present here). New tests: the inline data elements are present, one copy, equal to `brief.json`, free of `<`; `<base>` appears in all three pages only with `--public-url`, the bare flag resolves to `post_health.DASHBOARD_URL`'s directory, and no `href="#` survives a `--public-url` render; headless Chrome from `file://` (every fetch fails, the published host's condition) renders the Brief, the PR view (`run.html?build=…`) and the legacy page whole with class `fresh` and the badge `updated Tue 10:30 AM ET · 0m ago · regenerated every 15 min` and no `UNREACHABLE`; inlined data three hours old reads `STALE · …` amber; a page stripped of its `inline-brief` element shows the could-not-render page. The legacy contract tripwire now asserts `UNREACHABLE` has left the shipped script.
- `make docs-check` clean; `python3 scripts/check_context_budget.py` unchanged (AGENTS.md not touched); `prettier@3.9.6 --check` clean on `ci-health.yml` and `SCHEMA.md`; `bash -n hack/ci-dashboard-refresh.sh` clean.

### Live validation

Rendered from the real published data (`gsutil cp gs://kube-agents-dashboards/evals/{data,brief,health}.json health-history.jsonl`, read-only; nothing was written to the bucket) with `render.py --health … --health-history … --public-url`, then opened via `file://` in headless Chrome. With `<base href>` pointing at `storage.cloud.google.com`, the page's poll really went to that host and failed cross-origin, which is the exact condition the published page is in. All three pages render fully; the header badge reads `updated Fri 9:59 AM ET · 27m ago · regenerated every 15 min` in the normal style, no amber, no `UNREACHABLE`; `<base href="https://storage.cloud.google.com/kube-agents-dashboards/evals/">` is in each `<head>`, and the rendered `legacy.html` has no fragment-only link. The Brief (healthy state, real data):

![dashboard-inline-brief](https://raw.githubusercontent.com/jayantid/kube-agents/pr-evidence/dashboard-inline-brief-2d1af18924c5-20260911T144227Z.png)

_Published 20260911T144227Z at commit 2d1af18924c5 — pre-captured image (brief.png)._

The PR view, `run.html?build=2098261704302399488` (a red run with an unexplained case):

![dashboard-inline-run](https://raw.githubusercontent.com/jayantid/kube-agents/pr-evidence/dashboard-inline-run-2d1af18924c5-20260911T144232Z.png)

_Published 20260911T144232Z at commit 2d1af18924c5 — pre-captured image (run.png)._

The legacy page (baked content, same badge rule):

![dashboard-inline-legacy](https://raw.githubusercontent.com/jayantid/kube-agents/pr-evidence/dashboard-inline-legacy-2d1af18924c5-20260911T144236Z.png)

_Published 20260911T144236Z at commit 2d1af18924c5 — pre-captured image (legacy.png)._

Not covered: the behaviour on `storage.cloud.google.com` itself. That host only serves a cookie-authenticated browser session, so it is verified only after publish, which the `ci-health` workflow does within 15 minutes of merge; the first published tick is the check to watch (badge un-amber, "Numbers" / "PR view" / "Legacy view" navigating within the site). Also not covered: a poll that *succeeds* (a host that serves the JSON with a same-origin 200), which is the pre-existing path and is untouched apart from `live = true` now sitting inside the payload-accepted branch. No test artifacts were left behind; the temporary `forkhttps` remote used for the screenshots was removed.

## Self-Review

Two passes, each in a fresh subagent handed the commit range and the skill file and nothing else: `review-adversarial` and `review-docs-drift`, both against `origin/main..HEAD`.

Adversarial pass, looked for: JS boot/refresh/badge state bugs, injection through the inline JSON element, `<base href>` side effects on fragment links and fetch targets, `argparse nargs="?"` ordering at both call sites, tests that claim more than they prove, magic constants, unrelated formatting drift, commit-message claims the diff does not support.

- **Blocking, fixed (2d1af189):** under `<base href>` the legacy page's bare `#agent` / `#gate` / `#nightly` / `#release` links resolved to the bucket directory, a cross-document navigation. They carry `legacy.html` now; the render test asserts no `href="#` survives a `--public-url` render.
- **Should fix, fixed:** `hack/ci-dashboard-refresh.sh` passed `--public-url` unconditionally, so a local-directory target got the production base. Now only for `gs://*`.
- **Should fix, fixed:** `live = true` sat after the payload guard, so a 200 body without `runs[]` dropped the "regenerated" suffix while the inlined data stayed on screen. Moved inside the guard.
- **Should fix, addressed:** the first commit message says the pages "now" need no request beyond themselves; on `main` the brief was already a JS literal in `pages.js`. Stated plainly in the second commit and in What Changed above; the user-visible fixes are the badge and the absolute links. The "legacy page renders whole" claim now has a content assertion, not only a badge one.
- **Nit, docs corrected:** `inline-health` is the same normalized document as `brief.health`; the docstring, `SCHEMA.md` and the `pages.js` comment called it "health.json beside it". Kept the element (a stable id for the verdict), corrected the wording.
- **Nit, fixed:** a missing/unparseable `inline-brief` rendered a plausible empty dashboard; it now takes the could-not-render path, with a test.
- **Nit, fixed:** help text says an empty `--public-url` value emits no `<base>`.
- **Nit, not fixed:** `republishMinutes: 15` restates the `*/15` cron in `pages.js`, the legacy template, `SCHEMA.md` and a test literal with nothing tying them. Wiring the cron value through render.py is more plumbing than this fix should carry; the constant is named in both scripts and the comment points at the cron.
- Checked clean by the pass: every `pages.js` href carries a file name, `scrollIntoView` / `querySelector(hash)` unaffected by `<base>`, injection covered (`bootstrap_json` strips `<`, `base_html` HTML-escapes, both tested), the flag is last at both call sites and render.py has no positionals, no test removed or skipped, #1446 does not touch the render-invocation lines or the badge code.

Docs-drift pass, no Blocking. Nits fixed: `render.py` Usage block names `--public-url`; the docstring says the poll covers `brief.json` and `health.json`; the "one source" comment no longer claims it (`health.py` carries an identical `DASHBOARD_URL` literal, pre-existing and left alone); `publish.py`'s no-cache rationale names the three polled objects; a test comment no longer cites the UNREACHABLE label. Not fixed: `hack/ci-dashboard-refresh.sh`'s header still says "hourly" in two places while its own line 46 and the badge say 15 minutes; pre-existing drift in a file #1446 is also editing, left for that PR to avoid a conflict. `docs/README.md` needs no row (no new document).

Formatting drift: the local ruff hook rewrote four unrelated lines during editing (`re.I` → `re.IGNORECASE` twice, an `if/elif` merge); all reverted before committing.

Generated with the help of Claude Code.

## Risk & Rollout

Blast radius is the three static pages and the two render invocations; no runtime kube-agents path is touched. New failure mode: `<base href>` makes every relative link on the published pages absolute to `storage.cloud.google.com`, so if the pages are ever served from another host the links still go there (that is the intent). Revert is a plain `git revert`; the next `ci-health` tick republishes the previous pages. Nothing has to happen at merge time; the first tick after merge is the live check named above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
