### PR TITLE
chore(bot): nominate review-adversarial as kube-agents-bot's review playbook

### DIFF
--- a/.agents/rules/pre_pr_review.md
+++ b/.agents/rules/pre_pr_review.md
@@ -2,8 +2,8 @@
 
 [`AGENTS.md`](../../AGENTS.md) owns both rules below — that adversarial self-review and live
 validation are required before opening a pull request, and that each is recorded in the pull
-request body. This file holds the mechanics of carrying them out. Change the rule in `AGENTS.md`;
-change how it is done here.
+request body. This file holds the mechanics of carrying them out, and what the automated review
+shares with the first of them. Change the rule in `AGENTS.md`; change how it is done here.
 
 ## Adversarial self-review
 
@@ -41,6 +41,23 @@ The rule, and the requirement to fill in the template's **Self-Review** section,
   spends the reviewer's trust before they reach the code. Name the kind of context each pass ran
   in — subagent, fresh session, or the one that wrote the change — so the claim above it is
   something a reviewer can weigh rather than take on trust.
+- **The automated review runs the same skill.** `.github/kube-agents-bot.yml`, read from this
+  repository's default branch, nominates
+  [`review-adversarial`](../skills/review-adversarial/SKILL.md) as `kube-agents-bot`'s playbook,
+  and the bot reads the skill from the pull request's base commit — for a pull request into
+  `main`, a version this pull request did not write. Its candidate passes work the skill's angles
+  less angle J; a step the skill says to run is reasoned about and named as not run, never
+  dropped. The bar is the bot's own — a confidence score and a floor that differs between the
+  automatic review and `/review` — not step 5's keep-what-survives rule, though the re-derivation
+  step 5 asks for is the same. So a finding in one pass and not the other can be the floor, the
+  missing shell, or the model, and is worth reading as any of the three rather than dismissed as
+  variance. With the playbook in force, prose the change makes false and a guard or test the
+  change claims that does not cover what it says are candidates the bot raises rather than
+  classes its false-positive list suppresses — bounded as the bot's own prompt bounds them, so
+  "this should be documented" and "this needs more tests" stay excluded — and the wave still
+  scores them. Changing the skill changes what the bot looks for on every pull request after the
+  change merges. The bot's own README and design document are canonical for the key and the
+  mechanism.
 
 ## Live validation
 

--- a/.github/kube-agents-bot.yml
+++ b/.github/kube-agents-bot.yml
@@ -1,0 +1,12 @@
+# What kube-agents-bot, the GitHub App that reviews every pull request here, reads about this
+# repository. Read from the default branch only, so a pull request cannot reconfigure its own
+# reviewer; the keys and their meanings are the bot's own README (gke-labs/kube-agents-bot).
+#
+# The review method the bot's candidate passes follow: the same skill an author runs before
+# opening a pull request (AGENTS.md, "Pull Request Hygiene"), read from the base commit, so the
+# pre-PR self-review and the automated review look for the same things. Measured on the core set
+# of gke-labs/kube-agents-bot#75 before it was set, one run per arm: no change to HIGH+ recall; the
+# docs-made-false and description-contradicted findings a second reader had posted now posted by
+# the bot; about 13% more cost per review, and more findings posted per pull request
+# (gke-labs/kube-agents-bot#78).
+playbook: .agents/skills/review-adversarial/SKILL.md


### PR DESCRIPTION
## Summary

`kube-agents-bot` now reads pull requests here with this repository's own `review-adversarial` skill as its method. `.github/kube-agents-bot.yml` nominates it as the bot's playbook (gke-labs/kube-agents-bot#88), so the pre-PR self-review an author runs and the automated review look for the same things, and `.agents/rules/pre_pr_review.md` says what that means for an author: shared angles less the ones the bot cannot run, the bot's own bar, and two classes the bot now raises that it used to file under documentation and coverage. Second half of gke-labs/kube-agents-bot#78, for gke-labs/kube-agents-bot#75. Generated with the help of Claude Code.

## Why This Change

gke-labs/kube-agents-bot#75 listed eleven pull requests here where the bot said `No findings` and a run of this skill in a fresh context found a HIGH or BLOCKER the author confirmed, and its author proposed one playbook for both reviews. The bot side shipped the mechanism (#88) and this repository's skill was revised for that reader (#1473). The measurement §13 of the bot's design asked for before nominating is on gke-labs/kube-agents-bot#78: over the core set of those pull requests, replayed with and without the skill as the method, HIGH+ recall is unchanged (8 of 12 kept in each arm), and the arm with the skill posts the docs-made-false and description-contradicted findings the second reader had posted and the built-in lenses scored down, at about 13% more per review.

## What Changed

- `.github/kube-agents-bot.yml` (new): `playbook: .agents/skills/review-adversarial/SKILL.md`, with a comment saying where the bot reads it from and what the measurement showed. The bot reads this file from the default branch only, so it takes effect on the pull request after this one merges.
- `.agents/rules/pre_pr_review.md`: one bullet under _Adversarial self-review_ — the page's own rule puts prose mechanics there rather than in `docs/pull-request-workflow.md`, and `AGENTS.md` is at its context budget. It states which branch the config and the skill are read from, that the angles are shared less angle J and anything the skill says to run, that the bar is the bot's own floor rather than the skill's step 5, what the two carve-outs are and that the wave still scores them, and that a change to the skill changes what the bot looks for after it merges.

## Context

Part of gke-labs/kube-agents-bot#78, for gke-labs/kube-agents-bot#75; the skill revision was #1473. No open pull request adds this file; #1451 edits `docs/pull-request-workflow.md`, which this change no longer touches.

## Testing

`make docs-check` at the pushed commit: all relative links and design-doc citations resolve, map coverage complete (`.github/` and `.agents/` are exempt), always-loaded files at 38.0k of the 38,000-char budget. `npx prettier@3.9.6 --check` on both files: clean. The YAML parses to a bare string the bot accepts: the key is in its `KNOWN_KEYS`, the path passes its rulebook restriction (`.agents/`), the file exists at HEAD at 25 KB against the bot's 64 KB cap.

### Live validation

Not live-tested against a kube-agents installation; the change touches no cluster, image, or agent runtime. Under `.agents/rules/eval_driven_development.md` this change is exempt: it changes nothing the Platform or Cluster agent does — it configures a GitHub App in another repository and `.agents/` ships in no agent image — so no bench case can grade it. What stands in for the loop is the measurement the change cites: seven reviews replayed twice over the same commits through the bot's own funnel (gke-labs/kube-agents-bot#84), with and without this skill as the method, scored against the confirmed findings from #75 (gke-labs/kube-agents-bot#78). The config cannot be exercised from a branch because the bot reads it from the default branch only; the first pull request opened after this merges is where `reading gke-labs/kube-agents with the playbook .agents/skills/review-adversarial/SKILL.md at <base>` appears in the bot's logs, and the bot's introduction comment already states the contract.

## Self-Review

**Passes run, all in subagents handed the range and nothing else:** `review-adversarial` (once) and `review-docs-drift` (twice — initial, and again after the first round's fixes relocated and rewrote the paragraph). `make docs-check` clean before each. Neither pass could run anything: the change is a config file and a paragraph. The bot's behaviour was verified against `gke-labs/kube-agents-bot` at `main`, and the measurement numbers against the #78 comment.

**Angles worked with no finding:** A, B, D (the base-commit trust boundary — see the LOW below), E, F, G. Angle J: no open pull request adds this file; #1451 edits `docs/pull-request-workflow.md`, which the final change does not touch.

**Findings and dispositions, deduplicated (round in brackets):**

- HIGH / Blocking, CONFIRMED, both passes [1] — the new paragraph said the bot and the author's pass work "at the same bar, so a difference is the model and not the method"; the bot's floor and scoring replace the skill's step 5, and angle J and every run-dependent step differ. **Fixed:** the bullet names the shared angles less J, the bot's own bar, and the three things a difference can be.
- MEDIUM / Advisory, CONFIRMED, both passes [1] — "findings the bot posts, not notes it scores down" overstated a carve-out that scopes candidate passes, and "Self-Review claim" widened its second class. **Fixed:** candidates the bot raises rather than classes its false-positive list suppresses; the wave still scores them; the class is a guard or test the change claims.
- LOW, CONFIRMED, adversarial [1] — the page's own scope rule puts prose mechanics in `.agents/rules/`, not `docs/pull-request-workflow.md`; the drift pass raised the same placement point from the section's disclaimer. **Fixed:** moved to `pre_pr_review.md`, whose opening sentence now says it holds this too; `AGENTS.md` is at its budget and the bot's introduction comment already states the contract.
- LOW, CONFIRMED, adversarial [1] — the paragraph did not say the config is read from the default branch, and "it" was ambiguous. **Fixed.**
- LOW, CONFIRMED, adversarial [1] — "a version it did not write" is unconditional where the bot's design is conditional on the base. **Fixed:** qualified to a pull request into `main`; round two narrowed it further to "this pull request did not write".
- LOW, CONFIRMED, adversarial [1] — the sources the YAML cites are in a private repository. **Deliberately kept:** the bot's README and design document are the canonical home for its keys and mechanism, the skill names them the same way, and there is no public restatement to point at; the bullet carries the facts an author needs.
- LOW, CONFIRMED, adversarial [1] — the YAML quoted the measurement's wins only. **Fixed:** cost and posted-findings volume added, with the one-run-per-arm caveat (drift [2]).
- PLAUSIBLE, adversarial [1] — the eval-driven-development exemption line was outside the range. **Addressed:** stated under Live validation above.
- Blocking, docs-drift [2] — "less … anything the skill says to run" read as run-dependent steps dropped; both sources say reasoned about, never dropped. **Fixed.**
- Advisory, docs-drift [2] — "not the skill's step 5" overshot (the re-derivation discipline does apply); "author could not have written" versus "pull request did not write"; the carve-out sentence garden-pathed and lacked the bot's own bounds; a 194-character line; "13%" without a unit; the file's opening sentence no longer describing it. **All fixed.**
- Advisory, docs-drift [1] — `docs/README.md`'s row for the workflow page and `contributing.md`'s bullets. **Moot / deliberately not:** the workflow page is no longer touched; `contributing.md` summarises the bot's contract and defers to `AGENTS.md`, which is unchanged and still true.

**Not re-run after round two:** the fixes were clause-level wording against sources the pass had just verified; a third context was not spent on them.

**Not covered:** the config cannot be exercised from a branch, so the first pull request after this merges is the live check; whether the wave scores the carve-out classes the same under a real review as in the replay is a question for a week of reviews, not this pull request.

## Risk & Rollout

Reviews here cost the bot's operator roughly 13% more and post more findings per pull request; the samples read on #78 were the second reader's own findings rather than nits, but the noise question is open until a week of real reviews has run under it. Reverting is deleting the file, and the bot's `REPO_CONFIG=off` switch is the operator's kill switch for every repository at once. A pull request that edits the skill is reviewed under the base's version, so the skill cannot be used to review itself.
