### PR TITLE
docs(agents): point the gate section at the eval dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,11 +351,10 @@ Agents with a user in the loop follow this file.
 ### The behavioural presubmit gate
 
 `pull-kube-agents-smoke-test` runs the eval matrix in `hack/ci-eval-pr.sh` — every active case,
-three repetitions each — and has been merge-blocking since 2026-09-02
-(GoogleCloudPlatform/oss-test-infra#2677). It takes 1.5 to 3.5 hours against a 360-minute
-ceiling, and a push restarts it unless only inert paths changed (step 0), so open the pull request
-early and batch changes. Another pull request merging usually does not — the green status is
-re-pinned to `main`'s new head.
+three repetitions each — and has blocked merges since 2026-09-02 (oss-test-infra#2677). It takes
+1.5 to 3.5 hours against a 360-minute ceiling, and a push restarts it unless only inert paths
+changed (step 0), so open the pull request early and batch changes. Another pull request merging
+usually does not — the green status is re-pinned to `main`'s new head.
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
 of its repetitions — one failed repetition out of three does nothing on its own. Or any case,
@@ -368,12 +367,12 @@ for what is admitted, `docs/eval-gate-roster.md` for demotion, and
 [`docs/designs/testing-strategy.md`](docs/designs/testing-strategy.md) §4.2 for the full verdict
 ladder.
 
-On a red, the dashboard, <https://storage.cloud.google.com/kube-agents-dashboards/evals/index.html>,
-tags each failed case as the gate's or yours. If yours or unexplained, fix it. If the gate's, file
-an issue with the `presubmit-gate` label; fix it yourself if the cause is evident and the fix
-quick, or keep working while the eval crew classifies it. One `/retest` is reasonable
-for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
-never instruct anyone to.
+On a red, the health bot's comment on your pull request (and the dashboard,
+<https://storage.cloud.google.com/kube-agents-dashboards/evals/index.html>) tags each failed case
+as the gate's or yours. If yours, fix it; if unexplained, read the transcript first. If the gate's,
+file an issue with the `presubmit-gate` label; fix it yourself if quick, or keep working while the
+eval crew classifies it. One `/retest` is reasonable for a suspected transient; blind repeats are
+noise. Never merge around a red gate, and never instruct anyone to.
 
 `/override` (admin-only) is only for a red the eval crew classified as not the pull request's;
 the rest of the override mechanics, and why an approved, green pull request can sit unmerged,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,11 +352,10 @@ Agents with a user in the loop follow this file.
 
 `pull-kube-agents-smoke-test` runs the eval matrix in `hack/ci-eval-pr.sh` — every active case,
 three repetitions each — and has been merge-blocking since 2026-09-02
-(GoogleCloudPlatform/oss-test-infra#2677). It is slow — recent green runs took 1.5 to 3.5 hours
-against a 360-minute ceiling — and a push restarts it unless only inert paths changed (step 0), so
-open the pull request early and batch changes. Another pull request merging usually does not — the
-green status is re-pinned to `main`'s new head
-([how a change merges](docs/pull-request-workflow.md#how-a-change-merges)).
+(GoogleCloudPlatform/oss-test-infra#2677). It takes 1.5 to 3.5 hours against a 360-minute
+ceiling, and a push restarts it unless only inert paths changed (step 0), so open the pull request
+early and batch changes. Another pull request merging usually does not — the green status is
+re-pinned to `main`'s new head.
 
 Two things red it. A case on the `BOOTSTRAP_ADMITTED` roster in `hack/ci-eval-pr.sh` fails **all**
 of its repetitions — one failed repetition out of three does nothing on its own. Or any case,
@@ -369,9 +368,10 @@ for what is admitted, `docs/eval-gate-roster.md` for demotion, and
 [`docs/designs/testing-strategy.md`](docs/designs/testing-strategy.md) §4.2 for the full verdict
 ladder.
 
-On a red, ask whether your diff explains it. If yes, fix it. If no, file an issue with the
-`presubmit-gate` label; if the cause is evident and the fix is quick, fixing it yourself is
-welcome — otherwise keep working while the eval crew classifies it. One `/retest` is reasonable
+On a red, the dashboard, <https://storage.cloud.google.com/kube-agents-dashboards/evals/index.html>,
+tags each failed case as the gate's or yours. If yours or unexplained, fix it. If the gate's, file
+an issue with the `presubmit-gate` label; fix it yourself if the cause is evident and the fix
+quick, or keep working while the eval crew classifies it. One `/retest` is reasonable
 for a suspected transient; repeated blind retests are noise. Never merge around a red gate, and
 never instruct anyone to.
 


### PR DESCRIPTION
## Summary

AGENTS.md's gate section told a reader with a red `pull-kube-agents-smoke-test` run to "ask whether your diff explains it" without saying where that answer already is. It now says: the health bot's comment on the pull request (and the eval dashboard, whose URL appears in AGENTS.md for the first time) tags each failed case as the gate's or yours; if yours, fix it; if unexplained, read the transcript first; if the gate's, file a `presubmit-gate` issue. The context budget for the always-loaded instruction files had ten characters of headroom, so the new words are paid for inside the same section with trims that lose no fact.

## Why This Change

#1492's remaining in-repo item: "one line in AGENTS.md's gate section pointing at the dashboard URL (the context budget has room for about one line; pay for it if not)". Without it an agent on a red has the classification posted on its own pull request by `gate_comment.py` (live since #1486) and a dashboard that explains every red, and AGENTS.md points at neither. The old sentence also told an author with an *unexplained* failure the same thing as one whose failure is clearly theirs, which is stronger than the dashboard's own advice for that class (`classify.py`'s `DO_UNCLEAR`: read the transcript, it may be yours) and wrong for the first pull request hit by a fresh infrastructure breakage.

## What Changed

- AGENTS.md, "The behavioural presubmit gate", the "On a red" paragraph: names the gate comment first and the dashboard URL (`https://storage.cloud.google.com/kube-agents-dashboards/evals/index.html`, the same string as `post_health.DASHBOARD_URL`) second; "if yours, fix it; if unexplained, read the transcript first; if the gate's, file an issue".
- Paid for in the same section: the duplicate `[how a change merges]` link in the first paragraph is dropped (the section's last paragraph keeps it); "It is slow — recent green runs took 1.5 to 3.5 hours" is "It takes 1.5 to 3.5 hours"; "(GoogleCloudPlatform/oss-test-infra#2677)" is "(oss-test-infra#2677)"; "repeated blind retests are noise" is "blind repeats are noise"; "if the cause is evident and the fix quick" is "if quick".
- Nothing else in the file moved; no code touched.

## Context

Part of #1492 (the rest of that issue is merging #1446/#1479, a `gsutil rm`, a browser pass on the published host, a channel post and a design decision, none of which is a change in this repository). The absolute dashboard URL is still not in `docs/ci-health.md`, which only carries relative deep links; adding it there is a one-line follow-up for the next edit of that file (#1491's).

## Testing

- `python3 scripts/check_context_budget.py` → exit 0, "38.0k chars … 0.0k under the 38,000-char budget". Exact: AGENTS.md 37,763 + CLAUDE.md 237 = 38,000 of 38,000. The check fails only above the budget, so this passes, and the next character added to AGENTS.md will not; that headroom was 10 before this change.
- `make docs-check` → generated regions ok, relative links in 307 Markdown files resolve, terminology ok, docs map ok, context budget ok.
- Changed lines are at most 99 characters, inside the file's wrap.
- Could not run here: `prettier --check` (not installed on this machine). There is no `.prettierrc`, so prettier's defaults apply (`proseWrap: preserve`), which leave this reflow and the `<url>` autolink alone; CI's prettier job will confirm.

### Live validation

Not live-tested: a Markdown-only change to an instruction file; no agent, runtime or CI path changes.

## Self-Review

Reviewed in a context that did not write the change (a separate agent handed the diff range against `origin/main`), all three axes, adversarial and docs-drift:

- Found and fixed: the first draft pointed only at the dashboard, a page `storage.cloud.google.com` serves behind a Google login, while the same per-case tags already reach an agent on its own pull request through the gate comment; the sentence now names the comment first. Found and fixed: "If yours or unexplained, fix it" contradicted `classify.py:157`'s advice for `unexplained`; it now says read the transcript first.
- Checked and fine: the removed `[how a change merges]` link is still at two other places in AGENTS.md (the "Pull Request Hygiene" list and the section's last paragraph); the URL matches `post_health.py:129` and `health.py:243` byte for byte; #1474 (pages render on that host) and #1486 (the gate comment) are on `main`; the commit message's claims about the budget are true.
- Deliberately not fixed: the sentence "Another pull request merging usually does not — the green status is re-pinned to `main`'s new head" lost its adjacent link; the same link four paragraphs down covers it and the budget has no room for a second copy. `docs/ci-health.md` still lacks the absolute URL (follow-up above).

## Risk & Rollout

Low risk: one instruction file, no runtime code paths. The one operational effect is the context budget sitting at exactly its limit, which the next AGENTS.md edit has to pay for or raise (`scripts/check_context_budget.py` says how). Revert is one commit.

This pull request was generated with the help of Claude.
