### PR TITLE
fix(ci): bake health and incident history into eval-PR dashboard publish hook

### DIFF
--- a/hack/ci-dashboard-refresh.sh
+++ b/hack/ci-dashboard-refresh.sh
@@ -214,10 +214,15 @@ if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
   render_args=()
   [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
   [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
-  # A bucket target is the published site: --public-url (bare) emits
-  # <base href> for post_health.DASHBOARD_URL'"'"'s host, so the pages link
-  # there wherever the browser landed. A local directory keeps relative links.
-  case "$3" in gs://*) render_args+=(--public-url) ;; esac
+  # A bucket target is the published site: derive <base href> from the target
+  # URL so every relative link resolves there without hardcoding production
+  # when targeting a staging bucket. A local directory keeps relative links.
+  case "$3" in
+    gs://*)
+      render_target="${3#gs://}"
+      render_args+=(--public-url "https://storage.cloud.google.com/${render_target%/}")
+      ;;
+  esac
   python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}"
   python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
 ' _ "${DASH_SRC}" "${WORK}" "${EVAL_DASHBOARD_TARGET}" "${EVAL_DASHBOARD_PR_GLOB}" \

--- a/hack/ci-dashboard-refresh.sh
+++ b/hack/ci-dashboard-refresh.sh
@@ -223,15 +223,10 @@ if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
   render_args=()
   [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
   [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
-  # A bucket target is the published site: derive <base href> from the target
-  # URL so every relative link resolves there without hardcoding production
+  # A bucket target is the published site: pass the target to derive <base href>
+  # so every relative link resolves there without hardcoding production
   # when targeting a staging bucket. A local directory keeps relative links.
-  case "$3" in
-    gs://*)
-      render_target="${3#gs://}"
-      render_args+=(--public-url "https://storage.cloud.google.com/${render_target%/}")
-      ;;
-  esac
+  case "$3" in gs://*) render_args+=(--public-url "$3") ;; esac
   python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" "${render_args[@]}"
   python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
 ' _ "${DASH_SRC}" "${WORK}" "${EVAL_DASHBOARD_TARGET}" "${EVAL_DASHBOARD_PR_GLOB}" \

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -578,17 +578,35 @@ import json, sys
 if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
     sys.exit(\"collected zero runs: source unreadable or empty; refusing to publish an empty dashboard over a good one\")
 " "$2/data.json"
-    # Same --public-url rule as hack/ci-dashboard-refresh.sh: a bucket target
-    # is the published site, so the bare flag emits the <base href> that makes
-    # every relative link resolve there. Without it this hook would overwrite
-    # the refresh job'"'"'s pages with a set whose nav is dead on
-    # storage.cloud.google.com until the next 15-minute refresh.
-    # The parity stops at that flag. That script also renders --health and
-    # --health-history from files it downloads from the bucket first, and this
-    # hook downloads neither, so the Brief it publishes reads NO VERDICT until
-    # the next refresh. Closing that needs the download step, not an argument.
+    # The adjudicator verdict and its history, when the target has them, so the
+    # rendered Brief bakes the current state instead of waiting for the first
+    # page poll (and on storage.cloud.google.com that XHR redirects and fails).
+    # Missing is the normal case until the adjudicator has run.
+    case "$3" in
+      gs://*)
+        gsutil cp "${3%/}/health.json" "$2/health.json" 2>&1 || rm -f "$2/health.json"
+        gsutil cp "${3%/}/health-history.jsonl" "$2/health-history.jsonl" 2>&1 || rm -f "$2/health-history.jsonl"
+        ;;
+      *)
+        [ -f "${3%/}/health.json" ] && cp "${3%/}/health.json" "$2/health.json" || true
+        [ -f "${3%/}/health-history.jsonl" ] && cp "${3%/}/health-history.jsonl" "$2/health-history.jsonl" || true
+        ;;
+    esac
     render_args=()
-    case "$3" in gs://*) render_args+=(--public-url) ;; esac
+    [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
+    [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
+    # Same --public-url rule as hack/ci-dashboard-refresh.sh: a bucket target
+    # is the published site, so derive <base href> from the target URL so every
+    # relative link resolves there without hardcoding production when
+    # targeting a staging bucket. Without it this hook would overwrite the
+    # refresh job pages with a set whose nav is dead on
+    # storage.cloud.google.com until the next 15-minute refresh.
+    case "$3" in
+      gs://*)
+        render_target="${3#gs://}"
+        render_args+=(--public-url "https://storage.cloud.google.com/${render_target%/}")
+        ;;
+    esac
     python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" ${render_args[@]+"${render_args[@]}"}
     python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
   ' _ "${dash_src}" "${dash_tmp}" "${EVAL_DASHBOARD_TARGET}" >"${dash_tmp}/publish.log" 2>&1 || dash_rc=$?

--- a/hack/ci-eval-pr.sh
+++ b/hack/ci-eval-pr.sh
@@ -596,17 +596,10 @@ if not json.load(open(sys.argv[1], encoding=\"utf-8\")).get(\"runs\"):
     [ -f "$2/health.json" ] && render_args+=(--health "$2/health.json")
     [ -f "$2/health-history.jsonl" ] && render_args+=(--health-history "$2/health-history.jsonl")
     # Same --public-url rule as hack/ci-dashboard-refresh.sh: a bucket target
-    # is the published site, so derive <base href> from the target URL so every
-    # relative link resolves there without hardcoding production when
-    # targeting a staging bucket. Without it this hook would overwrite the
-    # refresh job pages with a set whose nav is dead on
-    # storage.cloud.google.com until the next 15-minute refresh.
-    case "$3" in
-      gs://*)
-        render_target="${3#gs://}"
-        render_args+=(--public-url "https://storage.cloud.google.com/${render_target%/}")
-        ;;
-    esac
+    # is the published site, so pass the target to derive <base href> without
+    # hardcoding production when targeting a staging bucket. A local directory
+    # target keeps links relative.
+    case "$3" in gs://*) render_args+=(--public-url "$3") ;; esac
     python3 "$1/render.py" --data "$2/data.json" --out-dir "$2/site" ${render_args[@]+"${render_args[@]}"}
     python3 "$1/publish.py" --out-dir "$2/site" --target "$3"
   ' _ "${dash_src}" "${dash_tmp}" "${EVAL_DASHBOARD_TARGET}" >"${dash_tmp}/publish.log" 2>&1 || dash_rc=$?

--- a/scripts/eval_dashboard/render.py
+++ b/scripts/eval_dashboard/render.py
@@ -98,6 +98,7 @@ import re
 import shutil
 import subprocess
 import sys
+import urllib.parse
 
 import yaml
 
@@ -1696,7 +1697,12 @@ def base_html(public_url: str | None) -> str:
     is known, which keeps a file:// render browsable."""
     if not public_url:
         return ""
-    return f'<base href="{esc(public_url.rstrip("/") + "/")}">'
+    url = public_url.strip()
+    if url.startswith("gs://"):
+        target = url[len("gs://"):].strip("/")
+        parsed = urllib.parse.urlsplit(PUBLISHED_SITE)
+        url = f"{parsed.scheme}://{parsed.netloc}/{target}"
+    return f'<base href="{esc(url.rstrip("/") + "/")}">'
 
 
 def render_page(data: dict, notes: dict, events: dict, public_url: str | None = None) -> str:
@@ -1764,7 +1770,7 @@ def main(argv: list[str] | None = None) -> int:
         const=PUBLISHED_SITE,
         default=None,
         metavar="BASE",
-        help=f"emit <base href> so every link resolves to this site; the bare flag means the published dashboard ({PUBLISHED_SITE}); default (or an empty value): none, links stay relative",
+        help=f"emit <base href> so every link resolves to this site; accepts a gs:// bucket path or URL (bare flag means {PUBLISHED_SITE}); default (or an empty value): none, links stay relative",
     )
     args = parser.parse_args(argv)
 

--- a/scripts/test_eval_dashboard_pages.py
+++ b/scripts/test_eval_dashboard_pages.py
@@ -405,8 +405,19 @@ class RenderedFilesTest(unittest.TestCase):
             out = render_to(pathlib.Path(tmp) / "bare", data, extra_args=["--public-url"])
             self.assertIn('<base href="https://storage.cloud.google.com/kube-agents-dashboards/evals/">', (out / "index.html").read_text())
             self.assertEqual(render.PUBLISHED_SITE + "/index.html", render.post_health.DASHBOARD_URL)
+            # A gs:// target derives <base href> using the published dashboard host.
+            out = render_to(pathlib.Path(tmp) / "gcs", data, extra_args=["--public-url", "gs://staging-bucket/test-evals/"])
+            self.assertIn('<base href="https://storage.cloud.google.com/staging-bucket/test-evals/">', (out / "index.html").read_text())
         self.assertEqual(render.base_html(None), "")
         self.assertEqual(render.base_html('https://h/"><script>'), '<base href="https://h/&quot;&gt;&lt;script&gt;/">')
+        self.assertEqual(
+            render.base_html("gs://staging-bucket/test-evals"),
+            '<base href="https://storage.cloud.google.com/staging-bucket/test-evals/">',
+        )
+        self.assertEqual(
+            render.base_html("gs://staging-bucket/test-evals/"),
+            '<base href="https://storage.cloud.google.com/staging-bucket/test-evals/">',
+        )
 
     def test_hostile_data_never_escapes_the_script_block(self):
         data = load_fixture()

--- a/scripts/test_eval_dashboard_publish.py
+++ b/scripts/test_eval_dashboard_publish.py
@@ -273,10 +273,10 @@ class PublishHookFailSafeTest(unittest.TestCase):
         """A bucket target is the published site, read from
         storage.cloud.google.com, which redirects to a locked domain that
         serves one object: without <base href> every relative link on the
-        page is dead there. The hook derives the public URL from the bucket
-        target without hardcoding production, so staging targets get a base
-        href pointing to staging rather than production. A local target
-        keeps relative links."""
+        page is dead there. The hook passes the bucket target to render.py,
+        which derives <base href> without hardcoding production, so staging
+        targets get a base href pointing to staging rather than production.
+        A local target keeps relative links."""
         collect_ok = """\
             import json, pathlib, sys
             out = sys.argv[sys.argv.index("--out") + 1]
@@ -287,8 +287,8 @@ class PublishHookFailSafeTest(unittest.TestCase):
             "pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(sys.argv[1:]))\n"
         )
         cases = (
-            ("gs://kube-agents-dashboards/evals/", "https://storage.cloud.google.com/kube-agents-dashboards/evals"),
-            ("gs://staging-bucket/test-evals", "https://storage.cloud.google.com/staging-bucket/test-evals"),
+            ("gs://kube-agents-dashboards/evals/", "gs://kube-agents-dashboards/evals/"),
+            ("gs://staging-bucket/test-evals", "gs://staging-bucket/test-evals"),
             ("/tmp/local-site", None),
         )
         for target, expected_url in cases:

--- a/scripts/test_eval_dashboard_publish.py
+++ b/scripts/test_eval_dashboard_publish.py
@@ -51,6 +51,7 @@ def run_hook(
     artifacts: str = "",
     timeout_s: str = "",
     rc_commit_sha: str = "",
+    path_prepend: str = "",
 ) -> subprocess.CompletedProcess:
     """Exit a `set -euo pipefail` shell with `exit_code`, real trap installed.
 
@@ -60,18 +61,22 @@ def run_hook(
     pipeline stubs do. Defaults to a main-branch shape (periodic, no
     PULL_NUMBER) because everything else is gated off before it can publish.
     """
-    script = "\n".join(
+    lines = [
+        "set -euo pipefail",
+        f'SCRIPT_DIR="{script_dir}"',
+        f'export JOB_TYPE="{job_type}"',
+        f'export PULL_NUMBER="{pull_number}"',
+        f'export RC_COMMIT_SHA="{rc_commit_sha}"',
+        # Always pinned: the suite itself runs under Prow, where a real
+        # $ARTIFACTS is set, and the hook copies its log there.
+        f'export ARTIFACTS="{artifacts}"',
+        f'export EVAL_DASHBOARD_TIMEOUT="{timeout_s}"',
+        f'export EVAL_DASHBOARD_TARGET="{target}"',
+    ]
+    if path_prepend:
+        lines.append(f'export PATH="{path_prepend}:$PATH"')
+    lines.extend(
         [
-            "set -euo pipefail",
-            f'SCRIPT_DIR="{script_dir}"',
-            f'export JOB_TYPE="{job_type}"',
-            f'export PULL_NUMBER="{pull_number}"',
-            f'export RC_COMMIT_SHA="{rc_commit_sha}"',
-            # Always pinned: the suite itself runs under Prow, where a real
-            # $ARTIFACTS is set, and the hook copies its log there.
-            f'export ARTIFACTS="{artifacts}"',
-            f'export EVAL_DASHBOARD_TIMEOUT="{timeout_s}"',
-            f'export EVAL_DASHBOARD_TARGET="{target}"',
             "collect_bench_results() { :; }",
             "profile_report() { :; }",
             "dump_prow_artifacts_on_failure() { echo \"called dumper with $?\"; }",
@@ -81,9 +86,17 @@ def run_hook(
             f"exit {exit_code}",
         ]
     )
+    script = "\n".join(lines)
     return subprocess.run(
         ["bash", "-c", script], capture_output=True, text=True, check=False
     )
+
+
+def write_stub(directory: pathlib.Path, name: str, body: str) -> pathlib.Path:
+    stub = directory / name
+    stub.write_text("#!/usr/bin/env bash\n" + body)
+    stub.chmod(stub.stat().st_mode | 0o755)
+    return stub
 
 
 def dashboard_stubs(root: pathlib.Path, collect_body: str) -> pathlib.Path:
@@ -260,10 +273,10 @@ class PublishHookFailSafeTest(unittest.TestCase):
         """A bucket target is the published site, read from
         storage.cloud.google.com, which redirects to a locked domain that
         serves one object: without <base href> every relative link on the
-        page is dead there. This hook publishes to the same bucket as
-        hack/ci-dashboard-refresh.sh, so it has to pass the same flag, or a
-        run of it replaces good pages with unnavigable ones until the next
-        15-minute refresh. A local target keeps relative links."""
+        page is dead there. The hook derives the public URL from the bucket
+        target without hardcoding production, so staging targets get a base
+        href pointing to staging rather than production. A local target
+        keeps relative links."""
         collect_ok = """\
             import json, pathlib, sys
             out = sys.argv[sys.argv.index("--out") + 1]
@@ -273,16 +286,137 @@ class PublishHookFailSafeTest(unittest.TestCase):
             "import json, pathlib, sys\n"
             "pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(sys.argv[1:]))\n"
         )
-        for target, expected in (("gs://kube-agents-dashboards/evals/", True), ("/tmp/local-site", False)):
+        cases = (
+            ("gs://kube-agents-dashboards/evals/", "https://storage.cloud.google.com/kube-agents-dashboards/evals"),
+            ("gs://staging-bucket/test-evals", "https://storage.cloud.google.com/staging-bucket/test-evals"),
+            ("/tmp/local-site", None),
+        )
+        for target, expected_url in cases:
             with tempfile.TemporaryDirectory() as tmp:
                 fake_hack = dashboard_stubs(pathlib.Path(tmp), collect_ok)
                 dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
                 (dash / "render.py").write_text(record_argv)
-                result = run_hook(0, fake_hack, target=target)
+                stubs_dir = pathlib.Path(tmp) / "stubs"
+                stubs_dir.mkdir()
+                write_stub(stubs_dir, "gsutil", "exit 1\n")
+                result = run_hook(0, fake_hack, target=target, path_prepend=str(stubs_dir))
                 self.assertEqual(result.returncode, 0, result.stderr)
                 argv = json.loads((dash / "render.py.argv").read_text())
-                self.assertEqual("--public-url" in argv, expected, f"{target}: {argv}")
+                if expected_url is not None:
+                    self.assertIn("--public-url", argv, f"{target}: {argv}")
+                    actual_url = argv[argv.index("--public-url") + 1]
+                    self.assertEqual(actual_url, expected_url)
+                else:
+                    self.assertNotIn("--public-url", argv, f"{target}: {argv}")
                 self.assertNotIn("", argv, "no empty argument from an unset array")
+
+    def test_health_and_history_passed_when_present(self):
+        """When health.json and health-history.jsonl exist at target, the
+        hook passes them to render.py so the Brief bakes the current verdict
+        and incident history instead of rendering NO VERDICT."""
+        collect_ok = """\
+            import json, pathlib, sys
+            out = sys.argv[sys.argv.index("--out") + 1]
+            pathlib.Path(out).write_text(json.dumps({"runs": [{"build": "1"}]}))
+            """
+        record_argv = """\
+            import json, pathlib, sys
+            argv = sys.argv[1:]
+            health_path = pathlib.Path(argv[argv.index('--health') + 1]) if '--health' in argv else None
+            hist_path = pathlib.Path(argv[argv.index('--health-history') + 1]) if '--health-history' in argv else None
+            result = {
+                'argv': argv,
+                'health_exists': health_path.is_file() if health_path else False,
+                'health_content': health_path.read_text() if health_path and health_path.is_file() else None,
+                'hist_exists': hist_path.is_file() if hist_path else False,
+            }
+            pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(result))
+            """
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack = dashboard_stubs(pathlib.Path(tmp), collect_ok)
+            dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
+            (dash / "render.py").write_text(textwrap.dedent(record_argv))
+            target = pathlib.Path(tmp) / "local-target"
+            target.mkdir()
+            (target / "health.json").write_text(json.dumps({"state": "GREEN"}))
+            (target / "health-history.jsonl").write_text(json.dumps({"state": "GREEN"}) + "\n")
+            result = run_hook(0, fake_hack, target=str(target))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            data = json.loads((dash / "render.py.argv").read_text())
+            argv = data["argv"]
+            self.assertIn("--health", argv)
+            self.assertTrue(data["health_exists"])
+            self.assertEqual(json.loads(data["health_content"]), {"state": "GREEN"})
+            self.assertIn("--health-history", argv)
+            self.assertTrue(data["hist_exists"])
+
+    def test_health_and_history_omitted_when_absent(self):
+        """When health.json and health-history.jsonl are absent at target,
+        --health and --health-history must not be passed to render.py."""
+        collect_ok = """\
+            import json, pathlib, sys
+            out = sys.argv[sys.argv.index("--out") + 1]
+            pathlib.Path(out).write_text(json.dumps({"runs": [{"build": "1"}]}))
+            """
+        record_argv = (
+            "import json, pathlib, sys\n"
+            "pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(sys.argv[1:]))\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack = dashboard_stubs(pathlib.Path(tmp), collect_ok)
+            dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
+            (dash / "render.py").write_text(record_argv)
+            target = pathlib.Path(tmp) / "empty-target"
+            target.mkdir()
+            result = run_hook(0, fake_hack, target=str(target))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            argv = json.loads((dash / "render.py.argv").read_text())
+            self.assertNotIn("--health", argv)
+            self.assertNotIn("--health-history", argv)
+
+    def test_gsutil_downloads_health_and_history_for_bucket_target(self):
+        """For a gs:// target, the hook calls gsutil cp to download
+        health.json and health-history.jsonl and passes them to render.py."""
+        collect_ok = """\
+            import json, pathlib, sys
+            out = sys.argv[sys.argv.index("--out") + 1]
+            pathlib.Path(out).write_text(json.dumps({"runs": [{"build": "1"}]}))
+            """
+        record_argv = (
+            "import json, pathlib, sys\n"
+            "pathlib.Path(sys.path[0], 'render.py.argv').write_text(json.dumps(sys.argv[1:]))\n"
+        )
+        fake_gsutil = """\
+            if [[ "$1" == "cp" ]]; then
+                src="$2"
+                dst="$3"
+                if [[ "$src" == *"health.json" ]]; then
+                    echo '{"state":"GREEN"}' > "$dst"
+                    exit 0
+                elif [[ "$src" == *"health-history.jsonl" ]]; then
+                    echo '{"state":"GREEN"}' > "$dst"
+                    exit 0
+                fi
+            fi
+            exit 1
+            """
+        with tempfile.TemporaryDirectory() as tmp:
+            fake_hack = dashboard_stubs(pathlib.Path(tmp), collect_ok)
+            dash = pathlib.Path(tmp) / "scripts" / "eval_dashboard"
+            (dash / "render.py").write_text(record_argv)
+            stubs_dir = pathlib.Path(tmp) / "stubs"
+            stubs_dir.mkdir()
+            write_stub(stubs_dir, "gsutil", textwrap.dedent(fake_gsutil))
+            result = run_hook(
+                0,
+                fake_hack,
+                target="gs://kube-agents-dashboards/evals/",
+                path_prepend=str(stubs_dir),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            argv = json.loads((dash / "render.py.argv").read_text())
+            self.assertIn("--health", argv)
+            self.assertIn("--health-history", argv)
 
     def test_zero_collected_runs_skip_instead_of_publishing_empty(self):
         """The evidence_store lesson: an unreadable source is not an empty

--- a/tests/test_eval_dashboard_refresh.py
+++ b/tests/test_eval_dashboard_refresh.py
@@ -130,6 +130,38 @@ class RefreshScriptTest(unittest.TestCase):
         self.assertEqual(data["schema_version"], 1)
         self.assertEqual(len(data["runs"]), 3)
         self.assertIn("<html", (self.target / "index.html").read_text().lower())
+        self.assertNotIn("<base href", (self.target / "index.html").read_text())
+
+    def test_bucket_target_emits_derived_base_href(self):
+        """gs:// target derives <base href> from the bucket URL rather than
+        hardcoding production, so staging bucket targets point to staging."""
+        stubs = self.tmp / "stubs"
+        stubs.mkdir()
+        published_capture = self.tmp / "captured_site"
+        published_capture.mkdir()
+        fake_gsutil = f"""
+        for arg in "$@"; do
+            if [[ -f "$arg" ]]; then
+                cp "$arg" "{published_capture}/"
+            fi
+        done
+        exit 0
+        """
+        write_stub(stubs, "gsutil", fake_gsutil)
+        proc = run_script(
+            env={
+                "EVAL_DASHBOARD_TARGET": "gs://staging-bucket/evals/",
+                "EVAL_DASHBOARD_FROM_DIR": str(TESTDATA),
+                "JOB_TYPE": "periodic",
+            },
+            path_prepend=str(stubs),
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        rendered_html = (published_capture / "index.html").read_text()
+        self.assertIn(
+            '<base href="https://storage.cloud.google.com/staging-bucket/evals/">',
+            rendered_html,
+        )
 
     def test_a_from_dir_run_never_reaches_the_rc_bucket(self):
         """EVAL_DASHBOARD_RC_GLOB defaults to a real bucket path, so the


### PR DESCRIPTION
## Summary

Bakes health verdict (`health.json`) and incident history (`health-history.jsonl`) into the CI eval-PR dashboard publish hook (`hack/ci-eval-pr.sh`), and normalizes bucket targets in `scripts/eval_dashboard/render.py` so published pages derive `<base href>` from their destination bucket without hardcoding production or burying URL literals mid-function in shell scripts.

## Why This Change

The eval-PR dashboard publish hook (`hack/ci-eval-pr.sh`) rendered the dashboard without `--health` and `--health-history` flags. As a result, every set of pages published by the hook read:
- `NO VERDICT · No gate verdict is published` in the headline
- `No incident history is published yet` in the "Last incident" block
until the next 15-minute refresh job (`hack/ci-dashboard-refresh.sh`) overwrote them. Because `storage.cloud.google.com` responds to subresource XHR polls for `health.json` with login redirects rather than CORS headers, pages rely on inlining health and history data at render time.

Additionally, both `hack/ci-eval-pr.sh` and `hack/ci-dashboard-refresh.sh` previously matched `gs://*` with a bare `--public-url` flag. The bare flag resolves to the production URL constant (`post_health.DASHBOARD_SITE`), meaning pointing `EVAL_DASHBOARD_TARGET` at a staging bucket would emit a `<base href>` pointing at production, causing the staging site to poll and display production data. Rather than introducing duplicate `https://storage.cloud.google.com/` magic constants across multiple shell scripts, `hack/ci-eval-pr.sh` and `hack/ci-dashboard-refresh.sh` now pass the target bucket directly (`--public-url "$3"`), and `render.py` derives the public base URL using the existing `PUBLISHED_SITE` host.

## What Changed

- `hack/ci-eval-pr.sh`:
  - Added step to download `health.json` and `health-history.jsonl` from the target bucket (`gsutil cp ... || rm -f ...`) or copy from a local directory target before rendering.
  - Passed `--health` and `--health-history` conditionally to `render.py` when present.
  - Passed `--public-url "$3"` for bucket targets (`gs://*`) so `render.py` derives `<base href>` from the destination bucket without hardcoding production or duplicating host literals.
- `hack/ci-dashboard-refresh.sh`:
  - Passed `--public-url "$3"` for bucket targets (`gs://*`) to match `hack/ci-eval-pr.sh`.
- `scripts/eval_dashboard/render.py`:
  - In `base_html`: normalized `gs://` target inputs by deriving the public base URL using the existing `PUBLISHED_SITE` host (`urllib.parse.urlsplit(PUBLISHED_SITE)`), ensuring the dashboard host constant remains centralized in `post_health.py` with trailing slash normalization.
  - Updated `--public-url` CLI argument help text to reflect acceptance of `gs://` bucket paths.
- `scripts/test_eval_dashboard_pages.py`:
  - In `test_base_href_only_with_a_public_url`: added assertions verifying `render.base_html` and `render_to` properly convert `gs://` targets into public URLs with trailing slashes.
- `scripts/test_eval_dashboard_publish.py`:
  - Added `test_health_and_history_passed_when_present` and `test_health_and_history_omitted_when_absent` asserting that `--health` and `--health-history` are provided and readable by `render.py` when present, and omitted when absent.
  - Added `test_gsutil_downloads_health_and_history_for_bucket_target` verifying `gsutil cp` downloads health files on bucket targets.
  - Updated `test_a_bucket_target_renders_with_the_public_url` to verify `--public-url "$3"` is passed for bucket targets and omitted for local directory targets.
  - Added `path_prepend` support to `run_hook` and hermetic `write_stub` helper so tests never execute uncontrolled network calls to cloud buckets.
- `tests/test_eval_dashboard_refresh.py`:
  - Added `test_bucket_target_emits_derived_base_href` verifying `ci-dashboard-refresh.sh` generates `<base href>` matching staging bucket targets.

## Context

Fixes #1497. Follows #1495 (incident deep links and fragment preservation across login redirects) and #1496 (bucket public-url flag in eval-PR hook). Addresses the parity gap noted in `hack/ci-eval-pr.sh` where the eval publish hook lacked the health file download step present in `hack/ci-dashboard-refresh.sh`.

## Testing

- Sabotage verification: Pre-fix run produced 3 targeted test failures in `scripts/test_eval_dashboard_publish.py` (`IndexError` on unargumented `--public-url`, and missing `--health` across bucket and local targets).
- Post-fix unit tests:
  - `PYTHONPATH=scripts python3 -m unittest scripts/test_eval_dashboard_publish.py`: Passed (18/18 tests).
  - `python3 -m unittest tests/test_eval_dashboard_refresh.py`: Passed (13/13 tests).
  - `PYTHONPATH=scripts python3 -m unittest scripts/test_eval_dashboard_pages.py`: Passed (42 tests, 27 skipped).
  - `PYTHONPATH=scripts python3 -m unittest discover -s scripts -p "test_eval_dashboard*.py"`: Passed (432 tests, 27 skipped).
- Syntax and quality gates:
  - `bash -n hack/ci-eval-pr.sh`: Clean.
  - `bash -n hack/ci-dashboard-refresh.sh`: Clean.
  - `make docs-check`: Clean (307 markdown files, 1192 code files).
  - `cd k8s-operator && go test -count=1 ./...`: Clean.

### Live validation

Not live-tested against a running cluster installation. The changed code path lives in CI dashboard publishing shell scripts (`hack/ci-eval-pr.sh`, `hack/ci-dashboard-refresh.sh`) and dashboard render code (`render.py`) executed during CI workflows; it alters no agent personas, prompt templates, cluster operator code, CRDs, or in-cluster runtime paths. Offline execution of the scripts with hermetic `gsutil` test doubles and end-to-end HTML inspection in unit tests comprehensively exercises the argument passing, file copying/downloading, and rendered HTML `<base href>` output.

## Self-Review

Run in isolated subagent contexts handed only the diff range (`upstream/main...HEAD`) with author notes withheld:

- **Adversarial pass:**
  - Audited subshell quoting: verified no single quotes exist inside comments within the `bash -c '...'` payload in `hack/ci-eval-pr.sh`.
  - Audited error handling: verified `gsutil cp ... 2>&1 || rm -f ...` cleanly handles missing health files and failures under `set -euo pipefail` without failing the publishing pipeline.
  - Audited local directory targets: verified file existence checks and copy fallback operate safely when targeting local filesystem paths.
  - Audited URL derivation and host normalization: verified `render.base_html` strips `gs://` prefixes, derives the public host from `PUBLISHED_SITE` via `urllib.parse.urlsplit`, and preserves trailing slashes without doubling (`gs://bucket/path/` and `gs://bucket/path` both produce `https://storage.cloud.google.com/bucket/path/`).
  - Audited magic constants: verified no hardcoded URL strings remain mid-function in `hack/ci-eval-pr.sh` or `hack/ci-dashboard-refresh.sh`; both pass positional `$3` directly to `--public-url`.
- **Docs-drift pass:**
  - Audited in-tree comment change in `hack/ci-dashboard-refresh.sh`: verified the updated comment accurately describes passing the target rather than bare flag emission.
  - Audited `hack/ci-eval-pr.sh` comments: verified the comments closing the health parity gap and describing the public URL derivation match current implementation.
  - Audited CLI help text in `render.py`: verified `--help` accurately describes acceptance of `gs://` bucket paths.
  - Audited repository documentation and `scripts/eval_dashboard/SCHEMA.md`: confirmed `SCHEMA.md` documents `render.py --public-url [BASE]` (where bare `--public-url` is still supported by `render.py` itself as a fallback to `post_health.DASHBOARD_URL`, while CI scripts now pass explicit URLs or bucket targets); verified `make docs-check` passes cleanly across all 307 markdown files.

## Risk & Rollout

Low risk. Confined to CI dashboard publishing scripts (`hack/ci-eval-pr.sh` and `hack/ci-dashboard-refresh.sh`) and dashboard rendering (`render.py`). Both scripts execute the render and publish logic within a fail-safe subshell block (`publish.log 2>&1 || dash_rc=$?`) that captures failures without blocking PR eval completion or aborting CI pipelines.

*Generated with the help of Gemini.*