### PR TITLE
fix(e2e): stop the token-minting probe skipping its refresh when find exits non-zero

### DIFF
--- a/tests/e2e/test_agent_fleet_audit.py
+++ b/tests/e2e/test_agent_fleet_audit.py
@@ -18,6 +18,22 @@ _AUDIT_REPORT_SCRIPT = (
 _POD_WAIT_TIMEOUT_SECONDS = 120
 _POD_POLL_INTERVAL_SECONDS = 5
 
+# Where the refresh client lives inside the pod the probe execs into. Both pod
+# layouts bake it into the image at /opt/defaults/scripts and their entrypoints
+# copy it onto the data volume at /opt/data/scripts on every start; the volume
+# copy is preferred because that is the one the agent itself runs. No wider
+# search: a copy found elsewhere (a GitOps clone under the data volume, say)
+# would let the probe pass on an image that lost its own.
+_REFRESH_SCRIPT_NAME = "github_token_refresh.py"
+_REFRESH_SCRIPT_CANDIDATES = (
+    f"/opt/data/scripts/{_REFRESH_SCRIPT_NAME}",
+    f"/opt/defaults/scripts/{_REFRESH_SCRIPT_NAME}",
+)
+_REFRESH_CONFIRMATION = "Refreshed GitHub credentials via"
+# The exec budget covers the refresh (its client waits up to 60s on the proxy)
+# plus the gh call, with room for a slow broker.
+_PROBE_TIMEOUT_SECONDS = 180
+
 # All Registered Audit Streams and their human titles
 AUDIT_STREAMS: List[Tuple[str, str]] = [
     ("compliance-audit", "Security & RBAC Posture Audit"),
@@ -39,11 +55,17 @@ def test_github_token_minting_and_connectivity(
 ) -> None:
     """Verifies live in-cluster GitHub authentication, token minting, and repository reachability.
 
-    Executes a genuinely 100% read-only probe inside the platform-agent pod:
-    1. Triggers token refresh via the Envoy credential proxy sidecar and GitHub Token Minter (Cloud KMS).
+    Executes a genuinely 100% read-only probe inside the agent's shell sandbox pod, or the
+    legacy gateway pod on an install that has no sandbox:
+    1. Triggers token refresh through the credential proxy and GitHub Token Minter (Cloud KMS).
     2. Executes `gh api repos/<target_repo>` from the shared workspace root.
     3. Verifies repository access and permissions over the network.
     Does NOT invoke `audit_report.py start`, preventing workspace reset, lease scrubbing, or label writes.
+
+    Step 1 is the only thing that mints on a fresh install: nothing at startup writes the
+    proxy's gh credentials, so a probe that skips it passes or fails on whether some earlier
+    task happened to mint. The probe therefore fails when the refresh client cannot be found
+    or the refresh fails, instead of falling through to `gh`.
     """
     if not gke_cluster_name or not github_repo:
         pytest.fail("GKE cluster name and GITHUB_REPO are required for live GitHub connectivity probe.")
@@ -108,14 +130,30 @@ def test_github_token_minting_and_connectivity(
     script = f"""
 import sys, subprocess, os
 
-# 1. Refresh credentials in the credential proxy via the broker client
-p_refresh = subprocess.run(['find', '/opt', '-name', 'github_token_refresh.py'], capture_output=True, text=True)
-if p_refresh.returncode == 0 and p_refresh.stdout.strip():
-    refresh_script = p_refresh.stdout.strip().splitlines()[0]
-    res_ref = subprocess.run(['python3', refresh_script, '{github_repo}'], capture_output=True, text=True)
-    if res_ref.returncode != 0:
-        print(f"Token refresh failed: {{res_ref.stderr}}", file=sys.stderr)
-        sys.exit(res_ref.returncode)
+# 1. Refresh credentials in the credential proxy via the broker client.
+# The script is resolved from its known locations, not searched for: as the
+# sandbox user, `find /opt` cannot enter the root-owned lost+found on the
+# data volume and exits non-zero even after printing a match, so an exit-code
+# gate on it skipped this step and left the probe to pass or fail on whatever
+# credentials an earlier task had left in the proxy.
+candidates = [p for p in {_REFRESH_SCRIPT_CANDIDATES!r} if os.path.isfile(p)]
+if not candidates:
+    print(
+        f"{_REFRESH_SCRIPT_NAME} not found at any of {_REFRESH_SCRIPT_CANDIDATES!r}; "
+        "the pod cannot mint a GitHub token.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+refresh_script = candidates[0]
+res_ref = subprocess.run(['python3', refresh_script, '{github_repo}'], capture_output=True, text=True)
+if res_ref.returncode != 0:
+    print(
+        f"Token refresh via {{refresh_script}} failed (exit {{res_ref.returncode}}):\\n"
+        f"STDOUT:\\n{{res_ref.stdout}}\\nSTDERR:\\n{{res_ref.stderr}}",
+        file=sys.stderr,
+    )
+    sys.exit(res_ref.returncode)
+print(f"{_REFRESH_CONFIRMATION} {{refresh_script}}")
 
 # 2. Execute read-only GitHub API verification via Envoy proxy from workspace root
 env = os.environ.copy()
@@ -151,16 +189,21 @@ print(f"Successfully authenticated and queried repository: {{full_name}}")
         cmd = base_exec + ["python3", "-c", script]
 
     try:
-        proc_start = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+        proc_start = subprocess.run(cmd, capture_output=True, text=True, timeout=_PROBE_TIMEOUT_SECONDS)
         assert proc_start.returncode == 0, (
             f"GitHub token minting and API probe failed inside pod '{pod_name}' (exit code {proc_start.returncode}):\n"
             f"STDOUT:\n{proc_start.stdout}\nSTDERR:\n{proc_start.stderr}"
+        )
+        assert _REFRESH_CONFIRMATION in proc_start.stdout, (
+            f"The probe reached `gh` without running the token refresh; stdout was:\n{proc_start.stdout}"
         )
         assert f"Successfully authenticated and queried repository: {github_repo}" in proc_start.stdout, (
             f"Expected successful repository query confirmation in stdout, got:\n{proc_start.stdout}"
         )
     except subprocess.TimeoutExpired:
-        pytest.fail(f"GitHub token minting / API probe timed out after 90s in pod '{pod_name}'")
+        pytest.fail(
+            f"GitHub token minting / API probe timed out after {_PROBE_TIMEOUT_SECONDS}s in pod '{pod_name}'"
+        )
 
 
 def test_github_token_minter_credential_isolation(


### PR DESCRIPTION
## Summary

The nightly GitHub token-minting probe could reach `gh` without ever asking the credential proxy to mint. Its first step located `github_token_refresh.py` with `find /opt` and only ran the refresh when `find` exited 0. As the sandbox user, `find` cannot enter the root-owned `lost+found` on the data volume, so it exits 1 even after printing the match, the refresh is skipped, and the probe passes or fails on whether an earlier task happened to leave credentials in the proxy. The probe now resolves the refresh client from its two known locations, fails when it is missing or the refresh fails, and asserts that the refresh ran before it trusts the `gh` result.

## Why This Change

Nightly run 34610666977 attempt 2 failed `test_github_token_minting_and_connectivity` on a fresh cluster with gh's own "run gh auth login" message and exit code 4, about a minute after the pods became ready. Attempt 3 re-ran only the failed job against the same cluster and the same test passed. Nothing at startup writes the proxy's gh credentials, so on a cold proxy the outcome depends on whether anything minted before the test got there. Without this change the test grades that race, not the minting path it is named for.

## What Changed

- The in-pod probe checks `/opt/data/scripts/github_token_refresh.py` then `/opt/defaults/scripts/github_token_refresh.py`. Both pod layouts bake the script into the image and copy it onto the data volume at start. There is no `find` fallback: a copy found elsewhere, such as a GitOps clone under the data volume, would let the probe pass on an image that lost its own.
- A missing script or a failed refresh exits non-zero with the refresh's stdout and stderr, instead of falling through to `gh`.
- The probe prints a confirmation line after the refresh and the test asserts it, so the test cannot pass without the mint having run.
- The exec budget is a named constant and rises from 90s to 180s, because it now encloses the refresh, whose client waits up to 60s on the proxy.
- The docstring says the probe runs in the shell sandbox pod (or the legacy gateway pod where no sandbox exists), through the credential proxy rather than a sidecar.

## Context

Closes #1480, which diagnosed the `find` exit-code gate from the same nightly run. Nightly run: https://github.com/gke-labs/kube-agents/actions/runs/34610666977 (attempt 2 failed the test, attempt 3 passed it on the same pod). The earlier 02:35 nightly (run 34555219269) failed for an unrelated reason, the staging-tag push lacking `workflows` permission, which #1470 already fixed.

## Testing

- `make docs-check`: all five checks pass.
- Rendered the in-pod probe script from the module constants and compiled it, then executed it on a machine where neither known path exists: it exits 1 with `github_token_refresh.py not found at any of (...)`, the intended failure instead of the old silent fall-through. Also confirmed the exec call now receives the 180s budget. Harness under the job's temp dir, not committed.
- The e2e test itself was not run: `tests/e2e/` runs only in the nightly release pipeline against a provisioned GKE install.

### Live validation

Read-only checks against the autopush install (`kube-agents-autopush`, cluster `platform-agent-host`, pod `platform-agent-shell-0` started 2026-09-11T15:09Z), via `kubectl exec` with no mutation and no lease taken:

```
lrwxrwxrwx  1    0    0    36 Sep 11 15:03 /opt/credential-proxy/bin/gh -> /usr/local/bin/credential-proxy-exec
drwxr-xr-x 17 1000 1000  4096 Sep 11 15:09 /opt/data
drwx------  2    0    0 16384 Sep  5 12:03 /opt/data/lost+found
-rwxr-xr-x  1 1000 1000 19966 Sep 11 14:57 /opt/data/scripts/github_token_refresh.py
-rwxr-xr-x  1 1000 1000 19966 Sep 11 14:57 /opt/defaults/scripts/github_token_refresh.py
```

This confirms the three facts the change rests on: `lost+found` on the data volume is root-owned mode 0700, so `find /opt` as uid 1000 hits EACCES and, per GNU findutils' documented exit status, exits non-zero; both candidate paths exist and are readable by the agent user; and `gh` on the sandbox PATH is the credential-proxy client, so the "gh auth login" text in the failing run was gh's own output relayed from a proxy with no minted credentials.

Not covered: running the revised probe end to end. That needs a fresh nightly-style install where nothing has minted yet, and the sandbox this branch was authored in refuses `kubectl exec` commands that carry shell text, so `find` was not executed as the agent user on the live pod. The next nightly runs the revised test as its blocking gate; I will watch that run.

## Self-Review

Passes: `review-adversarial` and `review-docs-drift`, each in its own fresh subagent handed the diff range and the skill path, told to derive intent from the diff and to edit nothing. Docs-drift re-ran in a fresh subagent after the fixes below; the adversarial pass was not re-run because the fixes only deleted the `find` fallback, hoisted a constant, and reworded prose.

- LOW, CONFIRMED (both passes): my new comment said the legacy single-pod layout ships only the image copy of the refresh script. Wrong; the agent entrypoint also copies it onto the data volume. Fixed: the comment now says both layouts carry both copies.
- LOW, PLAUSIBLE (adversarial): the `find` fallback was unreachable on a healthy pod and, when reached, could pick a GitOps clone's copy first and mask a missing image script. Fixed by removing the fallback; the probe fails on the two known paths.
- LOW, PLAUSIBLE (adversarial): the untouched 90s exec budget now also encloses the refresh, whose client waits up to 60s on the proxy, so a slow broker would surface as a bare timeout and discard the new diagnostics. Fixed: named constant, 180s.
- Advisory (docs-drift): the docstring said "shell sandbox pod" while the body keeps the legacy gateway fallback. Fixed in the docstring; the fallback itself is pre-existing and dead on current images, left for a separate change.
- Advisory (docs-drift): `scripts/release/README.md` and `docs/designs/e2e-testing-harness.md` say the test mints "inside the agent pod". Not changed: loose rather than wrong, pre-existing, and this diff does not alter what those sentences describe.
- Advisory (docs-drift re-run): "legacy gateway pod on an install that has no sandbox" could read as a supported layout, though the operator now refuses a CR with the sandbox off. Not changed: "legacy" is accurate, and the fallback code it describes is untouched here.
- Advisory (docs-drift re-run): the 60s in the timeout comment is the refresh client's socket timeout, not a wall-clock cap; the proxied call has a 300s ceiling. Not changed: the comment claims only what the client sets, and 180s covers the normal path, which is what a blocking gate should budget for.

Angles the passes covered with no finding: the rendered f-string compiles; the outer confirmation assertion is redundant with the exit code and kept as a tripwire against re-gating the refresh; env inheritance under `kubectl exec` and `runuser`; the no-magic-constants rule; removed behaviour is only the exit-code gate; no open PR touches `tests/e2e/`; every claim in the new prose about the entrypoints, the proxy refresh route and the absence of a startup mint matched source. Neither pass could run the e2e or verify `find`'s exit code live.

## Risk & Rollout

Test-only change to the nightly blocking gate. The new failure modes are deliberate: a nightly whose sandbox image lacks the refresh script, or whose mint fails, now reds the gate with the refresh's output instead of passing on cached credentials. Revert by reverting the commit. Nothing happens at merge time.

Generated with the help of Claude Code.
