### PR TITLE
fix(ci): render with --public-url when the eval-PR hook publishes to a bucket

### DIFF
--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -578,7 +578,18 @@ import json, sys
 if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
     sys.exit(\"collected zero runs: source unreadable or empty; refusing to publish an empty dashboard over a good one\")
 " "$2/data.json"
-    python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site"
+    # Same --public-url rule as hack/ci-dashboard-refresh.sh: a bucket target
+    # is the published site, so the bare flag emits the <base href> that makes
+    # every relative link resolve there. Without it this hook would overwrite
+    # the refresh job'"'"'s pages with a set whose nav is dead on
+    # storage.cloud.google.com until the next 15-minute refresh.
+    # The parity stops at that flag. That script also renders --health and
+    # --health-history from files it downloads from the bucket first, and this
+    # hook downloads neither, so the Brief it publishes reads NO VERDICT until
+    # the next refresh. Closing that needs the download step, not an argument.
+    render_args=()
+    case "$3" in gs://*) render_args+=(--public-url) ;; esac
+    python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" ${render_args[@]+"${render_args[@]}"}
     python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
   ' _ "${dash_src}" "${dash_tmp}" "${EVAL_DASHBOARD_TARGET}" >"${dash_tmp}/publish.log" 2>&1 || dash_rc=$?
   if [ "${dash_rc}" -eq 0 ]; then

--- a/scripts/test_eval_dashboard_publish.py
+++ b/scripts/test_eval_dashboard_publish.py
@@ -20,6 +20,7 @@ trap body around it -- lifted out of the real file, rather than grepping for
 guards, so it fails if the fail-safe is weakened by any future edit.
 """
 
+import json
 import pathlib
 import re
 import subprocess
@@ -254,6 +255,34 @@ class PublishHookFailSafeTest(unittest.TestCase):
                     result.stdout,
                 )
                 self.assertNotIn(SKIP, result.stdout)
+
+    def test_a_bucket_target_renders_with_the_public_url(self):
+        """A bucket target is the published site, read from
+        storage.cloud.google.com, which redirects to a locked domain that
+        serves one object: without <base href> every relative link on the
+        page is dead there. This hook publishes to the same bucket as
+        hack/ci-dashboard-refresh.sh, so it has to pass the same flag, or a
+        run of it replaces good pages with unnavigable ones until the next
+        15-minute refresh. A local target keeps relative links."""
+        collect_ok = """\
+            import json, pathlib, sys
+            out = sys.argv[sys.argv.index("--out") + 1]
+            pathlib.Path(out).write_text(json.dumps({"runs": [{"build": "1"}]}))
+            """
+        record_argv = (
+            "import json, pathlib, sys\n"
+            "pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(sys.argv[1:]))\n"
+        )
+        for target, expected in (("gs://kube-agents-dashboards/evals/", True), ("/tmp/local-site", False)):
+            with tempfile.TemporaryDirectory() as tmp:
+                fake_hack = dashboard_stubs(pathlib.Path(tmp), collect_ok)
+                dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
+                (dash / "render.py").write_text(record_argv)
+                result = run_hook(0, fake_hack, target=target)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                argv = json.loads((dash / "render.py.argv").read_text())
+                self.assertEqual("--public-url" in argv, expected, f"{target}: {argv}")
+                self.assertNotIn("", argv, "no empty argument from an unset array")
 
     def test_zero_collected_runs_skip_instead_of_publishing_empty(self):
         """The evidence_store lesson: an unreadable source is not an empty


### PR DESCRIPTION
## Summary

`hack/ci-eval-pr.sh`'s dashboard publish hook now passes `--public-url` to `render.py` when its target is a `gs://` bucket, so the pages it publishes carry the `<base href>` that #1474 added. #1474 wired that flag into `.github/workflows/ci-health.yml` and `hack/ci-dashboard-refresh.sh` and did not reach this third publisher.

## Why This Change

The published dashboard is read from `storage.cloud.google.com`, which redirects to a locked content domain that refuses relative navigation. #1474 fixed that by emitting `<base href>` so every relative link resolves back to the published site. Pages rendered without the flag still have bare relative links, and their nav is dead on that host.

This hook writes the same bucket as the 15-minute refresh job. A run of it therefore replaces that job's good pages with a set whose tabs do not work, and they stay that way until the next refresh overwrites them.

It is dormant today: no Prow job config sets `EVAL_DASHBOARD_TARGET`, so the hook reaches its skip line and never publishes. That is what makes this a latent gap rather than a live regression, and it is why the flag was missed when the other two call sites were updated — nothing went visibly wrong.

## What Changed

- `hack/ci-eval-pr.sh` builds a `render_args` array and adds `--public-url` for a `gs://` target, mirroring the `case` in `hack/ci-dashboard-refresh.sh`. The `${render_args[@]+"${render_args[@]}"}` expansion is the bash-3.2-safe form already used for `dash_timeout` in the same function; a plain `"${render_args[@]}"` passes an empty string argument when the array is empty.
- `scripts/test_eval_dashboard_publish.py` gains one test that overrides the fixture's `render.py` with a stub recording `sys.argv[1:]`, then asserts the flag is present for `gs://kube-agents-dashboards/evals/`, absent for a local `--out-dir` target, and that no empty argument is passed either way.

The comment in the shell script also records a wider defect in the same invocation that this PR does **not** fix — see Context.

## Context

Follows #1474, which is merged and did the `<base href>` work this depends on.

Not fixed here, and worth its own change: the same hook renders without `--health` and `--health-history`. `hack/ci-dashboard-refresh.sh` passes both, from files it downloads from the bucket first (`:158-167`, `:215-216`); this hook downloads neither, so the Brief it publishes reads `NO VERDICT · No gate verdict is published` with an empty "Last incident" block until the next refresh. Closing that needs the download step, not an argument, and adding bucket reads to a dormant hook is a different change with its own failure modes. There is a comment in the file naming it so the next reader does not assume parity.

Separately, and also inherited from `hack/ci-dashboard-refresh.sh:220`: the `gs://*` pattern matches any bucket while the bare flag resolves to a fixed constant, so a non-production `EVAL_DASHBOARD_TARGET` would get a `<base href>` pointing at production — and because `<base>` governs relative `fetch()` too, that site would display production data. Both scripts have the identical line; fixing one alone would make them disagree about what a bucket target means, so it belongs in a change that does both.

## Testing

- `scripts/`: 1469 tests OK, 1 skipped (the `timeout`-binary case, absent in this sandbox).
- `make docs-check` clean. `bash -n hack/ci-eval-pr.sh` clean.
- Mutation: removing the `case` line so the flag is never added fails the new test. The assertion is not vacuous.
- `shellcheck` and `actionlint` are not installed in this sandbox, so the script was reviewed by reading plus `bash -n`.

### Live validation

**Not live-tested against a running installation, and it cannot be.** This is CI infrastructure: the code path is a Prow presubmit hook that publishes to a GCS bucket, and it is gated behind `EVAL_DASHBOARD_TARGET`, which no job config sets. There is no installation to point it at and no way to make it execute without arming that variable on the eval job, which would publish real pages over the live dashboard.

What was exercised instead, at the layer the change touches: the new test runs `publish_eval_dashboard` end to end against a stubbed `render.py` and reads the actual argument vector the hook constructs, rather than asserting against the script's source text. That is what makes it catch the mutation above.

The premise the change rests on — that a page rendered without `--public-url` has dead nav on `storage.cloud.google.com` — is #1474's, already verified there and observable on the published site today.

Nothing was written to any bucket; no artifacts to clean up.

## Self-Review

Both required passes ran in **subagents that did not write the change**, each handed only the diff range, its skill path, and the `make docs-check` output, and told to derive intent from the diff without reading commit bodies or scratch notes. They ran against a superset of this diff — a larger branch that also moved the dashboard's link scope into the URL fragment — so this hunk and its test were reviewed as part of that range rather than in isolation. That larger work is being dropped in favour of #1495, which arrived first and does the same thing; the two files here are the part #1495 does not touch. Findings that bear on what is left:

- **The hook publishes a Brief with no verdict** (HIGH, CONFIRMED — adversarial). The pass verified it end to end by rendering the real fixture both ways and dumping the DOM in headless Chrome: the refresh job's pages read `🔴 OUTAGE · since Tue 5:00 AM ET`, the hook's read `⚪ NO VERDICT`. **Not fixed**, for the reason under Context; the comment in the file now names it, and it is filed separately.
- **Bare `--public-url` against a non-production bucket** (LOW, CONFIRMED — adversarial). The pass confirmed the emitted tag. **Not fixed**: inherited verbatim from the sibling script, and fixing one of the two would make them silently disagree.
- **Scope-of-change prose in a shipped file** (Advisory — docs-drift). My comment originally ended "Pre-existing … so it is not fixed here", which is PR-body content in a file that outlives the PR. **Fixed** — trimmed to the defect and what closing it needs.
- **The `${render_args[@]+"..."}` expansion and the `gs://*` literal** were both examined and cleared: the expansion is the idiom already used for `dash_timeout` in the same function, and the no-magic-constants rule exempts a literal that is the subject of its line, which is how the sibling script writes the identical pattern.

What the passes could not cover: neither could execute the hook, for the reason in Live validation. Adversarial's angle J (sibling pull requests) did not run in the pass, because `gh` is unauthenticated in this sandbox — I ran it afterwards against the anonymous API, which is how #1495 was found. No open PR touches `hack/ci-eval-pr.sh` or `scripts/test_eval_dashboard_publish.py`.

## Risk & Rollout

Two files, one of them a test. The changed code path is unreachable until `EVAL_DASHBOARD_TARGET` is set on a job config, so on merge nothing changes about what CI does. When that variable is armed, the effect is that the hook's pages get the same `<base href>` the other two publishers already emit. Revert is the commit; there is no state to unwind and nothing to do at merge time.

---

Generated with the help of Claude Opus 5 (Claude Code).
