### PR TITLE
docs(agents): state that gke-* platform skills are upstream copies and how to change them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,10 +147,9 @@ the assignee is the claim; do not apply `status:` labels to issues in this repos
 
 ## Skills Guidelines
 
-- Skills are located under `agents/platform/skills/` (Platform Agent: provisioning, governance, cost, manifest generation, GitOps) and `agents/cluster/skills/` (Cluster Agent: single-cluster runtime debugging and operations).
-- Each skill directory must contain a `SKILL.md` file providing instructions for that specific skill.
-- Place a skill according to its persona: fleet/provisioning/GitOps-write skills belong to the Platform Agent; read-only, single-cluster runtime-debugging skills belong to the Cluster Agent.
-- When adding new skills, ensure they follow the existing structure and are clearly documented to be understood by AI agents.
+- Skills live under `agents/platform/skills/` (Platform Agent) and `agents/cluster/skills/` (Cluster Agent); each skill directory holds a `SKILL.md` written for an AI agent.
+- Place a skill by persona: fleet, provisioning and GitOps-write skills belong to the Platform Agent; read-only, single-cluster runtime-debugging skills belong to the Cluster Agent.
+- `agents/platform/skills/gke-*` are mirrors of `google/skills`, deleted and recopied by `scripts/sync-upstream-skills.py` on every sync, so a direct edit lasts until the next run. Do not make one; add a `SKILL_SUBSTITUTIONS` or `SKILL_FOOTERS` entry in that script and rerun the sync.
 
 ## Engineering Rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,9 +147,9 @@ the assignee is the claim; do not apply `status:` labels to issues in this repos
 
 ## Skills Guidelines
 
-- Skills live under `agents/platform/skills/` (Platform Agent) and `agents/cluster/skills/` (Cluster Agent); each skill directory holds a `SKILL.md` written for an AI agent.
-- Place a skill by persona: fleet, provisioning and GitOps-write skills belong to the Platform Agent; read-only, single-cluster runtime-debugging skills belong to the Cluster Agent.
-- `agents/platform/skills/gke-*` are mirrors of `google/skills`, deleted and recopied by `scripts/sync-upstream-skills.py` on every sync, so a direct edit lasts until the next run. Do not make one; add a `SKILL_SUBSTITUTIONS` or `SKILL_FOOTERS` entry in that script and rerun the sync.
+- Skills live under `agents/platform/skills/` (Platform Agent) and `agents/cluster/skills/` (Cluster Agent); each holds a `SKILL.md` for an AI agent.
+- Place a skill by persona: fleet, provisioning and GitOps-write skills go to the Platform Agent; read-only, single-cluster runtime debugging to the Cluster Agent.
+- `agents/platform/skills/gke-*` are copies of `google/skills` that `scripts/sync-upstream-skills.py` overwrites wholesale, so the prefix is reserved and a direct edit lasts until the next sync. Put a `SKILL.md` change in its `SKILL_SUBSTITUTIONS` or `SKILL_FOOTERS` and make the same edit by hand; a rerun refreshes every skill from upstream.
 
 ## Engineering Rules
 


### PR DESCRIPTION
## Summary

One bullet in the Skills Guidelines section of `AGENTS.md` now says that `agents/platform/skills/gke-*` are copies of `google/skills` that `scripts/sync-upstream-skills.py` overwrites wholesale, that the prefix is reserved for that sync, and that a change to one of those files goes into the script's `SKILL_SUBSTITUTIONS` or `SKILL_FOOTERS` with the same edit made by hand, rather than as a direct edit. The other bullets in the section are tightened so the file stays inside the context budget.

## Why This Change

The rule existed only in the sync script's header comment and a `.prettierignore` comment, so nobody editing a mirrored skill saw it. #1226 added qualifiers directly to two mirrored files, and eight mirrored files across six merged pull requests (#691, #723, #829, #885, #945, #1226) now differ from upstream with no script entry to re-create them. The next sync run deletes and recopies every one of those directories and drops all of that work without a message. Naming the rule in the always-loaded file is the cheapest place to stop the next instance.

## What Changed

- `AGENTS.md`, Skills Guidelines: the mirror rule, which files it covers (the two hooks only reach `SKILL.md`), and that a rerun is a full refresh from upstream rather than a scoped update.
- The first two bullets lose their parenthetical restatements of the persona split, which the second bullet already states, to pay for the new one. The file is 38.0k of the 38,000-char budget after this change.

## Context

Part of #1440, which also proposes a lock file and a test that fails on a direct edit to a mirrored file, and a run of the sync itself. Those are separate changes; this one is the rule alone. A branch carrying the lock and test exists at `toshiowang/kube-agents:fix/mirrored-skills-guard` and will follow as its own pull request.

Open pull requests this rule bears on: #1384 and #1378 edit mirrored `SKILL.md` files directly; #591 adds a repo-native skill under the reserved `gke-` prefix, which the sync's prune step would delete; #1370 and #926 use the substitution and footer hooks the bullet asks for. #1365 adds a `SKILL_FOOTERS` entry and the matching footer, the pattern the bullet prescribes. No open pull request edits this section of `AGENTS.md`; #1438, #1319 and #1256 add to the file elsewhere and will meet the context budget in whichever order they land.

## Testing

- `make docs-check`: all five checks green; the context budget reports 0.0k under 38,000 chars.
- `prettier@3.9.6 --check AGENTS.md`: clean.

### Live validation

Not live-tested: the change is one paragraph in a contributor-facing instruction file and has no runtime path. Nothing in the agent images or the operator reads `AGENTS.md`.

## Self-Review

Both passes ran against `refs/kube-agents-base/main...HEAD`, each in a fresh subagent handed the range, the skill path and the `make docs-check` output and nothing else. The adversarial pass verified every claim in the new bullet against `scripts/sync-upstream-skills.py` and the `agents/` tree, diffed the tree against a fresh upstream clone, and checked the open pull requests that touch mirrored files. The docs-drift pass checked the bullet against the script, the skills concept page, the contributing guide, `.prettierignore`, `docs/README.md` and `.agents/rules/`, and audited what the dropped bullet text lost. Neither could run the sync itself.

1. **HIGH, CONFIRMED (adversarial).** The first draft ended "rerun the sync". Without a pin, a rerun refreshes every skill from upstream HEAD: today that deletes two directories upstream renamed, adds five new skills, and reverts the six merged edits above. Fixed in ec4ca98e: the bullet now says to add the hook entry and make the same edit by hand, which the hooks tolerate because both skip when their replacement text is already present, and states that a rerun is a full refresh.
2. **MEDIUM, CONFIRMED (adversarial; docs-drift advisory).** Both hooks open only `SKILL.md`, so a change to a reference or asset file has no sanctioned path. Fixed in ec4ca98e: the bullet scopes itself to `SKILL.md`. Extending the hooks to other files is in #1440.
3. **MEDIUM, PLAUSIBLE (adversarial; docs-drift advisory).** #591 adds a repo-native skill under the `gke-` prefix, which the sync would delete. Fixed in ec4ca98e by stating the prefix is reserved; the pull request itself is named in Context rather than commented on.
4. **LOW, CONFIRMED (adversarial).** "Mirrors" overstated it, since nine directories carry content absent upstream. Fixed in ec4ca98e: "copies that the sync overwrites wholesale".
5. **Advisory (docs-drift).** The `.prettierignore` comment says the `gke-*` skills are imported verbatim and its glob also covers the repo-native `agents/cluster/skills/gke-*`. Pre-existing and left alone: fixing the comment belongs with the lock change, and changing the glob would reformat unrelated files.
6. **Advisory (docs-drift).** The skills concept page tells image builders to copy skills into `agents/platform/skills/` without mentioning the reserved prefix. Left alone: that page addresses users building custom images, and the one-line pointer is in the follow-up branch.

Recorded as not findings: the dropped bullet text survives elsewhere (the persona descriptions in the second bullet and the concept page, "follow the existing structure" in the skill-review skill); the script's own header comment agrees with the bullet; nothing mechanical checks the identifiers in the root `AGENTS.md`, which is true of every path in that file.

## Risk & Rollout

One paragraph of contributor instructions; no runtime code path. Revert is a one-file revert. The file sits at the context budget, so the next addition to `AGENTS.md` needs an equal cut.
